### PR TITLE
Make keepScreenOn behavior configurable in SceneView

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -566,6 +566,8 @@ open class SceneView @JvmOverloads constructor(
         })
 
         lifecycle?.addObserver(lifecycleObserver)
+
+        keepScreenOn = true
     }
 
     /**
@@ -897,8 +899,6 @@ open class SceneView @JvmOverloads constructor(
             // to avoid getting called twice.
             Choreographer.getInstance().removeFrameCallback(frameCallback)
             Choreographer.getInstance().postFrameCallback(frameCallback)
-
-            activity?.setKeepScreenOn(true)
         }
 
         override fun onPause(owner: LifecycleOwner) {


### PR DESCRIPTION
Previously, SceneView enforced `keepScreenOn = true` by default, without providing a way to disable it. This caused issues in complex layouts - especially when SceneView is embedded within a RecyclerView or part of a composite screen - where screen wake behavior should be contextually controlled.

This patch replaces the hardcoded behavior with a standard public property:
`var keepScreenOn: Boolean `

Developers can now disable screen wake behavior by setting `SceneView.keepScreenOn = false `after instantiation.
Benefits:
- ✅ Preserves backward compatibility for existing integrations
- 🧩 Aligns with native Android practices for screen-on control
- 🔧 Enables fine-grained control over screen wake behavior in dynamic UI scenarios


