### PR TITLE
release: 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.1.2 — Sample polish, CI fixes, maintenance tooling
+
+### Fixes
+- `autopilot-demo`: remove deprecated `engine` parameter from `PlaneNode`, `CubeNode`, `CylinderNode` constructors (API aligned with composable node design)
+- CI: fix AR emulator stability — wait for launcher, dismiss ANR dialogs, kill Pixel Launcher before screenshots
+
+### Sample improvements
+- `model-viewer`: scale up Damaged Helmet 0.25 → 1.0; add Fox model (CC0, KhronosGroup glTF-Sample-Assets) with model picker chip row
+- `camera-manipulator`: scale up model 0.25 → 1.0; add gesture hint bar (Drag·Orbit / Pinch·Zoom / Pan·Move)
+
+### Developer tooling
+- `/maintain` Claude Code skill + daily maintenance GitHub Action for automated SDK upkeep
+- AR emulator CI job using x86\_64 Linux + ARCore emulator APK for screenshot verification
+- `ROADMAP.md` added covering 3.2–4.0 milestones
+
 ## 3.1.1 — Build compatibility patch
 
 - Downgrade AGP from 8.13.2 → 8.11.1 for Android Studio compatibility

--- a/arsceneview/gradle.properties
+++ b/arsceneview/gradle.properties
@@ -3,5 +3,5 @@
 ######################
 POM_NAME=ArSceneView
 POM_ARTIFACT_ID=arsceneview
-VERSION_NAME=3.1.1
+VERSION_NAME=3.1.2
 POM_PACKAGING=aar

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sceneview-mcp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "MCP server for SceneView — 3D and AR with Jetpack Compose for Android. Give Claude the full SceneView SDK so it writes correct, compilable Kotlin.",
   "keywords": [
     "mcp",

--- a/sceneview/gradle.properties
+++ b/sceneview/gradle.properties
@@ -3,5 +3,5 @@
 ######################
 POM_NAME=SceneView
 POM_ARTIFACT_ID=sceneview
-VERSION_NAME=3.1.1
+VERSION_NAME=3.1.2
 POM_PACKAGING=aar


### PR DESCRIPTION
## SceneView 3.1.2

**6 meaningful commits** since v3.1.1 — release threshold met.

### What's in this release

**Fixes**
- `autopilot-demo`: remove deprecated `engine` parameter from `PlaneNode`/`CubeNode`/`CylinderNode` (PR #663)
- CI: AR emulator stability — wait for launcher, dismiss ANR dialogs, kill Pixel Launcher before screenshots

**Sample improvements**
- `model-viewer`: Helmet scaled 0.25 → 1.0; Fox model (CC0) added with model picker chip row (PR #668)
- `camera-manipulator`: model scaled 0.25 → 1.0; gesture hint bar added

**Developer tooling**
- `/maintain` Claude Code skill + daily maintenance GitHub Action
- AR emulator CI job (x86_64 Linux + ARCore emulator APK)
- `ROADMAP.md` added

### Dependency PRs pending (not blocking this release)
- #664 Kotlin 2.1.21 → 2.3.20
- #667 Filament 1.56.0 → 1.70.0

## Test plan

- [x] All samples build (`./gradlew assembleDebug`)
- [x] Lint clean on both library modules
- [x] MCP: 178/178 tests passing
- [ ] CI will run full suite on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)