### PR TITLE
CI hardening, advanced tutorials, minSdk standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           ./gradlew \
             :samples:model-viewer:assembleDebug \
             :samples:ar-model-viewer:assembleDebug \
+            :samples:ar-augmented-image:assembleDebug \
+            :samples:ar-cloud-anchor:assembleDebug \
+            :samples:ar-point-cloud:assembleDebug \
             :samples:gltf-camera:assembleDebug \
             :samples:camera-manipulator:assembleDebug \
             :samples:autopilot-demo:assembleDebug \
@@ -41,6 +44,9 @@ jobs:
             :samples:text-labels:assembleDebug \
             :samples:reflection-probe:assembleDebug \
             --stacktrace
+
+      - name: Unit tests
+        run: ./gradlew :sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest --stacktrace
 
       - name: Lint
         run: ./gradlew :sceneview:lintDebug :arsceneview:lintDebug --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
         working-directory: mcp
         run: npm run prepare
 
+      - name: Test
+        working-directory: mcp
+        run: npm test
+
       - name: Publish
         working-directory: mcp
         run: npm publish --access public

--- a/docs/docs/codelabs/guide-dynamic-sky.md
+++ b/docs/docs/codelabs/guide-dynamic-sky.md
@@ -1,0 +1,118 @@
+# Advanced guide: Dynamic sky and fog
+
+**Time:** ~15 minutes
+**Level:** Intermediate
+**What you'll build:** A scene with a time-of-day sun cycle and atmospheric fog
+
+---
+
+## Overview
+
+SceneView 3.2.0 adds two atmospheric composables:
+
+- **`DynamicSkyNode`** — drives a sun light based on time-of-day (sunrise, noon, sunset, night)
+- **`FogNode`** — applies volumetric fog to the scene
+
+Both are declarative: just change a parameter and the scene reacts.
+
+---
+
+## Step 1 — Add a dynamic sun
+
+```kotlin
+@Composable
+fun SkyScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+
+    // Animate time from 0 (midnight) to 24 over 30 seconds
+    val infiniteTransition = rememberInfiniteTransition(label = "DayCycle")
+    val timeOfDay by infiniteTransition.animateFloat(
+        initialValue = 6f,   // sunrise
+        targetValue = 18f,   // sunset
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 30_000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "time"
+    )
+
+    Scene(engine = engine, modelLoader = modelLoader) {
+        DynamicSkyNode(
+            timeOfDay = timeOfDay,   // 0–24 hour float
+            turbidity = 2f,          // atmospheric haze [1–10]
+            sunIntensity = 110_000f  // max illuminance at noon (lux)
+        )
+
+        // Place your model here — it will be lit by the sun
+        rememberModelInstance(modelLoader, "models/scene.glb")?.let {
+            ModelNode(modelInstance = it)
+        }
+    }
+}
+```
+
+### Sun colour model
+
+| Time | Appearance |
+|---|---|
+| 0–5 (night) | Near-black, minimal light |
+| 6 (sunrise) | Warm orange-red |
+| 12 (noon) | Bright white (1.0, 0.98, 0.95) |
+| 18 (sunset) | Warm orange-red |
+| 19–24 (night) | Near-black |
+
+---
+
+## Step 2 — Add atmospheric fog
+
+```kotlin
+val view = rememberView(engine)
+var fogEnabled by remember { mutableStateOf(true) }
+var fogDensity by remember { mutableFloatStateOf(0.05f) }
+
+Scene(engine = engine, modelLoader = modelLoader, view = view) {
+    DynamicSkyNode(timeOfDay = timeOfDay)
+
+    FogNode(
+        view = view,
+        enabled = fogEnabled,
+        density = fogDensity,     // [0.0–1.0], higher = thicker
+        height = 1.0f,            // fog is denser below this Y
+        color = Color(0xFFCCDDFF) // light blue-grey
+    )
+
+    // Your scene content
+}
+```
+
+### Fog parameters
+
+| Parameter | Effect |
+|---|---|
+| `density` | Volumetric fog thickness `[0.0, 1.0]`. Try `0.02` for light haze, `0.15` for dense fog |
+| `height` | Height falloff — fog is denser below this world-space Y |
+| `color` | Fog colour. Match your sky tint for realism |
+| `enabled` | Toggle fog on/off reactively |
+
+---
+
+## Step 3 — Combine sky + fog for atmosphere
+
+The real power is combining both. As the sun sets, increase fog density for a moody twilight:
+
+```kotlin
+val fogDensity = if (timeOfDay in 6f..18f) 0.02f else 0.12f
+
+Scene(engine = engine, modelLoader = modelLoader, view = view) {
+    DynamicSkyNode(timeOfDay = timeOfDay, turbidity = 3f)
+    FogNode(view = view, density = fogDensity, color = Color(0xFFEED8AA))
+}
+```
+
+---
+
+## What's next
+
+- See the `dynamic-sky` sample for a full interactive implementation with a time slider
+- Combine with `ReflectionProbeNode` for indoor/outdoor transitions

--- a/docs/docs/codelabs/guide-lines-text.md
+++ b/docs/docs/codelabs/guide-lines-text.md
@@ -1,0 +1,158 @@
+# Advanced guide: Lines, paths, and text labels
+
+**Time:** ~15 minutes
+**Level:** Intermediate
+**What you'll build:** 3D line drawings and floating text labels in world space
+
+---
+
+## Overview
+
+SceneView 3.2.0 adds three geometry primitives for annotation and visualization:
+
+- **`LineNode`** — a single line segment between two points
+- **`PathNode`** — a polyline through multiple points (open or closed)
+- **`TextNode`** — a camera-facing text label rendered as a billboard
+
+---
+
+## Lines and paths
+
+### Single line
+
+```kotlin
+Scene(engine = engine, modelLoader = modelLoader) {
+    val line = remember(engine) {
+        LineNode(
+            engine = engine,
+            start = Position(x = -1f, y = 0f, z = 0f),
+            end = Position(x = 1f, y = 1f, z = 0f)
+        )
+    }
+    Node(node = line)
+}
+```
+
+### Path (polyline)
+
+```kotlin
+val points = remember {
+    (0..100).map { i ->
+        val t = i / 100f * Math.PI.toFloat() * 4
+        Position(
+            x = t * 0.1f - 2f,
+            y = sin(t) * 0.5f,
+            z = cos(t) * 0.5f
+        )
+    }
+}
+
+Scene(engine = engine, modelLoader = modelLoader) {
+    val path = remember(engine, points) {
+        PathNode(engine = engine, points = points)
+    }
+    Node(node = path)
+}
+```
+
+### Closed path (polygon)
+
+```kotlin
+val triangle = listOf(
+    Position(0f, 1f, 0f),
+    Position(-1f, -0.5f, 0f),
+    Position(1f, -0.5f, 0f)
+)
+
+val closedPath = remember(engine) {
+    PathNode(engine = engine, points = triangle, closed = true)
+}
+```
+
+---
+
+## Text labels
+
+`TextNode` renders text to a bitmap and displays it as a camera-facing billboard.
+
+```kotlin
+var cameraPos by remember { mutableStateOf(Position()) }
+
+Scene(
+    engine = engine,
+    modelLoader = modelLoader,
+    onFrame = { cameraPos = cameraNode.worldPosition }
+) {
+    TextNode(
+        materialLoader = materialLoader,
+        text = "Hello 3D!",
+        fontSize = 48f,
+        textColor = android.graphics.Color.WHITE,
+        backgroundColor = 0xCC000000.toInt(),
+        widthMeters = 0.6f,
+        heightMeters = 0.2f,
+        cameraPositionProvider = { cameraPos }
+    )
+}
+```
+
+### Parameters
+
+| Parameter | Effect |
+|---|---|
+| `text` | The string to display |
+| `fontSize` | Font size in pixels for the bitmap texture |
+| `textColor` | ARGB text colour |
+| `backgroundColor` | ARGB background fill |
+| `widthMeters` / `heightMeters` | Size of the quad in world space |
+| `cameraPositionProvider` | Lambda returning camera position — label faces the camera |
+| `bitmapWidth` / `bitmapHeight` | Resolution of the backing bitmap (default 512x128) |
+
+### Positioning labels
+
+Set the label's position like any node:
+
+```kotlin
+TextNode(
+    materialLoader = materialLoader,
+    text = "Earth",
+    cameraPositionProvider = { cameraPos }
+).apply {
+    position = Position(x = 0f, y = 2f, z = 0f)
+}
+```
+
+---
+
+## Combining lines and labels
+
+A common pattern is annotating a 3D scene with measurement lines and labels:
+
+```kotlin
+Scene(engine = engine, modelLoader = modelLoader) {
+    // Measurement line
+    val measureLine = remember(engine) {
+        LineNode(engine, start = Position(-1f, 0f, 0f), end = Position(1f, 0f, 0f))
+    }
+    Node(node = measureLine)
+
+    // Label at midpoint
+    TextNode(
+        materialLoader = materialLoader,
+        text = "2.0 m",
+        fontSize = 36f,
+        widthMeters = 0.4f,
+        heightMeters = 0.15f,
+        cameraPositionProvider = { cameraPos }
+    ).apply {
+        position = Position(0f, 0.2f, 0f)
+    }
+}
+```
+
+---
+
+## What's next
+
+- See the `line-path` sample for animated sine/Lissajous curves with parameter sliders
+- See the `text-labels` sample for an interactive solar system with label cycling

--- a/docs/docs/codelabs/guide-physics.md
+++ b/docs/docs/codelabs/guide-physics.md
@@ -1,0 +1,102 @@
+# Advanced guide: Physics simulation
+
+**Time:** ~15 minutes
+**Level:** Intermediate
+**What you'll build:** A scene with bouncing spheres affected by gravity
+
+---
+
+## Overview
+
+SceneView 3.2.0 includes a lightweight, built-in physics simulation via `PhysicsNode`.
+No external physics engine is required — gravity, floor collisions, and bounce are handled
+automatically.
+
+---
+
+## Step 1 — Create a sphere and attach physics
+
+```kotlin
+@Composable
+fun PhysicsScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
+    val environment = rememberEnvironment(environmentLoader) {
+        environmentLoader.createHDREnvironment("environments/sky_2k.hdr")!!
+    }
+
+    Scene(
+        engine = engine,
+        modelLoader = modelLoader,
+        environment = environment
+    ) {
+        // Create a sphere node
+        val sphere = remember(engine) {
+            SphereNode(engine, radius = 0.15f).apply {
+                position = Position(y = 3f)
+            }
+        }
+
+        // Attach physics — it will fall and bounce
+        PhysicsNode(
+            node = sphere,
+            mass = 1f,
+            restitution = 0.7f,          // 70% energy preserved per bounce
+            linearVelocity = Position(),  // starts at rest, gravity pulls it down
+            floorY = 0f,                  // bounce off Y = 0
+            radius = 0.15f               // match the sphere radius
+        )
+    }
+}
+```
+
+---
+
+## Step 2 — Key parameters
+
+| Parameter | Effect |
+|---|---|
+| `mass` | Object mass in kg (reserved for future force calculations) |
+| `restitution` | Bounciness `[0, 1]`. `0` = no bounce, `1` = perfectly elastic |
+| `linearVelocity` | Initial velocity in m/s — use `Position(x = 1f, y = 5f)` to launch at an angle |
+| `floorY` | Y-coordinate of the ground plane |
+| `radius` | Collision radius — offsets contact so the sphere surface touches the floor |
+
+---
+
+## Step 3 — Multiple objects with different properties
+
+```kotlin
+Scene(engine = engine, modelLoader = modelLoader, environment = environment) {
+    // Heavy bowling ball — low bounce
+    val heavyBall = remember(engine) {
+        SphereNode(engine, radius = 0.2f).apply {
+            position = Position(x = -0.5f, y = 4f)
+        }
+    }
+    PhysicsNode(node = heavyBall, mass = 5f, restitution = 0.2f, radius = 0.2f)
+
+    // Rubber ball — high bounce
+    val rubberBall = remember(engine) {
+        SphereNode(engine, radius = 0.1f).apply {
+            position = Position(x = 0.5f, y = 3f)
+        }
+    }
+    PhysicsNode(node = rubberBall, mass = 0.5f, restitution = 0.9f, radius = 0.1f)
+}
+```
+
+The physics system automatically:
+
+- Applies gravity (9.8 m/s² downward)
+- Detects floor collisions using the `floorY` + `radius` offset
+- Puts objects to sleep once they stop moving
+
+---
+
+## What's next
+
+- Combine with `ModelNode` to drop 3D models instead of primitive spheres
+- Use `linearVelocity` to create projectile effects
+- See the `physics-demo` sample for a complete interactive example with colour selection and a bounciness slider

--- a/docs/docs/codelabs/guide-reflection-probes.md
+++ b/docs/docs/codelabs/guide-reflection-probes.md
@@ -1,0 +1,140 @@
+# Advanced guide: Reflection probes
+
+**Time:** ~15 minutes
+**Level:** Intermediate
+**What you'll build:** A scene with zone-based environment reflections on metallic objects
+
+---
+
+## Overview
+
+`ReflectionProbeNode` lets you override the scene's image-based lighting (IBL) for specific
+zones. This is essential for realistic metallic or glossy materials — a chrome sphere should
+reflect the environment around it, not a generic sky.
+
+---
+
+## Step 1 — Global reflection probe
+
+The simplest use: replace the scene's default IBL with a specific environment.
+
+```kotlin
+@Composable
+fun ReflectionScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
+
+    val environment = rememberEnvironment(environmentLoader) {
+        environmentLoader.createHDREnvironment("environments/studio.hdr")!!
+    }
+
+    var cameraPosition by remember { mutableStateOf(Position()) }
+    val cameraNode = rememberCameraNode(engine) {
+        position = Position(z = 3f)
+    }
+
+    Scene(
+        engine = engine,
+        modelLoader = modelLoader,
+        cameraNode = cameraNode,
+        environment = environment,
+        onFrame = { cameraPosition = cameraNode.worldPosition }
+    ) {
+        // Global probe — always active (radius = 0)
+        ReflectionProbeNode(
+            filamentScene = scene,
+            environment = environment,
+            cameraPosition = cameraPosition
+        )
+
+        rememberModelInstance(modelLoader, "models/metallic_sphere.glb")?.let {
+            ModelNode(modelInstance = it)
+        }
+    }
+}
+```
+
+---
+
+## Step 2 — Local zone probes
+
+Use `radius` to create zones with different reflections — e.g., indoor vs outdoor:
+
+```kotlin
+val outdoorEnv = rememberEnvironment(environmentLoader) {
+    environmentLoader.createHDREnvironment("environments/sky.hdr")!!
+}
+val indoorEnv = rememberEnvironment(environmentLoader) {
+    environmentLoader.createHDREnvironment("environments/office.hdr")!!
+}
+
+Scene(
+    engine = engine,
+    modelLoader = modelLoader,
+    environment = outdoorEnv,
+    onFrame = { cameraPosition = cameraNode.worldPosition }
+) {
+    // Outdoor — global fallback
+    ReflectionProbeNode(
+        filamentScene = scene,
+        environment = outdoorEnv,
+        cameraPosition = cameraPosition
+    )
+
+    // Indoor zone — active within 3m of (0, 1, -5)
+    ReflectionProbeNode(
+        filamentScene = scene,
+        environment = indoorEnv,
+        position = Position(x = 0f, y = 1f, z = -5f),
+        radius = 3f,
+        priority = 1,  // wins over global when camera is inside
+        cameraPosition = cameraPosition
+    )
+}
+```
+
+### How zone priority works
+
+When the camera is inside multiple probe zones, the one with the highest `priority` wins.
+If priorities are equal, the last one in composition order wins.
+
+---
+
+## Step 3 — Toggle probes reactively
+
+Since probes are composables, toggling is just an `if` statement:
+
+```kotlin
+var probeEnabled by remember { mutableStateOf(true) }
+
+Scene(...) {
+    if (probeEnabled) {
+        ReflectionProbeNode(
+            filamentScene = scene,
+            environment = studioEnv,
+            cameraPosition = cameraPosition
+        )
+    }
+}
+```
+
+---
+
+## Parameters reference
+
+| Parameter | Effect |
+|---|---|
+| `filamentScene` | The Filament Scene whose indirect light is overridden |
+| `environment` | Environment containing the IndirectLight to apply |
+| `position` | Centre of the reflection zone in world space |
+| `radius` | Zone radius in metres. `0` = always active (global) |
+| `priority` | Higher value wins when zones overlap |
+| `cameraPosition` | Updated each frame from `onFrame` callback |
+
+---
+
+## What's next
+
+- See the `reflection-probe` sample for material switching (Chrome, Gold, Copper, Rough)
+- Combine with `FogNode` and `DynamicSkyNode` for complete atmospheric scenes

--- a/docs/docs/codelabs/index.md
+++ b/docs/docs/codelabs/index.md
@@ -2,6 +2,8 @@
 
 Step-by-step guides for building 3D and AR apps with SceneView and Jetpack Compose.
 
+## Getting started
+
 <div class="grid cards" markdown>
 
 -   :material-cube-outline: **3D with Compose**
@@ -23,5 +25,51 @@ Step-by-step guides for building 3D and AR apps with SceneView and Jetpack Compo
     **~20 minutes · Beginner**
 
     [:octicons-arrow-right-24: Start](codelab-ar-compose.md)
+
+</div>
+
+## Advanced guides
+
+<div class="grid cards" markdown>
+
+-   :material-soccer: **Physics simulation**
+
+    ---
+
+    Bouncing spheres with gravity, floor collisions, and configurable restitution.
+
+    **~15 minutes · Intermediate**
+
+    [:octicons-arrow-right-24: Start](guide-physics.md)
+
+-   :material-weather-sunset: **Dynamic sky & fog**
+
+    ---
+
+    Time-of-day sun cycle with atmospheric fog for moody outdoor scenes.
+
+    **~15 minutes · Intermediate**
+
+    [:octicons-arrow-right-24: Start](guide-dynamic-sky.md)
+
+-   :material-mirror: **Reflection probes**
+
+    ---
+
+    Zone-based IBL overrides for realistic metallic and glossy materials.
+
+    **~15 minutes · Intermediate**
+
+    [:octicons-arrow-right-24: Start](guide-reflection-probes.md)
+
+-   :material-vector-line: **Lines, paths & text**
+
+    ---
+
+    3D line drawings, polylines, and camera-facing text labels for annotation.
+
+    **~15 minutes · Intermediate**
+
+    [:octicons-arrow-right-24: Start](guide-lines-text.md)
 
 </div>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,10 @@ nav:
     - codelabs/index.md
     - 3D with Compose: codelabs/codelab-3d-compose.md
     - AR with Compose: codelabs/codelab-ar-compose.md
+    - "Guide: Physics": codelabs/guide-physics.md
+    - "Guide: Dynamic sky & fog": codelabs/guide-dynamic-sky.md
+    - "Guide: Reflection probes": codelabs/guide-reflection-probes.md
+    - "Guide: Lines & text": codelabs/guide-lines-text.md
   - Migration guide: migration.md
   - Changelog: changelog.md
   - API reference:
@@ -79,9 +83,9 @@ extra:
       link: https://github.com/SceneView/sceneview-android
     - icon: fontawesome/brands/discord
       link: https://discord.gg/UbNDDBTNqb
-  analytics:
-    provider: google
-    property: G-XXXXXXXXXX
+  # analytics:
+  #   provider: google
+  #   property: G-XXXXXXXXXX  # TODO: replace with real property ID
 
 extra_css:
   - stylesheets/extra.css

--- a/samples/ar-augmented-image/build.gradle
+++ b/samples/ar-augmented-image/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "io.github.sceneview.sample.araugmentedimage"
-        minSdk 24
+        minSdk 28
         targetSdk 36
         versionCode 1
         versionName "1.0.0"

--- a/samples/ar-cloud-anchor/build.gradle
+++ b/samples/ar-cloud-anchor/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "io.github.sceneview.sample.arcloudanchor"
-        minSdk 24
+        minSdk 28
         targetSdk 36
         versionCode 1
         versionName "1.0.0"


### PR DESCRIPTION
## Summary
- CI now builds **all 14 samples** (was 11) and runs unit tests
- Release workflow runs MCP tests before npm publish
- minSdk standardized to 28 across all samples
- Placeholder Google Analytics ID commented out
- **4 new advanced tutorial guides**: Physics, Dynamic Sky & Fog, Reflection Probes, Lines & Text
- Codelabs index reorganized into Getting Started + Advanced sections

## Test plan
- [ ] CI builds all 14 samples successfully
- [ ] Unit test step runs without error
- [ ] Advanced guides render correctly on docs site
- [ ] ar-augmented-image and ar-cloud-anchor compile with minSdk 28

https://claude.ai/code/session_01FpJ8JiZ4KVBhkJcUtCM35P