### PR TITLE
fix: AGP 8.11.1 does not exist, use 8.13.2 + sync Kotlin 2.3.20

### DIFF
--- a/arsceneview/build.gradle
+++ b/arsceneview/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.library'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
     id 'filament-tools-plugin'
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.compose'

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,20 @@
 import com.vanniktech.maven.publish.SonatypeHost
 
 buildscript {
-    ext.kotlin_version = '2.1.21'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21"
+        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20"
         // Maven Central Publish
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.33.0"
         // Dokka
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
         // Compose
-        classpath "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.1.21"
+        classpath "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.3.20"
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.13.2"
 kotlin = "2.3.20"
 composeCompiler = "2.3.20"
 coreKtx = "1.18.0"

--- a/sceneview/build.gradle
+++ b/sceneview/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.library'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
     id 'filament-tools-plugin'
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.compose'


### PR DESCRIPTION
## Summary

- AGP `8.11.1` was confused with Gradle wrapper `8.11.1` — the artifact doesn't exist on Google Maven. Updated to `8.13.2` which is the real version.
- Synced Kotlin from `2.1.21` → `2.3.20` in root `build.gradle` to match the version catalog.
- Updated deprecated `'kotlin-android'` plugin ID to `'org.jetbrains.kotlin.android'` in library modules.

## Root cause

Every CI run since the `v3.2.1` sweep has been failing because `com.android.tools.build:gradle:8.11.1` cannot be resolved from any Maven repository — it simply does not exist. The Gradle *wrapper* version is `8.11.1`, but the Android Gradle *Plugin* version must be a valid AGP release.

## Test plan

- [ ] CI `./gradlew assembleDebug` passes
- [ ] All sample builds pass
- [ ] Unit tests pass

https://claude.ai/code/session_01FpJ8JiZ4KVBhkJcUtCM35P