### PR TITLE
fix: add missing position parameter to SphereNode composable

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -366,6 +366,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         stacks: Int = Sphere.DEFAULT_STACKS,
         slices: Int = Sphere.DEFAULT_SLICES,
         materialInstance: MaterialInstance? = null,
+        position: Position = Position(x = 0f),
         apply: SphereNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null
     ) {
@@ -381,6 +382,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         }
         SideEffect {
             node.updateGeometry(radius = radius, center = center, stacks = stacks, slices = slices)
+            node.position = position
         }
         NodeLifecycle(node, content)
     }


### PR DESCRIPTION
## Summary

- Added `position` parameter to `SceneScope.SphereNode` composable, matching all other geometry nodes (CubeNode, CylinderNode, PlaneNode, etc.)
- This fixes the reflection-probe sample which passes `position` to `SphereNode`

## Test plan

- [ ] CI build passes (this was the remaining compilation error after AGP + Filament fixes)

https://claude.ai/code/session_01FpJ8JiZ4KVBhkJcUtCM35P