### PR TITLE
fix: downgrade Gradle 9.3.1 → 8.11.1 to fix CI

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 14 11:49:30 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Fixes the root cause of CI failures reported in #695 (5 failures in last 7 runs).

**Root cause**: The Gradle wrapper was set to **9.3.1** (designed for AGP 9.1.0), but the project uses **AGP 8.11.1**, which only supports Gradle 8.x. This version incompatibility caused all CI builds to fail at Gradle configuration time.

The rapid rollback PRs (#688-#694) changed Filament, Kotlin, and AGP versions trying to fix CI, but none addressed the actual Gradle wrapper mismatch.

## Change

- `gradle-wrapper.properties`: `gradle-9.3.1-bin.zip` → `gradle-8.11.1-bin.zip`

## Why this fix

| Component | Current | Compatible Gradle |
|-----------|---------|-------------------|
| AGP 8.11.1 | Used in build.gradle | Gradle 8.x |
| AGP 9.1.0 | Not used | Gradle 9.3.1 |

The project's toolchain (AGP 8.11.1 + Kotlin 2.1.21 + Filament 1.70.0) was last green with Gradle 8.x. Downgrading the wrapper restores that working state.

## Test plan

- [ ] CI build passes (this PR will trigger CI automatically)
- [ ] All 14 sample APKs build successfully
- [ ] Unit tests pass
- [ ] Lint passes

Closes #695

https://claude.ai/code/session_014jcBk8cGQ4wRF2Ai9kFPZw