### PR TITLE
chore: add /sync-check and /release commands

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,74 @@
+# /release — SceneView release workflow
+
+Guided workflow to bump version, update all references, and prepare a release.
+
+Ask the user: "What version are we releasing? (current: check root gradle.properties)"
+
+---
+
+## Step 1: Bump version everywhere
+
+Update VERSION_NAME in all these files to the new version:
+1. `gradle.properties` (root — source of truth)
+2. `sceneview/gradle.properties`
+3. `arsceneview/gradle.properties`
+4. `sceneview-core/gradle.properties`
+5. `mcp/package.json` (version field)
+
+## Step 2: Update documentation versions
+
+Replace the old version string with the new one in:
+1. `llms.txt` (Android artifact versions near top)
+2. `docs/docs/index.md` (install snippets, badge)
+3. `docs/docs/quickstart.md` (dependency snippet)
+4. `README.md` (install snippets)
+
+## Step 3: Update CHANGELOG.md
+
+Add a new section at the top of CHANGELOG.md with:
+- Version number and short title
+- Categorized changes: New, Improved, Fixed, Breaking (if any)
+- Pull from recent git log: `git log <last-tag>..HEAD --oneline`
+
+## Step 4: Rebuild MCP
+
+```bash
+cd mcp && npm run prepare && npm test
+```
+
+Verify dist/ files are updated and tests pass.
+
+## Step 5: Update CLAUDE.md
+
+Update the "Current state" section:
+- Date to today
+- Active branch
+- Summary of what changed
+
+## Step 6: Run /sync-check
+
+Run the sync-check command to verify everything is aligned.
+
+## Step 7: Commit and tag
+
+```bash
+git add -A
+git commit -m "chore: release <version>"
+git tag v<version>
+```
+
+## Step 8: Create PR or push
+
+Ask the user: "Push to main and create a GitHub release, or create a PR first?"
+
+If PR: `gh pr create --title "chore: release <version>"`
+If direct: `git push origin main --tags && gh release create v<version> --generate-notes`
+
+## Step 9: Publish MCP to npm (optional)
+
+Ask the user: "Publish MCP server to npm?"
+If yes: `cd mcp && npm publish`
+
+---
+
+**Important:** Never skip the /sync-check step. Version drift is the #1 source of bugs in this repo.

--- a/.claude/commands/sync-check.md
+++ b/.claude/commands/sync-check.md
@@ -1,0 +1,70 @@
+# /sync-check — Verify SceneView repo synchronization
+
+Run this before every PR or at the end of a session to catch drift between the different areas of the repo.
+
+---
+
+## 1. Version alignment
+
+Check that VERSION_NAME is identical across all modules:
+- `gradle.properties` (root)
+- `sceneview/gradle.properties`
+- `arsceneview/gradle.properties`
+- `sceneview-core/gradle.properties`
+- `mcp/package.json` (version field)
+
+Then check that docs and references match:
+- `llms.txt` (Android artifact versions near top of file)
+- `docs/docs/index.md`
+- `docs/docs/quickstart.md`
+- `README.md`
+
+Report any mismatches with: file, current value, expected value.
+
+## 2. MCP dist freshness
+
+Compare timestamps and version strings between `mcp/src/index.ts` and `mcp/dist/index.js`.
+If the source is newer or versions differ, run `cd mcp && npm run prepare` and report what changed.
+
+## 3. llms.txt vs Swift source
+
+For each Swift file in `SceneViewSwift/Sources/SceneViewSwift/`:
+- Check that the node/struct is documented in the iOS section of `llms.txt`
+- Verify the documented signature matches the actual public API
+
+Report any undocumented nodes or signature mismatches.
+
+## 4. llms.txt vs Kotlin source
+
+Check if any new `@Composable` functions or public node classes were added since the last tag:
+```bash
+git diff v3.2.0..HEAD -- sceneview/src/ arsceneview/src/ | grep "^+.*fun \|^+.*@Composable\|^+.*class.*Node"
+```
+If new APIs exist, flag them as needing llms.txt documentation.
+
+## 5. CLAUDE.md freshness
+
+- Is the "Active branch" correct? (compare with `git branch --show-current`)
+- Is the "last updated" date today or recent?
+- Does the "Current state" summary match reality?
+
+## 6. Build artifacts check
+
+- Are there any tracked build artifacts? `git ls-files -- '*.o' '*.pcm' '*.swiftmodule' '*.class' 'build.db'`
+- Are `SceneViewSwift/.build/`, `docs/.cache/`, `docs/site/` in `.gitignore`?
+
+## 7. Summary
+
+Print a table:
+
+| Check | Status | Details |
+|---|---|---|
+| Versions aligned | OK/FAIL | ... |
+| MCP dist fresh | OK/FAIL | ... |
+| llms.txt iOS | OK/FAIL | ... |
+| llms.txt Android | OK/FAIL | ... |
+| CLAUDE.md | OK/FAIL | ... |
+| No build artifacts | OK/FAIL | ... |
+
+If all checks pass, print: "All sync checks passed."
+If any fail, list the fixes needed.


### PR DESCRIPTION
## Summary
- `/sync-check` — pre-PR verification of version alignment, doc freshness, MCP dist, llms.txt
- `/release` — guided release workflow with checklist

## Test plan
- [x] Commands created and tested
- [x] No conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)