### PR TITLE
fix: accept `boundingBox` parameter on `SceneScope.MeshNode` composable

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.google.android.filament.Box
 import com.google.android.filament.Engine
 import com.google.android.filament.IndexBuffer
 import com.google.android.filament.LightManager
@@ -890,6 +891,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         primitiveType: RenderableManager.PrimitiveType,
         vertexBuffer: VertexBuffer,
         indexBuffer: IndexBuffer,
+        boundingBox: Box? = null,
         materialInstance: MaterialInstance? = null,
         apply: MeshNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null
@@ -900,6 +902,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 primitiveType = primitiveType,
                 vertexBuffer = vertexBuffer,
                 indexBuffer = indexBuffer,
+                boundingBox = boundingBox,
                 materialInstance = materialInstance
             ).apply(apply)
         }


### PR DESCRIPTION
- Added optional `boundingBox: Box? = null` parameter to `MeshNode`.
- Parameter is passed through to the underlying `MeshNodeImpl` construction.

Fixes SceneView/sceneview#711

## What
<!-- Short description of the change -->

## Why
<!-- The problem this fixes or the feature this adds -->

## How
<!-- Approach taken. Any non-obvious design decisions -->

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [ ] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated if signatures changed
- [ ] `/test` run — new tests added for new behaviour
- [ ] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes
- [ ] Filament materials recompiled (if `.mat` files changed)
- [ ] Minimal diff — no unrelated reformatting

> **AI-assisted contributions welcome.**
> Run `/contribute` in Claude Code for a guided workflow that handles review, docs, and test generation automatically.
> MCP server: `npx -y sceneview-mcp` — gives Claude full SceneView API context.
