### PR TITLE
Add PRIVACY_POLICY.md for Play Store

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,53 @@
+# Privacy Policy — SceneView Demo
+
+**Last updated:** March 27, 2026
+
+## Summary
+
+**SceneView Demo does not collect, store, or transmit any personal data.**
+
+## Details
+
+### Data Collection
+
+- **No personal data collected** — The app does not collect names, email addresses, IP addresses, or any other personally identifiable information.
+- **No analytics or tracking** — No analytics SDKs, telemetry, fingerprinting, or behavioral tracking of any kind.
+- **No network requests** — The app operates entirely offline. All 3D models, textures, and environments are bundled locally.
+- **No accounts** — The app does not require or support user accounts.
+
+### Camera Usage (AR Features)
+
+- The app uses the device camera **exclusively** for augmented reality features powered by Google ARCore.
+- Camera data is processed **locally on-device** in real time for plane detection and object placement.
+- **No camera images or video are stored, recorded, or transmitted** to any server.
+- Camera access is only requested when the user navigates to the AR tab.
+
+### Third-Party SDKs
+
+| SDK | Purpose | Data collected |
+|-----|---------|---------------|
+| Google Filament | 3D rendering engine | None |
+| Google ARCore | Augmented reality | Camera processed locally, no data sent to Google |
+| Jetpack Compose | UI framework | None |
+
+### Data Sharing
+
+- No data is shared with third parties.
+- No data is sold or used for advertising.
+
+### Children's Privacy
+
+- The app does not knowingly collect any data from children under 13.
+- The app is rated for ages 13 and older.
+
+### Changes to This Policy
+
+We may update this Privacy Policy from time to time. Changes will be posted in this file with an updated date.
+
+### Contact
+
+If you have questions about this Privacy Policy, please contact:
+
+- **Email:** thomas.gorisse@gmail.com
+- **Website:** https://sceneview.github.io
+- **GitHub:** https://github.com/sceneview/sceneview


### PR DESCRIPTION
## Summary
- Adds `PRIVACY_POLICY.md` at repo root for Play Store compliance
- The old URL (`SceneView/sceneview-android/...`) returns 404 since the repo was renamed
- New URL: `https://github.com/sceneview/sceneview/blob/main/PRIVACY_POLICY.md`
- Already updated in Play Console — this unblocks "Send for review"

## Test plan
- [x] File exists at repo root
- [x] Play Console privacy policy URL updated to point here
- [x] Content covers: no data collection, camera AR usage, third-party SDKs, children's privacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)