### PR TITLE
Fix iOS CI: macos-15 for Xcode 16

### DIFF
--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   deploy:
     name: Build & Upload to TestFlight
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         working-directory: samples/ios-demo


### PR DESCRIPTION
SceneViewSwift needs Xcode 16 (iOS 18 APIs). macos-14 only has 15.4.