### PR TITLE
Bump iOS to 18.0 for App Store build

### DIFF
--- a/SceneViewSwift/Package.swift
+++ b/SceneViewSwift/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "SceneViewSwift",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
         .macOS(.v14),
         .visionOS(.v1)
     ],

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -235,7 +235,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -256,7 +256,7 @@
 				INFOPLIST_FILE = SceneViewDemo/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SceneView;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -286,7 +286,7 @@
 				INFOPLIST_FILE = SceneViewDemo/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SceneView;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
RealityKit APIs need iOS 18. Fixes TestFlight build.