### PR TITLE
Fix iOS: add bundle ID to Info.plist

### DIFF
--- a/samples/ios-demo/SceneViewDemo/Info.plist
+++ b/samples/ios-demo/SceneViewDemo/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleDisplayName</key>
 	<string>SceneView</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Archive failed with Missing Bundle Identifier