### PR TITLE
Add Claude Desktop/Code integration to website

### DIFF
--- a/website-static/index.html
+++ b/website-static/index.html
@@ -73,7 +73,7 @@
       "url": "https://github.com/sceneview"
     },
     "codeRepository": "https://github.com/sceneview/sceneview",
-    "programmingLanguage": ["Kotlin", "Swift", "JavaScript"],
+    "programmingLanguage": ["Kotlin", "Swift", "JavaScript", "TypeScript", "Dart"],
     "keywords": "3D, AR, Augmented Reality, Jetpack Compose, SwiftUI, Filament, RealityKit, ARCore, ARKit, glTF, USDZ"
   }
   </script>
@@ -137,7 +137,7 @@
         <h1 class="hero__title">SceneView</h1>
         <p class="hero__subtitle">3D & AR in a few lines of code</p>
         <p class="hero__description">Open-source, AI-first SDK for building 3D and augmented reality apps with Jetpack Compose and SwiftUI.</p>
-        <p class="hero__platforms">Android &middot; iOS &middot; macOS &middot; visionOS &middot; Web &middot; Desktop &middot; TV &middot; Flutter &middot; React Native</p>
+        <p class="hero__platforms">Android &middot; iOS &middot; macOS &middot; visionOS &middot; Web &middot; Desktop &middot; TV &middot; Flutter &middot; React Native &middot; Claude</p>
         <div class="hero__actions">
           <a href="https://github.com/sceneview/sceneview#install" class="btn btn--primary">Get Started</a>
           <a href="https://github.com/sceneview/sceneview" class="btn btn--outline">
@@ -199,6 +199,7 @@
         <div class="tabs__nav">
           <button class="tabs__btn tabs__btn--active" data-tab="kotlin">Kotlin (Android)</button>
           <button class="tabs__btn" data-tab="swift">Swift (iOS)</button>
+          <button class="tabs__btn" data-tab="claude">Claude (AI)</button>
         </div>
         <div class="tabs__panels">
           <div class="tabs__panel tabs__panel--active" data-panel="kotlin">
@@ -241,6 +242,18 @@
         }
     }
 }</code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="claude">
+            <pre class="code-block"><code><span class="cm">// Ask Claude Desktop or Claude Code:</span>
+
+<span class="str">"Build me an AR app that lets users
+ place 3D furniture in their room"</span>
+
+<span class="cm">// Claude uses the SceneView MCP to generate</span>
+<span class="cm">// correct, working Compose/SwiftUI code.</span>
+<span class="cm">// Setup: add to your MCP config:</span>
+
+<span class="kw">npx</span> <span class="fn">sceneview-mcp</span></code></pre>
           </div>
         </div>
       </div>
@@ -679,6 +692,8 @@
           <button class="tabs__btn" data-tab="ios">iOS</button>
           <button class="tabs__btn" data-tab="web">Web</button>
           <button class="tabs__btn" data-tab="flutter">Flutter</button>
+          <button class="tabs__btn" data-tab="reactnative">React Native</button>
+          <button class="tabs__btn" data-tab="claude-mcp">Claude / MCP</button>
           <button class="tabs__btn" data-tab="desktop">Desktop</button>
         </div>
         <div class="tabs__panels">
@@ -719,6 +734,30 @@
 
 <span class="cm"># Then run:</span>
 <span class="kw">flutter</span> pub get</code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="reactnative">
+            <pre class="code-block"><code><span class="cm">// package.json</span>
+<span class="str">"dependencies"</span>: {
+  <span class="str">"react-native-sceneview"</span>: <span class="str">"github:sceneview/sceneview#react-native"</span>
+}
+
+<span class="cm">// Then run:</span>
+<span class="kw">npm</span> install
+<span class="kw">npx</span> pod-install <span class="cm">// iOS only</span></code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="claude-mcp">
+            <pre class="code-block"><code><span class="cm">// Claude Desktop &mdash; add to claude_desktop_config.json</span>
+{
+  <span class="str">"mcpServers"</span>: {
+    <span class="str">"sceneview"</span>: {
+      <span class="str">"command"</span>: <span class="str">"npx"</span>,
+      <span class="str">"args"</span>: [<span class="str">"sceneview-mcp"</span>]
+    }
+  }
+}
+
+<span class="cm">// Claude Code &mdash; run from terminal</span>
+<span class="kw">claude</span> mcp add sceneview -- <span class="fn">npx</span> <span class="str">sceneview-mcp</span></code></pre>
           </div>
           <div class="tabs__panel" data-panel="desktop">
             <pre class="code-block"><code><span class="cm">// Compose Desktop (alpha &mdash; software renderer)</span>
@@ -786,13 +825,22 @@
         <div class="ai-section__content">
           <div class="ai-section__badge">AI-first SDK</div>
           <h2 class="section__title">Built for AI assistants</h2>
-          <p class="section__subtitle">SceneView is the first 3D SDK designed so AI assistants can generate correct, working code on the first try. MCP integration gives Claude, Cursor, and Windsurf full access to the API reference, samples, and best practices.</p>
-          <pre class="code-block code-block--compact"><code><span class="kw">npx</span> <span class="str">sceneview-mcp</span></code></pre>
-          <p class="ai-section__hint">Add to your MCP config for instant AI-powered 3D & AR development.</p>
-          <a href="/claude-3d.html" class="btn btn--primary" style="margin-top:var(--space-lg);gap:8px">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-            See AI + 3D in action
-          </a>
+          <p class="section__subtitle">SceneView is the first 3D SDK designed so AI assistants can generate correct, working code on the first try. MCP integration gives Claude Desktop, Claude Code, Cursor, and Windsurf full access to the API reference, samples, and best practices.</p>
+          <pre class="code-block code-block--compact"><code><span class="cm">// Claude Code</span>
+<span class="kw">claude</span> mcp add sceneview -- <span class="fn">npx</span> <span class="str">sceneview-mcp</span></code></pre>
+          <pre class="code-block code-block--compact" style="margin-top:var(--space-sm)"><code><span class="cm">// Claude Desktop &mdash; claude_desktop_config.json</span>
+{ <span class="str">"mcpServers"</span>: { <span class="str">"sceneview"</span>: { <span class="str">"command"</span>: <span class="str">"npx"</span>, <span class="str">"args"</span>: [<span class="str">"sceneview-mcp"</span>] } } }</code></pre>
+          <p class="ai-section__hint">Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP-compatible client.</p>
+          <div style="display:flex;gap:var(--space-md);flex-wrap:wrap;margin-top:var(--space-lg)">
+            <a href="/claude-3d.html" class="btn btn--primary" style="gap:8px">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+              See AI + 3D in action
+            </a>
+            <a href="https://www.npmjs.com/package/sceneview-mcp" class="btn btn--outline" style="gap:8px" target="_blank" rel="noopener">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M12 8v8M8 12h8"/></svg>
+              sceneview-mcp on npm
+            </a>
+          </div>
         </div>
         <div class="ai-section__graphic">
           <div class="ai-section__terminal">


### PR DESCRIPTION
## Summary
- Add **Claude (AI)** tab to code examples showing natural language prompt workflow
- Add **Claude / MCP** and **React Native** tabs to Quick Install section with setup commands for Claude Desktop (`claude_desktop_config.json`) and Claude Code (`claude mcp add`)
- Expand the AI-first section with both Claude Desktop and Claude Code setup snippets, plus npm link to `sceneview-mcp`
- Add Dart and TypeScript to JSON-LD `programmingLanguage` metadata
- Add "Claude" to the hero platforms line

## Test plan
- [ ] Verify all new tabs render and switch correctly
- [ ] Verify Claude/MCP install code blocks display properly
- [ ] Verify AI section shows both Claude Desktop and Claude Code commands
- [ ] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)