### PR TITLE
Add all language tabs + fix light mode contrast

### DIFF
--- a/website-static/index.html
+++ b/website-static/index.html
@@ -144,6 +144,10 @@
             <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
             View on GitHub
           </a>
+          <a href="https://claude.ai/new?mcp=sceneview-mcp" class="btn btn--claude" title="Open in Claude Desktop with SceneView MCP">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15l-5-5 1.41-1.41L11 14.17l7.59-7.59L20 8l-9 9z"/></svg>
+            Open in Claude
+          </a>
         </div>
         <div class="hero__stores">
           <span class="hero__stores-label">Try the demo apps</span>
@@ -199,6 +203,9 @@
         <div class="tabs__nav">
           <button class="tabs__btn tabs__btn--active" data-tab="kotlin">Kotlin (Android)</button>
           <button class="tabs__btn" data-tab="swift">Swift (iOS)</button>
+          <button class="tabs__btn" data-tab="js">JavaScript (Web)</button>
+          <button class="tabs__btn" data-tab="dart">Dart (Flutter)</button>
+          <button class="tabs__btn" data-tab="ts">TypeScript (React Native)</button>
           <button class="tabs__btn" data-tab="claude">Claude (AI)</button>
         </div>
         <div class="tabs__panels">
@@ -241,6 +248,46 @@
             )
         }
     }
+}</code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="js">
+            <pre class="code-block"><code><span class="cm">// One line in your HTML:</span>
+<span class="kw">&lt;script</span> <span class="fn">src</span>=<span class="str">"https://unpkg.com/sceneview@1.2.0"</span><span class="kw">&gt;&lt;/script&gt;</span>
+
+<span class="kw">&lt;scene-view</span>
+  <span class="fn">model</span>=<span class="str">"models/helmet.glb"</span>
+  <span class="fn">environment</span>=<span class="str">"envs/sky.hdr"</span>
+  <span class="fn">camera-orbit</span>=<span class="str">"45deg 55deg 4m"</span>
+  <span class="fn">auto-rotate</span>
+<span class="kw">&gt;&lt;/scene-view&gt;</span></code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="dart">
+            <pre class="code-block"><code><span class="kw">import</span> <span class="str">'package:sceneview_flutter/sceneview_flutter.dart'</span>;
+
+<span class="kw">class</span> <span class="fn">MyScene</span> <span class="kw">extends</span> <span class="fn">StatelessWidget</span> {
+  <span class="kw">@override</span>
+  <span class="fn">Widget</span> <span class="fn">build</span>(<span class="fn">BuildContext</span> context) {
+    <span class="kw">return</span> <span class="fn">SceneView</span>(
+      model: <span class="str">'models/helmet.glb'</span>,
+      environment: <span class="str">'envs/sky.hdr'</span>,
+      cameraOrbit: <span class="fn">true</span>,
+    );
+  }
+}</code></pre>
+          </div>
+          <div class="tabs__panel" data-panel="ts">
+            <pre class="code-block"><code><span class="kw">import</span> { <span class="fn">SceneView</span>, <span class="fn">ModelNode</span> } <span class="kw">from</span> <span class="str">'react-native-sceneview'</span>;
+
+<span class="kw">export default function</span> <span class="fn">App</span>() {
+  <span class="kw">return</span> (
+    <span class="kw">&lt;SceneView</span> <span class="fn">style</span>={{ <span class="fn">flex</span>: <span class="num">1</span> }}<span class="kw">&gt;</span>
+      <span class="kw">&lt;ModelNode</span>
+        <span class="fn">source</span>=<span class="str">"models/helmet.glb"</span>
+        <span class="fn">position</span>={[<span class="num">0</span>, <span class="num">0</span>, <span class="num">-2</span>]}
+        <span class="fn">autoOrbit</span>
+      <span class="kw">/&gt;</span>
+    <span class="kw">&lt;/SceneView&gt;</span>
+  );
 }</code></pre>
           </div>
           <div class="tabs__panel" data-panel="claude">

--- a/website-static/styles.css
+++ b/website-static/styles.css
@@ -10,8 +10,8 @@
   --color-surface-dim: #f3f4f6;
   --color-surface-container: #ffffff;
   --color-on-surface: #1f2937;
-  --color-on-surface-dim: #6b7280;
-  --color-on-surface-faint: #9ca3af;
+  --color-on-surface-dim: #4b5563;
+  --color-on-surface-faint: #6b7280;
   --color-outline: #e5e7eb;
   --color-outline-subtle: #f0f0f0;
 


### PR DESCRIPTION
## Summary
- Add JavaScript (Web), Dart (Flutter), TypeScript (React Native) code sample tabs in "Declarative 3D" section
- Add "Open in Claude" button with MCP deeplink in hero section
- Fix light mode text contrast (--color-on-surface-dim darkened from #6b7280 to #4b5563)

## Test plan
- [ ] All 6 tabs visible and working (Kotlin, Swift, JS, Dart, TS, Claude)
- [ ] Light mode text readable on all sections
- [ ] "Open in Claude" button visible in hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)