### PR TITLE
Move 3D showcases higher + store coming soon links

### DIFF
--- a/website-static/index.html
+++ b/website-static/index.html
@@ -150,33 +150,18 @@
           </a>
         </div>
         <div class="hero__stores">
-          <span class="hero__stores-label">Try the demo apps</span>
-          <div class="hero__stores-badges">
-            <a href="#" class="store-badge" id="playstore-badge" title="Get it on Google Play">
-              <svg viewBox="0 0 135 40" width="135" height="40">
-                <rect width="135" height="40" rx="5" fill="#000"/>
-                <rect x="0.5" y="0.5" width="134" height="39" rx="4.5" fill="none" stroke="#a6a6a6" stroke-width="0.8"/>
-                <text x="47" y="13" fill="#fff" font-size="6.5" font-family="Inter,sans-serif" letter-spacing="0.05em">GET IT ON</text>
-                <text x="47" y="28" fill="#fff" font-size="13" font-family="Inter,sans-serif" font-weight="600">Google Play</text>
-                <g transform="translate(12,7) scale(0.65)">
-                  <path d="M1 1.48v37.04c0 .46.36.72.73.48L21.2 24.08 1.73 1C1.36.76 1 1.02 1 1.48z" fill="#4285f4"/>
-                  <path d="M26.16 18.76L21.2 24.08 1.73 39c-.18.12-.38.14-.55.08L22.24 18.02l3.92.74z" fill="#34a853"/>
-                  <path d="M30.5 18.88l-4.34-2.42L22.24 18l3.92 2.7 4.34-1.82z" fill="#fbbc04"/>
-                  <path d="M1.18 1.08c.17-.06.37-.04.55.08L21.2 16.08l5-2.42L1.18 1.08z" fill="#ea4335"/>
-                </g>
-              </svg>
+          <span class="hero__stores-label" style="display:flex;align-items:center;gap:8px">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" opacity="0.6"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+            Demo apps coming soon on Play Store &amp; App Store
+          </span>
+          <div class="hero__stores-badges" style="align-items:center">
+            <a href="https://github.com/sceneview/sceneview/releases" class="btn btn--outline" style="font-size:0.8rem;padding:8px 16px;gap:6px" target="_blank" rel="noopener" title="Watch releases to get notified">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+              Notify me
             </a>
-            <a href="#" class="store-badge" id="appstore-badge" title="Download on the App Store">
-              <svg viewBox="0 0 120 40" width="120" height="40">
-                <rect width="120" height="40" rx="5" fill="#000"/>
-                <rect x="0.5" y="0.5" width="119" height="39" rx="4.5" fill="none" stroke="#a6a6a6" stroke-width="0.8"/>
-                <text x="40" y="13" fill="#fff" font-size="6" font-family="Inter,sans-serif" letter-spacing="0.02em">Download on the</text>
-                <text x="40" y="28" fill="#fff" font-size="13" font-family="Inter,sans-serif" font-weight="600">App Store</text>
-                <g transform="translate(10,6) scale(1.15)">
-                  <path d="M15.77 13.29c-.03-2.57 2.1-3.8 2.19-3.86-1.19-1.74-3.05-1.98-3.71-2.01-1.58-.16-3.08.93-3.88.93-.8 0-2.04-.91-3.35-.89-1.72.03-3.31 1-4.2 2.55-1.79 3.1-.46 7.7 1.29 10.22.85 1.24 1.87 2.62 3.21 2.57 1.29-.05 1.77-.83 3.33-.83 1.55 0 1.99.83 3.35.8 1.38-.02 2.27-1.26 3.12-2.5.98-1.43 1.39-2.82 1.41-2.89-.03-.01-2.71-1.04-2.74-4.12z" fill="#fff"/>
-                  <path d="M13.21 5.67c.71-.86 1.19-2.05 1.06-3.24-1.02.04-2.26.68-2.99 1.54-.65.76-1.22 1.96-1.07 3.12 1.14.09 2.3-.58 3-1.42z" fill="#fff"/>
-                </g>
-              </svg>
+            <a href="https://github.com/sceneview/sceneview" class="btn btn--outline" style="font-size:0.8rem;padding:8px 16px;gap:6px" target="_blank" rel="noopener" title="Star the repo to follow updates">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+              Star on GitHub
             </a>
           </div>
         </div>
@@ -303,6 +288,138 @@
 <span class="kw">npx</span> <span class="fn">sceneview-mcp</span></code></pre>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== USE CASES ===== -->
+  <section class="section use-cases" id="use-cases">
+    <div class="container">
+      <h2 class="section__title">Built for real products</h2>
+      <p class="section__subtitle">Interact with these 3D models &mdash; orbit, zoom, rotate. This is what your users get.</p>
+
+      <div class="showcase-grid">
+
+        <!-- E-commerce -->
+        <div class="showcase-item">
+          <div class="showcase-item__viewer">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb"
+              alt="3D sneaker product viewer"
+              auto-rotate
+              camera-controls
+              touch-action="pan-y"
+              shadow-intensity="1"
+              exposure="0.8"
+              style="width:100%;height:100%;--poster-color:transparent;"
+              loading="lazy"
+              poster=""
+            >
+              <div class="showcase-item__badge">Drag to orbit</div>
+            </model-viewer>
+          </div>
+          <div class="showcase-item__info">
+            <div class="showcase-item__label">E-commerce</div>
+            <h3 class="showcase-item__title">3D Product Viewer</h3>
+            <p class="showcase-item__text">Replace flat product photos with interactive 3D. Customers orbit, zoom, and inspect every angle. AR lets them place products in their space before buying &mdash; boosting conversion by up to 94%.</p>
+            <pre class="showcase-item__code"><code>Scene {
+  ModelNode("sneaker.glb")
+}</code></pre>
+          </div>
+        </div>
+
+        <!-- Furniture AR -->
+        <div class="showcase-item showcase-item--reverse">
+          <div class="showcase-item__viewer">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb"
+              alt="3D chair for AR furniture placement"
+              auto-rotate
+              camera-controls
+              touch-action="pan-y"
+              shadow-intensity="1.2"
+              exposure="0.9"
+              camera-orbit="30deg 75deg 2m"
+              style="width:100%;height:100%;--poster-color:transparent;"
+              loading="lazy"
+              poster=""
+            >
+              <div class="showcase-item__badge">Drag to orbit</div>
+            </model-viewer>
+          </div>
+          <div class="showcase-item__info">
+            <div class="showcase-item__label">Furniture &amp; AR</div>
+            <h3 class="showcase-item__title">AR Room Staging</h3>
+            <p class="showcase-item__text">Let customers place furniture in their real room using AR. Anchor 3D models to detected surfaces with a single tap. Accurate scale, real-time shadows, physics-aware placement.</p>
+            <pre class="showcase-item__code"><code>ARScene {
+  AnchorNode {
+    ModelNode("chair.glb")
+  }
+}</code></pre>
+          </div>
+        </div>
+
+        <!-- Luxury product -->
+        <div class="showcase-item">
+          <div class="showcase-item__viewer">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/IridescentDishWithOlives/glTF-Binary/IridescentDishWithOlives.glb"
+              alt="Iridescent luxury product detail"
+              auto-rotate
+              camera-controls
+              touch-action="pan-y"
+              shadow-intensity="1"
+              exposure="1"
+              environment-image="neutral"
+              style="width:100%;height:100%;--poster-color:transparent;"
+              loading="lazy"
+              poster=""
+            >
+              <div class="showcase-item__badge">Drag to orbit</div>
+            </model-viewer>
+          </div>
+          <div class="showcase-item__info">
+            <div class="showcase-item__label">Luxury &amp; Detail</div>
+            <h3 class="showcase-item__title">PBR Material Showcase</h3>
+            <p class="showcase-item__text">Physically-based rendering with iridescence, sheen, and clearcoat. Filament renders materials indistinguishable from photography &mdash; perfect for luxury goods, jewelry, and collectibles.</p>
+            <pre class="showcase-item__code"><code>Scene {
+  ModelNode("product.glb",
+    autoAnimate = true)
+}</code></pre>
+          </div>
+        </div>
+
+        <!-- Animated character -->
+        <div class="showcase-item showcase-item--reverse">
+          <div class="showcase-item__viewer">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb"
+              alt="Animated 3D fox character"
+              auto-rotate
+              camera-controls
+              touch-action="pan-y"
+              autoplay
+              shadow-intensity="1"
+              exposure="0.8"
+              camera-orbit="20deg 75deg 120"
+              style="width:100%;height:100%;--poster-color:transparent;"
+              loading="lazy"
+              poster=""
+            >
+              <div class="showcase-item__badge">Drag to orbit</div>
+            </model-viewer>
+          </div>
+          <div class="showcase-item__info">
+            <div class="showcase-item__label">Gaming &amp; Entertainment</div>
+            <h3 class="showcase-item__title">Animated Characters</h3>
+            <p class="showcase-item__text">Skeletal animation, blend shapes, physics simulation. Build character-driven experiences with Compose state management. Spring animations, procedural geometry &mdash; no game engine required.</p>
+            <pre class="showcase-item__code"><code>Scene {
+  ModelNode("fox.glb",
+    autoAnimate = true)
+}</code></pre>
+          </div>
+        </div>
+
       </div>
     </div>
   </section>
@@ -476,138 +593,6 @@
           <h3 class="trusted__label">Government</h3>
           <p class="trusted__text">Urban planning, infrastructure visualization, and public services</p>
         </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===== USE CASES ===== -->
-  <section class="section use-cases" id="use-cases">
-    <div class="container">
-      <h2 class="section__title">Built for real products</h2>
-      <p class="section__subtitle">Interact with these 3D models &mdash; orbit, zoom, rotate. This is what your users get.</p>
-
-      <div class="showcase-grid">
-
-        <!-- E-commerce -->
-        <div class="showcase-item">
-          <div class="showcase-item__viewer">
-            <model-viewer
-              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb"
-              alt="3D sneaker product viewer"
-              auto-rotate
-              camera-controls
-              touch-action="pan-y"
-              shadow-intensity="1"
-              exposure="0.8"
-              style="width:100%;height:100%;--poster-color:transparent;"
-              loading="lazy"
-              poster=""
-            >
-              <div class="showcase-item__badge">Drag to orbit</div>
-            </model-viewer>
-          </div>
-          <div class="showcase-item__info">
-            <div class="showcase-item__label">E-commerce</div>
-            <h3 class="showcase-item__title">3D Product Viewer</h3>
-            <p class="showcase-item__text">Replace flat product photos with interactive 3D. Customers orbit, zoom, and inspect every angle. AR lets them place products in their space before buying &mdash; boosting conversion by up to 94%.</p>
-            <pre class="showcase-item__code"><code>Scene {
-  ModelNode("sneaker.glb")
-}</code></pre>
-          </div>
-        </div>
-
-        <!-- Furniture AR -->
-        <div class="showcase-item showcase-item--reverse">
-          <div class="showcase-item__viewer">
-            <model-viewer
-              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb"
-              alt="3D chair for AR furniture placement"
-              auto-rotate
-              camera-controls
-              touch-action="pan-y"
-              shadow-intensity="1.2"
-              exposure="0.9"
-              camera-orbit="30deg 75deg 2m"
-              style="width:100%;height:100%;--poster-color:transparent;"
-              loading="lazy"
-              poster=""
-            >
-              <div class="showcase-item__badge">Drag to orbit</div>
-            </model-viewer>
-          </div>
-          <div class="showcase-item__info">
-            <div class="showcase-item__label">Furniture &amp; AR</div>
-            <h3 class="showcase-item__title">AR Room Staging</h3>
-            <p class="showcase-item__text">Let customers place furniture in their real room using AR. Anchor 3D models to detected surfaces with a single tap. Accurate scale, real-time shadows, physics-aware placement.</p>
-            <pre class="showcase-item__code"><code>ARScene {
-  AnchorNode {
-    ModelNode("chair.glb")
-  }
-}</code></pre>
-          </div>
-        </div>
-
-        <!-- Luxury product -->
-        <div class="showcase-item">
-          <div class="showcase-item__viewer">
-            <model-viewer
-              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/IridescentDishWithOlives/glTF-Binary/IridescentDishWithOlives.glb"
-              alt="Iridescent luxury product detail"
-              auto-rotate
-              camera-controls
-              touch-action="pan-y"
-              shadow-intensity="1"
-              exposure="1"
-              environment-image="neutral"
-              style="width:100%;height:100%;--poster-color:transparent;"
-              loading="lazy"
-              poster=""
-            >
-              <div class="showcase-item__badge">Drag to orbit</div>
-            </model-viewer>
-          </div>
-          <div class="showcase-item__info">
-            <div class="showcase-item__label">Luxury &amp; Detail</div>
-            <h3 class="showcase-item__title">PBR Material Showcase</h3>
-            <p class="showcase-item__text">Physically-based rendering with iridescence, sheen, and clearcoat. Filament renders materials indistinguishable from photography &mdash; perfect for luxury goods, jewelry, and collectibles.</p>
-            <pre class="showcase-item__code"><code>Scene {
-  ModelNode("product.glb",
-    autoAnimate = true)
-}</code></pre>
-          </div>
-        </div>
-
-        <!-- Animated character -->
-        <div class="showcase-item showcase-item--reverse">
-          <div class="showcase-item__viewer">
-            <model-viewer
-              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb"
-              alt="Animated 3D fox character"
-              auto-rotate
-              camera-controls
-              touch-action="pan-y"
-              autoplay
-              shadow-intensity="1"
-              exposure="0.8"
-              camera-orbit="20deg 75deg 120"
-              style="width:100%;height:100%;--poster-color:transparent;"
-              loading="lazy"
-              poster=""
-            >
-              <div class="showcase-item__badge">Drag to orbit</div>
-            </model-viewer>
-          </div>
-          <div class="showcase-item__info">
-            <div class="showcase-item__label">Gaming &amp; Entertainment</div>
-            <h3 class="showcase-item__title">Animated Characters</h3>
-            <p class="showcase-item__text">Skeletal animation, blend shapes, physics simulation. Build character-driven experiences with Compose state management. Spring animations, procedural geometry &mdash; no game engine required.</p>
-            <pre class="showcase-item__code"><code>Scene {
-  ModelNode("fox.glb",
-    autoAnimate = true)
-}</code></pre>
-          </div>
-        </div>
-
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Move interactive 3D showcase section (sneaker, chair, olives, fox) right after code samples — more impactful placement
- Replace dead Play Store / App Store badge links with "Notify me" (→ GitHub releases) and "Star on GitHub" buttons
- Add "Demo apps coming soon on Play Store & App Store" message

## Test plan
- [ ] 3D showcases appear right after code samples section
- [ ] "Notify me" links to github.com/sceneview/sceneview/releases
- [ ] "Star on GitHub" links to github.com/sceneview/sceneview

🤖 Generated with [Claude Code](https://claude.com/claude-code)