### PR TITLE
Website: follow system theme automatically

### DIFF
--- a/website-static/script.js
+++ b/website-static/script.js
@@ -1,16 +1,18 @@
-// ===== DARK MODE =====
+// ===== DARK MODE — follows system theme =====
 (function initTheme() {
-  const saved = localStorage.getItem('sceneview-theme');
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const theme = saved || (prefersDark ? 'dark' : 'light');
-  document.documentElement.setAttribute('data-theme', theme);
+  var mq = window.matchMedia('(prefers-color-scheme: dark)');
+  function applySystemTheme() {
+    document.documentElement.setAttribute('data-theme', mq.matches ? 'dark' : 'light');
+  }
+  applySystemTheme();
+  // Auto-follow system theme changes (e.g. macOS auto dark mode)
+  mq.addEventListener('change', applySystemTheme);
 })();
 
 document.getElementById('themeToggle').addEventListener('click', function () {
-  const current = document.documentElement.getAttribute('data-theme');
-  const next = current === 'dark' ? 'light' : 'dark';
+  var current = document.documentElement.getAttribute('data-theme');
+  var next = current === 'dark' ? 'light' : 'dark';
   document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('sceneview-theme', next);
 });
 
 // ===== TAB SWITCHING =====


### PR DESCRIPTION
## Summary
- Theme follows system `prefers-color-scheme` instead of being locked to localStorage
- Auto-updates when system theme changes (e.g. macOS auto dark mode at sunset)
- Manual toggle still works but doesn't persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)