### PR TITLE
Fix CI workflow issues found during audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
       - 'mcp*/**'
       - '*.md'
       - 'llms*.txt'
-      - 'PRIVACY_POLICY.md'
       - 'LICENSE'
   pull_request:
     branches: [main]

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -22,9 +22,9 @@ jobs:
           ARCORE_LATEST=$(curl -s https://api.github.com/repos/google-ar/arcore-android-sdk/releases/latest | jq -r .tag_name | tr -d 'v')
           KOTLIN_LATEST=$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases/latest | jq -r .tag_name | tr -d 'v')
 
-          FILAMENT_CURRENT=$(grep "filament_version" buildSrc/src/main/groovy/FilamentPlugin.groovy 2>/dev/null | head -1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "unknown")
-          KOTLIN_CURRENT=$(grep "kotlin" gradle/libs.versions.toml 2>/dev/null | head -1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "unknown")
-          ARCORE_CURRENT=$(grep "arcore" gradle/libs.versions.toml 2>/dev/null | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 || echo "unknown")
+          FILAMENT_CURRENT=$(grep "filament_version" sceneview/build.gradle 2>/dev/null | head -1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "unknown")
+          KOTLIN_CURRENT=$(grep "^kotlin " gradle/libs.versions.toml 2>/dev/null | head -1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' || echo "unknown")
+          ARCORE_CURRENT=$(grep "^arCore " gradle/libs.versions.toml 2>/dev/null | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 || echo "unknown")
 
           echo "filament_latest=$FILAMENT_LATEST" >> $GITHUB_OUTPUT
           echo "filament_current=$FILAMENT_CURRENT" >> $GITHUB_OUTPUT
@@ -89,9 +89,9 @@ jobs:
           # true build failures count now. Threshold = 4 to avoid noise.
           if [ "$FAILURES" -gt 4 ]; then
             echo "CI is consistently failing — investigate"
-            gh issue list --label "ci-failure" --state open | grep -q "." || \
+            gh issue list --label "ci-health" --state open | grep -q "." || \
               gh issue create \
                 --title "CI health: $FAILURES failures in last 7 runs — $(date +%Y-%m-%d)" \
-                --label "bug" \
+                --label "bug,ci-health" \
                 --body "Automated maintenance detected $FAILURES CI failures in the last 7 runs. Please investigate."
           fi

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -36,6 +36,8 @@ jobs:
           java-version: 17
           cache: gradle
 
+      - run: chmod +x ./gradlew
+
       - name: Decode keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.UPLOAD_KEYSTORE_BASE64 }}
@@ -56,7 +58,7 @@ jobs:
           path: samples/android-demo/build/outputs/bundle/release/*.aab
 
       - name: Publish to Play Store
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           packageName: io.github.sceneview.demo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
         continue-on-error: true
 
       - name: Upload Dokka artifact
-        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: dokka-api-docs


### PR DESCRIPTION
## Summary
- **maintenance.yml**: Fix broken dependency version detection — filament version grep was looking in `FilamentPlugin.groovy` (wrong file), now correctly reads from `sceneview/build.gradle`. ARCore and Kotlin version greps now match exact line starts to avoid false matches. CI-health issue label aligned with dedup check to prevent duplicate issues.
- **play-store.yml**: Pin `r0adkll/upload-google-play` to `v1.1.3` (the `v1` tag points to a stale commit). Add missing `chmod +x ./gradlew` step.
- **ci.yml**: Remove redundant `PRIVACY_POLICY.md` entry from `paths-ignore` (already covered by `*.md` glob).
- **release.yml**: Remove misleading `if: success()` on Dokka artifact upload (prior step uses `continue-on-error: true`, making `success()` always true).

## Audit notes (no-fix-needed)
- **discord-notify.yml**: `DISCORD_WEBHOOK_URL` secret is not configured, but the workflow gracefully exits — no code fix needed, just needs the secret when ready.
- **docs.yml**: Dokka artifact download from release workflow is a dead step on normal pushes, but `continue-on-error: true` handles it correctly.
- **app-store.yml**: Well structured with proper secret validation and cleanup. All referenced secrets exist.
- **ios.yml**: Clean, proper Xcode selection fallback chain.
- **build-apks.yml**: No issues found.
- All actions use v4 (checkout, setup-java, upload-artifact, download-artifact) — no deprecated versions.
- All referenced paths/scripts verified to exist.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify `maintenance.yml` picks up correct filament/arcore/kotlin versions on next daily run

🤖 Generated with [Claude Code](https://claude.com/claude-code)