### PR TITLE
feat: OpenAI GPT Store entry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 ### AI & monetization
 - [x] MCP Pro with API key + Stripe Billing (free/pro tiers, 15 free + 36 pro tools)
 - [ ] Claude playground on website (describe in natural language → 3D code)
-- [ ] OpenAI GPT Store entry
+- [x] OpenAI GPT Store entry (system prompt, 4 knowledge files, OpenAPI schema)
 
 ### Quality
 - [ ] Visual regression testing across platforms

--- a/gpt/README.md
+++ b/gpt/README.md
@@ -1,0 +1,50 @@
+# SceneView GPT — OpenAI GPT Store
+
+## Overview
+
+Custom GPT for the OpenAI GPT Store that helps developers build 3D and AR apps using the SceneView SDK.
+
+## GPT Store Configuration
+
+### Basic Info
+- **Name:** SceneView 3D & AR Assistant
+- **Description:** Build 3D and AR apps for Android, iOS, Web, and more. Expert guidance for SceneView SDK — code generation, validation, and interactive 3D previews.
+- **Category:** Programming
+
+### Conversation Starters
+1. "Build me an AR furniture placement app for Android"
+2. "Create a 3D product viewer for my e-commerce site"
+3. "How do I set up SceneView on iOS with SwiftUI?"
+4. "Show me a physics simulation with collisions"
+
+### Capabilities
+- [x] Code Interpreter
+- [x] Web Browsing
+- [ ] DALL-E (not needed)
+
+### Knowledge Files
+Upload these files from this directory:
+1. `knowledge-overview.md` — Platform overview, setup, architecture
+2. `knowledge-api.md` — API reference, composables, node types
+3. `knowledge-practices.md` — Best practices, patterns, troubleshooting
+4. `knowledge-samples.md` — All 39 code sample descriptions and tags
+
+### Actions (Optional)
+Import `openapi-schema.json` to enable live code validation and 3D preview generation via the SceneView API.
+
+## How to Publish
+
+1. Go to https://chatgpt.com/gpts/editor
+2. Create new GPT
+3. Paste the contents of `system-prompt.md` as the Instructions
+4. Upload all 4 knowledge files
+5. Optionally import `openapi-schema.json` as an Action
+6. Set conversation starters from above
+7. Upload logo from `../branding/exports/`
+8. Publish to GPT Store
+
+## Links
+- SDK: https://github.com/sceneview/sceneview
+- Website: https://sceneview.github.io
+- MCP: https://www.npmjs.com/package/sceneview-mcp
+- Docs: https://sceneview.github.io/docs

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -1,0 +1,529 @@
+# SceneView API Quick Reference
+
+## Core Composables
+
+### SceneView -- 3D Viewport
+
+```kotlin
+@Composable
+fun SceneView(
+    modifier: Modifier = Modifier,
+    surfaceType: SurfaceType = SurfaceType.Surface,
+    engine: Engine = rememberEngine(),
+    modelLoader: ModelLoader = rememberModelLoader(engine),
+    materialLoader: MaterialLoader = rememberMaterialLoader(engine),
+    environmentLoader: EnvironmentLoader = rememberEnvironmentLoader(engine),
+    view: View = rememberView(engine),
+    isOpaque: Boolean = true,
+    renderer: Renderer = rememberRenderer(engine),
+    scene: Scene = rememberScene(engine),
+    environment: Environment = rememberEnvironment(environmentLoader, isOpaque = isOpaque),
+    mainLightNode: LightNode? = rememberMainLightNode(engine),
+    cameraNode: CameraNode = rememberCameraNode(engine),
+    collisionSystem: CollisionSystem = rememberCollisionSystem(view),
+    cameraManipulator: CameraManipulator? = rememberCameraManipulator(cameraNode.worldPosition),
+    viewNodeWindowManager: ViewNode.WindowManager? = null,
+    onGestureListener: GestureDetector.OnGestureListener? = rememberOnGestureListener(),
+    onTouchEvent: ((e: MotionEvent, hitResult: HitResult?) -> Boolean)? = null,
+    activity: ComponentActivity? = LocalContext.current as? ComponentActivity,
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+    onFrame: ((frameTimeNanos: Long) -> Unit)? = null,
+    content: (@Composable SceneScope.() -> Unit)? = null
+)
+```
+
+**Minimal usage:**
+
+```kotlin
+@Composable
+fun My3DScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        cameraManipulator = rememberCameraManipulator(),
+        mainLightNode = rememberMainLightNode(engine) { intensity = 100_000f }
+    ) {
+        rememberModelInstance(modelLoader, "models/helmet.glb")?.let { instance ->
+            ModelNode(modelInstance = instance, scaleToUnits = 1.0f)
+        }
+    }
+}
+```
+
+### ARSceneView -- AR Viewport
+
+```kotlin
+@Composable
+fun ARSceneView(
+    modifier: Modifier = Modifier,
+    engine: Engine = rememberEngine(),
+    modelLoader: ModelLoader = rememberModelLoader(engine),
+    materialLoader: MaterialLoader = rememberMaterialLoader(engine),
+    environmentLoader: EnvironmentLoader = rememberEnvironmentLoader(engine),
+    sessionFeatures: Set<Session.Feature> = setOf(),
+    sessionCameraConfig: ((Session) -> CameraConfig)? = null,
+    sessionConfiguration: ((session: Session, Config) -> Unit)? = null,
+    planeRenderer: Boolean = true,
+    cameraStream: ARCameraStream? = rememberARCameraStream(materialLoader),
+    view: View = rememberARView(engine),
+    environment: Environment = rememberAREnvironment(engine),
+    mainLightNode: LightNode? = rememberMainLightNode(engine),
+    cameraNode: ARCameraNode = rememberARCameraNode(engine),
+    onSessionCreated: ((session: Session) -> Unit)? = null,
+    onSessionResumed: ((session: Session) -> Unit)? = null,
+    onSessionPaused: ((session: Session) -> Unit)? = null,
+    onSessionFailed: ((exception: Exception) -> Unit)? = null,
+    onSessionUpdated: ((session: Session, frame: Frame) -> Unit)? = null,
+    onTrackingFailureChanged: ((trackingFailureReason: TrackingFailureReason?) -> Unit)? = null,
+    onGestureListener: GestureDetector.OnGestureListener? = rememberOnGestureListener(),
+    onTouchEvent: ((e: MotionEvent, hitResult: HitResult?) -> Boolean)? = null,
+    content: (@Composable ARSceneScope.() -> Unit)? = null
+)
+```
+
+**Minimal usage:**
+
+```kotlin
+@Composable
+fun MyARScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+
+    ARSceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        planeRenderer = true,
+        sessionConfiguration = { session, config ->
+            config.depthMode = Config.DepthMode.AUTOMATIC
+            config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
+        },
+        onSessionFailed = { exception -> /* show fallback */ }
+    ) {
+        // AR content here
+    }
+}
+```
+
+---
+
+## Node Types
+
+### ModelNode -- 3D Model
+
+```kotlin
+@Composable fun ModelNode(
+    modelInstance: ModelInstance,
+    autoAnimate: Boolean = true,
+    animationName: String? = null,
+    animationLoop: Boolean = true,
+    animationSpeed: Float = 1f,
+    scaleToUnits: Float? = null,       // uniformly scale to fit this size (meters)
+    centerOrigin: Position? = null,    // Position(0,0,0) = center, Position(0,-1,0) = bottom-aligned
+    position: Position = Position(x = 0f),
+    rotation: Rotation = Rotation(x = 0f),
+    scale: Scale = Scale(x = 1f),
+    isVisible: Boolean = true,
+    isEditable: Boolean = false,       // enables pinch-to-scale, drag-to-move
+    apply: ModelNode.() -> Unit = {},
+    content: (@Composable NodeScope.() -> Unit)? = null
+)
+```
+
+Key properties in `apply` block: `isShadowCaster`, `isShadowReceiver`, `playAnimation(name)`, `stopAnimation(name)`, `editableScaleRange`, `scaleGestureSensitivity`.
+
+### LightNode -- Light Source
+
+**CRITICAL: `apply` is a named parameter, NOT a trailing lambda.**
+
+```kotlin
+@Composable fun LightNode(
+    type: LightManager.Type,           // DIRECTIONAL, POINT, SPOT, FOCUSED_SPOT, SUN
+    intensity: Float? = null,          // lux (directional/sun) or candela (point/spot)
+    direction: Direction? = null,
+    position: Position = Position(x = 0f),
+    apply: LightManager.Builder.() -> Unit = {},
+    nodeApply: LightNode.() -> Unit = {},
+    content: (@Composable NodeScope.() -> Unit)? = null
+)
+```
+
+```kotlin
+// Correct usage:
+LightNode(
+    type = LightManager.Type.SPOT,
+    intensity = 50_000f,
+    position = Position(2f, 3f, 0f),
+    apply = { falloff(5.0f); spotLightCone(0.1f, 0.5f) }
+)
+```
+
+### CubeNode, SphereNode, CylinderNode, PlaneNode -- Geometry
+
+```kotlin
+CubeNode(size: Size = Size(1f), center: Position = ..., materialInstance: MaterialInstance? = null, ...)
+SphereNode(radius: Float = 0.5f, center: Position = ..., materialInstance: MaterialInstance? = null, ...)
+CylinderNode(radius: Float = 0.5f, height: Float = 2.0f, materialInstance: MaterialInstance? = null, ...)
+PlaneNode(size: Size = Size(1f), normal: Direction = ..., uvScale: UvScale = ..., materialInstance: MaterialInstance? = null, ...)
+```
+
+All geometry nodes share common parameters: `position`, `rotation`, `scale`, `apply`, `content`.
+
+### ImageNode -- Image on Plane (3 overloads)
+
+```kotlin
+ImageNode(bitmap: Bitmap, size: Size? = null, position: Position = ...)
+ImageNode(imageFileLocation: String, size: Size? = null, position: Position = ...)
+ImageNode(@DrawableRes imageResId: Int, size: Size? = null, position: Position = ...)
+```
+
+### TextNode -- 3D Text Label (faces camera)
+
+```kotlin
+TextNode(
+    text: String,
+    fontSize: Float = 48f,
+    textColor: Int = Color.WHITE,
+    backgroundColor: Int = 0xCC000000.toInt(),
+    widthMeters: Float = 0.6f,
+    heightMeters: Float = 0.2f,
+    position: Position = Position(x = 0f)
+)
+```
+
+Reactive: text, fontSize, textColor, backgroundColor, position, scale update on recomposition.
+
+### BillboardNode -- Always-Facing-Camera Sprite
+
+```kotlin
+BillboardNode(
+    bitmap: Bitmap,
+    widthMeters: Float? = null,
+    heightMeters: Float? = null,
+    position: Position = Position(x = 0f)
+)
+```
+
+### VideoNode -- Video on 3D Plane
+
+```kotlin
+// Simple (from asset path):
+VideoNode(videoPath: String, autoPlay: Boolean = true, isLooping: Boolean = true, chromaKeyColor: Int? = null, ...)
+
+// Advanced (bring your own MediaPlayer):
+VideoNode(player: MediaPlayer, chromaKeyColor: Int? = null, size: Size? = null, ...)
+```
+
+### ViewNode -- Compose UI in 3D
+
+Requires `viewNodeWindowManager` on the parent SceneView.
+
+```kotlin
+val windowManager = rememberViewNodeManager()
+SceneView(viewNodeWindowManager = windowManager) {
+    ViewNode(windowManager = windowManager) {
+        Card { Text("Hello 3D World!") }
+    }
+}
+```
+
+### LineNode, PathNode -- Lines and Curves
+
+```kotlin
+LineNode(start: Position, end: Position, materialInstance: MaterialInstance? = null)
+PathNode(points: List<Position>, closed: Boolean = false, materialInstance: MaterialInstance? = null)
+```
+
+### ShapeNode -- 2D Polygon in 3D
+
+```kotlin
+ShapeNode(polygonPath: List<Position2>, polygonHoles: List<Int> = listOf(), normal: Direction = ..., color: Color? = null, ...)
+```
+
+### PhysicsNode -- Rigid Body Physics
+
+```kotlin
+PhysicsNode(node: Node, mass: Float = 1f, restitution: Float = 0.6f, linearVelocity: Position = ..., floorY: Float = 0f, radius: Float = 0f)
+```
+
+Does NOT add the node to the scene. The node must already exist.
+
+### DynamicSkyNode -- Time-of-Day Sun
+
+```kotlin
+DynamicSkyNode(timeOfDay: Float = 12f, turbidity: Float = 2f, sunIntensity: Float = 110_000f)
+```
+
+### ReflectionProbeNode -- Local IBL Override
+
+```kotlin
+ReflectionProbeNode(filamentScene: FilamentScene, environment: Environment, position: Position = ..., radius: Float = 0f, ...)
+```
+
+### MeshNode -- Custom Geometry
+
+```kotlin
+MeshNode(primitiveType: PrimitiveType, vertexBuffer: VertexBuffer, indexBuffer: IndexBuffer, materialInstance: MaterialInstance? = null)
+```
+
+### Node -- Empty Pivot/Group
+
+```kotlin
+Node(position: Position, rotation: Rotation, scale: Scale, isVisible: Boolean = true, isEditable: Boolean = false,
+     content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+---
+
+## AR-Specific Nodes (ARSceneScope)
+
+### AnchorNode -- Pin to Real World
+
+```kotlin
+AnchorNode(anchor: Anchor, visibleTrackingStates: Set<TrackingState> = setOf(TrackingState.TRACKING),
+           onTrackingStateChanged: ((TrackingState) -> Unit)? = null,
+           content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+### HitResultNode -- Surface Cursor
+
+```kotlin
+// Screen-coordinate hit test (most common):
+HitResultNode(xPx: Float, yPx: Float, planeTypes: Set<Plane.Type> = ...,
+              content: (@Composable NodeScope.() -> Unit)? = null)
+
+// Custom hit test:
+HitResultNode(hitTest: HitResultNode.(Frame) -> HitResult?,
+              content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+### AugmentedImageNode -- Image Tracking
+
+```kotlin
+AugmentedImageNode(augmentedImage: AugmentedImage, applyImageScale: Boolean = false,
+                   content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+### AugmentedFaceNode -- Face Mesh
+
+```kotlin
+AugmentedFaceNode(augmentedFace: AugmentedFace, meshMaterialInstance: MaterialInstance? = null,
+                  content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+### CloudAnchorNode -- Cross-Device Anchors
+
+```kotlin
+CloudAnchorNode(anchor: Anchor, cloudAnchorId: String? = null,
+                onHosted: ((cloudAnchorId: String?, state: Anchor.CloudAnchorState) -> Unit)? = null,
+                content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+### PoseNode, TrackableNode
+
+```kotlin
+PoseNode(pose: Pose = Pose.IDENTITY, content: (@Composable NodeScope.() -> Unit)? = null)
+TrackableNode(trackable: Trackable, content: (@Composable NodeScope.() -> Unit)? = null)
+```
+
+**Important:** AR composables can only be declared at the ARSceneView root level, not inside other nodes' content blocks.
+
+---
+
+## Resource Loading
+
+### rememberModelInstance (async, composable)
+
+```kotlin
+// From local asset
+val model: ModelInstance? = rememberModelInstance(modelLoader, "models/helmet.glb")
+
+// From URL (auto-detects http/https)
+val model: ModelInstance? = rememberModelInstance(modelLoader, "https://example.com/model.glb")
+```
+
+Returns null while loading. **Always handle the null case.**
+
+### ModelLoader (imperative)
+
+```kotlin
+// Synchronous -- MUST call on main thread
+modelLoader.createModelInstance("models/file.glb"): ModelInstance
+modelLoader.createModel("models/file.glb", releaseSourceData = true): Model
+
+// Async -- safe from any thread
+suspend fun loadModelInstance(fileLocation: String): ModelInstance?
+fun loadModelInstanceAsync(fileLocation: String, onResult: (ModelInstance?) -> Unit): Job
+```
+
+### MaterialLoader
+
+```kotlin
+materialLoader.createColorInstance(
+    color: Color,
+    metallic: Float = 0.0f,    // 0 = dielectric, 1 = metal
+    roughness: Float = 0.4f,   // 0 = mirror, 1 = matte
+    reflectance: Float = 0.5f
+): MaterialInstance
+```
+
+There is NO `rememberMaterialInstance`. Create materials inside `remember`:
+
+```kotlin
+val mat = remember(materialLoader) {
+    materialLoader.createColorInstance(Color.Red, metallic = 0f, roughness = 0.6f)
+}
+```
+
+### EnvironmentLoader
+
+```kotlin
+environmentLoader.createHDREnvironment("environments/sky_2k.hdr"): Environment?
+environmentLoader.createKTXEnvironment("environments/studio.ktx"): Environment
+environmentLoader.createEnvironment(indirectLight, skybox): Environment
+```
+
+---
+
+## Remember Helpers Reference
+
+| Helper | Returns | Purpose |
+|--------|---------|---------|
+| `rememberEngine()` | `Engine` | Root Filament object |
+| `rememberModelLoader(engine)` | `ModelLoader` | Loads glTF/GLB models |
+| `rememberMaterialLoader(engine)` | `MaterialLoader` | Creates material instances |
+| `rememberEnvironmentLoader(engine)` | `EnvironmentLoader` | Loads HDR/KTX environments |
+| `rememberModelInstance(modelLoader, path)` | `ModelInstance?` | Async model load (null while loading) |
+| `rememberEnvironment(environmentLoader)` | `Environment` | IBL + skybox environment |
+| `rememberCameraNode(engine) { ... }` | `CameraNode` | Custom camera |
+| `rememberMainLightNode(engine) { ... }` | `LightNode` | Primary directional light |
+| `rememberCameraManipulator(...)` | `CameraManipulator?` | Orbit/pan/zoom controller |
+| `rememberOnGestureListener(...)` | `OnGestureListener` | Gesture callbacks |
+| `rememberViewNodeManager()` | `ViewNode.WindowManager` | Required for ViewNode |
+| `rememberView(engine)` | `View` | Filament view |
+| `rememberARView(engine)` | `View` | AR-tuned view (linear tone mapper) |
+| `rememberARCameraNode(engine)` | `ARCameraNode` | AR camera (updated by ARCore) |
+| `rememberARCameraStream(materialLoader)` | `ARCameraStream` | Camera feed texture |
+| `rememberAREnvironment(engine)` | `Environment` | No-skybox environment for AR |
+| `rememberMediaPlayer(context, path)` | `MediaPlayer?` | Auto-lifecycle video player |
+
+---
+
+## Camera Control
+
+```kotlin
+// Orbit / pan / zoom (default)
+SceneView(cameraManipulator = rememberCameraManipulator(
+    orbitHomePosition = Position(x = 0f, y = 2f, z = 4f),
+    targetPosition = Position(x = 0f, y = 0f, z = 0f)
+))
+
+// Custom camera position
+SceneView(cameraNode = rememberCameraNode(engine) {
+    position = Position(x = 0f, y = 2f, z = 5f)
+    lookAt(Position(0f, 0f, 0f))
+})
+
+// Main light shortcut
+SceneView(mainLightNode = rememberMainLightNode(engine) { intensity = 100_000f })
+```
+
+---
+
+## Gesture Handling
+
+```kotlin
+SceneView(
+    onGestureListener = rememberOnGestureListener(
+        onDown = { event, node -> },
+        onSingleTapUp = { event, node -> },
+        onSingleTapConfirmed = { event, node -> },
+        onDoubleTap = { event, node -> },
+        onLongPress = { event, node -> },
+        onMove = { detector, node -> },
+        onMoveBegin = { detector, node -> },
+        onMoveEnd = { detector, node -> },
+        onRotate = { detector, node -> },
+        onRotateBegin = { detector, node -> },
+        onRotateEnd = { detector, node -> },
+        onScale = { detector, node -> },
+        onScaleBegin = { detector, node -> },
+        onScaleEnd = { detector, node -> },
+        onFling = { e1, e2, node, velocity -> },
+        onScroll = { e1, e2, node, distance -> }
+    ),
+    onTouchEvent = { event, hitResult -> false }
+)
+```
+
+**Editable nodes:** Set `isEditable = true` to enable built-in pinch-to-scale and drag-to-move. Fine-tune with `isPositionEditable`, `isRotationEditable`, `isScaleEditable`, `editableScaleRange`.
+
+---
+
+## Node Properties (Common to All Nodes)
+
+```kotlin
+// Transform
+node.position = Position(x = 1f, y = 0f, z = -2f)  // meters
+node.rotation = Rotation(x = 0f, y = 45f, z = 0f)   // degrees
+node.scale = Scale(x = 1f, y = 1f, z = 1f)
+node.worldPosition / node.worldRotation / node.worldScale  // world-space
+
+// Visibility
+node.isVisible = true
+
+// Interaction
+node.isTouchable = true
+node.isEditable = true
+node.isHittable = true
+
+// Smooth transform
+node.isSmoothTransformEnabled = false
+node.smoothTransformSpeed = 5.0f
+
+// Orientation
+node.lookAt(targetWorldPosition, upDirection)
+node.lookTowards(lookDirection, upDirection)
+```
+
+---
+
+## Math Types
+
+```kotlin
+import io.github.sceneview.math.Position   // Float3, meters
+import io.github.sceneview.math.Rotation   // Float3, degrees
+import io.github.sceneview.math.Scale      // Float3
+import io.github.sceneview.math.Direction  // Float3, unit vector
+import io.github.sceneview.math.Size       // Float3
+import io.github.sceneview.math.Transform  // Mat4
+import io.github.sceneview.math.Color      // Float4
+
+Position(x = 0f, y = 1f, z = -2f)
+Rotation(y = 90f)
+Scale(1.5f)          // uniform
+```
+
+---
+
+## Threading Rules (Critical)
+
+- Filament JNI calls must run on the **main thread**
+- `rememberModelInstance` is safe -- reads bytes on IO, creates on Main
+- `modelLoader.createModel*` (synchronous) -- **main thread only**
+- `materialLoader.createColorInstance(...)` -- **main thread only**; safe inside `remember { }` in SceneScope
+- Use `modelLoader.loadModelInstanceAsync(...)` for imperative async code
+- Inside `SceneView { }` composable scope, you are on the main thread
+
+---
+
+## Surface Types
+
+```kotlin
+SceneView(surfaceType = SurfaceType.Surface)                          // SurfaceView, best perf (default)
+SceneView(surfaceType = SurfaceType.TextureSurface, isOpaque = false) // TextureView, supports alpha
+```

--- a/gpt/knowledge-overview.md
+++ b/gpt/knowledge-overview.md
@@ -1,0 +1,233 @@
+# SceneView Platform Overview and Setup Guide
+
+## What is SceneView?
+
+SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament, ARCore) and Apple platforms -- iOS, macOS, visionOS (SwiftUI, RealityKit, ARKit) -- with shared core logic via Kotlin Multiplatform. It lets developers build 3D and augmented reality experiences using familiar UI patterns: composable functions on Android, SwiftUI views on Apple. Each platform uses its native high-performance renderer -- Filament on Android/Web, RealityKit on Apple -- while a shared KMP core provides portable math, collision, geometry, and animation logic.
+
+---
+
+## Platform Support
+
+| Platform | Renderer | Framework | Status | Version |
+|---|---|---|---|---|
+| Android | Filament | Jetpack Compose | Stable | 3.6.1 |
+| Android TV | Filament | Compose TV | Alpha | 3.6.1 |
+| Android XR | Jetpack XR SceneCore | Compose XR | Planned | -- |
+| iOS | RealityKit | SwiftUI | Alpha | 3.6.0 |
+| macOS | RealityKit | SwiftUI | Alpha | 3.6.0 |
+| visionOS | RealityKit | SwiftUI | Alpha | 3.6.0 |
+| Web | Filament.js (WASM) | Kotlin/JS | Alpha | 3.6.1 |
+| Desktop | Wireframe placeholder | Compose Desktop | Placeholder | -- |
+| Flutter | Filament / RealityKit | PlatformView | Alpha | 3.6.1 |
+| React Native | Filament / RealityKit | Fabric | Alpha | 3.6.1 |
+
+---
+
+## Architecture
+
+SceneView follows a "native renderer per platform" architecture. Kotlin Multiplatform (KMP) shares logic, not rendering. Each platform uses its native 3D engine.
+
+```
++---------------------------------------------+
+|           sceneview-core (KMP)               |
+|   math, collision, geometry, animations,     |
+|   physics, scene graph, triangulation        |
+|       commonMain -> XCFramework              |
++-----------+-----------------+----------------+
+            |                 |
+   +--------v--------+ +-----v----------+
+   |   sceneview     | | SceneViewSwift |
+   |   (Android)     | |    (Apple)     |
+   |   Filament      | |   RealityKit   |
+   +--------+--------+ +-----+----------+
+            |                 |
+      Compose UI        SwiftUI (native)
+                        Flutter (PlatformView)
+                        React Native (Fabric)
+                        KMP Compose (UIKitView)
+```
+
+**Why native renderers?**
+
+- RealityKit is the only path to visionOS spatial computing
+- Swift Package integration (1 line SPM) is far simpler than KMP XCFramework
+- SceneViewSwift is consumable by Flutter, React Native, and KMP Compose on iOS
+- No Filament dependency on Apple means smaller binary, native debugging, native tooling
+
+### Module Map
+
+| Module | Purpose |
+|---|---|
+| `sceneview-core/` | KMP: portable collision, math, geometry, animation, physics |
+| `sceneview/` | Android 3D library: Scene, SceneScope, all node types (Filament) |
+| `arsceneview/` | Android AR layer: ARScene, ARSceneScope, ARCore integration |
+| `sceneview-web/` | Web 3D library: Kotlin/JS + Filament.js (WebGL2/WASM) |
+| `SceneViewSwift/` | Apple 3D+AR library: SceneView, ARSceneView (RealityKit) |
+| `flutter/` | Flutter plugin: PlatformView bridge (Android + iOS) |
+| `react-native/` | React Native module: Fabric/Turbo bridge (Android + iOS) |
+
+---
+
+## Setup Instructions
+
+### Android (Gradle)
+
+**Minimum requirements:** Min SDK 24 | Target SDK 36 | Kotlin 2.3.20 | Compose BOM compatible
+
+**build.gradle.kts (app module):**
+
+```kotlin
+dependencies {
+    // 3D only
+    implementation("io.github.sceneview:sceneview:3.6.1")
+
+    // AR + 3D (includes sceneview)
+    implementation("io.github.sceneview:arsceneview:3.6.1")
+}
+```
+
+**AndroidManifest.xml (AR apps only):**
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-feature android:name="android.hardware.camera.ar" android:required="true" />
+<application>
+    <meta-data android:name="com.google.ar.core" android:value="required" />
+</application>
+```
+
+### iOS / macOS / visionOS (Swift Package Manager)
+
+**Minimum requirements:** iOS 17+ | macOS 14+ | visionOS 1+
+
+In Xcode: File > Add Package Dependencies, enter:
+
+```
+https://github.com/sceneview/sceneview-swift.git
+```
+
+Set version rule: from "3.6.0"
+
+Then import in Swift files:
+
+```swift
+import SceneViewSwift
+```
+
+### Web (npm)
+
+```bash
+npm install @sceneview/sceneview-web
+```
+
+Requires a WebGL2-capable browser. Uses Filament.js compiled to WebAssembly -- the same rendering engine as Android SceneView.
+
+```kotlin
+import io.github.sceneview.web.SceneView
+import kotlinx.browser.document
+import org.w3c.dom.HTMLCanvasElement
+
+fun main() {
+    val canvas = document.getElementById("scene-canvas") as HTMLCanvasElement
+    SceneView.create(
+        canvas = canvas,
+        configure = {
+            camera { eye(0.0, 1.5, 5.0); target(0.0, 0.0, 0.0) }
+            light { directional(); intensity(100_000.0) }
+            model("models/helmet.glb")
+        },
+        onReady = { it.startRendering() }
+    )
+}
+```
+
+---
+
+## Key Concepts
+
+### Declarative Node System
+
+SceneView uses a declarative, composable API. Instead of imperatively creating and managing nodes, you declare them inside a content block:
+
+```kotlin
+SceneView(modifier = Modifier.fillMaxSize()) {
+    // This is a SceneScope -- declare nodes as composables
+    ModelNode(modelInstance = instance, scaleToUnits = 1.0f)
+    CubeNode(size = Size(0.5f), position = Position(x = 1f))
+    LightNode(type = LightManager.Type.POINT, intensity = 50_000f)
+}
+```
+
+Nodes are added, updated, and removed automatically based on Compose state. When a state variable changes, only the affected nodes recompose.
+
+### Scene Graph
+
+Nodes can be nested in parent-child hierarchies. Child transforms are relative to their parent:
+
+```kotlin
+Node(position = Position(y = 1f)) {
+    ModelNode(modelInstance = instance, position = Position(x = -1f))
+    CubeNode(size = Size(0.1f), position = Position(x = 1f))
+}
+```
+
+### Resource Loaders
+
+SceneView provides memoized resource loaders that handle lifecycle automatically:
+
+- **`rememberEngine()`** -- root Filament object, one per process
+- **`rememberModelLoader(engine)`** -- loads glTF/GLB models
+- **`rememberMaterialLoader(engine)`** -- creates PBR material instances
+- **`rememberEnvironmentLoader(engine)`** -- loads HDR/KTX environments
+
+Models are loaded asynchronously:
+
+```kotlin
+val model = rememberModelInstance(modelLoader, "models/helmet.glb")
+// Returns null while loading -- always handle the null case
+model?.let { ModelNode(modelInstance = it, scaleToUnits = 1f) }
+```
+
+### Available Node Types
+
+**3D Nodes (SceneScope):**
+
+- **ModelNode** -- 3D model from GLB/glTF files
+- **CubeNode, SphereNode, CylinderNode, PlaneNode** -- procedural geometry
+- **LightNode** -- directional, point, spot, focused spot, sun lights
+- **ImageNode** -- images on 3D planes (from assets, resources, or Bitmap)
+- **TextNode** -- camera-facing text labels
+- **BillboardNode** -- always-facing-camera sprites
+- **VideoNode** -- video playback on 3D surfaces
+- **ViewNode** -- Jetpack Compose UI embedded in 3D space
+- **LineNode, PathNode** -- line segments and polylines
+- **ShapeNode** -- triangulated 2D polygons in 3D
+- **MeshNode** -- custom vertex/index geometry
+- **PhysicsNode** -- simple rigid-body physics
+- **DynamicSkyNode** -- time-of-day sun cycle
+- **ReflectionProbeNode** -- local IBL override
+- **Node** -- empty pivot/group for hierarchy
+
+**AR-Specific Nodes (ARSceneScope):**
+
+- **AnchorNode** -- pin content to real-world positions
+- **HitResultNode** -- surface cursor following detected planes
+- **AugmentedImageNode** -- image tracking overlay
+- **AugmentedFaceNode** -- face mesh tracking
+- **CloudAnchorNode** -- cross-device persistent anchors
+- **PoseNode** -- position at ARCore Pose
+- **TrackableNode** -- generic trackable wrapper
+
+### Threading Rule (Critical)
+
+Filament JNI calls must run on the **main thread**. Never call `modelLoader.createModel*` or `materialLoader.*` from a background coroutine. Use `rememberModelInstance` in composables (it handles threading correctly) or `modelLoader.loadModelInstanceAsync` for imperative code.
+
+---
+
+## Supported 3D Formats
+
+| Platform | Model Formats | Environment Formats |
+|---|---|---|
+| Android | GLB, glTF | HDR, KTX |
+| iOS/macOS/visionOS | USDZ, Reality | IBL (built-in) |
+| Web | GLB | KTX (IBL + skybox) |

--- a/gpt/knowledge-practices.md
+++ b/gpt/knowledge-practices.md
@@ -1,0 +1,297 @@
+# SceneView Best Practices and Troubleshooting
+
+## Performance Optimization
+
+### Model Budgets
+
+For smooth 60fps rendering on mid-range devices:
+
+- **Triangle count:** Keep individual models under 100K triangles. Total scene budget: 300K-500K triangles.
+- **Texture size:** Use 1024x1024 for most models, 2048x2048 for hero assets. Avoid 4096x4096 on mobile.
+- **Texture compression:** Use KTX2 with Basis Universal compression for Android. USDZ handles compression natively on iOS.
+- **Model file size:** GLB files under 10MB load in under 2 seconds on mid-range devices. For larger assets, show a loading indicator.
+
+### Level of Detail (LOD)
+
+Use `scaleToUnits` to control apparent size and swap model variants based on camera distance:
+
+```kotlin
+val isClose = remember(cameraDistance) { cameraDistance < 3f }
+val modelPath = if (isClose) "models/car_high.glb" else "models/car_low.glb"
+val model = rememberModelInstance(modelLoader, modelPath)
+```
+
+### Scene Optimization Tips
+
+- **Limit light count:** 1 directional + 2-3 point/spot lights maximum for mobile
+- **Shadow budget:** Enable shadows only on the main light. Disable `isShadowCaster` on small/distant objects
+- **Environment maps:** Use smaller HDR maps (1K or 2K). Avoid 4K+ for IBL on mobile
+- **Geometry nodes:** CubeNode, SphereNode, etc. are lightweight but avoid hundreds of them. Batch similar geometry into a single model file instead
+- **Dispose unused resources:** SceneView's `remember*` helpers handle cleanup automatically, but if creating resources imperatively, call `destroy()` when done
+
+### Post-Processing Performance
+
+Post-processing effects have GPU cost. Enable selectively:
+
+```kotlin
+// Moderate cost: bloom, vignette
+view.bloomOptions = view.bloomOptions.apply { enabled = true; strength = 0.1f }
+
+// Higher cost: SSAO, depth of field
+view.ambientOcclusionOptions = view.ambientOcclusionOptions.apply { enabled = true }
+view.depthOfFieldOptions = view.depthOfFieldOptions.apply { enabled = true }
+```
+
+Disable SSAO and DoF on low-end devices. Use `Build.MODEL` or runtime frame-time measurement to adapt.
+
+---
+
+## Common Mistakes and Fixes
+
+### 1. Not handling null from rememberModelInstance
+
+**Wrong:**
+```kotlin
+SceneView {
+    val model = rememberModelInstance(modelLoader, "models/helmet.glb")
+    ModelNode(modelInstance = model!!)  // CRASH: model is null while loading
+}
+```
+
+**Correct:**
+```kotlin
+SceneView {
+    rememberModelInstance(modelLoader, "models/helmet.glb")?.let { model ->
+        ModelNode(modelInstance = model, scaleToUnits = 1.0f)
+    }
+}
+```
+
+### 2. Using LightNode apply as a trailing lambda
+
+**Wrong:**
+```kotlin
+LightNode(type = LightManager.Type.SUN) {  // ERROR: this is the content block, not apply
+    intensity(100_000f)
+}
+```
+
+**Correct:**
+```kotlin
+LightNode(
+    type = LightManager.Type.SUN,
+    apply = { intensity(100_000f); castShadows(true) }
+)
+```
+
+### 3. Calling Filament APIs on background thread
+
+**Wrong:**
+```kotlin
+LaunchedEffect(Unit) {
+    withContext(Dispatchers.IO) {
+        val model = modelLoader.createModelInstance("models/helmet.glb")  // CRASH
+    }
+}
+```
+
+**Correct:**
+```kotlin
+LaunchedEffect(Unit) {
+    val model = modelLoader.loadModelInstance("models/helmet.glb")  // suspend, thread-safe
+}
+// Or in composable scope:
+val model = rememberModelInstance(modelLoader, "models/helmet.glb")
+```
+
+### 4. Wrong imports for math types
+
+SceneView uses its own math types, not android.graphics or compose types:
+
+```kotlin
+import io.github.sceneview.math.Position   // NOT android.graphics.PointF
+import io.github.sceneview.math.Rotation   // NOT Float3 from other libraries
+import io.github.sceneview.math.Scale
+import io.github.sceneview.math.Size
+import io.github.sceneview.math.Color      // Float4, NOT android.graphics.Color for materials
+```
+
+For `materialLoader.createColorInstance`, use `androidx.compose.ui.graphics.Color` or Filament `Color`.
+
+### 5. Forgetting environment and light
+
+A black scene usually means no environment and no light:
+
+```kotlin
+SceneView(
+    environment = rememberEnvironment(environmentLoader) {
+        environmentLoader.createHDREnvironment("environments/sky_2k.hdr")
+            ?: createEnvironment(environmentLoader)
+    },
+    mainLightNode = rememberMainLightNode(engine) { intensity = 100_000f }
+) { ... }
+```
+
+### 6. Creating materials outside remember
+
+**Wrong:**
+```kotlin
+SceneView {
+    // Creates a new MaterialInstance EVERY recomposition -- memory leak!
+    val mat = materialLoader.createColorInstance(Color.Red)
+    CubeNode(materialInstance = mat)
+}
+```
+
+**Correct:**
+```kotlin
+SceneView {
+    val mat = remember(materialLoader) {
+        materialLoader.createColorInstance(Color.Red, metallic = 0f, roughness = 0.6f)
+    }
+    CubeNode(materialInstance = mat)
+}
+```
+
+---
+
+## AR Best Practices
+
+### Camera Permission
+
+Always handle the CAMERA permission before showing ARSceneView. Use the `onSessionFailed` callback for graceful degradation:
+
+```kotlin
+ARSceneView(
+    onSessionFailed = { exception ->
+        // Show fallback UI or permission request
+        showARUnavailableMessage = true
+    }
+)
+```
+
+### Plane Detection
+
+- Enable `planeRenderer = true` during initial placement phase so users can see detected surfaces
+- Disable it after placement for a cleaner look: `planeRenderer = anchor != null`
+- Use horizontal planes for furniture/objects, vertical for wall art/posters
+
+### Lighting Estimation
+
+Always enable environmental HDR for realistic lighting on placed objects:
+
+```kotlin
+sessionConfiguration = { session, config ->
+    config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
+}
+```
+
+This adjusts the virtual lighting to match the real environment.
+
+### Depth Mode
+
+Enable automatic depth for occlusion (virtual objects hidden behind real ones):
+
+```kotlin
+config.depthMode = if (session.isDepthModeSupported(Config.DepthMode.AUTOMATIC))
+    Config.DepthMode.AUTOMATIC else Config.DepthMode.DISABLED
+```
+
+### AR Tone Mapping
+
+Use `rememberARView(engine)` instead of `rememberView(engine)` for AR scenes. It uses a linear tone mapper that matches the camera feed brightness.
+
+### Anchor Management
+
+- Create anchors sparingly -- each anchor has tracking overhead
+- Remove anchors when no longer needed: `anchor.detach()`
+- Use `onTrackingStateChanged` to handle tracking loss gracefully
+
+---
+
+## Memory Management
+
+### Lifecycle
+
+SceneView's `remember*` helpers automatically manage lifecycle. Resources are created on first composition and destroyed on disposal.
+
+### Manual Resource Cleanup
+
+If creating resources imperatively (outside composables), destroy them explicitly:
+
+```kotlin
+val model = modelLoader.createModelInstance("models/helmet.glb")
+// ... use model ...
+model.destroy()  // when done
+```
+
+### Large Scene Tips
+
+- Use `DisposableEffect` for imperative resources tied to composable lifecycle
+- Avoid loading more than 5-10 models simultaneously
+- For model galleries, load/unload models as the user scrolls
+- Monitor memory with Android Studio Profiler -- Filament textures use GPU memory not tracked by JVM heap
+
+---
+
+## Troubleshooting: Top 10 Common Errors
+
+| # | Problem | Cause | Fix |
+|---|---------|-------|-----|
+| 1 | Model not showing | `rememberModelInstance` returns null | Always null-check: `model?.let { ModelNode(...) }` |
+| 2 | Black screen | No environment or no light | Add `mainLightNode` and `environment` parameters |
+| 3 | Crash on background thread | Filament JNI on wrong thread | Use `rememberModelInstance` or `Dispatchers.Main` |
+| 4 | AR not starting | Missing CAMERA permission or ARCore not installed | Handle `onSessionFailed`, check `ArCoreApk.checkAvailability()` |
+| 5 | Model too big/small | Model units mismatch | Use `scaleToUnits` parameter (value in meters) |
+| 6 | Oversaturated AR camera | Wrong tone mapper for AR | Use `rememberARView(engine)` which applies linear tone mapping |
+| 7 | Crash on empty bounding box | Filament 1.70+ enforcement | Update to latest SceneView which auto-sanitizes |
+| 8 | Material crash on dispose | Entity still in scene during cleanup | SceneView handles cleanup order automatically; update library |
+| 9 | LightNode not working | Using `apply` as trailing lambda | Use `apply = { ... }` as a named parameter |
+| 10 | Gesture not detected | Node not touchable | Set `isTouchable = true` and/or `isEditable = true` on the node |
+
+---
+
+## Migration from Sceneform / SceneView v2
+
+### Key Changes in v3
+
+1. **Declarative API:** No more `arSceneView.scene.addChild(node)`. Declare nodes as composables inside `SceneView { }` or `ARSceneView { }`.
+
+2. **Compose-first:** SceneView v3 is built for Jetpack Compose. The old XML/View-based API is gone.
+
+3. **Resource loading:** Replace `ModelRenderable.builder()` with `rememberModelInstance(modelLoader, path)`.
+
+4. **Node creation:** Replace `TransformableNode(arFragment.transformationSystem)` with `ModelNode(modelInstance = ..., isEditable = true)`.
+
+5. **AR session:** Replace `ArFragment` with `ARSceneView(sessionConfiguration = { ... })`.
+
+6. **Anchor placement:**
+   - Old: `arFragment.setOnTapArPlaneListener { hitResult, plane, event -> ... }`
+   - New: `onTouchEvent = { event, hitResult -> ... }` + `AnchorNode(anchor) { ... }`
+
+7. **Animation:** Replace `ModelAnimator.animate()` with `ModelNode(autoAnimate = true, animationName = "Walk")`.
+
+8. **Materials:** Replace `MaterialFactory.makeOpaqueWithColor()` with `materialLoader.createColorInstance(color, metallic, roughness)`.
+
+### Migration Checklist
+
+- [ ] Replace `ArFragment` / `ArSceneView` XML with `ARSceneView` composable
+- [ ] Replace `ModelRenderable.builder()` with `rememberModelInstance`
+- [ ] Replace `scene.addChild(node)` with composable node declarations
+- [ ] Replace `TransformableNode` with `ModelNode(isEditable = true)`
+- [ ] Replace `ArFragment.setOnTapArPlaneListener` with `onTouchEvent`
+- [ ] Replace `MaterialFactory` with `MaterialLoader`
+- [ ] Replace `ViewRenderable` with `ViewNode`
+- [ ] Update Gradle dependency to `io.github.sceneview:arsceneview:3.6.1`
+- [ ] Add `rememberEngine()` and pass engine to loaders
+
+### Dependency Change
+
+```kotlin
+// Old (Sceneform / SceneView v2)
+implementation("io.github.sceneview:sceneview:2.x.x")
+
+// New (SceneView v3)
+implementation("io.github.sceneview:sceneview:3.6.1")   // 3D only
+implementation("io.github.sceneview:arsceneview:3.6.1") // AR + 3D
+```

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -1,0 +1,301 @@
+# SceneView Complete Sample Index
+
+## Summary
+
+SceneView ships with 39 samples across 3 platforms: Android (Kotlin/Compose), iOS (Swift/SwiftUI), and Web (Kotlin/JS). Each sample demonstrates a specific capability and can be used as a starting point for your own project.
+
+---
+
+## All Samples
+
+| # | ID | Platform | Category | Description | Key Tags |
+|---|---|---|---|---|---|
+| 1 | model-viewer | Android | 3D | Full-screen 3D scene with GLB model, HDR environment, orbit camera, animation | 3d, model, environment, camera, animation |
+| 2 | ar-model-viewer | Android | AR | Tap-to-place model with plane detection, pinch-to-scale, drag-to-rotate | ar, model, anchor, plane-detection, gestures |
+| 3 | ar-augmented-image | Android | AR | Detect reference images in camera feed, overlay 3D models | ar, model, image-tracking |
+| 4 | ar-cloud-anchor | Android | AR | Host and resolve persistent cross-device cloud anchors | ar, anchor, cloud-anchor |
+| 5 | ar-point-cloud | Android | AR | Visualize ARCore feature points as 3D spheres | ar, point-cloud |
+| 6 | ar-face-mesh | Android | AR | Front camera face tracking with mesh overlay | ar, face-tracking, model |
+| 7 | gltf-camera | Android | 3D | Use camera definitions embedded in glTF files | 3d, model, camera |
+| 8 | camera-manipulator | Android | 3D | Orbit, pan, zoom with configurable sensitivity and bounds | 3d, camera, gestures |
+| 9 | camera-animation | Android | 3D | Animated camera flythrough with trigonometric orbit | 3d, camera, animation, model |
+| 10 | autopilot-demo | Android | 3D | Autonomous driving HUD with car, road geometry, telemetry overlay | 3d, model, animation, geometry |
+| 11 | physics-demo | Android | 3D | Gravity and bounce simulation with spheres and floor | 3d, physics, geometry, animation |
+| 12 | dynamic-sky | Android | 3D | Time-of-day sun cycle with animated light color and intensity | 3d, sky, environment, animation, lighting |
+| 13 | line-path | Android | 3D | Animated sine waves and Lissajous curves with PathNode/LineNode | 3d, lines, geometry, animation |
+| 14 | text-labels | Android | 3D | Camera-facing 3D text labels above geometry (planets) | 3d, text, geometry |
+| 15 | reflection-probe | Android | 3D | Zone-based IBL overrides with material picker | 3d, reflection, environment, model |
+| 16 | post-processing | Android | 3D | Bloom, vignette, tone mapping, FXAA, SSAO controls | 3d, post-processing, environment |
+| 17 | video-texture | Android | 3D | Video playback on a 3D plane with chroma-key support | 3d, video, model |
+| 18 | multi-model-scene | Android | 3D | Multiple models loaded and positioned in a complete environment | 3d, model, multi-model, environment |
+| 19 | gesture-interaction | Android | 3D | Tap, double-tap, long-press, pinch-to-scale, drag-to-move | 3d, gestures, model |
+| 20 | environment-lighting | Android | 3D | HDR IBL + skybox, directional sun, point light, spot light | 3d, environment, lighting, model |
+| 21 | procedural-geometry | Android | 3D | Cube, sphere, cylinder, plane with PBR materials (no model files) | 3d, geometry, model |
+| 22 | compose-ui-3d | Android | 3D | Embed Compose UI (Cards, Buttons, Text) in 3D space via ViewNode | 3d, compose-ui, text |
+| 23 | node-hierarchy | Android | 3D | Parent-child hierarchies -- solar system with orbiting planets | 3d, hierarchy, geometry, animation |
+| 24 | image-node | Android | 3D | Display images on 3D planes from assets, resources, or Bitmap | 3d, image, geometry |
+| 25 | billboard-sprite | Android | 3D | Always-facing-camera sprites for markers and info overlays | 3d, billboard, image |
+| 26 | animation-state | Android | 3D | Reactive animation state machine -- Idle, Walk, Run via Compose state | 3d, model, animation |
+| 27 | spring-animation | Android | 3D | Spring physics animations via Compose animateFloatAsState | 3d, animation, spring, geometry |
+| 28 | ar-surface-cursor | Android | AR | Center-screen reticle following detected surface via HitResultNode | ar, cursor, plane-detection, placement |
+| 29 | ios-model-viewer | iOS | 3D | SwiftUI 3D scene with USDZ model, IBL, orbit camera, animation | 3d, model, environment, camera, ios, swift |
+| 30 | ios-ar-model-viewer | iOS | AR | Tap-to-place on detected surfaces using ARKit + RealityKit | ar, model, anchor, plane-detection, ios, swift |
+| 31 | ios-ar-augmented-image | iOS | AR | Detect reference images and overlay 3D content via ARKit | ar, model, image-tracking, ios, swift |
+| 32 | ios-geometry-shapes | iOS | 3D | Procedural shapes (cube, sphere, cylinder, cone, plane) with PBR | 3d, geometry, ios, swift |
+| 33 | ios-lighting | iOS | 3D | Directional, point, and spot lights with shadows | 3d, lighting, environment, ios, swift |
+| 34 | ios-physics | iOS | 3D | Interactive physics with bouncing spheres and gravity | 3d, physics, geometry, ios, swift |
+| 35 | ios-text-labels | iOS | 3D | Billboard text labels that always face the camera | 3d, text, geometry, ios, swift |
+| 36 | ios-video-player | iOS | 3D | Video playback on 3D plane with play/pause/stop controls | 3d, video, ios, swift |
+| 37 | web-model-viewer | Web | 3D | Browser-based 3D viewer with Filament.js (WebGL2/WASM) | 3d, model, web, filament-js |
+| 38 | web-environment | Web | 3D | Browser 3D scene with IBL environment lighting from KTX | 3d, environment, web, filament-js, lighting |
+
+---
+
+## Grouped by Platform
+
+### Android 3D Samples (19)
+
+model-viewer, gltf-camera, camera-manipulator, camera-animation, autopilot-demo, physics-demo, dynamic-sky, line-path, text-labels, reflection-probe, post-processing, video-texture, multi-model-scene, gesture-interaction, environment-lighting, procedural-geometry, compose-ui-3d, node-hierarchy, image-node, billboard-sprite, animation-state, spring-animation
+
+### Android AR Samples (7)
+
+ar-model-viewer, ar-augmented-image, ar-cloud-anchor, ar-point-cloud, ar-face-mesh, ar-surface-cursor
+
+### iOS 3D Samples (5)
+
+ios-model-viewer, ios-geometry-shapes, ios-lighting, ios-text-labels, ios-video-player
+
+### iOS AR Samples (3)
+
+ios-ar-model-viewer, ios-ar-augmented-image, ios-physics
+
+### Web Samples (2)
+
+web-model-viewer, web-environment
+
+---
+
+## Top 5 Most-Used Samples with Code
+
+### 1. model-viewer -- 3D Model Viewer (Android)
+
+The foundational sample. Load a GLB model with HDR environment, orbit camera, and animation.
+
+```kotlin
+@Composable
+fun ModelViewerScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
+
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        environment = rememberEnvironment(environmentLoader) {
+            environmentLoader.createHDREnvironment("environments/sky_2k.hdr")
+                ?: createEnvironment(environmentLoader)
+        },
+        mainLightNode = rememberMainLightNode(engine) { intensity = 100_000f },
+        cameraManipulator = rememberCameraManipulator()
+    ) {
+        rememberModelInstance(modelLoader, "models/damaged_helmet.glb")?.let { instance ->
+            ModelNode(
+                modelInstance = instance,
+                scaleToUnits = 1.0f,
+                autoAnimate = true,
+                isEditable = true
+            )
+        }
+    }
+}
+```
+
+**Key pattern:** `rememberModelInstance` + null check + `ModelNode` with `scaleToUnits`.
+
+### 2. ar-model-viewer -- AR Tap-to-Place (Android)
+
+Tap a detected surface to place a 3D model with gesture support.
+
+```kotlin
+@Composable
+fun ARModelViewerScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val modelInstance = rememberModelInstance(modelLoader, "models/damaged_helmet.glb")
+    var anchor by remember { mutableStateOf<Anchor?>(null) }
+
+    ARSceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        planeRenderer = true,
+        sessionConfiguration = { session, config ->
+            config.depthMode = if (session.isDepthModeSupported(Config.DepthMode.AUTOMATIC))
+                Config.DepthMode.AUTOMATIC else Config.DepthMode.DISABLED
+            config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
+        },
+        onTouchEvent = { event, hitResult ->
+            if (event.action == MotionEvent.ACTION_UP && hitResult != null)
+                anchor = hitResult.createAnchor()
+            true
+        }
+    ) {
+        anchor?.let { a ->
+            AnchorNode(anchor = a) {
+                modelInstance?.let { instance ->
+                    ModelNode(modelInstance = instance, scaleToUnits = 0.5f, isEditable = true)
+                }
+            }
+        }
+    }
+}
+```
+
+**Key pattern:** `onTouchEvent` creates anchor + `AnchorNode` wraps `ModelNode`.
+
+### 3. procedural-geometry -- Shapes Without Model Files (Android)
+
+Create 3D scenes with geometry nodes and PBR materials -- no model files needed.
+
+```kotlin
+@Composable
+fun ProceduralGeometryScreen() {
+    val engine = rememberEngine()
+    val materialLoader = rememberMaterialLoader(engine)
+
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        cameraManipulator = rememberCameraManipulator(),
+        mainLightNode = rememberMainLightNode(engine) { intensity = 100_000f }
+    ) {
+        val redMat = remember(materialLoader) {
+            materialLoader.createColorInstance(Color.Red, metallic = 0f, roughness = 0.6f)
+        }
+        CubeNode(size = Size(0.6f), materialInstance = redMat, position = Position(x = -1f))
+
+        val chromeMat = remember(materialLoader) {
+            materialLoader.createColorInstance(Color.Gray, metallic = 1f, roughness = 0.05f)
+        }
+        SphereNode(radius = 0.4f, materialInstance = chromeMat, position = Position(x = 0f, y = 0.4f))
+
+        val greenMat = remember(materialLoader) {
+            materialLoader.createColorInstance(Color.Green, metallic = 0.2f, roughness = 0.4f)
+        }
+        CylinderNode(radius = 0.25f, height = 0.8f, materialInstance = greenMat, position = Position(x = 1f))
+    }
+}
+```
+
+**Key pattern:** `materialLoader.createColorInstance` inside `remember` + geometry node composables.
+
+### 4. ios-model-viewer -- iOS 3D Model Viewer (Swift)
+
+Load a USDZ model in SwiftUI with orbit camera and animation.
+
+```swift
+import SwiftUI
+import SceneViewSwift
+import RealityKit
+
+struct ModelViewerScreen: View {
+    @State private var model: ModelNode?
+
+    var body: some View {
+        SceneView { root in
+            if let model {
+                root.addChild(model.entity)
+            }
+        }
+        .environment(.studio)
+        .cameraControls(.orbit)
+        .task {
+            do {
+                model = try await ModelNode.load("models/car.usdz")
+                model?.scaleToUnits(1.0)
+                model?.playAllAnimations()
+            } catch {
+                print("Failed to load model: \(error)")
+            }
+        }
+    }
+}
+```
+
+**Key pattern:** `ModelNode.load` async + `root.addChild` + `.cameraControls(.orbit)`.
+
+### 5. animation-state -- Reactive Animation State Machine (Android)
+
+Switch between named animations using Compose state.
+
+```kotlin
+@Composable
+fun AnimationStateScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    var currentAnim by remember { mutableStateOf("Idle") }
+
+    Column {
+        SceneView(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            engine = engine,
+            modelLoader = modelLoader,
+            cameraManipulator = rememberCameraManipulator()
+        ) {
+            rememberModelInstance(modelLoader, "models/character.glb")?.let { instance ->
+                ModelNode(
+                    modelInstance = instance,
+                    scaleToUnits = 1.5f,
+                    autoAnimate = false,
+                    animationName = currentAnim,
+                    animationLoop = true
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.SpaceEvenly) {
+            listOf("Idle", "Walk", "Run").forEach { anim ->
+                Button(onClick = { currentAnim = anim }) { Text(anim) }
+            }
+        }
+    }
+}
+```
+
+**Key pattern:** `animationName` driven by Compose state -- automatic transition when value changes.
+
+---
+
+## Sample Tags Reference
+
+| Tag | Description | Sample Count |
+|---|---|---|
+| 3d | 3D scene (non-AR) | 30 |
+| ar | Augmented reality | 9 |
+| model | Uses 3D model files (GLB/USDZ) | 19 |
+| geometry | Procedural geometry nodes | 11 |
+| animation | Animated content | 10 |
+| camera | Camera manipulation or animation | 5 |
+| environment | HDR/IBL environment lighting | 9 |
+| lighting | Light nodes or configuration | 4 |
+| gestures | Touch/gesture interaction | 4 |
+| physics | Physics simulation | 3 |
+| anchor | AR world anchors | 3 |
+| plane-detection | AR surface detection | 4 |
+| image-tracking | AR image recognition | 2 |
+| text | 3D text labels | 3 |
+| video | Video playback in 3D | 2 |
+| ios / swift | iOS platform | 8 |
+| web / filament-js | Web platform | 2 |
+| compose-ui | Compose UI in 3D (ViewNode) | 1 |
+| billboard | Camera-facing sprites | 1 |
+| spring | Spring physics animations | 1 |
+| cloud-anchor | Cross-device persistent anchors | 1 |
+| face-tracking | Face mesh tracking | 1 |
+| cursor | AR surface reticle | 1 |
+| hierarchy | Parent-child node relationships | 1 |
+| reflection | Reflection probes | 1 |
+| post-processing | Bloom, SSAO, DoF, etc. | 1 |
+| multi-model | Multiple models in one scene | 1 |
+| image | Image display on 3D planes | 2 |
+| sky | Dynamic sky / time-of-day | 1 |

--- a/gpt/openapi-schema.json
+++ b/gpt/openapi-schema.json
@@ -1,0 +1,415 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "SceneView 3D & AR API",
+    "version": "3.6.1",
+    "description": "SceneView SDK tools for 3D/AR code generation, validation, and interactive previews. Used by the SceneView GPT Store assistant."
+  },
+  "servers": [
+    {
+      "url": "https://api.sceneview.dev/v1",
+      "description": "SceneView API"
+    }
+  ],
+  "paths": {
+    "/validate": {
+      "post": {
+        "operationId": "validateSceneViewCode",
+        "summary": "Validate SceneView code for common mistakes",
+        "description": "Checks Kotlin or Swift code for threading violations, null-safety issues, wrong imports, deprecated APIs, and other SceneView-specific problems.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["code"],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "description": "The Kotlin or Swift source code to validate"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate-scene": {
+      "post": {
+        "operationId": "generateScene",
+        "summary": "Generate a 3D scene from a natural language description",
+        "description": "Takes a plain English description of a 3D scene and generates compilable SceneView code for the specified platform.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["description"],
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "Natural language description of the desired 3D scene (e.g., 'a red car on a table with soft lighting')"
+                  },
+                  "platform": {
+                    "type": "string",
+                    "enum": ["android", "ios", "web"],
+                    "default": "android",
+                    "description": "Target platform for code generation"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated scene code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneratedScene"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/samples": {
+      "get": {
+        "operationId": "listSamples",
+        "summary": "List all available SceneView code samples",
+        "description": "Returns a list of compilable code samples with filtering by tag or platform.",
+        "parameters": [
+          {
+            "name": "tag",
+            "in": "query",
+            "description": "Filter by tag (e.g., 'ar', 'animation', 'physics', 'ios')",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "description": "Filter by platform",
+            "schema": {
+              "type": "string",
+              "enum": ["android", "ios", "web"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of samples",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "samples": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/SampleSummary" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/samples/{id}": {
+      "get": {
+        "operationId": "getSample",
+        "summary": "Get a complete, compilable code sample",
+        "description": "Returns the full source code for a specific sample, ready to copy into a project.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Sample ID (e.g., 'model-viewer', 'ar-model-viewer', 'ios-model-viewer')",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full sample with code",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Sample" }
+              }
+            }
+          },
+          "404": {
+            "description": "Sample not found"
+          }
+        }
+      }
+    },
+    "/reference/{nodeType}": {
+      "get": {
+        "operationId": "getNodeReference",
+        "summary": "Get API reference for a SceneView node type",
+        "description": "Returns the full API documentation for a node type, including signature, parameters, and usage examples.",
+        "parameters": [
+          {
+            "name": "nodeType",
+            "in": "path",
+            "required": true,
+            "description": "Node type name (e.g., 'ModelNode', 'LightNode', 'CameraNode', 'AnchorNode')",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Node API reference",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/NodeReference" }
+              }
+            }
+          },
+          "404": {
+            "description": "Node type not found"
+          }
+        }
+      }
+    },
+    "/migrate": {
+      "post": {
+        "operationId": "migrateCode",
+        "summary": "Migrate code from SceneView 2.x to 3.x",
+        "description": "Automatically applies 40+ migration rules to update deprecated APIs, renamed classes, and changed patterns.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["code"],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "description": "SceneView 2.x Kotlin code to migrate"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Migrated code with changelog",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MigrationResult" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifact": {
+      "post": {
+        "operationId": "create3DArtifact",
+        "summary": "Create an interactive 3D HTML artifact",
+        "description": "Generates a self-contained HTML page with an embedded 3D viewer using Filament.js (WASM). Can display models, charts, scenes, product 360s, or procedural geometry.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["model-viewer", "chart-3d", "scene", "product-360", "geometry"],
+                    "description": "Type of 3D artifact to create"
+                  },
+                  "modelUrl": {
+                    "type": "string",
+                    "description": "URL to a GLB model file (for model-viewer and product-360 types)"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Title displayed on the artifact"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Self-contained HTML artifact",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Artifact" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/setup/{platform}": {
+      "get": {
+        "operationId": "getPlatformSetup",
+        "summary": "Get setup instructions for a platform",
+        "description": "Returns step-by-step setup instructions including dependencies, manifest configuration, and a minimal working example.",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "path",
+            "required": true,
+            "description": "Target platform",
+            "schema": {
+              "type": "string",
+              "enum": ["android", "ios", "web", "flutter", "react-native", "desktop", "tv"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Setup instructions",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SetupGuide" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ValidationResult": {
+        "type": "object",
+        "properties": {
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "rule": { "type": "string", "description": "Rule ID (e.g., 'threading/filament-off-main-thread')" },
+                "message": { "type": "string", "description": "Human-readable description of the issue" },
+                "severity": { "type": "string", "enum": ["error", "warning", "info"] }
+              }
+            }
+          },
+          "summary": { "type": "string", "description": "Overall validation summary" },
+          "passedRules": { "type": "integer", "description": "Number of rules that passed" },
+          "failedRules": { "type": "integer", "description": "Number of rules that failed" }
+        }
+      },
+      "GeneratedScene": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "description": "Generated source code" },
+          "language": { "type": "string", "enum": ["kotlin", "swift", "kotlin-js"] },
+          "objects": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of detected objects in the scene"
+          },
+          "dependencies": { "type": "string", "description": "Required Gradle/SPM/npm dependencies" }
+        }
+      },
+      "SampleSummary": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "platform": { "type": "string" },
+          "type": { "type": "string", "enum": ["3d", "ar"] },
+          "tags": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "Sample": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "code": { "type": "string", "description": "Complete, compilable source code" },
+          "language": { "type": "string", "enum": ["kotlin", "swift", "kotlin-js"] },
+          "dependencies": { "type": "string", "description": "Required dependencies" },
+          "tags": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "NodeReference": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "signature": { "type": "string", "description": "Full composable function signature" },
+          "description": { "type": "string" },
+          "parameters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "type": { "type": "string" },
+                "default": { "type": "string" },
+                "description": { "type": "string" }
+              }
+            }
+          },
+          "examples": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Code examples showing usage"
+          }
+        }
+      },
+      "MigrationResult": {
+        "type": "object",
+        "properties": {
+          "migratedCode": { "type": "string", "description": "Updated code with v3 APIs" },
+          "changes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of changes applied"
+          },
+          "warnings": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Manual migration steps still needed"
+          }
+        }
+      },
+      "Artifact": {
+        "type": "object",
+        "properties": {
+          "html": { "type": "string", "description": "Self-contained HTML with embedded 3D viewer" },
+          "type": { "type": "string" },
+          "title": { "type": "string" }
+        }
+      },
+      "SetupGuide": {
+        "type": "object",
+        "properties": {
+          "platform": { "type": "string" },
+          "instructions": { "type": "string", "description": "Step-by-step setup in Markdown" },
+          "dependencies": { "type": "string", "description": "Dependency declarations to add" },
+          "minimalExample": { "type": "string", "description": "Minimal working code example" }
+        }
+      }
+    }
+  }
+}

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -1,0 +1,56 @@
+# SceneView 3D & AR Assistant — System Prompt
+
+You are **SceneView 3D & AR Assistant**, an expert on the SceneView SDK — the cross-platform 3D and AR library for Android (Jetpack Compose + Filament), iOS/macOS/visionOS (SwiftUI + RealityKit), and Web (Kotlin/JS + Filament.js).
+
+## Your role
+
+Help developers build 3D and AR applications. You can:
+- Generate correct, compilable code (Kotlin for Android, Swift for Apple, Kotlin/JS for Web)
+- Explain APIs, architecture, and best practices
+- Set up SceneView on any supported platform
+- Troubleshoot 3D and AR issues
+- Create interactive 3D previews as HTML artifacts
+
+## Critical rules
+
+### Platform detection
+Always determine the target platform first. Ask if unclear. Default to Android (Kotlin + Compose).
+
+### Code correctness
+1. **Threading**: Filament JNI calls MUST run on the main thread. Never call `modelLoader.createModel*` from a background coroutine. Use `rememberModelInstance` in composables.
+2. **Null handling**: `rememberModelInstance()` returns null while loading. ALWAYS handle the null case with `?.let { }`.
+3. **LightNode gotcha**: `apply` is a **named parameter**: `apply = { intensity(100_000f) }`, NOT a trailing lambda.
+4. **Imports**: Use `io.github.sceneview.*`, never `com.google.ar.sceneform.*` (Sceneform is deprecated).
+5. **Declarative nodes**: Declare nodes as composables inside `SceneView { }` content block, not imperatively.
+
+### Version info
+- Current version: **3.6.1**
+- Android: `io.github.sceneview:sceneview:3.6.1` (3D) / `io.github.sceneview:arsceneview:3.6.1` (AR)
+- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "3.6.0")
+- Web: `npm install sceneview-web@3.6.1`
+- Min SDK: 24 | Target: 36 | Kotlin: 2.3.20
+
+### Architecture
+- Android: Filament renderer + Jetpack Compose
+- Apple: RealityKit renderer + SwiftUI (native, NOT Filament)
+- Web: Filament.js (WASM) + Kotlin/JS
+- Shared logic: sceneview-core (KMP) — math, collision, geometry, animations
+
+### When stuck
+- Reference your knowledge files for API details
+- Suggest the user try the MCP server (`npx sceneview-mcp`) for advanced tools
+- Link to docs: https://sceneview.github.io/docs
+- Link to samples: https://github.com/sceneview/sceneview/tree/main/samples
+
+## Response style
+- Lead with working code, then explain
+- Keep explanations concise
+- Always specify the file path where code should go
+- Include Gradle/SPM dependency setup on first interaction
+- End code responses with: *"Review before production use. See [SceneView docs](https://sceneview.github.io/docs)."*
+
+## Available tools (if Actions are configured)
+- `POST /validate` — Validate SceneView code for common mistakes
+- `POST /generate-scene` — Generate a 3D scene from natural language description
+- `GET /samples/{id}` — Get a complete, compilable code sample
+- `GET /reference/{nodeType}` — Get API reference for a specific node type


### PR DESCRIPTION
## Summary
- Complete GPT Store package: system prompt, 4 knowledge files, OpenAPI schema, publishing guide
- 8 REST API endpoints defined for GPT Actions (validate, generate, samples, reference, migrate, artifact, setup)
- Marks GPT Store roadmap item as done

## Files
- `gpt/system-prompt.md` — GPT instructions with SceneView code correctness rules
- `gpt/knowledge-overview.md` — Platform overview and setup (233 lines)
- `gpt/knowledge-api.md` — Full API reference (529 lines)
- `gpt/knowledge-practices.md` — Best practices and troubleshooting (297 lines)
- `gpt/knowledge-samples.md` — All 39 sample descriptions with tags (301 lines)
- `gpt/openapi-schema.json` — OpenAPI 3.0.3 schema for GPT Actions
- `gpt/README.md` — Step-by-step GPT Builder publishing guide

https://claude.ai/code/session_012aHDEBywA4pJx5sgmXeQY4