### PR TITLE
feat(mcp): add analyze_project tool (local project scan)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -113,6 +113,7 @@ Same JSON config as above. The server communicates via **stdio** using the stand
 | `get_gesture_guide` | Guide for gestures: isEditable, onTouchEvent, tap-to-place, drag-to-rotate, pinch-to-scale |
 | `get_performance_tips` | Performance optimization: LOD, texture compression, instancing, profiling with Systrace/AGI |
 | `search_models` | Searches Sketchfab for free 3D models matching a query (BYOK — set `SKETCHFAB_API_KEY`) |
+| `analyze_project` | Scans a local SceneView project on disk — detects platform, extracts version, flags outdated deps and known anti-patterns (threading, LightNode bug, 2.x APIs) |
 
 #### `search_models` — find real 3D assets from the AI
 
@@ -137,6 +138,17 @@ Generated SceneView code is only useful if it points at an asset that actually e
 ```
 
 Call it like `search_models({ query: "red sports car", category: "cars-vehicles", maxResults: 6 })`. If the key is missing, the tool returns a clear message explaining how to get one instead of failing silently.
+
+#### `analyze_project` — local project scan
+
+Because the MCP server runs on the user's machine, `analyze_project` can read their project files directly. Given a `path` (default: `process.cwd()`), it:
+
+- Detects the project type by looking for `build.gradle(.kts)` with `io.github.sceneview:sceneview` (Android), `Package.swift` with `SceneViewSwift` (iOS), or `package.json` with `sceneview-web` (Web).
+- Extracts the SceneView dependency version and compares it against the latest release known to this MCP build, flagging outdated projects.
+- Walks up to **30** source files (`.kt`, `.kts`, `.swift`, `.js`, `.ts`) and up to **500 KB** total, scanning for well-known anti-patterns: Filament/ModelLoader calls inside background coroutines, the `LightNode(...) { ... }` trailing-lambda bug, deprecated 2.x APIs (`ArSceneView`, `TransformableNode`, `PlacementNode`, `ViewRenderable`, `loadModelAsync`), and `com.google.ar.sceneform.*` imports.
+- Returns a structured `{ projectType, sceneViewVersion, latestVersion, isOutdated, warnings, suggestions }` report, plus a Markdown summary.
+
+The tool is read-only, never writes to disk, and gracefully handles missing directories. Use it when the user asks "is my project up to date?" or as a quick sanity check before generating new code for an existing codebase.
 
 ### 2 resources
 

--- a/mcp/src/__fixtures__/analyze-project/android-ok/app/src/main/java/com/example/ok/MainActivity.kt
+++ b/mcp/src/__fixtures__/analyze-project/android-ok/app/src/main/java/com/example/ok/MainActivity.kt
@@ -1,0 +1,20 @@
+package com.example.ok
+
+import androidx.compose.runtime.Composable
+import io.github.sceneview.Scene
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.node.ModelNode
+import io.github.sceneview.loaders.rememberModelInstance
+
+@Composable
+fun ModelScreen() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val modelInstance = rememberModelInstance(modelLoader, "models/chair.glb")
+    Scene(engine = engine) {
+        modelInstance?.let {
+            ModelNode(modelInstance = it)
+        }
+    }
+}

--- a/mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts
+++ b/mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts
@@ -1,0 +1,21 @@
+// Minimal Android fixture — latest SceneView, no anti-patterns.
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.ok"
+    compileSdk = 34
+    defaultConfig {
+        applicationId = "com.example.ok"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+}
+
+dependencies {
+    implementation("io.github.sceneview:sceneview:3.6.2")
+}

--- a/mcp/src/__fixtures__/analyze-project/android-with-warnings/app/src/main/java/com/example/warn/BadScreen.kt
+++ b/mcp/src/__fixtures__/analyze-project/android-with-warnings/app/src/main/java/com/example/warn/BadScreen.kt
@@ -1,0 +1,25 @@
+package com.example.warn
+
+import androidx.compose.runtime.Composable
+import com.google.ar.sceneform.ux.ArFragment
+import io.github.sceneview.node.LightNode
+import io.github.sceneview.node.TransformableNode
+import io.github.sceneview.loaders.ModelLoader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+
+fun loadBad(scope: CoroutineScope, modelLoader: ModelLoader) {
+    scope.launch(Dispatchers.IO) {
+        modelLoader.createModelInstance("models/chair.glb")
+    }
+}
+
+@Composable
+fun BadLight(engine: Any) {
+    LightNode(engine = engine, type = 0) {
+        intensity(100_000f)
+    }
+    val t = TransformableNode(engine)
+    val af = ArFragment()
+}

--- a/mcp/src/__fixtures__/analyze-project/android-with-warnings/build.gradle.kts
+++ b/mcp/src/__fixtures__/analyze-project/android-with-warnings/build.gradle.kts
@@ -1,0 +1,15 @@
+// Android fixture — outdated version + multiple anti-patterns.
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.warn"
+    compileSdk = 34
+}
+
+dependencies {
+    // Old 2.x artifact, will be flagged as outdated.
+    implementation("io.github.sceneview:sceneview:2.2.1")
+}

--- a/mcp/src/__fixtures__/analyze-project/ios-outdated/Package.swift
+++ b/mcp/src/__fixtures__/analyze-project/ios-outdated/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "DemoApp",
+    platforms: [.iOS(.v17)],
+    dependencies: [
+        .package(url: "https://github.com/sceneview/sceneview", from: "3.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "DemoApp",
+            dependencies: [
+                .product(name: "SceneViewSwift", package: "sceneview")
+            ]
+        )
+    ]
+)

--- a/mcp/src/__fixtures__/analyze-project/ios-outdated/Sources/DemoApp/ContentView.swift
+++ b/mcp/src/__fixtures__/analyze-project/ios-outdated/Sources/DemoApp/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import SceneViewSwift
+import RealityKit
+
+struct ContentView: View {
+    @State private var model: ModelNode?
+
+    var body: some View {
+        SceneView { root in
+            if let model {
+                root.addChild(model.entity)
+            }
+        }
+        .task {
+            model = try? await ModelNode.load("models/robot.usdz")
+        }
+    }
+}

--- a/mcp/src/analyze-project.test.ts
+++ b/mcp/src/analyze-project.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+
+import {
+  analyzeProject,
+  formatAnalysisReport,
+  LATEST_SCENEVIEW_VERSION,
+  MAX_FILES_SCANNED,
+} from "./analyze-project.js";
+
+// Resolve the on-disk fixture directory. Fixtures live in `src/__fixtures__`
+// and are NOT copied to `dist/` by tsc (non-TS files are ignored). To make
+// the same test file runnable from either the `src/` sources or the compiled
+// `dist/` output, we locate the fixtures by walking up from `import.meta.url`
+// until we find the `src/__fixtures__/analyze-project` directory.
+function resolveFixtures(): string {
+  const hereDir = path.dirname(fileURLToPath(import.meta.url));
+  // `hereDir` is either `<repo>/mcp/src` or `<repo>/mcp/dist`. From either we
+  // go up to `<repo>/mcp` and descend into `src/__fixtures__/analyze-project`.
+  const mcpDir = path.dirname(hereDir);
+  return path.join(mcpDir, "src", "__fixtures__", "analyze-project");
+}
+
+const FIXTURES = resolveFixtures();
+
+const ANDROID_OK = path.join(FIXTURES, "android-ok");
+const ANDROID_WARN = path.join(FIXTURES, "android-with-warnings");
+const IOS_OUTDATED = path.join(FIXTURES, "ios-outdated");
+
+describe("analyzeProject — project type detection", () => {
+  it("detects an Android project via build.gradle.kts", async () => {
+    const result = await analyzeProject({ path: ANDROID_OK });
+    expect(result.projectType).toBe("android");
+    expect(result.sceneViewVersion).toBe("3.6.2");
+    expect(result.isOutdated).toBe(false);
+    expect(result.latestVersion).toBe(LATEST_SCENEVIEW_VERSION);
+  });
+
+  it("detects an iOS project via Package.swift", async () => {
+    const result = await analyzeProject({ path: IOS_OUTDATED });
+    expect(result.projectType).toBe("ios");
+    expect(result.sceneViewVersion).toBe("3.0.0");
+  });
+
+  it("flags an iOS project as outdated", async () => {
+    const result = await analyzeProject({ path: IOS_OUTDATED });
+    expect(result.isOutdated).toBe(true);
+    expect(result.suggestions.some((s) => s.type === "suggestion/upgrade-sceneview")).toBe(true);
+  });
+
+  it("returns unknown projectType + warning when no dep is found", async () => {
+    // Create an empty temp dir with just a placeholder file.
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "sv-analyze-empty-"));
+    try {
+      await fs.writeFile(path.join(tmp, "README.md"), "# empty");
+      const result = await analyzeProject({ path: tmp });
+      expect(result.projectType).toBe("unknown");
+      expect(result.sceneViewVersion).toBeNull();
+      expect(result.warnings.some((w) => w.type === "scan/no-sceneview-dependency")).toBe(true);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("analyzeProject — version extraction", () => {
+  it("extracts the patch version from a Gradle dependency string", async () => {
+    const result = await analyzeProject({ path: ANDROID_OK });
+    expect(result.sceneViewVersion).toBe("3.6.2");
+  });
+
+  it("extracts the version from a Package.swift `from:` clause", async () => {
+    const result = await analyzeProject({ path: IOS_OUTDATED });
+    expect(result.sceneViewVersion).toBe("3.0.0");
+  });
+
+  it("detects an outdated Android project", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    expect(result.projectType).toBe("android");
+    expect(result.sceneViewVersion).toBe("2.2.1");
+    expect(result.isOutdated).toBe(true);
+  });
+});
+
+describe("analyzeProject — anti-pattern detection", () => {
+  it("flags threading violations in the warnings fixture", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    const threadingWarnings = result.warnings.filter(
+      (w) => w.type === "threading/filament-off-main-thread",
+    );
+    expect(threadingWarnings.length).toBeGreaterThan(0);
+    expect(threadingWarnings[0].line).toBeGreaterThan(0);
+  });
+
+  it("flags the LightNode trailing-lambda bug", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    expect(result.warnings.some((w) => w.type === "api/light-node-trailing-lambda")).toBe(true);
+  });
+
+  it("flags TransformableNode as deprecated 2.x API", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    expect(result.warnings.some((w) => w.type === "migration/transformable-node-removed")).toBe(
+      true,
+    );
+  });
+
+  it("flags a Sceneform import", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    expect(result.warnings.some((w) => w.type === "migration/sceneform-import")).toBe(true);
+  });
+
+  it("adds a run-migrate-code suggestion when migration warnings exist", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    expect(result.suggestions.some((s) => s.type === "suggestion/run-migrate-code")).toBe(true);
+  });
+
+  it("does NOT report anti-patterns in a clean Android project", async () => {
+    const result = await analyzeProject({ path: ANDROID_OK });
+    const nonScanWarnings = result.warnings.filter((w) => !w.type.startsWith("scan/"));
+    expect(nonScanWarnings).toHaveLength(0);
+    expect(result.suggestions.some((s) => s.type === "suggestion/no-issues")).toBe(true);
+  });
+});
+
+describe("analyzeProject — graceful error handling", () => {
+  it("returns an error warning for a missing directory", async () => {
+    const bogus = path.join(os.tmpdir(), `sv-analyze-missing-${Date.now()}`);
+    const result = await analyzeProject({ path: bogus });
+    expect(result.projectType).toBe("unknown");
+    expect(result.warnings.some((w) => w.type === "scan/path-not-found")).toBe(true);
+    // Should NOT throw and should still return a structured result.
+    expect(result.latestVersion).toBe(LATEST_SCENEVIEW_VERSION);
+  });
+
+  it("returns a not-a-directory warning when the path is a file", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "sv-analyze-file-"));
+    const filePath = path.join(tmp, "a.txt");
+    await fs.writeFile(filePath, "hello");
+    try {
+      const result = await analyzeProject({ path: filePath });
+      expect(result.warnings.some((w) => w.type === "scan/not-a-directory")).toBe(true);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("handles an empty directory gracefully", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "sv-analyze-empty2-"));
+    try {
+      const result = await analyzeProject({ path: tmp });
+      expect(result.projectType).toBe("unknown");
+      expect(result.warnings.some((w) => w.type === "scan/no-sceneview-dependency")).toBe(true);
+      expect(result.filesScanned).toBe(0);
+      expect(result.bytesScanned).toBe(0);
+      expect(result.truncated).toBe(false);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults path to process.cwd() when none is provided", async () => {
+    // Easiest observable: when run from the repo root (Vitest cwd), this may or
+    // may not detect a SceneView dep depending on where tests run. We just
+    // verify the function returns a well-formed result.
+    const result = await analyzeProject();
+    expect(typeof result.projectType).toBe("string");
+    expect(result.scannedPath).toBe(path.resolve(process.cwd()));
+  });
+});
+
+describe("analyzeProject — formatting", () => {
+  it("renders a Markdown report with headings and counts", async () => {
+    const result = await analyzeProject({ path: ANDROID_WARN });
+    const report = formatAnalysisReport(result);
+    expect(report).toContain("## SceneView project analysis");
+    expect(report).toContain("**Project type:** android");
+    expect(report).toContain("Warnings");
+  });
+
+  it("renders a clean report when there are no anti-pattern warnings", async () => {
+    const result = await analyzeProject({ path: ANDROID_OK });
+    const report = formatAnalysisReport(result);
+    expect(report).toContain("## SceneView project analysis");
+    expect(report).toContain("**Project type:** android");
+    // Should not list migration warnings for a clean project.
+    expect(report).not.toContain("TransformableNode");
+  });
+});
+
+describe("analyzeProject — scan limits", () => {
+  // Guard-rails: ensure constants haven't been silently loosened.
+  it("caps at no more than 30 files by default", () => {
+    expect(MAX_FILES_SCANNED).toBeLessThanOrEqual(30);
+  });
+
+  it("respects the file cap when more than 30 source files exist", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "sv-analyze-cap-"));
+    try {
+      // Minimal Gradle build so it's detected as Android.
+      await fs.writeFile(
+        path.join(tmp, "build.gradle.kts"),
+        'dependencies {\n  implementation("io.github.sceneview:sceneview:3.6.2")\n}\n',
+      );
+      const srcDir = path.join(tmp, "src");
+      await fs.mkdir(srcDir, { recursive: true });
+      for (let i = 0; i < 45; i++) {
+        await fs.writeFile(path.join(srcDir, `File${i}.kt`), `// file ${i}\nval x${i} = ${i}\n`);
+      }
+      const result = await analyzeProject({ path: tmp });
+      expect(result.projectType).toBe("android");
+      expect(result.filesScanned).toBeLessThanOrEqual(MAX_FILES_SCANNED);
+      expect(result.truncated).toBe(true);
+      expect(result.warnings.some((w) => w.type === "scan/truncated")).toBe(true);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp/src/analyze-project.ts
+++ b/mcp/src/analyze-project.ts
@@ -1,0 +1,644 @@
+/**
+ * analyze-project — local filesystem scan of a SceneView project.
+ *
+ * Because the SceneView MCP server runs on the user's machine, we can read
+ * their project files directly: detect the platform (Android / iOS / Web),
+ * extract the SceneView dependency version, compare against the latest known
+ * release, and scan source files for well-known anti-patterns (threading
+ * violations, LightNode trailing-lambda bug, deprecated 2.x APIs, …).
+ *
+ * This is the first real *agentic* tool in the MCP — previous tools were
+ * static getters, this one actually inspects the caller's filesystem to
+ * produce a tailored report.
+ *
+ * Hard safety limits:
+ *   - at most {@link MAX_FILES_SCANNED} source files read
+ *   - at most {@link MAX_BYTES_SCANNED} bytes read in total
+ *   - at most {@link MAX_DIR_DEPTH} directory levels traversed
+ *
+ * When any limit is hit we stop walking and return a warning so the caller
+ * knows the scan was truncated — we never throw.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** The latest SceneView release known to this build of the MCP. */
+export const LATEST_SCENEVIEW_VERSION = "3.6.2";
+
+/** Hard cap on the number of source files inspected per call. */
+export const MAX_FILES_SCANNED = 30;
+
+/** Hard cap on total bytes read across all source files per call (500 KB). */
+export const MAX_BYTES_SCANNED = 500 * 1024;
+
+/** Max directory tree depth traversed from the project root. */
+export const MAX_DIR_DEPTH = 12;
+
+/** Directories we never recurse into (build outputs, caches, vendored deps). */
+const SKIP_DIRS = new Set<string>([
+  "node_modules",
+  ".git",
+  "build",
+  "dist",
+  ".gradle",
+  ".idea",
+  ".vscode",
+  ".claude",
+  "Pods",
+  "DerivedData",
+  ".build",
+  "out",
+  "target",
+]);
+
+/** File extensions we consider "source" for anti-pattern scanning. */
+const SOURCE_EXTENSIONS = new Set<string>([".kt", ".kts", ".swift", ".js", ".mjs", ".ts", ".tsx"]);
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type ProjectType = "android" | "ios" | "web" | "unknown";
+
+export interface AnalysisWarning {
+  /** Absolute file path the warning was found in, or a sentinel like `<scan>`. */
+  file: string;
+  /** 1-based line number, when the detector tracks it. */
+  line?: number;
+  /** Stable machine-readable warning id. */
+  type: string;
+  /** Human-readable explanation. */
+  message: string;
+}
+
+export interface AnalysisSuggestion {
+  /** Stable machine-readable suggestion id. */
+  type: string;
+  /** Human-readable recommendation. */
+  message: string;
+}
+
+export interface AnalysisResult {
+  /** Detected project type, or `"unknown"` if nothing matched. */
+  projectType: ProjectType;
+  /** The extracted SceneView dependency version, or `null` if none found. */
+  sceneViewVersion: string | null;
+  /** Latest version this MCP build is aware of. */
+  latestVersion: string;
+  /** True when {@link sceneViewVersion} is strictly older than {@link latestVersion}. */
+  isOutdated: boolean;
+  /** Any anti-patterns or scan-level concerns found, in the order they were discovered. */
+  warnings: AnalysisWarning[];
+  /** Recommended follow-ups derived from the analysis (upgrade, run validator, …). */
+  suggestions: AnalysisSuggestion[];
+  /** The absolute path that was actually scanned (after resolution / default). */
+  scannedPath: string;
+  /** Number of files actually read during the anti-pattern scan. */
+  filesScanned: number;
+  /** Total bytes actually read during the anti-pattern scan. */
+  bytesScanned: number;
+  /** When `true`, the scan was truncated because a hard limit was reached. */
+  truncated: boolean;
+}
+
+export interface AnalyzeProjectInput {
+  /** Absolute or relative path to the project root. Defaults to `process.cwd()`. */
+  path?: string;
+}
+
+// ─── Anti-pattern detectors ──────────────────────────────────────────────────
+
+interface AntiPatternDetector {
+  id: string;
+  /** Which languages this detector applies to — others are skipped for speed. */
+  languages: ReadonlySet<"kotlin" | "swift" | "js">;
+  /** Regex that, if matched, triggers the detector. */
+  pattern: RegExp;
+  /** Human-readable explanation returned in the warning. */
+  message: string;
+  /**
+   * Optional extra guard: runs on the full file contents after the line
+   * pattern matches. Used for cross-line context (e.g. "inside a `launch {`"
+   * for the threading rule).
+   */
+  fileGuard?: (fileContents: string) => boolean;
+}
+
+/**
+ * The curated list of anti-patterns we scan for. This is a deliberately
+ * smaller subset of the full `validator.ts` rules — the goal here is "fast
+ * sanity check of an entire project", not a per-file lint pass.
+ *
+ * Covered:
+ *   - threading: Filament/ModelLoader calls inside a background launch block
+ *   - API misuse: LightNode trailing-lambda bug
+ *   - 2.x deprecated APIs: ArSceneView, TransformableNode, PlacementNode,
+ *     ViewRenderable, loadModelAsync, Sceneform imports
+ */
+const ANTI_PATTERNS: AntiPatternDetector[] = [
+  // ─── Threading: modelLoader.createModel* inside a non-main launch ──────────
+  {
+    id: "threading/filament-off-main-thread",
+    languages: new Set(["kotlin"]),
+    pattern: /modelLoader\s*\.\s*createModel\w*\s*\(/,
+    message:
+      "`modelLoader.createModel*` is called in a file that also uses a background coroutine " +
+      "(`launch {` / `Dispatchers.IO` / `Dispatchers.Default`). Filament JNI calls must run on " +
+      "the main thread. Use `rememberModelInstance(modelLoader, path)` in composables, or " +
+      "`withContext(Dispatchers.Main)` in imperative code.",
+    fileGuard: (contents) =>
+      /\blaunch\s*\(?\s*Dispatchers\.(IO|Default)\b/.test(contents) ||
+      /\blaunch\s*\{/.test(contents) ||
+      /\bwithContext\s*\(\s*Dispatchers\.(IO|Default)\b/.test(contents),
+  },
+
+  // ─── API: LightNode(...) { ... } trailing-lambda bug ───────────────────────
+  {
+    id: "api/light-node-trailing-lambda",
+    languages: new Set(["kotlin"]),
+    pattern: /\bLightNode\s*\([^)]*\)\s*\{/,
+    message:
+      "`LightNode`'s configuration block is a **named parameter** `apply`, not a trailing " +
+      "lambda. Write `LightNode(engine = engine, type = ..., apply = { intensity(100_000f) })`. " +
+      "Without `apply =` the block is silently ignored.",
+  },
+
+  // ─── Deprecated 2.x APIs ───────────────────────────────────────────────────
+  {
+    id: "migration/ar-scene-view-rename",
+    languages: new Set(["kotlin"]),
+    pattern: /\bArSceneView\s*\(/,
+    message:
+      "`ArSceneView` was renamed to `ARSceneView` in SceneView 3.0. Update the call site " +
+      "(capital R). Run `migrate_code` for an automatic rewrite.",
+  },
+  {
+    id: "migration/transformable-node-removed",
+    languages: new Set(["kotlin"]),
+    pattern: /\bTransformableNode\b/,
+    message:
+      "`TransformableNode` was removed in SceneView 3.0. Set `isEditable = true` on a " +
+      "`ModelNode` or `GeometryNode` instead.",
+  },
+  {
+    id: "migration/placement-node-removed",
+    languages: new Set(["kotlin"]),
+    pattern: /\bPlacementNode\b/,
+    message:
+      "`PlacementNode` was removed in SceneView 3.0. Use `AnchorNode` + `HitResultNode` " +
+      "inside an `ARScene` instead.",
+  },
+  {
+    id: "migration/view-renderable-removed",
+    languages: new Set(["kotlin"]),
+    pattern: /\bViewRenderable\b/,
+    message:
+      "`ViewRenderable` was removed in SceneView 3.0. Use `ViewNode` with a `@Composable` " +
+      "content lambda instead.",
+  },
+  {
+    id: "migration/load-model-async",
+    languages: new Set(["kotlin"]),
+    pattern: /\bmodelLoader\s*\.\s*loadModelAsync\s*\(/,
+    message:
+      "`modelLoader.loadModelAsync` was removed in SceneView 3.0. Use " +
+      "`rememberModelInstance(modelLoader, path)` in composables, or " +
+      "`modelLoader.loadModelInstanceAsync(path)` in imperative code.",
+  },
+  {
+    id: "migration/sceneform-import",
+    languages: new Set(["kotlin"]),
+    pattern: /\bimport\s+com\.google\.ar\.sceneform\b/,
+    message:
+      "`com.google.ar.sceneform.*` was deprecated by Google in 2021. Replace with " +
+      "`io.github.sceneview.*` imports — SceneView is the official successor.",
+  },
+  {
+    id: "migration/scene-view-renamed",
+    languages: new Set(["kotlin"]),
+    pattern: /\bimport\s+com\.google\.ar\.sceneform\.ux\.ArFragment\b/,
+    message:
+      "`ArFragment` (Sceneform) removed. Replace with `ARScene { … }` composable from " +
+      "`io.github.sceneview.ar`.",
+  },
+];
+
+// ─── Core scanner ────────────────────────────────────────────────────────────
+
+type DetectedLanguage = "kotlin" | "swift" | "js";
+
+function languageOf(filePath: string): DetectedLanguage | null {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".kt" || ext === ".kts") return "kotlin";
+  if (ext === ".swift") return "swift";
+  if (ext === ".js" || ext === ".mjs" || ext === ".ts" || ext === ".tsx") return "js";
+  return null;
+}
+
+/** Walk `dir` depth-first and collect source files, respecting skip-dirs and depth. */
+async function collectSourceFiles(
+  rootDir: string,
+  dir: string,
+  depth: number,
+  out: string[],
+): Promise<void> {
+  if (depth > MAX_DIR_DEPTH) return;
+  if (out.length >= MAX_FILES_SCANNED) return;
+
+  let entries: { name: string; isDirectory: () => boolean; isFile: () => boolean }[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  // Deterministic order for reproducible tests.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    if (out.length >= MAX_FILES_SCANNED) return;
+    const abs = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
+      await collectSourceFiles(rootDir, abs, depth + 1, out);
+      continue;
+    }
+
+    if (!entry.isFile()) continue;
+    if (SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      out.push(abs);
+    }
+  }
+}
+
+// ─── Project type + version detection ────────────────────────────────────────
+
+interface ProjectDetection {
+  projectType: ProjectType;
+  sceneViewVersion: string | null;
+  /** The file the version was extracted from, for error reporting. */
+  sourceFile: string | null;
+}
+
+async function readFileSafe(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function tryRead(dir: string, ...relativeCandidates: string[]): Promise<{ path: string; contents: string } | null> {
+  for (const rel of relativeCandidates) {
+    const abs = path.join(dir, rel);
+    const contents = await readFileSafe(abs);
+    if (contents != null) return { path: abs, contents };
+  }
+  return null;
+}
+
+/** Extract `X.Y.Z` from a Gradle-style `io.github.sceneview:sceneview:X.Y.Z` reference. */
+function extractGradleVersion(contents: string): string | null {
+  const match = contents.match(
+    /io\.github\.sceneview:(?:sceneview|arsceneview|sceneview-core)[:"']?\s*[:"']?\s*(?:version\s*=\s*["'])?(\d+\.\d+\.\d+(?:-[\w.]+)?)/,
+  );
+  if (match) return match[1];
+  return null;
+}
+
+/** Extract `X.Y.Z` from a `Package.swift` `SceneViewSwift` dependency. */
+function extractSwiftVersion(contents: string): string | null {
+  // Matches `.package(url: ".../sceneview"..., from: "3.6.2")` or `.upToNextMajor(from: "3.6.0")`.
+  const fromMatch = contents.match(/sceneview[^"]*"[^)]*from:\s*"(\d+\.\d+\.\d+(?:-[\w.]+)?)"/i);
+  if (fromMatch) return fromMatch[1];
+  const exactMatch = contents.match(/sceneview[^"]*"[^)]*exact:\s*"(\d+\.\d+\.\d+(?:-[\w.]+)?)"/i);
+  if (exactMatch) return exactMatch[1];
+  const branchOrVersion = contents.match(/\.package\([^)]*sceneview[^)]*"(\d+\.\d+\.\d+)"/i);
+  if (branchOrVersion) return branchOrVersion[1];
+  return null;
+}
+
+/** Extract the `sceneview-web` version from a `package.json`. */
+function extractNpmVersion(contents: string): string | null {
+  try {
+    const pkg = JSON.parse(contents) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    for (const [name, spec] of Object.entries(deps)) {
+      if (name === "sceneview-web" || name === "@sceneview/sceneview-web") {
+        // Strip leading ^ / ~ / >= etc.
+        const cleaned = spec.replace(/^[^\d]*/, "");
+        const match = cleaned.match(/\d+\.\d+\.\d+(?:-[\w.]+)?/);
+        if (match) return match[0];
+      }
+    }
+  } catch {
+    // Not JSON — fall through.
+  }
+  return null;
+}
+
+async function detectProject(rootDir: string): Promise<ProjectDetection> {
+  // Android: build.gradle or build.gradle.kts anywhere reachable from root.
+  // We first check the root for speed, then one level down for typical module layouts.
+  const androidCandidates = [
+    "build.gradle.kts",
+    "build.gradle",
+    "app/build.gradle.kts",
+    "app/build.gradle",
+    "sample/build.gradle.kts",
+    "sample/build.gradle",
+  ];
+  for (const rel of androidCandidates) {
+    const read = await tryRead(rootDir, rel);
+    if (read && /io\.github\.sceneview:(sceneview|arsceneview|sceneview-core)/.test(read.contents)) {
+      return {
+        projectType: "android",
+        sceneViewVersion: extractGradleVersion(read.contents),
+        sourceFile: read.path,
+      };
+    }
+  }
+
+  // iOS: Package.swift at root mentioning SceneViewSwift.
+  const packageSwift = await tryRead(rootDir, "Package.swift");
+  if (packageSwift && /SceneViewSwift|sceneview\/sceneview/i.test(packageSwift.contents)) {
+    return {
+      projectType: "ios",
+      sceneViewVersion: extractSwiftVersion(packageSwift.contents),
+      sourceFile: packageSwift.path,
+    };
+  }
+
+  // Web: package.json referencing sceneview-web.
+  const packageJson = await tryRead(rootDir, "package.json");
+  if (packageJson && /"(?:@sceneview\/)?sceneview-web"/.test(packageJson.contents)) {
+    return {
+      projectType: "web",
+      sceneViewVersion: extractNpmVersion(packageJson.contents),
+      sourceFile: packageJson.path,
+    };
+  }
+
+  return { projectType: "unknown", sceneViewVersion: null, sourceFile: null };
+}
+
+// ─── Semver comparison (simple X.Y.Z) ────────────────────────────────────────
+
+/**
+ * Returns `true` when `version` is strictly older than `LATEST_SCENEVIEW_VERSION`.
+ * Falls back to `false` (don't flag) if either side fails to parse cleanly —
+ * we'd rather underreport than harass a user with a pre-release build.
+ */
+function isVersionOutdated(version: string | null): boolean {
+  if (!version) return false;
+  const parse = (v: string): [number, number, number] | null => {
+    const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!m) return null;
+    return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+  };
+  const a = parse(version);
+  const b = parse(LATEST_SCENEVIEW_VERSION);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] < b[i]) return true;
+    if (a[i] > b[i]) return false;
+  }
+  return false;
+}
+
+// ─── Public entrypoint ───────────────────────────────────────────────────────
+
+/**
+ * Scan a local SceneView project and return a structured analysis.
+ *
+ * Never throws for filesystem errors — missing directory, permission denied,
+ * broken file: all surface as a warning in the returned result.
+ */
+export async function analyzeProject(
+  input: AnalyzeProjectInput = {},
+): Promise<AnalysisResult> {
+  const rawPath = input.path ?? process.cwd();
+  const scannedPath = path.resolve(rawPath);
+
+  const result: AnalysisResult = {
+    projectType: "unknown",
+    sceneViewVersion: null,
+    latestVersion: LATEST_SCENEVIEW_VERSION,
+    isOutdated: false,
+    warnings: [],
+    suggestions: [],
+    scannedPath,
+    filesScanned: 0,
+    bytesScanned: 0,
+    truncated: false,
+  };
+
+  // Verify the path exists and is a directory.
+  let stat;
+  try {
+    stat = await fs.stat(scannedPath);
+  } catch (err) {
+    result.warnings.push({
+      file: scannedPath,
+      type: "scan/path-not-found",
+      message:
+        `Could not stat project path: ${(err as Error).message}. ` +
+        "Pass an existing directory in the `path` argument, or run the tool from inside your project.",
+    });
+    return result;
+  }
+  if (!stat.isDirectory()) {
+    result.warnings.push({
+      file: scannedPath,
+      type: "scan/not-a-directory",
+      message: `Project path exists but is not a directory: ${scannedPath}.`,
+    });
+    return result;
+  }
+
+  // Step 1: project type + version.
+  const detection = await detectProject(scannedPath);
+  result.projectType = detection.projectType;
+  result.sceneViewVersion = detection.sceneViewVersion;
+  result.isOutdated = isVersionOutdated(detection.sceneViewVersion);
+
+  if (detection.projectType === "unknown") {
+    result.warnings.push({
+      file: scannedPath,
+      type: "scan/no-sceneview-dependency",
+      message:
+        "No SceneView dependency was detected. Looked for `io.github.sceneview:sceneview` in " +
+        "Gradle files, `SceneViewSwift` in `Package.swift`, and `sceneview-web` in `package.json`.",
+    });
+  } else if (!detection.sceneViewVersion) {
+    result.warnings.push({
+      file: detection.sourceFile ?? scannedPath,
+      type: "scan/version-unresolved",
+      message:
+        "SceneView dependency was found but the version could not be extracted. This usually " +
+        "means the version is declared through a variable or a version catalog — check your " +
+        "`libs.versions.toml` or a shared `ext.sceneview_version` definition.",
+    });
+  }
+
+  if (result.isOutdated && detection.sceneViewVersion) {
+    result.suggestions.push({
+      type: "suggestion/upgrade-sceneview",
+      message:
+        `You are on SceneView ${detection.sceneViewVersion}. The latest known release is ` +
+        `${LATEST_SCENEVIEW_VERSION}. Consider upgrading — run \`get_migration_guide\` for ` +
+        "the 2.x → 3.x migration notes, or `migrate_code` for automatic Kotlin rewrites.",
+    });
+  }
+
+  // Step 2: anti-pattern scan (only if we have a known project type).
+  if (detection.projectType !== "unknown") {
+    const sourceFiles: string[] = [];
+    await collectSourceFiles(scannedPath, scannedPath, 0, sourceFiles);
+
+    const truncatedByFileCount = sourceFiles.length >= MAX_FILES_SCANNED;
+    let totalBytes = 0;
+
+    for (const file of sourceFiles) {
+      if (result.filesScanned >= MAX_FILES_SCANNED) {
+        result.truncated = true;
+        break;
+      }
+      if (totalBytes >= MAX_BYTES_SCANNED) {
+        result.truncated = true;
+        break;
+      }
+
+      const contents = await readFileSafe(file);
+      if (contents == null) continue;
+      const byteLen = Buffer.byteLength(contents, "utf-8");
+      // Would this file push us over the byte cap? If yes, still scan once
+      // (a single giant file shouldn't silently fail) then stop the loop.
+      totalBytes += byteLen;
+      result.filesScanned += 1;
+      result.bytesScanned = totalBytes;
+
+      const lang = languageOf(file);
+      if (!lang) continue;
+
+      scanFileForAntiPatterns(file, lang, contents, result.warnings);
+
+      if (totalBytes >= MAX_BYTES_SCANNED) {
+        result.truncated = true;
+        break;
+      }
+    }
+
+    if (truncatedByFileCount) {
+      result.truncated = true;
+    }
+
+    if (result.truncated) {
+      result.warnings.push({
+        file: scannedPath,
+        type: "scan/truncated",
+        message:
+          `Scan truncated at ${result.filesScanned} files / ${result.bytesScanned} bytes ` +
+          `(limits: ${MAX_FILES_SCANNED} files, ${MAX_BYTES_SCANNED} bytes). Some files may ` +
+          "not have been inspected — run `validate_code` on specific snippets for a deeper check.",
+      });
+    }
+  }
+
+  // Step 3: tailored suggestions.
+  if (result.warnings.some((w) => w.type.startsWith("migration/"))) {
+    result.suggestions.push({
+      type: "suggestion/run-migrate-code",
+      message:
+        "Deprecated 2.x APIs were detected. Run the `migrate_code` tool on the offending " +
+        "files for an automatic rewrite to 3.x.",
+    });
+  }
+  if (result.warnings.some((w) => w.type === "threading/filament-off-main-thread")) {
+    result.suggestions.push({
+      type: "suggestion/fix-threading",
+      message:
+        "Filament JNI calls were detected alongside background coroutines. Switch to " +
+        "`rememberModelInstance` in composables, or wrap imperative loads in " +
+        "`withContext(Dispatchers.Main)`.",
+    });
+  }
+  if (result.projectType !== "unknown" && result.warnings.filter((w) => !w.type.startsWith("scan/")).length === 0) {
+    result.suggestions.push({
+      type: "suggestion/no-issues",
+      message:
+        "No known anti-patterns detected in the scanned files. Call `validate_code` on " +
+        "individual snippets for a deeper per-file check.",
+    });
+  }
+
+  return result;
+}
+
+/** Run every registered detector on one file and append findings in place. */
+function scanFileForAntiPatterns(
+  file: string,
+  language: DetectedLanguage,
+  contents: string,
+  warnings: AnalysisWarning[],
+): void {
+  const lines = contents.split("\n");
+  for (const detector of ANTI_PATTERNS) {
+    if (!detector.languages.has(language)) continue;
+    if (detector.fileGuard && !detector.fileGuard(contents)) continue;
+    for (let i = 0; i < lines.length; i++) {
+      if (detector.pattern.test(lines[i])) {
+        warnings.push({
+          file,
+          line: i + 1,
+          type: detector.id,
+          message: detector.message,
+        });
+      }
+    }
+  }
+}
+
+// ─── Formatting helper (used by the MCP handler) ────────────────────────────
+
+/** Render an {@link AnalysisResult} as a Markdown report for MCP clients. */
+export function formatAnalysisReport(result: AnalysisResult): string {
+  const lines: string[] = [];
+  lines.push(`## SceneView project analysis`);
+  lines.push(``);
+  lines.push(`**Path:** \`${result.scannedPath}\``);
+  lines.push(`**Project type:** ${result.projectType}`);
+  lines.push(
+    `**SceneView version:** ${result.sceneViewVersion ?? "(not detected)"} — latest: ${result.latestVersion}${result.isOutdated ? " ⚠️ outdated" : ""}`,
+  );
+  lines.push(
+    `**Scan:** ${result.filesScanned} file(s), ${result.bytesScanned} byte(s)${result.truncated ? " (truncated)" : ""}`,
+  );
+  lines.push(``);
+
+  if (result.warnings.length === 0) {
+    lines.push(`### Warnings`);
+    lines.push(`No anti-patterns detected.`);
+  } else {
+    lines.push(`### Warnings (${result.warnings.length})`);
+    for (const w of result.warnings) {
+      const loc = w.line ? `${w.file}:${w.line}` : w.file;
+      lines.push(`- **${w.type}** — \`${loc}\`: ${w.message}`);
+    }
+  }
+  lines.push(``);
+
+  if (result.suggestions.length > 0) {
+    lines.push(`### Suggestions`);
+    for (const s of result.suggestions) {
+      lines.push(`- **${s.type}** — ${s.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/mcp/src/tiers.ts
+++ b/mcp/src/tiers.ts
@@ -4,7 +4,7 @@
 
 export type Tier = "free" | "pro";
 
-// ─── Free tools (16) ─────────────────────────────────────────────────────────
+// ─── Free tools (17) ─────────────────────────────────────────────────────────
 
 const FREE_TOOLS: readonly string[] = [
   "list_samples",
@@ -23,6 +23,7 @@ const FREE_TOOLS: readonly string[] = [
   "get_collision_guide",
   "get_platform_roadmap",
   "search_models",
+  "analyze_project",
 ] as const;
 
 // ─── Pro tools ────────────────────────────────────────────────────────────────

--- a/mcp/src/tools/definitions.ts
+++ b/mcp/src/tools/definitions.ts
@@ -487,4 +487,20 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       required: ["query"],
     },
   },
+  {
+    name: "analyze_project",
+    description:
+      "Scans a local SceneView project on the user's machine and returns a structured analysis: detected project type (Android, iOS, Web), extracted SceneView dependency version, whether it is outdated vs the latest known release, and any known anti-patterns found by reading source files (threading violations, LightNode trailing-lambda bug, deprecated 2.x APIs, Sceneform imports). Safe: scans at most 30 source files and 500 KB total, never writes to disk. Use this when a user asks 'is my project up to date?', 'what's wrong with my SceneView code?', or when you want a fast sanity check of a project before generating code for it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description:
+            "Absolute or relative path to the project root to scan. Defaults to the current working directory of the MCP server.",
+        },
+      },
+      required: [],
+    },
+  },
 ];

--- a/mcp/src/tools/handler.ts
+++ b/mcp/src/tools/handler.ts
@@ -66,6 +66,7 @@ import {
   WEB_RENDERING_GUIDE,
 } from "../extra-guides.js";
 import { searchModels, formatSearchResults } from "../search-models.js";
+import { analyzeProject, formatAnalysisReport } from "../analyze-project.js";
 import { LLMS_TXT } from "../generated/llms-txt.js";
 
 import type { DispatchContext, ToolResult, ToolTextContent } from "./types.js";
@@ -833,6 +834,27 @@ export async function dispatchTool(
         content: withDisclaimer([{ type: "text", text: searchText }]),
         isError: searchResult.ok ? undefined : true,
       };
+    }
+
+    // ── analyze_project ───────────────────────────────────────────────────────
+    case "analyze_project": {
+      const rawPath = args?.path;
+      const analyzePath = typeof rawPath === "string" && rawPath.length > 0 ? rawPath : undefined;
+      try {
+        const analysis = await analyzeProject({ path: analyzePath });
+        const report = formatAnalysisReport(analysis);
+        return { content: withDisclaimer([{ type: "text", text: report }]) };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `analyze_project failed: ${(err as Error).message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
     }
 
     default:


### PR DESCRIPTION
## Summary

First agentic MCP tool — reads the user's filesystem instead of returning static content. Implements chunk **T3** of `.claude/plans/v4.0-mcp-evolution.md`.

Given a project directory (defaults to `process.cwd()`), `analyze_project`:

1. **Detects the project type**
   - Android: `build.gradle(.kts)` containing `io.github.sceneview:sceneview`
   - iOS: `Package.swift` containing `SceneViewSwift`
   - Web: `package.json` containing `sceneview-web` (or `@sceneview/sceneview-web`)
2. **Extracts the SceneView version** from the dependency declaration and compares it against a hardcoded `LATEST_SCENEVIEW_VERSION = "3.6.2"`, flagging outdated projects.
3. **Scans up to 30 source files (`.kt`, `.kts`, `.swift`, `.js`, `.mjs`, `.ts`, `.tsx`)** — capped at **500 KB** total bytes and **12** directory levels — for well-known anti-patterns:
   - `threading/filament-off-main-thread` — `modelLoader.createModel*` in a file that also uses `launch {` / `Dispatchers.IO|Default` / `withContext(IO|Default)`
   - `api/light-node-trailing-lambda` — the `LightNode(...) { ... }` bug (must be `apply = { ... }`)
   - Deprecated 2.x APIs: `ArSceneView`, `TransformableNode`, `PlacementNode`, `ViewRenderable`, `loadModelAsync`
   - `com.google.ar.sceneform.*` imports (Sceneform was deprecated by Google in 2021)
4. **Returns a structured report** `{ projectType, sceneViewVersion, latestVersion, isOutdated, warnings[], suggestions[], scannedPath, filesScanned, bytesScanned, truncated }` plus a Markdown formatter used by the MCP handler.

## Safety

- Hard limits (`MAX_FILES_SCANNED=30`, `MAX_BYTES_SCANNED=500 KB`, `MAX_DIR_DEPTH=12`) are enforced by the walker; when any limit is hit the result includes a `scan/truncated` warning.
- Read-only: the tool never writes to disk.
- Never throws: missing paths, file-as-path, permission errors, broken JSON — all surface as structured warnings (`scan/path-not-found`, `scan/not-a-directory`, `scan/no-sceneview-dependency`, `scan/version-unresolved`).
- Skip list for the walker excludes `node_modules`, `.git`, `build`, `dist`, `.gradle`, `Pods`, `DerivedData`, `.build`, etc.

## How it works with the user's local filesystem

The SceneView MCP server runs on the user's machine, so it has direct read access to their project files via `node:fs/promises`. The tool resolves `path` (or `process.cwd()` as fallback), verifies the directory exists, probes the well-known manifest files, then walks the subtree collecting source files for the anti-pattern pass. Only `fs.stat`, `fs.readdir`, and `fs.readFile` are used — no child processes, no network, no writes.

## Fixtures added

Three tiny self-contained fake projects under `mcp/src/__fixtures__/analyze-project/` (each under 2 KB):

| Fixture | Purpose |
| --- | --- |
| `android-ok/` | Latest SceneView 3.6.2 + a clean composable — must produce zero anti-pattern warnings |
| `android-with-warnings/` | Outdated 2.2.1 + `launch(Dispatchers.IO) { modelLoader.createModelInstance(...) }` + `LightNode(...) { ... }` + `TransformableNode` + `com.google.ar.sceneform.ux.ArFragment` import |
| `ios-outdated/` | `Package.swift` with `SceneViewSwift` pinned to 3.0.0 (must flag as outdated) + minimal SwiftUI view |

## Tests added

`mcp/src/analyze-project.test.ts` — 21 tests covering:

- Project type detection (Android via `build.gradle.kts`, iOS via `Package.swift`)
- Version extraction (Gradle dep string, Swift `from:` clause, outdated Android project)
- Outdated flag and `suggestion/upgrade-sceneview`
- Each anti-pattern detector individually (threading, LightNode, TransformableNode, Sceneform import)
- `suggestion/run-migrate-code` when migration warnings exist
- Clean project produces no anti-pattern warnings and adds `suggestion/no-issues`
- Graceful error handling: missing directory, path-is-file, empty directory, default `path` fallback
- Markdown report formatting (`formatAnalysisReport`)
- Scan limits — a synthetic temp project with 45 `.kt` files is correctly capped at 30 with `scan/truncated`

## Wiring

- `mcp/src/tools/definitions.ts` — new `analyze_project` entry in `TOOL_DEFINITIONS`
- `mcp/src/tiers.ts` — added to `FREE_TOOLS`
- `mcp/src/tools/handler.ts` — new dispatch case that calls `analyzeProject`, formats the report with `formatAnalysisReport`, catches unexpected errors
- `mcp/README.md` — new row in the tools table plus a subsection explaining the scan behaviour and safety limits

## Dependencies

None added. Uses only `node:fs/promises` and `node:path` (plus `node:url` and `node:os` in the test file, both already available in Node 18+).

## Verification

```
cd mcp && npm install && npm test && npm run build
```

- `npm test` — 2538 tests passing across 106 files
- `npm run build` — `tsc` clean
- No version bump. No publish. No unrelated files touched.

## Test plan

- [ ] Reviewer runs `cd mcp && npm test` — expect 2538 tests passing
- [ ] Reviewer runs `cd mcp && npm run build` — expect `tsc` clean
- [ ] Reviewer spot-checks `analyze_project` against a real SceneView project by pointing the MCP at their checkout and calling `analyze_project` with the repo root