### PR TITLE
chore(mcp): bump sceneview-mcp 3.6.2 -> 3.6.3

### DIFF
--- a/mcp/dist/index.js
+++ b/mcp/dist/index.js
@@ -22,7 +22,7 @@ import { recordUsage, getConfiguredApiKey } from "./billing.js";
 import { recordClientInit, recordToolCall } from "./telemetry.js";
 import { getToolTier } from "./tiers.js";
 import { API_DOCS, TOOL_DEFINITIONS, dispatchTool, } from "./tools/index.js";
-const server = new Server({ name: "sceneview-mcp", version: "3.6.2" }, { capabilities: { resources: {}, tools: {} } });
+const server = new Server({ name: "sceneview-mcp", version: "3.6.3" }, { capabilities: { resources: {}, tools: {} } });
 // ─── Telemetry (anonymous, opt-out via SCENEVIEW_TELEMETRY=0) ────────────────
 //
 // Fire once when the client finishes the handshake. See `telemetry.ts` and

--- a/mcp/dist/telemetry.js
+++ b/mcp/dist/telemetry.js
@@ -38,7 +38,7 @@ function isEnabled() {
 // Falls back to "unknown" so payloads stay well-formed even if
 // something goes wrong.
 function getMcpVersion() {
-    return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.2";
+    return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.3";
 }
 /** Exposed for tests — resets the cached client context. */
 export function __resetClientContext() {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sceneview-mcp",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "mcpName": "io.github.sceneview/mcp",
   "description": "MCP server for SceneView — cross-platform 3D & AR SDK for Android and iOS. Give Claude the full SceneView SDK so it writes correct, compilable code.",
   "keywords": [

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -35,7 +35,7 @@ import {
 } from "./tools/index.js";
 
 const server = new Server(
-  { name: "sceneview-mcp", version: "3.6.2" },
+  { name: "sceneview-mcp", version: "3.6.3" },
   { capabilities: { resources: {}, tools: {} } }
 );
 

--- a/mcp/src/telemetry.ts
+++ b/mcp/src/telemetry.ts
@@ -49,7 +49,7 @@ function isEnabled(): boolean {
 // Falls back to "unknown" so payloads stay well-formed even if
 // something goes wrong.
 function getMcpVersion(): string {
-  return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.2";
+  return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.3";
 }
 
 /** Exposed for tests. */


### PR DESCRIPTION
## Summary

Bumps \`sceneview-mcp\` from **3.6.2** to **3.6.3**. Publish-ready.

## What's in 3.6.3

- #804 anonymous opt-out telemetry (no personal data, \`SCENEVIEW_TELEMETRY=0\` to opt out)
- #805 \`search_models\` tool (Sketchfab BYOK — \`SKETCHFAB_API_KEY\`)
- #807 \`analyze_project\` tool (local project scan, read-only)
- #808 sponsor CTA (one line every 10 tool calls, opt-out via \`SCENEVIEW_SPONSOR_CTA=0\`)

## Why ship now

Every \`sceneview-mcp\` user is still on 3.6.2. None of the above changes are visible to end users until we bump and publish. In particular, the **sponsor CTA** (the first monetization signal) will not reach any of the 3 400+ monthly installs until 3.6.3 is on npm.

## Not included

- No library version bump — Android/iOS/Web SceneView stays at 3.6.2 (the MCP package and the SDK libraries are versioned independently).
- The hosted Cloudflare gateway ships separately as \`sceneview-mcp@4.0.0-beta.1\` — go-live plan lives in \`.claude/plans/mcp-gateway-golive.md\`.

## Test plan

- [x] \`npx tsc\` clean
- [x] \`npx vitest run\` — **2694 passing** (up from 2629 on main at merge of #808)
- [x] Manual sanity: version string appears correctly in \`package.json\`, \`src/index.ts\` (Server version), \`src/telemetry.ts\` (default mcpVersion)

## After merge

Manual step by Thomas:
\`\`\`
cd mcp
npm publish
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>