### PR TITLE
fix(mcp): ship every runtime module in the npm tarball (3.6.4)

### DIFF
--- a/mcp/dist/index.js
+++ b/mcp/dist/index.js
@@ -22,7 +22,7 @@ import { recordUsage, getConfiguredApiKey } from "./billing.js";
 import { recordClientInit, recordToolCall } from "./telemetry.js";
 import { getToolTier } from "./tiers.js";
 import { API_DOCS, TOOL_DEFINITIONS, dispatchTool, } from "./tools/index.js";
-const server = new Server({ name: "sceneview-mcp", version: "3.6.3" }, { capabilities: { resources: {}, tools: {} } });
+const server = new Server({ name: "sceneview-mcp", version: "3.6.4" }, { capabilities: { resources: {}, tools: {} } });
 // ─── Telemetry (anonymous, opt-out via SCENEVIEW_TELEMETRY=0) ────────────────
 //
 // Fire once when the client finishes the handshake. See `telemetry.ts` and

--- a/mcp/dist/telemetry.js
+++ b/mcp/dist/telemetry.js
@@ -38,7 +38,7 @@ function isEnabled() {
 // Falls back to "unknown" so payloads stay well-formed even if
 // something goes wrong.
 function getMcpVersion() {
-    return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.3";
+    return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.4";
 }
 /** Exposed for tests — resets the cached client context. */
 export function __resetClientContext() {

--- a/mcp/llms.txt
+++ b/mcp/llms.txt
@@ -1955,6 +1955,19 @@ MCP server: `sceneview-mcp`. Add to `.claude/mcp.json`:
 { "mcpServers": { "sceneview": { "command": "npx", "args": ["-y", "sceneview-mcp"] } } }
 ```
 
+### Complete nodes reference
+
+For an exhaustive, AI-first reference covering every node composable — signatures, copy-paste examples, gotchas, lifecycle behaviour, nesting & coordinate spaces, and common mistakes — see **[docs/docs/nodes.md](https://sceneview.github.io/docs/nodes/)** (`NODES.md`). This file is the authoritative walkthrough for:
+
+- **Standard nodes:** ModelNode (animations, `scaleToUnits`), LightNode (intensity units by type, the `apply` trap), ViewNode (Compose UI on a plane, why `viewNodeWindowManager` is mandatory)
+- **Procedural geometry:** CubeNode / SphereNode / CylinderNode / PlaneNode / LineNode / PathNode / MeshNode — with the recomposition model for reactive geometry updates
+- **Content nodes:** TextNode, ImageNode, VideoNode, BillboardNode, ReflectionProbeNode
+- **AR-only nodes:** AnchorNode (the correct pattern for pinning state without 60 FPS recomposition), PoseNode, HitResultNode, AugmentedImageNode, AugmentedFaceNode, CloudAnchorNode, StreetscapeGeometryNode
+- **Composition & state:** nesting and parent→child coordinate spaces, reactive parameters, automatic destruction, imperative `apply = { … }` blocks, and a table of common mistakes with symptoms and fixes
+
+This reference is consumed by `sceneview-mcp` so Claude and other AI assistants can answer deep questions about any node without hallucinating parameter names.
+
+
 ### Claude Artifacts — 3D in claude.ai
 
 SceneView works inside Claude Artifacts (HTML type). Use this template:

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sceneview-mcp",
-  "version": "3.6.2",
+  "version": "3.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sceneview-mcp",
-      "version": "3.6.2",
+      "version": "3.6.4",
       "funding": [
         {
           "type": "github",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sceneview-mcp",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "mcpName": "io.github.sceneview/mcp",
   "description": "MCP server for SceneView — cross-platform 3D & AR SDK for Android and iOS. Give Claude the full SceneView SDK so it writes correct, compilable code.",
   "keywords": [
@@ -37,21 +37,9 @@
     "sceneview-mcp": "dist/index.js"
   },
   "files": [
-    "dist/index.js",
-    "dist/issues.js",
-    "dist/guides.js",
-    "dist/migration.js",
-    "dist/node-reference.js",
-    "dist/samples.js",
-    "dist/preview.js",
-    "dist/artifact.js",
-    "dist/validator.js",
-    "dist/platform-setup.js",
-    "dist/migrate-code.js",
-    "dist/debug-issue.js",
-    "dist/generate-scene.js",
-    "dist/advanced-guides.js",
-    "dist/extra-guides.js",
+    "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "!dist/**/__fixtures__/**",
     "llms.txt"
   ],
   "engines": {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -35,7 +35,7 @@ import {
 } from "./tools/index.js";
 
 const server = new Server(
-  { name: "sceneview-mcp", version: "3.6.3" },
+  { name: "sceneview-mcp", version: "3.6.4" },
   { capabilities: { resources: {}, tools: {} } }
 );
 

--- a/mcp/src/package-files.test.ts
+++ b/mcp/src/package-files.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression test: ensure every runtime module imported by src/index.ts
+ * (directly and transitively) is actually included in the npm tarball.
+ *
+ * Why this exists: on April 11 2026 the `files[]` whitelist in package.json
+ * lagged behind the refactor from a 1200-line monolith to multiple modules
+ * under `src/tools/`, `src/telemetry.ts`, `src/search-models.ts`, etc. A
+ * publish would have shipped a tarball missing most of the runtime, so every
+ * `npx sceneview-mcp` would crash at startup with a Cannot-find-module error.
+ *
+ * This test catches that class of bug by:
+ *   1. Running `npm pack --dry-run --json` to get the list of files the
+ *      tarball will contain.
+ *   2. Parsing `src/index.ts` and every transitively-reachable local import
+ *      to collect the full set of required `./foo.js` paths.
+ *   3. Asserting each required path is present in the tarball.
+ *
+ * The test also asserts that no `.test.js` files or fixtures leak into the
+ * tarball — those are dev-only and bloat the package.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const SRC_DIR = dirname(__filename);
+const MCP_ROOT = resolve(SRC_DIR, "..");
+
+/**
+ * Walk local ES-module imports starting from `entry`. Only follows imports
+ * of the form `"./foo.js"` or `"./foo/bar.js"` — skips bare specifiers (npm
+ * packages) and node: builtins.
+ */
+function collectLocalImports(entry: string): Set<string> {
+  const visited = new Set<string>();
+  const queue: string[] = [entry];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    let source: string;
+    try {
+      source = readFileSync(current, "utf8");
+    } catch {
+      continue;
+    }
+
+    // Match both `import ... from "./foo.js"` and `import("./foo.js")`.
+    const importRegex = /(?:import\s+[^'"]*?from\s+|import\()\s*['"](\.\.?\/[^'"]+)['"]/g;
+    let match: RegExpExecArray | null;
+    while ((match = importRegex.exec(source)) !== null) {
+      const specifier = match[1];
+      // We only care about `.js` specifiers (ES modules rewrite .ts→.js at build)
+      if (!specifier.endsWith(".js")) continue;
+
+      // Resolve to an absolute .ts source path (imports say `.js`, files are `.ts`)
+      const resolved = resolve(dirname(current), specifier.replace(/\.js$/, ".ts"));
+      if (existsSync(resolved)) {
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return visited;
+}
+
+/**
+ * Convert a set of absolute .ts source paths to the set of compiled `.js`
+ * paths under `dist/` that must ship in the tarball.
+ */
+function toDistPaths(srcPaths: Set<string>): string[] {
+  const result: string[] = [];
+  for (const src of srcPaths) {
+    const rel = relative(SRC_DIR, src);
+    if (rel.startsWith("..")) continue;
+    const distPath = `dist/${rel.replace(/\.ts$/, ".js")}`;
+    result.push(distPath);
+  }
+  return result.sort();
+}
+
+/**
+ * Run `npm pack --dry-run --json` and return the list of files that would
+ * ship in the tarball. Fast: no actual tarball is written.
+ *
+ * `--ignore-scripts` prevents the `prepare` hook from polluting stdout with
+ * non-JSON log lines (e.g. the generate-llms-txt script).
+ */
+function getTarballFiles(): string[] {
+  const stdout = execFileSync(
+    "npm",
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    { cwd: MCP_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  // Some tooling leaks non-JSON lifecycle banners onto stdout (e.g. the
+  // generate-llms-txt prebuild script). Find the start of the real JSON array
+  // by looking for the first newline followed by '['.
+  let jsonStart = stdout.indexOf("\n[");
+  if (jsonStart >= 0) {
+    jsonStart += 1; // skip the newline
+  } else if (stdout.trimStart().startsWith("[")) {
+    jsonStart = stdout.indexOf("[");
+  } else {
+    throw new Error(`Cannot locate JSON array in npm pack output:\n${stdout.slice(0, 400)}`);
+  }
+  const parsed = JSON.parse(stdout.slice(jsonStart)) as Array<{ files: Array<{ path: string }> }>;
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("npm pack --dry-run returned unexpected output");
+  }
+  return parsed[0].files.map((f) => f.path);
+}
+
+describe("npm tarball includes every runtime module imported by src/index.ts", () => {
+  const entrySrc = resolve(SRC_DIR, "index.ts");
+  const requiredSrcPaths = collectLocalImports(entrySrc);
+  const requiredDistPaths = toDistPaths(requiredSrcPaths);
+  const tarballFiles = getTarballFiles();
+  const tarballSet = new Set(tarballFiles);
+
+  it("all transitively-imported modules are present in the tarball", () => {
+    const missing = requiredDistPaths.filter((p) => !tarballSet.has(p));
+    expect(
+      missing,
+      `${missing.length} dist files are imported by src/index.ts (directly or indirectly) but missing from the npm tarball. Update the "files" array in package.json. Missing:\n${missing.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("does not leak *.test.js files into the tarball", () => {
+    const leaked = tarballFiles.filter((p) => p.endsWith(".test.js"));
+    expect(leaked, `${leaked.length} test files leaked: ${leaked.join(", ")}`).toEqual([]);
+  });
+
+  it("does not leak fixtures into the tarball", () => {
+    const leaked = tarballFiles.filter((p) => p.includes("__fixtures__"));
+    expect(leaked, `${leaked.length} fixture files leaked: ${leaked.join(", ")}`).toEqual([]);
+  });
+
+  it("ships the entry point dist/index.js", () => {
+    expect(tarballSet.has("dist/index.js")).toBe(true);
+  });
+
+  it("ships llms.txt (the SDK API reference resource)", () => {
+    expect(tarballSet.has("llms.txt")).toBe(true);
+  });
+
+  it("ships the generated llms-txt module used by the tools library", () => {
+    // Not directly imported by src/index.ts but imported by src/tools/handler.ts,
+    // so the transitive walk should pick it up.
+    expect(tarballSet.has("dist/generated/llms-txt.js")).toBe(true);
+  });
+});

--- a/mcp/src/telemetry.ts
+++ b/mcp/src/telemetry.ts
@@ -49,7 +49,7 @@ function isEnabled(): boolean {
 // Falls back to "unknown" so payloads stay well-formed even if
 // something goes wrong.
 function getMcpVersion(): string {
-  return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.3";
+  return process.env.SCENEVIEW_MCP_VERSION ?? "3.6.4";
 }
 
 /** Exposed for tests. */


### PR DESCRIPTION
## Summary

Fixes a **critical publish-blocker** discovered while preparing to publish sceneview-mcp 3.6.3 to npm. The \`files[]\` whitelist in \`mcp/package.json\` had fallen out of sync with the refactor that split the old 1200-line monolith into \`src/tools/*\`, \`src/telemetry.ts\`, \`src/auth.ts\`, \`src/billing.ts\`, \`src/tiers.ts\`, \`src/search-models.ts\`, and \`src/analyze-project.ts\`.

**Impact if we'd shipped:** every \`npx sceneview-mcp\` would crash at startup with \`Cannot find module './tools/index.js'\`.

## Root cause

Before the refactor, \`dist/index.js\` was a 1154-line self-contained file. The old \`files[]\` listed only the few flat modules that existed at the time. Since then, we've added:

- \`dist/tools/{definitions,handler,index,types}.js\` (tools library extraction)
- \`dist/telemetry.js\` (#804)
- \`dist/search-models.js\` (#805)
- \`dist/analyze-project.js\` (#807)
- \`dist/auth.js\`, \`dist/billing.js\`, \`dist/tiers.js\` (Pro tier)
- \`dist/generated/llms-txt.js\` (generated during prebuild)
- plus \`convert-platform\`, \`explain-api\`, \`generate-*\`, \`optimize-scene\`

**None of these were in \`files[]\`.** The 3.6.2 tarball currently on npm ships 19 files; the refactored code needs 33+.

## Fix

- Replace the explicit whitelist with a glob: \`dist/**/*.js\` with explicit excludes for \`*.test.js\` and \`__fixtures__/\`. Robust against future refactors.
- Bump 3.6.3 → 3.6.4. (3.6.3 remains the unpublished "broken tarball" marker on main — we never publish that version.)
- Update hardcoded \`"3.6.3"\` in \`src/index.ts\` (Server metadata) and \`src/telemetry.ts\` (default mcpVersion).

## Regression prevention

New test: \`src/package-files.test.ts\` (6 cases).

It runs \`npm pack --dry-run --json\`, walks every transitive local import reachable from \`src/index.ts\`, and asserts that each corresponding \`dist/**/*.js\` is present in the tarball. Also asserts that no \`*.test.js\` or fixture leaks into the published package.

If anyone refactors \`src/\` in the future and forgets to update \`files[]\`, CI will fail immediately with a clear list of the missing files.

## Dry-run verification

Before this PR:
- 19 files, 112.5 kB, **missing the entire tools/ subdir + telemetry/auth/billing/etc.**

After this PR:
\`\`\`
npm notice total files: 37
npm notice package size: 183.1 kB
npm notice unpacked size: 747.5 kB
\`\`\`
Contains every module reachable from the entry point, zero test files, zero fixtures.

## Test plan

- [x] \`npx tsc\` clean
- [x] \`npx vitest run\` — **2706 passing** (up from 2694)
- [x] \`npm pack --dry-run\` sanity: 37 files, no test leakage
- [x] New regression test covers the class of bug directly

## After merge

Manual step (Thomas): \`cd mcp && npm publish\` — or the release.yml workflow will pick it up on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>