### PR TITLE
fix(mcp-healthcare): publish missing tools.js + bump 1.1.0

### DIFF
--- a/mcp/packages/healthcare/package-lock.json
+++ b/mcp/packages/healthcare/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "healthcare-3d-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "healthcare-3d-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0"

--- a/mcp/packages/healthcare/package.json
+++ b/mcp/packages/healthcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthcare-3d-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for Healthcare & Medical 3D visualization with SceneView — anatomy viewers, molecular structures, medical imaging, surgical planning, and dental scanning.",
   "keywords": [
     "mcp",
@@ -37,14 +37,10 @@
     "healthcare-3d-mcp": "dist/index.js"
   },
   "files": [
-    "dist/index.js",
-    "dist/anatomy-viewer.js",
-    "dist/molecule-viewer.js",
-    "dist/medical-imaging.js",
-    "dist/surgical-planning.js",
-    "dist/dental-viewer.js",
-    "dist/medical-models.js",
-    "dist/validator.js"
+    "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "!dist/**/__fixtures__/**",
+    "README.md"
   ],
   "engines": {
     "node": ">=18"

--- a/mcp/packages/healthcare/src/index.ts
+++ b/mcp/packages/healthcare/src/index.ts
@@ -17,7 +17,7 @@ import {
 import { TOOL_DEFINITIONS, dispatchTool } from "./tools.js";
 
 const server = new Server(
-  { name: "healthcare-3d-mcp", version: "1.0.0" },
+  { name: "healthcare-3d-mcp", version: "1.1.0" },
   { capabilities: { tools: {} } }
 );
 


### PR DESCRIPTION
## Summary

Fixes the same class of publish-blocker as #810 but for \`healthcare-3d-mcp\`:

- \`files[]\` listed 8 modules but \`src/index.ts\` imports \`./tools.js\`, which in turn imports \`./medical-models.js\` and \`./validator.js\`. None were in \`files[]\`.
- A publish of \`healthcare-3d-mcp\` from current main would ship a tarball that crashes at startup with \`Cannot find module './tools.js'\`.

Healthcare-3d-mcp is **currently 404 on npm** — never published. This PR fixes the \`files[]\` bug and bumps to 1.1.0 so we can publish it for the first time.

## Changes

- \`mcp/packages/healthcare/package.json\`: \`files[]\` uses the same glob pattern as #810 (\`dist/**/*.js\` minus tests/fixtures plus \`README.md\`). Bump 1.0.0 → 1.1.0.
- \`mcp/packages/healthcare/src/index.ts\`: bump Server metadata version 1.0.0 → 1.1.0.
- No dist files committed — the healthcare \`.gitignore\` ignores \`dist\` and \`npm run prepare\` rebuilds before publish.

## Test plan

- [x] \`npx tsc\` clean
- [x] \`npx vitest run\` — **135 passing**
- [x] \`npm pack --dry-run\` — **12 files**, includes \`dist/tools.js\` (26.1 kB), zero test leakage
- [ ] Manual publish after merge

## After merge

\`\`\`
cd mcp/packages/healthcare
npm publish
\`\`\`

First-mover on 3D healthcare MCP — zero competition per the April 10 strategy report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>