### PR TITLE
fix(mcp-gaming,mcp-interior): robust files[] glob to unblock next publish

### DIFF
--- a/mcp/packages/gaming/dist/character-viewer.js
+++ b/mcp/packages/gaming/dist/character-viewer.js
@@ -36,7 +36,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -186,7 +186,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.AnchorNode
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine

--- a/mcp/packages/gaming/dist/character-viewer.test.js
+++ b/mcp/packages/gaming/dist/character-viewer.test.js
@@ -28,7 +28,7 @@ describe("generateCharacterViewer", () => {
     it("generates valid Kotlin code for humanoid style", () => {
         const code = generateCharacterViewer({ style: "humanoid" });
         expect(code).toContain("package com.example.gaming.character");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("rememberModelLoader");
@@ -53,7 +53,7 @@ describe("generateCharacterViewer", () => {
     });
     it("generates AR code when ar=true", () => {
         const code = generateCharacterViewer({ style: "humanoid", ar: true });
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("ARSceneView(");
         expect(code).toContain("android.permission.CAMERA");
         expect(code).toContain("arsceneview:3.6.0");

--- a/mcp/packages/gaming/dist/inventory-3d.js
+++ b/mcp/packages/gaming/dist/inventory-3d.js
@@ -29,7 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -272,7 +272,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/gaming/dist/inventory-3d.test.js
+++ b/mcp/packages/gaming/dist/inventory-3d.test.js
@@ -26,7 +26,7 @@ describe("generateInventory3D", () => {
     it("generates valid Kotlin code for grid layout", () => {
         const code = generateInventory3D({ layout: "grid" });
         expect(code).toContain("package com.example.gaming.inventory");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("rememberModelInstance");

--- a/mcp/packages/gaming/dist/level-editor.js
+++ b/mcp/packages/gaming/dist/level-editor.js
@@ -37,7 +37,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.node.CylinderNode
@@ -238,7 +238,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.rememberEngine

--- a/mcp/packages/gaming/dist/level-editor.test.js
+++ b/mcp/packages/gaming/dist/level-editor.test.js
@@ -54,7 +54,7 @@ describe("generateLevelEditor", () => {
     it("generates valid Kotlin code for dungeon theme", () => {
         const code = generateLevelEditor({ theme: "dungeon" });
         expect(code).toContain("package com.example.gaming.level");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("CubeNode");

--- a/mcp/packages/gaming/dist/particle-effects.js
+++ b/mcp/packages/gaming/dist/particle-effects.js
@@ -148,7 +148,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -371,7 +371,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/gaming/dist/particle-effects.test.js
+++ b/mcp/packages/gaming/dist/particle-effects.test.js
@@ -59,7 +59,7 @@ describe("generateParticleEffects", () => {
     it("generates valid Kotlin code for fire effect", () => {
         const code = generateParticleEffects({ effect: "fire" });
         expect(code).toContain("package com.example.gaming.particles");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("SphereNode");

--- a/mcp/packages/gaming/dist/physics-game.js
+++ b/mcp/packages/gaming/dist/physics-game.js
@@ -34,7 +34,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.node.CylinderNode
@@ -341,7 +341,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.SphereNode
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.rememberEngine

--- a/mcp/packages/gaming/dist/physics-game.test.js
+++ b/mcp/packages/gaming/dist/physics-game.test.js
@@ -43,7 +43,7 @@ describe("generatePhysicsGame", () => {
     it("generates valid Kotlin code for bouncing-balls", () => {
         const code = generatePhysicsGame({ preset: "bouncing-balls" });
         expect(code).toContain("package com.example.gaming.physics");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("SphereNode");

--- a/mcp/packages/gaming/package.json
+++ b/mcp/packages/gaming/package.json
@@ -38,14 +38,9 @@
     "gaming-3d-mcp": "dist/index.js"
   },
   "files": [
-    "dist/index.js",
-    "dist/character-viewer.js",
-    "dist/level-editor.js",
-    "dist/physics-game.js",
-    "dist/particle-effects.js",
-    "dist/inventory-3d.js",
-    "dist/game-models.js",
-    "dist/validator.js"
+    "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "!dist/**/__fixtures__/**"
   ],
   "engines": {
     "node": ">=18"

--- a/mcp/packages/interior/dist/furniture-placement.js
+++ b/mcp/packages/interior/dist/furniture-placement.js
@@ -31,7 +31,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.AnchorNode
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
@@ -170,7 +170,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/interior/dist/furniture-placement.test.js
+++ b/mcp/packages/interior/dist/furniture-placement.test.js
@@ -28,12 +28,12 @@ describe("generateFurniturePlacement", () => {
     it("generates AR code by default", () => {
         const code = generateFurniturePlacement({ category: "sofa" });
         expect(code).toContain("ARSceneView(");
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("android.permission.CAMERA");
     });
     it("generates 3D preview when ar=false", () => {
         const code = generateFurniturePlacement({ category: "sofa", ar: false });
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("SceneView(");
         expect(code).not.toContain("ARScene");
     });

--- a/mcp/packages/interior/dist/lighting-design.js
+++ b/mcp/packages/interior/dist/lighting-design.js
@@ -34,7 +34,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -168,7 +168,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/interior/dist/lighting-design.test.js
+++ b/mcp/packages/interior/dist/lighting-design.test.js
@@ -27,7 +27,7 @@ describe("generateLightingDesign", () => {
     it("generates valid Kotlin code for ambient + spot", () => {
         const code = generateLightingDesign({ lights: ["ambient", "spot"] });
         expect(code).toContain("package com.example.interior.lighting");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
     });
@@ -88,7 +88,7 @@ describe("generateLightingDesign", () => {
             ar: true,
         });
         expect(code).toContain("ARSceneView(");
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("android.permission.CAMERA");
     });
     it("handles loading state", () => {

--- a/mcp/packages/interior/dist/material-switcher.js
+++ b/mcp/packages/interior/dist/material-switcher.js
@@ -42,7 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -208,7 +208,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/interior/dist/material-switcher.test.js
+++ b/mcp/packages/interior/dist/material-switcher.test.js
@@ -25,7 +25,7 @@ describe("generateMaterialSwitcher", () => {
     it("generates valid Kotlin code for wall-paint", () => {
         const code = generateMaterialSwitcher({ surface: "wall-paint" });
         expect(code).toContain("package com.example.interior.materials");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
     });
@@ -62,7 +62,7 @@ describe("generateMaterialSwitcher", () => {
     it("generates AR code when ar=true", () => {
         const code = generateMaterialSwitcher({ surface: "wall-paint", ar: true });
         expect(code).toContain("ARSceneView(");
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("android.permission.CAMERA");
     });
     it("includes LightNode with named apply parameter", () => {

--- a/mcp/packages/interior/dist/room-planner.js
+++ b/mcp/packages/interior/dist/room-planner.js
@@ -26,7 +26,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.rememberEngine
@@ -218,7 +218,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.AnchorNode
 import io.github.sceneview.node.CubeNode
 import io.github.sceneview.rememberEngine

--- a/mcp/packages/interior/dist/room-planner.test.js
+++ b/mcp/packages/interior/dist/room-planner.test.js
@@ -34,7 +34,7 @@ describe("generateRoomPlanner", () => {
     it("generates valid Kotlin code for living room", () => {
         const code = generateRoomPlanner({ roomType: "living-room" });
         expect(code).toContain("package com.example.interior.planner");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
         expect(code).toContain("rememberModelLoader");
@@ -59,7 +59,7 @@ describe("generateRoomPlanner", () => {
     });
     it("generates AR code when ar=true", () => {
         const code = generateRoomPlanner({ roomType: "living-room", ar: true });
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("ARSceneView(");
         expect(code).toContain("arsceneview:3.6.0");
         expect(code).toContain("android.permission.CAMERA");

--- a/mcp/packages/interior/dist/room-tour.js
+++ b/mcp/packages/interior/dist/room-tour.js
@@ -32,7 +32,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.Scene
+import io.github.sceneview.SceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader
@@ -214,7 +214,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.sceneview.ar.ARScene
+import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberModelLoader

--- a/mcp/packages/interior/dist/room-tour.test.js
+++ b/mcp/packages/interior/dist/room-tour.test.js
@@ -26,7 +26,7 @@ describe("generateRoomTour", () => {
     it("generates valid Kotlin code for orbit tour", () => {
         const code = generateRoomTour({ tourStyle: "orbit" });
         expect(code).toContain("package com.example.interior.tour");
-        expect(code).toContain("import io.github.sceneview.Scene");
+        expect(code).toContain("import io.github.sceneview.SceneView");
         expect(code).toContain("@Composable");
         expect(code).toContain("rememberEngine()");
     });
@@ -66,7 +66,7 @@ describe("generateRoomTour", () => {
     it("generates AR code when ar=true", () => {
         const code = generateRoomTour({ tourStyle: "orbit", ar: true });
         expect(code).toContain("ARSceneView(");
-        expect(code).toContain("import io.github.sceneview.ar.ARScene");
+        expect(code).toContain("import io.github.sceneview.ar.ARSceneView");
         expect(code).toContain("android.permission.CAMERA");
     });
     it("AR version uses miniature scale", () => {

--- a/mcp/packages/interior/package.json
+++ b/mcp/packages/interior/package.json
@@ -37,14 +37,9 @@
     "interior-design-3d-mcp": "dist/index.js"
   },
   "files": [
-    "dist/index.js",
-    "dist/room-planner.js",
-    "dist/furniture-placement.js",
-    "dist/material-switcher.js",
-    "dist/lighting-design.js",
-    "dist/room-tour.js",
-    "dist/furniture-models.js",
-    "dist/validator.js"
+    "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "!dist/**/__fixtures__/**"
   ],
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Context

Two MCP packages in the vertical stack ship a pre-refactor monolithic `dist/index.js` on npm 1.0.0 and currently work, but they have the **same latent `files[]` whitelist bug** that bit us twice today:

- **sceneview-mcp** — fix in #810 (`3f3a595f`, merged + published as 3.6.4)
- **healthcare-3d-mcp** — fix in #811 (`56230bc5`, published as 1.1.0)

## The bug

The explicit `files[]` whitelist in `mcp-gaming/package.json` and `mcp-interior/package.json` was written for the pre-refactor layout and does not ship the post-refactor `dist/tools.js` module. Their current tarballs on npm 1.0.0 still work because they predate the refactor, but **any republish from current source would ship a broken tarball**:

```
npx gaming-3d-mcp
→ Error: Cannot find module './tools.js'
```

This is a ticking time bomb — the next routine publish would crash every `npx` install for all existing users.

## The fix

Apply the same glob pattern already shipped on `sceneview-mcp` and `healthcare-3d-mcp`:

```json
"files": [
  "dist/**/*.js",
  "!dist/**/*.test.js",
  "!dist/**/__fixtures__/**"
]
```

Robust against any future refactor — the pattern auto-picks up new modules under `dist/`.

## Verification

`npm pack --dry-run` on both packages confirms:

- **gaming-3d-mcp**: 11 files in the tarball, ships `dist/tools.js` (24.5 kB) and every runtime module, excludes `*.test.js`. **157 / 157 vitest passing.**
- **interior-design-3d-mcp**: 11 files in the tarball, ships `dist/tools.js` (26.9 kB) and every runtime module, excludes `*.test.js`. **129 / 129 vitest passing.**

## Follow-up after merge

Neither package needs an immediate republish — 1.0.0 on npm is unbroken. But when the next feature/bugfix bump ships, `files[]` will be correct and the publish won't explode silently.

No code changes outside `package.json` + `dist/` regenerated artifacts.