### PR TITLE
fix(sceneview): propagate animated values back to Node transforms (#388)

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/animation/NodeAnimator.kt
+++ b/sceneview/src/main/java/io/github/sceneview/animation/NodeAnimator.kt
@@ -3,6 +3,7 @@ package io.github.sceneview.animation
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.PropertyValuesHolder
+import dev.romainguy.kotlin.math.Float3
 import dev.romainguy.kotlin.math.Quaternion
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -27,7 +28,12 @@ object NodeAnimator {
             PropertyValuesHolder.ofFloat("x", *positions.map { it.x }.toFloatArray()),
             PropertyValuesHolder.ofFloat("y", *positions.map { it.y }.toFloatArray()),
             PropertyValuesHolder.ofFloat("z", *positions.map { it.z }.toFloatArray())
-        )
+        ).also { animator ->
+            animator.addUpdateListener { anim ->
+                val target = anim.animatedValue as Float3
+                node.position = Position(target.x, target.y, target.z)
+            }
+        }
 
     fun ofQuaternion(node: Node, vararg quaternions: Quaternion) =
         ObjectAnimator.ofPropertyValuesHolder(
@@ -36,19 +42,34 @@ object NodeAnimator {
             PropertyValuesHolder.ofFloat("y", *quaternions.map { it.y }.toFloatArray()),
             PropertyValuesHolder.ofFloat("z", *quaternions.map { it.z }.toFloatArray()),
             PropertyValuesHolder.ofFloat("w", *quaternions.map { it.w }.toFloatArray())
-        )
+        ).also { animator ->
+            animator.addUpdateListener { anim ->
+                val target = anim.animatedValue as Quaternion
+                node.quaternion = Quaternion(target.x, target.y, target.z, target.w)
+            }
+        }
 
     fun ofRotation(node: Node, vararg rotations: Rotation) = ObjectAnimator.ofPropertyValuesHolder(
         node.rotation,
         PropertyValuesHolder.ofFloat("x", *rotations.map { it.x }.toFloatArray()),
         PropertyValuesHolder.ofFloat("y", *rotations.map { it.y }.toFloatArray()),
         PropertyValuesHolder.ofFloat("z", *rotations.map { it.z }.toFloatArray())
-    )
+    ).also { animator ->
+        animator.addUpdateListener { anim ->
+            val target = anim.animatedValue as Float3
+            node.rotation = Rotation(target.x, target.y, target.z)
+        }
+    }
 
     fun ofScale(node: Node, vararg scales: Scale) = ObjectAnimator.ofPropertyValuesHolder(
         node.scale,
         PropertyValuesHolder.ofFloat("x", *scales.map { it.x }.toFloatArray()),
         PropertyValuesHolder.ofFloat("y", *scales.map { it.y }.toFloatArray()),
         PropertyValuesHolder.ofFloat("z", *scales.map { it.z }.toFloatArray())
-    )
+    ).also { animator ->
+        animator.addUpdateListener { anim ->
+            val target = anim.animatedValue as Float3
+            node.scale = Scale(target.x, target.y, target.z)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- NodeAnimator.ofPosition/ofQuaternion/ofRotation/ofScale were mutating a snapshot copy of Float3/Quaternion (value types) instead of writing back to node.position/quaternion/rotation/scale
- Fix: `addUpdateListener` on each ObjectAnimator that writes the animated value to the actual node property

Closes #388

## Test plan
- [ ] Verify `node.animatePositions()` actually moves the node
- [ ] Verify `node.animateRotations()` actually rotates the node
- [ ] Compile check passes (`./gradlew :sceneview:compileReleaseKotlin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>