### PR TITLE
Fix ViewNode not displaying

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/Scene.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Scene.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
@@ -63,6 +64,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import dev.romainguy.kotlin.math.Float2
+import io.github.sceneview.node.findActivity
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import androidx.core.net.toUri
 
 /**
  * A Filament 3D scene declared as Compose UI.
@@ -1107,10 +1112,31 @@ fun rememberViewNodeManager(
     creator: () -> ViewNode.WindowManager = {
         createViewNodeManager(context)
     }
-) = remember(context, creator).also {
-    DisposableEffect(it) {
-        onDispose {
-            it.destroy()
+): ViewNode.WindowManager {
+    val activity = LocalContext.current.findActivity()
+    val view = LocalView.current
+    return remember(context, creator).also { windowManager ->
+
+        LaunchedEffect(activity, view) {
+            activity
+                ?.lifecycle
+                ?.currentStateFlow
+                ?.onEach { state ->
+                    when (state) {
+                        Lifecycle.State.CREATED -> windowManager.pause()
+                        Lifecycle.State.RESUMED -> windowManager.resume(view)
+                        else -> {
+                            /* no-op */
+                        }
+                    }
+                }
+                ?.collect()
+        }
+
+        DisposableEffect(windowManager) {
+            onDispose {
+                windowManager.destroy()
+            }
         }
     }
 }

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -320,7 +320,7 @@ class ViewNode(
 }
 
 
-private fun Context.findActivity(): ComponentActivity? {
+internal fun Context.findActivity(): ComponentActivity? {
     return generateSequence(this) { (it as? ContextWrapper)?.baseContext }.filterIsInstance<ComponentActivity>()
         .firstOrNull()
 }


### PR DESCRIPTION
## Summary
`ViewNode` content was never visible because `rememberViewNodeManager` never called `resume(view)` on the `WindowManager`. The view was created and added to the window manager's layout, but without `resume`, the underlying `Presentation` was never shown.

## Type
<!-- Check one -->
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Testing done
This was manual verification on device with ARSceneView as root component

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [ ] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated if signatures changed
- [X] `/test` run — new tests added for new behaviour
- [X] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes
- [ ] Filament materials recompiled (if `.mat` files changed)
- [X] Minimal diff — no unrelated reformatting
