### PR TITLE
Fix default scale to 1.0f in all dimensions when scaleToUnitCube is not set

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -244,7 +244,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         centerOrigin: Position? = null,
         position: Position = Position(x = 0f),
         rotation: Rotation = Rotation(x = 0f),
-        scale: Scale = Scale(x = 1f),
+        scale: Scale = Scale(1f),
         isVisible: Boolean = true,
         isEditable: Boolean = false,
         apply: ModelNodeImpl.() -> Unit = {},


### PR DESCRIPTION
## Summary
Fix default scale to 1.0f in all dimensions when scaleToUnitCube is not set.

`Scale` is a `Float3`. `Scale(x = 1f)` only sets the x component to 1f — y and z default to 0f. Any model placed without `scaleToUnitCube` was scaled to zero on two axes and appeared invisible. 

## Type
<!-- Check one -->
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Testing done
Manual verification on device in ARSceneView root composable

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [ ] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated if signatures changed
- [ ] `/test` run — new tests added for new behaviour
- [X] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes
- [ ] Filament materials recompiled (if `.mat` files changed)
- [X] Minimal diff — no unrelated reformatting

