### PR TITLE
Fix release related crashes.

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRenderer.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRenderer.kt
@@ -35,7 +35,7 @@ import io.github.sceneview.texture.ImageTexture
  */
 class PlaneRenderer(
     val engine: Engine,
-    materialLoader: MaterialLoader,
+    private val materialLoader: MaterialLoader,
     private val scene: Scene
 ) {
 
@@ -200,11 +200,9 @@ class PlaneRenderer(
         visualizers.forEach { (_, planeVisualizer) -> planeVisualizer.destroy() }
 
         materialInstances.forEach { engine.safeDestroyMaterialInstance(it) }
-        engine.safeDestroyMaterialInstance(planeMaterial.defaultInstance)
-        engine.safeDestroyMaterial(planeMaterial)
+        materialLoader.destroyMaterial(planeMaterial)
+        materialLoader.destroyMaterial(shadowMaterial)
         engine.safeDestroyTexture(planeTexture)
-        engine.safeDestroyMaterialInstance(shadowMaterial.defaultInstance)
-        engine.safeDestroyMaterial(shadowMaterial)
     }
 
     /**

--- a/sceneview/src/androidTest/java/io/github/sceneview/node/ViewNodeTest.kt
+++ b/sceneview/src/androidTest/java/io/github/sceneview/node/ViewNodeTest.kt
@@ -1,0 +1,283 @@
+package io.github.sceneview.node
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.filament.Filament
+import com.google.android.filament.gltfio.Gltfio
+import com.google.android.filament.utils.Utils
+import io.github.sceneview.createEglContext
+import io.github.sceneview.createEngine
+import io.github.sceneview.loaders.MaterialLoader
+import io.github.sceneview.math.Size
+import io.github.sceneview.safeDestroy
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for [ViewNode] — construction, property setters, geometry updates, destroy safety,
+ * scene lifecycle callbacks, and [ViewNode.WindowManager].
+ */
+@RunWith(AndroidJUnit4::class)
+class ViewNodeTest {
+
+    private lateinit var engine: com.google.android.filament.Engine
+    private lateinit var materialLoader: MaterialLoader
+    private lateinit var windowManager: ViewNode.WindowManager
+
+    @Before
+    fun setup() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            Gltfio.init(); Filament.init(); Utils.init()
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            engine = createEngine(createEglContext())
+            materialLoader = MaterialLoader(engine, ctx)
+            windowManager = ViewNode.WindowManager(ctx)
+        }
+    }
+
+    @After
+    fun teardown() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            windowManager.destroy()
+            materialLoader.destroy()
+            engine.safeDestroy()
+        }
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private fun makeViewNode(): ViewNode = ViewNode(
+        engine = engine,
+        windowManager = windowManager,
+        materialLoader = materialLoader,
+        view = View(InstrumentationRegistry.getInstrumentation().targetContext)
+    )
+
+    // ── Construction & defaults ───────────────────────────────────────────────
+
+    @Test
+    fun viewNode_creation_withView_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+            node.destroy()
+        }
+    }
+
+    @Test
+    fun viewNode_creation_hasCorrectDefaults() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+
+            assertEquals("pxPerUnits default should be 250", 250.0f, node.pxPerUnits, 0.001f)
+            assertEquals("viewSize.x default should be 0", 0.0f, node.viewSize.x, 0.001f)
+            assertEquals("viewSize.y default should be 0", 0.0f, node.viewSize.y, 0.001f)
+            assertNotNull("layout should not be null", node.layout)
+            assertNotNull("stream should not be null", node.stream)
+            assertNotNull("texture should not be null", node.texture)
+
+            node.destroy()
+        }
+    }
+
+    // ── Property setters ──────────────────────────────────────────────────────
+
+    @Test
+    fun viewNode_pxPerUnits_setter_storesValue() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+
+            node.pxPerUnits = 500.0f
+
+            assertEquals("pxPerUnits should be stored", 500.0f, node.pxPerUnits, 0.001f)
+
+            node.destroy()
+        }
+    }
+
+    @Test
+    fun viewNode_viewSize_setter_storesValue() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+
+            node.viewSize = Size(100.0f, 50.0f)
+
+            assertEquals("viewSize.x should be stored", 100.0f, node.viewSize.x, 0.001f)
+            assertEquals("viewSize.y should be stored", 50.0f, node.viewSize.y, 0.001f)
+
+            node.destroy()
+        }
+    }
+
+    // ── Geometry updates ──────────────────────────────────────────────────────
+
+    @Test
+    fun viewNode_pxPerUnits_updatesGeometrySize() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+
+            node.viewSize = Size(500.0f, 250.0f)
+            node.pxPerUnits = 500.0f
+
+            // geometry.size = viewSize / pxPerUnits = (500/500, 250/500) = (1.0, 0.5)
+            assertEquals("geometry width should be 1.0", 1.0f, node.geometry.size.x, 0.01f)
+            assertEquals("geometry height should be 0.5", 0.5f, node.geometry.size.y, 0.01f)
+
+            node.destroy()
+        }
+    }
+
+    @Test
+    fun viewNode_viewSize_updatesGeometrySize() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+
+            node.pxPerUnits = 250.0f
+            node.viewSize = Size(500.0f, 500.0f)
+
+            // geometry.size = viewSize / pxPerUnits = (500/250, 500/250) = (2.0, 2.0)
+            assertEquals("geometry width should be 2.0", 2.0f, node.geometry.size.x, 0.01f)
+            assertEquals("geometry height should be 2.0", 2.0f, node.geometry.size.y, 0.01f)
+
+            node.destroy()
+        }
+    }
+
+    // ── Destroy safety ────────────────────────────────────────────────────────
+
+    @Test
+    fun viewNode_destroy_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+            node.destroy() // must not SIGABRT
+        }
+    }
+
+    @Test
+    fun viewNode_destroy_rapidCycle_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            repeat(20) {
+                val node = makeViewNode()
+                node.destroy()
+            }
+        }
+    }
+
+    @Test
+    fun viewNode_destroy_unregistersFromMaterialLoader() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+            node.destroy()
+            // Verified implicitly: teardown's materialLoader.destroy() must not crash,
+            // which would happen if the MaterialInstance were still tracked but its
+            // underlying texture had already been destroyed.
+        }
+    }
+
+    @Test
+    fun viewNode_destroy_withCustomPxPerUnits_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val node = makeViewNode()
+            node.pxPerUnits = 100.0f
+            node.destroy() // must not SIGABRT
+        }
+    }
+
+    // ── Scene lifecycle ───────────────────────────────────────────────────────
+
+    @Test
+    fun viewNode_onAddedToScene_addsLayoutToWindowManager() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val filamentScene = engine.createScene()
+            val node = makeViewNode()
+
+            node.onAddedToScene(filamentScene)
+
+            assertTrue(
+                "windowManager.layout should have the node layout as a child",
+                windowManager.layout.childCount > 0
+            )
+
+            node.destroy()
+            engine.destroyScene(filamentScene)
+        }
+    }
+
+    // ── WindowManager ─────────────────────────────────────────────────────────
+
+    @Test
+    fun windowManager_creation_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            wm.destroy()
+        }
+    }
+
+    @Test
+    fun windowManager_addView_increasesChildCount() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            val view = View(ctx)
+
+            val before = wm.layout.childCount
+            wm.addView(view)
+
+            assertEquals("child count should increase by 1", before + 1, wm.layout.childCount)
+
+            wm.destroy()
+        }
+    }
+
+    @Test
+    fun windowManager_removeView_decreasesChildCount() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            val view = View(ctx)
+
+            wm.addView(view)
+            val countAfterAdd = wm.layout.childCount
+            wm.removeView(view)
+
+            assertEquals("child count should decrease by 1", countAfterAdd - 1, wm.layout.childCount)
+
+            wm.destroy()
+        }
+    }
+
+    @Test
+    fun windowManager_pause_withoutAttach_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            wm.pause() // must not throw
+            wm.destroy()
+        }
+    }
+
+    @Test
+    fun windowManager_destroy_withoutAttach_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            wm.destroy() // must not throw
+        }
+    }
+
+    @Test
+    fun windowManager_multipleDestroy_isIdempotent() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+            val wm = ViewNode.WindowManager(ctx)
+            wm.destroy()
+            wm.destroy() // calling twice must not throw
+        }
+    }
+}

--- a/sceneview/src/main/java/io/github/sceneview/Scene.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Scene.kt
@@ -63,6 +63,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import dev.romainguy.kotlin.math.Float2
+import androidx.core.net.toUri
+import io.github.sceneview.logging.logWarning
 
 /**
  * A Filament 3D scene declared as Compose UI.
@@ -471,7 +473,7 @@ fun rememberModelInstance(
     assetFileLocation: String
 ): ModelInstance? {
     val context = LocalContext.current
-    return produceState<ModelInstance?>(
+    return produceState<Model?>(
         initialValue = null,
         key1 = modelLoader,
         key2 = assetFileLocation
@@ -480,8 +482,23 @@ fun rememberModelInstance(
         val buffer = withContext(Dispatchers.IO) {
             runCatching { context.assets.readBuffer(assetFileLocation) }.getOrNull()
         } ?: return@produceState
-        value = runCatching { modelLoader.createModelInstance(buffer) }.getOrNull()
-    }.value
+        value = runCatching { modelLoader.createModel(buffer) }
+            .onFailure {
+                logWarning("ModelLoad", "Failed to load model from asset '$assetFileLocation' ${it}")
+            }
+            .getOrNull()
+    }.value.also {
+        if (it != null) {
+            // Ensure we destroy the model properly, to avoid leaking when recomposition destroys node but not the
+            // whole scene/modelLoader. If the assetFile doesn't change, we won't reload and `modelInstance` is
+            // still reused
+            DisposableEffect(it) {
+                onDispose {
+                    modelLoader.destroyModel(it)
+                }
+            }
+        }
+    }?.instance
 }
 
 /**
@@ -507,21 +524,32 @@ fun rememberModelInstance(
         ModelLoader.getFolderPath(fileLocation, it)
     }
 ): ModelInstance? {
-    val uri = android.net.Uri.parse(fileLocation)
+    val uri = fileLocation.toUri()
     // Fast path: plain asset file name (no scheme) → use synchronous asset reader
     if (uri.scheme == null) {
         return rememberModelInstance(modelLoader, assetFileLocation = fileLocation)
     }
     // URL / file URI / content URI → use suspend loadModelInstance which handles http(s)
-    return produceState<ModelInstance?>(
+    return produceState<Model?>(
         initialValue = null,
         key1 = modelLoader,
         key2 = fileLocation
     ) {
         value = runCatching {
-            modelLoader.loadModelInstance(fileLocation, resourceResolver)
+            modelLoader.loadModel(fileLocation, resourceResolver)
         }.getOrNull()
-    }.value
+    }.value.also {
+        if (it != null) {
+            // Ensure we destroy the model properly, to avoid leaking when recomposition destroys node but not the
+            // whole scene/modelLoader. If the assetFile doesn't change, we won't reload and `modelInstance` is
+            // still reused
+            DisposableEffect(it) {
+                onDispose {
+                    modelLoader.destroyModel(it)
+                }
+            }
+        }
+    }?.instance
 }
 
 // ── Video helper ──────────────────────────────────────────────────────────────────────────────────

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -185,14 +185,14 @@ class ViewNode(
     }
 
     override fun destroy() {
-
         windowManager.removeView(layout)
+
+        super.destroy()
 
         materialLoader.destroyMaterialInstance(materialInstance)
         engine.safeDestroyTexture(texture)
         engine.safeDestroyStream(stream)
 
-        super.destroy()
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixing a couple of crashes related to memory management on release due to some _filament_ panic thrown.

1. ViewNode call super destroy first, otherwise there's a _panic_ in filament due to delete materialInstance already in use
2. Delete materials through the `MaterialLoader` to avoid the double deletion causing crash when `MaterialLoader` is destroyed.

## Type
<!-- Check one -->
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Testing done
Manual verification and tests added for `ViewNode`

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [ ] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated if signatures changed
- [X] `/test` run — new tests added for new behaviour
- [X] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes
- [ ] Filament materials recompiled (if `.mat` files changed)
- [X] Minimal diff — no unrelated reformatting

