### PR TITLE
Add position and rotation parameters to ViewNode

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -1133,6 +1133,8 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
      * @param windowManager         The [ViewNodeImpl.WindowManager] to attach the view to.
      * @param unlit                 If `true`, ignores scene lighting (always fully bright).
      * @param invertFrontFaceWinding Inverts face winding — useful for front-facing AR cameras.
+     * @param position              World-space position.
+     * @param rotation              World-space rotation (Euler angles in degrees).
      * @param apply                 Additional configuration on the [ViewNodeImpl] instance.
      * @param content               Optional 3D child nodes in a [NodeScope].
      * @param viewContent           The Compose UI to render inside the 3D node.
@@ -1142,6 +1144,8 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         windowManager: ViewNodeImpl.WindowManager,
         unlit: Boolean = false,
         invertFrontFaceWinding: Boolean = false,
+        position: Position = Position(x = 0f),
+        rotation: Rotation = Rotation(x = 0f),
         apply: ViewNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null,
         viewContent: @Composable () -> Unit
@@ -1155,6 +1159,10 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 invertFrontFaceWinding = invertFrontFaceWinding,
                 content = viewContent
             ).apply(apply)
+        }
+        SideEffect {
+            node.position = position
+            node.rotation = rotation
         }
         NodeLifecycle(node, content)
     }


### PR DESCRIPTION
## Summary
Exposes `position` and `rotation` as parameters on `ViewNode` since while the `apply` parameter exists as an alternative, it does not react to state changes dynamically.

## Type
<!-- Check one -->
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Testing done
Manual verification on Samsung Galaxy Z Flip4.

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [ ] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated if signatures changed
- [ ] `/test` run — new tests added for new behaviour
- [X] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes
- [ ] Filament materials recompiled (if `.mat` files changed)
- [X] Minimal diff — no unrelated reformatting

> **AI-assisted contributions welcome.**
> Run `/contribute` in Claude Code for a guided workflow that handles review, docs, and test generation automatically.
> MCP server: `npx -y sceneview-mcp` — gives Claude full SceneView API context.
