### PR TITLE
fix(node): destroy renderable before entity to prevent Filament SIGABRT on dispose

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
@@ -63,7 +63,12 @@ open class RenderableNode(
     }
 
     override fun destroy() {
-        super.destroy()
+        // Destroy the renderable component BEFORE Node.destroy() frees the entity ID.
+        // If safeDestroyEntity runs first, renderableManager.destroy(entity) silently fails
+        // (entity ID invalid), leaving Filament's internal MI/texture bindings dangling and
+        // causing "Invalid texture still bound to MaterialInstance" on the subsequent texture
+        // destroy.
         engine.safeDestroyRenderable(entity)
+        super.destroy()
     }
 }

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -185,14 +185,15 @@ class ViewNode(
     }
 
     override fun destroy() {
-
         windowManager.removeView(layout)
-
-        materialLoader.destroyMaterialInstance(materialInstance)
+        // Capture MI before super.destroy() removes the renderable component (after which
+        // getMaterialInstanceAt would fail). Destroy in order: renderable (via super) → MI → texture
+        // → stream, so Filament never sees a live texture binding on a dead MI or renderable.
+        val mi = materialInstance
+        super.destroy()
+        materialLoader.destroyMaterialInstance(mi)
         engine.safeDestroyTexture(texture)
         engine.safeDestroyStream(stream)
-
-        super.destroy()
     }
 
     /**


### PR DESCRIPTION
## Root cause

`RenderableNode.destroy()` was calling `super.destroy()` first, which runs `Node.destroy()` → `safeDestroyEntity(entity)`. Once the entity ID is freed, the subsequent `safeDestroyRenderable(entity)` call silently fails (`renderableManager.destroy()` on an invalid entity ID, swallowed by `runCatching`).

With the renderable component not properly cleaned up, Filament's internal tables still consider the `MaterialInstance` (and its bound `Texture`) as active. The crash fires when `destroyTexture()` runs its liveness check:

```
Precondition in commit:240
reason: Invalid texture still bound to MaterialInstance: 'Transparent Textured'
Fatal signal 6 (SIGABRT)
```

## Fix

**`RenderableNode.destroy()`** — call `safeDestroyRenderable(entity)` **before** `super.destroy()`, so the renderable component is removed from Filament's tables while the entity ID is still valid.

**`ViewNode.destroy()`** — had the same ordering problem: was destroying the `MaterialInstance` before `super.destroy()` removed the renderable (MI still in use by the renderable → "destroying MaterialInstance which is still in use by Renderable"). Aligned to ImageNode's pattern: capture MI ref → `super.destroy()` → destroy MI → texture → stream.

## Correct destroy order (after fix)

```
safeDestroyRenderable(entity)   ← unlinks MI from renderable in Filament
Node.destroy():
  safeDestroyTransformable(entity)
  safeDestroyEntity(entity)
[GeometryNode] safeDestroyGeometry(geometry)
[ImageNode]    destroyMaterialInstance(mi)  ← safe: no renderable references it
[ImageNode]    safeDestroyTexture(texture)  ← safe: no MI references it
```

## Fixes

Closes #646 — crash since v2.3.x, confirmed still broken in 4.0.1
Closes #847 — crash on dispose with ImageNode/TextNode/ViewNode (Filament precondition)
Closes #837 — crash when removing TextNode