### PR TITLE
Follow-ups to #789: AugmentedFaceNode tracking-state callback, normals encoding, cleanup

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -203,6 +203,13 @@ open class AugmentedFaceNode(
      * an empty list for [AugmentedFace] on the front camera. Manually sets [PoseNode] state
      * (session, frame, cameraTrackingState) since `super` cannot be called without
      * re-triggering the broken `getUpdatedTrackables` check.
+     *
+     * [update] (trackable) is invoked every frame regardless of tracking state so the
+     * `trackingState` setter in [TrackableNode] fires `onTrackingStateChanged` and
+     * `updateVisibility()` on TRACKING -> STOPPED/PAUSED transitions (e.g. face leaving the
+     * frame). Existing guards in [update] (trackable) skip mesh creation/buffer updates when
+     * not TRACKING. `onUpdated` only fires while TRACKING since the face data is only
+     * meaningful then.
      */
     override fun update(session: Session, frame: Frame) {
         // PoseNode state — set manually since we skip super
@@ -210,8 +217,12 @@ open class AugmentedFaceNode(
         this.frame = frame
         this.cameraTrackingState = frame.camera.trackingState
 
+        // Always propagate trackable state so onTrackingStateChanged fires on every
+        // transition, including TRACKING -> STOPPED/PAUSED. update(trackable) guards mesh
+        // work internally.
+        update(augmentedFace)
+
         if (augmentedFace.trackingState == TrackingState.TRACKING) {
-            update(augmentedFace)
             onUpdated?.invoke(augmentedFace)
         }
     }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -5,12 +5,15 @@ import com.google.android.filament.IndexBuffer
 import com.google.android.filament.MaterialInstance
 import com.google.android.filament.RenderableManager
 import com.google.android.filament.RenderableManager.PrimitiveType
+import com.google.android.filament.SurfaceOrientation
 import com.google.android.filament.VertexBuffer
 import com.google.android.filament.VertexBuffer.AttributeType
 import com.google.android.filament.VertexBuffer.VertexAttribute.POSITION
 import com.google.android.filament.VertexBuffer.VertexAttribute.TANGENTS
 import com.google.android.filament.VertexBuffer.VertexAttribute.UV0
 import com.google.ar.core.AugmentedFace
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import com.google.ar.core.AugmentedFace.RegionType
 import com.google.ar.core.Frame
 import com.google.ar.core.Session
@@ -102,6 +105,12 @@ open class AugmentedFaceNode(
     var meshNode: MeshNode? = null
         private set
 
+    // Reusable tangent-quaternion buffer: 4 floats per vertex, 16 bytes/vertex.
+    // Allocated lazily and grown on demand — the face mesh vertex count is stable
+    // across frames (ARCore returns a fixed-topology mesh), so this is typically
+    // allocated once and reused for the life of the node.
+    private var tangentsBuffer: ByteBuffer? = null
+
     /**
      * The region nodes at the tip of the nose, the detected face's left side of the forehead,
      * the detected face's right side of the forehead.
@@ -127,31 +136,42 @@ open class AugmentedFaceNode(
         val indices = augmentedFace.meshTriangleIndices
         val vertices = augmentedFace.meshVertices
         val normals = augmentedFace.meshNormals
+        // UVs are static per ARCore docs but `SurfaceOrientation` consumes them every
+        // frame to recompute tangent quaternions, so they have to be in scope here too.
+        val uvs = augmentedFace.meshTextureCoordinates
 
         if (indices.limit() == 0 || vertices.limit() == 0) return
 
+        val vertexCount = vertices.limit() / 3
+
+        // Compute tangent quaternions from positions + normals + uvs + indices.
+        // PBR materials require TANGENTS (FLOAT4 quaternions encoding normal + tangent
+        // + bitangent), not raw FLOAT3 normals — uploading normals as if they were
+        // quaternions left the mesh with undefined lighting and rendered it invisible
+        // under the transparent colored material used by the demo.
+        val tangents = computeTangents(vertices, normals, uvs, indices, vertexCount)
+
         if (meshNode == null) {
-            // UVs are static for the session — read once at mesh creation.
-            val uvs = augmentedFace.meshTextureCoordinates
             meshNode = MeshNode(
                 engine = engine,
                 primitiveType = PrimitiveType.TRIANGLES,
                 vertexBuffer = VertexBuffer.Builder()
-                    // Position + Normals + UV Coordinates
+                    // Position + Tangents (quaternion) + UV Coordinates
                     .bufferCount(3)
                     // Position Attribute (x, y, z)
                     .attribute(POSITION, 0, AttributeType.FLOAT3)
-                    // Tangents Attribute (Quaternion: x, y, z, w)
+                    // Tangents Attribute (Quaternion: x, y, z, w) — encodes normal + tangent
+                    // + bitangent for PBR lighting. Must be FLOAT4.
                     .attribute(TANGENTS, 1, AttributeType.FLOAT4)
                     .normalized(TANGENTS)
                     // Uv Attribute (x, y)
                     .attribute(UV0, 2, AttributeType.FLOAT2)
-                    .vertexCount(vertices.limit() / 3)
+                    .vertexCount(vertexCount)
                     .build(engine).apply {
                         // Fill all slots before the node becomes visible,
                         // so Filament can compute a non-empty AABB (build:552)
                         setBufferAt(engine, 0, vertices) // positions  (dynamic)
-                        setBufferAt(engine, 1, normals)  // normals    (dynamic)
+                        setBufferAt(engine, 1, tangents) // tangents   (dynamic, recomputed)
                         setBufferAt(engine, 2, uvs)      // UVs        (static)
                     },
                 indexBuffer = IndexBuffer.Builder()
@@ -183,10 +203,12 @@ open class AugmentedFaceNode(
             return
         }
 
-        // Update dynamic buffers every frame
+        // Update dynamic buffers every frame — positions + recomputed tangents.
+        // Tangent quaternions depend on normals and must be rebuilt whenever the
+        // mesh deforms (i.e. every tracked frame).
         meshNode?.vertexBuffer?.apply {
             setBufferAt(engine, 0, vertices) // positions
-            setBufferAt(engine, 1, normals)  // normals
+            setBufferAt(engine, 1, tangents) // tangent quaternions
         }
 
         centerNode.pose = augmentedFace.centerPose
@@ -225,5 +247,67 @@ open class AugmentedFaceNode(
         if (augmentedFace.trackingState == TrackingState.TRACKING) {
             onUpdated?.invoke(augmentedFace)
         }
+    }
+
+    /**
+     * Builds (or reuses) [tangentsBuffer] and fills it with quaternions computed from
+     * the supplied positions, normals, UVs and indices via Filament's
+     * [SurfaceOrientation]. The returned buffer holds `vertexCount * 16` bytes
+     * (4 floats per vertex) and is rewound to position 0, ready for upload.
+     */
+    private fun computeTangents(
+        positions: java.nio.FloatBuffer,
+        normals: java.nio.FloatBuffer,
+        uvs: java.nio.FloatBuffer,
+        indices: java.nio.ShortBuffer,
+        vertexCount: Int,
+    ): ByteBuffer {
+        val neededBytes = vertexCount * 4 * 4
+        val buf = tangentsBuffer?.takeIf { it.capacity() >= neededBytes }
+            ?: ByteBuffer.allocateDirect(neededBytes).order(ByteOrder.nativeOrder())
+                .also { tangentsBuffer = it }
+
+        buf.clear()
+        buf.limit(neededBytes)
+
+        val orientation = SurfaceOrientation.Builder()
+            .vertexCount(vertexCount)
+            .positions(positions.duplicate().rewind() as java.nio.Buffer)
+            .normals(normals.duplicate().rewind() as java.nio.Buffer)
+            .uvs(uvs.duplicate().rewind() as java.nio.Buffer)
+            .triangleCount(indices.limit() / 3)
+            .triangles_uint16(indices.duplicate().rewind() as java.nio.Buffer)
+            .build()
+        try {
+            orientation.getQuatsAsFloat(buf)
+        } finally {
+            orientation.destroy()
+        }
+        buf.rewind()
+        return buf
+    }
+
+    override fun destroy() {
+        // Destroy the face mesh resources we built in update() before tearing down
+        // the parent chain. Filament does not reclaim VertexBuffer / IndexBuffer when
+        // the owning Renderable is destroyed — they stay in the engine registry until
+        // Engine.destroy() runs, and because they're tied to this composable's
+        // disposable lifecycle, each back-navigation leaks two buffers per tracked face.
+        // More critically: destroying the Engine while a VertexBuffer is still
+        // attached to a not-yet-unregistered Renderable triggers a Filament
+        // PreconditionPanic ("resource still referenced") — that's the native abort
+        // users hit when leaving the Face Mesh demo via the back gesture.
+        val mn = meshNode
+        if (mn != null) {
+            val vb = mn.vertexBuffer
+            val ib = mn.indexBuffer
+            runCatching { mn.destroy() }
+            runCatching { engine.destroyVertexBuffer(vb) }
+            runCatching { engine.destroyIndexBuffer(ib) }
+            meshNode = null
+        }
+        runCatching { centerNode.destroy() }
+        regionNodes.values.forEach { runCatching { it.destroy() } }
+        super.destroy()
     }
 }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -70,8 +70,8 @@ import io.github.sceneview.node.MeshNode
 open class AugmentedFaceNode(
     engine: Engine,
     val augmentedFace: AugmentedFace,
-    meshMaterialInstance: MaterialInstance? = null,
-    builder: RenderableManager.Builder.() -> Unit = {},
+    private val meshMaterialInstance: MaterialInstance? = null,
+    private val builder: RenderableManager.Builder.() -> Unit = {},
     onTrackingStateChanged: ((TrackingState) -> Unit)? = null,
     onUpdated: ((AugmentedFace) -> Unit)? = null
 ) : TrackableNode<AugmentedFace>(
@@ -102,9 +102,6 @@ open class AugmentedFaceNode(
     var meshNode: MeshNode? = null
         private set
 
-    private val faceMaterialInstance = meshMaterialInstance
-    private val meshBuilder = builder
-
     /**
      * The region nodes at the tip of the nose, the detected face's left side of the forehead,
      * the detected face's right side of the forehead.
@@ -130,11 +127,12 @@ open class AugmentedFaceNode(
         val indices = augmentedFace.meshTriangleIndices
         val vertices = augmentedFace.meshVertices
         val normals = augmentedFace.meshNormals
-        val uvs = augmentedFace.meshTextureCoordinates
 
         if (indices.limit() == 0 || vertices.limit() == 0) return
 
         if (meshNode == null) {
+            // UVs are static for the session — read once at mesh creation.
+            val uvs = augmentedFace.meshTextureCoordinates
             meshNode = MeshNode(
                 engine = engine,
                 primitiveType = PrimitiveType.TRIANGLES,
@@ -162,7 +160,7 @@ open class AugmentedFaceNode(
                     .build(engine).apply {
                         setBuffer(engine, indices)       // indices    (static)
                     },
-                materialInstance = faceMaterialInstance,
+                materialInstance = meshMaterialInstance,
                 builder = {
                     // Filament computes AABB asynchronously after vertex buffer upload.
                     // If a render frame starts before AABB is updated, Filament aborts with
@@ -172,7 +170,7 @@ open class AugmentedFaceNode(
                     culling(false)
                     castShadows(false)
                     receiveShadows(false)
-                    meshBuilder()
+                    builder()
                 }
             ).apply { parent = centerNode }
 


### PR DESCRIPTION
## Summary
Three follow-ups on top of [#789](https://github.com/sceneview/sceneview/pull/789), found by post-merge review.

1. **Cleanup (`909c217f`)** — promote `meshMaterialInstance` and `builder` to `private val` constructor params, drop the trivial aliases.
2. **`onTrackingStateChanged` regression fix (`0a7c1e8d`)** — `AugmentedFaceNode.update(session, frame)` only called `update(augmentedFace)` when the face was already TRACKING, so the `trackingState` setter in `TrackableNode` never fired on `TRACKING -> STOPPED/PAUSED` (face leaving the frame). `onTrackingStateChanged` callbacks never observed the exit and `updateVisibility()` was not invoked. Fix: always invoke `update(augmentedFace)`; the existing TRACKING + non-empty-buffer guards inside `update(trackable)` still skip mesh work when not tracking. `onUpdated` stays guarded behind TRACKING.
3. **Normals encoding fix (`0046de68`)** — slot 1 of the face mesh `VertexBuffer` is declared as `TANGENTS / FLOAT4 / normalized`. Filament documents `TANGENTS` as a tangent-frame quaternion, not a vec3 normal. #789 plugged ARCore's FLOAT3 `meshNormals` into that slot directly: 12 bytes/vertex of unit normals read by Filament as 16-byte normalised quaternions, producing undefined tangent frames and broken PBR lighting on the lit `transparent_colored` material used by `ARFaceDemo`. Fix: compute proper tangent quaternions every frame from positions, normals, UVs and indices via Filament's `SurfaceOrientation.Builder` (`getQuatsAsFloat` into a reusable `nativeOrder` `ByteBuffer`). The face mesh has fixed topology across frames, so the tangents buffer is allocated once and rebuilt in-place when ARCore deforms the mesh. Also adds a defensive `destroy()` that drops the `VertexBuffer` and `IndexBuffer` Filament holds for the face mesh — without this, the engine still references those buffers when the composable disposes and the next `Engine.destroy()` trips a `PreconditionPanic` (the native abort users hit when leaving the Face Mesh demo via the back gesture).

## Test plan
- [x] `./gradlew :arsceneview:compileReleaseKotlin` — BUILD SUCCESSFUL
- [ ] Live device QA on `ARFaceDemo`: mesh now renders with correct PBR lighting under the transparent colored material
- [ ] Live device QA: `onTrackingStateChanged(STOPPED)` fires when the face leaves the frame (previously silent)
- [ ] Live device QA: back-navigating out of the Face Mesh demo no longer crashes the next `Engine.destroy()` with `PreconditionPanic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)