### PR TITLE
fix(viewnode): clean up rememberViewNodeManager + harden post-destroy race

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/Scene.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Scene.kt
@@ -65,9 +65,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import dev.romainguy.kotlin.math.Float2
 import io.github.sceneview.node.findActivity
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.onEach
-import androidx.core.net.toUri
 
 /**
  * A Filament 3D scene declared as Compose UI.
@@ -1113,32 +1110,27 @@ fun rememberViewNodeManager(
         createViewNodeManager(context)
     }
 ): ViewNode.WindowManager {
-    val activity = LocalContext.current.findActivity()
+    val activity = context.findActivity()
     val view = LocalView.current
-    return remember(context, creator).also { windowManager ->
+    val windowManager = remember(context, creator) { creator() }
 
-        LaunchedEffect(activity, view) {
-            activity
-                ?.lifecycle
-                ?.currentStateFlow
-                ?.onEach { state ->
-                    when (state) {
-                        Lifecycle.State.CREATED -> windowManager.pause()
-                        Lifecycle.State.RESUMED -> windowManager.resume(view)
-                        else -> {
-                            /* no-op */
-                        }
-                    }
-                }
-                ?.collect()
-        }
-
-        DisposableEffect(windowManager) {
-            onDispose {
-                windowManager.destroy()
+    LaunchedEffect(windowManager, activity, view) {
+        activity?.lifecycle?.currentStateFlow?.collect { state ->
+            when (state) {
+                Lifecycle.State.RESUMED -> windowManager.resume(view)
+                Lifecycle.State.CREATED -> windowManager.pause()
+                else -> { /* STARTED, INITIALIZED, DESTROYED handled elsewhere */ }
             }
         }
     }
+
+    DisposableEffect(windowManager) {
+        onDispose {
+            windowManager.destroy()
+        }
+    }
+
+    return windowManager
 }
 
 @Composable

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -250,6 +250,8 @@ class ViewNode(
         private val windowManager =
             context.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
 
+        private var destroyed = false
+
         val layout by lazy {
             FrameLayout(context).also {
                 context.findActivity()?.let { activity ->
@@ -273,10 +275,14 @@ class ViewNode(
          * Therefore, we must use post to ensure that the window is only added after resume is finished.
          */
         fun resume(ownerView: View) {
+            if (destroyed) return
             // A ownerView can only be added to the WindowManager after the activity has finished resuming.
             // Therefore, we must use post to ensure that the window is only added after resume is finished.
             ownerView.post {
-                if (ownerView.isAttachedToWindow) {
+                // Recheck after the post: destroy() may have run while we were queued — without this
+                // guard the layout would be re-attached to the system WindowManager *after* it was
+                // explicitly torn down, leaking the window for the lifetime of the process.
+                if (!destroyed && ownerView.isAttachedToWindow) {
                     tryAttachingView()
                 }
             }
@@ -291,6 +297,7 @@ class ViewNode(
         }
 
         fun destroy() {
+            destroyed = true
             tryDetachingView()
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #820. Three independent review passes (Compose/lifecycle correctness, Kotlin style, edge-case robustness) found a small set of nits and one latent leak. This PR addresses the consensus items.

### Changes

- **Drop ghost import** `androidx.core.net.toUri` from `Scene.kt` — added by #820 but never referenced.
- **Replace deprecated `kotlinx.coroutines.flow.collect()` no-arg terminal** with the canonical `collect { state -> ... }` lambda form. Removes one deprecated import and the now-redundant `onEach` intermediate.
- **Use the `context` parameter** for `findActivity()` instead of re-reading `LocalContext.current`. Before, a caller passing an overridden context to `rememberViewNodeManager(context = …)` was silently ignored when resolving the activity.
- **Canonicalize the `remember(...)` shape** in `rememberViewNodeManager` — `val wm = remember(context, creator) { creator() }` matches the other `remember*` helpers in `Scene.kt` and removes the surprising `.also { ... }` indirection.
- **Guard the post-destroy race** in `ViewNode.WindowManager`. `resume(ownerView)` posts to the owner View's queue; if `destroy()` ran while the runnable was queued, the layout was re-attached to the system `WindowManager` *after* it had been torn down — leaking the window for the process lifetime. A new `destroyed` flag bails both synchronously in `resume()` and inside the queued runnable.

### Type
- [X] Bug fix (latent leak) + cleanup

### Testing done
- `./gradlew :sceneview:compileDebugKotlin :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` — green
- Behavioral path identical to #820 for the golden case (activity RESUMED → `resume(view)`, CREATED → `pause()`, dispose → `destroy()`)

### Out of scope (deferred)
The reviewers also flagged: (a) silent no-op when used outside a `ComponentActivity`, (b) collisions when two `rememberViewNodeManager` instances share the same activity (both panels register with identical `title="ViewNodeWindowManager"`), (c) `movableContentOf` host-`View` swaps that can leave the layout parented to the previous owner. These need API-shape decisions and belong in dedicated PRs.

### Checklist
- [X] Minimal diff — no unrelated reformatting
- [X] `:sceneview:compileReleaseKotlin` + `:arsceneview:compileReleaseKotlin` pass
- [ ] No new tests — all changes are local refactors of #820's behavior plus a defensive flag