### PR TITLE
fix(viewnode): restore scale + isVisible reactive params, switch to DisposableEffect (closes #856)

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -1135,6 +1135,8 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
      * @param invertFrontFaceWinding Inverts face winding — useful for front-facing AR cameras.
      * @param position              World-space position.
      * @param rotation              World-space rotation (Euler angles in degrees).
+     * @param scale                 Local scale.
+     * @param isVisible             Whether the node should be rendered.
      * @param apply                 Additional configuration on the [ViewNodeImpl] instance.
      * @param content               Optional 3D child nodes in a [NodeScope].
      * @param viewContent           The Compose UI to render inside the 3D node.
@@ -1146,6 +1148,8 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         invertFrontFaceWinding: Boolean = false,
         position: Position = Position(x = 0f),
         rotation: Rotation = Rotation(x = 0f),
+        scale: Scale = Scale(1f),
+        isVisible: Boolean = true,
         apply: ViewNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null,
         viewContent: @Composable () -> Unit
@@ -1160,10 +1164,18 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 content = viewContent
             ).apply(apply)
         }
-        SideEffect {
-            node.position = position
-            node.rotation = rotation
+        // Keyed on scalar components (Float3 uses reference equality so a fresh
+        // Position(x = …) on each recomposition would re-trigger even when unchanged).
+        DisposableEffect(node, position.x, position.y, position.z) {
+            node.position = position; onDispose {}
         }
+        DisposableEffect(node, rotation.x, rotation.y, rotation.z) {
+            node.rotation = rotation; onDispose {}
+        }
+        DisposableEffect(node, scale.x, scale.y, scale.z) {
+            node.scale = scale; onDispose {}
+        }
+        DisposableEffect(node, isVisible) { node.isVisible = isVisible; onDispose {} }
         NodeLifecycle(node, content)
     }
 


### PR DESCRIPTION
## Summary

Closes #856.

PR #842 added `position`/`rotation` as reactive params on the `ViewNode` composable but left two regressions vs the prior `7d82701c` implementation:

1. **`scale` and `isVisible` were dropped** — toggling visibility from Compose state no longer affects the rendered ViewNode. The android-demo Visible-toggle QA case regressed silently.
2. **`SideEffect` was used in place of `DisposableEffect`** keyed on scalar components. `Float3` / `Scale` / `Rotation` use reference equality, so a fresh `Position(x = 0f)` default on every call rendered SideEffect-based keying useless — the assignment fired on every recomposition.

This PR restores all four reactive params (`position`, `rotation`, `scale`, `isVisible`) and uses `DisposableEffect` keyed on scalar components, matching the original `7d82701c` pattern.

## Test plan

- [x] `./gradlew :sceneview:compileReleaseKotlin` — BUILD SUCCESSFUL
- [ ] Manual verification: toggle the "Visible" switch in the android-demo ViewNode card — the 3D card should hide/show
- [ ] Manual verification: drive `position`/`rotation`/`scale` from `mutableStateOf` and confirm the node updates without recomposition cost (ideally checked in a render-test follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)