### PR TITLE
docs: bump SPM "sceneview-swift" version refs from 4.0.0/4.0.1 to 4.0.2

### DIFF
--- a/.claude/plans/global-issues-2026-04-11.md
+++ b/.claude/plans/global-issues-2026-04-11.md
@@ -56,7 +56,7 @@ curl -sL "https://repo1.maven.org/maven2/io/github/sceneview/sceneview/maven-met
 
 **Status:** `README.md`, `llms.txt`, `docs/docs/cheatsheet-ios.md`, and likely other docs all tell iOS/macOS/visionOS users to install via:
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 But `gh api repos/sceneview/sceneview-swift` returns **404 — Repository not found**. The repo does not exist on GitHub. Any user following the install instructions gets a clone failure before they can try the SDK.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,7 @@ fun MyARScreen() {
 
 ## iOS code generation rules (SceneViewSwift)
 
-1. SPM: `https://github.com/sceneview/sceneview-swift.git` from: "4.0.1"`
+1. SPM: `https://github.com/sceneview/sceneview-swift.git` from: "4.0.2"`
 2. Use `SceneView` for 3D, `ARSceneView` for AR (SwiftUI views)
 3. Load models: `try await ModelNode.load("models/car.usdz")` — async
 4. Minimum: iOS 17+, macOS 14+, visionOS 1+

--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -21,7 +21,7 @@ Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.2")
 ]
 ```
 

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -16,7 +16,7 @@ A quick reference for SceneViewSwift's most-used APIs. Print it, pin it, keep it
 
 ```swift
 // Package.swift or Xcode SPM
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 
 ```swift

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.2`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.0")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.10 | **Compose BOM compatible**
 

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -49,7 +49,7 @@ https://github.com/sceneview/sceneview-swift.git
 !!! tip
     You can also add the dependency manually in your `Package.swift`:
     ```swift
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
     ```
 
 ---

--- a/docs/docs/samples-ios.md
+++ b/docs/docs/samples-ios.md
@@ -11,7 +11,7 @@ description: "SwiftUI + RealityKit sample code for SceneViewSwift: model viewer,
 These samples demonstrate SceneViewSwift capabilities using **SwiftUI + RealityKit** on iOS, macOS, and visionOS. Each example is a self-contained SwiftUI view you can drop into an Xcode project after adding the SceneViewSwift package.
 
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 
 ---

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -26,7 +26,7 @@ Always determine the target platform first. Ask if unclear. Default to Android (
 ### Version info
 - Current version: **3.6.2**
 - Android: `io.github.sceneview:sceneview:3.6.2` (3D) / `io.github.sceneview:arsceneview:3.6.2` (AR)
-- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.1")
+- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 - Web: `npm install sceneview-web@3.6.2`
 - Min SDK: 24 | Target: 36 | Kotlin: 2.3.20
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.2`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.0")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 

--- a/mcp/llms.txt
+++ b/mcp/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.1`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.0")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -1860,7 +1860,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ]
 ```
 
@@ -2539,7 +2539,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 
 Import: `import SceneViewSwift`

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.0")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -1807,7 +1807,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ]
 ```
 
@@ -2481,7 +2481,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 
 Import: `import SceneViewSwift`

--- a/website-static/llms.txt
+++ b/website-static/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.0")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.2")
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -1807,7 +1807,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ]
 ```
 
@@ -2481,7 +2481,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.2")
 ```
 
 Import: `import SceneViewSwift`


### PR DESCRIPTION
## Summary

Found by `.claude/scripts/impact-check.sh` after the v4.0.2 release — the impact-check has a SPM version consistency rule that asserts every `sceneview-swift` import line in Markdown / llms.txt / system-prompt files matches the current `gradle.properties` version.

12 tracked files updated. Both forms covered:
- code blocks: `.package(url: "...sceneview-swift.git", from: "4.0.2")`
- prose / list mentions: `(from: "4.0.2")`

(Stale references in gitignored `marketing/` are local drafts, not shipped — skipped.)

## Test plan

- [x] `bash .claude/scripts/impact-check.sh` — SPM consistency gate passes for tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)