### PR TITLE
ci(play-store): clean versionName on tagged deploys + tag push trigger

### DIFF
--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -10,6 +10,8 @@ on:
       - 'samples/android-demo/**'
       - 'samples/android-demo-assets/**'
       - 'samples/common/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       track:
@@ -50,17 +52,25 @@ jobs:
 
       - run: chmod +x ./gradlew
 
-      # Auto-versioning: versionCode = run_number (always increasing)
-      # versionName = git tag or YYYY.MM.DD-<short_sha>
+      # Auto-versioning:
+      #   versionCode = run_number (always increasing)
+      #   versionName = - "X.Y.Z" when HEAD is exactly on a release tag (clean public version)
+      #                 - "X.Y.Z-<short_sha>" when on main past the latest tag (snapshot)
+      #                 - "YYYY.MM.DD-<short_sha>" when there is no tag yet
       - name: Calculate version
         id: version
         run: |
           VERSION_CODE=${{ github.run_number }}
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$TAG" ]; then
-            VERSION_NAME="${TAG#v}-$(git rev-parse --short HEAD)"
+          EXACT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          if [ -n "$EXACT_TAG" ]; then
+            VERSION_NAME="${EXACT_TAG#v}"
           else
-            VERSION_NAME="$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            if [ -n "$TAG" ]; then
+              VERSION_NAME="${TAG#v}-$(git rev-parse --short HEAD)"
+            else
+              VERSION_NAME="$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
+            fi
           fi
           echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
           echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The Play Store currently shows the SceneView demo as **`4.0.2-8615c8c8`** (Run #25406459067, deployed 2026-05-05 22:46), not `4.0.2` — the version display has a SHA suffix that makes the published build look like a snapshot to end users.

Two related causes:

1. **Versioning logic** always appended `-<short_sha>` even when HEAD was exactly on a release tag.
2. **Workflow trigger** only matched `push: branches: [main]` — when `v4.0.2` was tagged, the workflow didn't fire on the tag itself, only on subsequent main pushes (which are post-tag and therefore SHA-suffixed).

## Fix

- Use `git describe --tags --exact-match HEAD` to detect a clean tag and produce a verbatim version (`4.0.2`)
- Add `push.tags: 'v[0-9]+.[0-9]+.[0-9]+'` so the release tag itself triggers a deploy

## Follow-up after merge

Re-trigger to publish a clean v4.0.2 to the production track:

```
gh workflow run play-store.yml --ref v4.0.2
```

The new versionCode will be `github.run_number + 1` (so it bumps past 158 cleanly) and versionName will be `4.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)