### PR TITLE
fix(PhysicsDemo): remove diagnostic static sphere debug aid

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
@@ -112,13 +112,6 @@ fun PhysicsDemo(onBack: () -> Unit) {
                     position = Position(y = -0.5f),
                 )
 
-                // Diagnostic static sphere (no physics) — if even this is not visible, the bug
-                // is in the rendering pipeline, not the physics simulation.
-                SphereNode(
-                    radius = 0.1f,
-                    materialInstance = sphereMaterials[0],  // red
-                    position = Position(x = -0.5f, y = 0.2f, z = 0f)
-                )
 
                 for (i in 0 until sphereCount) {
                     // Spread spheres across the floor plane in a 5×N grid so a "Drop 10"
@@ -153,3 +146,4 @@ fun PhysicsDemo(onBack: () -> Unit) {
         }
     }
 }
+


### PR DESCRIPTION
## Summary

Removes stale debug scaffolding — a static diagnostic sphere at position `(-0.5f, 0.2f, 0)` — from the PhysicsDemo sample.

## Fix

The sphere was added during a previous debugging session to check the rendering pipeline when physics appeared broken. As described in #950, users see a stationary red ball and are confused about its purpose.

**Deleted (7 lines):**
```kotlin
// Diagnostic static sphere (no physics) — if even this is not visible, the bug
// is in the rendering pipeline, not the physics simulation.
SphereNode(
    radius = 0.1f,
    materialInstance = sphereMaterials[0],  // red
    position = Position(x = -0.5f, y = 0.2f, z = 0f)
)
```

This is purely a cosmetic fix — the actual physics simulation (droppable spheres) continues to work normally.

## Testing

The physics spheres spawned by the `Drop` / `Drop 10` buttons are unaffected — they use a separate `SphereNode` instance with `PhysicsNode` applied.

## Checklist

- [x] Target branch: main  
- [x] Self-reviewed: minimal changes, correct fix
- [x] Issue linked: fixes #950
- [x] GH007 compliant (commit email: 166608075+Jah-yee@users.noreply.github.com)