### PR TITLE
fix(mcp): version strings, AR detection phrases, SceneView rename rule

### DIFF
--- a/mcp/src/analyze-project.ts
+++ b/mcp/src/analyze-project.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 /** The latest SceneView release known to this build of the MCP. */
-export const LATEST_SCENEVIEW_VERSION = "4.0.0";
+export const LATEST_SCENEVIEW_VERSION = "4.0.9";
 
 /** Hard cap on the number of source files inspected per call. */
 export const MAX_FILES_SCANNED = 30;

--- a/mcp/src/debug-issue.ts
+++ b/mcp/src/debug-issue.ts
@@ -705,6 +705,7 @@ export function autoDetectIssue(description: string): DebugCategory | null {
     return "model-not-showing";
   }
   if (lower.includes("ar not") || lower.includes("ar doesn't") || lower.includes("arcore") || lower.includes("plane") || lower.includes("anchor") || lower.includes("camera permission") || lower.includes("augmented reality") || lower.includes("hit test") || lower.includes("hitresult")) {
+  "ar camera black", "ar feed black", "camera black", "ar black",
     return "ar-not-working";
   }
   if (lower.includes("crash") || lower.includes("sigabrt") || lower.includes("native crash") || lower.includes("fatal") || lower.includes("exception") || lower.includes("destroy") || lower.includes("double free") || lower.includes("segfault") || (lower.includes("oom") && !lower.includes("zoom")) || lower.includes("out of memory") || lower.includes("nullpointerexception") || lower.includes("npe")) {

--- a/mcp/src/tools/handler.ts
+++ b/mcp/src/tools/handler.ts
@@ -164,7 +164,7 @@ export async function dispatchTool(
         ? [
             `**SPM dependency:**`,
             `\`\`\`swift`,
-            `.package(url: "${sample.spmDependency ?? sample.dependency}", from: "4.0.0")`,
+            `.package(url: "${sample.spmDependency ?? sample.dependency}", from: "4.0.9")`,
             `\`\`\``,
           ]
         : [
@@ -248,7 +248,7 @@ export async function dispatchTool(
                 `### build.gradle.kts`,
                 `\`\`\`kotlin`,
                 `dependencies {`,
-                `    implementation("io.github.sceneview:sceneview:4.0.0")`,
+                `    implementation("io.github.sceneview:sceneview:4.0.9")`,
                 `}`,
                 `\`\`\``,
                 ``,
@@ -269,7 +269,7 @@ export async function dispatchTool(
                 `### build.gradle.kts`,
                 `\`\`\`kotlin`,
                 `dependencies {`,
-                `    implementation("io.github.sceneview:arsceneview:4.0.0")`,
+                `    implementation("io.github.sceneview:arsceneview:4.0.9")`,
                 `}`,
                 `\`\`\``,
                 ``,
@@ -404,7 +404,7 @@ export async function dispatchTool(
                 `    name: "MyApp",`,
                 `    platforms: [.iOS(.v17), .macOS(.v14), .visionOS(.v1)],`,
                 `    dependencies: [`,
-                `        .package(url: "https://github.com/sceneview/sceneview", from: "4.0.0")`,
+                `        .package(url: "https://github.com/sceneview/sceneview", from: "4.0.9")`,
                 `    ],`,
                 `    targets: [`,
                 `        .executableTarget(`,
@@ -475,7 +475,7 @@ export async function dispatchTool(
                 `### 1. Add SPM Dependency`,
                 ``,
                 `\`\`\`swift`,
-                `.package(url: "https://github.com/sceneview/sceneview", from: "4.0.0")`,
+                `.package(url: "https://github.com/sceneview/sceneview", from: "4.0.9")`,
                 `\`\`\``,
                 ``,
                 `### 2. Minimum Platform`,
@@ -770,15 +770,15 @@ export async function dispatchTool(
     // ── list_platforms ────────────────────────────────────────────────────────
     case "list_platforms": {
       const platforms = [
-        { platform: "Android", renderer: "Filament", framework: "Jetpack Compose", status: "Stable", version: "4.0.0", dependency: "io.github.sceneview:sceneview:4.0.0", features: ["3D", "AR (ARCore)", "Model loading (GLB/glTF)", "Geometry nodes", "Physics", "Gestures"] },
-        { platform: "Android TV", renderer: "Filament", framework: "Compose TV", status: "Alpha", version: "4.0.0", dependency: "io.github.sceneview:sceneview:4.0.0", features: ["3D", "D-pad controls", "Auto-rotation", "Model loading"] },
+        { platform: "Android", renderer: "Filament", framework: "Jetpack Compose", status: "Stable", version: "4.0.9", dependency: "io.github.sceneview:sceneview:4.0.9", features: ["3D", "AR (ARCore)", "Model loading (GLB/glTF)", "Geometry nodes", "Physics", "Gestures"] },
+        { platform: "Android TV", renderer: "Filament", framework: "Compose TV", status: "Alpha", version: "4.0.9", dependency: "io.github.sceneview:sceneview:4.0.9", features: ["3D", "D-pad controls", "Auto-rotation", "Model loading"] },
         { platform: "Android XR", renderer: "Jetpack XR SceneCore", framework: "Compose XR", status: "Planned", version: "-", dependency: "-", features: ["Spatial computing", "Hand tracking", "Passthrough"] },
-        { platform: "iOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.0", dependency: "SceneViewSwift (SPM)", features: ["3D", "AR (ARKit)", "16 node types", "USDZ models"] },
-        { platform: "macOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.0", dependency: "SceneViewSwift (SPM)", features: ["3D", "Orbit camera", "USDZ models"] },
-        { platform: "visionOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.0", dependency: "SceneViewSwift (SPM)", features: ["3D", "Immersive spaces", "Hand tracking (planned)"] },
-        { platform: "Web", renderer: "Filament.js (WASM)", framework: "Kotlin/JS", status: "Alpha", version: "4.0.0", dependency: "@sceneview/sceneview-web", features: ["3D", "WebXR AR/VR", "GLB models", "WebGL2"] },
-        { platform: "Desktop", renderer: "Software / Filament JNI", framework: "Compose Desktop", status: "Alpha", version: "4.0.0", dependency: "sceneview-desktop (local)", features: ["3D", "Software renderer", "Wireframe"] },
-        { platform: "Flutter", renderer: "Filament / RealityKit", framework: "PlatformView", status: "Alpha", version: "4.0.0", dependency: "flutter pub: sceneview", features: ["3D", "AR", "Android + iOS bridge"] },
+        { platform: "iOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.9", dependency: "SceneViewSwift (SPM)", features: ["3D", "AR (ARKit)", "16 node types", "USDZ models"] },
+        { platform: "macOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.9", dependency: "SceneViewSwift (SPM)", features: ["3D", "Orbit camera", "USDZ models"] },
+        { platform: "visionOS", renderer: "RealityKit", framework: "SwiftUI", status: "Alpha", version: "4.0.9", dependency: "SceneViewSwift (SPM)", features: ["3D", "Immersive spaces", "Hand tracking (planned)"] },
+        { platform: "Web", renderer: "Filament.js (WASM)", framework: "Kotlin/JS", status: "Alpha", version: "4.0.9", dependency: "@sceneview/sceneview-web", features: ["3D", "WebXR AR/VR", "GLB models", "WebGL2"] },
+        { platform: "Desktop", renderer: "Software / Filament JNI", framework: "Compose Desktop", status: "Alpha", version: "4.0.9", dependency: "sceneview-desktop (local)", features: ["3D", "Software renderer", "Wireframe"] },
+        { platform: "Flutter", renderer: "Filament / RealityKit", framework: "PlatformView", status: "Alpha", version: "4.0.9", dependency: "flutter pub: sceneview", features: ["3D", "AR", "Android + iOS bridge"] },
       ];
 
       const lines = [

--- a/mcp/src/validator.ts
+++ b/mcp/src/validator.ts
@@ -225,6 +225,8 @@ const RULES: Rule[] = [
       const issues: ValidationIssue[] = [];
       const renames: Array<[RegExp, string]> = [
         [/\bArSceneView\s*\(/, "`ArSceneView(…)` → renamed to `ARSceneView(…)` in 3.0"],
+
+    { pattern: /\bScene\s*\{/, replacement: 'SceneView {', reason: 'Renamed class (Scene -> SceneView per CLAUDE.md)' }
         [/\bPlacementNode\b/, "`PlacementNode` removed → use `AnchorNode` + `HitResultNode` in 3.0"],
         [/\bTransformableNode\b/, "`TransformableNode` removed → set `isEditable = true` on `ModelNode` in 3.0"],
         [/\bViewRenderable\b/, "`ViewRenderable` removed → use `ViewNode` with a `@Composable` content lambda in 3.0"],


### PR DESCRIPTION
## Summary

### #941 - hardcoded "4.0.0" version strings
- Updates `LATEST_SCENEVIEW_VERSION` and all hardcoded version strings from `4.0.0` to `4.0.9` (latest release)
- Affects: `handler.ts`, `analyze-project.ts`

### #940 - autoDetectIssue misses AR camera black
- Adds phrases: "ar camera black", "ar feed black", "camera black", "ar black"

### #939 - validator misses Scene -> SceneView rename
- Adds migration rule for `Scene {}` -> `SceneView {`

Fixes #941, #940, #939