### PR TITLE
fix(release): multi-line SPM regex + RN --legacy-peer-deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,13 @@ jobs:
         if: steps.check-rn.outputs.skip != 'true'
         working-directory: react-native/react-native-sceneview
         run: |
-          npm install --no-audit --no-fund
+          # react-native 0.84.x peer-deps require @types/react@^19 but the
+          # bridge's devDeps still pin @types/react@^18 (RN bridges scoped
+          # to RN 0.72.x consumers). The v4.1.0 release failed at this step
+          # with ERESOLVE; --legacy-peer-deps unblocks the publish without
+          # forcing a breaking @types/react bump on consumers. Real fix
+          # tracked in #909 (RN/Flutter bridges coverage).
+          npm install --no-audit --no-fund --legacy-peer-deps
           npm run build
 
       - name: Publish to npm
@@ -307,9 +313,13 @@ jobs:
             echo "::error::Missing at tag ${GITHUB_REF_NAME}: ${missing[*]}"
             exit 1
           fi
-          # Both manifests must declare the SceneViewSwift product.
+          # Both manifests must declare the SceneViewSwift product. The
+          # `.library(...)` block in SwiftPM manifests is conventionally
+          # written across multiple lines (`.library(\n    name: "X",\n    targets: ...)`)
+          # so we flatten the file to one line before the regex check
+          # (the previous single-line grep silently failed on v4.1.0).
           for f in Package.swift SceneViewSwift/Package.swift; do
-            if ! grep -qE '\.library\(name:\s*"SceneViewSwift"' "$f"; then
+            if ! tr '\n' ' ' < "$f" | grep -qE '\.library\(\s*name:\s*"SceneViewSwift"'; then
               echo "::error::$f does not declare a SceneViewSwift product"
               exit 1
             fi


### PR DESCRIPTION
## Summary

v4.1.0 release cut surfaced two latent bugs in \`release.yml\`:

1. **\`Validate SceneViewSwift SPM tag\` job failed** — the single-line grep \`\\.library\\(name:\\s*\"SceneViewSwift\"\` cannot match the conventional multi-line \`.library(\\n    name: \"SceneViewSwift\", ...)\` formatting that both \`Package.swift\` files use. The regex has silently failed on every tag since #920 added the root \`Package.swift\`; nobody noticed because Maven / npm publishes already had succeeded by the time the SPM gate fires. Fix: flatten with \`tr '\\n' ' '\` before grep.

2. **\`Publish @sceneview-sdk/react-native to npm\` job failed** — \`npm install\` resolves \`react-native@0.84.1\` which now requires \`@types/react@^19.1.1\` as a peerOptional, but the bridge's devDeps pin \`@types/react@^18.2.0\`. ERESOLVE. Adding \`--legacy-peer-deps\` unblocks the publish without forcing a breaking bump on consumers. Real fix tracked in #909 (RN/Flutter bridges coverage sprint).

Both failures cascaded → \`Create GitHub Release\` job was skipped because the gate requires all four publish jobs to succeed. The v4.1.0 GitHub Release body was filled in manually after the fact. Maven Central + sceneview-web npm + Dokka shipped fine.

## Test plan

- [ ] Next \`v*\` tag triggers a successful \`Validate SceneViewSwift SPM tag\` run
- [ ] Next tag also publishes \`@sceneview-sdk/react-native\` to npm
- [ ] \`Create GitHub Release\` job runs and produces a populated body automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)