### PR TITLE
chore(spm-refs): bump 12 SPM install snippets to 4.1.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,7 @@ fun MyARScreen() {
 
 ## iOS code generation rules (SceneViewSwift)
 
-1. SPM: `https://github.com/sceneview/sceneview-swift.git` from: "4.0.9"`
+1. SPM: `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0")`
 2. Use `SceneView` for 3D, `ARSceneView` for AR (SwiftUI views)
 3. Load models: `try await ModelNode.load("models/car.usdz")` — async
 4. Minimum: iOS 17+, macOS 14+, visionOS 1+

--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -21,7 +21,7 @@ Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.0")
 ]
 ```
 

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -16,7 +16,7 @@ A quick reference for SceneViewSwift's most-used APIs. Print it, pin it, keep it
 
 ```swift
 // Package.swift or Xcode SPM
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ```
 
 ```swift

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -83,7 +83,7 @@ No boilerplate. No manual cleanup. Just declare what you want.
 === "Swift (iOS / macOS / visionOS)"
 
     ```swift
-    // Package.swift: .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.9")
+    // Package.swift: .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.0")
 
     SceneView { root in
         let model = try? await ModelNode.load("helmet.usdz")
@@ -207,7 +207,7 @@ Rigid body physics with gravity, collisions, and restitution. Drop objects, boun
 
     ```swift
     // Package.swift or Xcode > Add Package Dependency
-    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.0")
     ```
 
 === "Web"

--- a/docs/docs/platforms.md
+++ b/docs/docs/platforms.md
@@ -45,7 +45,7 @@ SceneViewSwift provides a native SwiftUI library powered by RealityKit and ARKit
 - **3D**: `SceneView { }` with ModelNode, GeometryNode, LightNode, and more
 - **AR**: `ARSceneView()` with plane detection and tap-to-place (iOS only)
 - **Min versions**: iOS 17+, macOS 14+, visionOS 1+
-- **Install**: `.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")`
+- **Install**: `.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")`
 
 [:octicons-arrow-right-24: Apple Quickstart](quickstart-ios.md)
 

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -49,7 +49,7 @@ https://github.com/sceneview/sceneview-swift.git
 !!! tip
     You can also add the dependency manually in your `Package.swift`:
     ```swift
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
     ```
 
 ---

--- a/docs/docs/samples-ios.md
+++ b/docs/docs/samples-ios.md
@@ -11,7 +11,7 @@ description: "SwiftUI + RealityKit sample code for SceneViewSwift: model viewer,
 These samples demonstrate SceneViewSwift capabilities using **SwiftUI + RealityKit** on iOS, macOS, and visionOS. Each example is a self-contained SwiftUI view you can drop into an Xcode project after adding the SceneViewSwift package.
 
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ```
 
 ---

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -26,7 +26,7 @@ Always determine the target platform first. Ask if unclear. Default to Android (
 ### Version info
 - Current version: **4.0.9**
 - Android: `io.github.sceneview:sceneview:4.0.9` (3D) / `io.github.sceneview:arsceneview:4.0.9` (AR)
-- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.9")
+- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
 - Web: `npm install sceneview-web@4.0.9` (also `<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js">`)
 - MCP: `npx sceneview-mcp` (latest 4.0.11) — adds 28 AI tools
 - Min SDK: 24 | Target: 36 | Kotlin: 2.3.20

--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -212,7 +212,7 @@ I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old a
 **Answer:**
 [SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.0.9"`
+**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.1.0"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.0.9"`
+1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.1.0"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.9`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.9")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -2070,7 +2070,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ]
 ```
 
@@ -2753,7 +2753,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ```
 
 Import: `import SceneViewSwift`

--- a/website-static/llms.txt
+++ b/website-static/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.0.9`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.0.9")
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -2070,7 +2070,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ]
 ```
 
@@ -2753,7 +2753,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.0")
 ```
 
 Import: `import SceneViewSwift`


### PR DESCRIPTION
Post-v4.1.0, `bash .claude/scripts/impact-check.sh` flagged 12 files where the SwiftPM `.package(url: ..., from: "4.0.9")` install snippet drifted independently of the canonical `sync-versions.sh` sweep. Pure docs / install-snippet changes — no code risk.

Follow-up filed below as a comment: `sync-versions.sh` should learn to cover these SwiftPM `from: "..."` clauses so the next release bump catches them automatically.