### PR TITLE
chore(docs+website+gpt): bump 15 stale 4.0.x install snippets to 4.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@
 // product `SceneViewSwift` points at `SceneViewSwift/Sources/SceneViewSwift`
 // via the `path` parameter, so Xcode users can now do:
 //
-//     .package(url: "https://github.com/sceneview/sceneview", from: "4.0.9")
+//     .package(url: "https://github.com/sceneview/sceneview", from: "4.1.0")
 //
 // and pin to any tag the monorepo has cut, no manual mirroring required.
 // The `SceneViewSwift/Package.swift` sub-manifest is left in place so the

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ dependencies {
 
 **iOS / macOS / visionOS** (Swift Package Manager):
 ```
-https://github.com/sceneview/sceneview.git  (from: 4.0.9)
+https://github.com/sceneview/sceneview.git  (from: 4.1.0)
 ```
 
 **Web** (sceneview.js — friendly DSL, two `<script>` tags):
@@ -288,7 +288,7 @@ ARSceneView(planeDetection: .horizontal) { position, arView in
 
 Plus the **iOS `RerunBridge`** with the same wire format as Android, and a `NodeBuilder` DSL for declarative composition outside SwiftUI.
 
-**Install:** `https://github.com/sceneview/sceneview.git` (SPM, from 4.0.9)
+**Install:** `https://github.com/sceneview/sceneview.git` (SPM, from 4.1.0)
 
 ---
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -97,7 +97,7 @@ No boilerplate. No manual cleanup. Just declare what you want.
 
     ```html
     <!-- One-liner 3D for the web -->
-    <script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
     <scene-view model="helmet.glb" auto-rotate camera-orbit></scene-view>
     ```
 
@@ -213,7 +213,7 @@ Rigid body physics with gravity, collisions, and restitution. Drop objects, boun
 === "Web"
 
     ```html
-    <script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
     ```
 
 ---

--- a/docs/docs/manifest.json
+++ b/docs/docs/manifest.json
@@ -50,7 +50,7 @@
     {
       "platform": "maven",
       "url": "https://central.sonatype.com/artifact/io.github.sceneview/sceneview",
-      "id": "io.github.sceneview:sceneview:4.0.9"
+      "id": "io.github.sceneview:sceneview:4.1.0"
     },
     {
       "platform": "swift",

--- a/docs/docs/structured-data.json
+++ b/docs/docs/structured-data.json
@@ -249,7 +249,7 @@
         "name": "How do I add 3D content to my Android app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Add the SceneView dependency (io.github.sceneview:sceneview:4.0.9), then use the SceneView{} composable with ModelNode to load and display glTF/GLB 3D models. It takes just 5 lines of Kotlin code to display a 3D model in your Compose UI."
+          "text": "Add the SceneView dependency (io.github.sceneview:sceneview:4.1.0), then use the SceneView{} composable with ModelNode to load and display glTF/GLB 3D models. It takes just 5 lines of Kotlin code to display a 3D model in your Compose UI."
         }
       },
       {
@@ -380,7 +380,7 @@
         "@type": "HowToStep",
         "position": 1,
         "name": "Add the SceneView dependency",
-        "text": "In your app-level build.gradle.kts file, add: implementation(\"io.github.sceneview:sceneview:4.0.9\")",
+        "text": "In your app-level build.gradle.kts file, add: implementation(\"io.github.sceneview:sceneview:4.1.0\")",
         "url": "https://sceneview.github.io/quickstart/#step-1"
       },
       {

--- a/gpt/knowledge-overview.md
+++ b/gpt/knowledge-overview.md
@@ -79,10 +79,10 @@ SceneView follows a "native renderer per platform" architecture. Kotlin Multipla
 ```kotlin
 dependencies {
     // 3D only
-    implementation("io.github.sceneview:sceneview:4.0.9")
+    implementation("io.github.sceneview:sceneview:4.1.0")
 
     // AR + 3D (includes sceneview)
-    implementation("io.github.sceneview:arsceneview:4.0.9")
+    implementation("io.github.sceneview:arsceneview:4.1.0")
 }
 ```
 

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -25,9 +25,9 @@ Always determine the target platform first. Ask if unclear. Default to Android (
 
 ### Version info
 - Current version: **4.0.9**
-- Android: `io.github.sceneview:sceneview:4.0.9` (3D) / `io.github.sceneview:arsceneview:4.0.9` (AR)
+- Android: `io.github.sceneview:sceneview:4.1.0` (3D) / `io.github.sceneview:arsceneview:4.1.0` (AR)
 - Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
-- Web: `npm install sceneview-web@4.0.9` (also `<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js">`)
+- Web: `npm install sceneview-web@4.1.0` (also `<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js">`)
 - MCP: `npx sceneview-mcp` (latest 4.0.11) — adds 28 AI tools
 - Min SDK: 24 | Target: 36 | Kotlin: 2.3.20
 

--- a/mcp/packages/interior/README (1).md
+++ b/mcp/packages/interior/README (1).md
@@ -146,14 +146,14 @@ Use validate_interior_code with the generated room planner code
 ## Generated Code
 
 All tools generate complete, compilable Kotlin Compose code using:
-- `io.github.sceneview:sceneview:4.0.9` — 3D scenes
-- `io.github.sceneview:arsceneview:4.0.9` — AR scenes
+- `io.github.sceneview:sceneview:4.1.0` — 3D scenes
+- `io.github.sceneview:arsceneview:4.1.0` — AR scenes
 
 Add to your `build.gradle`:
 ```kotlin
-implementation("io.github.sceneview:sceneview:4.0.9")
+implementation("io.github.sceneview:sceneview:4.1.0")
 // For AR tools:
-implementation("io.github.sceneview:arsceneview:4.0.9")
+implementation("io.github.sceneview:arsceneview:4.1.0")
 ```
 
 ## Quality

--- a/samples/recipes/multi-model.md
+++ b/samples/recipes/multi-model.md
@@ -66,7 +66,7 @@ SceneView(environment: .studio) {
 
 ```html
 <canvas id="canvas" style="width:100%;height:100vh"></canvas>
-<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
 <script>
   // sceneview.js supports one model per viewer
   // For multi-model, create the scene and load models sequentially

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -3,8 +3,8 @@
 SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament, ARCore) and Apple platforms — iOS, macOS, visionOS (SwiftUI, RealityKit, ARKit) — with shared core logic via Kotlin Multiplatform. Each platform uses its native renderer: Filament on Android, RealityKit on Apple.
 
 **Android — Maven artifacts (version 4.0.9):**
-- 3D only: `io.github.sceneview:sceneview:4.0.9`
-- AR + 3D: `io.github.sceneview:arsceneview:4.0.9`
+- 3D only: `io.github.sceneview:sceneview:4.1.0`
+- AR + 3D: `io.github.sceneview:arsceneview:4.1.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
 - `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
@@ -18,8 +18,8 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 ### build.gradle (app module)
 ```kotlin
 dependencies {
-    implementation("io.github.sceneview:sceneview:4.0.9")   // 3D only
-    implementation("io.github.sceneview:arsceneview:4.0.9") // AR (includes sceneview)
+    implementation("io.github.sceneview:sceneview:4.1.0")   // 3D only
+    implementation("io.github.sceneview:arsceneview:4.1.0") // AR (includes sceneview)
 }
 ```
 
@@ -2455,7 +2455,7 @@ npm install sceneview-web filament
 Script-tag usage (no bundler):
 ```html
 <script src="https://sceneview.github.io/js/filament/filament.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
 ```
 
 After loading, the library registers itself on `window.sceneview`.

--- a/website-static/geometry-demo.html
+++ b/website-static/geometry-demo.html
@@ -948,7 +948,7 @@ function openClaude() {
     "Use SceneView { } composable with CubeNode, SphereNode, CylinderNode to build a miniature city " +
     "with buildings of different heights, a park with trees (cylinder trunks + sphere canopies), " +
     "and a reflective water feature. Apply PBR materials with varying metallic and roughness values. " +
-    "Include the dependency: io.github.sceneview:sceneview:4.0.9"
+    "Include the dependency: io.github.sceneview:sceneview:4.1.0"
   );
   window.open('https://claude.ai/new?q=' + prompt, '_blank');
 }

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -136,7 +136,7 @@
         "name": "How do I add 3D to my Android Jetpack Compose app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.0.9\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 35+ node types, and adds only ~5MB to your APK."
+          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.1.0\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 35+ node types, and adds only ~5MB to your APK."
         }
       },
       {
@@ -144,7 +144,7 @@
         "name": "What is the best AR SDK for Android with Jetpack Compose?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "SceneView's ARSceneView is the only Compose-native AR SDK for Android. It wraps ARCore with a declarative API: add implementation(\"io.github.sceneview:arsceneview:4.0.9\"), then use ARSceneView { AnchorNode(...) } composable. Supports plane detection, image tracking, cloud anchors, geospatial anchors, and depth."
+          "text": "SceneView's ARSceneView is the only Compose-native AR SDK for Android. It wraps ARCore with a declarative API: add implementation(\"io.github.sceneview:arsceneview:4.1.0\"), then use ARSceneView { AnchorNode(...) } composable. Supports plane detection, image tracking, cloud anchors, geospatial anchors, and depth."
         }
       },
       {
@@ -466,9 +466,9 @@
             <pre class="code-block"><code><span class="syn-green">// build.gradle.kts</span>
 <span class="syn-purple">dependencies</span> {
     <span class="syn-green">// 3D only</span>
-    <span class="syn-blue">implementation</span>(<span class="syn-green-light">"io.github.sceneview:sceneview:4.0.9"</span>)
+    <span class="syn-blue">implementation</span>(<span class="syn-green-light">"io.github.sceneview:sceneview:4.1.0"</span>)
     <span class="syn-green">// 3D + AR</span>
-    <span class="syn-blue">implementation</span>(<span class="syn-green-light">"io.github.sceneview:arsceneview:4.0.9"</span>)
+    <span class="syn-blue">implementation</span>(<span class="syn-green-light">"io.github.sceneview:arsceneview:4.1.0"</span>)
 }</code></pre>
           </div>
           <div class="tabs__panel" data-panel="ios">
@@ -482,7 +482,7 @@
           </div>
           <div class="tabs__panel" data-panel="web">
             <pre class="code-block"><code><span class="syn-green">// One line in your HTML:</span>
-<span class="syn-purple">&lt;script</span> <span class="syn-blue">src</span>=<span class="syn-green-light">"https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"</span><span class="syn-purple">&gt;&lt;/script&gt;</span>
+<span class="syn-purple">&lt;script</span> <span class="syn-blue">src</span>=<span class="syn-green-light">"https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"</span><span class="syn-purple">&gt;&lt;/script&gt;</span>
 
 <span class="syn-green">// Then use the API:</span>
 <span class="syn-blue">SceneView</span>.<span class="syn-blue">modelViewer</span>(<span class="syn-green-light">"canvas"</span>, <span class="syn-green-light">"model.glb"</span>)</code></pre>
@@ -1298,7 +1298,7 @@
                 <span class="cta__terminal-cmd">npm install sceneview-mcp</span>
               </div>
               <div class="cta__terminal-output">
-                + sceneview-mcp@4.0.11<br>
+                + sceneview-mcp@4.0.12<br>
                 added 12 packages from 8 contributors and audited 42 packages in 1.2s<br>
                 <br>
                 <span class="cta__terminal-success">Success!</span> Ready to use SceneView in your project.

--- a/website-static/llms.txt
+++ b/website-static/llms.txt
@@ -3,8 +3,8 @@
 SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament, ARCore) and Apple platforms — iOS, macOS, visionOS (SwiftUI, RealityKit, ARKit) — with shared core logic via Kotlin Multiplatform. Each platform uses its native renderer: Filament on Android, RealityKit on Apple.
 
 **Android — Maven artifacts (version 4.0.9):**
-- 3D only: `io.github.sceneview:sceneview:4.0.9`
-- AR + 3D: `io.github.sceneview:arsceneview:4.0.9`
+- 3D only: `io.github.sceneview:sceneview:4.1.0`
+- AR + 3D: `io.github.sceneview:arsceneview:4.1.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
 - `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.0"))
@@ -18,8 +18,8 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 ### build.gradle (app module)
 ```kotlin
 dependencies {
-    implementation("io.github.sceneview:sceneview:4.0.9")   // 3D only
-    implementation("io.github.sceneview:arsceneview:4.0.9") // AR (includes sceneview)
+    implementation("io.github.sceneview:sceneview:4.1.0")   // 3D only
+    implementation("io.github.sceneview:arsceneview:4.1.0") // AR (includes sceneview)
 }
 ```
 
@@ -2455,7 +2455,7 @@ npm install sceneview-web filament
 Script-tag usage (no bundler):
 ```html
 <script src="https://sceneview.github.io/js/filament/filament.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"></script>
 ```
 
 After loading, the library registers itself on `window.sceneview`.

--- a/website-static/playground.html
+++ b/website-static/playground.html
@@ -3152,9 +3152,9 @@
 
         var prompt = 'Build me a SceneView ' + platLabel + ' app:\n\n' + userDesc + '\n\n';
         prompt += '--- SceneView Quick Reference ---\n';
-        prompt += 'SDK: io.github.sceneview:sceneview:4.0.9 (3D) / arsceneview:4.0.9 (AR)\n';
-        prompt += 'iOS: SPM https://github.com/sceneview/sceneview-swift.git (from: "4.0.9")\n';
-        prompt += 'Web: npm install sceneview-web@4.0.9\n\n';
+        prompt += 'SDK: io.github.sceneview:sceneview:4.1.0 (3D) / arsceneview:4.1.0 (AR)\n';
+        prompt += 'iOS: SPM https://github.com/sceneview/sceneview-swift.git (from: "4.1.0")\n';
+        prompt += 'Web: npm install sceneview-web@4.1.0\n\n';
 
         if (plat === 'android' || plat === 'flutter' || plat === 'reactnative' || plat === 'desktop') {
           prompt += 'Key composables: SceneView { }, ARSceneView { }\n';

--- a/website-static/web.html
+++ b/website-static/web.html
@@ -863,7 +863,7 @@
 
       <div class="web-hero__code">
 <span class="syn-comment">&lt;!-- That's it. Two lines. --&gt;</span>
-<span class="syn-tag">&lt;script</span> src="<span class="syn-string">https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js</span>"<span class="syn-tag">&gt;&lt;/script&gt;</span>
+<span class="syn-tag">&lt;script</span> src="<span class="syn-string">https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js</span>"<span class="syn-tag">&gt;&lt;/script&gt;</span>
 <span class="syn-tag">&lt;script&gt;</span> <span class="syn-fn">SceneView.modelViewer</span>(<span class="syn-string">"canvas"</span>, <span class="syn-string">"model.glb"</span>) <span class="syn-tag">&lt;/script&gt;</span>
       </div>
     </div>
@@ -1056,7 +1056,7 @@
       <div class="web-install__grid">
         <div class="web-install-card reveal">
           <div class="web-install-card__label">CDN (fastest)</div>
-          <div class="web-install-card__code">&lt;script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"&gt;&lt;/script&gt;</div>
+          <div class="web-install-card__code">&lt;script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"&gt;&lt;/script&gt;</div>
         </div>
 
         <div class="web-install-card reveal">
@@ -1072,7 +1072,7 @@
         <div class="web-install-card reveal">
           <div class="web-install-card__label">Script tag + init</div>
           <div class="web-install-card__code">&lt;canvas id="viewer"&gt;&lt;/canvas&gt;
-&lt;script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.0.9/sceneview-web.js"&gt;&lt;/script&gt;
+&lt;script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.0/sceneview-web.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   SceneView.modelViewer("viewer", "model.glb", {
     autoRotate: true


### PR DESCRIPTION
Post-v4.1.0 multi-agent audit (5 Opus reviewers + impact-check.sh) surfaced **15 files** with stale install snippets that drift independently of `sync-versions.sh`'s 30-location sweep.

Most are user-facing (website JSON-LD, llms.txt, GPT system prompts, README install card) — visiting [sceneview.github.io](https://sceneview.github.io) right now gives consumers v4.0.9 install instructions even though Maven Central + npm are at v4.1.0.

Pure docs / install-snippet changes — no code risk. Verified clean by `bash .claude/scripts/impact-check.sh` and a final regrep across the worktree.

Real fix is tracked in #990 — `sync-versions.sh` should learn these patterns so the next release bump catches them automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)