### PR TITLE
fix(release): publish-library skip-if-published + validate-spm always + relax gate (FU10/FU11/FU13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,34 @@ jobs:
 
       - run: chmod +x ./gradlew
 
+      - name: Check if version already published
+        id: check-maven
+        run: |
+          # Maven Central artifacts are immutable — re-publishing the same
+          # version always fails with `Component … already exists`. The npm
+          # publish jobs below skip-if-published; mirror that here so a
+          # workflow_dispatch retry after a partial failure (e.g. an npm
+          # job blew up but Maven succeeded) doesn't leave Create GitHub
+          # Release stuck. Closes FU10 (#1003 follow-up).
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
+          else
+            VERSION=${GITHUB_REF_NAME#v}
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # HEAD against the published .pom — 200 means already on Central.
+          STATUS=$(curl -sI -o /dev/null -w "%{http_code}" \
+            "https://repo1.maven.org/maven2/io/github/sceneview/sceneview/${VERSION}/sceneview-${VERSION}.pom")
+          if [ "$STATUS" = "200" ]; then
+            echo "::notice::sceneview ${VERSION} already on Maven Central — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing sceneview ${VERSION} (HTTP ${STATUS} on Central probe)"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish
+        if: steps.check-maven.outputs.skip != 'true'
         run: ./gradlew publishAndReleaseToMavenCentral --no-daemon --no-parallel --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -288,7 +315,10 @@ jobs:
     name: Validate SceneViewSwift SPM tag
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Runs on both tag pushes AND workflow_dispatch — previously gated on
+    # `startsWith(github.ref, 'refs/tags/v')` which made it SKIP on dispatch,
+    # which then blocked `create-release` (whose gate required
+    # `validate-spm.result == 'success'` strictly). Closes FU11 (#1003 follow-up).
     permissions:
       contents: read
     steps:
@@ -344,16 +374,24 @@ jobs:
     # version was missing from the registry. Skipped (because the version
     # is already on the registry) is OK — only an outright failure blocks.
     # See #962.
+    # Skipped is OK (e.g. version already on the registry) — only outright
+    # failure blocks. Previously `publish-library` and `validate-spm` were
+    # checked with strict `== 'success'`, which made the GitHub Release
+    # unreachable on workflow_dispatch retries (publish-library would
+    # already-exists fail or validate-spm would skip). Now harmonised with
+    # the npm jobs' `!= 'failure' && != 'cancelled'` pattern. Closes FU13.
     if: |
       always()
-      && needs.publish-library.result == 'success'
+      && needs.publish-library.result != 'failure'
+      && needs.publish-library.result != 'cancelled'
       && needs.publish-mcp.result != 'failure'
       && needs.publish-mcp.result != 'cancelled'
       && needs.publish-web.result != 'failure'
       && needs.publish-web.result != 'cancelled'
       && needs.publish-rn.result != 'failure'
       && needs.publish-rn.result != 'cancelled'
-      && needs.validate-spm.result == 'success'
+      && needs.validate-spm.result != 'failure'
+      && needs.validate-spm.result != 'cancelled'
       && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write


### PR DESCRIPTION
Three coupled hardening changes from Agent 2 of the v4.1.0 5-agent post-ship audit. Together they unblock workflow_dispatch retries after a partial tag-push failure.

**FU10** — `publish-library` skip-if-published guard (HEAD against `repo1.maven.org/.../sceneview-${VERSION}.pom` returns 200 → already on Central → skip). Mirrors the npm jobs' idempotency. Without this, every workflow_dispatch retry against an already-shipped version blows up with "Component already exists".

**FU11** — `validate-spm` runs on `workflow_dispatch` too. Drop the `if: startsWith(github.ref, 'refs/tags/v')` gate so the SPM-product assertion isn't unreachable on dispatch (which would then make `create-release` unreachable too).

**FU13** — `create-release` gate harmonised. `publish-library == 'success'` AND `validate-spm == 'success'` were strict; relaxed to `!= 'failure' && != 'cancelled'` to match the npm jobs. A skipped (idempotent) job no longer blocks the GitHub Release.

Surfaced by v4.1.0 → workflow_dispatch retry → Maven-already-exists → `Create GitHub Release` skipped → had to populate the v4.1.0 Release body manually. v4.1.1 just shipped today and this PR ensures the next hotfix doesn't repeat the same cycle.

Pure CI workflow change — no code/test risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)