### PR TITLE
chore(gitignore): drop Google Drive sync-conflict duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,14 @@ samples/screenshots/qa_log*.txt
 # QA / device-test artifacts (transient screenshots)
 tools/qa-screenshots/
 
+# Google Drive / iCloud Drive sync-conflict duplicates.
+# When the same file is touched concurrently in two checkouts of a synced
+# folder, Drive creates "filename (1).ext" (and (2), (3)…) on disk. These
+# pollute `git status` and have caused build failures (duplicate Swift
+# symbols when xcodebuild scans the entire SceneViewDemo/ subtree) and
+# stash-pop conflicts on tracked files. They are NEVER source — drop them
+# on sight. Surfaced by the 2026-05-13 upbeat-kare iOS visual smoke test.
+**/* (1)*
+**/* (2)*
+**/* (3)*
+


### PR DESCRIPTION
Drive auto-creates `* (1).ext` duplicates when the same file is touched concurrently in two checkouts of a synced folder. They have caused: stash-pop conflicts on tracked files, duplicate-Swift-symbol build failures during the v4.1.0 iOS visual smoke test, and persistent git-status noise across sessions. Drop them via .gitignore (Drive keeps creating them but git ignores). Pure config change, no code risk. Surfaced by Agent 3 of the v4.1.0 5-agent post-ship audit.