### PR TITLE
fix(ios): real entity hit-test in onEntityTapped + clarify CameraNode.exposure no-op (#928)

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/CameraNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/CameraNode.swift
@@ -158,20 +158,34 @@ public struct CameraNode: Sendable {
 
     // MARK: - Exposure
 
-    /// Sets the exposure compensation value.
+    /// Sets the exposure compensation value (no-op on iOS today).
     ///
-    /// - Important: **This method is a no-op on iOS.** RealityKit's `PerspectiveCameraComponent`
-    ///   does not expose exposure settings as of Xcode 26.x. The method is kept for Android API
-    ///   parity but performs no operation. Use `ARSceneView(cameraExposure:)` for AR scenes, or
-    ///   adjust scene lighting intensity to control overall brightness.
+    /// - Important: **This method is a no-op on iOS.** RealityKit's
+    ///   `PerspectiveCameraComponent` does not expose an exposure or
+    ///   exposure-compensation property as of Xcode 26.x (the closest available
+    ///   knob is `ImageBasedLightComponent.intensityExponent` on the IBL receiver,
+    ///   which `SceneView.renderQuality(_:)` already tunes per-preset — see
+    ///   `RenderQuality.swift`). The method is kept for Android API parity.
+    ///
+    /// For control over scene brightness on iOS, use one of:
+    /// - `ARSceneView(cameraExposure:)` for AR scenes (real exposure)
+    /// - `SceneView { ... }.renderQuality(.cinematic / .performance)` to tune IBL intensity
+    /// - Per-light `LightNode.directional(intensity:)` to adjust the key/fill ratio
+    ///
+    /// Investigated as part of the #928 silent-stub batch. Confirmed via direct build
+    /// against Xcode 26.x that no `PerspectiveCameraComponent.exposureCompensation`
+    /// property exists despite an earlier audit suggestion otherwise.
     ///
     /// - Parameter value: Exposure compensation in EV stops (ignored).
     /// - Returns: Self for chaining.
-    @available(*, deprecated, message: "No-op on iOS — RealityKit's PerspectiveCameraComponent does not support exposure. Use ARSceneView(cameraExposure:) for AR, or adjust lighting intensity for 3D scenes.")
+    @available(*, deprecated, message: "No-op on iOS — PerspectiveCameraComponent does not expose exposure. Use ARSceneView(cameraExposure:) for AR, SceneView.renderQuality(_:) to tune IBL, or per-light intensity for 3D scenes.")
     @discardableResult
     public func exposure(_ value: Float) -> CameraNode {
-        // PerspectiveCameraComponent does not have an `exposure` property in current RealityKit.
-        // This method is reserved for future use when the API becomes available.
+        // PerspectiveCameraComponent does not have an `exposure` property in current
+        // RealityKit. Investigation note: verified via direct Xcode 26.x build that
+        // `camera.exposureCompensation` is not a member. The IBL receiver's
+        // `ImageBasedLightComponent.intensityExponent` is the practical knob and is
+        // already tuned per RenderQuality preset.
         return self
     }
 }

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -464,9 +464,18 @@ private struct SceneViewRepresentation: View {
     }
 
     private var tapGesture: some Gesture {
+        // Wire real entity hit-testing via SwiftUI's `targetedToAnyEntity()` — the
+        // SpatialTapGesture's `value.entity` is the actual RealityKit entity at the
+        // tap location, not the scene root. Closes part of #928 (this used to pass
+        // `entities.root` unconditionally regardless of where the user tapped, which
+        // made the callback useless for picking objects in the scene).
+        //
+        // Requires iOS 17+ / macOS 14+ / visionOS 1+ (RealityKit 2.x). All current
+        // SceneViewSwift platforms already require those baselines.
         SpatialTapGesture()
-            .onEnded { _ in
-                onEntityTapped?(entities.root)
+            .targetedToAnyEntity()
+            .onEnded { value in
+                onEntityTapped?(value.entity)
             }
     }
 }


### PR DESCRIPTION
Two #928 silent-stub batch fixes:

1. **`SceneView.onEntityTapped(_:)`** was a silent stub — ALWAYS called the handler with `entities.root` regardless of where the user actually tapped. Wired real entity hit-testing via SwiftUI's `SpatialTapGesture().targetedToAnyEntity()` so `value.entity` is now the actual RealityKit entity at the tap location.

2. **`CameraNode.exposure(_:)`** stays a deprecated no-op (Agent 4 of the v4.1.0 audit claimed `PerspectiveCameraComponent.exposureCompensation` exists; verified via direct Xcode 26.x build that it does NOT). Docs now include the investigation note + redirect to working alternatives: `ARSceneView(cameraExposure:)`, `SceneView.renderQuality(_:)` (#1018), per-light intensity.

Build green on iOS simulator.