### PR TITLE
fix(ios): wire model-viewer + multi-model deep-link routes (closes #1015)

### DIFF
--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -66,6 +66,17 @@ enum DemoDeepLinkRegistry {
         case "image":         ImageDemo()
         case "animation":     AnimationDemo()
 
+        // Android has dedicated `model-viewer` (single hero model, orbit camera)
+        // and `multi-model` (multiple models on a tabletop) demos. iOS doesn't
+        // have 1:1 ports — the Sketchfab Explore tab IS the canonical iOS
+        // model-viewer experience, but it's a Tab in the main TabView, not a
+        // standalone View we can present modally from a sheet. Route both ids
+        // to SceneGalleryDemo so the user lands on real 3D content (multiple
+        // shapes in a composed scene) instead of the "Coming soon" placeholder
+        // they would otherwise hit. Closes #1015.
+        case "model-viewer":  SceneGalleryDemo()
+        case "multi-model":   SceneGalleryDemo()
+
         // Lighting + effects.
         case "lighting":      LightingDemo()
         case "movable-light": MovableLightDemo()


### PR DESCRIPTION
Closes #1015 (Agent 3 finding of the v4.1.0 audit).

`DemoDeepLinkRegistry.allowedIds` had `model-viewer` + `multi-model` listed but `destination(for:)` had no cases — they fell to the default branch = "Coming soon" placeholder. Any QR scan of `sceneview://demo/model-viewer` (the helmet hero on the App Store listing) dead-ended.

iOS doesn't have 1:1 ports of those Android demos. The Sketchfab Explore tab IS the canonical iOS model-viewer experience but it's a Tab inside TabView (not modally presentable). Route both ids to `SceneGalleryDemo` so user lands on real 3D content (composed multi-shape scene) instead of the placeholder. Mapping rationale documented inline.

Build green on iOS simulator.