### PR TITLE
fix(mcp): auto-sync analyze-project fixture with gradle.properties VERSION_NAME

### DIFF
--- a/mcp/scripts/generate-version.js
+++ b/mcp/scripts/generate-version.js
@@ -77,9 +77,17 @@ console.error(
 // accidentally rewrite the unrelated `versionName "1.0"` line of the app
 // fixture itself. A single `implementation("io.github.sceneview:sceneview:X.Y.Z")`
 // is the only line we touch. The version pattern matches everything up to
-// the closing quote, so pre-release suffixes like `-rc.1` or `-beta.2`
-// round-trip correctly (an earlier `[\d.]+` regex truncated suffixes and
-// left the previous tail behind on the revert path).
+// the closing quote OR single-quote OR closing paren (Groovy and Kotlin
+// gradle DSLs are both covered), so pre-release suffixes like `-rc.1` or
+// `-beta.2` round-trip correctly (an earlier `[\d.]+` regex truncated
+// suffixes and left the previous tail behind on the revert path).
+//
+// IMPORTANT — only `android-ok/` is auto-synced. The sister fixtures
+// `android-with-warnings/build.gradle.kts` (pinned at `2.2.1`) and
+// `ios-outdated/Package.swift` (pinned at `3.0.0`) are *intentionally
+// stale* — `analyze-project.test.ts` asserts `isOutdated === true` and
+// the exact version against those values. Broadening the sync target
+// would flip those tests to false-positive.
 const fixturePath = resolve(
   mcpRoot,
   "src/__fixtures__/analyze-project/android-ok/build.gradle.kts",
@@ -87,7 +95,7 @@ const fixturePath = resolve(
 try {
   const current = readFileSync(fixturePath, "utf8");
   const updated = current.replace(
-    /(io\.github\.sceneview:sceneview:)[^"\s]+/,
+    /(io\.github\.sceneview:sceneview:)[^"'\s)]+/,
     `$1${sdkVersion}`,
   );
   if (updated !== current) {

--- a/mcp/scripts/generate-version.js
+++ b/mcp/scripts/generate-version.js
@@ -65,3 +65,41 @@ console.error(
   `[generate-version] wrote ${outPath} ` +
     `(mcp=${version}, sdk=${sdkVersion})`,
 );
+
+// Keep the `android-ok` test fixture's SceneView pin in sync with the SDK
+// version we just snapshotted into `generated/version.ts`. The
+// `analyze-project.test.ts` "up-to-date" assertion compares the analyzer's
+// extracted version to LATEST_SCENEVIEW_VERSION; if the fixture drifts off
+// gradle.properties (as it did between v4.1.1 and v4.1.2, see PR #1012),
+// the test asserts `4.1.1 === 4.1.2` and fails the whole quality gate.
+//
+// The replacement is anchored on the gradle dependency syntax so we don't
+// accidentally rewrite the unrelated `versionName "1.0"` line of the app
+// fixture itself. A single `implementation("io.github.sceneview:sceneview:X.Y.Z")`
+// is the only line we touch. The version pattern matches everything up to
+// the closing quote, so pre-release suffixes like `-rc.1` or `-beta.2`
+// round-trip correctly (an earlier `[\d.]+` regex truncated suffixes and
+// left the previous tail behind on the revert path).
+const fixturePath = resolve(
+  mcpRoot,
+  "src/__fixtures__/analyze-project/android-ok/build.gradle.kts",
+);
+try {
+  const current = readFileSync(fixturePath, "utf8");
+  const updated = current.replace(
+    /(io\.github\.sceneview:sceneview:)[^"\s]+/,
+    `$1${sdkVersion}`,
+  );
+  if (updated !== current) {
+    writeFileSync(fixturePath, updated, "utf8");
+    console.error(
+      `[generate-version] synced fixture ${fixturePath} -> sceneview:${sdkVersion}`,
+    );
+  }
+} catch (err) {
+  // Non-fatal — the fixture is a test artefact, not a runtime dependency.
+  // Log loudly so a CI failure can still surface what happened.
+  console.error(
+    `[generate-version] WARNING: could not sync fixture (${err.message})`,
+  );
+}


### PR DESCRIPTION
## Why

PR #1012 had to hand-bump `mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts` from `sceneview:4.1.1` to `sceneview:4.1.2` after the v4.1.2 release. Same will need to happen for every future patch.

Root cause: the fixture's gradle line is hardcoded, but `LATEST_SCENEVIEW_VERSION` is regenerated from `gradle.properties:VERSION_NAME` on every `npm run build`. The test asserts they're equal — when they drift, the whole quality gate fails on main.

## What

`scripts/generate-version.js` now patches the fixture in lockstep with `generated/version.ts`. Single regex replacement on the gradle dependency line, idempotent.

## Validation

- ✅ Idempotent at current v4.1.2 (no fixture change today)
- ✅ Simulated `5.0.0-rc.1` bump → fixture updates → revert restores cleanly (pre-release suffix round-trips because the regex matches `[^"\\s]+`, not `[\\d.]+`)
- ✅ All 2536 vitest tests pass

## Behaviour

| Case | Behaviour |
|---|---|
| Fixture matches latest | No write (idempotent) |
| Fixture drifts | Overwrite + log to stderr |
| Fixture missing | Log WARNING and continue (non-fatal, test-only artefact) |

Closes the recurrence path of PR #1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)