### PR TITLE
docs(llms+spm): expose v4.2.0 iOS APIs + bump 11 stale SPM refs to 4.1.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,7 @@ fun MyARScreen() {
 
 ## iOS code generation rules (SceneViewSwift)
 
-1. SPM: `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.1")`
+1. SPM: `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.2")`
 2. Use `SceneView` for 3D, `ARSceneView` for AR (SwiftUI views)
 3. Load models: `try await ModelNode.load("models/car.usdz")` — async
 4. Minimum: iOS 17+, macOS 14+, visionOS 1+

--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -21,7 +21,7 @@ Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.2")
 ]
 ```
 

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -16,7 +16,7 @@ A quick reference for SceneViewSwift's most-used APIs. Print it, pin it, keep it
 
 ```swift
 // Package.swift or Xcode SPM
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ```
 
 ```swift

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -83,7 +83,7 @@ No boilerplate. No manual cleanup. Just declare what you want.
 === "Swift (iOS / macOS / visionOS)"
 
     ```swift
-    // Package.swift: .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.9")
+    // Package.swift: .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.2")
 
     SceneView { root in
         let model = try? await ModelNode.load("helmet.usdz")
@@ -207,7 +207,7 @@ Rigid body physics with gravity, collisions, and restitution. Drop objects, boun
 
     ```swift
     // Package.swift or Xcode > Add Package Dependency
-    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.0.9")
+    .package(url: "https://github.com/sceneview/sceneview-swift", from: "4.1.2")
     ```
 
 === "Web"

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -2909,8 +2909,75 @@ View modifiers (chainable):
 ```swift
 .environment(_ environment: SceneEnvironment) -> SceneView  // IBL lighting
 .cameraControls(_ mode: CameraControlMode) -> SceneView     // .orbit (default), .pan, .firstPerson
-.onEntityTapped(_ handler: @escaping (Entity) -> Void) -> SceneView
+.onEntityTapped(_ handler: @escaping (Entity) -> Void) -> SceneView   // real entity hit-test (v4.2.0+)
 .autoRotate(speed: Float = 0.3) -> SceneView                // radians/s, default 0.3
+.mainLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — see LightSlot below
+.fillLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — Android-parity 2-light setup
+.renderQuality(_ preset: RenderQuality) -> SceneView        // v4.2.0+ — .cinematic / .default / .performance
+```
+
+### Render defaults (v4.2.0+)
+
+iOS now ships the Android-parity 2-light setup out of the box (matches the v4.1.0 BREAKING render-defaults change finally landing on iOS):
+
+- **Main / key light**: `LightNode.directional(intensity: 10_000, castsShadow: true)` pointing straight down (`(0, -1, 0)`)
+- **Fill light**: `LightNode.fill(intensity: 3_000, castsShadow: false)` from `(0.5, -0.5, 0.5)` (upper-back-left → down-front-right) — 30% of main intensity, lifts the shadow side without flattening
+- **Defaults applied via `.systemDefault` slot value** — overridable per-slot
+
+```swift
+public enum LightSlot {
+    case systemDefault   // built-in default (Android-parity)
+    case disabled        // remove the slot — single-light setup with .fillLight(.disabled)
+    case custom(LightNode)
+}
+```
+
+Examples:
+```swift
+SceneView { /* ... */ }
+  .fillLight(.disabled)                                // single-light hard-shadow look
+
+SceneView { /* ... */ }
+  .mainLight(.custom(LightNode.directional(intensity: 5_000)))   // dimmer key
+  .fillLight(.custom(LightNode.fill(intensity: 6_000)))          // brighter fill
+
+SceneView { /* ... */ }
+  .renderQuality(.cinematic)         // shadows on, IBL ≥ 1.0
+SceneView { /* ... */ }
+  .renderQuality(.performance)       // shadows off, IBL halved (low-end devices)
+```
+
+### Per-entity gestures (v4.2.0+)
+
+`NodeGesture` lets you scope tap / drag / scale / rotate / longPress handlers per-entity (mirrors Android's gesture detection). Enabled automatically when `SceneView` is in the view hierarchy — `targetedToAnyEntity()` ensures empty-space gestures keep driving the camera.
+
+```swift
+let cube = GeometryNode.cube(size: 0.3, color: .blue)
+cube.entity
+    .onTap { print("Cube tapped!") }
+    .onDrag { translation in cube.position += translation }
+    .onScale { magnification in cube.scale *= magnification }
+    .onRotate { angle in cube.rotation = simd_quatf(angle: angle, axis: [0, 1, 0]) }
+    .onLongPress { print("Cube held 0.5s") }
+```
+
+Or via the imperative API:
+```swift
+NodeGesture.onTap(cube.entity) { print("Tapped!") }
+NodeGesture.removeAll(from: cube.entity)   // cleanup when content unloads
+```
+
+### AR Anchors (v4.2.0+)
+
+`AnchorNode` factories cover all ARKit anchor types:
+
+```swift
+AnchorNode.world(position: SIMD3<Float>) -> AnchorNode             // world-space pose
+AnchorNode.plane(alignment: .horizontal | .vertical,               // detected plane
+                 minimumBounds: SIMD2<Float>) -> AnchorNode
+AnchorNode.image(group: String, name: String) -> AnchorNode        // detected reference image
+AnchorNode.face() -> AnchorNode                                    // front-camera face (pose only)
+AnchorNode.body() -> AnchorNode                                    // rear-camera body root joint
 ```
 
 Minimal usage:

--- a/docs/docs/platforms.md
+++ b/docs/docs/platforms.md
@@ -45,7 +45,7 @@ SceneViewSwift provides a native SwiftUI library powered by RealityKit and ARKit
 - **3D**: `SceneView { }` with ModelNode, GeometryNode, LightNode, and more
 - **AR**: `ARSceneView()` with plane detection and tap-to-place (iOS only)
 - **Min versions**: iOS 17+, macOS 14+, visionOS 1+
-- **Install**: `.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.0.9")`
+- **Install**: `.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")`
 
 [:octicons-arrow-right-24: Apple Quickstart](quickstart-ios.md)
 

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -49,7 +49,7 @@ https://github.com/sceneview/sceneview-swift.git
 !!! tip
     You can also add the dependency manually in your `Package.swift`:
     ```swift
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
     ```
 
 ---

--- a/docs/docs/samples-ios.md
+++ b/docs/docs/samples-ios.md
@@ -11,7 +11,7 @@ description: "SwiftUI + RealityKit sample code for SceneViewSwift: model viewer,
 These samples demonstrate SceneViewSwift capabilities using **SwiftUI + RealityKit** on iOS, macOS, and visionOS. Each example is a self-contained SwiftUI view you can drop into an Xcode project after adding the SceneViewSwift package.
 
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ```
 
 ---

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -24,10 +24,10 @@ Always determine the target platform first. Ask if unclear. Default to Android (
 5. **Declarative nodes**: Declare nodes as composables inside `SceneView { }` content block, not imperatively.
 
 ### Version info
-- Current version: **4.1.1**
-- Android: `io.github.sceneview:sceneview:4.1.1` (3D) / `io.github.sceneview:arsceneview:4.1.1` (AR)
-- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.1"))
-- Web: `npm install sceneview-web@4.1.1` (also `<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.1/sceneview-web.js">`)
+- Current version: **4.1.2**
+- Android: `io.github.sceneview:sceneview:4.1.2` (3D) / `io.github.sceneview:arsceneview:4.1.2` (AR)
+- Apple: SPM `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.2"))
+- Web: `npm install sceneview-web@4.1.2` (also `<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.1.2/sceneview-web.js">`)
 - MCP: `npx sceneview-mcp` (latest 4.0.12) — adds 28 AI tools
 - Min SDK: 24 | Target: 36 | Kotlin: 2.3.20
 

--- a/llms.txt
+++ b/llms.txt
@@ -2909,8 +2909,75 @@ View modifiers (chainable):
 ```swift
 .environment(_ environment: SceneEnvironment) -> SceneView  // IBL lighting
 .cameraControls(_ mode: CameraControlMode) -> SceneView     // .orbit (default), .pan, .firstPerson
-.onEntityTapped(_ handler: @escaping (Entity) -> Void) -> SceneView
+.onEntityTapped(_ handler: @escaping (Entity) -> Void) -> SceneView   // real entity hit-test (v4.2.0+)
 .autoRotate(speed: Float = 0.3) -> SceneView                // radians/s, default 0.3
+.mainLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — see LightSlot below
+.fillLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — Android-parity 2-light setup
+.renderQuality(_ preset: RenderQuality) -> SceneView        // v4.2.0+ — .cinematic / .default / .performance
+```
+
+### Render defaults (v4.2.0+)
+
+iOS now ships the Android-parity 2-light setup out of the box (matches the v4.1.0 BREAKING render-defaults change finally landing on iOS):
+
+- **Main / key light**: `LightNode.directional(intensity: 10_000, castsShadow: true)` pointing straight down (`(0, -1, 0)`)
+- **Fill light**: `LightNode.fill(intensity: 3_000, castsShadow: false)` from `(0.5, -0.5, 0.5)` (upper-back-left → down-front-right) — 30% of main intensity, lifts the shadow side without flattening
+- **Defaults applied via `.systemDefault` slot value** — overridable per-slot
+
+```swift
+public enum LightSlot {
+    case systemDefault   // built-in default (Android-parity)
+    case disabled        // remove the slot — single-light setup with .fillLight(.disabled)
+    case custom(LightNode)
+}
+```
+
+Examples:
+```swift
+SceneView { /* ... */ }
+  .fillLight(.disabled)                                // single-light hard-shadow look
+
+SceneView { /* ... */ }
+  .mainLight(.custom(LightNode.directional(intensity: 5_000)))   // dimmer key
+  .fillLight(.custom(LightNode.fill(intensity: 6_000)))          // brighter fill
+
+SceneView { /* ... */ }
+  .renderQuality(.cinematic)         // shadows on, IBL ≥ 1.0
+SceneView { /* ... */ }
+  .renderQuality(.performance)       // shadows off, IBL halved (low-end devices)
+```
+
+### Per-entity gestures (v4.2.0+)
+
+`NodeGesture` lets you scope tap / drag / scale / rotate / longPress handlers per-entity (mirrors Android's gesture detection). Enabled automatically when `SceneView` is in the view hierarchy — `targetedToAnyEntity()` ensures empty-space gestures keep driving the camera.
+
+```swift
+let cube = GeometryNode.cube(size: 0.3, color: .blue)
+cube.entity
+    .onTap { print("Cube tapped!") }
+    .onDrag { translation in cube.position += translation }
+    .onScale { magnification in cube.scale *= magnification }
+    .onRotate { angle in cube.rotation = simd_quatf(angle: angle, axis: [0, 1, 0]) }
+    .onLongPress { print("Cube held 0.5s") }
+```
+
+Or via the imperative API:
+```swift
+NodeGesture.onTap(cube.entity) { print("Tapped!") }
+NodeGesture.removeAll(from: cube.entity)   // cleanup when content unloads
+```
+
+### AR Anchors (v4.2.0+)
+
+`AnchorNode` factories cover all ARKit anchor types:
+
+```swift
+AnchorNode.world(position: SIMD3<Float>) -> AnchorNode             // world-space pose
+AnchorNode.plane(alignment: .horizontal | .vertical,               // detected plane
+                 minimumBounds: SIMD2<Float>) -> AnchorNode
+AnchorNode.image(group: String, name: String) -> AnchorNode        // detected reference image
+AnchorNode.face() -> AnchorNode                                    // front-camera face (pose only)
+AnchorNode.body() -> AnchorNode                                    // rear-camera body root joint
 ```
 
 Minimal usage:

--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -212,7 +212,7 @@ I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old a
 **Answer:**
 [SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.1.1"`
+**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.1.2"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.1.1"`
+1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.1.2"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.1.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.1"))
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.2"))
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -2070,7 +2070,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ]
 ```
 
@@ -2753,7 +2753,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ```
 
 Import: `import SceneViewSwift`

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -1298,7 +1298,7 @@
                 <span class="cta__terminal-cmd">npm install sceneview-mcp</span>
               </div>
               <div class="cta__terminal-output">
-                + sceneview-mcp@4.0.11<br>
+                + sceneview-mcp@4.0.12<br>
                 added 12 packages from 8 contributors and audited 42 packages in 1.2s<br>
                 <br>
                 <span class="cta__terminal-success">Success!</span> Ready to use SceneView in your project.

--- a/website-static/llms.txt
+++ b/website-static/llms.txt
@@ -7,7 +7,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - AR + 3D: `io.github.sceneview:arsceneview:4.1.0`
 
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
-- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.1"))
+- `https://github.com/sceneview/sceneview-swift.git` (from: "4.1.2"))
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
@@ -2070,7 +2070,7 @@ React Native (Turbo Module / Fabric), KMP Compose iOS (UIKitView).
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+    .package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ]
 ```
 
@@ -2753,7 +2753,7 @@ Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift
-.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.1")
+.package(url: "https://github.com/sceneview/sceneview-swift.git", from: "4.1.2")
 ```
 
 Import: `import SceneViewSwift`


### PR DESCRIPTION
Two batched doc updates (pure docs PR, no code risk):

1. **llms.txt** — adds the v4.2.0-WIP iOS API surface so AI assistants generating SceneView code on iOS know about the modifiers / factories landed today (LightSlot, LightNode.fill, RenderQuality, NodeGesture, AnchorNode AR factories, render-defaults table).

2. **11 stale SPM install snippets** bumped to latest `from: "4.1.2"` (surfaced by `impact-check.sh`).

Real fix for the recurring SPM drift tracked in #990. Build green; impact-check clean.