### PR TITLE
iOS parity v4.3.0: CameraControls modes + auto-center + RealityKit-impossible docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v4.3.0 — iOS CameraControls.pan/.firstPerson + auto-center + parity table (UNRELEASED)
+
+**Status**: in-progress. Closes the last #928 silent-stub item and the biggest
+v4.2.0 UX gap on iOS demos. PR [#1038](https://github.com/sceneview/sceneview/pull/1038).
+
+### Added — `CameraControls.pan` + `.firstPerson` wired ([#1034](https://github.com/sceneview/sceneview/issues/1034))
+
+Previously, calling `.cameraControls(.pan)` or `.cameraControls(.firstPerson)` produced orbit behaviour because `applyCamera()` ignored the mode and `pinchGesture` always dollied the orbit radius. Three things shipped:
+
+- **`.pan`**: drag translates the orbit `target` along the camera-aligned right + up vectors (the scene appears to slide), pinch keeps dollying.
+- **`.firstPerson`**: drag rotates the view, no orbit translation; pinch adjusts the perspective camera's `fieldOfViewInDegrees` — mirrors Android `FovZoomCameraManipulator` (range `10°..120°`, default `60°`).
+- **Mode picker in iOS demo**: `CameraControlsDemo` gets a 3-way `Picker` segment so the v4.3.0 wiring can be felt at a glance.
+
+New `CameraControls` properties: `panSpeed`, `moveSpeed`, `fov`, `minFov`, `maxFov`, `pinchFovSpeed`.
+
+Gesture divergence from Android (documented in `CameraControlMode.pan` doc-comment): iOS uses 1-finger drag for pan; Android disambiguates via 2-finger strafe.
+
+### Added — Library-level auto-center content ([#1026](https://github.com/sceneview/sceneview/issues/1026))
+
+iOS demos placing content at e.g. `z = -2` rendered in the bottom-third of the viewport because the default perspective camera at `[0, 0.3, 2]` looks at world origin. Auto-center via intermediate `contentRoot` entity translates user content so its centroid lands at the orbit pivot on the first frame `visualBounds` is non-empty (bounds query in `contentRoot`-local space — invariant of orbit rotation + scale). Lights stay on `entities.root` so they're not moved by the centring translation.
+
+- **`.autoCenterContent(_ enabled: Bool)` modifier** (default `true`). Pass `false` for narrative scenes with intentional off-centre placement.
+- **iOS-only vs Android**: Android achieves the same via per-demo `ModelNode(centerOrigin = Position.ZERO)`. Cross-platform code porting Android verbatim sees iOS re-centre implicitly; opt out for strict parity.
+
+### Added — `docs/docs/cheatsheet-ios.md` parity table ([#1036](https://github.com/sceneview/sceneview/issues/1036))
+
+Three-bucket reference: **Deprecated on iOS** (3 rows — DoF, exposure, shadowColor), **Android-only / no port** (4 rows — playbackDataset, SurfaceType.texture, StreetscapeGeometry, TerrainAnchor/RooftopAnchor), **Approximated** (3 rows — fog variants, reflection probe volumes, subsurface). Same table in `llms.txt` for MCP consumers.
+
+### BREAKING-ish — silent-stub modes now active
+
+Apps that called `.cameraControls(.pan)` or `.cameraControls(.firstPerson)` as effective no-ops in v4.2.0 will now see the modes do something different. To restore the v4.2.0 silent behaviour, drop the modifier (defaults to `.orbit`).
+
+Apps with intentionally off-centre content will see the centroid re-centred at the orbit pivot. To restore the v4.2.0 layout, append `.autoCenterContent(false)`.
+
+### Fixed — Inertia mode-gating
+
+`CameraControls.applyInertia()` now dispatches on `mode`: `.pan` glides the `target` translation; `.orbit` and `.firstPerson` keep the rotation path. Previously the inertia velocity stored during a `.pan` drag would inject ghost rotation on release.
+
+---
+
 ## v4.2.0 — iOS parity sprint: LightSlot, RenderQuality, NodeGesture, AR anchors (2026-05-13)
 
 **Status**: stable. Ports the v4.1.0 BREAKING render-defaults change finally to iOS, plus closes the bulk of the [#928 silent-stub batch](https://github.com/sceneview/sceneview/issues/928) and major chunks of the [iOS parity umbrella #1004](https://github.com/sceneview/sceneview/issues/1004).

--- a/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
@@ -14,12 +14,27 @@ public enum CameraControlMode: Sendable {
     /// Pan the camera in the view plane. Drag translates the orbit target
     /// laterally (the scene appears to slide), pinch keeps dollying in/out.
     /// Rotation is preserved so callers can pan first then orbit.
+    ///
+    /// **Gesture divergence from Android (#1034)**: Android disambiguates
+    /// pan with a 2-finger strafe drag (see `CameraGestureDetector.kt`'s
+    /// `isPanGesture()` confidence test); iOS uses a 1-finger drag here
+    /// because SwiftUI's `DragGesture` does not expose multi-pointer state
+    /// the same way as `MotionEvent`. Switch via `.cameraControls(.pan)`
+    /// rather than expecting 2-finger detection.
     case pan
 
-    /// First-person look-around. Drag rotates the scene with no orbit
-    /// translation (camera stays put visually), pinch adjusts the
-    /// perspective camera's field of view — mirrors Android's
-    /// `FovZoomCameraManipulator`.
+    /// First-person look-around. Drag rotates the scene content around the
+    /// world origin (the default perspective camera at `[0, 0.3, 2]` stays
+    /// fixed); pinch adjusts the camera's field of view — mirrors
+    /// Android's `FovZoomCameraManipulator`.
+    ///
+    /// **Limitation (#1034)**: true first-person look — rotating the
+    /// camera *about its own position* instead of rotating world content —
+    /// is not yet implemented because the orbit pivot is shared with
+    /// ``orbit`` mode. The visual effect is a tight orbit at radius `2`
+    /// rather than a stationary look-around; this is good enough for
+    /// inspection demos but not for FPS-style navigation. Tracked as a
+    /// v4.4.0 follow-up.
     case firstPerson
 }
 
@@ -236,6 +251,13 @@ public struct CameraControls: Sendable {
 
     /// Applies inertia deceleration. Call this on each frame after drag ends.
     ///
+    /// Mode-gated so `.pan` doesn't see ghost rotation from the last drag's
+    /// stored `inertiaVelocity` (drag in `.pan` mutates `target`, not
+    /// `azimuth`/`elevation`, but the velocity is captured unconditionally
+    /// at `handleDrag`'s tail; this guard prevents that velocity from
+    /// leaking into rotation when the user releases a pan drag). Closes the
+    /// Agent 1 MAJOR finding on PR #1038.
+    ///
     /// - Returns: `true` while inertia is still active.
     @discardableResult
     public mutating func applyInertia() -> Bool {
@@ -246,9 +268,20 @@ public struct CameraControls: Sendable {
             return false
         }
 
-        azimuth -= Float(inertiaVelocity.width) * sensitivity
-        elevation += Float(inertiaVelocity.height) * sensitivity
-        clampElevation()
+        switch mode {
+        case .orbit, .firstPerson:
+            azimuth -= Float(inertiaVelocity.width) * sensitivity
+            elevation += Float(inertiaVelocity.height) * sensitivity
+            clampElevation()
+        case .pan:
+            // Inertia in pan mode keeps translating the target so the scene
+            // continues to glide after release — same semantics as
+            // `handleDrag(.pan)`.
+            let right = SIMD3<Float>(cos(azimuth), 0, -sin(azimuth))
+            let up = SIMD3<Float>(0, 1, 0)
+            target += right * Float(inertiaVelocity.width) * panSpeed
+            target += up * Float(-inertiaVelocity.height) * panSpeed
+        }
 
         inertiaVelocity.width *= CGFloat(inertiaDamping)
         inertiaVelocity.height *= CGFloat(inertiaDamping)

--- a/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
@@ -4,15 +4,22 @@ import RealityKit
 
 /// Camera interaction mode for the 3D scene.
 ///
-/// Mirrors SceneView Android's camera manipulator modes.
+/// Mirrors SceneView Android's camera manipulator modes
+/// (`CameraGestureDetector` + `FovZoomCameraManipulator`).
 public enum CameraControlMode: Sendable {
-    /// Orbit around a target point. Drag to rotate, pinch to zoom.
+    /// Orbit around a target point. Drag rotates the scene around the orbit
+    /// pivot; pinch dollies in/out by scaling the scene root.
     case orbit
 
-    /// Pan the camera in the view plane. Drag to move, pinch to zoom.
+    /// Pan the camera in the view plane. Drag translates the orbit target
+    /// laterally (the scene appears to slide), pinch keeps dollying in/out.
+    /// Rotation is preserved so callers can pan first then orbit.
     case pan
 
-    /// First-person camera. Drag to look around, pinch to move forward/back.
+    /// First-person look-around. Drag rotates the scene with no orbit
+    /// translation (camera stays put visually), pinch adjusts the
+    /// perspective camera's field of view — mirrors Android's
+    /// `FovZoomCameraManipulator`.
     case firstPerson
 }
 
@@ -81,6 +88,20 @@ public struct CameraControls: Sendable {
 
     /// First-person move speed (first-person mode only).
     public var moveSpeed: Float = 0.1
+
+    /// Field-of-view in degrees for ``CameraControlMode/firstPerson`` (pinch zoom).
+    /// Mirrors Android's `FovZoomCameraManipulator` (default range 10°..120°).
+    public var fov: Float = 60.0
+
+    /// Minimum FOV in degrees (firstPerson pinch-in limit).
+    public var minFov: Float = 10.0
+
+    /// Maximum FOV in degrees (firstPerson pinch-out limit).
+    public var maxFov: Float = 120.0
+
+    /// Per-pixel FOV delta in degrees (firstPerson pinch sensitivity).
+    /// Mirrors Android `FovZoomCameraManipulator.DEFAULT_PINCH_FOV_SPEED`.
+    public var pinchFovSpeed: Float = 0.05
 
     /// Whether touch/drag interaction is enabled.
     public var isEnabled: Bool = true
@@ -194,10 +215,23 @@ public struct CameraControls: Sendable {
 
     /// Updates orbit radius from a magnification gesture.
     ///
+    /// In ``CameraControlMode/orbit`` and ``CameraControlMode/pan`` this scales
+    /// the dolly radius (zoom). In ``CameraControlMode/firstPerson`` it
+    /// adjusts the perspective camera's field-of-view instead — mirrors
+    /// Android's `FovZoomCameraManipulator`.
+    ///
     /// - Parameter scale: The pinch gesture magnification factor.
     public mutating func handlePinch(_ scale: CGFloat) {
-        orbitRadius /= Float(scale)
-        orbitRadius = min(max(orbitRadius, minRadius), maxRadius)
+        guard isEnabled else { return }
+        switch mode {
+        case .orbit, .pan:
+            orbitRadius /= Float(scale)
+            orbitRadius = Swift.min(Swift.max(orbitRadius, minRadius), maxRadius)
+        case .firstPerson:
+            // Pinch out (scale > 1) ⇒ user wants to zoom IN ⇒ smaller FOV.
+            fov /= Float(scale)
+            fov = Swift.min(Swift.max(fov, minFov), maxFov)
+        }
     }
 
     /// Applies inertia deceleration. Call this on each frame after drag ends.

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -263,6 +263,14 @@ public struct SceneView: View {
     /// `ModelNode(centerOrigin: …)` work either way — the centring is
     /// idempotent and reverses an off-centre placement to origin.
     ///
+    /// **iOS-only behaviour vs Android (#1026)**: Android achieves the
+    /// same effect per-demo via `ModelNode(centerOrigin = Position.ZERO)`
+    /// and there is no library-level auto-centre on Android. Cross-platform
+    /// code that ports Android scenes verbatim will see iOS implicitly
+    /// re-centre content that was laid out with explicit positions —
+    /// pass `false` here to disable the library-level pass and restore
+    /// strict Android-parity placement semantics.
+    ///
     /// ```swift
     /// SceneView { root in
     ///     // Hero piece placed deliberately off-centre for a horizon-line shot
@@ -567,17 +575,30 @@ private struct SceneViewRepresentation: View {
     ///
     /// Opt-out via ``SceneView/autoCenterContent(_:)`` for scenes that
     /// rely on intentional off-centre placement.
+    /// Smallest mesh extent (in meters) the auto-centre pass will accept
+    /// as "content has loaded enough to be centred". Below this threshold
+    /// the bounds are assumed to come from an async load that hasn't
+    /// populated yet, and the pass is deferred to the next frame.
+    private static let minVisualExtent: Float = 0.001
+
     @MainActor
     private func refreshContentCentering() {
         guard !didCenterContent else { return }
-        let bounds = entities.contentRoot.visualBounds(relativeTo: entities.root)
+        // Query bounds in contentRoot-local space so they're invariant of
+        // `entities.root`'s rotation + scale (applied every frame by
+        // `applyCamera()`). Sampling `relativeTo: entities.root` would
+        // rescale extents with pinch-zoom, opening a race where an
+        // early-pinch + slow-loading model flips the `minVisualExtent`
+        // gate true/false between frames and centres at the wrong moment.
+        let bounds = entities.contentRoot.visualBounds(relativeTo: entities.contentRoot)
         let extents = bounds.extents
         // Skip empty / degenerate bounds — async loads not done yet.
-        // `BoundingBox` defaults to (.init(repeating: -.infinity), .init(repeating: .infinity))
-        // for empty entities; the resulting extents are NaN/Inf.
+        // RealityKit's empty `BoundingBox` returns `min = +∞`, `max = -∞`
+        // so the `max - min` extents are non-finite (or zero for a
+        // zero-extent placeholder); both cases are caught here.
         guard extents.x.isFinite, extents.y.isFinite, extents.z.isFinite else { return }
         let extentMax = max(extents.x, extents.y, extents.z)
-        guard extentMax > 0.001 else { return }
+        guard extentMax > Self.minVisualExtent else { return }
         entities.contentRoot.position = -bounds.center
         didCenterContent = true
     }
@@ -641,16 +662,21 @@ private struct SceneViewRepresentation: View {
             entities.root.position = -camera.target * zoomScale
 
         case .firstPerson:
-            // First-person: no scale change (pinch mutates FOV instead — see
-            // pinchGesture). Rotation makes the scene yaw/pitch around the
-            // user as if they were standing still and looking around.
+            // First-person inspection: no scale change (pinch mutates FOV
+            // instead — see pinchGesture). Rotation makes the scene
+            // yaw/pitch around the world origin while the camera stays
+            // fixed at `[0, 0.3, 2]`. NB: this is NOT a true "stand still
+            // and look around" camera-orientation rotation — see the
+            // `firstPerson` enum doc-comment for the v4.4.0 follow-up.
             entities.root.scale = SIMD3<Float>(repeating: 1)
             entities.root.position = .zero
             #if os(iOS) || os(macOS)
             // Sync the perspective camera FOV to the camera-controls state.
-            // Done every frame so external mutations of `camera.fov` also
-            // take effect; cheap enough that the cost is negligible.
-            entities.perspCamera.camera.fieldOfViewInDegrees = camera.fov
+            // Skip the property write when nothing changed so RealityKit
+            // doesn't re-evaluate the projection matrix on idle frames.
+            if entities.perspCamera.camera.fieldOfViewInDegrees != camera.fov {
+                entities.perspCamera.camera.fieldOfViewInDegrees = camera.fov
+            }
             #endif
         }
     }

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -93,6 +93,13 @@ public struct SceneView: View {
     // Default `.default` preserves the scene's loaded settings.
     var renderQualityPreset: RenderQuality = .default
 
+    // Auto-centre user content the first frame the bounds are non-empty so
+    // demos placing objects at e.g. `z = -2` show up visually centred in
+    // the viewport. Mirrors Android's per-demo `ModelNode(centerOrigin: …)`
+    // pattern but at the library level. Default `true`; opt out via
+    // `.autoCenterContent(false)`. Closes #1026.
+    var autoCenterContentEnabled: Bool = true
+
     /// Creates a 3D scene with imperative content setup.
     ///
     /// - Parameter content: A closure that populates the scene. Receives a root
@@ -132,7 +139,8 @@ public struct SceneView: View {
             autoRotateSpeed: autoRotateSpeed,
             mainLightSlot: mainLightSlot,
             fillLightSlot: fillLightSlot,
-            renderQualityPreset: renderQualityPreset
+            renderQualityPreset: renderQualityPreset,
+            autoCenterContentEnabled: autoCenterContentEnabled
         )
     }
 
@@ -243,6 +251,30 @@ public struct SceneView: View {
         copy.renderQualityPreset = preset
         return copy
     }
+
+    /// Controls whether the library translates the user-content root entity
+    /// so its centroid lands at the orbit pivot on the first frame the
+    /// scene's `visualBounds` is non-empty. Default `true`. Closes #1026.
+    ///
+    /// Pass `false` for scenes that rely on intentional off-centre
+    /// placement (e.g. carousels, narrative dioramas, story-mode demos
+    /// where the camera is meant to look down on content placed below).
+    /// All existing demos and code that previously called
+    /// `ModelNode(centerOrigin: …)` work either way — the centring is
+    /// idempotent and reverses an off-centre placement to origin.
+    ///
+    /// ```swift
+    /// SceneView { root in
+    ///     // Hero piece placed deliberately off-centre for a horizon-line shot
+    ///     root.addChild(model.entity)
+    /// }
+    /// .autoCenterContent(false)
+    /// ```
+    public func autoCenterContent(_ enabled: Bool) -> SceneView {
+        var copy = self
+        copy.autoCenterContentEnabled = enabled
+        return copy
+    }
 }
 
 // MARK: - Scene entities holder
@@ -252,7 +284,17 @@ public struct SceneView: View {
 /// or recreated across SwiftUI re-renders — critical because @State on a
 /// reference type does not guarantee identity stability in all SwiftUI versions.
 private final class SceneEntities: ObservableObject {
+    /// The orbit / scale pivot. Receives the camera-controls rotation and
+    /// scale every frame so the scene appears to orbit / zoom around its
+    /// origin. Lights are added here so the auto-centering translation
+    /// applied to ``contentRoot`` does not move them.
     let root = Entity()
+    /// Holds user-supplied content. Translated by the auto-center helper
+    /// on the first frame where ``Entity/visualBounds(relativeTo:)`` is
+    /// non-empty, so demos placing objects at e.g. `z = -2` show up
+    /// visually centred in the viewport without each demo having to
+    /// `centerOrigin` itself. Closes #1026.
+    let contentRoot = Entity()
     let ibl = Entity()
     #if os(iOS) || os(macOS)
     /// Holds the perspective camera so gesture handlers can mutate its
@@ -276,6 +318,11 @@ private struct SceneViewRepresentation: View {
     let mainLightSlot: LightSlot
     let fillLightSlot: LightSlot
     let renderQualityPreset: RenderQuality
+    /// When true (default), the first frame where the user content's
+    /// `visualBounds` is non-empty triggers a one-time translation of
+    /// `entities.contentRoot` so the scene's centroid lands at the orbit
+    /// pivot. Closes #1026.
+    let autoCenterContentEnabled: Bool
 
     @State private var camera = CameraControls(mode: .orbit)
     @StateObject private var entities = SceneEntities()
@@ -286,6 +333,11 @@ private struct SceneViewRepresentation: View {
     /// stays untouched. Closes #1034.
     @State private var initialPinchFov: Float? = nil
     @State private var isDragging = false
+
+    /// Set to `true` once ``refreshContentCentering()`` has translated
+    /// `entities.contentRoot` so subsequent frames are a cheap no-op.
+    /// Closes #1026.
+    @State private var didCenterContent = false
 
     // Reactive light-slot caches — compared in `update:` closure to detect when the
     // caller mutated `.mainLight(_:)` / `.fillLight(_:)` so the corresponding entity
@@ -345,6 +397,13 @@ private struct SceneViewRepresentation: View {
             // pattern in `Scene.kt:287-305` ported to iOS).
             refreshLightSlot(.main, slot: mainLightSlot)
             refreshLightSlot(.fill, slot: fillLightSlot)
+            // Auto-center user content the first frame where `visualBounds`
+            // becomes non-empty (i.e. async-loaded models have populated).
+            // No-op once centered; opt-out via `.autoCenterContent(false)`.
+            // Closes #1026.
+            if autoCenterContentEnabled {
+                refreshContentCentering()
+            }
         }
         #else
         // RealityView requires macOS 15.0+; fall back to a placeholder on older SDKs
@@ -380,6 +439,11 @@ private struct SceneViewRepresentation: View {
 
         // Root entity holds all user content
         realityContent.add(entities.root)
+        // Intermediate contentRoot — user content goes here so the
+        // auto-center pass (refreshContentCentering, called from the
+        // RealityView.update: closure) can translate it independently of
+        // lights, IBL, and camera. Closes #1026.
+        entities.root.addChild(entities.contentRoot)
 
         // IBL entity (will be configured when environment loads)
         realityContent.add(entities.ibl)
@@ -393,8 +457,11 @@ private struct SceneViewRepresentation: View {
         appliedMainSlot = mainLightSlot
         appliedFillSlot = fillLightSlot
 
-        // Populate user content
-        content(entities.root)
+        // Populate user content. Goes into `contentRoot` (a child of root)
+        // instead of `root` directly so the auto-center translation in
+        // `refreshContentCentering()` only affects user content, not the
+        // lights provisioned just above.
+        content(entities.contentRoot)
 
         // Apply RenderQuality preset to all directional lights + the IBL receiver entity.
         // Runs AFTER lights + content are added so the preset walks the full scene tree.
@@ -482,6 +549,37 @@ private struct SceneViewRepresentation: View {
         } else {
             appliedFillSlot = slot
         }
+    }
+
+    // MARK: - Auto-center content (#1026)
+
+    /// Translates ``SceneEntities/contentRoot`` so the centroid of its
+    /// `visualBounds` lands at the parent (`entities.root`) origin. Runs
+    /// once on the first frame the bounds are non-empty — most async
+    /// model loads complete within a handful of frames after `setupScene`.
+    ///
+    /// Without this, iOS demos placing content at e.g. `z = -2` render
+    /// in the bottom-third of the viewport: the default perspective
+    /// camera at `[0, 0.3, 2]` looks at world origin, but content is far
+    /// from origin. Android achieves the same effect via the per-demo
+    /// `ModelNode(centerOrigin = …)` parameter; iOS now does it at the
+    /// library level so every demo benefits without per-demo plumbing.
+    ///
+    /// Opt-out via ``SceneView/autoCenterContent(_:)`` for scenes that
+    /// rely on intentional off-centre placement.
+    @MainActor
+    private func refreshContentCentering() {
+        guard !didCenterContent else { return }
+        let bounds = entities.contentRoot.visualBounds(relativeTo: entities.root)
+        let extents = bounds.extents
+        // Skip empty / degenerate bounds — async loads not done yet.
+        // `BoundingBox` defaults to (.init(repeating: -.infinity), .init(repeating: .infinity))
+        // for empty entities; the resulting extents are NaN/Inf.
+        guard extents.x.isFinite, extents.y.isFinite, extents.z.isFinite else { return }
+        let extentMax = max(extents.x, extents.y, extents.z)
+        guard extentMax > 0.001 else { return }
+        entities.contentRoot.position = -bounds.center
+        didCenterContent = true
     }
 
     // MARK: - Environment IBL

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -254,6 +254,13 @@ public struct SceneView: View {
 private final class SceneEntities: ObservableObject {
     let root = Entity()
     let ibl = Entity()
+    #if os(iOS) || os(macOS)
+    /// Holds the perspective camera so gesture handlers can mutate its
+    /// field-of-view directly. Used by ``CameraControlMode/firstPerson``
+    /// pinch — see #1034. visionOS renders through the headset, no manual
+    /// camera entity exists.
+    let perspCamera = PerspectiveCamera()
+    #endif
 }
 
 // MARK: - Internal implementation
@@ -274,6 +281,10 @@ private struct SceneViewRepresentation: View {
     @StateObject private var entities = SceneEntities()
     @State private var lastDragTranslation: CGSize = .zero
     @State private var initialPinchRadius: Float? = nil
+    /// Snapshotted FOV when a pinch begins in ``CameraControlMode/firstPerson``
+    /// — kept separate from `initialPinchRadius` so the orbit/pan dolly path
+    /// stays untouched. Closes #1034.
+    @State private var initialPinchFov: Float? = nil
     @State private var isDragging = false
 
     // Reactive light-slot caches — compared in `update:` closure to detect when the
@@ -360,10 +371,11 @@ private struct SceneViewRepresentation: View {
         // simulate orbit. The slight Y elevation gives a natural bird's-eye angle.
         // look(at:from:) handles both position and orientation — in RealityKit,
         // entities face +Z by default so explicit orientation is required.
-        let perspCamera = PerspectiveCamera()
-        perspCamera.camera.fieldOfViewInDegrees = 60
-        perspCamera.look(at: .zero, from: [0, 0.3, 2], relativeTo: nil)
-        realityContent.add(perspCamera)
+        // We keep a ref on the SceneEntities holder so `.firstPerson` pinch can
+        // mutate the FOV at runtime (#1034).
+        entities.perspCamera.camera.fieldOfViewInDegrees = 60
+        entities.perspCamera.look(at: .zero, from: [0, 0.3, 2], relativeTo: nil)
+        realityContent.add(entities.perspCamera)
         #endif
 
         // Root entity holds all user content
@@ -500,12 +512,49 @@ private struct SceneViewRepresentation: View {
     // MARK: - Camera
 
     private func applyCamera() {
+        // Sync the camera state's mode with the modifier-provided value. Done
+        // every frame because the modifier propagates as a `let` while the
+        // camera state is `@State` — without this, calling
+        // `.cameraControls(.pan)` would be silently ignored. Closes #1034.
+        if camera.mode != cameraControlMode {
+            camera.mode = cameraControlMode
+        }
+
         let yaw = simd_quatf(angle: -camera.azimuth, axis: [0, 1, 0])
         let pitch = simd_quatf(angle: -camera.elevation, axis: [1, 0, 0])
         entities.root.orientation = yaw * pitch
 
-        let zoomScale = 5.0 / camera.orbitRadius
-        entities.root.scale = SIMD3<Float>(repeating: zoomScale)
+        // Per-mode application of zoom + translation. Mirrors Android's
+        // `CameraGestureDetector` modes (ORBIT / PAN / FREE_FLIGHT) — closes
+        // #1034 (last #928 silent-stub item).
+        switch camera.mode {
+        case .orbit:
+            // Standard orbit: pinch scales scene; no translation.
+            let zoomScale = 5.0 / camera.orbitRadius
+            entities.root.scale = SIMD3<Float>(repeating: zoomScale)
+            entities.root.position = .zero
+
+        case .pan:
+            // Pan: pinch still dollies, drag translates `target` laterally.
+            // Visually the scene slides in screen space — equivalent to
+            // moving the camera in the opposite direction.
+            let zoomScale = 5.0 / camera.orbitRadius
+            entities.root.scale = SIMD3<Float>(repeating: zoomScale)
+            entities.root.position = -camera.target * zoomScale
+
+        case .firstPerson:
+            // First-person: no scale change (pinch mutates FOV instead — see
+            // pinchGesture). Rotation makes the scene yaw/pitch around the
+            // user as if they were standing still and looking around.
+            entities.root.scale = SIMD3<Float>(repeating: 1)
+            entities.root.position = .zero
+            #if os(iOS) || os(macOS)
+            // Sync the perspective camera FOV to the camera-controls state.
+            // Done every frame so external mutations of `camera.fov` also
+            // take effect; cheap enough that the cost is negligible.
+            entities.perspCamera.camera.fieldOfViewInDegrees = camera.fov
+            #endif
+        }
     }
 
     // MARK: - Gestures
@@ -528,21 +577,40 @@ private struct SceneViewRepresentation: View {
     }
 
     private var pinchGesture: some Gesture {
+        // Mode-aware pinch: orbit/pan dollies the radius, firstPerson scales
+        // the perspective camera's FOV (#1034). We snapshot the value at
+        // gesture start so the delta is applied to a stable base — same
+        // pattern as Android's `Manipulator.scrollBegin / scrollUpdate`.
         MagnifyGesture()
             .onChanged { value in
-                if initialPinchRadius == nil {
-                    initialPinchRadius = camera.orbitRadius
-                }
-                if let initial = initialPinchRadius {
-                    let newRadius = initial / Float(value.magnification)
-                    camera.orbitRadius = min(
-                        max(newRadius, camera.minRadius),
-                        camera.maxRadius
-                    )
+                switch camera.mode {
+                case .orbit, .pan:
+                    if initialPinchRadius == nil {
+                        initialPinchRadius = camera.orbitRadius
+                    }
+                    if let initial = initialPinchRadius {
+                        let newRadius = initial / Float(value.magnification)
+                        camera.orbitRadius = min(
+                            max(newRadius, camera.minRadius),
+                            camera.maxRadius
+                        )
+                    }
+                case .firstPerson:
+                    if initialPinchFov == nil {
+                        initialPinchFov = camera.fov
+                    }
+                    if let initial = initialPinchFov {
+                        let newFov = initial / Float(value.magnification)
+                        camera.fov = min(
+                            max(newFov, camera.minFov),
+                            camera.maxFov
+                        )
+                    }
                 }
             }
             .onEnded { _ in
                 initialPinchRadius = nil
+                initialPinchFov = nil
             }
     }
 

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsModeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsModeTests.swift
@@ -137,5 +137,98 @@ final class CameraControlsModeTests: XCTestCase {
             XCTAssertEqual(c.fov, fov, "disabled pinch must no-op (mode=\(mode))")
         }
     }
+
+    // MARK: - rotated-camera pan
+
+    /// Pan should translate `target` along the camera-aligned right + up
+    /// vectors, NOT the world-aligned x/y axes. Tests Agent 3's pinning
+    /// gap: previous `testDragPanMode_translatesTarget` only covered
+    /// azimuth=0 (trivial case where camera right vector == world x).
+    func testDragPanMode_rotatedCamera_translatesAlongCameraRight() {
+        var c = CameraControls(mode: .pan)
+        c.azimuth = .pi / 2  // 90° — camera looks along +X axis
+        let initialTarget = c.target
+
+        c.handleDrag(CGSize(width: 100, height: 0))
+
+        // With azimuth=π/2: right = (cos(π/2), 0, -sin(π/2)) = (0, 0, -1).
+        // Width = 100 px × panSpeed 0.01 ⇒ +1 along right.
+        // So target.z should DECREASE by 1, x and y unchanged.
+        XCTAssertEqual(c.target.x, initialTarget.x, accuracy: 0.001)
+        XCTAssertEqual(c.target.y, initialTarget.y, accuracy: 0.001)
+        XCTAssertEqual(c.target.z, initialTarget.z - 1.0, accuracy: 0.01,
+                       "rotated-camera pan must follow camera-aligned right vector")
+    }
+
+    // MARK: - autoRotation works in all modes
+
+    func testApplyAutoRotation_orbitMode_rotatesAzimuth() {
+        var c = CameraControls(mode: .orbit)
+        c.isAutoRotating = true
+        c.autoRotateSpeed = 1.0
+        let initialAz = c.azimuth
+
+        c.applyAutoRotation(dt: 0.5)
+        XCTAssertEqual(c.azimuth, initialAz + 0.5, accuracy: 0.001)
+    }
+
+    func testApplyAutoRotation_firstPersonMode_rotatesAzimuth() {
+        // FirstPerson uses the same azimuth/elevation rotation as orbit
+        // (the visual difference is in `applyCamera`'s scale + position
+        // handling, not in the rotation math). Auto-rotation must still
+        // tick azimuth so the demo's turntable mode works.
+        var c = CameraControls(mode: .firstPerson)
+        c.isAutoRotating = true
+        c.autoRotateSpeed = 1.0
+        let initialAz = c.azimuth
+
+        c.applyAutoRotation(dt: 0.5)
+        XCTAssertEqual(c.azimuth, initialAz + 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - applyInertia mode-gated
+
+    func testApplyInertia_orbitMode_rotatesAzimuthAndElevation() {
+        var c = CameraControls(mode: .orbit)
+        c.inertiaVelocity = CGSize(width: 100, height: 50)
+        let initialAz = c.azimuth
+        let initialEl = c.elevation
+        let initialTarget = c.target
+
+        let active = c.applyInertia()
+
+        XCTAssertTrue(active)
+        XCTAssertNotEqual(c.azimuth, initialAz, "orbit inertia must rotate yaw")
+        XCTAssertNotEqual(c.elevation, initialEl, "orbit inertia must rotate pitch")
+        XCTAssertEqual(c.target, initialTarget, "orbit inertia must NOT translate target")
+    }
+
+    func testApplyInertia_panMode_translatesTarget_notAzimuthElevation() {
+        // The Agent 1 MAJOR — applyInertia previously always rotated,
+        // injecting ghost rotation when a `.pan` drag ended. Now mode-gated.
+        var c = CameraControls(mode: .pan)
+        c.inertiaVelocity = CGSize(width: 100, height: 0)
+        let initialAz = c.azimuth
+        let initialEl = c.elevation
+        let initialTarget = c.target
+
+        let active = c.applyInertia()
+
+        XCTAssertTrue(active)
+        XCTAssertEqual(c.azimuth, initialAz, "pan inertia must NOT rotate yaw")
+        XCTAssertEqual(c.elevation, initialEl, "pan inertia must NOT rotate pitch")
+        XCTAssertNotEqual(c.target, initialTarget, "pan inertia must glide target")
+    }
+
+    func testApplyInertia_firstPersonMode_rotatesAzimuthAndElevation() {
+        var c = CameraControls(mode: .firstPerson)
+        c.inertiaVelocity = CGSize(width: 100, height: 50)
+        let initialAz = c.azimuth
+
+        let active = c.applyInertia()
+
+        XCTAssertTrue(active)
+        XCTAssertNotEqual(c.azimuth, initialAz, "firstPerson inertia must rotate yaw")
+    }
 }
 #endif

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsModeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsModeTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import SceneViewSwift
+
+#if os(iOS) || os(visionOS) || os(macOS)
+/// Pins per-mode `CameraControls` behaviour — closes #1034.
+///
+/// Mirrors the per-mode handler split from Android
+/// `CameraGestureDetector` (ORBIT / PAN / FREE_FLIGHT). Each test asserts
+/// that swapping `mode` redirects the drag / pinch math to the right
+/// channel without bleeding into the orbit defaults.
+final class CameraControlsModeTests: XCTestCase {
+
+    // MARK: - drag math is mode-aware
+
+    func testDragOrbitMode_updatesAzimuthAndElevation_butNotTarget() {
+        var c = CameraControls(mode: .orbit)
+        let initialTarget = c.target
+        let initialAz = c.azimuth
+        let initialEl = c.elevation
+
+        c.handleDrag(CGSize(width: 100, height: 50))
+
+        XCTAssertNotEqual(c.azimuth, initialAz, "orbit drag must rotate yaw")
+        XCTAssertNotEqual(c.elevation, initialEl, "orbit drag must rotate pitch")
+        XCTAssertEqual(c.target, initialTarget, "orbit drag must NOT translate target")
+    }
+
+    func testDragPanMode_translatesTarget_butNotAzimuthOrElevation() {
+        var c = CameraControls(mode: .pan)
+        let initialAz = c.azimuth
+        let initialEl = c.elevation
+        let initialTarget = c.target
+
+        c.handleDrag(CGSize(width: 100, height: 50))
+
+        XCTAssertEqual(c.azimuth, initialAz, "pan drag must NOT rotate yaw")
+        XCTAssertEqual(c.elevation, initialEl, "pan drag must NOT rotate pitch")
+        XCTAssertNotEqual(c.target, initialTarget, "pan drag must translate target")
+        // panSpeed=0.01, width=100 ⇒ ~1 unit X; height=50 (screen-down ⇒ -y world)
+        XCTAssertEqual(c.target.x, initialTarget.x + 1.0, accuracy: 0.01)
+        XCTAssertEqual(c.target.y, initialTarget.y - 0.5, accuracy: 0.01)
+    }
+
+    func testDragFirstPersonMode_updatesAzimuthAndElevation_butNotTarget() {
+        var c = CameraControls(mode: .firstPerson)
+        let initialTarget = c.target
+        let initialAz = c.azimuth
+
+        c.handleDrag(CGSize(width: 200, height: 0))
+
+        XCTAssertNotEqual(c.azimuth, initialAz, "firstPerson drag must rotate yaw")
+        XCTAssertEqual(c.target, initialTarget, "firstPerson drag must NOT translate target")
+    }
+
+    // MARK: - pinch math is mode-aware
+
+    func testPinchOrbitMode_scalesOrbitRadius_butNotFov() {
+        var c = CameraControls(mode: .orbit)
+        let initialFov = c.fov
+        let initialRadius = c.orbitRadius
+
+        c.handlePinch(2.0)
+
+        XCTAssertLessThan(c.orbitRadius, initialRadius, "orbit pinch must dolly radius")
+        XCTAssertEqual(c.fov, initialFov, "orbit pinch must NOT mutate FOV")
+    }
+
+    func testPinchPanMode_scalesOrbitRadius_butNotFov() {
+        var c = CameraControls(mode: .pan)
+        let initialFov = c.fov
+        let initialRadius = c.orbitRadius
+
+        c.handlePinch(2.0)
+
+        XCTAssertLessThan(c.orbitRadius, initialRadius, "pan pinch must dolly radius")
+        XCTAssertEqual(c.fov, initialFov, "pan pinch must NOT mutate FOV")
+    }
+
+    func testPinchFirstPersonMode_scalesFov_butNotOrbitRadius() {
+        var c = CameraControls(mode: .firstPerson)
+        let initialFov = c.fov
+        let initialRadius = c.orbitRadius
+
+        c.handlePinch(2.0)
+
+        XCTAssertLessThan(c.fov, initialFov, "firstPerson pinch out (zoom in) must shrink FOV")
+        XCTAssertEqual(c.orbitRadius, initialRadius, "firstPerson pinch must NOT mutate orbit radius")
+    }
+
+    func testFirstPersonFovClampedToMinFov() {
+        var c = CameraControls(mode: .firstPerson)
+        c.minFov = 20.0
+
+        // Extreme zoom-in
+        c.handlePinch(1000.0)
+
+        XCTAssertGreaterThanOrEqual(c.fov, c.minFov, "FOV must clamp to minFov")
+    }
+
+    func testFirstPersonFovClampedToMaxFov() {
+        var c = CameraControls(mode: .firstPerson)
+        c.maxFov = 90.0
+
+        // Extreme zoom-out
+        c.handlePinch(0.001)
+
+        XCTAssertLessThanOrEqual(c.fov, c.maxFov, "FOV must clamp to maxFov")
+    }
+
+    // MARK: - per-mode defaults
+
+    func testFirstPersonFovDefaultMatchesPerspectiveCamera() {
+        let c = CameraControls(mode: .firstPerson)
+        // Matches the perspCamera default set in SceneView.setupScene.
+        XCTAssertEqual(c.fov, 60.0, accuracy: 0.01)
+    }
+
+    func testFirstPersonFovRangeMatchesAndroidDefault() {
+        let c = CameraControls(mode: .firstPerson)
+        // Mirrors Android `FovZoomCameraManipulator.fovRangeDegrees = 10°..120°`.
+        XCTAssertEqual(c.minFov, 10.0, accuracy: 0.01)
+        XCTAssertEqual(c.maxFov, 120.0, accuracy: 0.01)
+    }
+
+    // MARK: - isEnabled gates all modes
+
+    func testHandlePinchRespectsIsEnabled() {
+        for mode in [CameraControlMode.orbit, .pan, .firstPerson] {
+            var c = CameraControls(mode: mode)
+            c.isEnabled = false
+            let radius = c.orbitRadius
+            let fov = c.fov
+
+            c.handlePinch(2.0)
+
+            XCTAssertEqual(c.orbitRadius, radius, "disabled pinch must no-op (mode=\(mode))")
+            XCTAssertEqual(c.fov, fov, "disabled pinch must no-op (mode=\(mode))")
+        }
+    }
+}
+#endif

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -43,9 +43,13 @@ SceneView { root in
     root.addChild(model.entity)
 }
 .environment(.studio)              // IBL lighting preset
-.cameraControls(.orbit)            // orbit / pan / zoom gestures
+.cameraControls(.orbit)            // .orbit (default) | .pan | .firstPerson (v4.3.0+)
 .onEntityTapped { entity in }      // tap handler
 .autoRotate(speed: 0.3)            // turntable auto-rotation
+.autoCenterContent(true)           // v4.3.0+ — library translates content centroid to orbit pivot (default true; pass false to keep explicit placements)
+.mainLight(.systemDefault)         // v4.2.0+ — see LightSlot
+.fillLight(.systemDefault)         // v4.2.0+
+.renderQuality(.default)           // v4.2.0+ — .cinematic | .default | .performance
 ```
 
 ---
@@ -321,32 +325,45 @@ model?.stopAllAnimations()
 
 ---
 
-## RealityKit-impossible APIs — parity gaps (#1036)
+## iOS parity status (#1036)
 
-A handful of Android APIs cannot be implemented on iOS because RealityKit
-does not expose the underlying feature. They stay deprecated with a clear
-redirect to a working alternative — `@available(*, deprecated, message: …)`
-fires at call site so consumers see the right path. This table is the
-canonical reference; consult it before re-attacking a deprecated API as if
-it were a silent stub.
+Some Android APIs map imperfectly to iOS because RealityKit / ARKit do
+not expose the underlying feature. They fall into three buckets — keep
+this table at hand before re-attacking a deprecated API as if it were a
+silent stub.
+
+### Deprecated on iOS (compile-warning, no-op at runtime)
 
 | Symbol | Why iOS can't | Working alternative |
 |---|---|---|
+| `CameraNode.depthOfField(...)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process required (out of scope) |
+| `CameraNode.exposure(_:)` | No `exposureCompensation` on `PerspectiveCameraComponent` (verified Xcode 26.x compile failure in #1019) | `ARSceneView(cameraExposure:)` for AR; `SceneView.renderQuality(_:)` to tune IBL for 3D |
 | `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | Use `castsShadow(_:)` + `shadowMaximumDistance(_:)` |
-| `CustomMaterial.subsurface(...)` | RealityKit has no subsurface scattering | Approximate with `metallic` + `roughness` PBR tuning |
-| `ReflectionProbeNode.box(...) / .sphere(...)` (volumetric) | `ImageBasedLightReceiverComponent` is unbounded — no volume | Use a single global IBL via `SceneView.environment(...)` |
-| `FogNode.linear / .exponential / .heightBased` | RealityKit has no fog | Single fog mode kept; variant deprecated |
-| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | iOS gets record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
+
+### Android-only — no port planned (or pending)
+
+| Symbol | Why iOS can't | iOS path |
+|---|---|---|
+| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | Record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
 | `SurfaceType.texture` | RealityKit always renders to `MTKView` | N/A — no port needed |
-| `CameraNode.depthOfField(focusDistance:aperture:)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process required (out of scope) |
-| `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x compile failure in #1019) | `ARSceneView(cameraExposure:)` for AR; `SceneView.renderQuality(_:)` to tune IBL for 3D |
-| `StreetscapeGeometry` | ARGeoTrackingConfiguration exists but no mesh equivalent of ARCore's | iOS-skip with doc warning |
+| `StreetscapeGeometry` | ARGeoTrackingConfiguration exists but no mesh equivalent | iOS-skip with doc warning |
 | `TerrainAnchor / RooftopAnchor` (geo-anchored to terrain or rooftop) | `ARGeoAnchor` only does ground; rooftop has no ARKit equivalent | iOS-skip with doc warning |
 
-**Why this matters for AI assistants:** when generating SceneViewSwift code,
-treat the symbols in the left column as deprecated-only. Suggesting them
-will surface a compile-time warning and the alternative listed in the
-right column is always available, type-safe, and ships in the same module.
+### Approximated — iOS implements via different mechanism
+
+Same public API name on both platforms, but the iOS render path differs.
+Use as you would on Android; expect minor visual differences.
+
+| Symbol | Android renderer | iOS approximation |
+|---|---|---|
+| `FogNode.linear / .exponential / .heightBased` | Filament fog modes | Translucent-sphere shader (visual approximation; same factory API) |
+| `ReflectionProbeNode.box(...) / .sphere(...)` | Volumetric Filament probe | Unbounded `ImageBasedLightReceiverComponent` (volume scope is best-effort) |
+| `CustomMaterial.subsurface(...)` | Filament SSS | PBR `metallic` + `roughness` tuning |
+
+**Why this matters for AI assistants:** when generating SceneViewSwift
+code, treat the Deprecated row as no-ops to avoid; Android-only entries
+as iOS-not-implemented; Approximated entries are fine to use as-is and
+will compile + render with visual fidelity differences only.
 
 ---
 

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -321,6 +321,35 @@ model?.stopAllAnimations()
 
 ---
 
+## RealityKit-impossible APIs — parity gaps (#1036)
+
+A handful of Android APIs cannot be implemented on iOS because RealityKit
+does not expose the underlying feature. They stay deprecated with a clear
+redirect to a working alternative — `@available(*, deprecated, message: …)`
+fires at call site so consumers see the right path. This table is the
+canonical reference; consult it before re-attacking a deprecated API as if
+it were a silent stub.
+
+| Symbol | Why iOS can't | Working alternative |
+|---|---|---|
+| `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | Use `castsShadow(_:)` + `shadowMaximumDistance(_:)` |
+| `CustomMaterial.subsurface(...)` | RealityKit has no subsurface scattering | Approximate with `metallic` + `roughness` PBR tuning |
+| `ReflectionProbeNode.box(...) / .sphere(...)` (volumetric) | `ImageBasedLightReceiverComponent` is unbounded — no volume | Use a single global IBL via `SceneView.environment(...)` |
+| `FogNode.linear / .exponential / .heightBased` | RealityKit has no fog | Single fog mode kept; variant deprecated |
+| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | iOS gets record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
+| `SurfaceType.texture` | RealityKit always renders to `MTKView` | N/A — no port needed |
+| `CameraNode.depthOfField(focusDistance:aperture:)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process required (out of scope) |
+| `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x compile failure in #1019) | `ARSceneView(cameraExposure:)` for AR; `SceneView.renderQuality(_:)` to tune IBL for 3D |
+| `StreetscapeGeometry` | ARGeoTrackingConfiguration exists but no mesh equivalent of ARCore's | iOS-skip with doc warning |
+| `TerrainAnchor / RooftopAnchor` (geo-anchored to terrain or rooftop) | `ARGeoAnchor` only does ground; rooftop has no ARKit equivalent | iOS-skip with doc warning |
+
+**Why this matters for AI assistants:** when generating SceneViewSwift code,
+treat the symbols in the left column as deprecated-only. Suggesting them
+will surface a compile-time warning and the alternative listed in the
+right column is always available, type-safe, and ships in the same module.
+
+---
+
 ## Android
 
 Building for Android with Jetpack Compose? See the [Android API Cheatsheet](cheatsheet.md).

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -7,6 +7,63 @@ description: "Migration guides for SceneView: 3.6.x to 4.0.0 Rerun integration, 
 
 ---
 
+## SceneView 4.2.x to 4.3.0 (iOS) — silent-stub modes now active
+
+### `.cameraControls(.pan)` and `.cameraControls(.firstPerson)` no longer silently orbit ([#1034](https://github.com/sceneview/sceneview/issues/1034))
+
+In v4.2.0 these two modes existed in the enum but `applyCamera()` ignored
+them — they produced orbit behaviour at runtime. v4.3.0 wires them to
+real per-mode handlers.
+
+**Action**:
+
+- Apps that called `.cameraControls(.pan)` *expecting* orbit behaviour
+  should switch to `.cameraControls(.orbit)` (or drop the modifier
+  entirely — orbit is the default).
+- Apps that called `.cameraControls(.firstPerson)` get FOV-zoom pinch
+  instead of dolly. To keep the v4.2.0 orbit-with-dolly behaviour,
+  switch to `.orbit`.
+
+```swift
+// v4.2.0 (silent stub)
+SceneView { /* ... */ }
+  .cameraControls(.pan)   // actually orbited
+
+// v4.3.0 (wired)
+SceneView { /* ... */ }
+  .cameraControls(.pan)   // now translates target; drop modifier for orbit
+```
+
+### Library-level auto-center is on by default ([#1026](https://github.com/sceneview/sceneview/issues/1026))
+
+iOS v4.3.0 introduces an intermediate `contentRoot` Entity and translates
+it on the first frame the scene's `visualBounds` is non-empty so the
+centroid lands at the orbit pivot. Most demos benefit; scenes that rely
+on intentional off-centre placement (carousels, dioramas, story-mode)
+will see content re-centre.
+
+**Action**: append `.autoCenterContent(false)` for off-centre-by-design
+scenes.
+
+```swift
+// v4.2.0 — manual per-demo centring
+SceneView { root in
+    let model = ModelNode.load("hero.usdz")
+    model.entity.position = .init(x: 0, y: -0.5, z: -2)  // intentional offset
+    root.addChild(model.entity)
+}
+
+// v4.3.0 — opt out of library centring to keep the offset
+SceneView { root in
+    let model = ModelNode.load("hero.usdz")
+    model.entity.position = .init(x: 0, y: -0.5, z: -2)
+    root.addChild(model.entity)
+}
+.autoCenterContent(false)   // ← restore strict v4.2.0 placement
+```
+
+---
+
 ## SceneView 3.6.x to 4.0.0 (Release Candidate)
 
 **Status:** `v4.0.0` is live as a release candidate. Maven Central and Swift Package Manager artifacts are **not** built from the RC tag — pin to the tag manually to test, or wait for the `v4.0.0` stable tag.

--- a/llms.txt
+++ b/llms.txt
@@ -3348,9 +3348,9 @@ public protocol EntityProvider {
 
 ```swift
 public enum CameraControlMode: Sendable {
-    case orbit         // drag to rotate, pinch to zoom (default)
-    case pan           // drag to pan, pinch to zoom
-    case firstPerson   // drag to look around
+    case orbit         // drag rotates the scene around the orbit pivot, pinch dollies (default)
+    case pan           // drag translates the target laterally, pinch dollies
+    case firstPerson   // drag rotates the view (no orbit translation), pinch adjusts FOV
 }
 
 public struct CameraControls: Sendable {
@@ -3364,6 +3364,11 @@ public struct CameraControls: Sendable {
     public var sensitivity: Float = 0.005
     public var isAutoRotating: Bool = false
     public var autoRotateSpeed: Float = 0.3
+    // firstPerson FOV controls (#1034)
+    public var fov: Float = 60.0
+    public var minFov: Float = 10.0
+    public var maxFov: Float = 120.0
+    public var pinchFovSpeed: Float = 0.05
 }
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -2352,27 +2352,42 @@ video.play() / .pause() / .stop() / .seek(to: 30.0) / .volume(0.5)
 CameraNode().position(.init(x: 0, y: 1.5, z: 3)).lookAt(.zero).fieldOfView(60)
 ```
 
-**iOS deprecations — RealityKit-impossible parity gaps (#1036):**
+**iOS parity status (#1036):**
 
-Full canonical table lives in `docs/docs/cheatsheet-ios.md` — these symbols cannot
-be implemented on iOS because RealityKit does not expose the underlying feature.
-They compile with `@available(*, deprecated, message: …)` so the call site warns
-the consumer and the alternative is always available, type-safe, and in the same module.
+Full canonical reference in `docs/docs/cheatsheet-ios.md`. Three buckets:
+
+### Deprecated on iOS (v4.0.10+ — compile-warning, no-op runtime)
+
+These three APIs ship as `@available(*, deprecated, message: …)` factories and silently no-op when called. Migrate to the alternative listed.
 
 | Deprecated | Why iOS can't | Replacement |
 |---|---|---|
 | `CameraNode.depthOfField(...)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process (out of scope) |
-| `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x build) | `ARSceneView(cameraExposure:)` (AR) or `.renderQuality(_:)` IBL tune (3D) |
+| `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x build, #1019) | `ARSceneView(cameraExposure:)` (AR) or `.renderQuality(_:)` IBL tune (3D) |
 | `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | `.castsShadow(_:)` + `.shadowMaximumDistance(_:)` |
-| `CustomMaterial.subsurface(...)` | No subsurface scattering in RealityKit | Approximate via `metallic` + `roughness` PBR tuning |
-| `ReflectionProbeNode.box(...) / .sphere(...)` (volumetric) | `ImageBasedLightReceiverComponent` is unbounded — no volume | Single global IBL via `SceneView.environment(...)` |
-| `FogNode.linear / .exponential / .heightBased` | RealityKit has no fog | Single fog mode kept; variant deprecated |
-| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
+
+### Android-only — no port planned or pending
+
+These symbols do not exist on iOS (no `@available(*, deprecated)` factory — they have no Swift declaration at all). Code targeting cross-platform must guard with `#if !os(iOS) && !os(macOS) && !os(visionOS)`.
+
+| Symbol | Why iOS can't | iOS path |
+|---|---|---|
+| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | Record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
 | `SurfaceType.texture` | RealityKit always renders to `MTKView` | N/A — no port needed |
-| `StreetscapeGeometry` | ARGeoTrackingConfiguration has no mesh equivalent of ARCore | iOS-skip with doc warning |
+| `StreetscapeGeometry` | ARGeoTrackingConfiguration exists but no mesh equivalent | iOS-skip with doc warning |
 | `TerrainAnchor / RooftopAnchor` | `ARGeoAnchor` only does ground; rooftop has no ARKit equivalent | iOS-skip with doc warning |
 
-These modifiers compile with deprecation warnings and silently no-op at runtime; do not regenerate code that calls them.
+### Approximated — iOS implements via different mechanism
+
+Same public API name on both platforms; the iOS render path differs but the factories are NOT deprecated. Use as you would on Android; expect minor visual differences.
+
+| Symbol | Android renderer | iOS approximation |
+|---|---|---|
+| `FogNode.linear / .exponential / .heightBased` | Filament fog modes | Translucent-sphere shader |
+| `ReflectionProbeNode.box(...) / .sphere(...)` | Volumetric Filament probe | Unbounded `ImageBasedLightReceiverComponent` (volume scope is best-effort) |
+| `CustomMaterial.subsurface(...)` | Filament SSS | PBR `metallic` + `roughness` tuning |
+
+When generating SceneViewSwift code: treat the Deprecated row as no-ops to avoid, Android-only entries as iOS-not-implemented, Approximated entries as fine to use as-is.
 
 **PhysicsNode** — rigid body:
 ```swift

--- a/llms.txt
+++ b/llms.txt
@@ -2352,15 +2352,27 @@ video.play() / .pause() / .stop() / .seek(to: 30.0) / .volume(0.5)
 CameraNode().position(.init(x: 0, y: 1.5, z: 3)).lookAt(.zero).fieldOfView(60)
 ```
 
-**iOS deprecations (v4.0.10+ — RealityKit-incompatible, no-op):**
+**iOS deprecations — RealityKit-impossible parity gaps (#1036):**
 
-| Deprecated | Replacement |
-|---|---|
-| `CameraNode.depthOfField(...)` | Use `.cameraControls(.cinematic)` or attach `DepthOfFieldEffect` via the underlying `ARView.cameraMode` — RealityKit lacks per-camera DoF. |
-| `CameraNode.exposure(_:)` | Use `ARSceneView(cameraExposure:)` (AR) or `.environment(...)` intensity (3D). |
-| `LightNode.shadowColor(_:)` | Removed — RealityKit shadow color is fixed. Tune ambient/IBL tint via `SceneEnvironment.custom(...)` instead. |
+Full canonical table lives in `docs/docs/cheatsheet-ios.md` — these symbols cannot
+be implemented on iOS because RealityKit does not expose the underlying feature.
+They compile with `@available(*, deprecated, message: …)` so the call site warns
+the consumer and the alternative is always available, type-safe, and in the same module.
 
-These three modifiers compile with a `@available(*, deprecated)` warning and silently no-op at runtime. Migrate before the v4.1 hard removal.
+| Deprecated | Why iOS can't | Replacement |
+|---|---|---|
+| `CameraNode.depthOfField(...)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process (out of scope) |
+| `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x build) | `ARSceneView(cameraExposure:)` (AR) or `.renderQuality(_:)` IBL tune (3D) |
+| `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | `.castsShadow(_:)` + `.shadowMaximumDistance(_:)` |
+| `CustomMaterial.subsurface(...)` | No subsurface scattering in RealityKit | Approximate via `metallic` + `roughness` PBR tuning |
+| `ReflectionProbeNode.box(...) / .sphere(...)` (volumetric) | `ImageBasedLightReceiverComponent` is unbounded — no volume | Single global IBL via `SceneView.environment(...)` |
+| `FogNode.linear / .exponential / .heightBased` | RealityKit has no fog | Single fog mode kept; variant deprecated |
+| `ARSceneView(playbackDataset:)` | ARKit has no deterministic recording playback | record-only via [#1032 ReplayKit](https://github.com/sceneview/sceneview/issues/1032); replay stays Android-only |
+| `SurfaceType.texture` | RealityKit always renders to `MTKView` | N/A — no port needed |
+| `StreetscapeGeometry` | ARGeoTrackingConfiguration has no mesh equivalent of ARCore | iOS-skip with doc warning |
+| `TerrainAnchor / RooftopAnchor` | `ARGeoAnchor` only does ground; rooftop has no ARKit equivalent | iOS-skip with doc warning |
+
+These modifiers compile with deprecation warnings and silently no-op at runtime; do not regenerate code that calls them.
 
 **PhysicsNode** — rigid body:
 ```swift

--- a/llms.txt
+++ b/llms.txt
@@ -2914,6 +2914,7 @@ View modifiers (chainable):
 .mainLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — see LightSlot below
 .fillLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — Android-parity 2-light setup
 .renderQuality(_ preset: RenderQuality) -> SceneView        // v4.2.0+ — .cinematic / .default / .performance
+.autoCenterContent(_ enabled: Bool) -> SceneView            // v4.3.0+ — default true; translates content so its centroid lands at the orbit pivot
 ```
 
 ### Render defaults (v4.2.0+)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
@@ -8,7 +8,7 @@ import SceneViewSwift
 /// and ``CameraControlMode/firstPerson`` to feel the difference in gesture
 /// handling. Closes #1034 (last #928 silent-stub item).
 struct CameraControlsDemo: View {
-    @State private var mode: CameraControlMode = .firstPerson
+    @State private var mode: CameraControlMode = .orbit
 
     var body: some View {
         ZStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
@@ -2,13 +2,18 @@ import SwiftUI
 import RealityKit
 import SceneViewSwift
 
-/// Interactive orbit camera with grid reference and instructions.
-/// Named `CameraControlsDemo` to mirror the Android demo of the same name.
+/// Interactive camera controls demo — mirrors Android `CameraControlsDemo.kt`.
+///
+/// Users can switch between ``CameraControlMode/orbit``, ``CameraControlMode/pan``,
+/// and ``CameraControlMode/firstPerson`` to feel the difference in gesture
+/// handling. Closes #1034 (last #928 silent-stub item).
 struct CameraControlsDemo: View {
+    @State private var mode: CameraControlMode = .orbit
+
     var body: some View {
         ZStack {
             SceneView { root in
-                // Central object
+                // Central object — orange PBR cube
                 let cube = GeometryNode.cube(
                     size: 0.35,
                     material: .pbr(color: .systemOrange, metallic: 0.7, roughness: 0.2),
@@ -17,7 +22,7 @@ struct CameraControlsDemo: View {
                 cube.entity.position = .init(x: 0, y: 0, z: -2)
                 root.addChild(cube.entity)
 
-                // Reference grid
+                // Reference grid so .pan and .firstPerson translations are visible.
                 let grid = PathNode.grid(
                     size: 2.0,
                     divisions: 10,
@@ -26,7 +31,7 @@ struct CameraControlsDemo: View {
                 ).position(.init(x: 0, y: -0.3, z: -2))
                 root.addChild(grid.entity)
 
-                // Axis gizmo
+                // Axis gizmo to anchor user orientation when panning/looking around.
                 let gizmo = LineNode.axisGizmo(
                     at: .init(x: -0.8, y: -0.29, z: -1.2),
                     length: 0.2,
@@ -36,7 +41,6 @@ struct CameraControlsDemo: View {
                     root.addChild(line.entity)
                 }
 
-                // Axis labels
                 let xLabel = TextNode(text: "X", fontSize: 0.04, color: .red, depth: 0.005)
                     .position(.init(x: -0.55, y: -0.27, z: -1.2))
                 root.addChild(xLabel.entity)
@@ -47,14 +51,25 @@ struct CameraControlsDemo: View {
                     .position(.init(x: -0.8, y: -0.27, z: -0.95))
                 root.addChild(zLabel.entity)
             }
-            .cameraControls(.orbit)
+            .cameraControls(mode)
             .ignoresSafeArea()
 
             VStack {
                 Spacer()
+
+                // Mode picker — segmented so users feel the live mode switch.
+                Picker("Camera mode", selection: $mode) {
+                    Text("Orbit").tag(CameraControlMode.orbit)
+                    Text("Pan").tag(CameraControlMode.pan)
+                    Text("Look").tag(CameraControlMode.firstPerson)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 6)
+
                 VStack(spacing: 6) {
-                    instructionRow(icon: "hand.draw.fill", text: "1 finger -- Orbit")
-                    instructionRow(icon: "hand.pinch.fill", text: "Pinch -- Zoom")
+                    instructionRow(icon: gestureIconForMode, text: dragHintForMode)
+                    instructionRow(icon: "hand.pinch.fill", text: pinchHintForMode)
                 }
                 .padding()
                 .background(.ultraThinMaterial)
@@ -64,6 +79,31 @@ struct CameraControlsDemo: View {
             }
         }
         .background(Color.black)
+    }
+
+    // MARK: - Per-mode hints
+
+    private var gestureIconForMode: String {
+        switch mode {
+        case .orbit:       return "arrow.triangle.2.circlepath"
+        case .pan:         return "hand.draw.fill"
+        case .firstPerson: return "eye.fill"
+        }
+    }
+
+    private var dragHintForMode: String {
+        switch mode {
+        case .orbit:       return "Drag — orbit around object"
+        case .pan:         return "Drag — translate scene"
+        case .firstPerson: return "Drag — look around"
+        }
+    }
+
+    private var pinchHintForMode: String {
+        switch mode {
+        case .orbit, .pan: return "Pinch — zoom in / out"
+        case .firstPerson: return "Pinch — zoom field of view"
+        }
     }
 
     private func instructionRow(icon: String, text: String) -> some View {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift
@@ -8,7 +8,7 @@ import SceneViewSwift
 /// and ``CameraControlMode/firstPerson`` to feel the difference in gesture
 /// handling. Closes #1034 (last #928 silent-stub item).
 struct CameraControlsDemo: View {
-    @State private var mode: CameraControlMode = .orbit
+    @State private var mode: CameraControlMode = .firstPerson
 
     var body: some View {
         ZStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -253,10 +253,10 @@ struct SamplesTab: View {
                 PhysicsDemo()
             },
 
-            // MARK: Interaction (mostly coming soon — Android-only today)
-            // Note: "Camera Controls" itself ships in the .advanced section via
-            // CameraControlsDemo (orbit + grid). The advanced pan/fly/first-person
-            // modes are tracked separately as Android-only for now.
+            // MARK: Interaction
+            // CameraControlsDemo ships in the .advanced section with the full
+            // 3-way mode picker (orbit / pan / firstPerson) since v4.3.0 (#1034).
+            // Gesture-editing demos below are still pending iOS port.
 
             DemoItem(
                 comingSoonTitle: "Gesture Editing",


### PR DESCRIPTION
## Summary

Three iOS-parity items from the [v4.2.0 handoff](https://github.com/sceneview/sceneview/issues/1004) shipped in one branch, all post-v4.2.0:

- **#1034** — `CameraControls.firstPerson` + `.pan` finally wired through per-mode handlers in `applyCamera()` + `pinchGesture` (last #928 silent-stub item)
- **#1026** — library-level auto-center via intermediate `contentRoot` entity; opt-out modifier `.autoCenterContent(false)` for narrative scenes
- **#1036** — canonical RealityKit-impossible parity table added to `docs/docs/cheatsheet-ios.md` + expanded in `llms.txt` (3 → 10 entries)

## Commits

| Commit | Issue | Scope |
|---|---|---|
| `90399e6e` | [#1034](https://github.com/sceneview/sceneview/issues/1034) | feat: CameraControls per-mode handlers + 11 pinning tests + demo mode picker |
| `e175da10` | [#1026](https://github.com/sceneview/sceneview/issues/1026) | feat: auto-center contentRoot Entity + `.autoCenterContent(_:)` opt-out |
| `435eee3b` | [#1036](https://github.com/sceneview/sceneview/issues/1036) | docs: 10-row RealityKit-impossible parity table |

## Behaviour deltas

- `.cameraControls(.pan)` now translates the orbit `target` and slides the scene (was orbiting)
- `.cameraControls(.firstPerson)` now rotates the view without orbit translation; pinch adjusts the perspective camera's `fieldOfViewInDegrees` instead of dollying (was orbiting + dolly)
- iOS demos placing content at `z = -2` now render centred in the viewport without per-demo `centerOrigin` — opt out with `.autoCenterContent(false)`

## Test plan

- [x] `swift build` green for SceneViewSwift library
- [x] 11 new tests in `CameraControlsModeTests.swift` (per-mode drag/pinch/FOV-clamp/isEnabled gating)
- [ ] Visual smoke test on iPhone 17 simulator — `CameraControlsDemo` mode picker swap, off-centre demos now visually centred
- [ ] Multi-agent Opus review

🤖 Generated with [Claude Code](https://claude.com/claude-code)