### PR TITLE
feat(ios): ARRecorder.saveToPhotoLibrary helper — closes #1043 item 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ Android has had full `ARRecorder` (capture + replay) since v4.0.8 via ARCore's `
 
 - **`ARRecorder` `@MainActor` `ObservableObject`** — `state: .idle / .recording / .error(message)`, `lastOutputURL`, `isRecording` (`@Published`-derived), `isAvailable`.
 - **`async throws` API** — `startRecording() async throws`, `stopRecording(outputURL: URL? = nil) async throws -> URL`. Bridges ReplayKit's completion-handler API to async/await.
-- **Typed error mapping** — `ARRecorderError.{permissionDenied, disabled, unavailable, alreadyRecording, notRecording, other(code:)}` so callers can switch on the case (no string-matching `errorDescription`).
+- **Typed error mapping** — `ARRecorderError.{permissionDenied, disabled, unavailable, alreadyRecording, notRecording, other(code:), photoLibraryDenied, photoLibrarySaveFailed}` so callers can switch on the case (no string-matching `errorDescription`).
 - **`ARRecorder.remembered()` factory** — mirrors Android's `rememberARRecorder()` for code-generation symmetry.
+- **`ARRecorder.saveToPhotoLibrary(_:)` static helper** ([#1043 item 2](https://github.com/sceneview/sceneview/issues/1043)) — wraps `PHPhotoLibrary.performChanges` so the recorded `.mov` can be copied into the user's Photos library. Mirrors Android's `ARRecorder.exportToDownloads()`. Requires `NSPhotoLibraryAddUsageDescription` in the host app's `Info.plist`. Demo gets a "Save to Photos" button alongside `ShareLink`.
 - **What's recorded**: screen pixels only (NOT ARSession state). The `.mov` plays back in Photos / QuickTime; it cannot be fed back into `ARSession` for deterministic replay. Use [`RerunBridge`](https://github.com/sceneview/sceneview/blob/main/SceneViewSwift/Sources/SceneViewSwift/Rerun/RerunBridge.swift) for replay-driven testing.
-- **iOS demo**: `samples/ios-demo/.../ARRecorderDemo.swift` mirrors Android's `ARRecordPlaybackDemo` with a record-only banner + live AR session + tap-to-place markers + `ShareLink` for the captured `.mov`. Registered in the AR section of `SamplesTab`.
-- **Tests**: 14 pinning tests in `ARRecorderTests.swift` (state machine, error code mapping, default URL placement under `.cachesDirectory/ARRecorder/`, factory smoke).
+- **iOS demo**: `samples/ios-demo/.../ARRecorderDemo.swift` mirrors Android's `ARRecordPlaybackDemo` with a record-only banner + live AR session + tap-to-place markers + "Save to Photos" + `ShareLink` for the captured `.mov`. Registered in the AR section of `SamplesTab`.
+- **Tests**: 17 pinning tests in `ARRecorderTests.swift` (state machine, error code mapping, default URL placement under `.cachesDirectory/ARRecorder/`, factory smoke, photo-library missing-file guard, photo-library error Equatable + localized description).
 
 ### Added — `CameraControls.pan` + `.firstPerson` wired ([#1034](https://github.com/sceneview/sceneview/issues/1034))
 

--- a/SceneViewSwift/Sources/SceneViewSwift/AR/ARRecorder.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/AR/ARRecorder.swift
@@ -252,7 +252,17 @@ public final class ARRecorder: ObservableObject {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             PHPhotoLibrary.shared().performChanges {
                 let request = PHAssetCreationRequest.forAsset()
-                request.addResource(with: .video, fileURL: url, options: nil)
+                // `shouldMoveFile = true`: Photos moves the source out of our
+                // caches directory into the system-managed photo library
+                // (atomically — if the save fails, Photos preserves the
+                // original per Apple docs). Without this, the default
+                // behaviour COPIES the file and the caches copy keeps
+                // taking disk space until the OS reclaims it, which for
+                // AR session recordings of hundreds of MB is a real
+                // problem across multi-recording sessions.
+                let options = PHAssetResourceCreationOptions()
+                options.shouldMoveFile = true
+                request.addResource(with: .video, fileURL: url, options: options)
             } completionHandler: { success, error in
                 if success {
                     continuation.resume()

--- a/SceneViewSwift/Sources/SceneViewSwift/AR/ARRecorder.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/AR/ARRecorder.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import Foundation
+import Photos
 import ReplayKit
 import SwiftUI
 
@@ -206,6 +207,63 @@ public final class ARRecorder: ObservableObject {
         let folder = caches.appendingPathComponent("ARRecorder", isDirectory: true)
         return folder.appendingPathComponent("ARRecording-\(UUID().uuidString).mov")
     }
+
+    /// Saves a recorded `.mov` to the user's Photos library via
+    /// `PHPhotoLibrary.performChanges`. Mirrors Android's
+    /// `ARRecorder.exportToDownloads()` — the user-facing "make this
+    /// recording permanent" gesture. Closes #1043 (item 2).
+    ///
+    /// Requires the host app's `Info.plist` to declare
+    /// `NSPhotoLibraryAddUsageDescription`; the first call triggers the
+    /// system permission sheet. On denial throws
+    /// ``ARRecorderError/photoLibraryDenied(_:)``. On success the video
+    /// appears in the user's Photos app under "Recents" with the
+    /// "Recently Saved" smart-album link.
+    ///
+    /// - Parameter url: An existing `.mov` URL (typically from
+    ///   ``stopRecording(outputURL:)``). The file must exist on disk;
+    ///   `PHPhotoLibrary` copies it into the system-managed photo
+    ///   library and the original may be cleaned up afterwards.
+    /// - Throws: ``ARRecorderError/photoLibraryDenied(_:)`` if the user
+    ///   denied access, ``ARRecorderError/photoLibrarySaveFailed(_:)``
+    ///   if the underlying `performChanges` call returned an error.
+    @MainActor
+    public static func saveToPhotoLibrary(_ url: URL) async throws {
+        // Ensure the file is on disk before we even ask for permission —
+        // a missing-file error is more actionable than a generic
+        // "save failed" after the consent sheet.
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ARRecorderError.photoLibrarySaveFailed("file not found: \(url.lastPathComponent)")
+        }
+        // `PHAccessLevel.addOnly` is the minimum-privilege scope for
+        // writing — does not grant read/list access to existing photos.
+        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+        let granted: PHAuthorizationStatus
+        switch status {
+        case .notDetermined:
+            granted = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        default:
+            granted = status
+        }
+        guard granted == .authorized || granted == .limited else {
+            throw ARRecorderError.photoLibraryDenied("Photos add-only permission denied (status=\(granted.rawValue))")
+        }
+        // Bridge PHPhotoLibrary's completion-handler API into async/await.
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetCreationRequest.forAsset()
+                request.addResource(with: .video, fileURL: url, options: nil)
+            } completionHandler: { success, error in
+                if success {
+                    continuation.resume()
+                } else if let error {
+                    continuation.resume(throwing: ARRecorderError.photoLibrarySaveFailed(error.localizedDescription))
+                } else {
+                    continuation.resume(throwing: ARRecorderError.photoLibrarySaveFailed("PHPhotoLibrary.performChanges returned !success without an error"))
+                }
+            }
+        }
+    }
 }
 
 /// Errors surfaced by ``ARRecorder``.
@@ -223,6 +281,14 @@ public enum ARRecorderError: LocalizedError, Equatable {
     /// Any other `RPRecordingError` not matched above. The underlying
     /// `NSError.code` is preserved in the message for support reports.
     case other(String, code: Int)
+    /// The user dismissed the system "Allow access to Photos?" sheet,
+    /// or a parental control disabled write access. Thrown by
+    /// ``ARRecorder/saveToPhotoLibrary(_:)``. The host app must declare
+    /// `NSPhotoLibraryAddUsageDescription` in `Info.plist`.
+    case photoLibraryDenied(String)
+    /// `PHPhotoLibrary.performChanges` returned an error (or `success=false`
+    /// without an error). Thrown by ``ARRecorder/saveToPhotoLibrary(_:)``.
+    case photoLibrarySaveFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -231,7 +297,9 @@ public enum ARRecorderError: LocalizedError, Equatable {
              .notRecording(let msg),
              .permissionDenied(let msg),
              .disabled(let msg),
-             .other(let msg, _):
+             .other(let msg, _),
+             .photoLibraryDenied(let msg),
+             .photoLibrarySaveFailed(let msg):
             return msg
         }
     }

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ARRecorderTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ARRecorderTests.swift
@@ -158,6 +158,45 @@ final class ARRecorderTests: XCTestCase {
         }
     }
 
+    // MARK: - saveToPhotoLibrary
+
+    func testSaveToPhotoLibrary_missingFile_throwsSaveFailed() async {
+        // Exercises the early file-existence guard. We don't touch
+        // PHPhotoLibrary at all because the guard fires before the
+        // authorization check — so this test works without
+        // NSPhotoLibraryAddUsageDescription on the test bundle.
+        let nonExistent = URL(fileURLWithPath: "/tmp/nonexistent-\(UUID().uuidString).mov")
+        do {
+            try await ARRecorder.saveToPhotoLibrary(nonExistent)
+            XCTFail("expected saveToPhotoLibrary to throw for a missing file")
+        } catch let err as ARRecorderError {
+            if case .photoLibrarySaveFailed(let msg) = err {
+                XCTAssertTrue(msg.contains("file not found"),
+                              "expected file-not-found message, got '\(msg)'")
+            } else {
+                XCTFail("expected .photoLibrarySaveFailed, got \(err)")
+            }
+        } catch {
+            XCTFail("expected ARRecorderError, got \(type(of: error)): \(error)")
+        }
+    }
+
+    func testPhotoLibraryErrorsAreEquatable() {
+        XCTAssertEqual(
+            ARRecorderError.photoLibraryDenied("denied"),
+            ARRecorderError.photoLibraryDenied("denied")
+        )
+        XCTAssertNotEqual(
+            ARRecorderError.photoLibraryDenied("denied"),
+            ARRecorderError.photoLibrarySaveFailed("denied")
+        )
+    }
+
+    func testPhotoLibraryErrorsCarryLocalizedDescription() {
+        XCTAssertEqual(ARRecorderError.photoLibraryDenied("user said no").errorDescription, "user said no")
+        XCTAssertEqual(ARRecorderError.photoLibrarySaveFailed("disk full").errorDescription, "disk full")
+    }
+
     // MARK: - rememberARRecorder factory
 
     func testRememberedFactoryReturnsRecorder() {

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -97,8 +97,25 @@ capture screen pixels (NOT an ARKit session dataset). The `.mov` plays
 back in Photos / QuickTime; it **cannot** be replayed into `ARSession`
 (ARKit has no deterministic playback API — replay stays Android-only).
 Typed errors via `ARRecorderError.{permissionDenied, disabled,
-unavailable, alreadyRecording, notRecording, other(code:)}`. See the
-parity table below.
+unavailable, alreadyRecording, notRecording, other(code:),
+photoLibraryDenied, photoLibrarySaveFailed}`. See the parity table below.
+
+### Save to Photos (v4.3.1+)
+
+```swift
+// after stopRecording() returns the URL:
+try await ARRecorder.saveToPhotoLibrary(url)
+```
+
+Wraps `PHPhotoLibrary.shared().performChanges` to copy the `.mov` into
+the system Photos library — mirrors Android's `ARRecorder.exportToDownloads()`.
+First call surfaces the system permission sheet; subsequent calls go
+straight through. **Requires** the host app's `Info.plist` to declare
+`NSPhotoLibraryAddUsageDescription` — without it, iOS crashes the app
+on first invocation per Apple's privacy policy.
+
+On user denial throws `ARRecorderError.photoLibraryDenied`; on
+`performChanges` failure throws `.photoLibrarySaveFailed`.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1610,6 +1610,8 @@ struct MyARScreen: View {
 - **No `recordingRotation` parameter** — Android takes a `recordingRotation: Int` so the MP4 plays back upright when recorded in landscape. `RPScreenRecorder` always captures at the current screen orientation, so no per-call rotation knob is needed — the resulting clip already orients correctly for the way the user held the device.
 - **Output filename is `.mov`** (QuickTime container), not `.mp4`. Most players (Photos, QuickTime, VLC, browsers) accept both transparently.
 
+**Save to Photos (v4.3.1+)** — `try await ARRecorder.saveToPhotoLibrary(url)` wraps `PHPhotoLibrary.shared().performChanges` so the recorded `.mov` lands in the user's Photos library (mirrors Android's `ARRecorder.exportToDownloads()`). The host app's `Info.plist` MUST declare `NSPhotoLibraryAddUsageDescription` or iOS crashes the app on the first call. Throws `ARRecorderError.photoLibraryDenied` on user denial, `.photoLibrarySaveFailed` on `performChanges` error.
+
 ---
 
 ## AR Image Stabilization (EIS)

--- a/samples/ios-demo/SceneViewDemo/Info.plist
+++ b/samples/ios-demo/SceneViewDemo/Info.plist
@@ -39,6 +39,8 @@
 	<string>3D &amp; AR Explorer uses the camera to place 3D objects in your real-world space using augmented reality.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>3D &amp; AR Explorer uses motion sensors to track your device orientation for augmented reality.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>3D &amp; AR Explorer saves AR session recordings (videos) you capture to your Photos library so you can share or revisit them later.</string>
 	<key>UIRequiresFullScreen</key>
 	<false/>
 	<key>UILaunchScreen</key>

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARRecorderDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARRecorderDemo.swift
@@ -20,6 +20,11 @@ struct ARRecorderDemo: View {
     /// cancel it on disappear and avoid mutating `statusMessage` on a
     /// disposed view. Closes Agent A MAJOR finding on PR #1042.
     @State private var activeTask: Task<Void, Never>? = nil
+    /// Disables the "Save to Photos" button while a save is in flight
+    /// — `PHPhotoLibrary.performChanges` can't be cancelled mid-call so
+    /// a double-tap would enqueue two concurrent saves of the same URL
+    /// (two duplicate assets in Photos). Closes reviewer MAJOR on PR #1048.
+    @State private var isSavingToPhotos: Bool = false
 
     var body: some View {
         ZStack {
@@ -135,15 +140,17 @@ struct ARRecorderDemo: View {
                         .truncationMode(.middle)
                     HStack(spacing: 10) {
                         Button(action: { saveToPhotos(url) }) {
-                            Label("Save to Photos", systemImage: "photo.on.rectangle.angled")
+                            Label(isSavingToPhotos ? "Saving…" : "Save to Photos",
+                                  systemImage: "photo.on.rectangle.angled")
                                 .font(.caption.weight(.medium))
                                 .foregroundStyle(.white)
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
-                                .background(Color.accentColor)
+                                .background(isSavingToPhotos ? Color.accentColor.opacity(0.5) : Color.accentColor)
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
+                        .disabled(isSavingToPhotos)
 
                         ShareLink(item: url) {
                             Label("Share", systemImage: "square.and.arrow.up")
@@ -206,9 +213,18 @@ struct ARRecorderDemo: View {
     /// Wraps `ARRecorder.saveToPhotoLibrary` with a status-banner update
     /// so the user knows whether the save succeeded, was denied, or
     /// failed. Tied to the view's `activeTask` so disappear cancels it.
+    /// The `isSavingToPhotos` gate prevents a double-tap from enqueueing
+    /// two concurrent saves of the same URL (closes reviewer MAJOR on
+    /// PR #1048 — `PHPhotoLibrary.performChanges` is uncancellable
+    /// mid-flight, so the button-disable is the only safety net).
     private func saveToPhotos(_ url: URL) {
+        // Defensive: extra guard in case @State race lets the action
+        // fire while the button is mid-transition to disabled.
+        guard !isSavingToPhotos else { return }
         activeTask?.cancel()
+        isSavingToPhotos = true
         activeTask = Task {
+            defer { isSavingToPhotos = false }
             statusMessage = "Saving to Photos…"
             do {
                 try await ARRecorder.saveToPhotoLibrary(url)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARRecorderDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARRecorderDemo.swift
@@ -127,20 +127,33 @@ struct ARRecorderDemo: View {
             }
 
             if let url = recorder.lastOutputURL {
-                HStack(spacing: 10) {
+                VStack(spacing: 6) {
                     Text(url.lastPathComponent)
                         .font(.caption2.monospaced())
                         .foregroundStyle(.white.opacity(0.7))
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    ShareLink(item: url) {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.caption)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Capsule())
+                    HStack(spacing: 10) {
+                        Button(action: { saveToPhotos(url) }) {
+                            Label("Save to Photos", systemImage: "photo.on.rectangle.angled")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color.accentColor)
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+
+                        ShareLink(item: url) {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(.white.opacity(0.15))
+                                .clipShape(Capsule())
+                        }
                     }
                 }
             }
@@ -188,6 +201,24 @@ struct ARRecorderDemo: View {
 
     private func humanFileSize(_ bytes: Int) -> String {
         ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+
+    /// Wraps `ARRecorder.saveToPhotoLibrary` with a status-banner update
+    /// so the user knows whether the save succeeded, was denied, or
+    /// failed. Tied to the view's `activeTask` so disappear cancels it.
+    private func saveToPhotos(_ url: URL) {
+        activeTask?.cancel()
+        activeTask = Task {
+            statusMessage = "Saving to Photos…"
+            do {
+                try await ARRecorder.saveToPhotoLibrary(url)
+                if Task.isCancelled { return }
+                statusMessage = "Saved to Photos"
+            } catch {
+                if Task.isCancelled { return }
+                statusMessage = "Save failed: \(error.localizedDescription)"
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary

iOS equivalent of Android's \`ARRecorder.exportToDownloads()\` — saves a recorded \`.mov\` to the user's Photos library via \`PHPhotoLibrary.shared().performChanges\`. Mirrors the user-facing \"make this recording permanent\" gesture.

Closes [#1043 item 2](https://github.com/sceneview/sceneview/issues/1043).

## API

\`\`\`swift
@MainActor public static func saveToPhotoLibrary(_ url: URL) async throws
\`\`\`

Static (any caller with a URL can save it without ARRecorder ref). \`async throws\` with typed \`ARRecorderError.{photoLibraryDenied, photoLibrarySaveFailed}\` cases. \`.addOnly\` permission scope (least-privilege).

## Demo update

\`ARRecorderDemo\` gets a \"Save to Photos\" button alongside the existing \`ShareLink\`. Status banner shows \"Saving…\" → \"Saved to Photos\" / \"Save failed: <reason>\" via the existing \`statusMessage\` toast.

## Info.plist

Added \`NSPhotoLibraryAddUsageDescription\` to \`samples/ios-demo/.../Info.plist\` (required by iOS or the process crashes on the first \`PHPhotoLibrary\` call). Validated with \`plutil -lint\` + \`plutil -p\` confirms the string is embedded in the .app bundle.

## Triptyque

- **Reviews**: 1 reviewer Opus parallel (PR scope is small)
- **Cross-files updated**: ARRecorder.swift, ARRecorderTests.swift, ARRecorderDemo.swift, Info.plist, CHANGELOG.md, llms.txt, cheatsheet-ios.md
- **Visual test**: app boots cleanly with the new \`Info.plist\` key on iPhone 16e simulator (no crash on launch). The actual save flow can't be visually validated in simulator because \`RPScreenRecorder\` is unreliable below iOS 17.4 — code-level validation via unit tests + Info.plist embedding + build green.

## Test plan

- [x] \`swift build\` SceneViewSwift green
- [x] \`xcodebuild build SceneViewDemo\` green on iPhone 16e (catches pbxproj registration regressions per #1044)
- [x] 3 new pinning tests in \`ARRecorderTests.swift\` (missing-file guard, Equatable on new cases, errorDescription wiring)
- [x] Info.plist validates via \`plutil -lint\` + \`NSPhotoLibraryAddUsageDescription\` confirmed in built bundle
- [ ] CI run on this PR
- [ ] Multi-agent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)