### PR TITLE
feat(samples): bundle ARCore session recording for emulator-testable AR demos

### DIFF
--- a/samples/android-demo/src/debug/assets/ar-recordings/README.md
+++ b/samples/android-demo/src/debug/assets/ar-recordings/README.md
@@ -1,0 +1,56 @@
+# Bundled AR session recordings (debug-only)
+
+ARCore session datasets (`.mp4` with H.264 video + ARCore metadata streams).
+This directory lives in the `debug` sourceSet so files here are bundled in
+**debug APKs only** — the release APK does NOT ship them, keeping the Play
+Store APK lean (#934).
+
+The `ARRecordPlaybackDemo` extracts each file here on first launch into
+`context.getExternalFilesDir("ar-recordings")/` so it appears in the
+**Playback** tab alongside any sessions the user records on-device.
+
+This makes the AR demos **testable on devices without ARCore tracking**
+(emulators, dev machines via the iframe Rerun viewer, CI runners) — replay
+a stable real-world capture instead of needing live camera + IMU.
+
+## Files
+
+| File | Source device | Duration | Streams | Use case |
+|---|---|---|---|---|
+| `bundled-pixel9-sample.mp4` | Pixel 9 | 18 s | H.264 640×480 + 4 metadata tracks (pose, IMU, depth, point cloud) | Default starter — generic indoor scan |
+
+## Adding a new bundled recording
+
+1. Run the demo app on a real ARCore-capable device (Pixel 4+ recommended).
+2. Open **Record & Playback** demo, tap **Start**, capture an AR session.
+3. Pull the `.mp4` from the device:
+   ```bash
+   adb -s <SERIAL> pull /sdcard/Android/data/io.github.sceneview.demo/files/ar-recordings/<filename>.mp4
+   ```
+4. Verify the dataset is well-formed:
+   ```bash
+   ffprobe -v error -show_streams <filename>.mp4 | grep "codec_type"
+   # Expect: 1 video (h264), 4+ data (mett) streams
+   ```
+5. Rename to a descriptive `bundled-<device>-<scene>.mp4`, drop here.
+6. Document it in the table above.
+7. The Robolectric test
+   `samples/android-demo/.../ARBundledRecordingsTest.kt` automatically
+   validates every file in this directory parses cleanly — no demo-side
+   wiring needed for the new file to be picked up.
+
+## ARCore SDK compatibility
+
+Recordings are **bound to the ARCore SDK major version that produced them**.
+The current pin lives in `gradle/libs.versions.toml` (`arCore = "X.Y.Z"`) —
+read it there rather than mirror the version into this README, where it
+would silently drift on the next bump.
+
+If a future ARCore SDK upgrade breaks playback, the demo's auto-extraction
+will surface as "Playback list still shows the file but ARCore replays
+nothing". Re-record on a fresh device with the bumped SDK; the auto-extract
+length-check in `ARRecordPlaybackDemo` (`target.length() == expectedBytes`)
+will replace the stale extracted copy on next entry.
+
+The recordings here are NOT versioned per release — they live alongside the
+app as static debug assets. Re-record only when the runtime fails.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
@@ -137,6 +137,56 @@ fun ARRecordPlaybackDemo(onBack: () -> Unit) {
     val recordingsDir = remember(context) {
         context.getExternalFilesDir("ar-recordings")!!.also { it.mkdirs() }
     }
+    // Extract any bundled recordings shipped in `src/debug/assets/ar-recordings/`
+    // into `recordingsDir` on first launch — gives emulator + ARCore-less
+    // debug-build devices a known-good playback dataset out of the box, so the
+    // AR demos are reproducible without a physical capture session. The bundle
+    // lives in the `debug` sourceSet so the release APK doesn't ship it (#934).
+    // See `samples/android-demo/src/debug/assets/ar-recordings/README.md`.
+    LaunchedEffect(recordingsDir) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            try {
+                val assetMgr = context.assets
+                val bundled = assetMgr.list("ar-recordings")?.filter {
+                    it.endsWith(".mp4", ignoreCase = true)
+                } ?: emptyList()
+                for (name in bundled) {
+                    val target = File(recordingsDir, name)
+                    val expectedBytes = assetMgr.openFd("ar-recordings/$name").use { it.length }
+                    // Skip if already present AND length matches the bundled
+                    // asset — a future release that ships an updated recording
+                    // (e.g. bumped to a newer ARCore SDK) will re-extract.
+                    if (target.exists() && target.length() == expectedBytes) continue
+                    // Write to a `.tmp` first then rename, so a kill / process
+                    // death mid-copy can't leave a half-written file that the
+                    // next `target.exists()` check would silently accept.
+                    val tmp = File(recordingsDir, "$name.tmp")
+                    try {
+                        assetMgr.open("ar-recordings/$name").use { input ->
+                            tmp.outputStream().use { output -> input.copyTo(output) }
+                        }
+                        if (!tmp.renameTo(target)) {
+                            tmp.delete()
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        // Re-throw to keep structured concurrency intact — the
+                        // parent LaunchedEffect cancel must propagate (lesson
+                        // from #980). Drop the partial tmp file first.
+                        tmp.delete()
+                        throw e
+                    } catch (_: Throwable) {
+                        tmp.delete()
+                    }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // Bundled extraction is a nice-to-have; missing files just
+                // mean the user sees an empty Playback list and can record
+                // their own session.
+            }
+        }
+    }
     val recordings = remember { mutableStateListOf<File>() }
     fun refreshRecordings() {
         recordings.clear()

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARBundledRecordingsTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARBundledRecordingsTest.kt
@@ -1,0 +1,130 @@
+package io.github.sceneview.demo.demos
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Locks the bundled ARCore session datasets shipped under
+ * `samples/android-demo/src/debug/assets/ar-recordings/` (every `.mp4`
+ * file in that directory) against four silent-corruption modes that
+ * would otherwise only surface as
+ * "Mode.PLAYBACK shows nothing on the next user's emulator":
+ *
+ * 1. The assets directory exists.
+ * 2. At least one `.mp4` is bundled (so the AR demos are exercisable
+ *    out-of-the-box without a physical capture).
+ * 3. Each `.mp4` opens, declares a non-zero size, and starts with the MP4
+ *    `ftyp` box header — catches a 0-byte commit, a Git-LFS pointer file
+ *    that was never resolved, or a truncated copy.
+ * 4. Each `.mp4` carries the H.264 video track AND at least one ARCore
+ *    metadata track (`mett` codec tag), without which `ARSession`'s
+ *    `setPlaybackDataset` accepts the file but replays nothing.
+ *
+ * These checks run pure-JVM under Robolectric — no device, no ARCore SDK
+ * call. They protect the README's "drop a file in here, the test
+ * automatically picks it up" contribution flow.
+ *
+ * Memory: the bytes for each file are loaded ONCE per test class via
+ * [bytesByName] and reused across the per-file assertions. With three or
+ * four 16 MB recordings this cap (~80 MB) stays comfortably under the
+ * Robolectric default heap of 256–512 MB. If the bundle ever grows past
+ * that, switch to a streaming `BufferedInputStream` boyer-moore scan.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ARBundledRecordingsTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private fun listBundled(): List<String> =
+        context.assets.list("ar-recordings")
+            ?.filter { it.endsWith(".mp4", ignoreCase = true) }
+            ?: emptyList()
+
+    private val bytesByName: Map<String, ByteArray> by lazy {
+        listBundled().associateWith { name ->
+            context.assets.open("ar-recordings/$name").use { it.readBytes() }
+        }
+    }
+
+    @Test
+    fun `assets ar-recordings directory ships at least one mp4`() {
+        val files = listBundled()
+        assertTrue(
+            "Expected at least one bundled `.mp4` under " +
+                "samples/android-demo/src/debug/assets/ar-recordings/. The AR demos " +
+                "rely on bundled recordings so emulators / ARCore-less devices have " +
+                "a known-good playback dataset. Found: $files",
+            files.isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `every bundled mp4 starts with the MP4 ftyp box header`() {
+        for ((name, bytes) in bytesByName) {
+            assertTrue(
+                "$name is suspiciously small (< 1 KB) — likely an empty commit or " +
+                    "an unresolved Git-LFS pointer.",
+                bytes.size >= 1024,
+            )
+            // ISO BMFF 14496-12: every MP4 starts with a `ftyp` box. Bytes 4-7
+            // are the ASCII tag `ftyp`. The first 4 bytes are the box size.
+            val tag = String(bytes.copyOfRange(4, 8))
+            assertEquals(
+                "$name does not start with an MP4 `ftyp` box — got tag '$tag'. " +
+                    "File is corrupt or not an MP4 dataset.",
+                "ftyp",
+                tag,
+            )
+        }
+    }
+
+    @Test
+    fun `every bundled mp4 carries an ARCore metadata track marker`() {
+        for ((name, bytes) in bytesByName) {
+            // ARCore `Session.startRecording` writes camera frames as `avc1`
+            // (H.264) and emits ARCore-specific tracks tagged `mett` (per
+            // ISO 14496-12, codec_tag for "metadata text" / generic data). A
+            // session dataset MUST contain BOTH or `setPlaybackDataset`
+            // succeeds-then-replays-nothing.
+            val haveAvc1 = containsAscii(bytes, "avc1")
+            val haveMett = containsAscii(bytes, "mett")
+            assertTrue(
+                "$name is missing the H.264 video track tag `avc1` — not an " +
+                    "ARCore camera-frame dataset.",
+                haveAvc1,
+            )
+            assertTrue(
+                "$name is missing the ARCore metadata track tag `mett` — " +
+                    "this is camera-only video, not a session dataset (replay " +
+                    "would silently produce no anchors / no tracking).",
+                haveMett,
+            )
+        }
+    }
+
+    @Test
+    fun `recordings dir resolves to a real assets path`() {
+        // Catches the trivial typo of renaming the assets dir without
+        // updating the demo + test in lockstep.
+        val list = context.assets.list("ar-recordings")
+        assertNotNull("assets/ar-recordings/ directory not on the classpath", list)
+    }
+
+    private fun containsAscii(bytes: ByteArray, needle: String): Boolean {
+        if (needle.isEmpty() || bytes.size < needle.length) return false
+        val target = needle.toByteArray(Charsets.US_ASCII)
+        outer@ for (i in 0..(bytes.size - target.size)) {
+            for (j in target.indices) {
+                if (bytes[i + j] != target[j]) continue@outer
+            }
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Closes the "perenne AR test infra" ask: Thomas captured a 16 MB / 18.3 s ARCore session on Pixel 9; the demo extracts it on first launch into the playback list so AR demos are exercisable on emulators / dev machines without live ARCore tracking.

## What changed

- `samples/android-demo/src/debug/assets/ar-recordings/bundled-pixel9-sample.mp4` (16 MB) — **debug sourceSet only**, so release APK does NOT ship it (#934 stays at 84 MB).
- `samples/android-demo/src/debug/assets/ar-recordings/README.md` — contribution flow, pinning notes.
- `ARRecordPlaybackDemo.kt` — first-launch auto-extract on `Dispatchers.IO`, `.tmp` rename, length-check version detection, `CancellationException` re-throw.
- `ARBundledRecordingsTest.kt` (new, 4 tests, all pass) — guards `ftyp` MP4 header + `avc1`+`mett` codec tags so `setPlaybackDataset` actually replays content.

## 3-pillar QA applied

- **Independent review** (1 Opus agent): caught **3 BLOCKERs + 3 MAJORs** on the first draft, all fixed in this commit. APK size moved to debug-only, `runCatching` → try/catch with CancellationException re-throw, copy moved off Main dispatcher, length check added, README ARCore version drift fixed, test memory-shared.
- **Sync-check** `sync-versions.sh` 45/45 OK ✅, `impact-check.sh` PASS ✅
- **Visual smoke** on Pixel_7a AVD: `bundled-pixel9-sample.mp4 17.0 MB` visible in Playback list after auto-extract ✅

## Test plan

- [x] Robolectric `ARBundledRecordingsTest` 4/4 pass
- [x] `:samples:android-demo:compileDebugKotlin` + `compileDebugUnitTestKotlin` green
- [x] Manual visual smoke on Pixel_7a AVD: file extracts, demo lists it
- [ ] Visual smoke on Pixel 9 (real ARCore) — pending the AR-rendering audit follow-up

## Follow-ups

- [#1050](https://github.com/sceneview/sceneview/issues/1050) — screenshot regression pipeline via this recording (deferred from this PR; needs CI emulator orchestration).
- New issues to be filed from the AR rendering audit (white models, camera color rendering — Thomas flagged on his Pixel 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)