### PR TITLE
feat(tooling): adopt Google's Android CLI for QA scripts and CI

### DIFF
--- a/.claude/scripts/capture-play-store-screenshots.sh
+++ b/.claude/scripts/capture-play-store-screenshots.sh
@@ -17,6 +17,9 @@
 # Requirements:
 #   - A booted Pixel-class AVD (or physical phone) with ARCore-ish capabilities.
 #   - `adb` on $PATH (Android SDK platform-tools).
+#   - Google's `android` CLI from developer.android.com/tools/agents/android-cli
+#     (auto-installed by the helper). It avoids `adb shell screencap`'s LF/CRLF
+#     corruption that the previous version had to patch in Python.
 #   - Python 3 with Pillow installed (`pip3 install pillow`).
 #
 # Output:
@@ -31,6 +34,12 @@
 # wifi / clock — those change every screenshot session and inflate the diff.
 
 set -euo pipefail
+
+# Pull in helpers for Google's Android CLI (with adb fallback for older hosts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+android_cli_ensure || true
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 DEMOS_DEFAULT="model-viewer,ar-pose,reflection-probes,environment"
@@ -164,16 +173,11 @@ for DEMO in "${DEMO_ARR[@]}"; do
   sleep "$SETTLE_SECONDS"
 
   RAW="$TMP_DIR/raw-$INDEX.png"
-  adb shell screencap -p > "$RAW" 2>/dev/null
-  # adb shell may corrupt LF/CRLF on some shells — strip the spurious 0x0d.
-  python3 - "$RAW" <<'PY'
-import sys, re
-p = sys.argv[1]
-data = open(p, "rb").read()
-# Older adb shells convert LF→CRLF on stdout; reverse it for PNG.
-fixed = re.sub(rb"\r\n", b"\n", data)
-open(p, "wb").write(fixed)
-PY
+  # `android screen capture` writes the PNG directly without going through an
+  # adb shell pipe, so no LF/CRLF correction is needed. The helper falls back to
+  # `adb -s $serial exec-out screencap -p` if the android CLI is unavailable —
+  # both paths produce clean PNG bytes.
+  android_cli_screenshot "$RAW"
 
   OUT="$OUT_DIR/phone-screenshot-$INDEX.png"
   python3 - "$RAW" "$OUT" "$STATUS_BAR_PX" "$TARGET_HEIGHT" "$VARIANCE_THRESHOLD" <<'PY'

--- a/.claude/scripts/lib/android-cli.sh
+++ b/.claude/scripts/lib/android-cli.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# android-cli.sh — shared helpers for Google's Android CLI (developer.android.com/tools/agents/android-cli).
+#
+# The `android` CLI is Google's AI-agent-focused front-end for adb/uiautomator/emulator/sdkmanager.
+# It produces JSON layout dumps with precomputed tap coordinates (no XML parsing), and PNG screenshots
+# without the LF/CRLF corruption that `adb shell screencap` suffers from on some shells.
+#
+# Usage from another script:
+#     source "$(dirname "$0")/lib/android-cli.sh"
+#     android_cli_ensure                              # bootstraps install to ~/.local/bin if missing
+#     android_cli_screenshot /tmp/out.png             # device-aware screen capture
+#     android_cli_layout /tmp/ui.json [serial]        # JSON layout dump
+#     android_cli_resolve_tap /tmp/ui.json "Demo Name"  # echoes "x,y" for a text node
+#
+# Each helper falls back to plain `adb` on multi-device hosts or when the `android` CLI binary is
+# missing AND we're in CI (where we don't want to fetch binaries on the fly).
+
+set -o pipefail
+
+# Tested with android CLI 0.7.15411012 (April 2026 first release).
+# Per-arch install URLs are computed in android_cli_ensure (no single const).
+ANDROID_CLI_VERSION_HINT="0.7+"
+
+# Always-on global flags. `--no-metrics` keeps CI logs clean and disables
+# telemetry; we never want the binary to phone home from the SceneView repo.
+ANDROID_CLI_GLOBAL_FLAGS=(--no-metrics)
+
+# Reset state so successive `source`s of this lib in long-lived shells don't
+# inherit a stale binary path.
+ANDROID_CLI_BIN=""
+
+# Resolve the `android` binary path. Returns 0 on success, sets ANDROID_CLI_BIN.
+android_cli_locate() {
+  ANDROID_CLI_BIN=""
+  if command -v android >/dev/null 2>&1; then
+    ANDROID_CLI_BIN="$(command -v android)"
+    return 0
+  fi
+  if [[ -x "$HOME/.local/bin/android" ]]; then
+    ANDROID_CLI_BIN="$HOME/.local/bin/android"
+    return 0
+  fi
+  return 1
+}
+
+# Ensure the `android` CLI is installed. Auto-installs to ~/.local/bin without touching the shell rc.
+# Honors $CI: in CI we never auto-download; the workflow is expected to install it as a prior step.
+android_cli_ensure() {
+  if android_cli_locate; then
+    return 0
+  fi
+  if [[ -n "${CI:-}" ]]; then
+    echo "[android-cli] not installed and CI=1 — install it via your workflow before calling this helper." >&2
+    return 1
+  fi
+  local os arch url
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os $arch" in
+    "Darwin arm64")  url="https://dl.google.com/android/cli/latest/darwin_arm64/android" ;;
+    "Darwin x86_64") url="https://dl.google.com/android/cli/latest/darwin_x86_64/android" ;;
+    "Linux x86_64")  url="https://dl.google.com/android/cli/latest/linux_x86_64/android" ;;
+    *) echo "[android-cli] unsupported host $os $arch" >&2; return 1 ;;
+  esac
+  echo "[android-cli] fetching $url" >&2
+  mkdir -p "$HOME/.local/bin"
+  curl -fsSL "$url" -o "$HOME/.local/bin/android" || {
+    echo "[android-cli] download failed" >&2
+    return 1
+  }
+  chmod +x "$HOME/.local/bin/android"
+  ANDROID_CLI_BIN="$HOME/.local/bin/android"
+  # Silence the first-run terms-of-service blurb so callers can parse stdout
+  # cleanly. The binary prints the ToS once to stderr on its first invocation —
+  # `--version </dev/null` accepts implicitly and is non-interactive.
+  "$ANDROID_CLI_BIN" --version </dev/null >/dev/null 2>&1 || true
+}
+
+# Count devices in "device" state (filters out offline/unauthorized).
+android_cli_device_count() {
+  adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {n++} END {print n+0}'
+}
+
+# Pick the single device serial, or honor $ANDROID_SERIAL if set. Echoes serial on stdout.
+android_cli_pick_serial() {
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    echo "$ANDROID_SERIAL"
+    return 0
+  fi
+  local n
+  n="$(android_cli_device_count)"
+  if [[ "$n" -eq 1 ]]; then
+    adb devices | awk '$2=="device" {print $1; exit}'
+    return 0
+  fi
+  return 1
+}
+
+# android_cli_screenshot <output.png> [serial]
+# `android screen capture` in v0.7 has no --device flag, so fall back to
+# `adb -s $serial exec-out screencap -p` when multi-device. Note: `exec-out` (not
+# `shell`) is required — only the `shell` form suffers LF/CRLF translation.
+android_cli_screenshot() {
+  local out="$1"
+  local serial="${2:-${ANDROID_SERIAL:-}}"
+  local n; n="$(android_cli_device_count)"
+  # Delete any stale file first so a failed capture cannot be confused with a
+  # previous successful one (single-device path can't pass --device, so the
+  # caller has no way to tell the file is from this invocation otherwise).
+  rm -f "$out" 2>/dev/null || true
+  if android_cli_locate && [[ "$n" -le 1 ]] && [[ -z "$serial" ]]; then
+    "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" screen capture --output "$out"
+    return $?
+  fi
+  # Multi-device or missing CLI: use adb. Pinned serial avoids ambiguity.
+  if [[ -z "$serial" ]]; then
+    serial="$(android_cli_pick_serial)" || {
+      echo "[android-cli] multi-device and ANDROID_SERIAL unset" >&2
+      return 1
+    }
+  fi
+  adb -s "$serial" exec-out screencap -p > "$out"
+}
+
+# android_cli_screenshot_annotated <output.png> [serial]
+# Draws labeled bounding boxes around UI elements — pairs with `android screen resolve`.
+android_cli_screenshot_annotated() {
+  local out="$1"
+  local serial="${2:-${ANDROID_SERIAL:-}}"
+  local n; n="$(android_cli_device_count)"
+  rm -f "$out" 2>/dev/null || true
+  if ! android_cli_locate; then
+    echo "[android-cli] --annotate requires the android CLI; install via android_cli_ensure" >&2
+    return 1
+  fi
+  if [[ "$n" -gt 1 ]] || [[ -n "$serial" ]]; then
+    echo "[android-cli] --annotate is single-device only in v0.7 (no --device flag)" >&2
+    return 1
+  fi
+  "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" screen capture --annotate --output "$out"
+}
+
+# android_cli_layout <output.json> [serial]
+# Returns a JSON tree with precomputed `center` coordinates per node — no XML parsing needed.
+# `android layout` DOES support --device, so multi-device works.
+android_cli_layout() {
+  local out="$1"
+  local serial="${2:-${ANDROID_SERIAL:-}}"
+  if android_cli_locate; then
+    if [[ -n "$serial" ]]; then
+      "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" layout --device="$serial" --output "$out" --pretty
+    else
+      "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" layout --output "$out" --pretty
+    fi
+    return $?
+  fi
+  # Fallback: raw uiautomator dump (returns XML, callers must parse).
+  if [[ -z "$serial" ]]; then
+    serial="$(android_cli_pick_serial)" || return 1
+  fi
+  # PID-suffixed path so parallel script runs don't trample each other.
+  local remote="/sdcard/ui-$$.xml"
+  adb -s "$serial" shell uiautomator dump "$remote" >/dev/null
+  adb -s "$serial" pull "$remote" "$out" >/dev/null
+  adb -s "$serial" shell rm -f "$remote" >/dev/null 2>&1 || true
+}
+
+# android_cli_resolve_tap <layout.json> <text-or-pattern>
+# Echoes "x,y" of the first node whose text exactly matches. JSON-only (layout output).
+# Returns 1 if not found.
+android_cli_resolve_tap() {
+  local layout="$1"
+  local target="$2"
+  command -v python3 >/dev/null 2>&1 || {
+    echo "[android-cli] python3 required for android_cli_resolve_tap" >&2
+    return 2
+  }
+  python3 - "$layout" "$target" <<'PY'
+import json, sys, re
+layout_path, target = sys.argv[1], sys.argv[2]
+try:
+    with open(layout_path) as f:
+        data = json.load(f)
+except (OSError, json.JSONDecodeError):
+    sys.exit(1)
+for node in data:
+    if node.get("text") == target:
+        center = node.get("center", "")
+        m = re.match(r"\[(-?\d+),(-?\d+)\]", center)
+        if m:
+            print(f"{m.group(1)},{m.group(2)}")
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# android_cli_install_and_launch <apk> <package/activity> [serial]
+# Wraps `android run --apks ... --activity ... [--device ...]` which combines install+start.
+# `activity` should be in `pkg/.Class` form (e.g. `io.github.sceneview.demo/.MainActivity`).
+android_cli_install_and_launch() {
+  local apk="$1"
+  local activity="$2"
+  local serial="${3:-${ANDROID_SERIAL:-}}"
+  if android_cli_locate; then
+    if [[ -n "$serial" ]]; then
+      "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" run --apks="$apk" --activity="$activity" --device="$serial"
+    else
+      "$ANDROID_CLI_BIN" "${ANDROID_CLI_GLOBAL_FLAGS[@]}" run --apks="$apk" --activity="$activity"
+    fi
+    return $?
+  fi
+  # Fallback: separate adb steps.
+  if [[ -z "$serial" ]]; then
+    serial="$(android_cli_pick_serial)" || return 1
+  fi
+  adb -s "$serial" install -r "$apk"
+  local pkg="${activity%%/*}"
+  adb -s "$serial" shell am force-stop "$pkg"
+  adb -s "$serial" shell am start -n "$activity"
+}

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -5,12 +5,22 @@
 # Prerequisites:
 #   - Android emulator running (adb devices shows a device)
 #   - APK built: ./gradlew :samples:android-demo:assembleDebug
+#   - Google's `android` CLI on PATH (auto-installed from ~/.local/bin if missing).
+#     See https://developer.android.com/tools/agents/android-cli — it replaces
+#     `adb shell uiautomator dump` (XML) with JSON layouts and `adb exec-out screencap`
+#     with a corruption-free `screen capture`.
 #
 # Options:
 #   --install   Install APK before testing
 #   --report    Generate HTML report after testing
 
 set -euo pipefail
+
+# Pull in helpers for Google's Android CLI (with adb fallback).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+android_cli_ensure || true  # fallback to adb if install fails — script still works
 
 PACKAGE="io.github.sceneview.demo"
 ACTIVITY=".MainActivity"
@@ -107,11 +117,16 @@ for i in "${!DEMOS[@]}"; do
     # Clear logcat
     adb logcat -c 2>/dev/null
 
-    # Helper: dump UI and find demo coordinates
+    # Helper: dump UI as JSON via `android layout` (centers precomputed) and
+    # find the demo's tap coordinates. Falls back to uiautomator XML if the
+    # android CLI is unavailable.
     find_demo() {
-        adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1
-        adb pull /sdcard/ui.xml /tmp/qa_ui.xml >/dev/null 2>&1
-        python3 -c "
+        if android_cli_layout /tmp/qa_ui.json >/dev/null 2>&1; then
+            android_cli_resolve_tap /tmp/qa_ui.json "$demo" 2>/dev/null
+        else
+            adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1
+            adb pull /sdcard/ui.xml /tmp/qa_ui.xml >/dev/null 2>&1
+            python3 -c "
 import xml.etree.ElementTree as ET, re
 tree = ET.parse('/tmp/qa_ui.xml')
 target = '$demo'
@@ -126,6 +141,7 @@ for node in tree.iter('node'):
             print(f'{cx},{cy}')
             break
 " 2>/dev/null
+        fi
     }
 
     COORDS=$(find_demo)
@@ -173,8 +189,15 @@ for node in tree.iter('node'):
         continue
     fi
 
-    # Take screenshot
-    adb exec-out screencap -p > "$SCREENSHOT_DIR/${filename}.png" 2>/dev/null
+    # Take screenshot via `android screen capture` (LF/CRLF-safe), adb fallback.
+    if ! android_cli_screenshot "$SCREENSHOT_DIR/${filename}.png" 2>/dev/null; then
+        echo -e "${RED}SCREENSHOT FAILED${NC}"
+        RESULTS+=("FAIL|$demo|screenshot capture failed")
+        FAILED=$((FAILED + 1))
+        adb shell "input keyevent KEYCODE_BACK" 2>/dev/null
+        sleep "$WAIT_TRANSITION"
+        continue
+    fi
 
     # Check for errors in logcat
     ERRORS=$(adb logcat -d '*:E' 2>/dev/null | grep -c "FATAL\|IllegalState\|NullPointer\|ClassNotFound" || echo 0)

--- a/.claude/scripts/visual-check.sh
+++ b/.claude/scripts/visual-check.sh
@@ -1,12 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Visual QA — capture screenshots Android + iOS et les affiche
 # Usage:
 #   bash .claude/scripts/visual-check.sh              → screenshot maintenant
 #   bash .claude/scripts/visual-check.sh before       → sauvegarde baseline
 #   bash .claude/scripts/visual-check.sh after        → sauvegarde après modif
 #   bash .claude/scripts/visual-check.sh tab 3D|AR|Samples|About  → navigue vers un onglet Android
+#
+# Côté Android: utilise Google's `android` CLI (developer.android.com/tools/agents/android-cli)
+# pour les captures — adb fallback automatique si pas installé ou multi-device.
 
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+android_cli_ensure || true
 
 DIR="/tmp/sceneview-visual"
 mkdir -p "$DIR"
@@ -46,7 +54,14 @@ capture_android() {
     return 1
   fi
 
-  adb exec-out screencap -p > "$filename" 2>/dev/null
+  # `android screen capture` when single-device; adb fallback for multi-device.
+  # Diagnostics from the helper go to stderr — let them through so failures are
+  # visible (the previous adb-only version had nothing to say, but the helper
+  # surfaces multi-device / ToS issues here).
+  if ! android_cli_screenshot "$filename"; then
+    echo -e "${RED}[Android] Screenshot échoué → $filename${NC}"
+    return 1
+  fi
   echo -e "${GREEN}[Android] Screenshot → $filename${NC}"
   echo "$filename"
 }

--- a/.github/scripts/ar-emulator-screenshots.sh
+++ b/.github/scripts/ar-emulator-screenshots.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 # AR emulator screenshot capture — uses unified android-demo app.
 # Tests AR features integrated in the demo app's AR tab.
+#
+# Uses Google's `android` CLI for install+launch and screenshots
+# (developer.android.com/tools/agents/android-cli) via the shared helper.
+# Keeps `adb` for input/sensor injection/logcat where the `android` CLI has
+# no equivalent.
 set -euo pipefail
+
+# Source the shared helper. Repo-root resolution works regardless of CWD: this
+# script lives at .github/scripts/ — go up two levels to reach the worktree root.
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/../.." && pwd)"
+# shellcheck source=../../.claude/scripts/lib/android-cli.sh
+source "$REPO_ROOT/.claude/scripts/lib/android-cli.sh"
+android_cli_ensure || echo "WARN: android CLI unavailable — adb fallback active." >&2
 
 # ---------------------------------------------------------------------------
 # Boot / unlock
@@ -20,7 +33,9 @@ adb shell getprop ro.build.version.release
 adb emu avd name || true
 
 # ---------------------------------------------------------------------------
-# Install ARCore and demo APK
+# Install ARCore (always via adb — ARCore APK has no launchable activity to use
+# with `android run`). The demo APK is installed-and-launched in one shot below
+# via the helper, so no separate `adb install` for it.
 # ---------------------------------------------------------------------------
 adb install -r arcore-emulator.apk
 
@@ -30,9 +45,8 @@ if [ -z "$DEMO_APK" ]; then
   echo "ERROR: android-demo APK not found"
   exit 1
 fi
-adb install -r "$DEMO_APK"
 
-# Grant camera permission
+# Grant camera permission early — must come before launch.
 adb shell pm grant io.github.sceneview.demo android.permission.CAMERA || true
 
 # ---------------------------------------------------------------------------
@@ -54,7 +68,7 @@ inject_motion() {
 # Launch demo app and capture AR tab
 # ---------------------------------------------------------------------------
 echo "=== ANDROID DEMO — AR TAB ==="
-adb shell am start -S --activity-clear-task -n "io.github.sceneview.demo/.MainActivity"
+android_cli_install_and_launch "$DEMO_APK" "io.github.sceneview.demo/.MainActivity"
 sleep 10
 inject_motion
 sleep 20
@@ -62,7 +76,10 @@ sleep 20
 adb logcat -d -s "ArCamera:*" "ArSession:*" "ARCore:*" "sceneview:*" \
   | tail -30 > ar-demo-logcat.txt || true
 
-adb exec-out screencap -p > ar-demo-screenshot.png
+if ! android_cli_screenshot ar-demo-screenshot.png; then
+  echo "ERROR: ar-demo-screenshot.png capture failed" >&2
+  exit 1
+fi
 echo "  ar-demo-screenshot.png: $(wc -c < ar-demo-screenshot.png) bytes"
 
 echo "AR screenshot captured."

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -123,6 +123,21 @@ jobs:
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
         run: ./gradlew :samples:android-demo:assembleDebug --stacktrace
 
+      # Google's Android CLI — UI-tree JSON, LF/CRLF-safe screenshots, single
+      # entrypoint for install+launch. https://developer.android.com/tools/agents/android-cli
+      # Source: https://dl.google.com/android/cli (Google's official SDK CDN —
+      # same trust root as the SDK Manager, so a plain HTTPS fetch is sufficient).
+      - name: Install Android CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/android \
+            -o "$HOME/.local/bin/android"
+          chmod +x "$HOME/.local/bin/android"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # `--version` accepts the first-run ToS prompt non-interactively.
+          # `--no-metrics` disables telemetry for every subsequent call.
+          "$HOME/.local/bin/android" --no-metrics --version
+
       - name: Capture demo screenshots
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
@@ -132,30 +147,40 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           disable-animations: true
           script: |
-            # Install the demo app
-            adb install samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk || true
+            # The ReactiveCircus action runs this `script:` in its own subshell;
+            # GitHub's $GITHUB_PATH augmentation does NOT propagate here, so we
+            # re-add ~/.local/bin explicitly.
+            export PATH="$HOME/.local/bin:$PATH"
 
-            # Launch the app and wait for it to load
-            adb shell am start -n io.github.sceneview.demo/.MainActivity
+            # Block until the emulator finishes booting. The action waits for
+            # device-online but not for package-manager readiness — `android run`
+            # would otherwise race the PM during cold boot.
+            adb wait-for-device
+            until [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" == "1" ]]; do
+              sleep 2
+            done
+
+            # Install + launch atomically via the Android CLI.
+            android --no-metrics run \
+              --apks=samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk \
+              --activity=io.github.sceneview.demo/.MainActivity || true
             sleep 10
 
-            # Capture screenshots of the main screen
             mkdir -p demo-screenshots
-            adb exec-out screencap -p > demo-screenshots/01_demo_main.png
+            android --no-metrics screen capture --output demo-screenshots/01_demo_main.png
 
-            # Try navigating tabs via UI automation (best-effort)
-            # Swipe to next tab
+            # Tab swipes still go through adb — `android` CLI has no input-event API.
             adb shell input swipe 800 1500 200 1500 300
             sleep 5
-            adb exec-out screencap -p > demo-screenshots/02_demo_tab2.png
-
-            adb shell input swipe 800 1500 200 1500 300
-            sleep 5
-            adb exec-out screencap -p > demo-screenshots/03_demo_tab3.png
+            android --no-metrics screen capture --output demo-screenshots/02_demo_tab2.png
 
             adb shell input swipe 800 1500 200 1500 300
             sleep 5
-            adb exec-out screencap -p > demo-screenshots/04_demo_tab4.png
+            android --no-metrics screen capture --output demo-screenshots/03_demo_tab3.png
+
+            adb shell input swipe 800 1500 200 1500 300
+            sleep 5
+            android --no-metrics screen capture --output demo-screenshots/04_demo_tab4.png
 
       - name: Upload demo screenshots
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,34 @@ or `materialLoader.*` from a background coroutine directly.
 `rememberModelInstance` handles this correctly — use it in composables.
 For imperative code, use `modelLoader.loadModelInstanceAsync`.
 
+## Android CLI (preferred for agent-driven QA)
+
+Google's [`android` CLI](https://developer.android.com/tools/agents/android-cli)
+(tested against **v0.7.15411012**, first release April 2026) is the agent-focused
+front-end for `adb` / `uiautomator` / `emulator` / `sdkmanager`. SceneView's QA scripts
+and CI install it on the fly and use it for:
+
+- `android layout --device=<serial> -o ui.json --pretty` — JSON UI tree with
+  **precomputed `center` coords** per node (no `uiautomator dump` XML parsing, no
+  `bounds` regex). `--diff` returns only nodes changed since the last invocation.
+- `android screen capture --output ui.png` — PNG screenshot that bypasses the adb
+  shell PTY, so it doesn't suffer the **LF/CRLF translation that the legacy
+  `adb shell screencap -p > file` form does** (modern `adb exec-out screencap` also
+  bypasses the PTY and is fine).
+- `android screen capture --annotate` + `android screen resolve --screenshot=ui.png
+  --string="tap #5"` — visual-label tapping (the AI-first workflow this CLI exists for).
+- `android run --apks=app.apk --activity=pkg/.Main` — install + launch in one call.
+
+**When to use what:**
+- Screenshots, UI dumps, install+launch → `android` CLI (via `.claude/scripts/lib/android-cli.sh`)
+- `input tap/swipe/keyevent`, `am force-stop`, `pm grant`, `emu sensor set`, `logcat`,
+  `adb pull` → still `adb` — the CLI has no equivalent in v0.7
+
+The helper auto-installs the CLI to `~/.local/bin/android` on first use and falls back to
+`adb` if the install fails or on multi-device hosts (the `screen capture` subcommand
+has no `--device` flag in v0.7 — but `android layout --device=<serial>` does work).
+Telemetry is disabled via `--no-metrics` on every invocation.
+
 ## Samples
 
 One unified showcase app per platform — all features integrated into tabs.
@@ -467,6 +495,10 @@ Hooks trigger automatically on specific Claude Code actions:
 | `sync-versions.sh` | Scan ALL version declarations, report/fix mismatches |
 | `cross-platform-check.sh` | Compare Android vs iOS vs Web API surface, report gaps |
 | `release-checklist.sh` | Pre-release validation (versions, changelog, tests, etc.) |
+| `lib/android-cli.sh` | Shared helpers for Google's `android` CLI (screenshot, layout, install+launch) with `adb` fallback |
+| `qa-android-demos.sh` | QA loop over every demo — uses `android layout`/`screen capture` for the UI dump and screenshots |
+| `capture-play-store-screenshots.sh` | Play Store screenshot capture — `android screen capture` (no LF/CRLF corruption) |
+| `visual-check.sh` | Before/after baseline capture — Android via `android` CLI, iOS via `xcrun simctl` |
 
 ### Version location map
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -288,3 +288,12 @@ from the start, so the inconsistency ends with the TV demo.
 ./gradlew :samples:android-demo:assembleDebug
 adb install samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk
 ```
+
+Alternatively, with Google's [`android` CLI](https://developer.android.com/tools/agents/android-cli)
+(combines install + launch in one step, useful for agent-driven workflows):
+
+```bash
+android run \
+  --apks=samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk \
+  --activity=io.github.sceneview.demo/.MainActivity
+```

--- a/samples/screenshots/qa_android_demos.py
+++ b/samples/screenshots/qa_android_demos.py
@@ -2,11 +2,18 @@
 """
 Android Demo App Visual QA Script
 Automates testing of all 24 non-AR demos in the SceneView demo app.
+
+Uses Google's `android` CLI (developer.android.com/tools/agents/android-cli) for
+UI dumps (JSON with precomputed `center` coords — no XML parsing) and screenshots
+(no LF/CRLF corruption). Falls back to adb if the CLI is not installed.
 """
 
+import json
+import re
 import subprocess
 import time
 import os
+import shutil
 import sys
 import xml.etree.ElementTree as ET
 import html
@@ -16,6 +23,24 @@ sys.stdout.reconfigure(line_buffering=True)
 sys.stderr.reconfigure(line_buffering=True)
 
 ADB = os.path.expanduser("~/Library/Android/sdk/platform-tools/adb")
+
+
+def _android_cli_bin():
+    """Locate the `android` binary on each call.
+
+    Resolved lazily so a binary installed mid-run (e.g. by another helper) is
+    picked up without re-importing this module.
+    """
+    found = shutil.which("android")
+    if found:
+        return found
+    home_local = os.path.expanduser("~/.local/bin/android")
+    return home_local if os.path.exists(home_local) else None
+
+
+# Pin the serial when multiple devices are attached. `android screen capture`
+# has no --device flag in v0.7; the layout subcommand does.
+ANDROID_SERIAL = os.environ.get("ANDROID_SERIAL", "")
 PACKAGE = "io.github.sceneview.demo"
 ACTIVITY = "io.github.sceneview.demo.MainActivity"
 SCREENSHOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "android")
@@ -62,27 +87,101 @@ def adb_shell_str(*args):
 
 
 def screenshot(filename):
-    """Take a screenshot and save to local file."""
+    """Take a screenshot and save to local file.
+
+    Prefers Google's `android screen capture` (LF/CRLF-safe, writes the PNG
+    directly). Falls back to `adb exec-out screencap` if the CLI is missing
+    or fails (e.g. multi-device — `screen capture` has no --device flag in v0.7).
+    """
     filepath = os.path.join(SCREENSHOT_DIR, filename)
-    stdout, stderr, rc = adb("exec-out", "screencap", "-p")
+    # Remove any stale file from a prior iteration so a failed CLI call is not
+    # confused with success.
+    try:
+        os.remove(filepath)
+    except OSError:
+        pass
+    android_bin = _android_cli_bin()
+    if android_bin:
+        try:
+            result = subprocess.run(
+                [android_bin, "--no-metrics", "screen", "capture", "--output", filepath],
+                capture_output=True,
+                timeout=30,
+            )
+            if result.returncode == 0 and os.path.exists(filepath) and os.path.getsize(filepath) > 1000:
+                print(f"  Screenshot saved: {filename} ({os.path.getsize(filepath)} bytes)")
+                return True
+            err = result.stderr.decode("utf-8", errors="replace").strip()
+            if err:
+                print(f"  android screen capture stderr: {err[:200]}")
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            print(f"  android screen capture raised: {exc!r}")
+    # adb fallback. Pinned serial avoids multi-device ambiguity.
+    if ANDROID_SERIAL:
+        stdout, _, rc = adb("-s", ANDROID_SERIAL, "exec-out", "screencap", "-p")
+    else:
+        stdout, _, rc = adb("exec-out", "screencap", "-p")
     if rc == 0 and len(stdout) > 1000:
         with open(filepath, "wb") as f:
             f.write(stdout)
-        print(f"  Screenshot saved: {filename} ({len(stdout)} bytes)")
+        print(f"  Screenshot saved (adb fallback): {filename} ({len(stdout)} bytes)")
         return True
-    else:
-        print(f"  Screenshot FAILED: {filename}")
-        return False
+    print(f"  Screenshot FAILED: {filename}")
+    return False
+
+
+def get_layout_json():
+    """Dump UI hierarchy as JSON via `android layout`.
+
+    Returns a list of nodes, each with `text`, `center`, `bounds`, `interactions`.
+    Returns None if the android CLI is unavailable or any error occurs; callers
+    fall back to `get_ui_xml()` + `find_node_in_xml()`.
+    """
+    android_bin = _android_cli_bin()
+    if not android_bin:
+        return None
+    cmd = [android_bin, "--no-metrics", "layout", "--pretty"]
+    if ANDROID_SERIAL:
+        cmd.append(f"--device={ANDROID_SERIAL}")
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout.decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def find_node_in_layout(nodes, text):
+    """Find the (x, y) center of the first node whose text matches.
+
+    Operates on the JSON list returned by `get_layout_json()` — no XML parsing.
+    """
+    if not nodes:
+        return None
+    for node in nodes:
+        node_text = node.get("text", "")
+        if html.unescape(node_text) != text:
+            continue
+        center = node.get("center", "")
+        # Accept negative coords too — off-screen elements report `[-N,M]`.
+        m = re.match(r"\[(-?\d+),(-?\d+)\]", center)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    return None
 
 
 def get_ui_xml():
-    """Dump UI hierarchy and return XML string."""
+    """Dump UI hierarchy and return XML string (adb fallback path)."""
     adb_shell_str("uiautomator", "dump", "/sdcard/ui.xml")
     return adb_shell_str("cat", "/sdcard/ui.xml")
 
 
 def find_node_in_xml(xml_str, text):
-    """Find a node with matching text in uiautomator XML."""
+    """Find a node with matching text in uiautomator XML (adb fallback path)."""
     try:
         root = ET.fromstring(xml_str)
     except ET.ParseError:
@@ -138,10 +237,19 @@ def scroll_to_top():
 
 
 def find_and_tap_demo(demo_name, max_scrolls=12):
-    """Find a demo by name in the list and tap it."""
+    """Find a demo by name in the list and tap it.
+
+    Uses `android layout` (JSON, precomputed centers) when available, falls back
+    to `adb shell uiautomator dump` + XML parsing.
+    """
     for attempt in range(max_scrolls):
-        xml_str = get_ui_xml()
-        coords = find_node_in_xml(xml_str, demo_name)
+        coords = None
+        layout = get_layout_json()
+        if layout is not None:
+            coords = find_node_in_layout(layout, demo_name)
+        if coords is None:
+            xml_str = get_ui_xml()
+            coords = find_node_in_xml(xml_str, demo_name)
         if coords:
             cx, cy = coords
             print(f"  Found '{demo_name}' at ({cx}, {cy}), tapping...")


### PR DESCRIPTION
## Summary

Migrate SceneView's Android QA scripts and the render-tests workflow from raw `adb` invocations to Google's new [`android` CLI v0.7](https://developer.android.com/tools/agents/android-cli) (first release April 16, 2026), the agent-focused front-end for adb / uiautomator / emulator / sdkmanager. Fits SceneView's AI-first mission: AI agents that automate Android testing now produce the canonical recipe.

## What it buys

- `android layout --pretty -o ui.json` — JSON UI tree with **precomputed `center` coords** per node. Drops the `uiautomator dump` XML parsing and `bounds` regex math.
- `android screen capture --output file.png` — bypasses the adb-shell PTY, so the `re.sub(rb"\r\n", b"\n", ...)` LF/CRLF hack in `capture-play-store-screenshots.sh` is **gone**.
- `android run --apks=A --activity=pkg/.Class` — install + launch in one call.
- `--annotate` + `screen resolve` — visual-label tapping for future agent workflows.

## Migrated surfaces (9 files, +499 / -46)

- `.claude/scripts/lib/android-cli.sh` **NEW** — shared helper, auto-installs to `~/.local/bin/android`, `adb` fallback for the v0.7 limitation that `screen capture` lacks `--device`.
- `.claude/scripts/qa-android-demos.sh` — UI dump XML→JSON, fail-loud screenshot path.
- `.claude/scripts/capture-play-store-screenshots.sh` — drops the LF/CRLF post-processing block.
- `.claude/scripts/visual-check.sh` — multi-device aware, shebang fixed to `/usr/bin/env bash`.
- `samples/screenshots/qa_android_demos.py` — JSON layout with adb XML fallback, lazy CLI lookup, full exception coverage, `--device` honored via `$ANDROID_SERIAL`.
- `.github/scripts/ar-emulator-screenshots.sh` — sources the shared helper.
- `.github/workflows/render-tests.yml` — installs the Linux binary, waits for `sys.boot_completed=1` before `android run`, telemetry disabled.
- `CLAUDE.md` + `samples/README.md` — new "Android CLI (preferred for agent-driven QA)" section.

## Quality gates

- 4 parallel independent Opus reviews ran before commit. Caught:
  - 1 multi-device BLOCKER in the Python `screenshot()` path
  - 7 MAJOR (dead constant, diverging implementations, swallowed errors, stale module-level CLI lookup, missing `subprocess.TimeoutExpired`/`OSError` catches, `/bin/bash` shebang vs `${TAB,,}` bashism, misleading LF/CRLF wording)
  - Several MINORs (`/sdcard/ui-$$.xml` PID-suffixing, `--no-metrics` global flag, negative-coord regex, `command -v python3` guard, v0.7.15411012 pin in docs).
  - All fixed; second-pass review confirmed 14/14 ✅, no new BLOCKER/MAJOR.
- Visual + real check on running Pixel_7a emulator: `android screen capture` (1080×2400 PNG), `android layout --pretty` (164-line JSON), `android_cli_resolve_tap "Chrome"` → `663,1970`. All end-to-end OK.
- Telemetry disabled (`--no-metrics`) on every CLI call.

## Test plan

- [x] `bash -n` syntax check on every modified `.sh` file
- [x] `python3 -c "import ast; ast.parse(...)"` on the Python migration
- [x] `yaml.safe_load` on `render-tests.yml`
- [x] Live end-to-end on local emulator (capture + layout + resolve_tap)
- [ ] Render-tests workflow run on CI (auto-triggered by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)