### PR TITLE
fix(samples): MovableLightDemo migrates to rememberUnlitMaterialInstance (#979)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MovableLightDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MovableLightDemo.kt
@@ -39,6 +39,7 @@ import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.max
@@ -114,10 +115,10 @@ fun MovableLightDemo(onBack: () -> Unit) {
     }
 
     // Yellow unlit material for the marker sphere — see iOS rationale. Unlit
-    // = always glowing, regardless of the user-light's position.
-    val markerMaterial = remember(materialLoader) {
-        materialLoader.createUnlitColorInstance(color = Color(0xFFFFEB3B))
-    }
+    // = always glowing, regardless of the user-light's position. Helper has
+    // a DisposableEffect-backed onDispose → no JNI MaterialInstance leak on
+    // recompose / navigate-away (#979).
+    val markerMaterial = rememberUnlitMaterialInstance(materialLoader, Color(0xFFFFEB3B))
 
     DemoScaffold(
         title = "Movable Light",


### PR DESCRIPTION
Closes [#979](https://github.com/sceneview/sceneview/issues/979).

`samples/android-demo/.../MovableLightDemo.kt:118` was creating its yellow marker MaterialInstance via `materialLoader.createUnlitColorInstance(...)` inside a plain `remember { }` block — no matching `onDispose { destroy() }`, so every navigation away from the demo leaked one Filament JNI handle.

Migrated to `rememberUnlitMaterialInstance(materialLoader, color)` from `samples/common/.../RememberMaterialInstance.kt` which has the DisposableEffect-backed onDispose baked in.

ShapeDemo (the other demo flagged by #979) was already migrated in a prior commit — confirmed via grep.

## 3-pillar QA

- ✅ `:samples:android-demo:compileDebugKotlin` green
- ✅ `:samples:android-demo:testDebugUnitTest` 41+ tests green
- ✅ Diff is 1 import + 1 inline change

## Test plan

- [x] Compile + JVM tests
- [ ] Manual: navigate to MovableLight demo 20× consecutively on a Pixel device, verify no growth in Filament's `MaterialInstance` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)