### PR TITLE
fix(samples): migrate 5 demos to rememberMaterialInstance helper (#971 batch1)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
@@ -29,6 +29,7 @@ import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
 
 /**
  * Augmented face mesh tracking demo.
@@ -64,9 +65,7 @@ fun ARFaceDemo(onBack: () -> Unit) {
     // which is `doubleSided: true` — pairs with `culling(false)` on the face mesh.
     // We use a translucent overlay (not opaque blue) so the user can SEE their face
     // through the fitted topology — that's the entire point of a face-mesh demo.
-    val faceMaterial = remember(materialLoader) {
-        materialLoader.createUnlitColorInstance(SceneViewColors.PrimaryOverlay)
-    }
+    val faceMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.PrimaryOverlay)
 
     DemoScaffold(
         title = "Face Mesh",

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPoseDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPoseDemo.kt
@@ -30,6 +30,7 @@ import io.github.sceneview.math.Size
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
  * AR pose placement demo.
@@ -69,22 +70,20 @@ fun ARPoseDemo(onBack: () -> Unit) {
     //
     // Two materials so cube and sphere read as distinct objects, not a single white
     // blob — matches the same brand-ramp split used elsewhere in the demos.
-    val cubeMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(
-            color = SceneViewColors.Accent,
-            metallic = 0.0f,
-            roughness = 0.85f,
-            reflectance = 0.1f
-        )
-    }
-    val sphereMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(
-            color = SceneViewColors.Primary,
-            metallic = 0.0f,
-            roughness = 0.85f,
-            reflectance = 0.1f
-        )
-    }
+    val cubeMaterial = rememberMaterialInstance(
+        materialLoader = materialLoader,
+        color = SceneViewColors.Accent,
+        metallic = 0.0f,
+        roughness = 0.85f,
+        reflectance = 0.1f,
+    )
+    val sphereMaterial = rememberMaterialInstance(
+        materialLoader = materialLoader,
+        color = SceneViewColors.Primary,
+        metallic = 0.0f,
+        roughness = 0.85f,
+        reflectance = 0.1f,
+    )
 
     DemoScaffold(
         title = "Pose Placement",

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
@@ -31,6 +31,7 @@ import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberOnGestureListener
+import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
  * Demonstrates custom geometry using built-in geometry nodes composed together.
@@ -49,12 +50,8 @@ fun CustomMeshDemo(onBack: () -> Unit) {
 
     // Atom spheres in SceneView primary blue, bonds in the accent purple — the same hero
     // gradient the brand palette uses.
-    val sphereMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(SceneViewColors.Primary)
-    }
-    val bondMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(SceneViewColors.Accent)
-    }
+    val sphereMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Primary)
+    val bondMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Accent)
 
     // Hero yaw auto-pauses on first camera gesture so orbit/pinch don't fight the spin.
     // Triggered by the user's Auto-Rotate switch.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LinesPathsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LinesPathsDemo.kt
@@ -25,6 +25,7 @@ import io.github.sceneview.math.Position
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -91,12 +92,8 @@ fun LinesPathsDemo(onBack: () -> Unit) {
             // path polyline. Same hero gradient as the product. Unlit because lines have ~0
             // surface area (lighting contributes nothing useful) and we want crisp readable
             // strokes regardless of scene illumination.
-            val lineMaterial = remember(materialLoader) {
-                materialLoader.createUnlitColorInstance(SceneViewColors.Primary)
-            }
-            val pathMaterial = remember(materialLoader) {
-                materialLoader.createUnlitColorInstance(SceneViewColors.Accent)
-            }
+            val lineMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Primary)
+            val pathMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Accent)
 
             // Single line segment — 1 px on most GPUs, so we also draw a pair of spheres at the
             // endpoints (scaled by lineWidth) to give the line a visible thickness.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
@@ -28,6 +28,7 @@ import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
  * Demonstrates [PhysicsNode] — drop spheres that fall under gravity and bounce off the floor.
@@ -97,9 +98,9 @@ fun PhysicsDemo(onBack: () -> Unit) {
                         intensity(100_000f)
                     }
                 )
-                val groundMaterial = remember(materialLoader) {
-                    materialLoader.createColorInstance(SceneViewColors.SurfaceDim)
-                }
+                val groundMaterial = rememberMaterialInstance(
+                    materialLoader, SceneViewColors.SurfaceDim
+                )
                 val sphereMaterials = remember(materialLoader) {
                     SceneViewColors.Ramp4.map { materialLoader.createColorInstance(it) }
                 }


### PR DESCRIPTION
Partial close on [#971](https://github.com/sceneview/sceneview/issues/971) — 5 of 10 direct `materialLoader.create*ColorInstance(...)` call sites migrated to the disposal-aware `rememberMaterialInstance` / `rememberUnlitMaterialInstance` helpers.

## Migrated

| Demo | Calls | Helper |
|---|---|---|
| `CustomMeshDemo.kt` | 2 | `rememberMaterialInstance` |
| `PhysicsDemo.kt` (groundMaterial) | 1 | `rememberMaterialInstance` |
| `LinesPathsDemo.kt` | 2 | `rememberUnlitMaterialInstance` |
| `ARFaceDemo.kt` | 1 | `rememberUnlitMaterialInstance` |
| `ARPoseDemo.kt` (cube + sphere with PBR params) | 2 | `rememberMaterialInstance` |

## Skipped (follow-up batches)

- `PhysicsDemo.kt:104` `SceneViewColors.Ramp4.map { ... }` — list of materials, needs either unrolled migration or a `rememberMaterialInstances(colors: List<Color>)` helper variant
- `VideoDemo.kt:253-276` — nested in custom node creation, deeper review needed
- `ARStreetscapeDemo.kt:232` — single but in complex context
- `LightingDemo` + `GeometryDemo` — slider-driven, want a dedicated review pass to verify the helper's PBR key-stability guarantees aren't violated
- `Axes3DNode.kt` — not a composable, different lifecycle pattern

## 3-pillar QA

- ✅ `:samples:android-demo:compileDebugKotlin` green
- ✅ `:samples:android-demo:testDebugUnitTest` 41+ tests green (DemoMath, ARRecordPlayback, ARBundledRecordings, DeepLinkRouter, GeometryDemoControls, SketchfabService — no regression)
- ✅ Diff is `+27 / -34` LoC across 5 files — strictly mechanical with consistent helper-call shape

## Test plan

- [x] Compile + JVM tests
- [ ] Manual: navigate to each migrated demo 20× consecutively, verify no growth in Filament `MaterialInstance` count via `dumpsys gfxinfo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)