### PR TITLE
fix(3d): IBL intensity 30k→10k + PostProcessingDemo SSAO toggle ON (#1075, #1076)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PostProcessingDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PostProcessingDemo.kt
@@ -44,7 +44,13 @@ import io.github.sceneview.rememberView
  */
 @Composable
 fun PostProcessingDemo(onBack: () -> Unit) {
-    var ssaoEnabled by remember { mutableStateOf(false) }
+    // Initial state mirrors the SDK's library defaults from `SceneFactories.kt:93-112`
+    // (`createView`): SSAO on, MSAA off, FXAA on, dithering on. Pre-#1076 this demo
+    // shipped `ssaoEnabled = false` which silently disabled SSAO on first paint,
+    // teaching users the wrong default. Now the toggles reflect what the library
+    // actually does out of the box; flipping them shows the user the contrast
+    // vs. the default.
+    var ssaoEnabled by remember { mutableStateOf(true) }
     var msaaEnabled by remember { mutableStateOf(false) }
     var fxaaEnabled by remember { mutableStateOf(true) }
     var ditheringEnabled by remember { mutableStateOf(true) }

--- a/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
@@ -66,6 +66,22 @@ val DEFAULT_FILL_LIGHT_INTENSITY = DEFAULT_FILL_LIGHT_COLOR_INTENSITY
 
 val DEFAULT_OBJECT_POSITION = Position(0.0f, 0.0f, -4.0f)
 
+/**
+ * Default `IndirectLight` intensity (lux).
+ *
+ * Lowered from Filament's hard-coded `30_000` default — too bright after the v4.1.0
+ * main+fill rebalancing (10k+3k direct + 30k IBL = ambient dominated everything,
+ * shadows looked weak, key-vs-fill ratio invisible). 10k matches the main light so
+ * direct + indirect are roughly balanced (≈ 60/40), giving the carefully-tuned 3-point
+ * setup actual visible contrast. See [#1075](https://github.com/sceneview/sceneview/issues/1075).
+ *
+ * Cross-platform parity note: iOS RealityKit uses `IBLComponent.intensityExponent = 0`
+ * which exposes-out at ≈1000 lux equivalent. Android stays at 10× that for now (Filament
+ * doesn't have an exposure-relative IBL knob); the absolute values diverge but the
+ * key:IBL ratio matches.
+ */
+const val DEFAULT_IBL_INTENSITY = 10_000.0f
+
 fun createEglContext(): EGLContext {
     filamentInit  // ensure init
     return OpenGL.createEglContext()
@@ -195,7 +211,7 @@ fun createEnvironment(
     indirectLight = KTX1Loader.createIndirectLight(
         environmentLoader.engine,
         environmentLoader.context.assets.readBuffer("environments/neutral/neutral_ibl.ktx"),
-    ).indirectLight
+    ).indirectLight?.also { it.intensity = DEFAULT_IBL_INTENSITY },
 )
 
 fun createEnvironment(

--- a/sceneview/src/main/java/io/github/sceneview/loaders/EnvironmentLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/EnvironmentLoader.kt
@@ -100,6 +100,9 @@ class EnvironmentLoader(
         }
         val indirectLight = IndirectLight.Builder()
             .reflections(reflections)
+            // Sensible default — Filament's hardcoded 30k drowns the v4.1.0 main+fill
+            // (10k+3k) in ambient. Set BEFORE `apply` so callers can override (#1075).
+            .intensity(io.github.sceneview.DEFAULT_IBL_INTENSITY)
             .apply(indirectLightApply)
             .build(engine)
 
@@ -246,7 +249,13 @@ class EnvironmentLoader(
         iblBuffer: Buffer? = null,
         skyboxBuffer: Buffer? = null
     ) = createEnvironment(
-        indirectLight = iblBuffer?.let { KTX1Loader.createIndirectLight(engine, it).indirectLight },
+        // Apply the v4.1.0-balanced IBL intensity (#1075) so callers don't need to
+        // remember it; the KTX1Loader-built IBL otherwise inherits Filament's 30k
+        // default which dominates the 10k main + 3k fill light setup.
+        indirectLight = iblBuffer?.let {
+            KTX1Loader.createIndirectLight(engine, it).indirectLight
+                ?.also { ibl -> ibl.intensity = io.github.sceneview.DEFAULT_IBL_INTENSITY }
+        },
         skybox = skyboxBuffer?.let { KTX1Loader.createSkybox(engine, it).skybox },
         sphericalHarmonics = iblBuffer?.rewind()?.let { KTX1Loader.getSphericalHarmonics(it) }
     )


### PR DESCRIPTION
Closes the 2 P0s from the [#1074 SceneView 3D rendering audit](https://github.com/sceneview/sceneview/issues/1074). Pre-v3 footguns equivalent in pattern to the AR audit's "no default IBL" + "EV15" findings — defaults that drifted out of sync after the v4.1.0 light/exposure rebalancing.

## Bug 1 ([#1075](https://github.com/sceneview/sceneview/issues/1075)) — IBL ships at Filament default 30k lux, 3× the v4.1.0 main light

`KTX1Loader.createIndirectLight(...)` returns an IBL with Filament's hard-coded **30 000 lux** intensity. The v4.1.0 audit dropped the directional main from 100k → 10k and added a 3k fill — but the IBL stayed at 30k. **Ambient is now 3× the direct lighting**, washing out diffuse and burying shadows.

Fix: new `DEFAULT_IBL_INTENSITY = 10_000f` constant alongside the main+fill defaults. Applied at 3 IBL creation paths in `SceneFactories.kt` + `EnvironmentLoader.kt`. For `createHDREnvironment`'s Builder path, set BEFORE `apply(indirectLightApply)` so callers can still override.

## Bug 2 ([#1076](https://github.com/sceneview/sceneview/issues/1076)) — `PostProcessingDemo` silently disables SSAO on first paint

`var ssaoEnabled by remember { mutableStateOf(false) }` started the demo with the toggle OFF, but the library default is ON. The `SideEffect` then wrote `view.ambientOcclusionOptions.enabled = false` → **disabled the SSAO the user opened the demo to see**. Demo was teaching the wrong default.

Fix: flip initial state to `mutableStateOf(true)` to match the library default. Toggle now correctly reflects what the SDK does out of the box.

## 3-pillar QA

- **Sync-check** `sync-versions.sh` 45/45 OK ✅
- **Compile** `:sceneview:compileReleaseKotlin` + `:samples:android-demo:compileDebugKotlin` green ✅
- **JVM tests** `:sceneview:test` 306 tests green + `:samples:android-demo:testDebugUnitTest` 41+ tests green ✅
- ⚠️ **Visual smoke** deferred — Pixel 9 disconnected. The expected change:
  - PBR helmet (`model-viewer`): shadows visible, key+fill ratio readable, less washed-out diffuse
  - `EnvironmentGalleryDemo`: cycle 5 environments, each contributes proportionally to direct lighting (not dominated)
  - `PostProcessingDemo`: opens with SSAO actually visible at first paint; toggle flips it off → contrast obvious

## Test plan

- [x] Compile + JVM tests
- [ ] Visual on Pixel 9: PBR helmet + EnvironmentGallery + PostProcessing
- [ ] Cross-check that the AR audit's `createAREnvironment` path (PR #1069's `ARFactories.kt`) also uses `DEFAULT_IBL_INTENSITY` once both PRs land — one-line follow-up

## Same-audit follow-ups (filed separately)

- [#1077](https://github.com/sceneview/sceneview/issues/1077) isOpaque = false is broken (uiHelper + view.blendMode never wired)
- [#1078](https://github.com/sceneview/sceneview/issues/1078) RenderQuality clobbers user view.colorGrading on every recomposition
- 6 more P1/P2/P3 cataloged in [#1074](https://github.com/sceneview/sceneview/issues/1074) umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)