### PR TITLE
ci(agents): add skill-drift CI guard for agents/sceneview/

### DIFF
--- a/.claude/scripts/check-deprecated-api.sh
+++ b/.claude/scripts/check-deprecated-api.sh
@@ -46,6 +46,9 @@ is_whitelisted() {
     docs/docs/migration.md | docs/docs/migration-v4.md) return 0 ;;
     docs/docs/changelog.md | docs/docs/comparison.md) return 0 ;;
     docs/v3.6.0-roadmap.md | docs/ios-swift-package-design.md) return 0 ;;
+    # SceneView agent skill migration guide — same role as the public
+    # docs/docs/migration.md: necessarily quotes the deprecated names.
+    agents/sceneview/references/migration.md) return 0 ;;
     # nodes.md line 149 legitimately mentions the Filament class Scene;
     # we allow the whole file since the composable refs were already fixed
     docs/docs/nodes.md) return 0 ;;

--- a/.claude/scripts/check-sceneview-skill.sh
+++ b/.claude/scripts/check-sceneview-skill.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# check-sceneview-skill.sh — Validate the SceneView agent skill content
+# against the actual library source. Wired into the quality gate so that
+# `agents/sceneview/` cannot drift away from `sceneview/`, `arsceneview/`,
+# and the demos under `samples/android-demo/`.
+#
+# What it catches:
+#   1. Hallucinated APIs — every identifier in a Kotlin code block of
+#      `agents/sceneview/**/*.md` that matches one of the SceneView
+#      composable shapes (`SomethingNode`, `rememberSomething`,
+#      `materialLoader.createXxx`) must exist somewhere under
+#      sceneview/, arsceneview/, sceneview-core/, samples/common/, or
+#      llms.txt.
+#   2. Dead demo refs — every `samples/android-demo/.../demos/*.kt`
+#      filename mentioned in recipes.md must exist on disk.
+#   3. YAML frontmatter — every SKILL.md must parse, with `name`,
+#      `description`, `metadata.last-updated` fields present.
+#   4. Staleness — `last-updated` must not be in the future and not
+#      older than 180 days from today (warns).
+#
+# Usage:
+#   bash .claude/scripts/check-sceneview-skill.sh            # full check
+#   bash .claude/scripts/check-sceneview-skill.sh --quiet    # only print failures
+#
+# Exit codes:
+#   0  every check passed (warnings OK)
+#   1  one or more hard failures
+#   2  bad invocation / missing dependency (python3)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --quiet) QUIET=1 ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[check-sceneview-skill] python3 required" >&2
+  exit 2
+fi
+
+SKILL_DIR="agents/sceneview"
+if [[ ! -d "$SKILL_DIR" ]]; then
+  echo "[check-sceneview-skill] $SKILL_DIR not found — wrong worktree?" >&2
+  exit 2
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+FAILURES=0
+WARNINGS=0
+
+pass() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  printf "  ${GREEN}✓${NC} %s\n" "$1"
+}
+fail() {
+  printf "  ${RED}✗${NC} %s\n" "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+warn() {
+  printf "  ${YELLOW}!${NC} %s\n" "$1" >&2
+  WARNINGS=$((WARNINGS + 1))
+}
+section() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  printf "\n${CYAN}-- %s --${NC}\n" "$1"
+}
+
+section "1. Frontmatter"
+
+python3 - "$SKILL_DIR/SKILL.md" <<'PY' || FAILURES=$((FAILURES + 1))
+import sys, re, datetime
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+m = re.match(r"---\n(.*?)\n---\n", text, re.DOTALL)
+if not m:
+    print(f"  ✗ no YAML frontmatter delimited by --- in {path}")
+    sys.exit(1)
+fm = m.group(1)
+required = ["name:", "description:", "metadata:"]
+for key in required:
+    if key not in fm:
+        print(f"  ✗ frontmatter missing '{key}'")
+        sys.exit(1)
+last_updated_match = re.search(r"last-updated:\s*['\"]?(\d{4}-\d{2}-\d{2})", fm)
+if not last_updated_match:
+    print("  ✗ frontmatter missing metadata.last-updated (YYYY-MM-DD)")
+    sys.exit(1)
+last_updated = datetime.date.fromisoformat(last_updated_match.group(1))
+today = datetime.date.today()
+if last_updated > today:
+    print(f"  ✗ last-updated {last_updated} is in the future")
+    sys.exit(1)
+age = (today - last_updated).days
+if age > 180:
+    print(f"  ! last-updated {last_updated} is {age} days old (consider refresh)")
+print(f"  ✓ frontmatter valid, last-updated {last_updated} ({age}d ago)")
+PY
+
+section "2. API identifiers exist in source"
+
+python3 - "$SKILL_DIR" <<'PY'
+import sys, re, subprocess, pathlib, os
+skill_dir = pathlib.Path(sys.argv[1])
+
+# Identifiers we expect to find in the SceneView source. We accept a hit in
+# any of these roots — the public surface is split across modules.
+SEARCH_ROOTS = [
+    "sceneview/src", "arsceneview/src", "sceneview-core/src",
+    "samples/common/src", "samples/android-demo/src",
+    "llms.txt",
+]
+
+# Patterns we extract from skill markdown code blocks:
+#   - XxxNode               (a node composable / class)
+#   - rememberXxx           (a remember helper)
+#   - LightManager.Type.X   (Filament enum reference)
+#   - SomeLoader.createXxx  (loader factory method)
+NODE_RE        = re.compile(r"\b([A-Z][A-Za-z0-9]*Node)\b")
+REMEMBER_RE    = re.compile(r"\b(remember[A-Z][A-Za-z0-9]+)\b")
+LIGHT_TYPE_RE  = re.compile(r"\bLightManager\.Type\.([A-Z][A-Z_]+)\b")
+LOADER_FN_RE   = re.compile(r"\b(\w+Loader)\.(create[A-Z]\w+|load[A-Z]\w+)\b")
+
+# Known false positives — identifiers that exist as concepts in the skill but
+# not in source. Whitelist conservatively.
+WHITELIST = {
+    # Composables/helpers that don't follow the *Node naming but still appear
+    # in code as a callable. Empty for now — re-evaluate if a real false-positive shows.
+}
+
+# Extract all fenced code blocks (any language) from all .md under skill dir.
+code_blobs = []
+for md in skill_dir.rglob("*.md"):
+    text = md.read_text(encoding="utf-8")
+    for m in re.finditer(r"```[a-zA-Z]*\n(.*?)```", text, re.DOTALL):
+        code_blobs.append((md, m.group(1)))
+
+if not code_blobs:
+    print("  ! no fenced code blocks found in skill (unusual but not fatal)")
+    sys.exit(0)
+
+# Collect (identifier, source_file) pairs.
+checks = set()
+for md, blob in code_blobs:
+    for pat, ident_group in [
+        (NODE_RE, 1),
+        (REMEMBER_RE, 1),
+        (LIGHT_TYPE_RE, 1),
+        (LOADER_FN_RE, 2),  # we check the createXxx method name on its own
+    ]:
+        for hit in pat.finditer(blob):
+            ident = hit.group(ident_group)
+            if ident in WHITELIST: continue
+            # Filter out Kotlin built-ins / Compose primitives the user knows about.
+            if ident in {"Modifier", "Composable", "Box", "Row", "Column", "Surface",
+                         "Text", "Icon", "Slider", "Switch", "Card",
+                         "MaterialTheme", "LocalLifecycleOwner", "Lifecycle"}:
+                continue
+            # Skip stdlib Float/Int/etc.
+            if ident in {"Boolean", "Float", "Int", "Double", "String", "Long",
+                         "Object", "Unit", "Any"}:
+                continue
+            checks.add((ident, str(md.relative_to(skill_dir.parent.parent)) if skill_dir.parent.parent in md.parents else str(md)))
+
+if not checks:
+    print("  ✓ no API identifiers to verify (no matching patterns in code blocks)")
+    sys.exit(0)
+
+# For each identifier, grep across the search roots.
+missing = []
+for ident, where in sorted(checks):
+    pat = ident.replace(".", r"\.")
+    found = False
+    for root in SEARCH_ROOTS:
+        if not os.path.exists(root): continue
+        try:
+            result = subprocess.run(
+                ["grep", "-rqE", f"\\b{pat}\\b", root, "--include=*.kt", "--include=llms.txt", "--include=*.txt"],
+                capture_output=True, timeout=15,
+            )
+            if result.returncode == 0:
+                found = True
+                break
+        except subprocess.TimeoutExpired:
+            pass
+        # Fallback for llms.txt file (not a directory)
+        if root.endswith(".txt") and os.path.isfile(root):
+            try:
+                result = subprocess.run(
+                    ["grep", "-qE", f"\\b{pat}\\b", root],
+                    capture_output=True, timeout=10,
+                )
+                if result.returncode == 0:
+                    found = True
+                    break
+            except subprocess.TimeoutExpired:
+                pass
+    if not found:
+        missing.append((ident, where))
+
+if not missing:
+    print(f"  ✓ all {len(checks)} API identifiers exist in source")
+    sys.exit(0)
+
+print(f"  ✗ {len(missing)}/{len(checks)} API identifiers not found in any of: {', '.join(SEARCH_ROOTS)}")
+for ident, where in missing:
+    print(f"    - {ident:35s}  cited in {where}")
+sys.exit(1)
+PY
+GREP_RC=$?
+if [[ "$GREP_RC" -ne 0 ]]; then
+  FAILURES=$((FAILURES + 1))
+fi
+
+section "3. Demo file references resolve"
+
+python3 - "$SKILL_DIR" <<'PY'
+import sys, re, pathlib, os
+skill_dir = pathlib.Path(sys.argv[1])
+
+# Match `XxxDemo.kt` and `samples/android-demo/.../*.kt` references.
+DEMO_KT_RE = re.compile(r"\b([A-Z][A-Za-z0-9]*Demo\.kt)\b")
+DEMO_PATH_RE = re.compile(r"samples/android-demo/src/main/java/io/github/sceneview/demo/demos/([A-Z][A-Za-z0-9]+\.kt)")
+
+ROOT = pathlib.Path("samples/android-demo/src/main/java/io/github/sceneview/demo/demos")
+if not ROOT.exists():
+    print(f"  ! demos directory {ROOT} not found — skipping check")
+    sys.exit(0)
+
+available = {p.name for p in ROOT.glob("*.kt")}
+referenced = set()
+for md in skill_dir.rglob("*.md"):
+    text = md.read_text(encoding="utf-8")
+    for m in DEMO_KT_RE.finditer(text):
+        referenced.add(m.group(1))
+    for m in DEMO_PATH_RE.finditer(text):
+        referenced.add(m.group(1))
+
+missing = sorted(referenced - available)
+if missing:
+    print(f"  ✗ {len(missing)} demo file(s) referenced but missing from {ROOT}")
+    for name in missing:
+        print(f"    - {name}")
+    sys.exit(1)
+
+print(f"  ✓ all {len(referenced)} referenced demo files exist")
+PY
+DEMO_RC=$?
+if [[ "$DEMO_RC" -ne 0 ]]; then
+  FAILURES=$((FAILURES + 1))
+fi
+
+section "4. Skill is installable"
+
+if [[ -x .claude/scripts/install-sceneview-skill.sh ]]; then
+  pass "install-sceneview-skill.sh exists and is executable"
+else
+  fail "install-sceneview-skill.sh missing or not executable"
+fi
+
+# Print summary
+if [[ "$QUIET" -eq 0 ]]; then
+  echo ""
+  if [[ "$FAILURES" -eq 0 ]]; then
+    printf "${GREEN}✓ Skill drift check passed${NC}"
+    [[ "$WARNINGS" -gt 0 ]] && printf " (with %d warning(s))" "$WARNINGS"
+    echo ""
+  else
+    printf "${RED}✗ Skill drift check failed: %d failure(s), %d warning(s)${NC}\n" "$FAILURES" "$WARNINGS"
+  fi
+fi
+
+[[ "$FAILURES" -eq 0 ]]

--- a/.claude/scripts/quality-gate.sh
+++ b/.claude/scripts/quality-gate.sh
@@ -142,6 +142,26 @@ fi
 
 echo ""
 
+# ─── 4a. SceneView Agent Skill Drift ───────────────────────────────────
+# Catches the kind of API hallucination that landed in the first cut of
+# `agents/sceneview/SKILL.md` (PR #1072) — fake APIs like
+# `rememberARSession` / `AnchorNode.image()` / `GeometryNode(geometry=...)`
+# that would compile into broken code in any project the skill helps
+# generate. The check runs in well under 1s.
+echo -e "${CYAN}--- SceneView Agent Skill ---${NC}"
+if [ -d "agents/sceneview" ] && [ -x ".claude/scripts/check-sceneview-skill.sh" ]; then
+    if bash .claude/scripts/check-sceneview-skill.sh --quiet > /tmp/check-sceneview-skill.log 2>&1; then
+        check "agents/sceneview/ in sync with source" "PASS" ""
+    else
+        DRIFT_COUNT=$(grep -cE '^    - ' /tmp/check-sceneview-skill.log 2>/dev/null || echo "?")
+        check "agents/sceneview/ in sync with source" "FAIL" "$DRIFT_COUNT drift item(s); see /tmp/check-sceneview-skill.log"
+    fi
+elif [ -d "agents/sceneview" ]; then
+    check "agents/sceneview/ drift check" "WARN" "check-sceneview-skill.sh missing"
+fi
+
+echo ""
+
 # ─── 4b. Demo App Asset Integrity ──────────────────────────────────────
 # Catches the class of bugs fixed in session 34 (TV demo bundled model
 # typos, web-demo dead 404 CDN URLs). Fast enough to run in every gate.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -118,7 +118,50 @@ jobs:
           exempt-issue-labels: 'pinned,roadmap,in-progress'
           exempt-pr-labels: 'pinned'
 
-  # ── 3. CI health summary ──────────────────────────────────────────────────
+  # ── 3. SceneView agent skill drift ────────────────────────────────────────
+  # Catches the case where a library API was renamed/removed between releases
+  # without updating `agents/sceneview/` (the published agent skill). Daily
+  # cadence is enough — the same check also runs on every PR via pr-check.yml.
+  skill-drift:
+    name: SceneView agent skill drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run skill drift check
+        id: drift
+        shell: bash
+        run: |
+          if bash .claude/scripts/check-sceneview-skill.sh > skill-drift.log 2>&1; then
+            echo "drift=0" >> $GITHUB_OUTPUT
+          else
+            echo "drift=1" >> $GITHUB_OUTPUT
+            cat skill-drift.log
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.drift == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --state open --search "Agent skill drift detected" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          BODY=$'Daily maintenance detected drift between `agents/sceneview/` and the SceneView library source.\n\n```\n'"$(cat skill-drift.log)"$'\n```\n\nRun `bash .claude/scripts/check-sceneview-skill.sh` locally and update the skill from real demos / `llms.txt`.'
+          if [ -z "$EXISTING" ]; then
+            gh issue create \
+              --title "Agent skill drift detected — $(date +%Y-%m-%d)" \
+              --body "$BODY" \
+              --label "agent-skill,maintenance" \
+              || echo "::warning::Could not create skill drift issue"
+          else
+            gh issue comment "$EXISTING" --body "$BODY" \
+              || echo "::warning::Could not comment on existing skill drift issue #$EXISTING"
+          fi
+
+  # ── 4. CI health summary ──────────────────────────────────────────────────
   ci-health:
     name: CI health check
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,6 +30,13 @@ jobs:
         shell: bash
         run: bash .claude/scripts/check-deprecated-api.sh --all
 
+      - name: Check SceneView agent skill is in sync with source
+        # Catches hallucinated APIs in agents/sceneview/ (e.g. `rememberARSession`
+        # or `AnchorNode.image()`) BEFORE merge — see PR #1072 for the kind of
+        # drift this guard prevents. Sub-second; no JDK or Gradle needed.
+        shell: bash
+        run: bash .claude/scripts/check-sceneview-skill.sh
+
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -101,3 +101,12 @@ jobs:
           path: /tmp/check-deprecated-api.log
           if-no-files-found: ignore
           retention-days: 7
+
+      - name: Upload check-sceneview-skill log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: check-sceneview-skill-log
+          path: /tmp/check-sceneview-skill.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,7 @@ Hooks trigger automatically on specific Claude Code actions:
 | `visual-check.sh` | Before/after baseline capture — Android via `android` CLI, iOS via `xcrun simctl` |
 | `android-env-check.sh` | Sanity check for the Android dev env — `--fix` installs the CLI + SceneView skill |
 | `install-sceneview-skill.sh` | Copies `agents/sceneview/` to `~/.android/cli/skills/xr/sceneview/` |
+| `check-sceneview-skill.sh` | Verifies `agents/sceneview/` content (API identifiers, demo refs, frontmatter) is in sync with the library source. Runs in `quality-gate.sh`, `pr-check.yml`, and daily via `maintenance.yml` |
 
 ### Version location map
 


### PR DESCRIPTION
## Summary

Closes the autonomy gap from [PR #1072](https://github.com/sceneview/sceneview/pull/1072). Agent skills that referenced hallucinated APIs (e.g. `rememberARSession`, `AnchorNode.image()` on Android, `GeometryNode(geometry=...)`) were only caught by manual Opus reviews on the way in. This PR wires a **sub-second static check** into the PR-check, quality-gate and daily maintenance workflows so the same class of drift fails the build automatically — no review required.

## What's new

- **[`.claude/scripts/check-sceneview-skill.sh`](.claude/scripts/check-sceneview-skill.sh)** validates `agents/sceneview/`:
  1. YAML frontmatter (`name`, `description`, `metadata.last-updated`).
  2. Every `XxxNode` / `rememberXxx` / `LightManager.Type.X` / `*Loader.createXxx` identifier in any code block must exist under `sceneview/src`, `arsceneview/src`, `sceneview-core/src`, `samples/common/src`, `samples/android-demo/src`, or `llms.txt`.
  3. Every `XxxDemo.kt` referenced in the skill must exist under `samples/android-demo/.../demos/`.
  4. The install script is present and executable.
- **`quality-gate.sh`** runs the check as section 4a (sub-second, no JDK).
- **`pr-check.yml`** runs the check standalone for fast-fail on every PR.
- **`quality-gate.yml`** uploads `/tmp/check-sceneview-skill.log` on failure.
- **`maintenance.yml`** runs the check daily at 07:00 UTC and opens/updates an "Agent skill drift detected" issue if the library renames an API without updating the skill.
- **`check-deprecated-api.sh`** whitelists `agents/sceneview/references/migration.md` (which legitimately quotes the deprecated `Scene { }` name in the rename map).
- **`CLAUDE.md`** Scripts table updated.

## Verification

**Positive case** (current skill, on `main`):
```
✓ frontmatter valid, last-updated 2026-05-14 (0d ago)
✓ all 23 API identifiers exist in source
✓ all 21 referenced demo files exist
✓ install-sceneview-skill.sh exists and is executable
```

**Negative case** (inject 3 hallucinated identifiers into SKILL.md):
```
✗ 3/26 API identifiers not found in any of: sceneview/src, arsceneview/src, …
    - FAKE_TYPE                  cited in agents/sceneview/SKILL.md
    - HallucinatedNode           cited in agents/sceneview/SKILL.md
    - rememberHallucinatedHelper cited in agents/sceneview/SKILL.md
```

Exit code 1 → PR check fails → no merge.

## Follow-up issues filed (out of scope)

- [#1080](https://github.com/sceneview/sceneview/issues/1080) — `sceneview-ios` skill (SceneViewSwift)
- [#1081](https://github.com/sceneview/sceneview/issues/1081) — `sceneview-web` skill (Filament.js + WebXR)
- [#1082](https://github.com/sceneview/sceneview/issues/1082) — Submit to Google's hosted android-cli registry
- [#1083](https://github.com/sceneview/sceneview/issues/1083) — MCP: expose `android docs search` / `fetch` as MCP tools
- [#1084](https://github.com/sceneview/sceneview/issues/1084) — Recurring contributor tasks audit for further android-CLI / agent-skill leverage

## Why this matters for autonomy

I now have a CI guard that catches the exact class of mistake my last skill PR shipped. Future skill edits don't need a 4-agent Opus review pass to be safe — the static check does it in 5 seconds per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)