### PR TITLE
fix(ci): POSIX-safe boot-wait loop in render-tests.yml (dash bashism)

### DIFF
--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -155,9 +155,15 @@ jobs:
             # Block until the emulator finishes booting. The action waits for
             # device-online but not for package-manager readiness — `android run`
             # would otherwise race the PM during cold boot.
+            #
+            # POSIX-shell only: ReactiveCircus/android-emulator-runner runs this
+            # `script:` block under /usr/bin/sh (dash on Ubuntu runners), where
+            # `[[ ... ]]` is a syntax error. Use plain `[ ... ]` + `=`.
             adb wait-for-device
-            until [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" == "1" ]]; do
+            attempts=0
+            while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do
               sleep 2
+              attempts=$((attempts + 1))
             done
 
             # Install + launch atomically via the Android CLI.


### PR DESCRIPTION
## Summary

PR #1068's android-CLI migration introduced a wait-for-boot gate in `render-tests.yml` so `android run` wouldn't race the package manager on cold-boot. The gate used `until [[ ... ]] do ... done` — but `ReactiveCircus/android-emulator-runner@v2` runs the \`script:\` block under \`/usr/bin/sh\` (dash on Ubuntu runners), where \`[[ ... ]]\` is a syntax error.

Every render-tests run since the merge has died with:

\`\`\`
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting \"done\")
##[error]The process '/usr/bin/sh' failed with exit code 2
\`\`\`

Seen on run [25835999142](https://github.com/sceneview/sceneview/actions/runs/25835999142) and every render-tests run on every branch since (claude/scene-3d-p0-fixes, claude/issue-955-i18n-fr, claude/issue-971-material-helper-batch1, claude/issue-979-material-leak, claude/ar-rendering-p0-fixes — all hit the same root cause).

## Fix

Strict-POSIX \`while [ ... ]\` loop bounded to 120s:

\`\`\`sh
attempts=0
while [ \"\$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\\\\r\\\\n')\" != \"1\" ] \\
      && [ \"\$attempts\" -lt 60 ]; do
  sleep 2
  attempts=\$((attempts + 1))
done
\`\`\`

## Verification

\`\`\`
$ dash -c 'attempts=0; while [ \"x\" != \"y\" ] && [ \"\$attempts\" -lt 3 ]; do echo iter \$attempts; attempts=\$((attempts + 1)); done; echo done'
iter 0
iter 1
iter 2
done

$ python3 -c 'import yaml; yaml.safe_load(open(\".github/workflows/render-tests.yml\"))'
(no error)
\`\`\`

## Test plan

- [x] dash + bash both parse the new form
- [x] YAML still valid
- [ ] CI run on this PR (auto-triggered) shows render-tests no longer dies on the boot-wait line

🤖 Generated with [Claude Code](https://claude.com/claude-code)