### PR TITLE
fix(ar): ARDefaultCameraNode EV15→EV11.6 + #1075 IBL intensity follow-up (#1067)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARFactories.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARFactories.kt
@@ -21,9 +21,10 @@ import java.nio.Buffer
 /**
  * Creates an [ARCameraNode] with default AR-appropriate exposure settings.
  *
- * The default exposure (aperture 16, shutter speed 1/125s, ISO 100) is tuned to match
- * ARCore's light estimation output so that virtual objects blend naturally with the
- * real-world camera feed.
+ * The default exposure (`f/12, 1/200 s, ISO 200` ≈ EV 11.6) matches the 3D
+ * `DefaultCameraNode` and the v4.1.0 main+fill light setup (10k + 3k lux). See
+ * [ARDefaultCameraNode] for why the previous "sunny-16" exposure broke after
+ * the v4.1.0 light rebalance (#1067).
  */
 fun createARCameraNode(engine: Engine): ARCameraNode = ARDefaultCameraNode(engine)
 
@@ -54,15 +55,28 @@ fun createAREnvironment(
 ) = createEnvironment(
     engine = engine,
     isOpaque = true,
-    indirectLight = iblBuffer?.let { KTX1Loader.createIndirectLight(engine, it).indirectLight },
+    // Apply DEFAULT_IBL_INTENSITY (10k lux) so the AR baseline IBL doesn't blow out
+    // direct lighting once ARCore ENVIRONMENTAL_HDR replaces it (#1075). Same pattern
+    // as the 3D `createEnvironment` path.
+    indirectLight = iblBuffer?.let {
+        KTX1Loader.createIndirectLight(engine, it).indirectLight
+            ?.also { ibl -> ibl.intensity = io.github.sceneview.DEFAULT_IBL_INTENSITY }
+    },
     skybox = null,
 )
 
 /**
- * Default AR camera node with exposure tuned for ARCore light estimation.
+ * Default AR camera node, exposure realigned with the v4.1.0 main+fill light setup
+ * (10k + 3k lux + 10k IBL after #1075).
+ *
+ * Mirrors the 3D `DefaultCameraNode` exposure at `f/12, 1/200 s, ISO 200` (≈ EV 11.6).
+ * The previous `f/16, 1/125 s, ISO 100` ("sunny-16", ≈ EV 15) assumed the pre-v4.1.0
+ * 100k lux main light. After the v4.1.0 rebalance the AR camera was 10× too dim,
+ * which is why every AR demo had to override `cameraExposure = -1.0f` as a workaround.
+ * With #1067 those workarounds become removable (track via the AR demo audit).
  */
 class ARDefaultCameraNode(engine: Engine) : ARCameraNode(engine) {
     init {
-        setExposure(16.0f, 1.0f / 125.0f, 100.0f)
+        setExposure(12.0f, 1.0f / 200.0f, 200.0f)
     }
 }


### PR DESCRIPTION
Closes [#1067](https://github.com/sceneview/sceneview/issues/1067) + lands the cross-PR follow-up to [#1075](https://github.com/sceneview/sceneview/issues/1075) noted in PR #1079's description.

## #1067 — ARDefaultCameraNode exposure misaligned with v4.1.0 lights

Was `f/16, 1/125 s, ISO 100` (sunny-16, ≈ EV 15) — assumed the pre-v4.1.0 100k lux main light. After the rebalance to 10k + 3k fill, AR scenes were 10× too dim → 11 of 14 AR demos had to override `cameraExposure = -1.0f` as a workaround.

Mirror the 3D `DefaultCameraNode`: `f/12, 1/200 s, ISO 200` (≈ EV 11.6). The per-demo `-1.0f` workaround becomes removable in a follow-up batch.

## #1075 follow-up — createAREnvironment also needs DEFAULT_IBL_INTENSITY

PR #1079 fixed the 3D paths. The AR `createAREnvironment(engine, iblBuffer)` factory I shipped in #1069 went through the same `KTX1Loader.createIndirectLight` → inherited Filament's hardcoded 30k. Same fix here.

Now ALL 4 `KTX1Loader.createIndirectLight` call sites in the repo are aligned at 10k lux.

## QA

- ✅ `:arsceneview:compileReleaseKotlin` green
- ✅ `:arsceneview:testDebugUnitTest` 11 LightEstimator + 3 ARMainLightBaseline tests green
- [ ] Visual on Pixel 9: AR demos brightness should match 3D demos when comparing the same scene
- [ ] Audit pass: remove the `cameraExposure = -1.0f` workaround from the 11 demos that have it (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)