### PR TITLE
fix(3d): RenderQuality preset uses LaunchedEffect — stops clobbering user tweaks (#1078)

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/Scene.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Scene.kt
@@ -262,6 +262,14 @@ fun SceneView(
         view.camera = cameraNode.camera
         cameraNode.collisionSystem = collisionSystem
         cameraNode.setView(view)
+    }
+    // Keyed `LaunchedEffect` so the preset is reapplied ONLY when `renderQuality`
+    // actually changes (#1078). The previous unkeyed `SideEffect` ran on every
+    // recomposition and silently overwrote any post-Scene `view.colorGrading`,
+    // `view.bloomOptions.strength`, etc. tweaks — breaking the contract documented
+    // at `RenderQuality.kt`'s "Apply additional View tweaks AFTER calling this —
+    // they will not be undone".
+    LaunchedEffect(view, renderQuality) {
         view.applyRenderQuality(renderQuality)
     }
 


### PR DESCRIPTION
Closes [#1078](https://github.com/sceneview/sceneview/issues/1078).

`view.applyRenderQuality(renderQuality)` lived inside an unkeyed `SideEffect` that ran on every recomposition → silently overwrote any user `view.bloomOptions.strength`, `view.colorGrading`, etc. tweaks. The `RenderQuality.kt` KDoc explicitly tells users they CAN tweak after — contract was broken.

One-line fix: hoist into a keyed `LaunchedEffect(view, renderQuality)`. Other lines in the SideEffect (scene.indirectLight wiring, view.camera) stay — they ARE meant to track recomposition.

## QA

- ✅ `:sceneview:compileReleaseKotlin` green
- ✅ `:sceneview:test` 306 tests green
- ✅ `:samples:android-demo:compileDebugKotlin` green
- [ ] Manual: open any 3D demo, set `view.bloomOptions.strength = 0.2f` post-Scene composition, trigger a recomposition, verify strength stays at 0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)