### PR TITLE
fix(ar): LightEstimator stops double-closing ARCore Images in cubemap callback (#1090)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/light/LightEstimator.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/light/LightEstimator.kt
@@ -239,15 +239,21 @@ class LightEstimator(
                         cubeMapTexture.setImage(
                             engine,
                             0,
+                            // No-op callback — `arImages` were already closed synchronously
+                            // by `image.use {}` above (line 209), and the next reuse cycle
+                            // calls `cubeMapBuffer.clear()` at line ≈200. The previous
+                            // callback `{ arImages.forEach { it.close() }; buffer.clear() }`
+                            // was dead code that double-closed already-closed Images
+                            // (silently swallowed by Filament today, but a Filament SDK
+                            // upgrade that surfaces callback errors would explode), AND
+                            // raced with the next-frame buffer reuse path (#1090).
                             Texture.PixelBufferDescriptor(
                                 buffer,
                                 Texture.Format.RGB,
                                 Texture.Type.HALF,
-                                1, 0, 0, 0, null
-                            ) {
-                                arImages.forEach { it.close() }
-                                buffer.clear()
-                            },
+                                1, 0, 0, 0, null,
+                                Runnable { /* no-op — see comment above */ }
+                            ),
                             faceOffsets
                         )
                         reflections = if (environmentalHdrSpecularFilter) {


### PR DESCRIPTION
Closes [#1090](https://github.com/sceneview/sceneview/issues/1090).

Two issues caught during the LightEstimator deep audit:

1. **Double-close of `android.media.Image`** — `image.use { … }` closes synchronously, then the async `PixelBufferDescriptor` callback called `image.close()` again → `IllegalStateException`. Today swallowed by Filament's callback wrapper; tomorrow a Filament SDK upgrade explodes.
2. **Buffer race** — the callback's `buffer.clear()` raced with the next-frame `cubeMapBuffer.clear()` reuse path. Masked by ARCore's ~1 Hz cadence today.

Fix: replace the callback body with a no-op `Runnable`. Both responsibilities (image close + buffer reset) are already handled in the synchronous code path.

## QA

- ✅ `:arsceneview:compileReleaseKotlin` green
- ✅ `:arsceneview:testDebugUnitTest` 11 LightEstimator + 3 ARMainLightBaseline tests green
- [ ] Visual: open `OrbitalARDemo` for 60 s on Pixel 9, verify no `IllegalStateException` in logcat (pre-fix would have logged silently swallowed exceptions on every ARCore HDR cubemap update)

## Audit context

This is the first concrete fix from the LightEstimator deep audit Thomas asked for. The audit agent stalled but captured this finding + several others (per-frame allocations, missing ENVIRONMENTAL_HDR capability check, undocumented `1.8` magic number, SH coefficient ordering verification). I'll file each as a separate issue from focused re-audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)