### PR TITLE
fix(collision): Box ray-parallel detection + spherePlaneResponse contact (#1096, #1097)

### DIFF
--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Box.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Box.kt
@@ -82,7 +82,7 @@ class Box : CollisionShape {
         var e = Vector3.dot(axis, delta)
         var f = Vector3.dot(rayDirection, axis)
 
-        if (!MathHelper.almostEqualRelativeAndAbs(f, 0.0f)) {
+        if (kotlin.math.abs(f) >= 1.0E-6f) {
             var t1 = (e + min.x) / f
             var t2 = (e + max.x) / f
 
@@ -104,7 +104,7 @@ class Box : CollisionShape {
         e = Vector3.dot(axis, delta)
         f = Vector3.dot(rayDirection, axis)
 
-        if (!MathHelper.almostEqualRelativeAndAbs(f, 0.0f)) {
+        if (kotlin.math.abs(f) >= 1.0E-6f) {
             var t1 = (e + min.y) / f
             var t2 = (e + max.y) / f
 
@@ -126,7 +126,7 @@ class Box : CollisionShape {
         e = Vector3.dot(axis, delta)
         f = Vector3.dot(rayDirection, axis)
 
-        if (!MathHelper.almostEqualRelativeAndAbs(f, 0.0f)) {
+        if (kotlin.math.abs(f) >= 1.0E-6f) {
             var t1 = (e + min.z) / f
             var t2 = (e + max.z) / f
 

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/CollisionResponse.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/CollisionResponse.kt
@@ -81,7 +81,12 @@ fun spherePlaneResponse(
     if (penetration <= 0f) return CollisionResult(collided = false)
 
     val normal = if (signedDist >= 0f) planeNormal else planeNormal.negated()
-    val contactPoint = Vector3.subtract(center, normal.scaled(signedDist))
+    // Project along the original `planeNormal` (NOT the flipped `normal`) so the
+    // contact point lands ON the plane regardless of which side the sphere is on
+    // (#1097). Using the flipped normal here moved the contact AWAY from the plane
+    // when the sphere was on the negative side → physics integrator pushed the
+    // sphere further out → ball clipping through floor.
+    val contactPoint = Vector3.subtract(center, planeNormal.scaled(signedDist))
     val bounce = reflect(velocity, normal)
 
     return CollisionResult(

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/MathHelper.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/MathHelper.kt
@@ -14,7 +14,17 @@ object MathHelper {
     /** Machine epsilon for single-precision IEEE 754 floats. */
     internal const val FLT_EPSILON = 1.19209290E-07f
 
-    /** Absolute tolerance for near-zero comparisons. */
+    /**
+     * Absolute tolerance for near-zero comparisons.
+     *
+     * Note: deliberately small because `almostEqualRelativeAndAbs` is also called with
+     * SQUARED magnitudes (e.g. `lengthSquared` in [Vector3.normalized]). Bumping this
+     * higher would cause small-but-non-zero vectors (length ≈ 1e-4 → length² ≈ 1e-8)
+     * to be classified as zero. Call sites that need a coarser epsilon for non-squared
+     * floats (e.g. ray-direction parallelism in `Box.rayIntersection`) should use a
+     * direct `abs(x) < epsilon` check at the call site instead of widening this
+     * constant. See #1096.
+     */
     internal const val MAX_DELTA = 1.0E-10f
 
     /**

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/collision/CollisionResponseTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/collision/CollisionResponseTest.kt
@@ -59,6 +59,24 @@ class CollisionResponseTest {
         assertFalse(result.collided)
     }
 
+    /** Pinning #1097: contact point lands on the plane on either side. */
+    @Test
+    fun spherePlaneResponseContactPointLandsOnPlaneOnEitherSide() {
+        // Sphere on POSITIVE side of the y=0 plane, halfway intersecting.
+        val abovePlane = Sphere(1f, Vector3(0f, 0.3f, 0f))
+        val above = spherePlaneResponse(abovePlane, Vector3(0f, 1f, 0f), 0f)
+        // Contact point Y should be exactly 0 (on the plane).
+        assertTrue(abs(above.contactPoint.y) < 0.01f)
+
+        // Same sphere on NEGATIVE side (below). Pre-#1097 the bug moved the contact
+        // AWAY from the plane (into negative Y), which made physics integrators
+        // push the sphere further down → ball clipping floor.
+        val belowPlane = Sphere(1f, Vector3(0f, -0.3f, 0f))
+        val below = spherePlaneResponse(belowPlane, Vector3(0f, 1f, 0f), 0f)
+        // Contact point should ALSO land on the plane (y=0), not at y=-0.6 (the buggy result).
+        assertTrue(abs(below.contactPoint.y) < 0.01f)
+    }
+
     @Test
     fun reflectVector() {
         // Incoming direction: (1, -1, 0) hitting a floor (normal = 0,1,0)


### PR DESCRIPTION
Closes [#1096](https://github.com/sceneview/sceneview/issues/1096) + [#1097](https://github.com/sceneview/sceneview/issues/1097). Two pre-v3 correctness bugs from the math/collision deep audit.

## #1096 Box.rayIntersection parallel-ray detection silently fails

Initially tried bumping `MathHelper.MAX_DELTA` from `1e-10` to `1e-5` (the audit's first suggestion) — but that broke `Vector3.normalized()` for small vectors (`lengthSquared = 1e-8` would become "zero"). Cleaner fix:
- Keep `MAX_DELTA = 1e-10` (preserves normalize)
- Replace 3 call sites in `Box.rayIntersection` with `abs(f) >= 1e-6f` — direct epsilon check on ray-direction parallelism, isolated from the squared-magnitude consumers
- Updated KDoc on `MAX_DELTA` to explain why call sites needing coarser epsilon should use direct checks

## #1097 spherePlaneResponse projects from the wrong normal on negative side

`contactPoint = center - normal.scaled(signedDist)` used the flipped `normal` → contact point moved AWAY from plane when sphere was on negative side. Symptom: bouncing balls clipped through floor.

One-line fix: project along the original `planeNormal` (signedDist already carries the sign).

## QA

- ✅ `:sceneview-core:allTests` — 709 tests across android/ios/jvm/js targets all pass
- ✅ JVM regression test pinning sphere-plane contact on both sides
- ✅ Pre-existing `Vector3Test.normalizeSmallButAboveThreshold` still passes
- [ ] Visual: `PhysicsDemo` — drop balls 100×, no floor clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)