### PR TITLE
fix(ci): collapse render-tests boot-wait `while` to a single line

### DIFF
--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -156,15 +156,13 @@ jobs:
             # device-online but not for package-manager readiness — `android run`
             # would otherwise race the PM during cold boot.
             #
-            # POSIX-shell only: ReactiveCircus/android-emulator-runner runs this
-            # `script:` block under /usr/bin/sh (dash on Ubuntu runners), where
-            # `[[ ... ]]` is a syntax error. Use plain `[ ... ]` + `=`.
+            # The `script:` block is executed line-by-line by the action via
+            # `sh -c <line>` (not `bash <script>`), so a multi-line `while … done`
+            # gets sliced — the `while` opens a syntax that never sees its `done`
+            # on the same invocation. The whole loop must live on ONE physical
+            # line. POSIX-only (dash): `[ … ]` + `=`, no `[[ … ]]`.
             adb wait-for-device
-            attempts=0
-            while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do
-              sleep 2
-              attempts=$((attempts + 1))
-            done
+            attempts=0; while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do sleep 2; attempts=$((attempts + 1)); done
 
             # Install + launch atomically via the Android CLI.
             android --no-metrics run \


### PR DESCRIPTION
## Summary

[PR #1087](https://github.com/sceneview/sceneview/pull/1087) fixed the \`[[ ]]\` → \`[ ]\` bashism in render-tests.yml's boot-wait loop, but the loop still failed on every render-tests run because it spanned multiple lines:

\`\`\`
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting \"done\")
\`\`\`

Caught from run [25838607418](https://github.com/sceneview/sceneview/actions/runs/25838607418) on \`claude/issue-1093-sh-coefficients\`.

## Root cause

\`ReactiveCircus/android-emulator-runner@v2\` invokes the multi-line \`script:\` value as **one \`sh -c\` invocation per physical line**. A multi-line \`while … done\` therefore opens \`while\` in one invocation, runs \`sleep 2\` in a separate invocation that knows nothing about the loop, and finally hits \`done\` orphaned — the syntax error fires on the first invocation because dash can't find the matching \`done\` on its input line.

## Fix

Collapse the loop to one physical line so it lives in a single \`sh -c\` invocation:

\`\`\`sh
adb wait-for-device
attempts=0; while [ \"\$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\\\\r\\\\n')\" != \"1\" ] && [ \"\$attempts\" -lt 60 ]; do sleep 2; attempts=\$((attempts + 1)); done
\`\`\`

## Verification

\`\`\`
$ dash -c 'attempts=0; while [ \"x\" != \"y\" ] && [ \"\$attempts\" -lt 3 ]; do echo iter \$attempts; attempts=\$((attempts + 1)); done; echo done'
iter 0
iter 1
iter 2
done
\`\`\`

YAML parses. CI on this PR will verify end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)