### PR TITLE
ci(dependabot): pin filament + material3-alpha19 out of auto-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,18 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Filament runtime ↔ .filamat ABI invariant: a runtime bump WITHOUT
+      # recompiling every `.filamat` blob in the same PR ships a crash (cf.
+      # CLAUDE.md "Filament runtime ↔ .filamat ABI invariant"). Dependabot
+      # can't recompile blobs, so its filament bumps always fail quality-gate
+      # for the wrong reason — block them and let a contributor cut the bump
+      # plus the matc recompile in a single manual PR.
+      - dependency-name: "com.google.android.filament:*"
+      # Compose Material3 alphas now require AGP 9.1+ / compileSdk 37+ ahead
+      # of the rest of the toolchain. Re-enable when the project upgrades
+      # AGP (tracked separately in the maintenance dep-version-check report).
+      - dependency-name: "androidx.compose.material3:material3"
+        versions: [">=1.5.0-alpha19"]
 
   # npm — MCP server
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

Two recurring red-X Dependabot PRs that can never merge as-is, plus the noise they generate on every push:

| PR | Dep | Why it can't merge |
|---|---|---|
| [#992](https://github.com/sceneview/sceneview/pull/992) | filament 1.71.0 → 1.71.3 | Filament runtime ↔ `.filamat` ABI invariant: a runtime bump without recompiling every `.filamat` blob in the same PR ships a startup crash. Dependabot can't run \`matc\`, so this PR is structurally un-mergeable. |
| [#999](https://github.com/sceneview/sceneview/pull/999) | material3 1.5.0-alpha17 → 1.5.0-alpha19 | alpha19 requires AGP 9.1+ and compileSdk 37. We're on AGP 8.13.2 / compileSdk 36 → needs an AGP upgrade as a prereq. |

## Fix

Pin both in `.github/dependabot.yml`. The daily maintenance job's dep-version-check report (already in `maintenance.yml`) keeps surfacing latest upstream versions, so nothing is hidden — just routed through human review.

## Re-enable when

- **filament**: a contributor cuts the runtime bump + matc-recompile of all `.filamat` blobs in the same PR.
- **material3**: the AGP upgrade lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)