### PR TITLE
fix(node): destroyMaterialsOnDispose flag on RenderableNode + GeometryNode (#1123)

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
@@ -38,12 +38,20 @@ open class GeometryNode(
     open val geometry: Geometry,
     materialInstances: List<MaterialInstance?>,
     primitivesOffsets: List<IntRange> = geometry.primitivesOffsets,
+    /**
+     * If `true`, [destroy] also destroys every non-null entry of [materialInstances].
+     *
+     * See [RenderableNode]'s `destroyMaterialsOnDispose` KDoc for usage guidance. Default
+     * `false` for backward compatibility (#1123).
+     */
+    destroyMaterialsOnDispose: Boolean = false,
     builderApply: RenderableManager.Builder.() -> Unit = {}
 ) : RenderableNode(
     engine = engine,
     primitiveCount = primitivesOffsets.size,
     boundingBox = geometry.boundingBox,
     materialInstances = materialInstances,
+    destroyMaterialsOnDispose = destroyMaterialsOnDispose,
     builder = {
         geometry(geometry, primitivesOffsets)
         materials(materialInstances)
@@ -54,12 +62,14 @@ open class GeometryNode(
         engine: Engine,
         geometry: Geometry,
         materialInstance: MaterialInstance? = null,
+        destroyMaterialsOnDispose: Boolean = false,
         builderApply: RenderableManager.Builder.() -> Unit = {}
     ) : this(
         engine = engine,
         geometry = geometry,
         materialInstances = listOf(materialInstance),
         primitivesOffsets = listOf(0..geometry.primitivesOffsets.last().last),
+        destroyMaterialsOnDispose = destroyMaterialsOnDispose,
         builderApply = builderApply
     )
 

--- a/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
@@ -9,6 +9,7 @@ import io.github.sceneview.Entity
 import io.github.sceneview.FilamentEntity
 import io.github.sceneview.components.RenderableComponent
 import io.github.sceneview.math.toVector3Box
+import io.github.sceneview.safeDestroyMaterialInstance
 import io.github.sceneview.safeDestroyRenderable
 
 /**
@@ -25,6 +26,15 @@ open class RenderableNode(
     @FilamentEntity entity: Entity = EntityManager.get().create(),
 ) : Node(engine, entity), RenderableComponent {
 
+    /**
+     * Material instances this node owns and will tear down on [destroy].
+     *
+     * Populated only when the [primitiveCount] constructor is called with
+     * `destroyMaterialsOnDispose = true`. Direct callers of the no-arg constructor manage
+     * their own materials.
+     */
+    private var ownedMaterialInstances: List<MaterialInstance> = emptyList()
+
     constructor(
         engine: Engine,
         @FilamentEntity entity: Entity = EntityManager.get().create(),
@@ -39,8 +49,31 @@ open class RenderableNode(
          * If no material is specified, Filament will fall back to a basic default material.
          */
         materialInstances: List<MaterialInstance?> = listOf(),
+        /**
+         * If `true`, [destroy] also destroys every non-null entry of [materialInstances] via
+         * [Engine.safeDestroyMaterialInstance].
+         *
+         * Use `true` when this node owns the lifecycle of its materials end-to-end — typically
+         * when you build a one-off node with a freshly-created `MaterialInstance` and let the
+         * node go out of scope (the common per-demo pattern). Without this flag, the bound
+         * `MaterialInstance`s outlive the renderable and accumulate in Filament's internal
+         * tables until engine teardown — a steady-state memory leak (#1123).
+         *
+         * Use `false` (the default) when a `MaterialLoader` or other long-lived owner is
+         * responsible for destroying the materials externally — for example via the
+         * `rememberMaterialInstance` Compose helper or a manual `DisposableEffect`.
+         *
+         * Note: this calls `engine.safeDestroyMaterialInstance(...)`. If the material was
+         * created through a `MaterialLoader`, the loader's internal tracking set is **not**
+         * cleaned up automatically — prefer `materialLoader.destroyMaterialInstance(...)` in
+         * an external `DisposableEffect` for loader-managed materials.
+         */
+        destroyMaterialsOnDispose: Boolean = false,
         builder: RenderableManager.Builder.() -> Unit,
     ) : this(engine, entity) {
+        if (destroyMaterialsOnDispose) {
+            ownedMaterialInstances = materialInstances.filterNotNull()
+        }
         RenderableManager.Builder(primitiveCount)
             .boundingBox(boundingBox)
             .apply {
@@ -69,6 +102,10 @@ open class RenderableNode(
         // causing "Invalid texture still bound to MaterialInstance" on the subsequent texture
         // destroy.
         engine.safeDestroyRenderable(entity)
+        // Then tear down owned MaterialInstances if the constructor opted in (#1123).
+        // safeDestroyMaterialInstance is a no-op (via runCatching) if the instance is already
+        // destroyed or invalid — robust against double-destroy.
+        ownedMaterialInstances.forEach { engine.safeDestroyMaterialInstance(it) }
         super.destroy()
     }
 }


### PR DESCRIPTION
## Summary

Pre-fix: [\`RenderableNode.destroy()\`](https://github.com/sceneview/sceneview/blob/main/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt#L65-L73) only destroyed the renderable component. Any \`MaterialInstance\` passed via the \`materialInstances\` constructor stayed alive in Filament's internal tables until engine teardown — a **steady-state memory leak** for the common per-demo pattern of creating a fresh \`materialLoader.createColorInstance(...)\` per \`GeometryNode\` and letting it go out of scope.

The samples-side [\`rememberMaterialInstance\`](https://github.com/sceneview/sceneview/blob/main/samples/common/src/main/java/io/github/sceneview/sample/RememberMaterialInstance.kt) helper (#937, #971, #979, #1071) papers over this for sample code, but library consumers writing their own demos hit the same trap.

## Fix

Add \`destroyMaterialsOnDispose: Boolean = false\` flag to \`RenderableNode\`'s \`primitiveCount\` constructor + propagate through \`GeometryNode\` (both the primary and single-material delegating constructors).

When \`true\`, \`destroy()\` calls \`engine.safeDestroyMaterialInstance(...)\` on every non-null entry of the materialInstances list. Default \`false\` for backward compatibility.

KDoc on both classes explains:
- When to set it **true** — node owns material lifetime end-to-end.
- When to leave it **false** — MaterialLoader or external \`DisposableEffect\` manages it.
- Caveat — calling \`engine.safeDestroyMaterialInstance\` directly does **not** clean up MaterialLoader's internal tracking set; for loader-managed materials, an external \`DisposableEffect\` with \`materialLoader.destroyMaterialInstance(...)\` is still preferred.

## Acceptance (from #1123)

- [x] \`destroyMaterialsOnDispose\` flag added (default \`false\`)
- [x] KDoc explains when to set it true
- [ ] At least 1 demo migrated to use \`destroyMaterialsOnDispose = true\` — **filing as follow-up** to keep this PR scoped (most samples already use the \`rememberMaterialInstance\` helper which handles disposal externally, so a migration target needs to be chosen carefully)
- [ ] Long-term: consider making \`true\` the default for v5.0 — **v5.0 milestone task**

## Validation

- ✅ \`./gradlew :sceneview:compileReleaseKotlin\` green
- ✅ \`./gradlew :sceneview:testDebugUnitTest\` green
- ❌ Regression test (build node with mock material, destroy, verify Filament MI count drops) not added — needs Filament instrumented context. Filing as follow-up if needed.

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)