### PR TITLE
fix(animation): SpringAnimator underdamped uses analytical velocity (#1126 item 1)

### DIFF
--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/animation/SpringAnimation.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/animation/SpringAnimation.kt
@@ -83,14 +83,18 @@ class SpringAnimator(
                     displacement * cosT +
                             ((velocity + zeta * omega0 * displacement) / dampedOmega) * sinT
                     )
+            // Analytical velocity of the damped harmonic oscillator (derivative of the
+            // displacement closed-form solution). Use this — not a finite-difference
+            // `(newDisplacement - displacement) / deltaSeconds` — so the result is
+            // frame-rate-independent. The critically-damped and overdamped branches below
+            // already follow the analytical pattern; this brings underdamped in line (#1126).
             val newVelocity = envelope * (
                     velocity * cosT -
                             (displacement * dampedOmega + velocity * zeta * omega0 / dampedOmega +
                                     zeta * omega0 * displacement * zeta * omega0 / dampedOmega) * sinT
                     )
-            // Recompute velocity via finite difference for stability
-            velocity = (newDisplacement - displacement) / deltaSeconds
             displacement = newDisplacement
+            velocity = newVelocity
         } else if (zeta == 1f) {
             // ── Critically damped ───────────────────────────────────────────
             val envelope = exp(-omega0 * deltaSeconds)

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/animation/SpringConfigTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/animation/SpringConfigTest.kt
@@ -126,4 +126,31 @@ class SpringConfigTest {
         assertTrue(animator.isSettled)
         assertClose(1f, animator.value)
     }
+
+    // ── Regression: frame-rate independence (#1126) ──────────────────────────────
+
+    @Test
+    fun springAnimatorUnderdampedConvergesAcrossFrameRates() {
+        // Pre-#1126: the underdamped branch overwrote the analytical velocity with a
+        // finite-difference `(newDisplacement - displacement) / deltaSeconds`. The
+        // displacement formula then read this lagged velocity on the next tick, so
+        // the trajectory drifted as a function of frame rate. At 30 fps the spring
+        // settled to a visibly different value than at 120 fps over the same total
+        // time — exactly the "underdamped lags at 30 fps" symptom #1126 reported.
+        //
+        // Post-fix: both branches use the analytical velocity → frame-rate independent.
+        val config = SpringConfig.BOUNCY  // underdamped (dampingRatio = 0.4)
+
+        val at30Hz = SpringAnimator(config)
+        val at120Hz = SpringAnimator(config)
+
+        // 1 second of simulation at each rate
+        repeat(30) { at30Hz.update(1f / 30f) }
+        repeat(120) { at120Hz.update(1f / 120f) }
+
+        // Values should agree to within 5% after 1 s — the analytical solver is
+        // approximation-free for the underdamped DHO closed-form. Pre-fix this
+        // tolerance was exceeded.
+        assertClose(at120Hz.value, at30Hz.value, epsilon = 0.05f)
+    }
 }


### PR DESCRIPTION
## Bug

[`SpringAnimation.kt:82-93`](https://github.com/sceneview/sceneview/blob/main/sceneview-core/src/commonMain/kotlin/io/github/sceneview/animation/SpringAnimation.kt#L82-L93): the underdamped branch of `SpringAnimator.update()` computed the analytical `newVelocity` from the DHO closed-form solution, then *discarded* it in favor of a finite-difference:

```kotlin
velocity = (newDisplacement - displacement) / deltaSeconds
```

This is the **average velocity over the tick window**. At 30 Hz that's averaging over 33 ms; at 120 Hz over 8.3 ms. The next tick reads this stale velocity in the displacement formula → trajectory drifts as a function of frame rate. 30 fps users observe underdamped springs lagging behind 60+ fps users on the same animation.

The critically-damped and overdamped branches already use the analytical `newVelocity`. Underdamped was the outlier.

## Fix (1-line semantic)

`velocity = newVelocity` instead of the finite-diff approximation. Plus an explanatory comment.

## Regression test

`springAnimatorUnderdampedConvergesAcrossFrameRates` — runs 1 s at 30 Hz vs 120 Hz with the `BOUNCY` preset and asserts values converge to within 5%. Pre-fix the divergence exceeded this tolerance because the velocity error compounded each tick through the displacement formula.

## Scope

This is **item 1 of 4** in the #1126 math/animation umbrella:
- ✅ Spring velocity (this PR)
- ❌ Slerp frame-rate dependence
- ❌ Matrix.decomposeRotation thread-safety
- ❌ Segment closest-points symmetry

#1126 stays open until the other 3 land.

Refs #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)