### PR TITLE
fix(collision): closestPointsBetweenSegments — Ericson §5.1.9 sign (#1126 item 4)

### DIFF
--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Capsule.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Capsule.kt
@@ -226,19 +226,29 @@ internal fun closestPointOnSegment(
 /**
  * Closest points between two line segments AB and CD.
  * Returns (closest on AB, closest on CD).
+ *
+ * Implements Christer Ericson, *Real-Time Collision Detection* §5.1.9.
+ *
+ * Pre-#1126 this routine used `r = c - a` and inherited a consistent sign
+ * flip on `d4`/`d5` (Ericson's `c`/`f`). The bug was masked for collinear
+ * inputs (where `denom ≈ 0` and the degenerate branch dominates) but
+ * surfaced as wildly wrong closest pairs on perpendicular / skew segments —
+ * e.g. AB=(0,0,0)→(2,0,0), CD=(1,1,0)→(1,3,0) returned `(0,0,0)/(1,2,0)`
+ * (distance √5) instead of the correct `(1,0,0)/(1,1,0)` (distance 1).
+ * Fix: align with Ericson's convention `r = a - c`.
  */
 internal fun closestPointsBetweenSegments(
     a: Vector3, b: Vector3, c: Vector3, d: Vector3
 ): Pair<Vector3, Vector3> {
     val ab = Vector3.subtract(b, a)
     val cd = Vector3.subtract(d, c)
-    val ac = Vector3.subtract(c, a)
+    val r = Vector3.subtract(a, c)  // Ericson's `r = p1 - p2`
 
-    val d1 = Vector3.dot(ab, ab)
-    val d2 = Vector3.dot(ab, cd)
-    val d3 = Vector3.dot(cd, cd)
-    val d4 = Vector3.dot(ab, ac)
-    val d5 = Vector3.dot(cd, ac)
+    val d1 = Vector3.dot(ab, ab)         // a in Ericson
+    val d2 = Vector3.dot(ab, cd)         // b in Ericson
+    val d3 = Vector3.dot(cd, cd)         // e in Ericson
+    val d4 = Vector3.dot(ab, r)          // c in Ericson
+    val d5 = Vector3.dot(cd, r)          // f in Ericson
 
     val denom = d1 * d3 - d2 * d2
 

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/collision/CapsuleTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/collision/CapsuleTest.kt
@@ -107,4 +107,60 @@ class CapsuleTest {
         assertTrue(abs(t - 1f) < 1e-5f)
         assertTrue(abs(closest.y - 2f) < 1e-5f)
     }
+
+    // ── Regression: closestPointsBetweenSegments — Ericson §5.1.9 (#1126) ────
+
+    private fun assertVecClose(expected: Vector3, actual: Vector3, eps: Float = 1e-4f) {
+        val dx = abs(expected.x - actual.x)
+        val dy = abs(expected.y - actual.y)
+        val dz = abs(expected.z - actual.z)
+        assertTrue(
+            dx < eps && dy < eps && dz < eps,
+            "Expected (${expected.x},${expected.y},${expected.z}) " +
+                    "but got (${actual.x},${actual.y},${actual.z})"
+        )
+    }
+
+    @Test
+    fun closestPointsBetweenSegmentsPerpendicular() {
+        // Canonical perpendicular skew case that pre-#1126 returned wildly wrong points:
+        // AB lies on x-axis from 0..2, CD is vertical at x=1 from y=1..y=3.
+        // Closest points are (1,0,0) on AB and (1,1,0) on CD (distance 1).
+        // Pre-fix: returned (0,0,0) and (1,2,0) — distance √5.
+        val (p1, p2) = closestPointsBetweenSegments(
+            a = Vector3(0f, 0f, 0f),
+            b = Vector3(2f, 0f, 0f),
+            c = Vector3(1f, 1f, 0f),
+            d = Vector3(1f, 3f, 0f)
+        )
+        assertVecClose(Vector3(1f, 0f, 0f), p1)
+        assertVecClose(Vector3(1f, 1f, 0f), p2)
+    }
+
+    @Test
+    fun closestPointsBetweenSegmentsSymmetricUnderSwap() {
+        // Swapping the two segments must mirror the result pair. Pre-#1126 the
+        // sign error broke this symmetry on non-collinear inputs.
+        val a = Vector3(0f, 0f, 0f); val b = Vector3(2f, 0f, 0f)
+        val c = Vector3(1f, 1f, 0f); val d = Vector3(1f, 3f, 0f)
+        val (p1, p2) = closestPointsBetweenSegments(a, b, c, d)
+        val (q1, q2) = closestPointsBetweenSegments(c, d, a, b)
+        assertVecClose(p1, q2)
+        assertVecClose(p2, q1)
+    }
+
+    @Test
+    fun closestPointsBetweenSegmentsCollinearSeparated() {
+        // Two collinear non-overlapping segments along x-axis.
+        // Closest pair is (1,0,0) and (2,0,0). The degenerate `denom ≈ 0`
+        // branch must still produce a correct pair.
+        val (p1, p2) = closestPointsBetweenSegments(
+            a = Vector3(0f, 0f, 0f),
+            b = Vector3(1f, 0f, 0f),
+            c = Vector3(2f, 0f, 0f),
+            d = Vector3(3f, 0f, 0f)
+        )
+        assertVecClose(Vector3(1f, 0f, 0f), p1)
+        assertVecClose(Vector3(2f, 0f, 0f), p2)
+    }
 }


### PR DESCRIPTION
## Bug

[`Capsule.kt:230-258`](https://github.com/sceneview/sceneview/blob/main/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Capsule.kt#L230-L258): the routine used `r = c - a` and inherited a consistent sign flip on `d4`/`d5` (Ericson's `c` and `f`). The bug was masked for collinear inputs (where `denom ≈ 0` and the degenerate branch dominates) but surfaced as wildly wrong closest pairs on perpendicular / skew segments.

## Concrete failing case

- AB = (0,0,0)→(2,0,0), CD = (1,1,0)→(1,3,0)
- Pre-fix returned **(0,0,0) and (1,2,0)** (distance √5)
- Correct answer **(1,0,0) and (1,1,0)** (distance 1)

This routine drives `capsuleCapsuleIntersection` → silently wrong capsule-capsule collision reports on generic geometry. The perpendicular-segments case is exactly the kind of pose a thin character's limbs hit during animation.

## Fix

Align with Ericson's *Real-Time Collision Detection* §5.1.9 convention `r = a - c` (single argument swap on `Vector3.subtract`). All downstream formulas (`s`, `t`, the two `t`-clamping branches) are correct against that convention with no further changes.

## Tests

3 regression tests added to `CapsuleTest`:
- `closestPointsBetweenSegmentsPerpendicular` — the canonical bug case
- `closestPointsBetweenSegmentsSymmetricUnderSwap` — pins that swapping (a,b) with (c,d) mirrors the result (broken pre-fix)
- `closestPointsBetweenSegmentsCollinearSeparated` — guards the degenerate `denom ≈ 0` branch

`:sceneview-core:allTests` green on JVM + iosSimulatorArm64.

**Item 4 of 4** in the #1126 math/animation umbrella.

Refs #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)