### PR TITLE
fix(math): slerp transform uses exponential decay (#1126 item 2)

### DIFF
--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/Math.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/Math.kt
@@ -23,6 +23,7 @@ import dev.romainguy.kotlin.math.translation
 import io.github.sceneview.collision.Matrix
 import io.github.sceneview.collision.Vector3
 import kotlin.math.abs
+import kotlin.math.exp
 import kotlin.math.max
 
 /** 2D position (x, y). */
@@ -161,15 +162,22 @@ fun normalToTangent(normal: Float3): Quaternion {
 }
 
 /**
- * ### Spherical Linear Interpolate a transform
+ * Spherical / linear interpolate a transform toward [end] with frame-rate-independent
+ * exponential decay.
  *
- * @epsilon Smooth Epsilon minimum equality limit
- * This is used to avoid very near positions/rotations/scale smooth modifications.
- * It prevents:
- * - The modifications from appearing too quick if the ranges are too close because of linearly
- * interpolation for upper dot products
- * - The end value to take to much time to be reached
- * - The end to never be reached because of matrices calculations floating points
+ * The interpolation factor is `1 - exp(-speed * deltaSeconds)`, which makes the result
+ * invariant to the time-step distribution: 30 ticks at 1/30 s and 120 ticks at 1/120 s
+ * produce the same trajectory over the same wall-clock total.
+ *
+ * Pre-#1126 this function used the linear approximation `clamp(speed * dt, 0, 1)` —
+ * correct only at high frame rates, with visible divergence (and outright snap-to-target
+ * when `speed * dt > 1`) at lower frame rates.
+ *
+ * @param start Current transform.
+ * @param end Target transform.
+ * @param deltaSeconds Time since last call. Negative values are clamped to 0.
+ * @param speed Convergence rate (s⁻¹). Higher = faster approach. The 63 % point is
+ * reached after `1 / speed` seconds regardless of the caller's tick rate.
  */
 fun slerp(
     start: Transform,
@@ -177,7 +185,11 @@ fun slerp(
     deltaSeconds: Double,
     speed: Float
 ): Transform {
-    val lerpFactor = clamp((deltaSeconds * speed).toFloat(), 0.0f, 1.0f)
+    val lerpFactor = if (deltaSeconds <= 0.0 || speed <= 0f) {
+        0f
+    } else {
+        (1.0 - exp(-speed.toDouble() * deltaSeconds)).toFloat().coerceIn(0f, 1f)
+    }
     return Transform(
         position = lerp(start.position, end.position, lerpFactor),
         quaternion = slerp(start.quaternion, end.quaternion, lerpFactor),

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/animation/SmoothTransformTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/animation/SmoothTransformTest.kt
@@ -4,6 +4,8 @@ import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.math.Scale
 import io.github.sceneview.math.Transform
+import kotlin.math.abs
+import kotlin.math.exp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -115,5 +117,51 @@ class SmoothTransformTest {
         // Actually slerp with factor 0 returns start, which equals current → convergence triggers
         // This is fine — the point is no NaN or crash
         assertFalse(result.state.current.position.x.isNaN())
+    }
+
+    // ── Regression: slerp frame-rate independence (#1126 item 2) ──────────────────
+
+    @Test
+    fun smoothTransformConvergesIndependentlyOfFrameRate() {
+        // Pre-#1126: lerpFactor = clamp(speed * dt, 0, 1) — linear approximation that
+        // diverges at low frame rates and even snaps to target when speed*dt >= 1.
+        // Post-fix: lerpFactor = 1 - exp(-speed * dt) is the standard frame-rate-
+        // independent exponential decay used by Unity's Lerp + every game-physics
+        // textbook (Glenn Fiedler, "Fix Your Timestep!").
+        //
+        // Pre-fix at speed=20 over 0.1s:
+        //   30 Hz (3 ticks of 0.667 each) → (1 - 0.667)^3 = 3.7% remaining → 96.3%
+        //   120 Hz (12 ticks of 0.167 each) → (1 - 0.167)^12 = 11.2% remaining → 88.8%
+        //   Divergence ≈ 7.5 % at the same wall-clock instant.
+        // Post-fix:
+        //   Both rates converge to 1 - exp(-2) ≈ 86.5 % — frame-rate-independent.
+        val speed = 20f
+        val totalSeconds = 0.1
+
+        val ticks30 = 3
+        val ticks120 = 12
+        val dt30 = totalSeconds / ticks30
+        val dt120 = totalSeconds / ticks120
+
+        var at30Hz = SmoothTransformState(current = origin, target = target, speed = speed)
+        repeat(ticks30) { at30Hz = updateSmoothTransform(at30Hz, dt30).state }
+
+        var at120Hz = SmoothTransformState(current = origin, target = target, speed = speed)
+        repeat(ticks120) { at120Hz = updateSmoothTransform(at120Hz, dt120).state }
+
+        // Both rates should land within 2 % of each other at the same wall-clock instant.
+        val deltaX = abs(at30Hz.current.position.x - at120Hz.current.position.x)
+        assertTrue(
+            deltaX < 0.2f,
+            "30 Hz x=${at30Hz.current.position.x} vs 120 Hz x=${at120Hz.current.position.x} " +
+                    "diverged by $deltaX (>0.2 of the 0..10 range); pre-fix divergence was >0.75."
+        )
+
+        // And both should be near the analytical target of (1 - exp(-speed*total)) * 10.
+        val expected = (1.0 - exp(-speed.toDouble() * totalSeconds)).toFloat() * 10f
+        assertTrue(
+            abs(at120Hz.current.position.x - expected) < 0.1f,
+            "120 Hz x=${at120Hz.current.position.x} should be near analytical $expected"
+        )
     }
 }


### PR DESCRIPTION
## Bug

[`Math.kt:174-186`](https://github.com/sceneview/sceneview/blob/main/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/Math.kt#L174-L186) computed:

```kotlin
val lerpFactor = clamp((deltaSeconds * speed).toFloat(), 0.0f, 1.0f)
```

This is the **linear approximation** of an exponential decay rate. At low frame rates or high speeds it diverges visibly from a true frame-rate-independent interpolation; with `speed * dt >= 1` it snaps to target in a single frame, making the same animation produce different trajectories at 30 fps vs 120 fps.

Concrete numbers at speed=20 over 0.1 s wall-clock:
- 30 Hz (3 ticks × 0.667 each): `(1 - 0.667)^3` = 3.7 % remaining → 96.3 % of way to target
- 120 Hz (12 ticks × 0.167 each): `(1 - 0.167)^12` = 11.2 % remaining → 88.8 % of way to target
- **Same wall-clock, ~7.5 % divergence.**

## Fix

`lerpFactor = 1 - exp(-speed * deltaSeconds)` — the standard exponential decay formula (Glenn Fiedler, *Fix Your Timestep!*; Unity's Lerp pattern). Both rates now converge to `1 - exp(-2)` ≈ 86.5 % — identical.

Semantic shift on `speed`: from "linear ratio per second (≈ rate at high fps)" to "exponential rate constant — 63 % point reached after `1 / speed` seconds regardless of tick distribution". Existing callers see slightly different absolute timings at the same `speed` value (slower at low fps where the linear approximation was overshooting); the visual feel is preserved because the convergence rate is now what was intended.

Also guards `deltaSeconds <= 0 || speed <= 0` → `lerpFactor = 0` (previously silently produced a negative `lerpFactor` that was then clamped).

## Test

`smoothTransformConvergesIndependentlyOfFrameRate` in `SmoothTransformTest.kt` drives the helper at 30 Hz and 120 Hz for the same 0.1 s wall-clock and asserts both reach the same position within 2 % of the 0..10 m range. Pre-fix the divergence was ~7.5 %.

`:sceneview-core:allTests` green on JVM + iosSimulatorArm64 + jsTest.

**Item 2 of 4** in the #1126 math/animation umbrella.

Refs #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)