### PR TITLE
fix(ar): AR cubemap Texture.Builder needs GEN_MIPMAPPABLE (v4.3.0 BLOCKER)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/light/LightEstimator.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/light/LightEstimator.kt
@@ -346,6 +346,16 @@ class LightEstimator(
                                 .levels(0xff)
                                 .sampler(Texture.Sampler.SAMPLER_CUBEMAP)
                                 .format(Texture.InternalFormat.R11F_G11F_B10F)
+                                // GEN_MIPMAPPABLE is REQUIRED — `iblPrefilter.specularFilter()`
+                                // below internally calls `Texture.generateMipmaps()`, which
+                                // Filament 1.70+ asserts on if the texture wasn't built with
+                                // this usage flag. Pre-PR #1086 the specular prefilter was off
+                                // by default so the missing flag was latent; flipping the
+                                // default to `true` then made every AR demo SIGABRT on the
+                                // first cubemap update (caught by CORR-D visual QA on
+                                // Pixel 9). Cross-reference: ImageTexture.kt:23-26 already
+                                // applies the same flag for the same reason.
+                                .usage(Texture.Usage.DEFAULT or Texture.Usage.GEN_MIPMAPPABLE)
                                 .build(engine)
                                 .also {
                                     cubeMapTexture = it


### PR DESCRIPTION
## 🛑 v4.3.0 BLOCKER

CORR-D visual QA on Pixel 9 (Android 16) caught **SIGABRT on EVERY AR demo launch** since PR [#1086](https://github.com/sceneview/sceneview/pull/1086) flipped `environmentalHdrSpecularFilter` default to `true`:

```
Filament: Precondition in generateMipmaps:767
reason: Texture usage does not have GEN_MIPMAPPABLE set
Fatal signal 6 (SIGABRT)
```

Full CORR-D report: [#1106 comment](https://github.com/sceneview/sceneview/issues/1106#issuecomment-).

## Root cause

`iblPrefilter.specularFilter()` (called when `environmentalHdrSpecularFilter == true`) internally invokes `Texture.generateMipmaps()`. Filament 1.70+ asserts on this if the texture wasn't built with `Texture.Usage.GEN_MIPMAPPABLE`. Pre-#1086 the prefilter was off by default so the missing flag was latent — until PR #1086 made the cubemap go through the prefilter unconditionally.

## Fix

The exact pattern already used in [`ImageTexture.kt:23-26`](https://github.com/sceneview/sceneview/blob/main/sceneview/src/main/java/io/github/sceneview/texture/ImageTexture.kt#L23-L26) for the same reason:

```kotlin
.usage(Texture.Usage.DEFAULT or Texture.Usage.GEN_MIPMAPPABLE)
```

Single 2-line addition to the `Texture.Builder()` chain in [LightEstimator.kt:343-352](https://github.com/sceneview/sceneview/blob/main/arsceneview/src/main/java/io/github/sceneview/ar/light/LightEstimator.kt#L343-L352).

## Validation

- ✅ `./gradlew :arsceneview:compileReleaseKotlin` green
- ✅ `./gradlew :arsceneview:testDebugUnitTest` green
- 🟡 On-device re-verification on Pixel 9 to follow this PR's merge (visual smoke from CORR-D umbrella #1106 to be re-run, expected to flip from BLOCKING-REGRESSION-FOUND → CLEAR-FOR-v4.3.0-CUT)

## v4.3.0 cut gate

This unblocks the v4.3.0 cut that CORR-D's BLOCKING verdict was holding. The remaining 4/7 targeted-PR checks (#1079, #1098, #1100, #1092) were all PASS or N/A. After this fix lands the AR demos should also be CLEAR.

Refs #1106 (visual QA umbrella, CORR-D report), #1086 (the spec filter default flip that exposed the latent bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)