### PR TITLE
feat(ios): port LightSlot + .fillLight(_:) to ARSceneView (#1138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added — iOS parity: `LightSlot` + `.fillLight(_:)` on `ARSceneView` ([#1138](https://github.com/sceneview/sceneview/issues/1138))
+
+Port the second half of Android v4.3.0's `#1063` (dual-light AR baseline + `ENVIRONMENTAL_HDR` default) to `SceneViewSwift.ARSceneView`. The 3D `SceneView` already shipped these in v4.2.0 (`#1016`); AR was the missing surface.
+
+- **`.mainLight(_:)` / `.fillLight(_:)` modifiers on `ARSceneView`** — same `LightSlot` enum as the 3D `SceneView`. Default `.systemDefault` provisions a `10 000`-lux directional main + a `3 000`-lux fill, matching Android's `ARSceneView(mainLightNode = …, fillLightNode = …)` defaults.
+- **Reactive swap path** — when the caller mutates the modifier value, the previous light's `AnchorEntity` is removed from `arView.scene` and a new one is added in its place. Mirrors `Scene.kt:540`'s `prevFillLightRef` diff pattern. No full RealityView teardown.
+- **`ENVIRONMENTAL_HDR` parity documented** — `config.environmentTexturing = .automatic` (already set, now annotated) is the ARKit equivalent of ARCore's `Config.LightEstimationMode.ENVIRONMENTAL_HDR`. Both drive PBR cubemap reflections for runtime-built environment probes; neither exposes a per-frame directional light estimate on `fillLight`.
+- **Tests**: 9 pinning tests in `ARSceneViewTests.swift` (default slots, modifier copy-semantics, `.disabled` round-trip, `.custom(LightNode)` entity-identity retention, last-modifier-wins, chaining with `.cameraExposure` + `.onSessionStarted`).
+- **Docs sync**: `docs/docs/cheatsheet-ios.md` AR section + Android↔Apple mapping table; `llms.txt` (root + `docs/docs`) ARSceneView signature + LightSlot notes.
+
 ## v4.3.0 — Android rendering pipeline overhaul + iOS CameraControls.pan/.firstPerson + ARRecorder + parity table (2026-05-14)
 
 **Status**: shipped. 14-PR Android rendering audit (#1062 → #1142) hardens AR + 3D

--- a/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
@@ -36,6 +36,21 @@ public struct ARSceneView: UIViewRepresentable {
     private var onImageDetected: ((String, AnchorNode, ARView) -> Void)?
     private var onFrame: ((ARFrame, ARView) -> Void)?
 
+    // Light slot overrides — read once during scene setup and re-applied via
+    // `updateUIView` when the caller mutates the modifier value. Defaults to
+    // `.systemDefault` which provisions Android-parity 10 000-lux main + 3 000-lux
+    // fill (matches PR #1136 / #1063 — `ARSceneView` Android exposes
+    // `mainLightNode` + `fillLightNode` parameters with the same defaults).
+    //
+    // ARCore's `ENVIRONMENTAL_HDR` light estimation only drives `mainLightNode`
+    // on Android (it returns SH coefficients and main-light direction/intensity).
+    // ARKit's `.automatic` environment texturing is the closest equivalent — it
+    // populates a runtime cubemap on `ARView` for PBR reflections — but does NOT
+    // mutate any explicit directional light. The fill light therefore keeps its
+    // baseline intensity each frame on both platforms.
+    var mainLightSlot: LightSlot = .systemDefault
+    var fillLightSlot: LightSlot = .systemDefault
+
     /// Plane detection modes matching Android's ARCore config.
     public enum PlaneDetectionMode: Sendable {
         case none
@@ -143,6 +158,60 @@ public struct ARSceneView: UIViewRepresentable {
         return copy
     }
 
+    /// Configures the main / key directional light slot for the AR scene.
+    ///
+    /// Mirrors SceneView Android's `ARSceneView(mainLightNode = ...)`
+    /// composable parameter (`ARScene.kt:294`). Default (`.systemDefault`):
+    /// directional light at `10 000` lux pointing straight down (`-Y`),
+    /// shadow casting enabled — same baseline as the 3D ``SceneView``.
+    ///
+    /// On Android, ARCore's `ENVIRONMENTAL_HDR` light estimation mutates
+    /// the main light's color + intensity each frame. ARKit has no
+    /// equivalent on the explicit-light side; instead `.automatic`
+    /// environment texturing populates the IBL cubemap for PBR reflections.
+    /// The directional light therefore keeps its baseline values unless
+    /// you override them via `.custom(LightNode...)`.
+    ///
+    /// ```swift
+    /// ARSceneView(planeDetection: .horizontal)
+    ///   .mainLight(.custom(LightNode.directional(intensity: 5_000)))  // dimmer key
+    ///
+    /// ARSceneView(planeDetection: .horizontal)
+    ///   .mainLight(.disabled)                                          // IBL-only AR
+    /// ```
+    public func mainLight(_ slot: LightSlot) -> ARSceneView {
+        var copy = self
+        copy.mainLightSlot = slot
+        return copy
+    }
+
+    /// Configures the secondary fill directional light slot for the AR scene.
+    ///
+    /// Mirrors SceneView Android's `ARSceneView(fillLightNode = ...)`
+    /// composable parameter shipped in PR #1136 (closes the iOS half of
+    /// `#1063`). Default (`.systemDefault`): ``LightNode/fill(color:intensity:castsShadow:)``
+    /// at `3 000` lux, no shadow, oriented along the canonical Android
+    /// direction `(0.5, -0.5, 0.5)` (upper-back-left → down-front-right)
+    /// so the unlit side of objects gets a soft kick without flattening
+    /// the AR shading.
+    ///
+    /// Pair with ``mainLight(_:)`` to fully override the dual-light setup.
+    /// Pass `.disabled` for a single-light AR scene (rare — most demos
+    /// look harsh with a single hard directional light + no fill).
+    ///
+    /// ```swift
+    /// ARSceneView(planeDetection: .horizontal)
+    ///   .fillLight(.custom(LightNode.fill(intensity: 6_000)))   // brighter fill
+    ///
+    /// ARSceneView(planeDetection: .horizontal)
+    ///   .fillLight(.disabled)                                    // single-light AR
+    /// ```
+    public func fillLight(_ slot: LightSlot) -> ARSceneView {
+        var copy = self
+        copy.fillLightSlot = slot
+        return copy
+    }
+
     // MARK: - UIViewRepresentable
 
     public func makeUIView(context: Context) -> ARView {
@@ -152,6 +221,12 @@ public struct ARSceneView: UIViewRepresentable {
         // Configure AR session
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = planeDetection.arPlaneDetection
+        // RealityKit's `.automatic` environment texturing is the functional
+        // equivalent of ARCore's `Config.LightEstimationMode.ENVIRONMENTAL_HDR`
+        // (Android default since v4.3.0 / `#1063`) — ARKit auto-builds the
+        // runtime cubemap that drives PBR reflections on metallic + glossy
+        // materials. There is no enum to toggle: it's on by default, off when
+        // unsupported. Closes the env-texturing half of #1138.
         config.environmentTexturing = .automatic
 
         // Image tracking
@@ -192,6 +267,17 @@ public struct ARSceneView: UIViewRepresentable {
         // Store reference for coordinator
         context.coordinator.arView = arView
 
+        // Provision both light slots BEFORE the host app's session-started callback
+        // runs, so user-supplied content sees the dual-light baseline already in
+        // place. Mirrors Android's `ARSceneView { content }` ordering where the
+        // composable's `mainLightNode` / `fillLightNode` parameters are added to
+        // the scene before the trailing `content` lambda. Closes the iOS half
+        // of #1063 / #1138.
+        provisionARLightSlot(.main, slot: mainLightSlot, in: arView, coordinator: context.coordinator)
+        provisionARLightSlot(.fill, slot: fillLightSlot, in: arView, coordinator: context.coordinator)
+        context.coordinator.appliedMainSlot = mainLightSlot
+        context.coordinator.appliedFillSlot = fillLightSlot
+
         // Initial content callback
         onSessionStarted?(arView)
 
@@ -207,6 +293,107 @@ public struct ARSceneView: UIViewRepresentable {
         // Converts the EV value to a CIColorControls brightness offset and installs
         // (or removes) a post-process render callback on the ARView.
         applyExposure(cameraExposure, to: arView)
+
+        // Diff light slots and swap entities when the caller's modifier value
+        // changed since last frame. Mirrors the reactive light path in
+        // ``SceneView`` (#1017) and Android's `prevFillLightRef` pattern in
+        // `ARScene.kt:540`. Closes #1138.
+        refreshARLightSlot(.main, slot: mainLightSlot, in: arView, coordinator: context.coordinator)
+        refreshARLightSlot(.fill, slot: fillLightSlot, in: arView, coordinator: context.coordinator)
+    }
+
+    // MARK: - Light slot provisioning (#1138)
+
+    /// Identifies the active light anchor in `arView.scene.anchors` so the
+    /// reactive diff can locate it on subsequent renders.
+    fileprivate enum LightSlotKind { case main, fill }
+
+    /// Provisions a directional light anchor on `arView.scene` for the given
+    /// slot, applying the per-slot defaults when `slot == .systemDefault`.
+    /// The anchor reference is cached on the coordinator so the reactive
+    /// diff in ``refreshARLightSlot(_:slot:in:coordinator:)`` can replace it
+    /// when the caller's `LightSlot` value changes.
+    ///
+    /// Lights are added as `AnchorEntity(world: .zero)` children of
+    /// `arView.scene` — RealityKit AR scenes are rooted in `AnchorEntity`s,
+    /// not bare `Entity`s, so this is the only way to inject a fixed-pose
+    /// directional light. The light still renders relative to the world
+    /// origin (which is where ARKit sets the session origin at session start).
+    @MainActor
+    private func provisionARLightSlot(
+        _ which: LightSlotKind,
+        slot: LightSlot,
+        in arView: ARView,
+        coordinator: Coordinator
+    ) {
+        let lightEntity: Entity?
+        switch slot {
+        case .systemDefault:
+            switch which {
+            case .main:
+                let main = LightNode.directional(
+                    color: .white,
+                    intensity: 10_000,
+                    castsShadow: true
+                )
+                main.entity.look(at: .zero, from: [0, 1, 0], relativeTo: nil)
+                lightEntity = main.entity
+            case .fill:
+                let fill = LightNode.fill(intensity: 3_000)
+                fill.entity.look(at: .zero, from: [-0.5, 0.5, -0.5], relativeTo: nil)
+                lightEntity = fill.entity
+            }
+        case .disabled:
+            lightEntity = nil
+        case .custom(let node):
+            lightEntity = node.entity
+        }
+        guard let lightEntity = lightEntity else { return }
+        // Wrap in a fixed world anchor so RealityKit accepts it at the scene
+        // root (an AR scene's `anchors` collection only takes AnchorEntities).
+        let anchor = AnchorEntity(world: .zero)
+        anchor.addChild(lightEntity)
+        arView.scene.addAnchor(anchor)
+        switch which {
+        case .main: coordinator.mainLightAnchor = anchor
+        case .fill: coordinator.fillLightAnchor = anchor
+        }
+    }
+
+    /// Diffs the current slot value against the cached `applied{Main,Fill}Slot`
+    /// stored on the coordinator and swaps the anchored light in-place when
+    /// they differ. Called from `updateUIView(_:context:)`. Closes #1138.
+    @MainActor
+    private func refreshARLightSlot(
+        _ which: LightSlotKind,
+        slot: LightSlot,
+        in arView: ARView,
+        coordinator: Coordinator
+    ) {
+        let applied: LightSlot? = (which == .main)
+            ? coordinator.appliedMainSlot
+            : coordinator.appliedFillSlot
+        guard applied != slot else { return }   // no change since last frame
+        // Remove the old tagged anchor if present.
+        let cachedAnchor: AnchorEntity?
+        switch which {
+        case .main: cachedAnchor = coordinator.mainLightAnchor
+        case .fill: cachedAnchor = coordinator.fillLightAnchor
+        }
+        if let cached = cachedAnchor {
+            arView.scene.removeAnchor(cached)
+        }
+        switch which {
+        case .main: coordinator.mainLightAnchor = nil
+        case .fill: coordinator.fillLightAnchor = nil
+        }
+        // Provision the new one (or none if the new slot is .disabled).
+        provisionARLightSlot(which, slot: slot, in: arView, coordinator: coordinator)
+        // Update the cache so the next frame's diff is a no-op.
+        switch which {
+        case .main: coordinator.appliedMainSlot = slot
+        case .fill: coordinator.appliedFillSlot = slot
+        }
     }
 
     // MARK: - Exposure helpers
@@ -298,6 +485,16 @@ public struct ARSceneView: UIViewRepresentable {
         var environmentTexturing: ARWorldTrackingConfiguration.EnvironmentTexturing = .automatic
         weak var arView: ARView?
         private var detectedImageNames: Set<String> = []
+
+        // Light-slot reactive plumbing — same pattern as ``SceneView`` (#1017)
+        // adapted for AR. The anchor refs let the diff in `refreshARLightSlot`
+        // tear down the previous light's `AnchorEntity` before adding a new one.
+        // `applied{Main,Fill}Slot` is the cached previous value; the diff is a
+        // no-op when it equals the current `LightSlot`.
+        var mainLightAnchor: AnchorEntity?
+        var fillLightAnchor: AnchorEntity?
+        var appliedMainSlot: LightSlot?
+        var appliedFillSlot: LightSlot?
 
         init(
             onTapOnPlane: ((SIMD3<Float>, ARView) -> Void)?,

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ARSceneViewTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ARSceneViewTests.swift
@@ -175,5 +175,102 @@ final class ARSceneViewTests: XCTestCase {
         let anchor = AnchorNode.plane(alignment: .vertical)
         XCTAssertNotNil(anchor)
     }
+
+    // MARK: - LightSlot modifier wire-up (#1138)
+
+    /// Default `ARSceneView()` must initialise both light slots to
+    /// ``LightSlot/systemDefault`` so the Android-parity dual-light
+    /// (10 000-lux main + 3 000-lux fill) renders out of the box.
+    func testDefaultLightSlotsAreSystemDefault() {
+        let view = ARSceneView()
+        XCTAssertEqual(view.mainLightSlot, .systemDefault)
+        XCTAssertEqual(view.fillLightSlot, .systemDefault)
+    }
+
+    /// `.mainLight(_:)` returns a new view (value-type copy semantics).
+    func testMainLightModifierReturnsNewInstance() {
+        let original = ARSceneView()
+        let modified = original.mainLight(.disabled)
+        XCTAssertEqual(modified.mainLightSlot, .disabled)
+        // Original instance must NOT have been mutated.
+        XCTAssertEqual(original.mainLightSlot, .systemDefault)
+    }
+
+    /// `.fillLight(_:)` returns a new view (value-type copy semantics).
+    func testFillLightModifierReturnsNewInstance() {
+        let original = ARSceneView()
+        let modified = original.fillLight(.disabled)
+        XCTAssertEqual(modified.fillLightSlot, .disabled)
+        XCTAssertEqual(original.fillLightSlot, .systemDefault)
+    }
+
+    /// `.fillLight(.disabled)` is the canonical single-light AR setup. Verify
+    /// the slot value round-trips through the modifier.
+    func testFillLightDisabledRoundTrip() {
+        let view = ARSceneView()
+            .fillLight(.disabled)
+        XCTAssertEqual(view.fillLightSlot, .disabled)
+    }
+
+    /// `.mainLight(.custom(LightNode))` stores the caller's node reference.
+    ///
+    /// `@MainActor` because ``LightNode/directional(color:intensity:castsShadow:)``
+    /// and ``LightNode/entity`` are MainActor-isolated (RealityKit
+    /// `DirectionalLight` lives on the main actor).
+    @MainActor
+    func testMainLightCustomLightNode() {
+        let custom = LightNode.directional(intensity: 5_000)
+        let view = ARSceneView()
+            .mainLight(.custom(custom))
+        // Equatable on .custom compares entity identity (===), so verify both
+        // the variant and the underlying entity reference.
+        if case .custom(let stored) = view.mainLightSlot {
+            XCTAssertTrue(stored.entity === custom.entity)
+        } else {
+            XCTFail("Expected .custom slot, got \(view.mainLightSlot)")
+        }
+    }
+
+    /// `.fillLight(.custom(LightNode))` stores the caller's node reference.
+    @MainActor
+    func testFillLightCustomLightNode() {
+        let brighterFill = LightNode.fill(intensity: 6_000)
+        let view = ARSceneView()
+            .fillLight(.custom(brighterFill))
+        if case .custom(let stored) = view.fillLightSlot {
+            XCTAssertTrue(stored.entity === brighterFill.entity)
+        } else {
+            XCTFail("Expected .custom slot, got \(view.fillLightSlot)")
+        }
+    }
+
+    /// Calling `.mainLight(_:)` twice — the last value wins (copy semantics).
+    func testMainLightModifierLastWins() {
+        let view = ARSceneView()
+            .mainLight(.disabled)
+            .mainLight(.systemDefault)
+        XCTAssertEqual(view.mainLightSlot, .systemDefault)
+    }
+
+    /// Calling `.fillLight(_:)` twice — the last value wins (copy semantics).
+    func testFillLightModifierLastWins() {
+        let view = ARSceneView()
+            .fillLight(.disabled)
+            .fillLight(.systemDefault)
+        XCTAssertEqual(view.fillLightSlot, .systemDefault)
+    }
+
+    /// Chaining `.mainLight` + `.fillLight` + `.cameraExposure` + `.onSessionStarted`
+    /// must all return a valid view (no compile errors, no crashes).
+    @MainActor
+    func testLightModifiersChainWithOtherModifiers() {
+        let view = ARSceneView(planeDetection: .horizontal)
+            .mainLight(.custom(LightNode.directional(intensity: 5_000)))
+            .fillLight(.disabled)
+            .cameraExposure(0.5)
+            .onSessionStarted { _ in }
+        XCTAssertNotNil(view)
+        XCTAssertEqual(view.fillLightSlot, .disabled)
+    }
 }
 #endif // os(iOS)

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -68,11 +68,23 @@ ARSceneView(
     }
 )
 .onSessionStarted { arView in }       // called when AR session begins
+.mainLight(.systemDefault)             // v4.3.0+ — see LightSlot (default 10 000-lux directional + shadow)
+.fillLight(.systemDefault)             // v4.3.0+ — Android-parity 3 000-lux fill on by default
 ```
 
 Environment texturing defaults to `.automatic` — RealityKit's equivalent of ARCore's
 `ENVIRONMENTAL_HDR` (which became the Android default in v4.3.0, `#1063`). PBR reflections
 are driven by runtime-built environment probes; no configuration knob is exposed.
+
+The dual-light setup matches the 3D ``SceneView`` defaults (issue [`#1138`](https://github.com/sceneview/sceneview/issues/1138)).
+ARKit has no equivalent of ARCore's directional-light estimation, so the explicit lights
+keep their baseline intensities each frame. Override or disable them via:
+
+```swift
+ARSceneView(planeDetection: .horizontal)
+  .mainLight(.custom(LightNode.directional(intensity: 5_000)))   // dimmer key light
+  .fillLight(.disabled)                                            // single-light AR
+```
 
 ## ARRecorder (v4.3.0+, record-only)
 
@@ -369,6 +381,9 @@ model?.stopAllAnimations()
 | `CubeNode(size, material)` | `GeometryNode.cube(size:color:)` |
 | `SphereNode(radius, material)` | `GeometryNode.sphere(radius:color:)` |
 | `LightNode(type, apply = { })` | `LightNode.directional(...)` / `.point(...)` / `.spot(...)` |
+| `Scene(mainLightNode = …, fillLightNode = …)` (3D) | `.mainLight(_:)` / `.fillLight(_:)` on `SceneView` (v4.2.0+) |
+| `ARSceneView(mainLightNode = …, fillLightNode = …)` (AR) | `.mainLight(_:)` / `.fillLight(_:)` on `ARSceneView` (v4.3.0+, `#1138`) |
+| `Config.LightEstimationMode.ENVIRONMENTAL_HDR` | `ARWorldTrackingConfiguration.environmentTexturing = .automatic` (on by default in `ARSceneView`) |
 | `rememberEnvironmentLoader` | `.environment(.studio)` view modifier |
 | `rememberCameraManipulator()` | `.cameraControls(.orbit)` view modifier |
 | `AnchorNode(anchor)` | `AnchorNode.world(position:)` |

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -3119,6 +3119,8 @@ View modifiers (chainable):
 .onSessionStarted(_ handler: @escaping (ARView) -> Void) -> ARSceneView
 .cameraExposure(_ ev: Float?) -> ARSceneView   // EV stops; iOS 15+ CIColorControls post-process
 .onFrame(_ handler: @escaping (ARFrame, ARView) -> Void) -> ARSceneView
+.mainLight(_ slot: LightSlot) -> ARSceneView   // v4.3.0+ — Android-parity directional key light (#1138)
+.fillLight(_ slot: LightSlot) -> ARSceneView   // v4.3.0+ — Android-parity dual-light AR baseline (#1138)
 ```
 
 `PlaneDetectionMode` values: `.none`, `.horizontal`, `.vertical`, `.both`
@@ -3127,6 +3129,13 @@ View modifiers (chainable):
 - Mirrors Android's `ARSceneView(cameraExposure: Float?)`.
 - Positive values brighten; negative values darken. One stop = ±0.5 brightness unit.
 - Implemented via `ARView.renderCallbacks.postProcess` (iOS 15+); no-op on earlier versions.
+
+`mainLight` / `fillLight` notes (v4.3.0+, `#1138` — iOS half of `#1063`):
+- Mirrors Android's `ARSceneView(mainLightNode = …, fillLightNode = …)` parameters.
+- Default `LightSlot.systemDefault` provisions a `10 000`-lux directional main + a `3 000`-lux fill (matches the Android v4.1.0 BREAKING render-defaults change). Same `LightSlot` enum as the 3D ``SceneView``.
+- ARKit has no equivalent of ARCore's `ENVIRONMENTAL_HDR` directional-light estimation; the explicit lights keep their baseline intensities each frame. `.automatic` environment texturing handles PBR cubemap reflections.
+- Pass `.disabled` on `fillLight` for a single-light AR setup (rare — looks harsh).
+- The light is added as a `AnchorEntity(world: .zero)` so it renders at session-start origin.
 
 Minimal AR usage:
 ```swift

--- a/llms.txt
+++ b/llms.txt
@@ -3119,6 +3119,8 @@ View modifiers (chainable):
 .onSessionStarted(_ handler: @escaping (ARView) -> Void) -> ARSceneView
 .cameraExposure(_ ev: Float?) -> ARSceneView   // EV stops; iOS 15+ CIColorControls post-process
 .onFrame(_ handler: @escaping (ARFrame, ARView) -> Void) -> ARSceneView
+.mainLight(_ slot: LightSlot) -> ARSceneView   // v4.3.0+ — Android-parity directional key light (#1138)
+.fillLight(_ slot: LightSlot) -> ARSceneView   // v4.3.0+ — Android-parity dual-light AR baseline (#1138)
 ```
 
 `PlaneDetectionMode` values: `.none`, `.horizontal`, `.vertical`, `.both`
@@ -3127,6 +3129,13 @@ View modifiers (chainable):
 - Mirrors Android's `ARSceneView(cameraExposure: Float?)`.
 - Positive values brighten; negative values darken. One stop = ±0.5 brightness unit.
 - Implemented via `ARView.renderCallbacks.postProcess` (iOS 15+); no-op on earlier versions.
+
+`mainLight` / `fillLight` notes (v4.3.0+, `#1138` — iOS half of `#1063`):
+- Mirrors Android's `ARSceneView(mainLightNode = …, fillLightNode = …)` parameters.
+- Default `LightSlot.systemDefault` provisions a `10 000`-lux directional main + a `3 000`-lux fill (matches the Android v4.1.0 BREAKING render-defaults change). Same `LightSlot` enum as the 3D ``SceneView``.
+- ARKit has no equivalent of ARCore's `ENVIRONMENTAL_HDR` directional-light estimation; the explicit lights keep their baseline intensities each frame. `.automatic` environment texturing handles PBR cubemap reflections.
+- Pass `.disabled` on `fillLight` for a single-light AR setup (rare — looks harsh).
+- The light is added as a `AnchorEntity(world: .zero)` so it renders at session-start origin.
 
 Minimal AR usage:
 ```swift


### PR DESCRIPTION
## Summary

Ports the second half of Android v4.3.0's [#1063](https://github.com/sceneview/sceneview/issues/1063) (dual-light AR baseline + `ENVIRONMENTAL_HDR` default) to `SceneViewSwift.ARSceneView`. The 3D `SceneView` already shipped these in v4.2.0 ([#1016](https://github.com/sceneview/sceneview/pull/1016)); AR was the missing surface, surfaced by the [PR #1136](https://github.com/sceneview/sceneview/pull/1136) review.

- `.mainLight(_:)` / `.fillLight(_:)` modifiers on `ARSceneView` accept the same `LightSlot` enum used by the 3D `SceneView` (`.systemDefault` / `.disabled` / `.custom(LightNode)`).
- Default `.systemDefault` provisions a 10 000-lux directional main + a 3 000-lux fill, matching Android's `ARSceneView(mainLightNode = …, fillLightNode = …)` defaults from PR #1136.
- Reactive swap path mirrors `Scene.kt:540`'s `prevFillLightRef` diff — when the caller mutates the modifier value, the previous light's `AnchorEntity` is removed from `arView.scene` and a new one is added in its place. No full RealityView teardown.
- `config.environmentTexturing = .automatic` (already set) is now annotated as the ARKit equivalent of ARCore's `Config.LightEstimationMode.ENVIRONMENTAL_HDR` — both drive PBR cubemap reflections via runtime-built environment probes; neither exposes a per-frame fill-light estimate.

## Files touched

- `SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift` (+197 lines) — `mainLightSlot` / `fillLightSlot` fields, `.mainLight(_:)` / `.fillLight(_:)` modifiers, `provisionARLightSlot` / `refreshARLightSlot` helpers, Coordinator caches.
- `SceneViewSwift/Tests/SceneViewSwiftTests/ARSceneViewTests.swift` (+97 lines) — 9 pinning tests (default slots, modifier copy semantics, `.disabled` round-trip, `.custom(LightNode)` entity-identity retention, last-modifier-wins, chaining with `.cameraExposure` + `.onSessionStarted`).
- `CHANGELOG.md` — "Unreleased" entry under iOS parity.
- `docs/docs/cheatsheet-ios.md` — AR section + Android↔Apple mapping table.
- `llms.txt` (root + `docs/docs/llms.txt`) — ARSceneView signature + LightSlot notes.

## Test plan

- [x] `xcodebuild build -scheme SceneViewSwift -destination "platform=iOS Simulator,name=iPhone 16e"` → **BUILD SUCCEEDED**.
- [ ] `xcodebuild test -scheme SceneViewSwift` — local Xcode 26.3 / iPhone 16e fails to compile pre-existing tests (`LightNodeTests.swift`, `NodeBuilderTests.swift`, `AugmentedImageNodeTests.swift`) due to strict-concurrency / try-handling regressions ALREADY present on `main` (verified by stashing my changes and re-running). The CI runs on `iPhone 16 Pro` / different SDK where these pass. Skipping local test run, ios.yml workflow will validate.
- [x] `bash .claude/scripts/impact-check.sh` → PASS (1 pre-existing WARN about Swift-only nodes, unrelated to this PR).
- [x] iOS API parity surface mirrors the 3D `SceneView` `.mainLight(_:)` / `.fillLight(_:)` already shipped in v4.2.0.

## Followups (out of scope)

- `samples/ios-demo/.../ARSamples/ARLightingDemo.swift` demo file from the issue acceptance — defer to a follow-up so this PR can ship the library + tests first.
- Pre-existing `LightNodeTests.swift` strict-concurrency cleanup on Xcode 26.3+ local toolchains (tracked separately; CI iPhone 16 Pro passes).

Closes #1138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)