### PR TITLE
fix(ci): broken `android run \` multi-line in render-tests.yml + validator hardening (#1153)

### DIFF
--- a/.claude/scripts/check-workflow-scripts.sh
+++ b/.claude/scripts/check-workflow-scripts.sh
@@ -17,17 +17,27 @@
 #    as informational only (warnings, not gate failures), so the existing
 #    `run:` corpus stays green.
 #
-# Two real-world bugs that this gate would have caught at #1 time:
+# Three real-world bugs that this gate would have caught at #1 time:
 #   - PR #1068 used `[[ ... ]]` inside a `with.script:` block — shipped to
 #     main as a silent syntax error under dash; fixed by PR #1087.
 #   - PR #1068 used a multi-line `while ... done` block — sliced by the
 #     emulator runner's per-line `sh -c`; fixed by PR #1104.
+#   - HOTFIX-V430 (commit efc168bc) used a multi-line `android run \`
+#     backslash continuation — `dash -n` accepts a `\<EOL>` because the
+#     parser sees the whole file as one script, but the runner ships each
+#     line through `sh -c`, so the trailing `\` becomes a literal argv
+#     token (`Unmatched argument at index 2: '\\'`). Fixed by #1153, and
+#     the per-line slicing check below now catches the same class of bug.
 #
-# Both were validated locally on macOS, where `sh` is bash-backed, so the
-# original author saw zero failures. This script prevents that whole class
-# of bug by running the actual `dash` parser on every `with.script:` block.
+# All three were validated locally on macOS, where `sh` is bash-backed, so
+# the original authors saw zero failures. This script prevents that whole
+# class of bug by:
+#   - running the actual `dash` parser on every `with.script:` block, AND
+#   - simulating the per-line `sh -c` slicing the action does at runtime
+#     (catches trailing-backslash continuations + multi-line constructs
+#     that pass a whole-file syntax check but break under per-line exec).
 #
-# Closes #1114.
+# Closes #1114, #1153.
 
 set -euo pipefail
 
@@ -154,6 +164,34 @@ for f in "$TMPDIR_SCRIPTS/with-script"/*.sh; do
             sed 's/^/    /' "$f.sc.err"
             EXIT=1
         fi
+    fi
+
+    # Per-line slicing simulation. The ReactiveCircus runner exec's each
+    # logical line via `sh -c`, so trailing-backslash continuations are
+    # FATAL — the second physical line ships as its own command and the
+    # first one keeps a literal `\` in argv. `dash -n` above passes them
+    # because the whole-file parser glues continuations together first.
+    # awk handles inline `\` followed by EOL, ignoring quoted/escaped
+    # forms with a previous `\\` (rare in our corpus, but conservative).
+    if awk '
+        /\\[[:space:]]*$/ {
+            # A pure trailing `\` at EOL. Skip lines that are clearly
+            # comments (`#…\`) — those degrade to noise but not failures.
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            if (substr(line, 1, 1) == "#") next
+            print NR ": " $0
+            found = 1
+        }
+        END { exit found ? 1 : 0 }
+    ' "$f" > "$f.bslash.err"; then
+        : # no continuations found, OK
+    else
+        echo "::error::trailing-backslash continuation in $rel (line-by-line sh -c will mangle it)"
+        sed 's/^/    /' "$f.bslash.err"
+        echo "    Fix: collapse the multi-line invocation onto a single physical line,"
+        echo "    or split the action invocation across separate steps. See #1153."
+        EXIT=1
     fi
 done
 echo "  checked $SCRIPT_COUNT with.script: block(s)"

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -165,10 +165,13 @@ jobs:
             adb wait-for-device
             attempts=0; while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do sleep 2; attempts=$((attempts + 1)); done
 
-            # Install + launch atomically via the Android CLI.
-            android --no-metrics run \
-              --apks=samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk \
-              --activity=io.github.sceneview.demo/.MainActivity || true
+            # Install + launch atomically via the Android CLI. MUST live on a
+            # single physical line — see #1153: ReactiveCircus runs each line
+            # via `sh -c <line>`, so a trailing `\` becomes a literal argv
+            # token under POSIX `sh` and the second line ships standalone.
+            # The whole loop above (`attempts=0; while ...; done`) follows
+            # the same one-line rule and is documented at line 160-164.
+            android --no-metrics run --apks=samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk --activity=io.github.sceneview.demo/.MainActivity || true
             sleep 10
 
             mkdir -p demo-screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Documentation-only — no behavioral change.
 
 Sibling of [#1125](https://github.com/sceneview/sceneview/issues/1125) (PhysicsDemo). [`samples/android-demo/.../GeometryDemo.kt`](samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GeometryDemo.kt) added a 80 000-lux directional light on top of the v4.1.0 SceneView defaults (10 000-lux main + 3 000-lux fill + IBL @ 10 000), so the metallic/roughness sweep saturated to white at every slider value. Re-tuned to 5 000 lux to match PhysicsDemo's PR [#1144](https://github.com/sceneview/sceneview/pull/1144) retune — accent fill that complements the v4.1.0 defaults without dominating them. Acceptance #1125 only scanned for `100_000`, so 80 000 slipped through; this closes the gap.
 
+### Fixed — CI: `android-demo-screenshots` job unblocked + workflow validator hardened ([#1153](https://github.com/sceneview/sceneview/issues/1153))
+
+The v4.3.0 cut commit `efc168bc` introduced a multi-line backslash continuation in `.github/workflows/render-tests.yml` (the `android run \\ --apks=…` block under the `Capture demo screenshots` step). The `ReactiveCircus/android-emulator-runner@v2` action exec's each line of `with.script:` via `sh -c <line>`, so the trailing `\` survives as a literal argv token and `android run` died with `Unmatched argument at index 2: '\\'`. Every push to `main` since `efc168bc` failed that screenshot job, forcing chip PRs ([#1145](https://github.com/sceneview/sceneview/pull/1145) / [#1147](https://github.com/sceneview/sceneview/pull/1147) / [#1148](https://github.com/sceneview/sceneview/pull/1148) / [#1149](https://github.com/sceneview/sceneview/pull/1149)) to merge with `--admin` and hiding any genuine screenshot regression.
+
+- **Fix**: collapse the `android --no-metrics run …` invocation onto a single physical line, matching the documented per-line slicing rule already followed by the `attempts=0; while …; done` loop above it.
+- **Validator extension**: `.claude/scripts/check-workflow-scripts.sh` (shipped by [#1145](https://github.com/sceneview/sceneview/pull/1145)) now runs a per-line slicing simulation on every `with.script:` block — `dash -n` passes a `\<EOL>` because the whole-file parser splices continuations together first, but the runtime action does not. The new pass flags any trailing-backslash continuation and fails the PR check, so this class of bug can no longer ship to `main` undetected. Sanity-tested by reintroducing the original break locally — validator exits `1` with a pointed error message.
+- **Backwards compatibility**: `run:` blocks (which GitHub Actions defaults to `bash -e {0}`, executed as one script) are untouched; backslash continuations remain valid there. Only `with.script:` blocks (per-line `sh -c` semantics) are checked.
+
 ## Unreleased
 
 ### Added — iOS parity: `LightSlot` + `.fillLight(_:)` on `ARSceneView` ([#1138](https://github.com/sceneview/sceneview/issues/1138))


### PR DESCRIPTION
## Summary

Closes [#1153](https://github.com/sceneview/sceneview/issues/1153). Two fixes that together unblock CI on every push to `main`:

1. **`.github/workflows/render-tests.yml`** — collapse the broken multi-line `android run \` invocation introduced by the v4.3.0 cut commit [`efc168bc`](https://github.com/sceneview/sceneview/commit/efc168bc) onto a single physical line. The `ReactiveCircus/android-emulator-runner@v2` action exec's each line of `with.script:` via `sh -c <line>`, so the trailing `\` survives as a literal argv token and `android run` died with `Unmatched argument at index 2: '\\'`. The `attempts=0; while …; done` loop above already followed the one-line rule (documented at lines 160-164) — this fix extends that rule to the `android run` call right below it.

2. **`.claude/scripts/check-workflow-scripts.sh`** — extend the workflow validator (shipped by [#1145](https://github.com/sceneview/sceneview/pull/1145)) with a per-line slicing simulation pass. `dash -n` accepts a `\<EOL>` because the whole-file parser glues continuations together first, but the ReactiveCircus runner does not. New awk pass flags trailing-backslash continuations in `with.script:` blocks and fails the PR check, closing the gap that let `efc168bc` ship to `main` undetected.

3. **`CHANGELOG.md`** — entry under v4.3.1's `### Fixed — CI` section.

## Why this matters

Every push to `main` since `efc168bc` (4 PRs so far: #1145 / #1147 / #1148 / #1149) failed the `android-demo-screenshots` job, forcing each chip PR to merge with `--admin` and hiding any genuine screenshot regression.

## Validation

Local sanity test (documented in commit message):
- Validator on clean state: exits `0` ✅
- Reintroduce the original `efc168bc` break: validator exits `1` with pointed error message and line numbers ✅
- 102 existing `run:` blocks (Pass 2, bash-as-one-script) untouched — backslash continuations remain valid there ✅
- 2 existing `with.script:` blocks (Pass 1, per-line `sh -c`) still pass cleanly — no false positives ✅

## Backwards compatibility

- `with.script:` blocks only: trailing-backslash continuations now fail the validator.
- `run:` blocks (GitHub Actions defaults to `bash -e {0}`, single script execution): unchanged. The 102-block existing corpus includes many legitimate `\<EOL>` continuations (e.g. `curl -fsSL https://… \\ -o /tmp/foo`); all still pass.

## Test plan

- [x] Local `bash .claude/scripts/check-workflow-scripts.sh` → exit `0` on clean.
- [x] Local reintroduction of the bug → validator exit `1` with diagnostic.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-tests.yml'))"` → YAML valid.
- [x] `bash .claude/scripts/impact-check.sh` → PASS with 1 pre-existing warning unrelated to this change.
- [ ] CI: `pr-check` workflow runs the validator against this diff (auto on PR).
- [ ] CI: `render-tests` workflow `android-demo-screenshots` job goes green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)