### PR TITLE
fix(security): bump fast-xml-parser to 5.7.0+ via npm overrides (#139)

### DIFF
--- a/react-native/react-native-sceneview/package-lock.json
+++ b/react-native/react-native-sceneview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneview-sdk/react-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneview-sdk/react-native",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -2300,6 +2300,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4095,10 +4108,10 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -4108,7 +4121,28 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6604,6 +6638,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -7908,9 +7958,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
@@ -8453,6 +8503,22 @@
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/react-native/react-native-sceneview/package.json
+++ b/react-native/react-native-sceneview/package.json
@@ -54,6 +54,9 @@
     "react-native-builder-bob": "^0.23.0",
     "typescript": "^5.3.0"
   },
+  "overrides": {
+    "fast-xml-parser": "^5.7.0"
+  },
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #139](https://github.com/sceneview/sceneview/security/dependabot/139) — [CVE-2026-41650 / GHSA-gh4j-gqv2-49f6](https://github.com/NaturalIntelligence/fast-xml-parser/security/advisories/GHSA-gh4j-gqv2-49f6) — `fast-xml-parser` XMLBuilder fails to escape `-->` (comment) and `]]>` (CDATA) delimiters, allowing XML injection / XSS / SOAP-injection when user-controlled data flows into those contexts.

## Vulnerable package details

- **Package**: `fast-xml-parser` (npm, dev-only transitive)
- **Manifest**: `react-native/react-native-sceneview/package-lock.json`
- **Resolved version before fix**: `4.5.6`
- **First patched version**: `5.7.0`
- **Resolved version after fix**: `5.8.0`
- **Dependency chain**: `react-native` (devDep) → `@react-native-community/cli-platform-ios@11.4.1` → `fast-xml-parser@^4.0.12`
- **Severity**: moderate (CVSS 6.1)

## Fix strategy

Added an npm `overrides` block to `react-native/react-native-sceneview/package.json`:

```json
"overrides": {
  "fast-xml-parser": "^5.7.0"
}
```

This is the standard npm 8+ way to force a safe transitive version without bumping the direct parent (which would require migrating `react-native` from 0.72 to a newer line — out of scope for a security patch). `npm install --package-lock-only` regenerated the lockfile cleanly; `npm audit` reports `found 0 vulnerabilities`.

## Risk assessment

- **Dev-only**: every entry in the affected chain is marked `"dev": true` in the lockfile. No published runtime artefact from `@sceneview-sdk/react-native` ships `fast-xml-parser`.
- **API compatibility**: `cli-platform-ios` consumes `XMLParser` to read Xcode `.plist` files at build time. The parser-side API surface is stable across 4.x → 5.x; the 5.7.0 fix changes XMLBuilder escape behavior, which is not invoked by this consumer.
- **No source-code change** in any TS/Kotlin/Swift surface.

## Test plan

- [x] `npm install --package-lock-only --ignore-scripts` regenerates the lockfile with `fast-xml-parser@5.8.0`
- [x] `npm audit` → `found 0 vulnerabilities`
- [x] Lockfile diff is isolated to `fast-xml-parser` + its updated dependency closure (`strnum` bumped)
- [ ] CI green on this branch (Dependabot scan should re-trigger and close #139)

🤖 Generated with [Claude Code](https://claude.com/claude-code)