### PR TITLE
fix(ios): inject SKETCHFAB_API_KEY into TestFlight + App Store binaries (#1157)

### DIFF
--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -157,6 +157,16 @@ jobs:
             -clonedSourcePackagesDirPath SourcePackages
 
       - name: Build archive
+        # Inject the Sketchfab API key as a user-defined build setting so it
+        # gets substituted into `Info.plist`'s `SketchfabAPIKey =
+        # $(SKETCHFAB_API_KEY)` placeholder at archive time. Environment
+        # variables set on the runner don't survive `xcodebuild archive` into
+        # the shipped `.ipa`, so the legacy `ProcessInfo` lookup in
+        # `SketchfabConfig.swift` would return nil for every TestFlight +
+        # App Store build (issue #1157). Mirrors the Android pattern in
+        # `play-store.yml:170` / `build-apks.yml:47`.
+        env:
+          SKETCHFAB_API_KEY: ${{ secrets.SKETCHFAB_API_KEY }}
         run: |
           xcodebuild archive \
             -project SceneViewDemo.xcodeproj \
@@ -172,7 +182,8 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             DEVELOPMENT_TEAM=5G3DZ3TH45 \
             PROVISIONING_PROFILE_SPECIFIER="$PROVISIONING_PROFILE_UUID" \
-            ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
+            ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO \
+            SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY"
 
       - name: Export IPA and upload to TestFlight
         env:
@@ -420,6 +431,12 @@ jobs:
             -clonedSourcePackagesDirPath SourcePackages
 
       - name: Build archive
+        # See iOS variant above for the rationale on `SKETCHFAB_API_KEY=` —
+        # mirrored here so macOS App Store binaries also ship the
+        # Sketchfab key substituted into `Info.plist` rather than the
+        # unsubstituted `$(SKETCHFAB_API_KEY)` literal.
+        env:
+          SKETCHFAB_API_KEY: ${{ secrets.SKETCHFAB_API_KEY }}
         run: |
           xcodebuild archive \
             -project SceneViewDemo.xcodeproj \
@@ -434,7 +451,8 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             DEVELOPMENT_TEAM=5G3DZ3TH45 \
             PROVISIONING_PROFILE_SPECIFIER="$PROVISIONING_PROFILE_UUID" \
-            ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
+            ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO \
+            SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY"
 
       - name: Export and upload to App Store
         env:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -105,6 +105,14 @@ jobs:
 
       - name: Build iOS sample demo (catches missing pbxproj entries)
         if: always()
+        # Inject `SKETCHFAB_API_KEY` so the `Info.plist` placeholder
+        # substitution path (introduced for #1157) is exercised on every CI
+        # build, not just on `xcodebuild archive` in `app-store.yml`. Forks
+        # without the secret get an empty string — `SketchfabConfig.swift`
+        # silently falls back to `nil`, matching the existing graceful
+        # degradation in `ExploreTab.swift`.
+        env:
+          SKETCHFAB_API_KEY: ${{ secrets.SKETCHFAB_API_KEY }}
         working-directory: samples/ios-demo
         run: |
           xcodebuild build \
@@ -114,4 +122,5 @@ jobs:
             -clonedSourcePackagesDirPath SourcePackages \
             -skipPackagePluginValidation \
             -skipMacroValidation \
+            SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY" \
             | xcpretty --color 2>/dev/null || cat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Fixed — iOS: `SKETCHFAB_API_KEY` never reached TestFlight + App Store binaries ([#1157](https://github.com/sceneview/sceneview/issues/1157))
+
+Every iOS app-store ship since v3.6 silently degraded the Explore tab to bundled fallback models because the Sketchfab API key never made it into the `.ipa`. Two compounding root causes:
+
+- **`SketchfabConfig.swift` read the key via `ProcessInfo.processInfo.environment["SKETCHFAB_API_KEY"]`** — that path only works under Xcode's "Run" scheme. CI env vars set on the runner don't survive `xcodebuild archive` into the shipped binary, so `SketchfabConfig.apiKey == nil` for every TestFlight + App Store build → `SketchfabError.missingApiKey` → `ExploreTab` `runCatching` swallow → empty / fallback results with no error banner.
+- **`.github/workflows/app-store.yml` and `ios.yml` never referenced `SKETCHFAB_API_KEY`** — confirmed by `grep`. The Android pipelines (`play-store.yml:170`, `build-apks.yml:47`) inject the secret correctly and Android's `BuildConfig.SKETCHFAB_API_KEY` bakes it in at compile time, which is why Play Store builds were unaffected.
+
+Fix (single PR, 4 files):
+
+- [`samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift`](samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift) — `apiKey` now resolves from `Bundle.main.object(forInfoDictionaryKey: "SketchfabAPIKey")` first, with a guard that rejects the unsubstituted `$(SKETCHFAB_API_KEY)` xcconfig token literal. Legacy `ProcessInfo` lookup stays as a fallback so the Xcode "Run" scheme env-var workflow keeps working for contributors.
+- [`samples/ios-demo/SceneViewDemo/Info.plist`](samples/ios-demo/SceneViewDemo/Info.plist) — added `SketchfabAPIKey = $(SKETCHFAB_API_KEY)` placeholder. `xcodebuild` substitutes it from the user-defined build setting at archive time.
+- [`.github/workflows/app-store.yml`](.github/workflows/app-store.yml) — both iOS and macOS `xcodebuild archive` steps now pass `SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY"` (sourced from the `SKETCHFAB_API_KEY` repo secret).
+- [`.github/workflows/ios.yml`](.github/workflows/ios.yml) — same injection on the CI demo-build step so the `Info.plist` substitution path is exercised on every PR, not just on release tags.
+
+Verified locally on Xcode 26.3 / iPhone 16e simulator: `xcodebuild build … SKETCHFAB_API_KEY=dummy_key_for_test` produces a `SceneViewDemo.app/Info.plist` with `SketchfabAPIKey = dummy_key_for_test` (vs. the literal `$(SKETCHFAB_API_KEY)` placeholder without the build setting). Acceptance: next TestFlight build of v4.3.2+ surfaces non-empty `SketchfabConfig.apiKey` and `ExploreTab` shows live Sketchfab categories + search.
+
+Long-term proxy via `mcp-gateway` so end-user binaries don't ship the master key is tracked by the V1.1 TODO in `SketchfabConfig.swift` — this fix is the immediate "Explore tab works again" patch.
+
 ## v4.3.1 — CI hardening + iOS AR LightSlot parity + i18n migration (2026-05-14)
 
 CI hardening + docs accuracy + Android CLI migration + one v4.1.0-stale demo light tune,

--- a/samples/ios-demo/SceneViewDemo/Info.plist
+++ b/samples/ios-demo/SceneViewDemo/Info.plist
@@ -52,6 +52,18 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<!--
+		Sketchfab API key — injected at build time from the
+		`SKETCHFAB_API_KEY` user-defined build setting (passed by CI via
+		`-DSKETCHFAB_API_KEY=...` or `SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY"`
+		on the `xcodebuild archive` command line). When the setting is unset
+		(forks without the secret, contributors building locally without
+		the env var), `SketchfabConfig.apiKey` falls back to the legacy
+		`ProcessInfo` env var path. See
+		`samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift`.
+	-->
+	<key>SketchfabAPIKey</key>
+	<string>$(SKETCHFAB_API_KEY)</string>
+	<!--
 		Deep-link entry: scan a QR code on sceneview.github.io / README /
 		docs and land directly on the matching demo screen. Custom scheme
 		mirrors the Android intent-filter (`AndroidManifest.xml`).

--- a/samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift
@@ -2,9 +2,19 @@ import Foundation
 
 /// Configuration for the Sketchfab Data API v3.
 ///
-/// The API key is read from the `SKETCHFAB_API_KEY` environment variable so it
-/// can be injected at build time via the Xcode scheme or a CI secret rather
-/// than checked in.
+/// The API key is resolved in two stages:
+///
+/// 1. `Info.plist` — the canonical lookup. The `SketchfabAPIKey` entry is
+///    declared with the `$(SKETCHFAB_API_KEY)` build-setting placeholder so
+///    that `xcodebuild archive` substitutes the value into the shipped
+///    `Info.plist` at build time (CI passes the secret as a `SKETCHFAB_API_KEY`
+///    user-defined build setting — see `.github/workflows/app-store.yml` and
+///    `.github/workflows/ios.yml`). This is the only path that works for
+///    TestFlight + App Store builds because environment variables set in the
+///    CI job don't survive `xcodebuild archive` into the `.ipa`.
+/// 2. `ProcessInfo` — fallback for Xcode local development. The legacy
+///    `SKETCHFAB_API_KEY` scheme env var still works when running under
+///    Xcode's "Run" scheme so contributors don't have to edit `Info.plist`.
 ///
 /// TODO V1.1: move to backend proxy via mcp-gateway to avoid bundling key
 /// directly in the iOS app binary. End-users should authenticate against the
@@ -14,15 +24,29 @@ enum SketchfabConfig {
     /// Base URL of the Sketchfab Data API v3.
     static let baseURL = URL(string: "https://api.sketchfab.com/v3/")!
 
-    /// API key read from the process environment.
+    /// API key, resolved from `Info.plist` first then `ProcessInfo` fallback.
     ///
-    /// Returns `nil` when the variable is unset; callers should surface
-    /// `SketchfabError.missingApiKey` in that case rather than firing
-    /// unauthenticated requests.
+    /// Returns `nil` when neither source provides a non-empty value; callers
+    /// should surface `SketchfabError.missingApiKey` in that case rather than
+    /// firing unauthenticated requests.
     static var apiKey: String? {
-        let value = ProcessInfo.processInfo.environment["SKETCHFAB_API_KEY"]
-        guard let value, !value.isEmpty else { return nil }
-        return value
+        // Primary lookup: `Info.plist` (works for `xcodebuild archive` →
+        // TestFlight + App Store builds).
+        if let fromPlist = Bundle.main.object(forInfoDictionaryKey: "SketchfabAPIKey") as? String,
+           !fromPlist.isEmpty,
+           // Guard against an unsubstituted `$(SKETCHFAB_API_KEY)` xcconfig
+           // token leaking through as a string literal — happens when the
+           // build setting wasn't passed to `xcodebuild` (e.g. forks without
+           // the secret, manual Archive without -PSKETCHFAB_API_KEY=...).
+           fromPlist != "$(SKETCHFAB_API_KEY)" {
+            return fromPlist
+        }
+        // Fallback: legacy `ProcessInfo` env var. Works under Xcode "Run"
+        // schemes (Edit Scheme → Run → Arguments → Environment Variables)
+        // but NOT for archived builds.
+        let fromEnv = ProcessInfo.processInfo.environment["SKETCHFAB_API_KEY"]
+        guard let fromEnv, !fromEnv.isEmpty else { return nil }
+        return fromEnv
     }
 
     /// Maximum cache size on disk, in bytes (500 MB).

--- a/samples/ios-demo/SceneViewDemo/Services/SketchfabService+Tests.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SketchfabService+Tests.swift
@@ -4,8 +4,13 @@ import XCTest
 
 /// Unit tests for `SketchfabService`.
 ///
-/// Network-dependent tests are gated behind `SKETCHFAB_API_KEY` so they're
-/// skipped on machines/CI runners without the secret.
+/// Network-dependent tests are gated behind `SketchfabConfig.apiKey` (which
+/// resolves from `Info.plist`'s `SketchfabAPIKey` placeholder first, then
+/// falls back to the legacy `SKETCHFAB_API_KEY` env var — see
+/// `SketchfabConfig.swift`). The CI iOS workflow now injects the secret as a
+/// `xcodebuild` build setting, so this test actually executes on the SceneView
+/// repo CI; it stays skipped on forks without the secret + on contributor
+/// machines that haven't wired the env var in the Xcode scheme.
 final class SketchfabServiceTests: XCTestCase {
 
     /// Offline: verify the URL builder produces the expected `/v3/search?...`.


### PR DESCRIPTION
## Summary

Closes [#1157](https://github.com/sceneview/sceneview/issues/1157). Every iOS TestFlight + App Store ship since v3.6 silently degraded the Explore tab to bundled fallback models because the Sketchfab API key never reached the `.ipa`. Two compounding root causes:

1. `SketchfabConfig.swift:23` read the key via `ProcessInfo.processInfo.environment["SKETCHFAB_API_KEY"]`. CI env vars don't survive `xcodebuild archive` into the shipped binary, so `SketchfabConfig.apiKey == nil` for every archived build → `SketchfabError.missingApiKey` → `ExploreTab` `runCatching` swallow → empty / fallback results, no error banner.
2. `.github/workflows/app-store.yml` + `ios.yml` never referenced `SKETCHFAB_API_KEY` (vs. Android's `play-store.yml:170` / `build-apks.yml:47` which inject it correctly — that's why Play Store builds were fine).

## Fix (4 files, ~30 LOC)

- **`samples/ios-demo/SceneViewDemo/Services/SketchfabConfig.swift`** — read from `Bundle.main.object(forInfoDictionaryKey: "SketchfabAPIKey")` first, with a guard that rejects the unsubstituted `$(SKETCHFAB_API_KEY)` xcconfig token literal. Legacy `ProcessInfo` lookup stays as a fallback for Xcode "Run" scheme dev workflow.
- **`samples/ios-demo/SceneViewDemo/Info.plist`** — added `SketchfabAPIKey = $(SKETCHFAB_API_KEY)` placeholder. `xcodebuild` substitutes from the user-defined build setting at archive time.
- **`.github/workflows/app-store.yml`** — both iOS + macOS `xcodebuild archive` steps now pass `SKETCHFAB_API_KEY=$SKETCHFAB_API_KEY` as a user-defined build setting.
- **`.github/workflows/ios.yml`** — same injection on the CI demo-build step so the placeholder path is exercised on every PR.

CHANGELOG entry under **Unreleased** (v4.3.1 was cut by #1163 in parallel — entry placed under the new section above v4.3.1).

## Verification

Built locally on Xcode 26.3 / iPhone 16e simulator (`xcodebuild build ... SKETCHFAB_API_KEY=dummy_key_for_test`):

```
$ /usr/libexec/PlistBuddy -c "Print :SketchfabAPIKey" SceneViewDemo.app/Info.plist
dummy_key_for_test
```

vs. the literal `$(SKETCHFAB_API_KEY)` placeholder without the build setting. `BUILD SUCCEEDED`, no errors (only pre-existing main-actor warnings in `OrbitalARDemo.swift` and `RerunDebugDemo.swift` — unrelated).

## Test plan

- [ ] CI iOS workflow green (validates the new `SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY"` xcodebuild arg)
- [ ] Next TestFlight build of v4.3.2+ surfaces non-empty `SketchfabConfig.apiKey`
- [ ] Manual Explore tab verification: live Sketchfab categories + search results render instead of bundled fallbacks
- [ ] `SketchfabService+Tests.swift:44` live network test runs (instead of skipping) on the SceneView repo CI

## Out of scope

Long-term proxy via `mcp-gateway` so end-user binaries don't ship the master key — tracked by the V1.1 TODO in `SketchfabConfig.swift`. This PR is the immediate "Explore tab works again" patch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>