### PR TITLE
feat(samples): SceneGalleryDemo streams curated gallery category (#1152 — Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Added — Stage 2 demo migrations: `SceneGalleryDemo` streams the curated `gallery` category ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
+
+First Stage 2 migration on top of the [Stage 1 resolver foundations](#added--samples-sketchfab-streaming-foundations-1152--stage-1). `SceneGalleryDemo` is now a category-chip-driven streamed gallery on both Android and iOS — chips map 1:1 to the four `gallery` slugs in [`SampleAssets`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt) (Vintage Cassette, Polly the Parrot, Reading Lamp, Wooden Chair), the resolver hands back the streamed GLB/USDZ or the bundled fallback when no key is configured, and `SceneView` orbits the model. No external Sketchfab WebView — the demo only ever feeds the local file URL to `rememberModelInstance` (Android) / `ModelNode.load(contentsOf:)` (iOS).
+
+**Files touched:**
+
+- `samples/android-demo/.../demos/SceneGalleryDemo.kt` (new) — streams the four `gallery` slugs via `SketchfabAssetResolver`, warms the category on first frame with `prefetchAll("gallery")`, orbit camera, inline CC-BY author byline.
+- `samples/android-demo/.../DemoRegistry.kt` — new `scene-gallery` entry in the `3D Basics` category with the `Icons.Filled.Collections` icon.
+- `samples/android-demo/.../MainActivity.kt` — routes `scene-gallery` to `SceneGalleryDemo`.
+- `samples/android-demo/src/main/res/values/strings.xml` + `values-fr/strings.xml` — 4 new keys: `demo_scene_gallery_title`, `demo_scene_gallery_subtitle`, `demo_scene_gallery_loading`, `demo_scene_gallery_credit` (used for `"by %s · CC-BY 4.0"`). The chip labels themselves come from the catalogue's `SketchfabSlug.displayName` (curator-authored English ids, not localizable copy).
+- `samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift` — rewrote the placeholder shape-pedestal scene as the cross-platform mirror: same `gallery` category, same chip row + author byline, `SketchfabAssetResolver.shared.resolve(slug)` + `ModelNode.load(contentsOf:)`, `prefetchAll(category:)` warm, error path surfaces the resolver's `localizedDescription` rather than failing silently.
+
+**`SampleAssets` slugs added:** 0. The four `gallery` slugs (Vintage Cassette, Polly the Parrot, Reading Lamp, Wooden Chair) shipped in Stage 1 already and are now consumed by this PR for the first time.
+
+**i18n hygiene.** The chip labels render `SketchfabSlug.displayName` directly — those strings are curator-authored Sketchfab catalogue ids (English-only, like the `OrbitalARDemo` planet labels) and don't go through `stringResource()`. All demo scaffolding (title, subtitle, loading copy, attribution caption) goes through the new `demo_scene_gallery_*` keys in both `values/` and `values-fr/`. No raw English string leaks into a non-English locale.
+
+**Screen recording.** Deferred to the visual-smoke pass at the end of Stage 2 (one combined recording covering all three Stage 2 demos in this batch). Compile + unit tests gated this PR.
+
+**Acceptance:** Android `./gradlew :samples:android-demo:compileDebugKotlin` GREEN. `:samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27 sketchfab tests passing unchanged from Stage 1). iOS `xcodebuild` skipped in this batch (CHANGELOG entry kept honest — Stage 1 ran the Xcode build; the SceneGalleryDemo iOS rewrite is a small file replacement with no new Swift symbols).
+
 ### Added — Samples Sketchfab streaming foundations ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 1)
 
 Stage 1 of the [`#1152`](https://github.com/sceneview/sceneview/issues/1152) umbrella — `SketchfabAssetResolver` foundations that the Stage 2 demo migrations (`OrbitalARDemo`, `SceneGalleryDemo`, `AnimationDemo`, `MultiModelDemo`, `ARPlacementDemo`, `PhysicsDemo`, `MaterialsDemo`) will build on. **No demo is migrated in this PR** — the bundled GLBs/USDZs stay as they are. The resolver, registry, and tests are the foundation; demo migrations land 1 PR per demo.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoRegistry.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoRegistry.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.CenterFocusStrong
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.CloudCircle
+import androidx.compose.material.icons.filled.Collections
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.FilterCenterFocus
@@ -134,6 +135,7 @@ val ALL_DEMOS = listOf(
     DemoEntry("geometry", R.string.demo_geometry_title, R.string.demo_geometry_subtitle, DemoCategory.BASICS_3D, Icons.Filled.Category),
     DemoEntry("animation", R.string.demo_animation_title, R.string.demo_animation_subtitle, DemoCategory.BASICS_3D, Icons.Filled.RotateRight),
     DemoEntry("multi-model", R.string.demo_multi_model_title, R.string.demo_multi_model_subtitle, DemoCategory.BASICS_3D, Icons.Filled.Layers),
+    DemoEntry("scene-gallery", R.string.demo_scene_gallery_title, R.string.demo_scene_gallery_subtitle, DemoCategory.BASICS_3D, Icons.Filled.Collections),
     // Lighting & Environment
     DemoEntry("lighting", R.string.demo_lighting_title, R.string.demo_lighting_subtitle, DemoCategory.LIGHTING_ENVIRONMENT, Icons.Filled.Lightbulb),
     DemoEntry("movable-light", R.string.demo_movable_light_title, R.string.demo_movable_light_subtitle, DemoCategory.LIGHTING_ENVIRONMENT, Icons.Filled.AutoFixHigh),

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -39,6 +39,7 @@ import io.github.sceneview.demo.demos.GestureEditingDemo
 import io.github.sceneview.demo.demos.CollisionDemo
 import io.github.sceneview.demo.demos.DynamicSkyDemo
 import io.github.sceneview.demo.demos.MultiModelDemo
+import io.github.sceneview.demo.demos.SceneGalleryDemo
 import io.github.sceneview.demo.demos.PhysicsDemo
 import io.github.sceneview.demo.demos.PostProcessingDemo
 import io.github.sceneview.demo.demos.CustomMeshDemo
@@ -247,6 +248,7 @@ fun DemoRouter(id: String, onBack: () -> Unit) {
         "model-viewer" -> ModelViewerDemo(onBack)
         "geometry" -> GeometryDemo(onBack)
         "animation" -> AnimationDemo(onBack)
+        "scene-gallery" -> SceneGalleryDemo(onBack)
         // Lighting & Environment
         "lighting" -> LightingDemo(onBack)
         "movable-light" -> MovableLightDemo(onBack)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
@@ -1,0 +1,182 @@
+package io.github.sceneview.demo.demos
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.sceneview.SceneView
+import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.LoadingScrim
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
+import io.github.sceneview.math.Position
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberEnvironmentLoader
+import io.github.sceneview.rememberModelInstance
+import io.github.sceneview.rememberModelLoader
+
+/**
+ * Streamed model gallery — themed bundles (Animals, Furniture, Retro, …) rotating
+ * Sketchfab CC-BY content. Each chip selects one [SketchfabSlug] in the curated
+ * `gallery` category of [SampleAssets]; the resolver hands back either the
+ * streamed GLB or the bundled fallback when no API key is configured. The
+ * `SceneView` composable then renders the model with an automated orbit camera.
+ *
+ * Honours the umbrella's hard rules:
+ *  - **No Sketchfab WebView / external link** — the demo only ever points
+ *    [rememberModelInstance] at the local [java.io.File] returned by
+ *    [SketchfabAssetResolver.resolve].
+ *  - **No network required to render something useful** — empty key (App Store
+ *    cold-cache builds) → the resolver stages the bundled fallback under the
+ *    same cache root and the demo renders it the same way as the streamed file.
+ *  - **License attribution preserved** — the per-chip caption shows the author
+ *    name. The Credits sheet (Stage 3) will surface the full per-model
+ *    attribution.
+ *
+ * The chip labels come from [SketchfabSlug.displayName] (set by registry
+ * curators in English at design time) — they're not user-facing copy strings
+ * subject to translation. Authors and license URLs are user-data of the
+ * Sketchfab catalogue itself; only the demo scaffolding (title / subtitle /
+ * loading copy) goes through `stringResource()`.
+ *
+ * @see SampleAssets for the curated `gallery` category.
+ * @see SketchfabAssetResolver for the resolve / fallback contract.
+ */
+@Composable
+fun SceneGalleryDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val resolver = remember(context) { SketchfabAssetResolver.getInstance(context) }
+
+    // The four curated `gallery` slugs declared in SampleAssets. Stage 2 keeps
+    // the chip count low so the offline-fallback footprint stays bounded — Stage
+    // 2 follow-ups can fan out to ~10 via Sketchfab `search()`.
+    val slugs = remember { SampleAssets.byCategory["gallery"].orEmpty() }
+    var selectedIndex by remember { mutableStateOf(0) }
+    val selectedSlug = slugs.getOrNull(selectedIndex)
+
+    // Warm every gallery slug in parallel on first frame so chip taps switch
+    // instantly after the cold-start download. The resolver is idempotent
+    // (cache-hit -> touches lastModified only) so re-running is cheap.
+    LaunchedEffect(resolver) {
+        runCatching { resolver.prefetchAll("gallery") }
+    }
+
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
+
+    // Resolve the slug to a local file. produceState delegates IO + retries to
+    // the resolver; the `key1 = selectedSlug` rebinds the file when the user
+    // picks a new chip without leaking any prior coroutine.
+    val resolvedPath: String? by produceState<String?>(
+        initialValue = null,
+        key1 = resolver,
+        key2 = selectedSlug?.uid,
+    ) {
+        value = null
+        val slug = selectedSlug ?: return@produceState
+        value = runCatching { resolver.resolve(slug) }
+            .getOrNull()
+            ?.toURI()
+            ?.toString()
+    }
+
+    val modelInstance = resolvedPath?.let { path ->
+        // `rememberModelInstance(modelLoader, fileLocation)` accepts a `file://`
+        // URL; the underlying SceneView API auto-detects the scheme and uses
+        // `loadModelInstance` on the IO dispatcher (Filament JNI back to main
+        // is handled internally — we never touch JNI off-main here).
+        rememberModelInstance(modelLoader, path)
+    }
+
+    DemoScaffold(
+        title = stringResource(R.string.demo_scene_gallery_title),
+        onBack = onBack,
+        controls = {
+            // Category chips along the top of the controls sheet. We expose
+            // them as a horizontally scrolling row so the four labels never
+            // wrap at portrait phone widths. Each chip's label is a hand-
+            // curated English `displayName` from SampleAssets — these are
+            // catalogue identifiers, not localizable UI copy.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                slugs.forEachIndexed { index, slug ->
+                    FilterChip(
+                        selected = index == selectedIndex,
+                        onClick = { selectedIndex = index },
+                        label = { Text(slug.displayName) },
+                    )
+                }
+            }
+            // Author credit — required by CC-BY 4.0 attribution. Stage 3 adds
+            // a full Credits sheet; the inline byline below keeps the
+            // attribution visible without a tap.
+            selectedSlug?.let { slug ->
+                Text(
+                    text = stringResource(R.string.demo_scene_gallery_credit, slug.author),
+                )
+            }
+        },
+    ) {
+        // Hero orbit so lighting + reflections sweep over the same surface
+        // every frame — same camera contract as ModelViewerDemo, just bound
+        // to a different model. yHeight = 0 keeps the model centered in
+        // portrait without the empty-top-band artefact (QA finding
+        // 2026-05-11).
+        val cameraManipulator = rememberHeroOrbitCameraManipulator(
+            trigger = modelInstance != null,
+            radius = 1.6f,
+            yHeight = 0f,
+            durationMillis = 24_000,
+        )
+        Box(modifier = Modifier.fillMaxSize()) {
+            SceneView(
+                modifier = Modifier.fillMaxSize(),
+                engine = engine,
+                modelLoader = modelLoader,
+                environmentLoader = environmentLoader,
+                cameraManipulator = cameraManipulator,
+            ) {
+                val instance = modelInstance
+                val slug = selectedSlug
+                if (instance != null && slug != null) {
+                    ModelNode(
+                        modelInstance = instance,
+                        scaleToUnits = slug.scaleToUnits,
+                        // centerOrigin lets SceneView re-centre the model on the
+                        // world origin so the camera (looking at 0,0,0) frames
+                        // the body, not the model's authored pivot point.
+                        centerOrigin = Position(0f, 0f, 0f),
+                    )
+                }
+            }
+            LoadingScrim(
+                loading = modelInstance == null,
+                label = stringResource(R.string.demo_scene_gallery_loading),
+            )
+        }
+    }
+}

--- a/samples/android-demo/src/main/res/values-fr/strings.xml
+++ b/samples/android-demo/src/main/res/values-fr/strings.xml
@@ -182,6 +182,10 @@
     <string name="demo_animation_subtitle">Lire, mettre en pause et contrôler les animations</string>
     <string name="demo_multi_model_title">Multi-modèle</string>
     <string name="demo_multi_model_subtitle">Plusieurs modèles dans une scène</string>
+    <string name="demo_scene_gallery_title">Galerie de scènes</string>
+    <string name="demo_scene_gallery_subtitle">Modèles thématiques Sketchfab streamés à la demande</string>
+    <string name="demo_scene_gallery_loading">Streaming du modèle…</string>
+    <string name="demo_scene_gallery_credit">par %1$s · CC-BY 4.0</string>
     <string name="demo_lighting_title">Types de lumières</string>
     <string name="demo_lighting_subtitle">Lumières directionnelles, ponctuelles et spots</string>
     <string name="demo_movable_light_title">Lumière mobile</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -176,6 +176,10 @@
     <string name="demo_animation_subtitle">Play, pause, and control animations</string>
     <string name="demo_multi_model_title">Multi Model</string>
     <string name="demo_multi_model_subtitle">Multiple models in one scene</string>
+    <string name="demo_scene_gallery_title">Scene Gallery</string>
+    <string name="demo_scene_gallery_subtitle">Themed Sketchfab bundles streamed on demand</string>
+    <string name="demo_scene_gallery_loading">Streaming model…</string>
+    <string name="demo_scene_gallery_credit">by %1$s · CC-BY 4.0</string>
     <string name="demo_lighting_title">Light Types</string>
     <string name="demo_lighting_subtitle">Directional, point, and spot lights</string>
     <string name="demo_movable_light_title">Movable Light</string>

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
@@ -2,76 +2,141 @@ import SwiftUI
 import RealityKit
 import SceneViewSwift
 
-/// Scene gallery -- multiple shapes, text, lines, and lights in a composed scene.
+/// Streamed model gallery — themed bundles (Animals, Furniture, Retro, …)
+/// rotating Sketchfab CC-BY content. Each chip selects one `SketchfabSlug` in
+/// the curated `gallery` category of `SampleAssets`; the resolver hands back
+/// either the streamed asset or the bundled fallback when no API key is
+/// configured. `SceneView` then renders the model with an orbit camera.
+///
+/// Honours the umbrella's hard rules:
+///   - **No Sketchfab WebView / external link** — the demo only ever feeds the
+///     local `URL` returned by `SketchfabAssetResolver.resolve` to
+///     `ModelNode.load(contentsOf:)`.
+///   - **No network required to render something useful** — empty key (App Store
+///     cold-cache builds) → the resolver stages the bundled fallback under the
+///     same cache root and the demo renders it the same way as the streamed file.
+///   - **License attribution preserved** — the per-chip caption shows the
+///     author name. The Credits sheet (Stage 3) will surface the full
+///     per-model attribution.
 struct SceneGalleryDemo: View {
+    private let slugs: [SketchfabSlug] = SampleAssets.byCategory["gallery"] ?? []
+
+    @State private var selectedIndex: Int = 0
+    @State private var loadedNode: ModelNode?
+    @State private var loadError: String?
+
+    private var selectedSlug: SketchfabSlug? {
+        guard slugs.indices.contains(selectedIndex) else { return nil }
+        return slugs[selectedIndex]
+    }
+
     var body: some View {
         ZStack {
-            SceneView { root in
-                // Pedestals with shapes
-                let pedestals: [(String, Float, UIColor)] = [
-                    ("Cube", -0.8, .systemBlue),
-                    ("Sphere", -0.4, .systemRed),
-                    ("Cylinder", 0.0, .systemGreen),
-                    ("Cone", 0.4, .systemOrange),
-                    ("Plane", 0.8, .systemPurple),
-                ]
-
-                for (name, x, color) in pedestals {
-                    // Pedestal
-                    let pedestal = GeometryNode.cylinder(radius: 0.08, height: 0.02, color: .darkGray)
-                    pedestal.entity.position = .init(x: x, y: -0.25, z: -2)
-                    root.addChild(pedestal.entity)
-
-                    // Shape on pedestal
-                    let shape: GeometryNode
-                    switch name {
-                    case "Cube":
-                        shape = GeometryNode.cube(
-                            size: 0.12,
-                            material: .pbr(color: color, metallic: 0.6, roughness: 0.3),
-                            cornerRadius: 0.01
-                        )
-                    case "Sphere":
-                        shape = GeometryNode.sphere(
-                            radius: 0.07,
-                            material: .pbr(color: color, metallic: 0.8, roughness: 0.15)
-                        )
-                    case "Cylinder":
-                        shape = GeometryNode.cylinder(radius: 0.06, height: 0.12, color: color)
-                    case "Cone":
-                        shape = GeometryNode.cone(height: 0.14, radius: 0.06, color: color)
-                    default:
-                        shape = GeometryNode.plane(width: 0.12, depth: 0.12, color: color)
-                    }
-                    shape.entity.position = .init(x: x, y: -0.12, z: -2)
-                    root.addChild(shape.entity)
-
-                    // Billboard label
-                    let label = BillboardNode.text(name, fontSize: 0.025, color: color)
-                        .position(.init(x: x, y: 0.05, z: -2))
-                    root.addChild(label.entity)
-                }
-
-                // Decorative circle on floor
-                let circle = PathNode.circle(
-                    center: .init(x: 0, y: -0.25, z: -2),
-                    radius: 1.0,
-                    segments: 64,
-                    thickness: 0.003,
-                    color: .init(white: 0.25, alpha: 1)
-                )
-                root.addChild(circle.entity)
-
-                // Title at top
-                let title = TextNode(text: "SceneView Gallery", fontSize: 0.07, color: .white, depth: 0.01)
-                    .centered()
-                    .position(.init(x: 0, y: 0.4, z: -2.5))
-                root.addChild(title.entity)
+            sceneView
+            VStack {
+                Spacer()
+                controls
             }
-            .cameraControls(.orbit)
-            .autoRotate(speed: 0.2)
-            .ignoresSafeArea()
         }
         .background(Color.black)
+        .task(id: selectedSlug?.uid) {
+            await loadSelectedSlug()
+        }
+        .task {
+            // Warm the whole gallery on first appear so chip taps land on a
+            // hot cache. The resolver is idempotent — re-running it is cheap.
+            _ = await SketchfabAssetResolver.shared.prefetchAll(category: "gallery")
+        }
+    }
+
+    @ViewBuilder
+    private var sceneView: some View {
+        if let loadedNode {
+            SceneView { root in
+                loadedNode.entity.position = .init(x: 0, y: 0, z: -2)
+                root.addChild(loadedNode.entity)
+            }
+            .cameraControls(.orbit)
+            .autoRotate(speed: 0.25)
+            .ignoresSafeArea()
+            // Re-keys the SceneView when the selected slug changes so the
+            // previous entity is fully torn down rather than overlaid.
+            .id("gallery-\(selectedSlug?.uid ?? "none")")
+        } else {
+            VStack(spacing: 12) {
+                ProgressView()
+                    .tint(.white)
+                if let loadError {
+                    Text(loadError)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                } else {
+                    Text("Streaming model…")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+        }
+    }
+
+    private var controls: some View {
+        VStack(spacing: 8) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Array(slugs.enumerated()), id: \.element.uid) { index, slug in
+                        Button {
+                            selectedIndex = index
+                            #if os(iOS)
+                            HapticManager.lightTap()
+                            #endif
+                        } label: {
+                            Text(slug.displayName)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(index == selectedIndex ? Color.black : Color.white)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 8)
+                                .background(
+                                    Capsule()
+                                        .fill(index == selectedIndex ? Color.white : Color.white.opacity(0.12))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+
+            if let slug = selectedSlug {
+                // CC-BY 4.0 attribution lives inline so it's always visible
+                // without a tap. The Credits sheet (Stage 3) carries the full
+                // attribution + Sketchfab page link.
+                Text("by \(slug.author) · CC-BY 4.0")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.75))
+            }
+        }
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 24)
+    }
+
+    @MainActor
+    private func loadSelectedSlug() async {
+        guard let slug = selectedSlug else { return }
+        loadedNode = nil
+        loadError = nil
+        do {
+            let url = try await SketchfabAssetResolver.shared.resolve(slug)
+            let node = try await ModelNode.load(contentsOf: url)
+            _ = node.scaleToUnits(slug.scaleToUnits)
+            _ = node.centerOrigin()
+            loadedNode = node
+        } catch {
+            loadError = error.localizedDescription
+        }
     }
 }


### PR DESCRIPTION
## Summary

First Stage 2 migration on top of the [Stage 1 resolver foundations](https://github.com/sceneview/sceneview/pull/1168) of the [`#1152` umbrella](https://github.com/sceneview/sceneview/issues/1152). `SceneGalleryDemo` is now a category-chip-driven streamed gallery on both Android and iOS:

- Chips map 1:1 to the four `gallery` slugs in [`SampleAssets`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt) (Vintage Cassette · Polly the Parrot · Reading Lamp · Wooden Chair).
- The resolver hands back the streamed GLB/USDZ when a key is present, or the bundled fallback when it isn't.
- `SceneView` orbits the selected model with the same hero-orbit camera as `ModelViewerDemo`.
- **No external Sketchfab WebView.** The demo only ever feeds the local file URL to `rememberModelInstance` (Android) / `ModelNode.load(contentsOf:)` (iOS).

## i18n note

Chip labels render `SketchfabSlug.displayName` directly — those are curator-authored Sketchfab catalogue ids (English-only, like `OrbitalARDemo` planet labels) and don't go through `stringResource()`. **Every demo scaffolding string** (title, subtitle, loading copy, attribution caption) goes through the four new `demo_scene_gallery_*` keys in both `values/strings.xml` and `values-fr/strings.xml`. No raw English leaks on the FR locale.

## SampleAssets changes

0 new slugs — the four `gallery` slugs (Vintage Cassette, Polly the Parrot, Reading Lamp, Wooden Chair) shipped in Stage 1 and are now consumed by this PR for the first time.

## Screen recording

Deferred to the combined Stage 2 visual-smoke pass at the end of the Stage 2 demo migration batch.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` GREEN
- [x] `./gradlew :samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27/27, unchanged from Stage 1)
- [ ] Pixel 9 visual smoke (deferred — combined with rest of Stage 2 batch)
- [ ] iPhone 16e simulator visual smoke (deferred — combined with rest of Stage 2 batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)