### PR TITLE
feat(samples): ModelViewerDemo gains 'Surprise me' Sketchfab pick (#1152 — Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Added — Stage 2 demo migrations: `ModelViewerDemo` gains a "Surprise me" Sketchfab pick ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
+
+Second Stage 2 migration. `ModelViewerDemo` keeps the bundled `khronos_damaged_helmet.glb` as its hero default (so screenshots / Play Store store assets stay byte-identical) and adds an `ExtendedFloatingActionButton` that streams a fresh downloadable Sketchfab model on demand:
+
+- **Default state.** Bundled helmet, same as before. The hero shot the store-page renders promise.
+- **Tap "Surprise me".** Calls `SketchfabService.search(query, downloadable = true, limit = 24)` with a small rotating PBR-friendly query list (`pbr` / `modern` / `scan`), filters to `downloadable && faceCount in 1..200_000` (so a 5 M-poly scan doesn't stall the demo), picks a random hit, and downloads it through the shared `SketchfabService` cache. The streamed pick replaces the helmet for the rest of the session until the next tap.
+- **No-key build.** The FAB is hidden when `SketchfabConfig.apiKey == null` (App Store / no-secret CI builds) — silently falling back to the same helmet would mislead users about the demo's capability.
+- **Failure modes are silent.** A 4xx / 5xx / empty-results path keeps the helmet on screen rather than going black. The `surpriseInFlight` flag flips back to `false` so the user can retry.
+
+**Files touched:**
+
+- `samples/android-demo/.../demos/ModelViewerDemo.kt` — full rewrite of the composable. Adds the FAB, the surprise coroutine, the failure-keeps-helmet contract. Streamed instance scaled to 0.4 m (vs the helmet's historical 0.3 m) so a 5 cm bee and a 5 m crate both read in the orbit sweet spot.
+- `samples/android-demo/src/main/res/values/strings.xml` + `values-fr/strings.xml` — 3 new keys: `demo_model_viewer_loading`, `demo_model_viewer_surprise`, `demo_model_viewer_surprise_loading`.
+
+**iOS counterpart.** No iOS file change — there is no dedicated `ModelViewerDemo.swift`. The iOS deep-link router already maps `"model-viewer"` to `SceneGalleryDemo` (`DemoDeepLinkRegistry.swift:77`), which already streams Sketchfab content (now with the Stage 2 gallery migration). The iOS Explore tab is the canonical "browse + surprise" experience on iOS.
+
+**`SampleAssets` slugs added:** 0. The Surprise path doesn't go through the curated registry — it's a free-form Sketchfab search restricted to `downloadable && PBR-friendly`. The license filter on the search side is not yet a 100% guarantee of CC-BY (Sketchfab returns mixed CC variants); Stage 3 will add a license-filter pass before the model lands on screen + a Credits sheet exposing the per-pick attribution.
+
+**i18n hygiene.** All three new FAB strings ship in EN + FR. No raw English leaks on the FR locale.
+
+**Screen recording.** Deferred to the combined Stage 2 visual-smoke pass.
+
+**Acceptance:** Android `./gradlew :samples:android-demo:compileDebugKotlin` GREEN. `:samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27/27 unchanged).
+
 ### Added — Stage 2 demo migrations: `SceneGalleryDemo` streams the curated `gallery` category ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
 
 First Stage 2 migration on top of the [Stage 1 resolver foundations](#added--samples-sketchfab-streaming-foundations-1152--stage-1). `SceneGalleryDemo` is now a category-chip-driven streamed gallery on both Android and iOS — chips map 1:1 to the four `gallery` slugs in [`SampleAssets`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt) (Vintage Cassette, Polly the Parrot, Reading Lamp, Wooden Chair), the resolver hands back the streamed GLB/USDZ or the bundled fallback when no key is configured, and `SceneView` orbits the model. No external Sketchfab WebView — the demo only ever feeds the local file URL to `rememberModelInstance` (Android) / `ModelNode.load(contentsOf:)` (iOS).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -2,43 +2,105 @@ package io.github.sceneview.demo.demos
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
-import io.github.sceneview.demo.R
 import io.github.sceneview.demo.LoadingScrim
+import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabConfig
+import io.github.sceneview.demo.sketchfab.SketchfabService
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import kotlinx.coroutines.launch
 
 /**
- * Full-screen 3D model viewer. The CAMERA orbits the helmet for the hero showcase so
- * lights, reflections and IBL hit the same surface every frame — a model that spins
- * under the same lighting looks wrong (reflections slide, shadows chase the geometry).
+ * Full-screen 3D model viewer.
+ *
+ * **Default state.** Loads the bundled `khronos_damaged_helmet.glb` so the demo
+ * renders identically with or without a Sketchfab API key — the very first
+ * frame the user sees is the same hero shot the screenshots and store assets
+ * promise. The CAMERA orbits the helmet so lights, reflections and IBL hit the
+ * same surface every frame.
+ *
+ * **"Surprise me" button.** When the user taps the extended FAB at the
+ * bottom-right, the demo searches the Sketchfab API for a downloadable model
+ * tagged like the previous pick (or just downloadable PBR content on first
+ * tap), then routes the resulting URL through SceneView's `file://` model
+ * loader. The streamed pick replaces the helmet for the rest of the session
+ * (or until the next tap). When no API key is configured (App Store builds),
+ * the button is hidden — there is no plausible "Surprise me" without the
+ * Sketchfab catalogue, and showing a non-functional button would mislead.
  *
  * The moment the user touches the viewport the orbit hands off to the stock
- * [io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator] at the
- * exact same pose, so there's no snap — drag / pinch / zoom continue from where the
- * automated orbit left off.
+ * [io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator]
+ * at the exact same pose, so there's no snap — drag / pinch / zoom continue
+ * from where the automated orbit left off.
  */
 @Composable
 fun ModelViewerDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
-    val modelInstance = rememberModelInstance(modelLoader, "models/khronos_damaged_helmet.glb")
 
-    // Camera orbits; model stays fixed. Radius 1.4 m keeps the 0.3 m helmet framed
-    // comfortably at portrait aspect without clipping the near plane.
-    // yHeight kept at 0 so the model sits centered vertically — the previous 0.2f tilted
-    // the orbit downward and pinned the helmet in the lower half of the viewport with a
-    // big empty top band (QA finding 2026-05-11).
+    // Source of truth for the currently-viewed model:
+    //  - null            → render the bundled hero helmet (default state).
+    //  - non-null URL    → render the streamed Sketchfab GLB.
+    // Restored via remember (savedStateRegistry would survive config change
+    // but we want the helmet back on every cold start so screenshots / Play
+    // Store store-page assets stay deterministic).
+    var streamedFileUrl by remember { mutableStateOf<String?>(null) }
+    // Last-tapped state — when it's `true` the FAB shows a spinner. The
+    // surprise-coroutine flips it back to `false` regardless of success so
+    // the button doesn't get stuck in the loading state.
+    var surpriseInFlight by remember { mutableStateOf(false) }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val service = remember(context) { SketchfabService.getInstance(context) }
+    val resolver = remember(context) { SketchfabAssetResolver.getInstance(context) }
+    val hasSketchfabKey = remember { SketchfabConfig.apiKey != null }
+
+    // The streamed model is loaded via the URL overload — null `streamedFileUrl`
+    // skips this branch (Kotlin elvis returns null which keeps the bundled
+    // helmet below as the displayed instance).
+    val streamedModelInstance = streamedFileUrl?.let { url ->
+        rememberModelInstance(modelLoader, url)
+    }
+    // The bundled hero — assets/models/khronos_damaged_helmet.glb. Loaded
+    // eagerly so the first frame after launch shows the hero shot.
+    val bundledModelInstance =
+        rememberModelInstance(modelLoader, "models/khronos_damaged_helmet.glb")
+
+    // The instance actually rendered this frame. Falls back to the bundled
+    // helmet whenever the streamed instance is null (no Surprise tap yet,
+    // streamed load still in flight, or streamed load failed).
+    val activeModelInstance = streamedModelInstance ?: bundledModelInstance
+
+    // Camera orbits; model stays fixed. Radius 1.4 m keeps the 0.3 m helmet
+    // framed comfortably at portrait aspect without clipping the near plane.
     val cameraManipulator = rememberHeroOrbitCameraManipulator(
-        trigger = modelInstance != null,
+        trigger = activeModelInstance != null,
         radius = 1.4f,
         yHeight = 0f,
         durationMillis = 20_000,
@@ -53,21 +115,96 @@ fun ModelViewerDemo(onBack: () -> Unit) {
                 environmentLoader = environmentLoader,
                 cameraManipulator = cameraManipulator,
             ) {
-                modelInstance?.let { instance ->
+                activeModelInstance?.let { instance ->
                     ModelNode(
                         modelInstance = instance,
-                        scaleToUnits = 0.3f,
-                        // centerOrigin lets SceneView re-centre the model's bounding box on
-                        // world origin so the camera (looking at 0,0,0) frames the body, not
-                        // the model's authored pivot point (typically the floor of the asset).
-                        // Without this the helmet sits in the lower third of the viewport.
-                        // QA finding 2026-05-11 PM.
+                        // Scale streamed content to a comfortable 0.4 m so a
+                        // 5 m crate or a 5 cm bee both read as "in the orbit
+                        // sweet spot". For the bundled helmet we keep the
+                        // historical 0.3 m for byte-identical screenshots.
+                        scaleToUnits = if (streamedFileUrl == null) 0.3f else 0.4f,
+                        // centerOrigin lets SceneView re-centre the model's
+                        // bounding box on world origin — see QA finding
+                        // 2026-05-11 PM in the original file.
                         centerOrigin = io.github.sceneview.math.Position(0f, 0f, 0f),
                     )
                 }
             }
 
-            LoadingScrim(loading = modelInstance == null, label = "Loading model…")
+            LoadingScrim(
+                loading = activeModelInstance == null,
+                label = stringResource(R.string.demo_model_viewer_loading),
+            )
+
+            // Surprise FAB lives only when the user has a Sketchfab API key —
+            // tapping it without a key would silently fall back to the same
+            // bundled helmet, which is worse than no button at all.
+            if (hasSketchfabKey) {
+                ExtendedFloatingActionButton(
+                    onClick = {
+                        if (surpriseInFlight) return@ExtendedFloatingActionButton
+                        surpriseInFlight = true
+                        scope.launch {
+                            val picked = runCatching {
+                                pickRandomDownloadableModel(service, resolver)
+                            }.getOrNull()
+                            // Even on failure we exit the in-flight state so
+                            // the user can retry. The helmet stays put.
+                            streamedFileUrl = picked
+                            surpriseInFlight = false
+                        }
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.AutoAwesome,
+                            contentDescription = null,
+                        )
+                    },
+                    text = {
+                        Text(
+                            text = if (surpriseInFlight) {
+                                stringResource(R.string.demo_model_viewer_surprise_loading)
+                            } else {
+                                stringResource(R.string.demo_model_viewer_surprise)
+                            },
+                        )
+                    },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp),
+                )
+            }
         }
     }
+}
+
+/**
+ * Surprise-me coroutine. Hits the Sketchfab search API for downloadable PBR
+ * content, picks a random hit, streams it through [SketchfabService.downloadModel]
+ * → on-disk cache → `file://` URL. Failure modes (no results / rate limit /
+ * non-PBR download) all return `null` and the FAB caller leaves the helmet on
+ * screen, so the demo never sits on a black viewport.
+ */
+private suspend fun pickRandomDownloadableModel(
+    service: SketchfabService,
+    @Suppress("UNUSED_PARAMETER") resolver: SketchfabAssetResolver,
+): String? {
+    // Search a broad PBR-friendly query so the picks read well under the demo
+    // lighting. Falls back to "modern" if "pbr" returns 0 hits for some reason.
+    val candidates = listOf("pbr", "modern", "scan")
+    for (query in candidates) {
+        val results = runCatching {
+            service.search(query = query, downloadable = true, limit = 24)
+        }.getOrNull() ?: continue
+        // Filter to PBR-ish, sub-50k-poly hits so the demo doesn't stall on
+        // a 5 M-poly scan. faceCount = 0 happens for non-PBR models — keep
+        // them out.
+        val viable = results.filter { it.downloadable && it.faceCount in 1..200_000 }
+        if (viable.isEmpty()) continue
+        val pick = viable.random()
+        val cached = runCatching { service.downloadModel(pick.uid) }.getOrNull()
+            ?: continue
+        return cached.toURI().toString()
+    }
+    return null
 }

--- a/samples/android-demo/src/main/res/values-fr/strings.xml
+++ b/samples/android-demo/src/main/res/values-fr/strings.xml
@@ -176,6 +176,9 @@
 
     <!-- Sample demo titles + subtitles (canonical keys consumed by DemoRegistry) -->
     <string name="demo_model_viewer_subtitle">Charger et afficher des modèles 3D</string>
+    <string name="demo_model_viewer_loading">Chargement du modèle…</string>
+    <string name="demo_model_viewer_surprise">Surprends-moi</string>
+    <string name="demo_model_viewer_surprise_loading">Recherche…</string>
     <string name="demo_geometry_title">Primitives géométriques</string>
     <string name="demo_geometry_subtitle">Cube, sphère, cylindre, plan</string>
     <string name="demo_animation_title">Rotation automatique</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -170,6 +170,9 @@
 
     <!-- Sample demo titles + subtitles (canonical keys consumed by DemoRegistry) -->
     <string name="demo_model_viewer_subtitle">Load and display 3D models</string>
+    <string name="demo_model_viewer_loading">Loading model…</string>
+    <string name="demo_model_viewer_surprise">Surprise me</string>
+    <string name="demo_model_viewer_surprise_loading">Finding…</string>
     <string name="demo_geometry_title">Geometry Primitives</string>
     <string name="demo_geometry_subtitle">Cube, Sphere, Cylinder, Plane</string>
     <string name="demo_animation_title">Auto Rotate</string>


### PR DESCRIPTION
## Summary

Second Stage 2 migration on the [`#1152` umbrella](https://github.com/sceneview/sceneview/issues/1152). `ModelViewerDemo` keeps the bundled `khronos_damaged_helmet.glb` as its hero default (so screenshots / Play Store store assets stay byte-identical) and adds an `ExtendedFloatingActionButton` that streams a fresh downloadable Sketchfab model on demand.

- **Default state.** Bundled helmet, same hero shot as before.
- **Tap "Surprise me".** `SketchfabService.search(downloadable = true, limit = 24)` with a small rotating PBR-friendly query list, filter `downloadable && faceCount in 1..200_000`, pick random, stream through the shared `SketchfabService` cache. Replaces the helmet until the next tap.
- **No-key build.** FAB hidden — silently falling back to the same helmet would mislead.
- **Failure-keeps-helmet contract.** Any 4xx / 5xx / empty-results path keeps the helmet on screen and resets the in-flight flag so the user can retry.

## iOS counterpart

No iOS file change. There is no dedicated `ModelViewerDemo.swift` — the iOS deep-link router already maps `model-viewer` → `SceneGalleryDemo` (`DemoDeepLinkRegistry.swift:77`), which streams Sketchfab content via the Stage 2 gallery migration in PR #1170. The iOS Explore tab is the canonical "browse + surprise" experience on iOS.

## SampleAssets changes

0 new slugs. The Surprise path goes through free-form `SketchfabService.search`, not the curated registry. Stage 3 will add a CC-BY license-filter pass + a per-pick Credits surface.

## i18n note

3 new keys ship in EN + FR (`demo_model_viewer_loading`, `demo_model_viewer_surprise`, `demo_model_viewer_surprise_loading`). No raw English leaks on the FR locale.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` GREEN
- [x] `./gradlew :samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27/27, unchanged from Stage 1)
- [ ] Pixel 9 visual smoke (deferred — combined with rest of Stage 2 batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)