### PR TITLE
feat(samples): MaterialsDemo streams curated materials category (#1152 — Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added — Stage 2 demo migrations: `MaterialsDemo` streams the curated `materials` category ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
+
+Third Stage 2 migration. The previous `MaterialsDemo` (5-sphere metallic/roughness spectrum) didn't actually exercise any of the modern glTF material extensions — it was a hand-built PBR sweep useful for diagnosing the renderer, not for answering "what does `KHR_materials_sheen` look like in SceneView?". Stage 2 replaces it on both platforms with the curated extension-bearing models from `SampleAssets`'s `materials` category (Iridescent Beetle / Glass Decanter / Velvet Cushion — sheen, transmission, iridescence).
+
+**Why streamed.** Each model carries a glTF extension that depends on the author's source PBR tooling — bundling a hand-authored stand-in would either ship a giant binary (transmission demands a full IBL backdrop) or fake the look (and mislead the AI-first contract). Streaming the real Khronos / community assets keeps the demo honest.
+
+**Files touched:**
+
+- `samples/android-demo/.../demos/MaterialsDemo.kt` (new) — chip row + studio HDR + auto-orbit + per-chip extension tag (the registry's `tags[0]` is the `KHR_materials_*` extension name).
+- `samples/android-demo/.../DemoRegistry.kt` — new `materials` entry in the `Advanced` category with the `Icons.Filled.Palette` icon.
+- `samples/android-demo/.../MainActivity.kt` — routes `materials` to `MaterialsDemo`.
+- `samples/android-demo/src/main/res/values/strings.xml` + `values-fr/strings.xml` — 4 new keys: `demo_materials_title`, `demo_materials_subtitle`, `demo_materials_loading`, `demo_materials_credit`.
+- `samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift` — rewrote the 5-sphere PBR sweep as the streamed mirror. Same `materials` category, same chip row + extension tag + author byline, `SketchfabAssetResolver.shared.resolve(slug)` + `ModelNode.load(contentsOf:)`. The existing `SamplesTab` entry already wires up `MaterialsDemo()` — no dispatch change needed.
+
+**`SampleAssets` slugs added:** 0. The three `materials` slugs (Iridescent Beetle, Glass Decanter, Velvet Cushion) shipped in Stage 1 and are now consumed by this PR for the first time.
+
+**i18n hygiene.** All 4 new keys ship in EN + FR. The chip labels are catalogue-authored ids (English-only, per `OrbitalARDemo` convention). The extension tag (`KHR_materials_iridescence` etc.) is a glTF extension name and intentionally not localised — it's a spec identifier developers will Google.
+
+**Screen recording.** Deferred to the combined Stage 2 visual-smoke pass.
+
+**Acceptance:** Android `./gradlew :samples:android-demo:compileDebugKotlin` GREEN. `:samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27/27 unchanged).
+
 ### Added — Stage 2 demo migrations: `ModelViewerDemo` gains a "Surprise me" Sketchfab pick ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
 
 Second Stage 2 migration. `ModelViewerDemo` keeps the bundled `khronos_damaged_helmet.glb` as its hero default (so screenshots / Play Store store assets stay byte-identical) and adds an `ExtendedFloatingActionButton` that streams a fresh downloadable Sketchfab model on demand:

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoRegistry.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoRegistry.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.LocationCity
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.OpenWith
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PanoramaPhotosphere
 import androidx.compose.material.icons.filled.Pentagon
 import androidx.compose.material.icons.filled.PhotoCamera
@@ -154,6 +155,7 @@ val ALL_DEMOS = listOf(
     DemoEntry("collision", R.string.demo_collision_title, R.string.demo_collision_subtitle, DemoCategory.INTERACTION, Icons.Filled.CenterFocusStrong),
     DemoEntry("view-node", R.string.demo_view_node_title, R.string.demo_view_node_subtitle, DemoCategory.INTERACTION, Icons.Filled.Dashboard),
     // Advanced
+    DemoEntry("materials", R.string.demo_materials_title, R.string.demo_materials_subtitle, DemoCategory.ADVANCED, Icons.Filled.Palette),
     DemoEntry("physics", R.string.demo_physics_title, R.string.demo_physics_subtitle, DemoCategory.ADVANCED, Icons.Filled.ScatterPlot),
     DemoEntry("post-processing", R.string.demo_post_processing_title, R.string.demo_post_processing_subtitle, DemoCategory.ADVANCED, Icons.Filled.Tune),
     DemoEntry("custom-mesh", R.string.demo_custom_mesh_title, R.string.demo_custom_mesh_subtitle, DemoCategory.ADVANCED, Icons.Filled.Hexagon),

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -38,6 +38,7 @@ import io.github.sceneview.demo.demos.ViewNodeDemo
 import io.github.sceneview.demo.demos.GestureEditingDemo
 import io.github.sceneview.demo.demos.CollisionDemo
 import io.github.sceneview.demo.demos.DynamicSkyDemo
+import io.github.sceneview.demo.demos.MaterialsDemo
 import io.github.sceneview.demo.demos.MultiModelDemo
 import io.github.sceneview.demo.demos.SceneGalleryDemo
 import io.github.sceneview.demo.demos.PhysicsDemo
@@ -269,6 +270,7 @@ fun DemoRouter(id: String, onBack: () -> Unit) {
         // Advanced
         "dynamic-sky" -> DynamicSkyDemo(onBack)
         "multi-model" -> MultiModelDemo(onBack)
+        "materials" -> MaterialsDemo(onBack)
         "physics" -> PhysicsDemo(onBack)
         "post-processing" -> PostProcessingDemo(onBack)
         "custom-mesh" -> CustomMeshDemo(onBack)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -1,0 +1,189 @@
+package io.github.sceneview.demo.demos
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.sceneview.SceneView
+import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.LoadingScrim
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
+import io.github.sceneview.environment.rememberHDREnvironment
+import io.github.sceneview.math.Position
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberEnvironment
+import io.github.sceneview.rememberEnvironmentLoader
+import io.github.sceneview.rememberModelInstance
+import io.github.sceneview.rememberModelLoader
+
+/**
+ * Streamed showcase of the KHR_materials_* PBR extension family — sheen,
+ * transmission, iridescence — sourced from Sketchfab's CC-BY PBR catalogue
+ * (the same curated set declared in [SampleAssets]'s `materials` category).
+ *
+ * The previous version of this demo (parity with the iOS placeholder) was a
+ * 5-sphere metallic/roughness spectrum that didn't actually exercise any of
+ * the modern glTF material extensions. Stage 2 replaces it with curated
+ * extension-bearing models so the demo answers "what do KHR_materials_sheen
+ * / _transmission / _iridescence look like in SceneView?" at a glance.
+ *
+ * Lighting uses the studio HDR so reflections + IBL hit the streamed
+ * extension materials cleanly — sheen, transmission, and iridescence all
+ * rely heavily on environment lighting to read.
+ *
+ * Honours the umbrella's hard rules:
+ *   - **No Sketchfab WebView / external link.** Local file URLs only.
+ *   - **No network required to render something useful.** Empty key / cold
+ *     cache → resolver stages the bundled fallback for each slug. The
+ *     demo's fallback assets do not carry the actual extension materials
+ *     (those are author-controlled) but they keep the viewport non-empty
+ *     so the comparison UX stays understandable.
+ *
+ * @see SampleAssets for the curated `materials` category.
+ * @see SketchfabAssetResolver for the resolve / fallback contract.
+ */
+@Composable
+fun MaterialsDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val resolver = remember(context) { SketchfabAssetResolver.getInstance(context) }
+
+    // Three curated `materials` slugs — sheen, transmission, iridescence.
+    // Stage 2 keeps the count low so the offline-fallback footprint stays
+    // bounded; Stage 3 will expand once a CI maintenance cron validates each
+    // slug weekly.
+    val slugs = remember { SampleAssets.byCategory["materials"].orEmpty() }
+    var selectedIndex by remember { mutableStateOf(0) }
+    val selectedSlug = slugs.getOrNull(selectedIndex)
+
+    LaunchedEffect(resolver) {
+        runCatching { resolver.prefetchAll("materials") }
+    }
+
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
+
+    // Studio HDR — extension materials (sheen / transmission / iridescence)
+    // are heavily IBL-dependent and read flatly under default ambient light.
+    // Skybox enabled so the user can see the same environment the materials
+    // are reflecting / refracting.
+    val hdrEnvironment = rememberHDREnvironment(
+        environmentLoader,
+        "environments/studio_2k.hdr",
+        createSkybox = true,
+    )
+    val fallbackEnvironment = rememberEnvironment(environmentLoader)
+    val activeEnvironment = hdrEnvironment ?: fallbackEnvironment
+
+    val resolvedPath: String? by produceState<String?>(
+        initialValue = null,
+        key1 = resolver,
+        key2 = selectedSlug?.uid,
+    ) {
+        value = null
+        val slug = selectedSlug ?: return@produceState
+        value = runCatching { resolver.resolve(slug) }
+            .getOrNull()
+            ?.toURI()
+            ?.toString()
+    }
+
+    val modelInstance = resolvedPath?.let { path ->
+        rememberModelInstance(modelLoader, path)
+    }
+
+    DemoScaffold(
+        title = stringResource(R.string.demo_materials_title),
+        onBack = onBack,
+        controls = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                slugs.forEachIndexed { index, slug ->
+                    FilterChip(
+                        selected = index == selectedIndex,
+                        onClick = { selectedIndex = index },
+                        // displayName + the KHR_* tag give the user a clear
+                        // read of "which extension am I looking at" without
+                        // needing a second line of copy. tags is a
+                        // List<String> from the registry — we surface the
+                        // first one (`KHR_materials_*`).
+                        label = { Text(slug.displayName) },
+                    )
+                }
+            }
+            // Extension tag — the registry's `tags[0]` is the
+            // `KHR_materials_*` extension name. Displayed below the chips so
+            // the user can map the chip choice to the glTF extension being
+            // demonstrated.
+            selectedSlug?.let { slug ->
+                val extension = slug.tags.firstOrNull().orEmpty()
+                if (extension.isNotBlank()) {
+                    Text(
+                        text = extension,
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.demo_materials_credit, slug.author),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+        },
+    ) {
+        val cameraManipulator = rememberHeroOrbitCameraManipulator(
+            trigger = modelInstance != null,
+            radius = 1.2f,
+            yHeight = 0f,
+            durationMillis = 18_000,
+        )
+        Box(modifier = Modifier.fillMaxSize()) {
+            SceneView(
+                modifier = Modifier.fillMaxSize(),
+                engine = engine,
+                modelLoader = modelLoader,
+                environmentLoader = environmentLoader,
+                environment = activeEnvironment,
+                cameraManipulator = cameraManipulator,
+            ) {
+                val instance = modelInstance
+                val slug = selectedSlug
+                if (instance != null && slug != null) {
+                    ModelNode(
+                        modelInstance = instance,
+                        scaleToUnits = slug.scaleToUnits,
+                        centerOrigin = Position(0f, 0f, 0f),
+                    )
+                }
+            }
+            LoadingScrim(
+                loading = modelInstance == null,
+                label = stringResource(R.string.demo_materials_loading),
+            )
+        }
+    }
+}

--- a/samples/android-demo/src/main/res/values-fr/strings.xml
+++ b/samples/android-demo/src/main/res/values-fr/strings.xml
@@ -217,6 +217,10 @@
     <string name="demo_view_node_subtitle">UI Compose intégrée dans l\'espace 3D</string>
     <string name="demo_physics_title">Physique</string>
     <string name="demo_physics_subtitle">Gravité, collisions, corps rigides</string>
+    <string name="demo_materials_title">Matériaux PBR</string>
+    <string name="demo_materials_subtitle">Extensions KHR_materials_* streamées depuis Sketchfab</string>
+    <string name="demo_materials_loading">Streaming du matériau…</string>
+    <string name="demo_materials_credit">par %1$s · CC-BY 4.0</string>
     <string name="demo_post_processing_title">Post-traitement</string>
     <string name="demo_post_processing_subtitle">SSAO, anti-aliasing, mappage tonal</string>
     <string name="demo_custom_mesh_title">Maillage personnalisé</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -211,6 +211,10 @@
     <string name="demo_view_node_subtitle">Compose UI embedded in 3D space</string>
     <string name="demo_physics_title">Physics</string>
     <string name="demo_physics_subtitle">Gravity, collisions, rigid bodies</string>
+    <string name="demo_materials_title">PBR Materials</string>
+    <string name="demo_materials_subtitle">KHR_materials_* extensions streamed from Sketchfab</string>
+    <string name="demo_materials_loading">Streaming material…</string>
+    <string name="demo_materials_credit">by %1$s · CC-BY 4.0</string>
     <string name="demo_post_processing_title">Post Processing</string>
     <string name="demo_post_processing_subtitle">SSAO, anti-aliasing, tone mapping</string>
     <string name="demo_custom_mesh_title">Custom Mesh</string>

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
@@ -2,62 +2,142 @@ import SwiftUI
 import RealityKit
 import SceneViewSwift
 
-/// PBR material spectrum -- 5 spheres from rough to mirror.
+/// Streamed showcase of the `KHR_materials_*` PBR extension family — sheen,
+/// transmission, iridescence — sourced from Sketchfab's CC-BY PBR catalogue
+/// (the same curated set declared in `SampleAssets`'s `materials` category).
+///
+/// The previous version of this demo was a 5-sphere metallic/roughness
+/// spectrum that didn't actually exercise any of the modern glTF material
+/// extensions. Stage 2 replaces it with curated extension-bearing models so
+/// the demo answers "what do `KHR_materials_sheen` / `_transmission` /
+/// `_iridescence` look like in SceneView?" at a glance.
+///
+/// Honours the umbrella's hard rules:
+///   - **No Sketchfab WebView / external link.** Local file URLs only.
+///   - **No network required to render something useful.** Empty key / cold
+///     cache → the resolver stages the bundled fallback. The fallback
+///     assets do not carry the actual extension materials (those are
+///     author-controlled) but they keep the viewport non-empty.
 struct MaterialsDemo: View {
+    private let slugs: [SketchfabSlug] = SampleAssets.byCategory["materials"] ?? []
+
+    @State private var selectedIndex: Int = 0
+    @State private var loadedNode: ModelNode?
+    @State private var loadError: String?
+
+    private var selectedSlug: SketchfabSlug? {
+        guard slugs.indices.contains(selectedIndex) else { return nil }
+        return slugs[selectedIndex]
+    }
+
     var body: some View {
         ZStack {
-            SceneView { root in
-                let count = 5
-                for i in 0..<count {
-                    let progress = Float(i) / Float(count - 1)
-                    let metallic = progress
-                    let roughness = 1.0 - progress
-
-                    let sphere = GeometryNode.sphere(
-                        radius: 0.15,
-                        material: .pbr(color: .gray, metallic: metallic, roughness: roughness)
-                    )
-                    let x = Float(i - count / 2) * 0.4
-                    sphere.entity.position = .init(x: x, y: 0, z: -2)
-                    root.addChild(sphere.entity)
-                }
-            }
-            .cameraControls(.orbit)
-            .ignoresSafeArea()
-
+            sceneView
             VStack {
                 Spacer()
-                legendBar
+                controls
             }
         }
         .background(Color.black)
+        .task(id: selectedSlug?.uid) {
+            await loadSelectedSlug()
+        }
+        .task {
+            _ = await SketchfabAssetResolver.shared.prefetchAll(category: "materials")
+        }
     }
 
-    private var legendBar: some View {
-        HStack(spacing: 20) {
-            VStack(spacing: 2) {
-                Circle().fill(.gray.opacity(0.4)).frame(width: 10)
-                Text("Rough").font(.caption2).foregroundStyle(.white.opacity(0.7))
+    @ViewBuilder
+    private var sceneView: some View {
+        if let loadedNode {
+            SceneView { root in
+                loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
+                root.addChild(loadedNode.entity)
             }
-            Image(systemName: "arrow.right")
-                .font(.caption2)
-                .foregroundStyle(.white.opacity(0.4))
-            VStack(spacing: 2) {
-                Circle().fill(.gray.opacity(0.6)).frame(width: 10)
-                Text("Semi").font(.caption2).foregroundStyle(.white.opacity(0.7))
-            }
-            Image(systemName: "arrow.right")
-                .font(.caption2)
-                .foregroundStyle(.white.opacity(0.4))
-            VStack(spacing: 2) {
-                Circle().fill(.gray).frame(width: 10)
-                Text("Mirror").font(.caption2).foregroundStyle(.white.opacity(0.7))
+            .cameraControls(.orbit)
+            .autoRotate(speed: 0.3)
+            .ignoresSafeArea()
+            .id("materials-\(selectedSlug?.uid ?? "none")")
+        } else {
+            VStack(spacing: 12) {
+                ProgressView()
+                    .tint(.white)
+                if let loadError {
+                    Text(loadError)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                } else {
+                    Text("Streaming material…")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
             }
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
+    }
+
+    private var controls: some View {
+        VStack(spacing: 8) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Array(slugs.enumerated()), id: \.element.uid) { index, slug in
+                        Button {
+                            selectedIndex = index
+                            #if os(iOS)
+                            HapticManager.lightTap()
+                            #endif
+                        } label: {
+                            Text(slug.displayName)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(index == selectedIndex ? Color.black : Color.white)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 8)
+                                .background(
+                                    Capsule()
+                                        .fill(index == selectedIndex ? Color.white : Color.white.opacity(0.12))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+
+            if let slug = selectedSlug {
+                // `tags[0]` is the `KHR_materials_*` extension name in the
+                // curated registry — surface it so the user maps the chip
+                // choice to the extension being demoed.
+                if let ext = slug.tags.first, !ext.isEmpty {
+                    Text(ext)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+                Text("by \(slug.author) · CC-BY 4.0")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.75))
+            }
+        }
+        .padding(.vertical, 12)
         .background(.ultraThinMaterial)
-        .clipShape(Capsule())
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .padding(.horizontal, 16)
         .padding(.bottom, 24)
+    }
+
+    @MainActor
+    private func loadSelectedSlug() async {
+        guard let slug = selectedSlug else { return }
+        loadedNode = nil
+        loadError = nil
+        do {
+            let url = try await SketchfabAssetResolver.shared.resolve(slug)
+            let node = try await ModelNode.load(contentsOf: url)
+            _ = node.scaleToUnits(slug.scaleToUnits)
+            _ = node.centerOrigin()
+            loadedNode = node
+        } catch {
+            loadError = error.localizedDescription
+        }
     }
 }


### PR DESCRIPTION
## Summary

Third Stage 2 migration on the [`#1152` umbrella](https://github.com/sceneview/sceneview/issues/1152). The previous `MaterialsDemo` (5-sphere metallic/roughness spectrum) didn't actually exercise any of the modern glTF material extensions — it was a hand-built PBR sweep useful for diagnosing the renderer, not for answering "what does `KHR_materials_sheen` look like in SceneView?".

Stage 2 replaces it on both Android and iOS with the curated extension-bearing models from `SampleAssets`'s `materials` category:

- **Iridescent Beetle** — `KHR_materials_iridescence`
- **Glass Decanter** — `KHR_materials_transmission`
- **Velvet Cushion** — `KHR_materials_sheen`

Streaming the real Khronos / community assets keeps the demo honest — bundling a hand-authored stand-in would either ship a giant binary (transmission demands a full IBL backdrop) or fake the look.

## Files touched

- `samples/android-demo/.../demos/MaterialsDemo.kt` (new) — chip row + studio HDR + auto-orbit + per-chip extension tag.
- `samples/android-demo/.../DemoRegistry.kt` + `MainActivity.kt` — `materials` entry in the `Advanced` category, `Icons.Filled.Palette`.
- `samples/android-demo/src/main/res/values{,-fr}/strings.xml` — 4 new keys.
- `samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift` — rewrote the 5-sphere PBR sweep as the streamed mirror.

## SampleAssets changes

0 new slugs — the three `materials` slugs shipped in Stage 1 and are now consumed by this PR for the first time.

## i18n note

All 4 new keys ship in EN + FR. The chip labels (`SketchfabSlug.displayName`) and the extension tag (`KHR_materials_iridescence`) intentionally stay English — they're catalogue ids / spec identifiers, not localizable UI copy.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` GREEN
- [x] `./gradlew :samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` GREEN (27/27, unchanged from Stage 1)
- [ ] Pixel 9 visual smoke (deferred — combined with rest of Stage 2 batch)
- [ ] iPhone 16e simulator visual smoke (deferred — combined with rest of Stage 2 batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)