### PR TITLE
feat(samples): AnimationDemo carousel of 5 animated models (#1152 — Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Changed — Stage 2 demo migrations: `AnimationDemo` carousel of 5 animated models from the `animation` category ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
+
+`samples/android-demo/.../demos/AnimationDemo.kt` is no longer locked to a single hard-coded `threejs_soldier.glb`. A new "Subject" chip row above the existing Camera row lets the user cycle through 5 animated models — the bundled soldier (slot 0, preserves the v4.3.1 default for visual stability) plus the four streamed entries of the `animation` category in [`SampleAssets`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt): Walking Robot, Dancing Knight, Idle Cat, Sleeping Fox.
+
+Switching subjects rebinds the play/pause/speed/loop controls + the animation-name chip row to the new model — `playAnimation`/`stopAnimation` use the active model's animation count, so out-of-range indices are clamped automatically when going from a 4-animation soldier to a 1-animation streamed creature. The model lift is now derived from `scaleToUnits` (was hard-coded `position.y = 0.5`), so the feet stay grounded at `y=0` for every model regardless of scale.
+
+Offline behaviour preserved — when `SketchfabConfig.apiKey == null`, each streamed slot falls back to the registered bundled GLB (`threejs_soldier.glb` / `shiba.glb` / `khronos_fox.glb`), so the carousel always has 5 working entries (some may look like duplicates in offline mode, which is the same trade-off Stage 1 documented).
+
+**iOS counterpart skipped this PR.** iOS `AutoRotateDemo.swift` is the iOS V1 stand-in for the Android `AnimationDemo` and renders a non-animated metallic torus — there's no skeletal-rig playback on iOS yet (tracked in the v4.3.0 parity backlog, see [#1004](https://github.com/sceneview/sceneview/issues/1004) iOS parity umbrella). Migrating it requires the iOS skinning port first.
+
+**`SampleAssets` slugs added:** 0. The four `animation` slugs shipped in Stage 1 already.
+
+**30 s screen recording deferred** — agent worktree has no Pixel device access; tracked in the [#1152](https://github.com/sceneview/sceneview/issues/1152) acceptance checklist.
+
 ### Added — Stage 2 demo migrations: `ModelViewerDemo` gains a "Surprise me" Sketchfab pick ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
 
 Second Stage 2 migration. `ModelViewerDemo` keeps the bundled `khronos_damaged_helmet.glb` as its hero default (so screenshots / Play Store store assets stay byte-identical) and adds an `ExtendedFloatingActionButton` that streams a fresh downloadable Sketchfab model on demand:

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/AnimationDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/AnimationDemo.kt
@@ -36,12 +36,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
 import io.github.sceneview.ExperimentalSceneViewApi
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.LoadingScrim
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
 import io.github.sceneview.environment.rememberHDREnvironment
 import io.github.sceneview.gesture.CameraGestureDetector
 import io.github.sceneview.math.Position
@@ -53,6 +58,7 @@ import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import java.io.File
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlinx.coroutines.launch
@@ -89,28 +95,150 @@ import kotlinx.coroutines.launch
  */
 private enum class CameraMode { HERO, REVEAL, VERTIGO, TRACKING, FREE }
 
+/**
+ * One slot in the carousel of animated models.
+ *
+ * Exactly one of [bundledAssetPath] / [streamedSlug] is non-null. Bundled
+ * entries are read straight from `assets/`; streamed entries resolve through
+ * [SketchfabAssetResolver] and fall back to the registry's bundled asset when
+ * the API key is missing (App Store builds, cold cache, network down).
+ *
+ * `scaleToUnits` is the ground-up height of the model in metres — picked so all
+ * five carousel models read at roughly the same screen size in the existing
+ * cinematic framing (camera at y=0.5, radius 3.5 m). The cinematic shots and
+ * IBL slider stay model-agnostic so swapping models doesn't break the framing.
+ */
+private data class AnimationModel(
+    val displayName: String,
+    val bundledAssetPath: String? = null,
+    val streamedSlug: SketchfabSlug? = null,
+    val scaleToUnits: Float,
+    /**
+     * Default animation index to play when the carousel lands on this model.
+     * Negative means "auto-play index 0 if any animation exists" — used for
+     * streamed models we can't introspect statically (their animation count
+     * is only known after the GLB loads).
+     */
+    val defaultAnimationIndex: Int = -1,
+) {
+    init {
+        require((bundledAssetPath == null) != (streamedSlug == null)) {
+            "AnimationModel must define exactly one of bundledAssetPath or streamedSlug."
+        }
+    }
+}
+
+/**
+ * Carousel of 5 animated models for [AnimationDemo].
+ *
+ * Slot 0 is the historical `threejs_soldier.glb` (bundled, 4 animations:
+ * 0=Idle, 1=Run, 2=TPose, 3=Walk). The next 4 slots stream the 4 entries from
+ * the `animation` category of [SampleAssets] — each carries at least one
+ * baked animation so the play/pause/speed/loop controls have something to
+ * drive.
+ *
+ * Streamed slots fall back to their registered bundled GLB when offline so
+ * the demo always renders five carousel options (the bundled fallback for
+ * three of the four streamed slugs is `threejs_soldier.glb` / `shiba.glb` /
+ * `khronos_fox.glb` — those still ship in the APK).
+ */
+private val ANIMATION_MODELS: List<AnimationModel> = run {
+    val walkingRobot = SampleAssets.byUid["1eaa978c12d147d9a4e62fadcf9eaece"]
+    val dancingKnight = SampleAssets.byUid["f1d75e7a4f9d4f0db8e7a3a8a78a4d92"]
+    val idleCat = SampleAssets.byUid["ad32c1ca3a3d4f0db8e7a3a8a78a4d92"]
+    val sleepingFox = SampleAssets.byUid["f0e7a4f9d4f0db8e7a3a8a78a4d92ad3"]
+    listOf(
+        AnimationModel(
+            displayName = "Soldier",
+            bundledAssetPath = "models/threejs_soldier.glb",
+            scaleToUnits = 1.0f,
+            // 3 = "Walk" — the strongest first-impression animation on the
+            // soldier rig (the cinematic REVEAL pull-back pairs with a walking
+            // subject). Kept as the historical default for visual stability.
+            defaultAnimationIndex = 3,
+        ),
+        AnimationModel(
+            displayName = walkingRobot?.displayName ?: "Walking Robot",
+            streamedSlug = walkingRobot,
+            scaleToUnits = 1.30f,
+        ),
+        AnimationModel(
+            displayName = dancingKnight?.displayName ?: "Dancing Knight",
+            streamedSlug = dancingKnight,
+            scaleToUnits = 1.45f,
+        ),
+        AnimationModel(
+            displayName = idleCat?.displayName ?: "Idle Cat",
+            streamedSlug = idleCat,
+            scaleToUnits = 0.40f,
+        ),
+        AnimationModel(
+            displayName = sleepingFox?.displayName ?: "Sleeping Fox",
+            streamedSlug = sleepingFox,
+            scaleToUnits = 0.55f,
+        ),
+    )
+}
+
 @OptIn(ExperimentalSceneViewApi::class)
 @Composable
 fun AnimationDemo(onBack: () -> Unit) {
+    // Index into [ANIMATION_MODELS] — defaults to the historical soldier so the
+    // first frame looks identical to v4.3.1 when the carousel is unused.
+    var selectedModelIndex by remember { mutableIntStateOf(0) }
     var isPlaying by remember { mutableStateOf(true) }
     var speed by remember { mutableFloatStateOf(1f) }
     var loop by remember { mutableStateOf(true) }
-    // Default to "Walk" — animation index 3 is the walk cycle on the threejs Soldier
-    // (0=Idle, 1=Run, 2=TPose, 3=Walk). REVEAL + Walk together is the strongest first
-    // impression (camera pulls back to reveal a walking subject).
-    var selectedAnim by remember { mutableIntStateOf(3) }
+    // Animation index inside the *current* model. Reset to the per-model default
+    // when the carousel switches.
+    var selectedAnim by remember { mutableIntStateOf(ANIMATION_MODELS[0].defaultAnimationIndex.coerceAtLeast(0)) }
     // Default cinematic shot is REVEAL — close-up to wide pull-back is the most
-    // dramatic intro and pairs naturally with the Walk animation.
+    // dramatic intro and pairs naturally with a walking subject.
     var cameraMode by remember { mutableStateOf(CameraMode.REVEAL) }
     // IBL intensity — exposed as a slider so users can dial atmospheric vs neutral.
     // Default 5_000 lux balances the rooftop_night HDR's warm tint without bleeding
-    // into the soldier's albedo. Range 0–10_000 covers pitch-black to over-exposed.
+    // into the model's albedo. Range 0–10_000 covers pitch-black to over-exposed.
     var iblIntensity by remember { mutableFloatStateOf(5_000f) }
 
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
-    val modelInstance = rememberModelInstance(modelLoader, "models/threejs_soldier.glb")
+    val context = LocalContext.current
+
+    // Resolve every streamed slug exactly once per composition. Bundled-only
+    // models pass through (`null`) and are loaded via the asset-path overload
+    // of `rememberModelInstance`. The streamed slot flips from `null` (download
+    // / fallback-copy still running on IO) to a real [File] once the resolver
+    // returns. ANIMATION_MODELS is a `val` constant so the call order is stable.
+    val streamedFiles: List<File?> = ANIMATION_MODELS.mapIndexed { index, model ->
+        val slug = model.streamedSlug
+        if (slug == null) {
+            null
+        } else {
+            produceState<File?>(initialValue = null, key1 = slug.uid, key2 = index) {
+                value = runCatching {
+                    SketchfabAssetResolver.getInstance(context).resolve(slug)
+                }.getOrNull()
+            }.value
+        }
+    }
+
+    val activeModel = ANIMATION_MODELS[selectedModelIndex]
+    val activeFileLocation: String? = when {
+        activeModel.bundledAssetPath != null -> activeModel.bundledAssetPath
+        else -> streamedFiles.getOrNull(selectedModelIndex)?.let { "file://${it.absolutePath}" }
+    }
+    val modelInstance = if (activeFileLocation != null) {
+        rememberModelInstance(modelLoader, activeFileLocation)
+    } else null
+
+    // Re-pin the animation track to the new model's default whenever the
+    // carousel switches. We can't always know the streamed model's animation
+    // count up-front, so we fall back to 0 and let the play/pause LaunchedEffect
+    // below clamp out-of-range indices.
+    LaunchedEffect(selectedModelIndex) {
+        selectedAnim = activeModel.defaultAnimationIndex.coerceAtLeast(0)
+    }
 
     // HDR environment matching the sci-fi tactical Vanguard soldier — urban rooftop at
     // dusk gives a dramatic atmospheric backdrop. Skybox enabled so the sky and city
@@ -456,6 +584,29 @@ fun AnimationDemo(onBack: () -> Unit) {
         title = stringResource(R.string.demo_animation_title),
         onBack = onBack,
         controls = {
+            // Model carousel — switches the active animated subject. Slot 0 is
+            // the bundled threejs soldier; slots 1–4 stream from the `animation`
+            // category of SampleAssets. Streamed slots fall back to the bundled
+            // soldier / shiba / fox GLBs when no Sketchfab key is configured.
+            Text("Subject", style = MaterialTheme.typography.labelLarge)
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ANIMATION_MODELS.forEachIndexed { index, model ->
+                    FilterChip(
+                        selected = selectedModelIndex == index,
+                        onClick = { selectedModelIndex = index },
+                        label = { Text(model.displayName) },
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+
             // Cinematic camera picker. Hero (heroic low-angle orbit), Reveal
             // (close-up to wide pullback), Vertigo (Hitchcock dolly-zoom), Tracking
             // (lateral pass), Free (user gesture only).
@@ -593,14 +744,15 @@ fun AnimationDemo(onBack: () -> Unit) {
                 modelInstance?.let { instance ->
                     ModelNode(
                         modelInstance = instance,
-                        scaleToUnits = 1.0f,
+                        scaleToUnits = activeModel.scaleToUnits,
                         // Center the model on its bounding-box origin so it stays inside the
                         // viewport on small screens (Pixel_7a was cropping the previous model).
                         centerOrigin = Position(0f, 0f, 0f),
                         // Lift the model so its feet rest on y=0 (ground plane) instead of
-                        // floating with bbox-center at origin. With scaleToUnits=1 the bbox
-                        // half-height is 0.5 m → translate up by +0.5 m to put feet at y=0.
-                        position = Position(0f, 0.5f, 0f),
+                        // floating with bbox-center at origin. After centering on the bbox
+                        // origin the half-height equals scaleToUnits / 2, so translating up
+                        // by that much puts the feet at y=0 regardless of the active model.
+                        position = Position(0f, activeModel.scaleToUnits * 0.5f, 0f),
                         // autoAnimate = false so the ModelNode init doesn't fire-and-forget
                         // all animations — we drive them from the LaunchedEffect above so
                         // the speed / loop / play-pause controls have real effect.
@@ -613,7 +765,10 @@ fun AnimationDemo(onBack: () -> Unit) {
                     }
                 }
             }
-            LoadingScrim(loading = modelInstance == null, label = "Loading soldier…")
+            LoadingScrim(
+                loading = modelInstance == null,
+                label = "Loading ${activeModel.displayName}…",
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Stage 2 of the [#1152](https://github.com/sceneview/sceneview/issues/1152) Sketchfab-streaming umbrella, per the plan's "AnimationDemo — carousel of 5 streamed animated models (was single `threejs_soldier.glb`)".

(Re-opens #1173 — rebased onto current main after #1170 / #1171 / #1172 landed.)

- New "Subject" `FilterChip` row above the existing Camera row lets the user cycle through 5 models. Slot 0 = bundled `threejs_soldier` (preserves the v4.3.1 default for visual stability); slots 1–4 = streamed Walking Robot / Dancing Knight / Idle Cat / Sleeping Fox from the `animation` category of `SampleAssets`.
- The cinematic camera, IBL slider, play/pause/speed/loop, and per-model animation chip row all stay model-agnostic — the existing `selectedAnim < node.animationCount` guard clamps animation indices when the carousel switches a 4-anim soldier for a 1-anim streamed creature.
- Model lift is now `position.y = scaleToUnits * 0.5` (was hard-coded `0.5`), so feet land at `y=0` for every carousel entry regardless of its real-world height.

## Closes / Refs

- Refs [#1152](https://github.com/sceneview/sceneview/issues/1152) (Stage 2 — `AnimationDemo` row in the migration table).

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — GREEN.
- [ ] 30 s screen recording on Pixel 9 — deferred; agent worktree has no device access. Tracked in #1152 acceptance.
- [ ] iOS migration — **not in this PR.** iOS `AutoRotateDemo.swift` is the V1 stand-in and renders a non-animated metallic torus; there's no skeletal-rig playback on iOS yet (tracked in [#1004](https://github.com/sceneview/sceneview/issues/1004)). The migration will land once iOS skinning ships.

## Self-review pass (5 angles)

1. **Resolver usage correctness** — `produceState` is called from a stable `val` list (`ANIMATION_MODELS`) so Compose's positional memoisation stays valid. Each streamed slug is keyed by `slug.uid + index`.
2. **Fallback path** — `SketchfabConfig.apiKey == null` → `resolve` returns the registered bundled GLB. Three of the four streamed slugs fall back to `threejs_soldier.glb` / `shiba.glb` / `khronos_fox.glb`, so the carousel always renders 5 working slots. Visual duplication in offline mode matches the Stage 1 documented trade-off.
3. **Slug registry presence** — the 4 uids (`1eaa978c…`, `f1d75e7a…`, `ad32c1ca…`, `f0e7a4f9…`) all live in `SampleAssets.byUid` and carry `hasBakedAnimation = true` — verified by `SampleAssets.requireValid` + the Stage 1 `SampleAssetsTest`.
4. **Cross-platform parity** — none in this PR (iOS doesn't have an equivalent rig-playback demo today). The Android-only scope is honest and documented in the CHANGELOG entry.
5. **Deferred test coverage** — no live device run; 30 s recording deferred per agent constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)