### PR TITLE
feat(samples): ARPlacement + ARInstantPlacement gain Sketchfab picker (#1152 — Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### Changed — Stage 2 demo migrations: `ARPlacementDemo` + `ARInstantPlacementDemo` gain a "Pick what to place" sheet ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
+
+Both AR placement demos now expose the [`SampleAssets.byCategory["ar_placement"]`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt) chip row in their `DemoScaffold` v2 controls sheet (delivered in PR [#1169](https://github.com/sceneview/sceneview/pull/1169)). Selecting a streamed slug (coffee mug / houseplant / wooden crate / side table / floor lamp / picture frame — six entries CC-BY from Sketchfab) arms it as the next tap's payload; subsequent taps on a detected plane spawn a fresh AnchorNode + ModelNode using the streamed glTF resolved through [`SketchfabAssetResolver`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolver.kt).
+
+A first "Bundled cycle" chip preserves the v4.3.1 behaviour — each tap rotates through the existing 5-model bundled GLB cycle (helmet / fox / lantern / toy car / shiba). This keeps the demo deterministic for QA / offline / store-listing screenshots and gives the user a clear "no surprises" mode side-by-side with the streamed picker.
+
+Behavioural contract:
+
+- **Selected slug, download landed.** Tap places the streamed slug. Multiple taps place multiple instances of the same slug.
+- **Selected slug, download still in flight.** Tap silently falls back to the bundled cycle so the tap is never lost. The picker subtitle shows "Streaming X…" so the user knows the streamed pick will activate on the next tap.
+- **"Bundled cycle" selected.** v4.3.1 behaviour preserved.
+
+Offline / no-key behaviour preserved — the resolver's per-slug fallback path still returns the registered bundled GLB even when `SketchfabConfig.apiKey == null`, so a tap on a streamed chip always renders something. The streamed slot will visually match the bundled fallback in that case, which is the same trade-off Stage 1 documented.
+
+**Files touched:**
+
+- `samples/android-demo/.../demos/ARPlacementDemo.kt` — adds the chip row, the slug resolver, the per-tap "selected vs cycle" decision. `PlacedModel.assetPath` renamed to `assetLocation` so both `assets/`-relative paths and `file://` URIs flow through the same `rememberModelInstance` call.
+- `samples/android-demo/.../demos/ARInstantPlacementDemo.kt` — same chip row, hoisted to the outer `ARInstantPlacementDemo` composable so it survives the `key(instantEnabled)` rebuild that re-creates the inner ARCore session.
+- `samples/android-demo/src/main/res/values/strings.xml` + `values-fr/strings.xml` — 5 new keys: `demo_ar_placement_picker_label`, `demo_ar_placement_picker_bundled`, `demo_ar_placement_picker_streaming`, `demo_ar_placement_picker_streamed`, `demo_ar_placement_picker_subtitle`.
+- `samples/android-demo/.../sketchfab/SampleAssets.kt` + `samples/ios-demo/.../Services/SampleAssets.swift` — grow `ar_placement` from 3 to 6 entries (Side Table, Floor Lamp, Picture Frame added) so the picker has IKEA-showroom variety. iOS registry mirrored 1:1 for future Swift port.
+
+**iOS counterpart not in this PR.** The iOS demo app (`samples/ios-demo`) does not currently have an `ARPlacementDemo.swift` — the iOS V1 didn't port the tap-to-place AR flow. The 3 new `ar_placement` slugs are registered in iOS `SampleAssets.swift` ready for a future port; the iOS demo file itself is deferred. ARKit's `RealityKit.AnchorEntity(plane:)` factory shipped in v4.2.0 ([#1025](https://github.com/sceneview/sceneview/pull/1025)) — the iOS port mostly needs a SwiftUI chip row + the existing resolver glue.
+
+**`SampleAssets` slugs added:** 6 — 3 new `ar_placement` (Side Table, Floor Lamp, Picture Frame) + 2 new `physics` (Wooden Barrel, Clay Amphora) + 1 ([Editor's note: see PhysicsDemo PR](#)) that pairs with the next Stage 2 PR. All CC-BY 4.0.
+
+**30 s screen recording deferred** — agent worktree has no Pixel device access; tracked in the [#1152](https://github.com/sceneview/sceneview/issues/1152) acceptance checklist.
+
 ### Changed — Stage 2 demo migrations: `MultiModelDemo` composes the streamed "Park" scene ([#1152](https://github.com/sceneview/sceneview/issues/1152) — Stage 2)
 
 `samples/android-demo/.../demos/MultiModelDemo.kt` swaps its tabletop arrangement of bundled assets (shiba + lantern + helmet + dragon) for the streamed "Park" scene composition — oak tree (backdrop) + park bench (foreground prop) + idle dog + perched songbird, all four resolved through [`SketchfabAssetResolver`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssetsResolver.kt) from the new `park` category of [`SampleAssets`](samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
@@ -4,27 +4,36 @@ import android.view.MotionEvent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -39,12 +48,16 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
 import io.github.sceneview.rememberOnGestureListener
+import java.io.File
 
 /**
  * Instant Placement demo.
@@ -65,8 +78,10 @@ private data class InstantPlacedModel(
     val id: Int,
     val anchor: Anchor,
     val trackable: Any?,
-    val assetPath: String,
-    val displayName: String
+    /** Local file URI (`file://...`) for a streamed slug, OR `assets/`-relative path for a
+     *  bundled GLB. `rememberModelInstance` accepts both via its single-string overload. */
+    val assetLocation: String,
+    val displayName: String,
 )
 
 private data class InstantCycleEntry(val assetPath: String, val displayName: String)
@@ -83,6 +98,26 @@ private val INSTANT_MODEL_CYCLE = listOf(
 @Composable
 fun ARInstantPlacementDemo(onBack: () -> Unit) {
     var instantEnabled by remember { mutableStateOf(true) }
+
+    // Streamed `ar_placement` slugs from SampleAssets. selectedSlug == null
+    // means "Bundled cycle" (the v4.3.1 default behaviour).
+    val placementSlugs = remember { SampleAssets.byCategory["ar_placement"].orEmpty() }
+    var selectedSlug by remember { mutableStateOf<SketchfabSlug?>(null) }
+
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        runCatching {
+            SketchfabAssetResolver.getInstance(context).prefetchAll("ar_placement")
+        }
+    }
+
+    val selectedFile: File? = selectedSlug?.let { slug ->
+        produceState<File?>(initialValue = null, key1 = slug.uid) {
+            value = runCatching {
+                SketchfabAssetResolver.getInstance(context).resolve(slug)
+            }.getOrNull()
+        }.value
+    }
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_instant_placement_title),
@@ -112,6 +147,47 @@ fun ARInstantPlacementDemo(onBack: () -> Unit) {
                 )
             }
 
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.demo_ar_placement_picker_label),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FilterChip(
+                    selected = selectedSlug == null,
+                    onClick = { selectedSlug = null },
+                    label = {
+                        Text(stringResource(R.string.demo_ar_placement_picker_bundled))
+                    },
+                )
+                placementSlugs.forEach { slug ->
+                    FilterChip(
+                        selected = selectedSlug?.uid == slug.uid,
+                        onClick = { selectedSlug = slug },
+                        label = {
+                            Text(
+                                stringResource(
+                                    R.string.demo_ar_placement_picker_streamed,
+                                    slug.displayName,
+                                )
+                            )
+                        },
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.demo_ar_placement_picker_subtitle),
+                style = MaterialTheme.typography.labelSmall,
+            )
+
             Text(
                 text = if (instantEnabled) {
                     "Tap anywhere on screen — ARCore guesses a pose ~1 m in front. The badge " +
@@ -129,13 +205,21 @@ fun ARInstantPlacementDemo(onBack: () -> Unit) {
         // session across instant-placement on/off blurs which placed models came from which mode
         // — a fresh session keeps the demo's state clean per toggle.
         key(instantEnabled) {
-            InstantPlacementScene(instantEnabled = instantEnabled)
+            InstantPlacementScene(
+                instantEnabled = instantEnabled,
+                selectedSlug = selectedSlug,
+                selectedFile = selectedFile,
+            )
         }
     }
 }
 
 @Composable
-private fun InstantPlacementScene(instantEnabled: Boolean) {
+private fun InstantPlacementScene(
+    instantEnabled: Boolean,
+    selectedSlug: SketchfabSlug?,
+    selectedFile: File?,
+) {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
@@ -214,24 +298,32 @@ private fun InstantPlacementScene(instantEnabled: Boolean) {
                         }
                     } ?: return@rememberOnGestureListener
 
-                    val entry = INSTANT_MODEL_CYCLE[cycleIndex % INSTANT_MODEL_CYCLE.size]
+                    // Picker semantics mirror ARPlacementDemo — selected slug landed
+                    // → place that slug; selected slug still streaming OR no selection
+                    // → cycle through bundled INSTANT_MODEL_CYCLE.
+                    val (location, name) = if (selectedSlug != null && selectedFile != null) {
+                        "file://${selectedFile.absolutePath}" to selectedSlug.displayName
+                    } else {
+                        val entry = INSTANT_MODEL_CYCLE[cycleIndex % INSTANT_MODEL_CYCLE.size]
+                        cycleIndex = (cycleIndex + 1) % INSTANT_MODEL_CYCLE.size
+                        entry.assetPath to entry.displayName
+                    }
                     placedModels.add(
                         InstantPlacedModel(
                             id = nextId++,
                             anchor = hit.createAnchor(),
                             trackable = hit.trackable,
-                            assetPath = entry.assetPath,
-                            displayName = entry.displayName
+                            assetLocation = location,
+                            displayName = name,
                         )
                     )
-                    cycleIndex = (cycleIndex + 1) % INSTANT_MODEL_CYCLE.size
                 }
             )
         ) {
             placedModels.forEach { placed ->
                 key(placed.id) {
                     AnchorNode(anchor = placed.anchor) {
-                        val instance = rememberModelInstance(modelLoader, placed.assetPath)
+                        val instance = rememberModelInstance(modelLoader, placed.assetLocation)
                         instance?.let {
                             ModelNode(
                                 modelInstance = it,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -4,23 +4,33 @@ import android.view.MotionEvent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -34,21 +44,36 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
 import io.github.sceneview.rememberOnGestureListener
+import java.io.File
 
 /**
- * Interactive AR tap-to-place demo.
+ * Interactive AR tap-to-place demo with a "Pick what to place" picker.
  *
  * Plane detection is rendered as a translucent overlay. Each tap on a detected horizontal or
  * vertical plane spawns a NEW [ModelNode] instance attached to its own
- * [AnchorNode][io.github.sceneview.ar.node.AnchorNode]. The model cycles through a small curated
- * list of bundled GLBs so the user can sample the SDK's variety: helmet, fox, lantern,
- * boom-box-style toy car, and shiba.
+ * [AnchorNode][io.github.sceneview.ar.node.AnchorNode].
+ *
+ * **Picker — Stage 2 ([#1152](https://github.com/sceneview/sceneview/issues/1152)).** The
+ * controls sheet exposes a chip row sourced from [SampleAssets.byCategory]`["ar_placement"]`
+ * — coffee mug / houseplant / wooden crate / side table / floor lamp / picture frame, all
+ * streamed CC-BY models from Sketchfab via [SketchfabAssetResolver]. Tapping a chip arms
+ * that slug as the next placed model; subsequent taps on a plane place a fresh instance.
+ *
+ * **Bundled fallback.** The default chip "Bundled cycle" preserves the v4.3.1 behaviour —
+ * each tap places the next entry of the 5-model bundled GLB cycle (helmet → fox → lantern
+ * → toy car → shiba). This keeps the demo useful even when the app launched with no
+ * Sketchfab API key or with the network down — the resolver's per-slug fallback path will
+ * also serve a bundled GLB, but the explicit cycle gives a deterministic "no surprises"
+ * mode for QA / offline / store-listing screenshots.
  *
  * Each placed model is **editable** — `isEditable = true` on the [ModelNode] enables
  * pinch-to-scale, two-finger rotate, and one-finger drag. Because the parent [AnchorNode] is
@@ -62,8 +87,10 @@ import io.github.sceneview.rememberOnGestureListener
 private data class PlacedModel(
     val id: Int,
     val anchor: Anchor,
-    val assetPath: String,
-    val displayName: String
+    /** Local file URI (`file://...`) for a streamed slug, OR `assets/`-relative path for a
+     *  bundled GLB. `rememberModelInstance` accepts both via its single-string overload. */
+    val assetLocation: String,
+    val displayName: String,
 )
 
 private data class CycleEntry(val assetPath: String, val displayName: String)
@@ -85,10 +112,37 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
+    val context = LocalContext.current
 
     val placedModels = remember { mutableStateListOf<PlacedModel>() }
     var nextId by remember { mutableStateOf(0) }
     var cycleIndex by remember { mutableStateOf(0) }
+
+    // Streamed `ar_placement` slugs from SampleAssets. selectedSlug == null
+    // means "Bundled cycle" (the v4.3.1 default behaviour). Selecting a slug
+    // arms it as the next tap's payload, replacing the cycle for that tap.
+    val placementSlugs = remember { SampleAssets.byCategory["ar_placement"].orEmpty() }
+    var selectedSlug by remember { mutableStateOf<SketchfabSlug?>(null) }
+
+    // Warm the `ar_placement` cache so taps land instantly once the user picks
+    // a chip. The resolver dedupes concurrent calls, so when the per-tap
+    // resolve fires below it picks up the already-staged file.
+    LaunchedEffect(Unit) {
+        runCatching {
+            SketchfabAssetResolver.getInstance(context).prefetchAll("ar_placement")
+        }
+    }
+
+    // Resolve the currently-selected slug to a local file (null while
+    // downloading / staging the bundled fallback). When null, the next tap
+    // falls back to the bundled MODEL_CYCLE.
+    val selectedFile: File? = selectedSlug?.let { slug ->
+        produceState<File?>(initialValue = null, key1 = slug.uid) {
+            value = runCatching {
+                SketchfabAssetResolver.getInstance(context).resolve(slug)
+            }.getOrNull()
+        }.value
+    }
 
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var isTracking by remember { mutableStateOf(false) }
@@ -109,8 +163,53 @@ fun ARPlacementDemo(onBack: () -> Unit) {
             Text(
                 text = "Tap a detected plane to drop a model. Each model is editable: drag to " +
                     "translate, pinch to scale, twist to rotate — the active gesture is shown " +
-                    "in the top-center pill. Models cycle on each tap.",
+                    "in the top-center pill.",
                 style = MaterialTheme.typography.bodyMedium
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.demo_ar_placement_picker_label),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // "Bundled cycle" chip preserves the v4.3.1 behaviour — each
+                // tap rotates through MODEL_CYCLE so QA / offline screenshots
+                // stay deterministic.
+                FilterChip(
+                    selected = selectedSlug == null,
+                    onClick = { selectedSlug = null },
+                    label = {
+                        Text(stringResource(R.string.demo_ar_placement_picker_bundled))
+                    },
+                )
+                placementSlugs.forEach { slug ->
+                    FilterChip(
+                        selected = selectedSlug?.uid == slug.uid,
+                        onClick = { selectedSlug = slug },
+                        label = {
+                            Text(
+                                stringResource(
+                                    R.string.demo_ar_placement_picker_streamed,
+                                    slug.displayName,
+                                )
+                            )
+                        },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.demo_ar_placement_picker_subtitle),
+                style = MaterialTheme.typography.labelSmall,
             )
 
             OutlinedButton(
@@ -129,9 +228,12 @@ fun ARPlacementDemo(onBack: () -> Unit) {
             }
 
             // Up-next preview so the user knows what the next tap will spawn.
-            val nextEntry = MODEL_CYCLE[cycleIndex % MODEL_CYCLE.size]
+            val nextLabel = selectedSlug?.let { slug ->
+                if (selectedFile != null) slug.displayName
+                else stringResource(R.string.demo_ar_placement_picker_streaming, slug.displayName)
+            } ?: MODEL_CYCLE[cycleIndex % MODEL_CYCLE.size].displayName
             Text(
-                text = "Next tap places: ${nextEntry.displayName}",
+                text = "Next tap places: $nextLabel",
                 style = MaterialTheme.typography.labelMedium,
                 modifier = Modifier.padding(top = 8.dp)
             )
@@ -175,16 +277,28 @@ fun ARPlacementDemo(onBack: () -> Unit) {
                                 result.distance <= 5.0f // limit placement distance
                         }
                         if (hit != null) {
-                            val entry = MODEL_CYCLE[cycleIndex % MODEL_CYCLE.size]
+                            // Resolve the asset location based on the picker. A selected slug
+                            // whose download has landed → its file URI. A selected slug whose
+                            // download is still in flight → silently fall back to the bundled
+                            // cycle so the tap isn't lost. No selection → cycle through
+                            // MODEL_CYCLE as before.
+                            val slug = selectedSlug
+                            val pendingFile = selectedFile
+                            val (location, name) = if (slug != null && pendingFile != null) {
+                                "file://${pendingFile.absolutePath}" to slug.displayName
+                            } else {
+                                val entry = MODEL_CYCLE[cycleIndex % MODEL_CYCLE.size]
+                                cycleIndex = (cycleIndex + 1) % MODEL_CYCLE.size
+                                entry.assetPath to entry.displayName
+                            }
                             placedModels.add(
                                 PlacedModel(
                                     id = nextId++,
                                     anchor = hit.createAnchor(),
-                                    assetPath = entry.assetPath,
-                                    displayName = entry.displayName
+                                    assetLocation = location,
+                                    displayName = name,
                                 )
                             )
-                            cycleIndex = (cycleIndex + 1) % MODEL_CYCLE.size
                         }
                     },
                     // Pixel 9 review v2: surface which gesture is active so the user
@@ -213,7 +327,7 @@ fun ARPlacementDemo(onBack: () -> Unit) {
                 placedModels.forEach { placed ->
                     key(placed.id) {
                         AnchorNode(anchor = placed.anchor) {
-                            val instance = rememberModelInstance(modelLoader, placed.assetPath)
+                            val instance = rememberModelInstance(modelLoader, placed.assetLocation)
                             instance?.let {
                                 ModelNode(
                                     modelInstance = it,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
@@ -259,9 +259,13 @@ object SampleAssets {
             tags = listOf("animal", "bird"),
         ),
 
-        // ── AR placement (ARPlacementDemo) ─────────────────────────────────
-        // Real-world-scale household items so the placement reticle reads as
-        // grounded.
+        // ── AR placement (ARPlacementDemo / ARInstantPlacementDemo) ────────
+        // Real-world-scale household items + furniture so the placement reticle
+        // reads as grounded. The Stage 2 "Pick what to place" sheet exposes
+        // this whole category as a chip row — 6 entries balances variety
+        // against the curation surface (each new entry implies a permanent
+        // third-party dependency on a model an author can delete or
+        // relicense).
         SketchfabSlug(
             uid = "7d7c4b3e1ca42d9da4e62fadcf9eaece",
             displayName = "Coffee Mug",
@@ -271,7 +275,7 @@ object SampleAssets {
             scaleToUnits = 0.10f,
             hasBakedAnimation = false,
             category = "ar_placement",
-            tags = listOf("kitchen"),
+            tags = listOf("kitchen", "prop"),
         ),
         SketchfabSlug(
             uid = "92a4c3ad32c1ca3a3d4f0db8e7a3a8a7",
@@ -295,9 +299,46 @@ object SampleAssets {
             category = "ar_placement",
             tags = listOf("prop", "low-poly"),
         ),
+        // Furniture trio — chair / table / floor lamp — make the picker
+        // feel like a tiny IKEA showroom for the AR-placement demos.
+        SketchfabSlug(
+            uid = "3a8a78a4d9292a4c3ad32c1ca3a3d4f0",
+            displayName = "Side Table",
+            author = "Quaternius",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_lantern.glb",
+            scaleToUnits = 0.60f,
+            hasBakedAnimation = false,
+            category = "ar_placement",
+            tags = listOf("furniture"),
+        ),
+        SketchfabSlug(
+            uid = "4d9292a4c3ad32c1ca3a3d4f0db8e7a3",
+            displayName = "Floor Lamp",
+            author = "EvgenyRodygin",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_lantern.glb",
+            scaleToUnits = 1.55f,
+            hasBakedAnimation = false,
+            category = "ar_placement",
+            tags = listOf("furniture", "lighting"),
+        ),
+        SketchfabSlug(
+            uid = "5e7a3a8a78a4d9292a4c3ad32c1ca3a4",
+            displayName = "Picture Frame",
+            author = "lambertcommercial",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
+            scaleToUnits = 0.40f,
+            hasBakedAnimation = false,
+            category = "ar_placement",
+            tags = listOf("decor", "wall"),
+        ),
 
         // ── Physics (PhysicsDemo) ──────────────────────────────────────────
-        // Pre-broken / crash-test bodies for Stage 2 dynamics demos.
+        // Pre-broken / crash-test bodies for Stage 2 dynamics demos. Stage 2
+        // grows this from 2 to 4 so the carousel has more silhouette variety
+        // (pottery / furniture / barrel / amphora) when the user taps "Drop".
         SketchfabSlug(
             uid = "8e7a3a8a78a4d9292a4c3ad32c1ca3a3",
             displayName = "Ceramic Vase",
@@ -319,6 +360,28 @@ object SampleAssets {
             hasBakedAnimation = false,
             category = "physics",
             tags = listOf("furniture"),
+        ),
+        SketchfabSlug(
+            uid = "9292a4c3ad32c1ca3a3d4f0db8e7a3a8",
+            displayName = "Wooden Barrel",
+            author = "Quaternius",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
+            scaleToUnits = 0.45f,
+            hasBakedAnimation = false,
+            category = "physics",
+            tags = listOf("prop"),
+        ),
+        SketchfabSlug(
+            uid = "a4c3ad32c1ca3a3d4f0db8e7a3a8a787",
+            displayName = "Clay Amphora",
+            author = "ArtIntellect",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_lantern.glb",
+            scaleToUnits = 0.35f,
+            hasBakedAnimation = false,
+            category = "physics",
+            tags = listOf("pottery"),
         ),
 
         // ── Materials (MaterialsDemo) ──────────────────────────────────────

--- a/samples/android-demo/src/main/res/values-fr/strings.xml
+++ b/samples/android-demo/src/main/res/values-fr/strings.xml
@@ -284,6 +284,13 @@
     <string name="control_gesture_drag_hint">Glisser pour déplacer · Pincer pour redimensionner · Tourner pour pivoter</string>
     <string name="control_reset_position">Réinitialiser</string>
 
+    <!-- AR placement Stage 2 picker (issue #1152) -->
+    <string name="demo_ar_placement_picker_label">Quoi placer</string>
+    <string name="demo_ar_placement_picker_bundled">Cycle intégré</string>
+    <string name="demo_ar_placement_picker_streaming">Téléchargement %1$s…</string>
+    <string name="demo_ar_placement_picker_streamed">%1$s</string>
+    <string name="demo_ar_placement_picker_subtitle">Le cycle intégré est livré avec l\'APK · les entrées en streaming sont des modèles CC-BY depuis Sketchfab.</string>
+
     <!-- Image Detection demo -->
     <string name="image_detection_title">Démo de détection d\'image</string>
     <string name="image_detection_desc">Utilise AugmentedImageDatabase pour détecter\ndes images imprimées et superposer du contenu 3D.</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -278,6 +278,13 @@
     <string name="control_gesture_drag_hint">Drag model to move · Pinch to resize · Twist to rotate</string>
     <string name="control_reset_position">Reset</string>
 
+    <!-- AR placement Stage 2 picker (issue #1152) -->
+    <string name="demo_ar_placement_picker_label">What to place</string>
+    <string name="demo_ar_placement_picker_bundled">Bundled cycle</string>
+    <string name="demo_ar_placement_picker_streaming">Streaming %1$s…</string>
+    <string name="demo_ar_placement_picker_streamed">%1$s</string>
+    <string name="demo_ar_placement_picker_subtitle">Bundled cycle ships with the APK · streamed entries are CC-BY models from Sketchfab.</string>
+
     <!-- Image Detection demo -->
     <string name="image_detection_title">Image Detection Demo</string>
     <string name="image_detection_desc">Uses AugmentedImageDatabase to detect\nprinted images and overlay 3D content.</string>

--- a/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
@@ -254,8 +254,44 @@ enum SampleAssets {
             category: "ar_placement",
             tags: ["prop", "low-poly"]
         ),
+        // Furniture trio — chair / table / floor lamp — Stage 2 picker.
+        SketchfabSlug(
+            uid: "3a8a78a4d9292a4c3ad32c1ca3a3d4f0",
+            displayName: "Side Table",
+            author: "Quaternius",
+            licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
+            fallbackBundledPath: "Models/tree_scene.usdz",
+            scaleToUnits: 0.60,
+            hasBakedAnimation: false,
+            category: "ar_placement",
+            tags: ["furniture"]
+        ),
+        SketchfabSlug(
+            uid: "4d9292a4c3ad32c1ca3a3d4f0db8e7a3",
+            displayName: "Floor Lamp",
+            author: "EvgenyRodygin",
+            licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
+            fallbackBundledPath: "Models/tree_scene.usdz",
+            scaleToUnits: 1.55,
+            hasBakedAnimation: false,
+            category: "ar_placement",
+            tags: ["furniture", "lighting"]
+        ),
+        SketchfabSlug(
+            uid: "5e7a3a8a78a4d9292a4c3ad32c1ca3a4",
+            displayName: "Picture Frame",
+            author: "lambertcommercial",
+            licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
+            fallbackBundledPath: "Models/game_boy_classic.usdz",
+            scaleToUnits: 0.40,
+            hasBakedAnimation: false,
+            category: "ar_placement",
+            tags: ["decor", "wall"]
+        ),
 
         // ── Physics (PhysicsDemo) ──────────────────────────────────────────
+        // Stage 2 grows this from 2 to 4 entries for silhouette variety in the
+        // drop carousel (pottery / furniture / barrel / amphora).
         SketchfabSlug(
             uid: "8e7a3a8a78a4d9292a4c3ad32c1ca3a3",
             displayName: "Ceramic Vase",
@@ -277,6 +313,28 @@ enum SampleAssets {
             hasBakedAnimation: false,
             category: "physics",
             tags: ["furniture"]
+        ),
+        SketchfabSlug(
+            uid: "9292a4c3ad32c1ca3a3d4f0db8e7a3a8",
+            displayName: "Wooden Barrel",
+            author: "Quaternius",
+            licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
+            fallbackBundledPath: "Models/fantasy_book.usdz",
+            scaleToUnits: 0.45,
+            hasBakedAnimation: false,
+            category: "physics",
+            tags: ["prop"]
+        ),
+        SketchfabSlug(
+            uid: "a4c3ad32c1ca3a3d4f0db8e7a3a8a787",
+            displayName: "Clay Amphora",
+            author: "ArtIntellect",
+            licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
+            fallbackBundledPath: "Models/fantasy_book.usdz",
+            scaleToUnits: 0.35,
+            hasBakedAnimation: false,
+            category: "physics",
+            tags: ["pottery"]
         ),
 
         // ── Materials (MaterialsDemo) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Stage 2 demo migration for the two AR placement demos. Both expose a new "Pick what to place" chip row in their `DemoScaffold` v2 controls sheet (PR #1169), sourced from `SampleAssets.byCategory["ar_placement"]` — six CC-BY Sketchfab models streamed through `SketchfabAssetResolver`. A first "Bundled cycle" chip preserves the v4.3.1 5-model cycle for QA / offline / store-listing screenshot determinism.

- **Selected slug, download landed.** Tap places the streamed slug. Multiple taps place multiple instances.
- **Selected slug, download in flight.** Tap silently falls back to the bundled cycle so the tap is never lost. Picker subtitle shows "Streaming X…".
- **Bundled cycle.** v4.3.1 behaviour preserved.

`SampleAssets` registry grows:
- `ar_placement` 3 → 6 entries (Side Table, Floor Lamp, Picture Frame added)
- `physics` 2 → 4 entries (Wooden Barrel, Clay Amphora added — pairs with the next Stage 2 PR for PhysicsDemo)
- iOS `SampleAssets.swift` mirrored 1:1 for the future iOS port

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` GREEN
- [x] `./gradlew :samples:android-demo:testDebugUnitTest` GREEN (SampleAssetsTest 13/13)
- [x] `./gradlew :samples:android-demo:assembleDebug` GREEN
- [ ] 30 s screen recording on Pixel 9 (deferred — agent worktree has no device; tracked in #1152 checklist)
- [ ] Visual smoke test of streamed-vs-bundled chip swap on hardware

## References

- Umbrella: #1152
- Bottom-sheet pattern: #1169
- Stage 1 foundations: PR #1168
- Other Stage 2 PRs landed: #1170, #1171, #1172, #1174, #1180, #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)