### PR TITLE
ux(explore): snap-to-card fling + edge padding on Sketchfab carousels (#1182)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -16,8 +16,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -151,7 +154,19 @@ fun ExploreTabScreen(
 
         if (curatedSamples.isNotEmpty()) {
             CarouselSection(title = stringResource(R.string.explore_try_a_sample)) {
-                LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                val state = rememberLazyListState()
+                LazyRow(
+                    state = state,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    // Edge padding so the first/last card has breathing room
+                    // and never sits half-cropped at the viewport edge — the
+                    // Pixel 9 audit (#1182) caught a screenshot where a card
+                    // appeared truncated mid-name purely because of zero-pad.
+                    contentPadding = PaddingValues(horizontal = 4.dp),
+                    // Snap to card boundaries on fling so the user never
+                    // releases scroll on a half-card.
+                    flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
+                ) {
                     items(curatedSamples) { sample ->
                         SampleCard(sample = sample, onClick = { onSampleClick(sample) })
                     }
@@ -321,7 +336,17 @@ private fun FeedSection(
                 CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
             }
         }
-        LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        val state = rememberLazyListState()
+        LazyRow(
+            state = state,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            // Edge padding so the first/last card has breathing room and never
+            // sits half-cropped at the viewport edge (#1182).
+            contentPadding = PaddingValues(horizontal = 4.dp),
+            // Snap to card boundaries on fling so the user never releases
+            // scroll on a half-card mid-name.
+            flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
+        ) {
             items(models, key = { it.uid }) { m ->
                 FeaturedSketchfabCard(model = m, onClick = { onModelClick(m) })
             }


### PR DESCRIPTION
## Summary

Two small ergonomic improvements applied to both Explore-tab LazyRows (curated-samples + Sketchfab feed):

- `flingBehavior = rememberSnapFlingBehavior(state)` — releasing a scroll always lands on a card boundary, never mid-card.
- `contentPadding = PaddingValues(horizontal = 4.dp)` — first/last card has breathing room.

Pure UX polish, no behavioural change to the cards.

## Why

Pixel 9 audit (#1176) caught a frame where two Sketchfab cards appeared truncated mid-name (`queGRD`, `Myślinice`). The cards themselves use `maxLines = 1, overflow = TextOverflow.Ellipsis` correctly — the LazyRow released the scroll mid-flick with the first card half-cropped at the viewport edge.

Snap-fling guarantees a card boundary at rest. Edge padding ensures the visible card never sits flush against the screen edge.

## Test plan

- [ ] CI green.
- [ ] Pixel 9: open Explore tab. Flick the "Try a sample" / "Trending models" / "Recently added" carousels — scroll releases always show a card edge, not a partial card.
- [ ] Visual smoke test confirms no card is half-cropped at rest.

## Out of scope

Doesn't change card content, sizing, or accessibility. iOS has its own ScrollView/LazyHStack snapping config and is not touched here.

Closes #1182. Filed under audit umbrella #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)