### PR TITLE
fix(demos): UTF-8 Sketchfab + AR launcher M3 grid + iOS ARLightingDemo (#1181, #1185, #1155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased — v4.3.4 hotfix (in progress)
 
+### Fixed — Sketchfab Explore cosmetic & iOS demo gaps
+
+- **Sketchfab Explore — Polish name `My�linice` shows U+FFFD ([#1181](https://github.com/sceneview/sceneview/issues/1181))** — `SketchfabService.authenticatedGet` now decodes the response body as UTF-8 explicitly via `response.body.source().readString(Charsets.UTF_8)` instead of `body.string()`. OkHttp's `string()` honours the `Content-Type` charset and falls back to ISO-8859-1 when the header lacks a `charset=` parameter (which can happen at edge-cache rewrites), corrupting any non-ASCII byte. Sketchfab's API always returns UTF-8, so forcing the decode is both correct and defensive. New unit test `decodes non-ascii model names without substitution` exercises Polish / Czech / Greek / CJK fixtures.
+
+- **AR Examples menu — green pills replaced with M3 Expressive grid ([#1185](https://github.com/sceneview/sceneview/issues/1185))** — `ArViewTab.kt`'s `ArDemoCard` now mirrors the `DemoCard` pattern from `DemoListScreen.kt`: gradient-tinted icon header on top + title + subtitle below, using the "Augmented Reality" category green accent (light `#66BB6A` / dark `#A5D6A7`) so the AR View launcher feels like the same app as the Samples tab. Pre-refactor the cards used floating tertiary-tinted pills that read as a "different app" against the Samples-tab grid.
+
+- **iOS sample — `ARLightingDemo.swift` companion to #1151 fillLightNode port ([#1155](https://github.com/sceneview/sceneview/issues/1155))** — New AR demo at `samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift` showcases the `.mainLight(_:)` + `.fillLight(_:)` modifiers shipped in v4.2.0 (PR #1151). Three filter chips toggle between `.systemDefault` on both slots, dim-key `.custom(LightNode.directional(intensity: 5_000))`, and key-only (`.fillLight(.disabled)`) — registered under the AR section in `SamplesTab.swift`.
+
 ### Fixed — Pixel 9 v4.3.0 production audit follow-ups ([umbrella #1176](https://github.com/sceneview/sceneview/issues/1176))
 
 These two findings carried over from the v4.3.0 production audit and were not blocking enough to require a v4.3.3 cut, but accumulate for the next hotfix.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
@@ -221,13 +221,21 @@ class SketchfabService private constructor(
             .url(url)
             .header("Authorization", "Token $apiKey")
             .header("Accept", "application/json")
+            .header("Accept-Charset", "utf-8")
             .get()
             .build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 throw SketchfabError.RequestFailed(response.code)
             }
-            return response.body.string()
+            // Force UTF-8 decoding regardless of the Content-Type charset.
+            // `body.string()` honours the response charset and falls back to
+            // ISO-8859-1 when the header lacks a `charset=` parameter — which
+            // can happen with edge-cache rewrites — corrupting any non-ASCII
+            // character in model names like `Myślinice` (Polish ś → U+FFFD).
+            // The Sketchfab API always returns UTF-8 bytes, so decoding them
+            // as UTF-8 explicitly is both correct and defensive (#1181).
+            return response.body.source().readString(Charsets.UTF_8)
         }
     }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -809,8 +810,14 @@ private fun ArLauncherScreen(
             modifier = Modifier.padding(start = 4.dp, top = 4.dp),
         )
 
-        // Grid of 6 AR demo cards
+        // Grid of 6 AR demo cards — mirror the Samples-tab `DemoCard` pattern
+        // (gradient icon header on top + title + subtitle below) so the AR
+        // View tab feels like the same app when the user switches tabs.
+        // Pre-refactor (#1185) the cards used floating tertiary-tinted pills
+        // which read as a "different app" against the M3 Expressive grid in
+        // Samples.
         val featured = remember { FEATURED_AR_DEMOS }
+        val dark = isSystemInDarkTheme()
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             featured.chunked(2).forEach { row ->
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -818,6 +825,7 @@ private fun ArLauncherScreen(
                         ArDemoCard(
                             title = stringResource(demo.titleRes),
                             subtitle = stringResource(demo.subtitleRes),
+                            dark = dark,
                             onClick = { onArDemoClick(demo.id) },
                             modifier = Modifier.weight(1f),
                         )
@@ -831,55 +839,76 @@ private fun ArLauncherScreen(
     }
 }
 
+/**
+ * Mirrors `DemoListScreen.kt`'s `DemoCard` — gradient-tinted icon header
+ * on top + title + subtitle below — using the "Augmented Reality" category
+ * green accent so the launcher's demo cards feel like the same component
+ * as the Samples-tab grid (#1185).
+ */
 @Composable
 private fun ArDemoCard(
     title: String,
     subtitle: String,
+    dark: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Match the Samples-tab "Augmented Reality" accent verbatim so the two
+    // grids look like a single app surface. Keep these in sync with
+    // `DemoListScreen.categoryAccent*` if either palette ever changes.
+    val accent = if (dark) Color(0xFFA5D6A7) else Color(0xFF66BB6A)
+
     Surface(
         modifier = modifier
-            .heightIn(min = 124.dp)
+            .heightIn(min = 168.dp)
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(18.dp),
+        shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 1.dp,
     ) {
-        Column(
-            modifier = Modifier.padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Box(
                 modifier = Modifier
-                    .size(36.dp)
+                    .fillMaxWidth()
+                    .height(60.dp)
                     .background(
-                        color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.18f),
-                        shape = RoundedCornerShape(10.dp),
+                        brush = Brush.linearGradient(
+                            colors = listOf(
+                                accent.copy(alpha = 0.32f),
+                                accent.copy(alpha = 0.14f),
+                            ),
+                        ),
                     ),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     Icons.Filled.ViewInAr,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.tertiary,
-                    modifier = Modifier.size(20.dp),
+                    tint = accent,
+                    modifier = Modifier.size(28.dp),
                 )
             }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-            )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-                lineHeight = 16.sp,
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    lineHeight = 16.sp,
+                )
+            }
         }
     }
 }

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SketchfabServiceTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SketchfabServiceTest.kt
@@ -50,6 +50,75 @@ class SketchfabServiceTest {
         assertTrue("missing count param: $str", str.contains("count=24"))
     }
 
+    /**
+     * Regression for #1181 — Polish model names with `ś` were rendering as
+     * `My�linice` (U+FFFD REPLACEMENT CHARACTER) because OkHttp's
+     * `body.string()` falls back to ISO-8859-1 when the response
+     * `Content-Type` header lacks an explicit `charset=` parameter.
+     *
+     * Verifies that the Json parser the service uses round-trips a payload
+     * containing Polish / Czech / Greek / CJK names without substitution.
+     * This guards the schema layer; the wire-level UTF-8 enforcement is the
+     * `readString(Charsets.UTF_8)` call in `authenticatedGet` itself.
+     */
+    @Test
+    fun `decodes non-ascii model names without substitution`() {
+        val payload = """
+            {
+              "results": [
+                {
+                  "uid": "abc",
+                  "name": "Myślinice — Polish",
+                  "thumbnails": { "images": [] },
+                  "viewerUrl": "https://sketchfab.com/abc",
+                  "isDownloadable": true
+                },
+                {
+                  "uid": "def",
+                  "name": "Olomoucký hrad",
+                  "thumbnails": { "images": [] },
+                  "viewerUrl": "https://sketchfab.com/def",
+                  "isDownloadable": true
+                },
+                {
+                  "uid": "ghi",
+                  "name": "Παρθενών — Acropolis",
+                  "thumbnails": { "images": [] },
+                  "viewerUrl": "https://sketchfab.com/ghi",
+                  "isDownloadable": true
+                },
+                {
+                  "uid": "jkl",
+                  "name": "東京タワー",
+                  "thumbnails": { "images": [] },
+                  "viewerUrl": "https://sketchfab.com/jkl",
+                  "isDownloadable": true
+                }
+              ]
+            }
+        """.trimIndent()
+        val response = service.json.decodeFromString(
+            SketchfabSearchResponse.serializer(),
+            payload,
+        )
+        val names = response.results.map { it.name }
+        assertEquals(
+            listOf(
+                "Myślinice — Polish",
+                "Olomoucký hrad",
+                "Παρθενών — Acropolis",
+                "東京タワー",
+            ),
+            names,
+        )
+        for (name in names) {
+            assertTrue(
+                "name '$name' must not contain U+FFFD REPLACEMENT CHARACTER",
+                !name.contains('�'),
+            )
+        }
+    }
+
     @Test
     fun `search throws MissingApiKey when key is absent`() {
         // BuildConfig.SKETCHFAB_API_KEY is empty in unit tests (no env var,

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		C10000000000000000000024 /* DemoDeepLinkRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000024 /* DemoDeepLinkRegistry.swift */; };
 		C10000000000000000000025 /* OrbitalARDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000025 /* OrbitalARDemo.swift */; };
 		C10000000000000000000031 /* ARRecorderDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000031 /* ARRecorderDemo.swift */; };
+		C10000000000000000000032 /* ARLightingDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000032 /* ARLightingDemo.swift */; };
 		C10000000000000000000030 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000030 /* FavoritesManager.swift */; };
 		C10000000000000000000050 /* DemoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000050 /* DemoSheet.swift */; };
 		C10000000000000000000051 /* CreditsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000051 /* CreditsSheet.swift */; };
@@ -118,6 +119,7 @@
 		C20000000000000000000024 /* DemoDeepLinkRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoDeepLinkRegistry.swift; sourceTree = "<group>"; };
 		C20000000000000000000025 /* OrbitalARDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrbitalARDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000031 /* ARRecorderDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARRecorderDemo.swift; sourceTree = "<group>"; };
+		C20000000000000000000032 /* ARLightingDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARLightingDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000030 /* FavoritesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
 		C20000000000000000000050 /* DemoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoSheet.swift; path = SceneViewDemo/Views/Components/DemoSheet.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000051 /* CreditsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CreditsSheet.swift; path = SceneViewDemo/Views/CreditsSheet.swift; sourceTree = SOURCE_ROOT; };
@@ -260,6 +262,7 @@
 				C20000000000000000000022 /* RerunDebugDemo.swift */,
 				C20000000000000000000025 /* OrbitalARDemo.swift */,
 				C20000000000000000000031 /* ARRecorderDemo.swift */,
+				C20000000000000000000032 /* ARLightingDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -464,6 +467,7 @@
 				E11525021A2B40A19EAECE6700000003 /* SketchfabAssetResolver.swift in Sources */,
 				C10000000000000000000025 /* OrbitalARDemo.swift in Sources */,
 				C10000000000000000000031 /* ARRecorderDemo.swift in Sources */,
+				C10000000000000000000032 /* ARLightingDemo.swift in Sources */,
 				ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */,
 				C10000000000000000000050 /* DemoSheet.swift in Sources */,
 				C10000000000000000000051 /* CreditsSheet.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift
@@ -1,0 +1,208 @@
+#if os(iOS)
+import SwiftUI
+import RealityKit
+import ARKit
+import SceneViewSwift
+
+/// AR demonstration of the `.mainLight(_:)` + `.fillLight(_:)` modifiers
+/// shipped in v4.2.0 (PR #1151, closes #1138, follow-up demo #1155).
+///
+/// The two-light setup mirrors Android's `ARSceneView(mainLightNode = …,
+/// fillLightNode = …)` defaults (`#1063`):
+///
+/// - **Main light** — bright directional (~10 000 lux), straight down, casts shadows.
+/// - **Fill light** — soft directional (~3 000 lux), upper-front, no shadows.
+///
+/// Three filter chips at the bottom let the user toggle between:
+/// 1. **Default** — `.systemDefault` on both slots (Android-parity).
+/// 2. **Dim key** — `.custom(LightNode.directional(intensity: 5_000))` main +
+///    `.systemDefault` fill (moody studio-style lighting).
+/// 3. **Key only** — `.systemDefault` main + `.disabled` fill (single-light
+///    setup, hard shadows, dramatic).
+///
+/// The model auto-anchors at world origin (the camera pose when tracking
+/// begins), so the user just needs to point the camera at a clear floor area
+/// and walk around to compare the three lighting setups from different angles.
+///
+/// Mirrors Android `samples/android-demo/.../demos/ARPlacementDemo.kt` for the
+/// AR scaffolding (anchor at world origin, model load, status pill) but
+/// focuses the demo on the lighting modifiers rather than tap-to-place.
+struct ARLightingDemo: View {
+    /// The three lighting presets the user can switch between.
+    private enum LightingMode: String, CaseIterable, Identifiable {
+        case `default` = "Default"
+        case dimKey = "Dim Key"
+        case keyOnly = "Key Only"
+
+        var id: String { rawValue }
+
+        var subtitle: String {
+            switch self {
+            case .default: return "10k lux main + 3k lux fill"
+            case .dimKey: return "5k lux main + 3k lux fill"
+            case .keyOnly: return "10k lux main, no fill"
+            }
+        }
+
+        // `LightNode.directional(...)` is `@MainActor` (touches a RealityKit
+        // `Entity`), so the slot helpers that allocate it must be too. The
+        // call sites below are inside SwiftUI `body` / button actions that
+        // are already MainActor-isolated.
+        @MainActor
+        var mainSlot: LightSlot {
+            switch self {
+            case .default, .keyOnly: return .systemDefault
+            case .dimKey:
+                // Custom dimmer main light — half the default 10 000 lux. The
+                // factory does not bake in a direction so the ARSceneView
+                // default-orientation logic still applies (straight down).
+                return .custom(LightNode.directional(intensity: 5_000))
+            }
+        }
+
+        var fillSlot: LightSlot {
+            switch self {
+            case .default, .dimKey: return .systemDefault
+            case .keyOnly: return .disabled
+            }
+        }
+    }
+
+    @State private var mode: LightingMode = .default
+    @State private var modelLoaded = false
+    @State private var loadFailed = false
+
+    var body: some View {
+        ZStack {
+            #if !targetEnvironment(simulator)
+            arSceneView
+                .ignoresSafeArea()
+            #else
+            simulatorPlaceholder
+            #endif
+
+            VStack {
+                statusPill
+                Spacer()
+                modeChips
+            }
+        }
+        .navigationTitle("AR Lighting")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - AR Scene
+
+    #if !targetEnvironment(simulator)
+    private var arSceneView: some View {
+        // Re-creating the view when `mode` changes makes the SwiftUI diff pick
+        // up the new modifier values. Reactive light swapping inside a single
+        // ARSceneView is tracked as a follow-up — for the demo this clean
+        // re-init is fine (model reloads in a fraction of a second).
+        ARSceneView(
+            planeDetection: .horizontal,
+            showPlaneOverlay: false,
+            showCoachingOverlay: true
+        )
+        .mainLight(mode.mainSlot)
+        .fillLight(mode.fillSlot)
+        .onSessionStarted { arView in
+            // Anchor at the camera pose when tracking begins, ~1 m in front
+            // of the user so they always see the model without needing to
+            // hunt for it. The model is loaded asynchronously and added as
+            // a child of the anchor entity.
+            let anchor = AnchorNode.world(position: .init(0, -0.3, -1.0))
+            arView.scene.addAnchor(anchor.entity)
+
+            Task { @MainActor in
+                do {
+                    let node = try await ModelNode.load("phoenix_bird")
+                    _ = node.scaleToUnits(0.5)
+                    if node.animationCount > 0 {
+                        node.playAllAnimations()
+                    }
+                    anchor.add(node.entity)
+                    modelLoaded = true
+                } catch {
+                    print("[ARLighting] Failed to load model: \(error)")
+                    loadFailed = true
+                }
+            }
+        }
+        .id(mode)  // force re-init when the lighting mode flips
+    }
+    #endif
+
+    // MARK: - UI
+
+    private var statusPill: some View {
+        let label: String = {
+            if loadFailed { return "Couldn't load the model" }
+            if !modelLoaded { return "Loading model — keep the camera steady" }
+            return "\(mode.rawValue) — \(mode.subtitle)"
+        }()
+        return Text(label)
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(.ultraThinMaterial)
+            .clipShape(Capsule())
+            .padding(.top, 8)
+    }
+
+    private var modeChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(LightingMode.allCases) { option in
+                    Button {
+                        mode = option
+                        HapticManager.selectionChanged()
+                    } label: {
+                        VStack(spacing: 2) {
+                            Text(option.rawValue)
+                                .font(.subheadline.weight(.semibold))
+                            Text(option.subtitle)
+                                .font(.caption2)
+                                .opacity(0.85)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(
+                            mode == option
+                                ? AnyShapeStyle(.tint)
+                                : AnyShapeStyle(.regularMaterial),
+                            in: Capsule()
+                        )
+                        .foregroundStyle(mode == option ? Color.white : Color.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(option.rawValue) lighting: \(option.subtitle)")
+                    .accessibilityAddTraits(mode == option ? .isSelected : [])
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .scrollClipDisabled()
+        .padding(.bottom, 24)
+    }
+
+    // MARK: - Simulator placeholder
+
+    private var simulatorPlaceholder: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "lightbulb.max.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("AR requires a physical device")
+                .font(.headline)
+            Text("Run on iPhone or iPad to compare the three lighting modes.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGroupedBackground))
+    }
+}
+#endif

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -320,6 +320,9 @@ struct SamplesTab: View {
             DemoItem(title: "AR Recording", icon: "record.circle", subtitle: "Capture the AR session as a screen video (record-only on iOS)", category: .ar) {
                 ARRecorderDemo()
             },
+            DemoItem(title: "AR Lighting", icon: "lightbulb.max.fill", subtitle: "Compare .mainLight / .fillLight modifier presets", category: .ar) {
+                ARLightingDemo()
+            },
             DemoItem(
                 comingSoonTitle: "AR Plane Placement",
                 icon: "arkit",


### PR DESCRIPTION
## Summary

Three cosmetic / iOS-parity follow-ups for the v4.3.4 hotfix lineup.

- **#1181** — Sketchfab Polish name `Myślinice` was rendering as `My�linice` on Pixel 9. `SketchfabService.authenticatedGet` now forces UTF-8 decoding via `response.body.source().readString(Charsets.UTF_8)` instead of `body.string()` (which falls back to ISO-8859-1 when the response `Content-Type` lacks an explicit `charset=`).
- **#1185** — AR View launcher's `ArDemoCard` now mirrors the `DemoCard` pattern from `DemoListScreen.kt`: gradient icon header + title + subtitle, using the "Augmented Reality" category green accent. The pre-refactor tertiary pills read as a "different app" against the Samples-tab grid.
- **#1155** — New iOS `ARLightingDemo.swift` demonstrates `.mainLight(_:)` + `.fillLight(_:)` modifiers shipped in v4.2.0 (PR #1151). Three preset chips: default both / dim key / key only.
- **#1194** (iOS parity Stage 2) — verified current iOS state is honest per `feedback_ios_mirror_android.md` strict-subset rule. PhysicsDemo + AnimationDemo already exist (V1 auto-rotate form). AR Placement / Instant Placement / etc. stay as `comingSoonTitle`. The umbrella stays open as a v4.4+ tracker. No code change required.
- **#1182** — already closed by PR #1196 (snap-to-card fling) — skipped.

## Test plan

- [x] `./gradlew :samples:android-demo:assembleDebug` ✓
- [x] `./gradlew :samples:android-demo:testDebugUnitTest` ✓ — new test `decodes non-ascii model names without substitution` exercises Polish (`Myślinice`) / Czech (`Olomoucký hrad`) / Greek (`Παρθενών`) / CJK (`東京タワー`) fixtures.
- [x] `xcodebuild -scheme SceneViewDemo -destination 'generic/platform=iOS Simulator'` ✓
- [x] `bash .claude/scripts/impact-check.sh` ✓ PASS (1 pre-existing Swift-only nodes warning)
- [ ] Pixel 9 visual smoke: AR View tab launcher card alignment with Samples tab
- [ ] iPhone simulator visual smoke: ARLightingDemo presets cycle correctly (need physical device for real lighting toggle since simulator placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)