### PR TITLE
Compose 1.11.0 bump + 3 demo UX patterns (pull-to-refresh, predictive-back-ready BackHandler, shared-element hero morph)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased — v4.3.4 hotfix (in progress)
 
+### Added — Compose UX patterns in `samples/android-demo`
+
+- **Pull-to-refresh on Explore Sketchfab feeds** ([`ExploreTabScreen.kt`](samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt)) — `PullToRefreshBox` reloads the Trending / Staff Picks / Recently Added carousels on swipe-down. The pull-down affordance is conditionally wired so it only shows when the Sketchfab API key is present (no spinner-flash on builds without the key). The refresh path goes through a single cancel-then-restart pipeline (`refreshTick` LaunchedEffect key) so toggling the "Animated" filter mid-refresh can't race two concurrent loads writing to the same lists.
+- **System back exits live AR session** ([`ArViewTab.kt`](samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt)) — `BackHandler` routes the system gesture to the same exit path as the top-end Close button (detach anchors, return to the AR launcher screen). Manifest opts into `android:enableOnBackInvokedCallback="true"` so Android 13+ routes back via the new `OnBackInvokedDispatcher` (prerequisite for any future `PredictiveBackHandler` upgrade).
+- **Shared-element hero morph between viewer stages** ([`SketchfabModelViewerScreen.kt`](samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt)) — `Crossfade` replaced with `SharedTransitionLayout` + `AnimatedContent`. The 220 dp Preview thumbnail morphs in place into the 440 dp Ken-Burns Downloading hero, then into the live SceneView surface, sharing bounds across the three stages with a consistent rounded-corner clip. The live render uses `SurfaceType.TextureSurface` so the layer alpha is honoured during the morph (the default `SurfaceView` is a hardware overlay and would pop in opaque). Stage.Error is excluded from the shared bounds (no hero) and uses a clean 300 ms fade.
+
 ### Fixed — Pixel 9 v4.3.0 production audit follow-ups ([umbrella #1176](https://github.com/sceneview/sceneview/issues/1176))
 
 These two findings carried over from the v4.3.0 production audit and were not blocking enough to require a v4.3.3 cut, but accumulate for the next hotfix.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Build tools
 agp = "8.13.2"
 kotlin = "2.3.21"
-composeMultiplatform = "1.10.3"
+composeMultiplatform = "1.11.0"
 
 # AndroidX Core
 coreKtx = "1.18.0"

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_descriptor"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -284,10 +284,13 @@ fun ArViewTabContent(
     }
 
     // System back gesture exits the live AR session instead of dropping the
-    // user out of the tab. Predictive back is opted in via
-    // `android:enableOnBackInvokedCallback="true"` in AndroidManifest.xml, so
-    // Android 14+ users see the standard preview animation as they swipe.
-    BackHandler(enabled = true) {
+    // user out of the tab. Combined with `android:enableOnBackInvokedCallback="true"`
+    // in AndroidManifest.xml, Android 13+ routes back via the new
+    // OnBackInvokedDispatcher (a prerequisite for any future
+    // PredictiveBackHandler upgrade); today the user still sees the system's
+    // default home-peek animation during the swipe rather than an in-app
+    // preview of the launcher screen — see #1206 follow-up.
+    BackHandler {
         exitArSession()
     }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -9,6 +9,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
 import android.view.MotionEvent
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -272,6 +273,24 @@ fun ArViewTabContent(
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
 
+    // Shared exit path used by both the system back gesture (BackHandler) and
+    // the top-end Close button. Detaches every ARCore anchor first so the
+    // underlying session releases its native refs before the wrapper
+    // recomposes away.
+    val exitArSession: () -> Unit = {
+        placedAnchors.forEach { runCatching { it.anchor.detach() } }
+        placedAnchors.clear()
+        sessionStarted = false
+    }
+
+    // System back gesture exits the live AR session instead of dropping the
+    // user out of the tab. Predictive back is opted in via
+    // `android:enableOnBackInvokedCallback="true"` in AndroidManifest.xml, so
+    // Android 14+ users see the standard preview animation as they swipe.
+    BackHandler(enabled = true) {
+        exitArSession()
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Live ARSceneView — full bleed under the overlays.
         key(arSceneId) {
@@ -340,16 +359,10 @@ fun ArViewTabContent(
         }
 
         // Top-end exit button — back affordance from the live AR session.
-        // Flips `sessionStarted = false` so the user lands on the launcher
-        // again instead of being stuck with only the tab nav. Detaches every
-        // ARCore anchor first so the underlying session releases its native
-        // refs before the wrapper recomposes away.
+        // Mirrors the BackHandler above so users have a visible CTA in addition
+        // to the system gesture.
         FilledIconButton(
-            onClick = {
-                placedAnchors.forEach { runCatching { it.anchor.detach() } }
-                placedAnchors.clear()
-                sessionStarted = false
-            },
+            onClick = exitArSession,
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .windowInsetsPadding(WindowInsets.statusBars)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -47,9 +47,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -104,34 +102,43 @@ fun ExploreTabScreen(
     var recent by remember { mutableStateOf<List<SketchfabModel>>(emptyList()) }
     var loadingFeeds by remember { mutableStateOf(false) }
     var isRefreshing by remember { mutableStateOf(false) }
+    // Bumped on each pull-to-refresh so the LaunchedEffect below re-keys and
+    // cancels its previous run. This avoids the race where (a) the user pulls
+    // to refresh, then (b) toggles the "Animated" filter chip before the
+    // request returns: both would otherwise race writes into the same three
+    // feed lists. Keying the LaunchedEffect on both `animatedOnly` and
+    // `refreshTick` gives us a single cancel-then-restart pipeline.
+    var refreshTick by remember { mutableStateOf(0) }
 
     val sketchfabService = SketchfabService.getInstance(LocalContext.current)
-    val scope = rememberCoroutineScope()
 
-    suspend fun loadSketchfabFeeds() {
-        if (SketchfabConfig.apiKey == null) return
+    /** (re)load the three feeds when the animated toggle flips, on first composition, or on pull-to-refresh. */
+    LaunchedEffect(animatedOnly, refreshTick) {
+        if (SketchfabConfig.apiKey == null) return@LaunchedEffect
         loadingFeeds = true
         val animatedParam: Boolean? = if (animatedOnly) true else null
-        // supervisorScope so a single feed failure (transient 429, network blip)
-        // doesn't cancel the other two — surviving feeds still render (#980).
-        // Each catch re-throws CancellationException so the parent scope
-        // cancellation (toggle re-keys, navigation away) still tears down
-        // the in-flight requests cleanly. `runCatching` swallows
-        // CancellationException, which would break structured concurrency.
-        supervisorScope {
-            val a = async { catchingFeed { sketchfabService.staffPicks(animated = animatedParam, limit = 10) } }
-            val b = async { catchingFeed { sketchfabService.featured(animated = animatedParam, limit = 10) } }
-            val c = async { catchingFeed { sketchfabService.recentlyAdded(animated = animatedParam, limit = 10) } }
-            staffPicks = a.await()
-            mostLiked = b.await()
-            recent = c.await()
+        // supervisorScope so a single feed failure (transient 429, network
+        // blip) doesn't cancel the other two — surviving feeds still render
+        // (#980). Each `catchingFeed` re-throws CancellationException so the
+        // parent LaunchedEffect cancellation (toggle re-keys, pull-to-refresh
+        // re-keys, navigation away) still tears down the in-flight requests
+        // cleanly.
+        try {
+            supervisorScope {
+                val a = async { catchingFeed { sketchfabService.staffPicks(animated = animatedParam, limit = 10) } }
+                val b = async { catchingFeed { sketchfabService.featured(animated = animatedParam, limit = 10) } }
+                val c = async { catchingFeed { sketchfabService.recentlyAdded(animated = animatedParam, limit = 10) } }
+                staffPicks = a.await()
+                mostLiked = b.await()
+                recent = c.await()
+            }
+        } finally {
+            // try/finally so loadingFeeds + isRefreshing always reset even if
+            // the coroutine was cancelled mid-flight (otherwise the skeleton
+            // spinners would stay forever after navigating away mid-refresh).
+            loadingFeeds = false
+            isRefreshing = false
         }
-        loadingFeeds = false
-    }
-
-    /** (re)load the three feeds when the animated toggle flips or on first composition. */
-    LaunchedEffect(animatedOnly) {
-        loadSketchfabFeeds()
     }
 
     val body = @Composable {
@@ -157,18 +164,15 @@ fun ExploreTabScreen(
     // Pull-to-refresh is only wired when the Sketchfab carousels are visible —
     // without an API key there's nothing dynamic to refresh and pulling would
     // spin a spinner that immediately settles, which is worse than no affordance
-    // at all.
+    // at all. onRefresh just bumps `refreshTick`; the LaunchedEffect above
+    // owns the single cancel-then-restart pipeline.
     if (SketchfabConfig.apiKey != null) {
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = {
-                isRefreshing = true
-                scope.launch {
-                    try {
-                        loadSketchfabFeeds()
-                    } finally {
-                        isRefreshing = false
-                    }
+                if (!isRefreshing) {
+                    isRefreshing = true
+                    refreshTick++
                 }
             },
         ) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -41,12 +41,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -100,19 +103,20 @@ fun ExploreTabScreen(
     var mostLiked by remember { mutableStateOf<List<SketchfabModel>>(emptyList()) }
     var recent by remember { mutableStateOf<List<SketchfabModel>>(emptyList()) }
     var loadingFeeds by remember { mutableStateOf(false) }
+    var isRefreshing by remember { mutableStateOf(false) }
 
     val sketchfabService = SketchfabService.getInstance(LocalContext.current)
+    val scope = rememberCoroutineScope()
 
-    /** (re)load the three feeds when the animated toggle flips or on first composition. */
-    LaunchedEffect(animatedOnly) {
-        if (SketchfabConfig.apiKey == null) return@LaunchedEffect
+    suspend fun loadSketchfabFeeds() {
+        if (SketchfabConfig.apiKey == null) return
         loadingFeeds = true
         val animatedParam: Boolean? = if (animatedOnly) true else null
         // supervisorScope so a single feed failure (transient 429, network blip)
         // doesn't cancel the other two — surviving feeds still render (#980).
-        // Each catch re-throws CancellationException so the parent
-        // LaunchedEffect cancellation (toggle re-keys, navigation away) still
-        // tears down the in-flight requests cleanly. `runCatching` swallows
+        // Each catch re-throws CancellationException so the parent scope
+        // cancellation (toggle re-keys, navigation away) still tears down
+        // the in-flight requests cleanly. `runCatching` swallows
         // CancellationException, which would break structured concurrency.
         supervisorScope {
             val a = async { catchingFeed { sketchfabService.staffPicks(animated = animatedParam, limit = 10) } }
@@ -125,6 +129,78 @@ fun ExploreTabScreen(
         loadingFeeds = false
     }
 
+    /** (re)load the three feeds when the animated toggle flips or on first composition. */
+    LaunchedEffect(animatedOnly) {
+        loadSketchfabFeeds()
+    }
+
+    val body = @Composable {
+        ExploreBody(
+            scroll = scroll,
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            onSearchSubmit = { q -> if (q.isNotBlank()) recentSearches.push(q) },
+            animatedOnly = animatedOnly,
+            onToggleAnimated = { animatedOnly = !animatedOnly },
+            curatedSamples = curatedSamples,
+            onSampleClick = onSampleClick,
+            mostLiked = mostLiked,
+            staffPicks = staffPicks,
+            recent = recent,
+            loadingFeeds = loadingFeeds,
+            onModelClick = { selectedModel = it },
+            onCategoryClick = onCategoryClick,
+            recentSearches = recentSearches,
+        )
+    }
+
+    // Pull-to-refresh is only wired when the Sketchfab carousels are visible —
+    // without an API key there's nothing dynamic to refresh and pulling would
+    // spin a spinner that immediately settles, which is worse than no affordance
+    // at all.
+    if (SketchfabConfig.apiKey != null) {
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = {
+                isRefreshing = true
+                scope.launch {
+                    try {
+                        loadSketchfabFeeds()
+                    } finally {
+                        isRefreshing = false
+                    }
+                }
+            },
+        ) {
+            body()
+        }
+    } else {
+        body()
+    }
+
+    selectedModel?.let { model ->
+        SketchfabModelViewerScreen(model = model, onDismiss = { selectedModel = null })
+    }
+}
+
+@Composable
+private fun ExploreBody(
+    scroll: androidx.compose.foundation.ScrollState,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onSearchSubmit: (String) -> Unit,
+    animatedOnly: Boolean,
+    onToggleAnimated: () -> Unit,
+    curatedSamples: List<DemoEntry>,
+    onSampleClick: (DemoEntry) -> Unit,
+    mostLiked: List<SketchfabModel>,
+    staffPicks: List<SketchfabModel>,
+    recent: List<SketchfabModel>,
+    loadingFeeds: Boolean,
+    onModelClick: (SketchfabModel) -> Unit,
+    onCategoryClick: (SketchfabCategory) -> Unit,
+    recentSearches: RecentSearchesState,
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -142,14 +218,12 @@ fun ExploreTabScreen(
 
         SearchField(
             value = searchQuery,
-            onValueChange = { searchQuery = it },
-            onSubmit = { q ->
-                if (q.isNotBlank()) recentSearches.push(q)
-            },
+            onValueChange = onSearchQueryChange,
+            onSubmit = onSearchSubmit,
         )
 
         if (SketchfabConfig.apiKey != null) {
-            FiltersBar(animatedOnly = animatedOnly, onToggle = { animatedOnly = !animatedOnly })
+            FiltersBar(animatedOnly = animatedOnly, onToggle = onToggleAnimated)
         }
 
         if (curatedSamples.isNotEmpty()) {
@@ -189,19 +263,19 @@ fun ExploreTabScreen(
                 title = stringResource(R.string.explore_trending_models),
                 models = mostLiked,
                 loading = loadingFeeds && mostLiked.isEmpty(),
-                onModelClick = { selectedModel = it },
+                onModelClick = onModelClick,
             )
             FeedSection(
                 title = stringResource(R.string.explore_staff_picks),
                 models = staffPicks,
                 loading = loadingFeeds && staffPicks.isEmpty(),
-                onModelClick = { selectedModel = it },
+                onModelClick = onModelClick,
             )
             FeedSection(
                 title = stringResource(R.string.explore_recently_added),
                 models = recent,
                 loading = loadingFeeds && recent.isEmpty(),
-                onModelClick = { selectedModel = it },
+                onModelClick = onModelClick,
             )
         }
 
@@ -211,16 +285,12 @@ fun ExploreTabScreen(
             RecentSearchesSection(
                 items = recentSearches.items,
                 onClear = { recentSearches.clear() },
-                onClick = { searchQuery = it },
+                onClick = { onSearchQueryChange(it) },
                 onRemove = { recentSearches.remove(it) },
             )
         }
 
         Spacer(Modifier.height(16.dp))
-    }
-
-    selectedModel?.let { model ->
-        SketchfabModelViewerScreen(model = model, onDismiss = { selectedModel = null })
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
@@ -3,6 +3,8 @@
 package io.github.sceneview.demo.ui.explore
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -65,6 +67,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
+import io.github.sceneview.SurfaceType
 import io.github.sceneview.createEnvironment
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
 import io.github.sceneview.demo.sketchfab.SketchfabModel
@@ -109,11 +112,12 @@ fun SketchfabModelViewerScreen(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var stage by remember(model.uid) { mutableStateOf<Stage>(Stage.Preview) }
 
-    // Hoist Engine + loaders ABOVE the Crossfade so the Filament engine survives
-    // stage transitions. Previously every Crossfade swap (Preview → Downloading
-    // → Rendering) tore down and recreated the Engine inside RenderContent
-    // (200-400 ms freeze + black flash). With the engine remembered here it
-    // outlives the crossfade tween and only releases when the sheet closes.
+    // Hoist Engine + loaders ABOVE the SharedTransitionLayout so the Filament
+    // engine survives stage transitions. Previously every Crossfade swap
+    // (Preview → Downloading → Rendering) tore down and recreated the Engine
+    // inside RenderContent (200-400 ms freeze + black flash). With the engine
+    // remembered here it outlives the transition tween and only releases when
+    // the sheet closes.
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
@@ -126,25 +130,42 @@ fun SketchfabModelViewerScreen(
         // SharedTransitionLayout + AnimatedContent so the hero thumbnail
         // morphs smoothly between Preview (220 dp card) → Downloading
         // (440 dp Ken-Burns) → Rendering (live SceneView surface). Each
-        // stage opts in via the `heroModifier` slot. Stage.Error stays
-        // a hard fade because it has no hero — re-using the bounds would
-        // animate the error card sliding out of the now-empty hero.
+        // stage receives a `heroModifier` slot carrying `sharedBounds` +
+        // a matching `clip(RoundedCornerShape(24.dp))` so the corner
+        // radius stays consistent through the morph (without the clip
+        // baked into the shared modifier, Preview's rounded corners
+        // would snap to square corners at frame 1 of the animation).
+        // Stage.Error opts out — there is no hero so reusing the bounds
+        // would animate the error card sliding out of empty space.
+        val heroShape = RoundedCornerShape(24.dp)
+        val heroKey = "sketchfab-hero-${model.uid}"
         SharedTransitionLayout {
             AnimatedContent(
                 targetState = stage,
                 transitionSpec = {
-                    fadeIn(animationSpec = tween(500)) togetherWith
-                        fadeOut(animationSpec = tween(500))
+                    // Stages that share the hero (Preview / Downloading /
+                    // Rendering) opt out of fade so only `sharedBounds`
+                    // drives the morph — a parallel fadeIn/fadeOut would
+                    // wash the hero semi-transparent halfway through. Only
+                    // Stage.Error (no shared element) uses a real fade.
+                    val errorInvolved = initialState is Stage.Error || targetState is Stage.Error
+                    if (errorInvolved) {
+                        fadeIn(animationSpec = tween(300)) togetherWith
+                            fadeOut(animationSpec = tween(300))
+                    } else {
+                        EnterTransition.None togetherWith ExitTransition.None
+                    }
                 },
                 label = "sketchfab-stage",
             ) { s ->
-                val heroKey = "sketchfab-hero-${model.uid}"
                 val heroModifier: Modifier = when (s) {
                     Stage.Preview, Stage.Downloading, is Stage.Rendering ->
-                        Modifier.sharedBounds(
-                            sharedContentState = rememberSharedContentState(key = heroKey),
-                            animatedVisibilityScope = this@AnimatedContent,
-                        )
+                        Modifier
+                            .sharedBounds(
+                                sharedContentState = rememberSharedContentState(key = heroKey),
+                                animatedVisibilityScope = this@AnimatedContent,
+                            )
+                            .clip(heroShape)
                     is Stage.Error -> Modifier
                 }
                 when (s) {
@@ -318,8 +339,9 @@ private fun StatChip(label: String) {
 /**
  * Hero state while the GLB is downloading. Shows the Sketchfab thumbnail with a
  * slow Ken-Burns zoom (1.0 → 1.18) and a soft blur, so the screen feels like a
- * premium preview instead of a spinner. Cross-fades into the live SceneView via
- * the parent [Crossfade] when [RenderContent] takes over.
+ * premium preview instead of a spinner. Morphs into the live SceneView via
+ * the parent [SharedTransitionLayout] + [AnimatedContent] when [RenderContent]
+ * takes over — the 440 dp hero Box keeps its shared bounds across the swap.
  */
 @Composable
 private fun DownloadingContent(
@@ -469,6 +491,13 @@ private fun RenderContent(
         ) {
             SceneView(
                 modifier = Modifier.fillMaxSize(),
+                // TextureSurface so the live render respects the Compose layer
+                // alpha during the SharedTransitionLayout morph and the
+                // surrounding cinematic-vignette overlay. The default SurfaceView
+                // is a hardware overlay punched through the window and ignores
+                // Compose's fadeOut/fadeIn during the stage transition — the
+                // viewport would pop in opaque instead of morphing in.
+                surfaceType = SurfaceType.TextureSurface,
                 engine = engine,
                 modelLoader = modelLoader,
                 environmentLoader = environmentLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
@@ -1,14 +1,19 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 
 package io.github.sceneview.demo.ui.explore
 
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -118,34 +123,52 @@ fun SketchfabModelViewerScreen(
         sheetState = sheetState,
         containerColor = MaterialTheme.colorScheme.surface,
     ) {
-        // Cross-fade between Preview → Downloading (Ken-Burns thumbnail) →
-        // Rendering (live SceneView). The 500 ms tween is just long enough
-        // to read as "the model came to life" rather than "the spinner jumped
-        // to a new screen". Stage.Preview is excluded from the fade so the
-        // initial tap-to-open still feels snappy.
-        Crossfade(
-            targetState = stage,
-            animationSpec = tween(durationMillis = 500),
-            label = "sketchfab-stage",
-        ) { s ->
-            when (s) {
-                Stage.Preview -> PreviewContent(
-                    model = model,
-                    onOpenInSceneView = { stage = Stage.Downloading },
-                )
-                Stage.Downloading -> DownloadingContent(
-                    model = model,
-                    onReady = { file -> stage = Stage.Rendering(file) },
-                    onError = { stage = Stage.Error(it) },
-                )
-                is Stage.Rendering -> RenderContent(
-                    file = s.file,
-                    model = model,
-                    engine = engine,
-                    modelLoader = modelLoader,
-                    environmentLoader = environmentLoader,
-                )
-                is Stage.Error -> ErrorContent(message = s.message, onRetry = { stage = Stage.Preview })
+        // SharedTransitionLayout + AnimatedContent so the hero thumbnail
+        // morphs smoothly between Preview (220 dp card) → Downloading
+        // (440 dp Ken-Burns) → Rendering (live SceneView surface). Each
+        // stage opts in via the `heroModifier` slot. Stage.Error stays
+        // a hard fade because it has no hero — re-using the bounds would
+        // animate the error card sliding out of the now-empty hero.
+        SharedTransitionLayout {
+            AnimatedContent(
+                targetState = stage,
+                transitionSpec = {
+                    fadeIn(animationSpec = tween(500)) togetherWith
+                        fadeOut(animationSpec = tween(500))
+                },
+                label = "sketchfab-stage",
+            ) { s ->
+                val heroKey = "sketchfab-hero-${model.uid}"
+                val heroModifier: Modifier = when (s) {
+                    Stage.Preview, Stage.Downloading, is Stage.Rendering ->
+                        Modifier.sharedBounds(
+                            sharedContentState = rememberSharedContentState(key = heroKey),
+                            animatedVisibilityScope = this@AnimatedContent,
+                        )
+                    is Stage.Error -> Modifier
+                }
+                when (s) {
+                    Stage.Preview -> PreviewContent(
+                        model = model,
+                        onOpenInSceneView = { stage = Stage.Downloading },
+                        heroModifier = heroModifier,
+                    )
+                    Stage.Downloading -> DownloadingContent(
+                        model = model,
+                        onReady = { file -> stage = Stage.Rendering(file) },
+                        onError = { stage = Stage.Error(it) },
+                        heroModifier = heroModifier,
+                    )
+                    is Stage.Rendering -> RenderContent(
+                        file = s.file,
+                        model = model,
+                        engine = engine,
+                        modelLoader = modelLoader,
+                        environmentLoader = environmentLoader,
+                        heroModifier = heroModifier,
+                    )
+                    is Stage.Error -> ErrorContent(message = s.message, onRetry = { stage = Stage.Preview })
+                }
             }
         }
     }
@@ -161,7 +184,11 @@ private sealed interface Stage {
 // ── Preview ───────────────────────────────────────────────────────────────
 
 @Composable
-private fun PreviewContent(model: SketchfabModel, onOpenInSceneView: () -> Unit) {
+private fun PreviewContent(
+    model: SketchfabModel,
+    onOpenInSceneView: () -> Unit,
+    heroModifier: Modifier = Modifier,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -171,7 +198,8 @@ private fun PreviewContent(model: SketchfabModel, onOpenInSceneView: () -> Unit)
             modifier = Modifier
                 .fillMaxWidth()
                 .height(220.dp)
-                .clip(RoundedCornerShape(24.dp)),
+                .clip(RoundedCornerShape(24.dp))
+                .then(heroModifier),
         ) {
             AsyncNetworkImage(
                 url = model.preferredThumbnailUrl(minWidth = 640, maxWidth = 1280),
@@ -298,6 +326,7 @@ private fun DownloadingContent(
     model: SketchfabModel,
     onReady: (File) -> Unit,
     onError: (String) -> Unit,
+    heroModifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     LaunchedEffect(model.uid) {
@@ -326,7 +355,8 @@ private fun DownloadingContent(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(440.dp),
+            .height(440.dp)
+            .then(heroModifier),
     ) {
         AsyncNetworkImage(
             url = model.preferredThumbnailUrl(minWidth = 640, maxWidth = 1280),
@@ -394,6 +424,7 @@ private fun RenderContent(
     engine: Engine,
     modelLoader: ModelLoader,
     environmentLoader: EnvironmentLoader,
+    heroModifier: Modifier = Modifier,
 ) {
     // `rememberModelInstance` accepts asset paths or URIs; we pass a `file://`
     // URI so Filament reads from the local on-disk cache without re-decoding
@@ -433,7 +464,8 @@ private fun RenderContent(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(440.dp),
+                .height(440.dp)
+                .then(heroModifier),
         ) {
             SceneView(
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary

Two related pieces of work in one branch:

1. **Bump `org.jetbrains.compose` 1.10.3 → 1.11.0** (replaces stale dependabot #1108)
2. **Three new Compose UX patterns in `samples/android-demo`**, leveraging APIs already shipping in our `composeBom 2026.05.00`:
   - `PullToRefreshBox` on the Explore tab Sketchfab feeds (conditional — only wired when the API key is present)
   - `BackHandler` + `android:enableOnBackInvokedCallback=\"true\"` so system back exits the live AR session (prerequisite for any future `PredictiveBackHandler` upgrade)
   - `SharedTransitionLayout` + `sharedBounds` morph on the Sketchfab viewer hero (220 dp Preview → 440 dp Downloading → live SceneView surface, with a consistent rounded-corner clip)

## CMP 1.11.0 impact

Only `samples/desktop-demo` applies the `org.jetbrains.compose` plugin. All Android library + sample modules use only the kotlin compose-compiler (versioned by Kotlin, not CMP), so they're effectively unaffected by the version bump. The shorthand `compose.{ui,foundation,material3}` DSL getters now emit deprecation warnings — left as-is.

## Multi-agent review pass

5-agent Opus review found **3 BLOCKERs** in the first feature commit:

- **Hero morph never visibly happens** — `SceneView` defaulted to `SurfaceType.Surface` (hardware overlay punched through the window, ignores Compose alpha). Fix: `surfaceType = SurfaceType.TextureSurface` so the layer alpha is honoured during the morph.
- **Hero corner radius pops** — only `PreviewContent` had a `clip(RoundedCornerShape(24.dp))`; sharedBounds doesn't animate the clip shape. Fix: bake the clip into the `heroModifier` chain so all 3 stages match.
- **Hero washes through semi-transparent during morph** — `AnimatedContent` cross-faded outer content in parallel with sharedBounds. Fix: `transitionSpec` is stage-aware; shared-hero transitions use `EnterTransition.None togetherWith ExitTransition.None`, Stage.Error keeps a 300 ms fade.

Plus 1 MAJOR (pull-to-refresh + filter toggle race — fixed with single cancel-then-restart pipeline via `refreshTick` LaunchedEffect key) and a handful of MINORs (stale `Crossfade` doc references, redundant `enabled = true`, hoisted `heroKey`).

## iOS parity

[#1211](https://github.com/sceneview/sceneview/issues/1211) filed for the 3 iOS analogues (`.refreshable {}`, `matchedGeometryEffect` hero, ARTab exit affordance).

## Test plan

- [x] `:samples:android-demo:assembleDebug` ✅
- [x] `:samples:desktop-demo:compileKotlinDesktop` ✅
- [x] `:sceneview:compileReleaseKotlin` ✅
- [x] `:arsceneview:compileReleaseKotlin` ✅
- [x] Explore tab renders cleanly on Pixel_7a emulator with no API key (no PullToRefresh chrome — conditional wrapping works)
- [x] AR View launcher renders; system-back falls through to Explore tab (BackHandler not composed at this stage)
- [x] impact-check ✅ (only unrelated Swift-parity warning)
- [ ] Hero morph on a build with `SKETCHFAB_API_KEY` set (requires Thomas's key — can't reproduce in CI)
- [ ] Predictive back animation behaviour on Android 14+ device (emulator gesture-nav limited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)