### PR TITLE
fix(samples): Record & Playback — 'Replaying' → 'Stop' to avoid mid-word wrap (#1205)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Anchor
 import com.google.ar.core.Config
@@ -776,7 +777,15 @@ private fun RecordingRow(
                     onClick = onClick,
                     modifier = Modifier.weight(1f)
                 ) {
-                    Text(if (isSelected) "Replaying" else "Replay")
+                    // "Replaying" (9 chars) overflows the 1/3-row button width on
+                    // Pixel 9 and wraps mid-word as "Replayin\ng" (#1205). "Stop"
+                    // is the action the tap will perform when playback is active,
+                    // and reads cleaner than a status word on an action button.
+                    Text(
+                        text = if (isSelected) "Stop" else "Replay",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary

- The Playback-mode button label was "Replaying" (9 chars) — too long for the 1/3-row equal-weight column on Pixel 9. The text wrapped mid-word as "Replayin\ng".
- Changed to "Stop" (4 chars) when playback is active, "Replay" (6 chars) when idle. Mirrors common play/stop UX patterns and reads as an action verb rather than a status word.
- Added `maxLines = 1, overflow = TextOverflow.Ellipsis` as a defensive backstop against future i18n strings exceeding the button width.

## Evidence

Audit umbrella #1176, frame [`/tmp/pixel9-session-2026-05-14/key-frames-extra-sized/t185s.jpg`] shows the broken "Replayin\ng" rendering.

Code location: `samples/android-demo/.../ARRecordPlaybackDemo.kt:779`.

## Test plan

- [ ] CI green.
- [ ] On Pixel 9: open AR Samples → Record & Playback → Playback mode. Each recording row shows three buttons "Share / Export / Replay" that fit cleanly. After tapping Replay, the third button label becomes "Stop" (also fits cleanly).
- [ ] Verify "Stop" tap stops the active playback.

Closes #1205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)