### PR TITLE
fix(samples): guard About + Credits external links against ActivityNotFoundException (#1208)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/CreditsSheet.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/CreditsSheet.kt
@@ -62,7 +62,18 @@ fun CreditsSheet(onDismiss: () -> Unit) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
     val context = LocalContext.current
     val openUrl: (String) -> Unit = { url ->
-        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        // Devices without a browser (Android Go, stripped AOSP, user uninstalled
+        // Chrome) throw ActivityNotFoundException → app crashes. runCatching +
+        // toast keeps the app alive and tells the user why nothing happened. #1208
+        runCatching {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        }.onFailure {
+            android.widget.Toast.makeText(
+                context,
+                "No browser installed to open $url",
+                android.widget.Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
     ModalBottomSheet(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
@@ -152,7 +152,18 @@ private fun curatedSamplesForExplore(): List<DemoEntry> {
 private fun AboutTabContent() {
     val context = LocalContext.current
     val openLink: (String) -> Unit = { url ->
-        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        // Devices without a browser (Android Go, stripped AOSP, user uninstalled
+        // Chrome) throw ActivityNotFoundException → app crashes. runCatching +
+        // toast keeps the app alive and tells the user why nothing happened. #1208
+        runCatching {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        }.onFailure {
+            android.widget.Toast.makeText(
+                context,
+                "No browser installed to open $url",
+                android.widget.Toast.LENGTH_LONG
+            ).show()
+        }
     }
     // #1152 Stage 3 — CC-BY attribution for every streamed Sketchfab model
     // surfaces as a ModalBottomSheet anchored to the existing "Credits" card.


### PR DESCRIPTION
## Summary

Two `startActivity(ACTION_VIEW, https://…)` call sites in the demo app's UI were unguarded:
- `RootScreen.kt:155` — About tab links (Docs / GitHub / Playground / Sponsor)
- `CreditsSheet.kt:65` — Sketchfab attribution links

On devices without a browser (Android Go, stripped AOSP builds, users who uninstalled Chrome), tapping these throws `ActivityNotFoundException` and crashes the app.

Wrapped both in `runCatching { … }.onFailure { … }` and surface a `Toast` so the app keeps running and the user understands why nothing happened.

## Why

Audit umbrella #1176 caught this during a Pixel 9 v4.3.0 review. Severity is LOW (rare scenario in practice — most users have Chrome) but it IS a crash and the fix is trivial.

## Out of scope

The 3 other `startActivity` sites in the app are already safe and unchanged:
- `ARStreetscapeDemo.kt:186` — `ACTION_APPLICATION_DETAILS_SETTINGS` (system handler always present)
- `ARRecordPlaybackDemo.kt:880` — `Intent.createChooser` (shows picker even with no handlers)
- `ARRerunDemo.kt:243` — `Intent.createChooser`

## Test plan

- [ ] CI green.
- [ ] Repro on Pixel 9 with browser disabled: `adb shell pm disable-user com.google.android.apps.chrome`. Tap an About link. Expect Toast, no crash.
- [ ] Re-enable Chrome, tap same link, expect browser opens normally.

Closes #1208. Filed under audit umbrella #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)