### PR TITLE
fix(samples): Debug Overlay count=1 sphere position at origin (#1212)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
@@ -319,12 +319,23 @@ fun DebugOverlayDemo(onBack: () -> Unit) {
                 // per-node allocation, so the perf cost lives in the geometry buffers.
                 repeat(currentCount) { i ->
                     key(i) {
-                        val pos = remember(i) {
-                            Position(
-                                x = ((i % 10) - 5) * NODE_SPACING,
-                                y = (((i / 10) % 10) - 5) * NODE_SPACING,
-                                z = -((i / 100)) * NODE_SPACING,
-                            )
+                        // Count=1 special-case: place the single sphere at origin so the
+                        // demo opens with the sphere on screen (#1212). The 10×10×N grid
+                        // offsets (`-5 * NODE_SPACING`) assume the cluster averages back
+                        // to origin only when fully populated; for count=1 they place the
+                        // lone sphere at (-0.9, -0.9, 0), well outside the camera frustum.
+                        // The previous v2 fix raised the camera distance but didn't
+                        // address the position — re-applied here.
+                        val pos = remember(i, currentCount) {
+                            if (currentCount == 1) {
+                                Position(0f, 0f, 0f)
+                            } else {
+                                Position(
+                                    x = ((i % 10) - 5) * NODE_SPACING,
+                                    y = (((i / 10) % 10) - 5) * NODE_SPACING,
+                                    z = -((i / 100)) * NODE_SPACING,
+                                )
+                            }
                         }
                         SphereNode(
                             radius = NODE_RADIUS,


### PR DESCRIPTION
## Summary

The Debug Overlay demo's default count=1 state was showing an empty black SceneView even though the overlay correctly reported `Nodes: 1, Tris: 1,152` — the sphere was spawned but parked off-screen at `(-0.9, -0.9, 0)`.

Root cause: the 10×10×N grid offsets `((i % 10) - 5) * NODE_SPACING` only average to origin when the cluster is fully populated. For count=1, the lone sphere gets the `(0 - 5) * 0.18 = -0.9` clamp on both X and Y, parking it 3.6× outside the camera frustum.

Fix: special-case `currentCount == 1` to `Position(0f, 0f, 0f)`.

## Evidence

Pixel 9 v4.3.2 production install (2026-05-15 wireless sweep, audit #1176). Frame at `/tmp/sceneview-qa-2026-05-15/raw/debug-overlay.png` shows the overlay HUD with `Nodes: 1, Tris: 1,152` over a fully black viewport.

## Why the v2 fix wasn't enough

The earlier fix introduced `SINGLE_SPHERE_DISTANCE = 0.8f` in `autoFitDistance(...)` (the `count <= 1` branch). That correctly sets the camera 0.8 m from origin so a 4-cm sphere would fit — **but the sphere itself isn't at origin** when count=1, only the camera is. The viewport is just empty space.

## Test plan

- [ ] CI green.
- [ ] On Pixel 9: open Samples → Debug Overlay. Default state (count=1) → sphere visible at center, overlay reads `Nodes: 1, Tris: 1,152`.
- [ ] Tap presets 10 / 100 / 500 / 1000 → grid remains visually centered (no regression).
- [ ] Tap Stress test → count ramps 1 → 2000, visible cluster grows from center outward.

Closes #1212. Filed under audit umbrella #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)