### PR TITLE
chore: fix 2 stale SPM 4.3.3 → 4.3.4 drifts caught by impact-check

### DIFF
--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -212,7 +212,7 @@ I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old a
 **Answer:**
 [SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.3"`
+**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.3"`
+1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async


### PR DESCRIPTION
Pre-existing drift caught by `.claude/scripts/impact-check.sh` after I merged #1203. Both files in non-canonical directories (marketing / pro/gpt-store) so they slipped through the sync-versions.sh sweep during the v4.3.4 release cut (#1153).

- `pro/gpt-store/gpt-instructions.md:77`
- `marketing/stackoverflow/qa-drafts.md:215`

🤖 Generated with [Claude Code](https://claude.com/claude-code)