### PR TITLE
fix(samples): hide Clear All while empty in AR Instant Placement (#1199)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
@@ -457,19 +457,29 @@ private fun InstantPlacementScene(
         }
 
         // Clear-all control at the bottom-left.
-        OutlinedButton(
-            onClick = {
-                placedModels.forEach { runCatching { it.anchor.detach() } }
-                placedModels.clear()
-                trackingMethods.clear()
-                lostAnchors.clear()
-                cycleIndex = 0
-            },
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(16.dp)
+        // Only show Clear All when there's something to clear. The Pixel 9 audit
+        // (#1199) caught a startup screenshot where the empty Clear All button
+        // sat semi-transparent under the "Initializing camera" pill, producing a
+        // confusing stacked-buttons visual. Hiding it until the first tap lands
+        // also matches what the user expects: no action button for a no-op action.
+        AnimatedVisibility(
+            visible = placedModels.isNotEmpty(),
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.BottomStart),
         ) {
-            Text("Clear All")
+            OutlinedButton(
+                onClick = {
+                    placedModels.forEach { runCatching { it.anchor.detach() } }
+                    placedModels.clear()
+                    trackingMethods.clear()
+                    lostAnchors.clear()
+                    cycleIndex = 0
+                },
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text("Clear All")
+            }
         }
 
         // Scanning indicator overlay


### PR DESCRIPTION
## Summary

The Pixel 9 audit (#1176) caught a startup screenshot where the "Initializing camera — you can already tap to place" toast pill sat on top of a semi-transparent Clear All button — both at the bottom of the screen, producing a confusing stacked-buttons visual.

Root cause: Clear All is rendered before any model is placed, so the user sees an action button for an action that has no effect (nothing to clear yet).

Fix: wrap Clear All in `AnimatedVisibility(visible = placedModels.isNotEmpty())`. It now fades in after the first tap lands. During the empty state, the BottomStart corner is free of overlap with the BottomCenter "Initializing" pill.

## Evidence

`/tmp/pixel9-session-2026-05-14/key-frames/t285s.jpg` (audit umbrella #1176).

## Test plan

- [ ] CI green.
- [ ] On Pixel 9: open Samples → Instant Placement. Initial state shows BottomCenter "Initializing camera" pill alone — no half-visible Clear All. Tap to place a model → Clear All fades in at BottomStart.
- [ ] Tap Clear All → models clear, button fades back out.

Closes #1199. Filed under audit umbrella #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)