### PR TITLE
feat(ios-demo): .refreshable on Explore Sketchfab feeds (closes #1211 item 1)

### DIFF
--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -212,7 +212,7 @@ I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old a
 **Answer:**
 [SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.3"`
+**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.3"`
+1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
@@ -272,6 +272,13 @@ struct ExploreTab: View {
                 }
             }
             .task { await loadSketchfabFeeds() }
+            // Pull-to-refresh on the Sketchfab carousels — matches the Android
+            // ExploreTabScreen.PullToRefreshBox added in #1203. Only fires
+            // when an API key is configured (loadSketchfabFeeds early-returns
+            // otherwise) so builds without the key don't spin a useless
+            // spinner. `force: true` bypasses the "already loaded" guard so
+            // a manual refresh actually re-fetches.
+            .refreshable { await loadSketchfabFeeds(force: true) }
             .navigationDestination(item: $selectedModel) { model in
                 ModelViewerScreen(model: model)
             }
@@ -310,12 +317,15 @@ struct ExploreTab: View {
 
     /// Loads the three curated feeds in parallel. Falls back silently to the bundled
     /// `featuredModels` carousel when no API key is configured or the network call fails.
-    private func loadSketchfabFeeds() async {
-        guard SketchfabConfig.apiKey != nil,
-              sketchfabStaffPicks.isEmpty,
-              sketchfabMostLiked.isEmpty,
-              sketchfabRecent.isEmpty
-        else { return }
+    ///
+    /// Pass `force: true` from `.refreshable {}` so manual pull-to-refresh
+    /// bypasses the "already loaded" guard and actually re-fetches.
+    private func loadSketchfabFeeds(force: Bool = false) async {
+        guard SketchfabConfig.apiKey != nil else { return }
+        if !force,
+           !sketchfabStaffPicks.isEmpty || !sketchfabMostLiked.isEmpty || !sketchfabRecent.isEmpty {
+            return
+        }
         isLoadingFeeds = true
         defer { isLoadingFeeds = false }
 


### PR DESCRIPTION
Mirrors the Android `PullToRefreshBox` from #1203. First of three items in [#1211](https://github.com/sceneview/sceneview/issues/1211).

## Change

- `loadSketchfabFeeds(force: Bool = false)` — bypasses the \"already loaded\" guard when called from `.refreshable`.
- `.refreshable { await loadSketchfabFeeds(force: true) }` on the ExploreTab `ScrollView`.
- Conditional gating via `SketchfabConfig.apiKey` inside the loader — no spinner on builds without the key.

## Out of scope (left as follow-ups in #1211)

- **Item 2 — `matchedGeometryEffect` Explore card → viewer hero**: requires migrating the `.sheet → .fullScreenCover` flow to a single NavigationStack so iOS 18's `.navigationTransition(.zoom(sourceID:in:))` can fire across the transition.
- **Item 3 — ARTab Close affordance**: pre-existing gap, separate concern.

## Test

- [x] `xcodebuild ... -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)