### PR TITLE
fix(samples): use stringResource for "Scanning for surfaces" pill across 5 AR demos (#1234)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
@@ -323,7 +323,7 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
                                     "Not enough detail — try a textured surface"
                                 TrackingFailureReason.CAMERA_UNAVAILABLE -> "Camera unavailable"
                             }
-                        } ?: "Scanning for surfaces…",
+                        } ?: stringResource(R.string.ar_status_scanning),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
                     )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageStabilizationDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageStabilizationDemo.kt
@@ -353,7 +353,7 @@ fun ARImageStabilizationDemo(onBack: () -> Unit) {
                                     "Not enough detail — try a textured surface"
                                 TrackingFailureReason.CAMERA_UNAVAILABLE -> "Camera unavailable"
                             }
-                        } ?: "Scanning for surfaces…",
+                        } ?: stringResource(R.string.ar_status_scanning),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
                     )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
@@ -520,7 +520,7 @@ private fun InstantPlacementScene(
                     } ?: if (instantEnabled) {
                         "Initializing camera — you can already tap to place"
                     } else {
-                        "Scanning for surfaces…"
+                        stringResource(R.string.ar_status_scanning)
                     },
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -423,7 +423,7 @@ fun ARPlacementDemo(onBack: () -> Unit) {
                                     "Not enough detail — try a textured surface"
                                 TrackingFailureReason.CAMERA_UNAVAILABLE -> "Camera unavailable"
                             }
-                        } ?: "Scanning for surfaces…",
+                        } ?: stringResource(R.string.ar_status_scanning),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
                     )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRerunDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRerunDemo.kt
@@ -265,7 +265,7 @@ fun ARRerunDemo(onBack: () -> Unit) {
                                 "Not enough detail — try a textured surface"
                             TrackingFailureReason.CAMERA_UNAVAILABLE -> "Camera unavailable"
                         }
-                    } ?: "Scanning for surfaces…",
+                    } ?: stringResource(R.string.ar_status_scanning),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier


### PR DESCRIPTION
## Summary

5 AR demos rendered the **literal English string** `"Scanning for surfaces…"` instead of looking it up via `stringResource(R.string.ar_status_scanning)`. The `ar_status_scanning` resource was already defined in `values/strings.xml` and translated in `values-fr/strings.xml` ("Recherche de surfaces…") — the demos just didn't use it.

Mechanical replace, 5 sites changed, 5 lines:
- `ARPlacementDemo.kt:426`
- `ARImageStabilizationDemo.kt:356`
- `ARInstantPlacementDemo.kt:523`
- `ARDepthOcclusionDemo.kt:326`
- `ARRerunDemo.kt:268`

All 5 files already have `androidx.compose.ui.res.stringResource` + `io.github.sceneview.demo.R` imports (verified pre-commit).

## Why

Caught by the Pixel 9 wave-5 audit while testing the camera-permission-denied path: with `adb shell pm revoke io.github.sceneview.demo android.permission.CAMERA`, the demo lands on the "Scanning for surfaces…" pill while waiting for ARCore to recover. The pill rendered in English on a French device.

## Test plan

- [ ] CI green.
- [ ] On Pixel 9 with system locale = French: open AR Tap-to-Place → pill reads "Recherche de surfaces…".

## Out of scope

Sister umbrella for i18n follow-ups: [#1161](https://github.com/sceneview/sceneview/issues/1161). A `comm -23 strings.txt fr.txt` CI guard catching unused English literals would prevent recurrences — filed there.

Closes #1234. Filed under audit umbrella #1176 (now closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)