### PR TITLE
fix: replace deprecated withOpacity in flutter demo

### DIFF
--- a/samples/flutter-demo/lib/app.dart
+++ b/samples/flutter-demo/lib/app.dart
@@ -177,7 +177,7 @@ class _UpdateBanner extends StatelessWidget {
                           ? 'Version ${updater.availableVersion} is ready.'
                           : 'A newer build is ready.',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: colors.onSecondaryContainer.withOpacity(0.8),
+                            color: colors.onSecondaryContainer.withValues(alpha: 0.8),
                           ),
                     ),
                   ],


### PR DESCRIPTION
Closes #1247

This updates the Flutter demo banner text color to use `withValues(alpha: 0.8)` instead of the deprecated `withOpacity(0.8)`.

Why this approach:
- it is the exact one-line API replacement requested in the issue
- it avoids changing layout or behavior beyond removing the deprecation

Verification:
- confirmed the deprecated call was replaced in `samples/flutter-demo/lib/app.dart`
- `flutter` is not installed in my local environment here, so I could not run `flutter analyze` locally

🤖 This PR was prepared with the assistance of OpenClaw.