### PR TITLE
feat(scripts): automate resource hygiene (#1242)

### DIFF
--- a/.claude/scripts/disk-gated-spawn-check.sh
+++ b/.claude/scripts/disk-gated-spawn-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# disk-gated-spawn-check.sh — pre-flight safety gate before spawning agents
+#
+# Why: 2026-05-14 multi-agent orchestrator drove free disk down to 8.2 GB.
+# Memory rule feedback_resource_hygiene.md flags <15 GB as the alert
+# threshold. This script is the programmatic version of that rule:
+# source it in any agent-spawn loop and bail before piling on more
+# worktrees / Gradle daemons / emulator AVDs.
+#
+# Recommended usage:
+#
+#   if bash .claude/scripts/disk-gated-spawn-check.sh; then
+#       # spawn the next batch
+#   else
+#       # run gradle-cache-cleanup.sh + worktree-auto-prune.sh first
+#   fi
+#
+# Or capture the numeric value for logging:
+#
+#   eval "$(bash .claude/scripts/disk-gated-spawn-check.sh || true)"
+#   echo "free=$DISK_FREE_GB"
+#
+# Usage:
+#   bash .claude/scripts/disk-gated-spawn-check.sh                  # default 15 GB
+#   bash .claude/scripts/disk-gated-spawn-check.sh --min-gb=20      # custom
+#   bash .claude/scripts/disk-gated-spawn-check.sh --min-gb 20      # space form
+#   bash .claude/scripts/disk-gated-spawn-check.sh --quiet          # only emit DISK_FREE_GB= line
+#
+# Tracking: https://github.com/sceneview/sceneview/issues/1242
+#
+# Exit codes:
+#   0 = free space >= threshold (safe to spawn)
+#   1 = below threshold (do NOT spawn; cleanup first)
+
+set -euo pipefail
+
+MIN_GB=15
+QUIET=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --min-gb=*) MIN_GB="${1#--min-gb=}"; shift ;;
+        --min-gb)   MIN_GB="${2:-15}"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Validate MIN_GB is a positive number (integer or float)
+case "$MIN_GB" in
+    ''|*[!0-9.]*)
+        echo "Invalid --min-gb value: $MIN_GB" >&2
+        exit 2
+        ;;
+esac
+
+# Portable disk-free: df -k on macOS and Linux both yield 1K blocks in
+# column 4. Pulling from `/` covers the typical case where worktrees,
+# Gradle caches, and emulators all share the same volume on dev macs.
+FREE_GB=$(df -k / | awk 'NR==2 { printf "%.2f", $4 / 1024 / 1024 }')
+
+# stdout: machine-readable line (always present for easy capture)
+echo "DISK_FREE_GB=$FREE_GB"
+
+# awk again for portable float comparison (no bc, no [[ )
+if awk -v f="$FREE_GB" -v t="$MIN_GB" 'BEGIN { exit !(f >= t) }'; then
+    [ "$QUIET" = "true" ] || echo "OK: $FREE_GB GB free >= $MIN_GB GB threshold"
+    exit 0
+else
+    {
+        echo ""
+        echo "WARNING: disk free is ${FREE_GB} GB — below ${MIN_GB} GB threshold."
+        echo "Run cleanup BEFORE spawning more agents:"
+        echo "  bash .claude/scripts/gradle-cache-cleanup.sh"
+        echo "  bash .claude/scripts/worktree-auto-prune.sh --yes --keep \"\$(git rev-parse --show-toplevel)\""
+    } >&2
+    exit 1
+fi

--- a/.claude/scripts/gradle-cache-cleanup.sh
+++ b/.claude/scripts/gradle-cache-cleanup.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# gradle-cache-cleanup.sh — bounded Gradle cache pruning by mtime/atime
+#
+# Why: during multi-agent orchestrator runs, ~/.gradle/caches can grow
+# unboundedly (build-cache-1, transforms-*, modules-2/files-2.1).
+# This script reclaims disk WITHOUT stopping daemons — `./gradlew --stop`
+# is unsafe when concurrent agents are mid-build.
+#
+# Strategy: delete only entries older than the safe-to-evict window for
+# each subcache, so a parallel build re-fetches at worst.
+#
+# Usage:
+#   bash .claude/scripts/gradle-cache-cleanup.sh            # do it
+#   bash .claude/scripts/gradle-cache-cleanup.sh --dry-run  # preview only
+#
+# Tracking: https://github.com/sceneview/sceneview/issues/1242
+#
+# Portability: uses BSD-compatible find flags (-atime, -mtime, -empty,
+# -type d). Tested on macOS 14+ (BSD find) and Linux (GNU find).
+#
+# Exit codes:
+#   0 = success (or nothing to do)
+#   1 = unexpected error
+
+set -euo pipefail
+
+DRY_RUN=false
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY_RUN=true
+fi
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+GRADLE_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
+
+if [ ! -d "$GRADLE_HOME" ]; then
+    echo -e "${YELLOW}No Gradle cache at $GRADLE_HOME — nothing to do.${NC}"
+    exit 0
+fi
+
+# Disk-free helper. df on macOS and Linux both support -k; we parse the
+# 4th column (Available KB) from the last data line. Avoids -h which
+# adds unit suffixes that differ across platforms.
+df_free_gb() {
+    df -k / | awk 'NR==2 { printf "%.2f", $4 / 1024 / 1024 }'
+}
+
+BEFORE_GB=$(df_free_gb)
+
+echo -e "${CYAN}=== Gradle cache cleanup ===${NC}"
+echo "GRADLE_USER_HOME: $GRADLE_HOME"
+echo "Disk free before: ${BEFORE_GB} GB"
+if [ "$DRY_RUN" = "true" ]; then
+    echo -e "${YELLOW}DRY RUN — no files will be deleted.${NC}"
+fi
+echo ""
+
+# Helper: list candidates matching a find spec. Stays silent on missing
+# directories (|| true) so first-run on a fresh host doesn't error.
+list_candidates() {
+    local label="$1"; shift
+    local count
+    count=$("$@" 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+    echo -e "${CYAN}--- $label ---${NC}"
+    echo "  candidates: $count"
+    if [ "$DRY_RUN" = "true" ] && [ "$count" -gt 0 ] && [ "$count" -le 20 ]; then
+        "$@" 2>/dev/null | sed 's/^/    /'
+    elif [ "$DRY_RUN" = "true" ] && [ "$count" -gt 20 ]; then
+        "$@" 2>/dev/null | head -10 | sed 's/^/    /'
+        echo "    ... (${count} total)"
+    fi
+}
+
+# ─── 1. build-cache-1: entries not accessed in 7+ days ────────────────────
+if [ -d "$GRADLE_HOME/caches/build-cache-1" ]; then
+    list_candidates "build-cache-1 (atime > 7d)" \
+        find "$GRADLE_HOME/caches/build-cache-1" -type f -atime +7
+    if [ "$DRY_RUN" != "true" ]; then
+        find "$GRADLE_HOME/caches/build-cache-1" -type f -atime +7 -delete 2>/dev/null || true
+    fi
+fi
+
+# ─── 2. transforms-*: entries not modified in 14+ days ────────────────────
+# transforms is regenerated cheaply, safe to evict more aggressively
+# Use a portable for-loop instead of `find ... transforms-*` (glob expansion in find -path is fragile).
+for tdir in "$GRADLE_HOME"/caches/transforms-*; do
+    if [ -d "$tdir" ]; then
+        list_candidates "$(basename "$tdir") (mtime > 14d)" \
+            find "$tdir" -mindepth 1 -mtime +14
+        if [ "$DRY_RUN" != "true" ]; then
+            find "$tdir" -mindepth 1 -mtime +14 -delete 2>/dev/null || true
+        fi
+    fi
+done
+
+# ─── 3. modules-2/files-2.1: empty dirs after upstream cleanups ───────────
+# This sweeps EMPTY directories only — never deletes resolved JARs/AARs.
+# It's just GC for the directory tree left behind when Gradle evicted
+# a module version.
+if [ -d "$GRADLE_HOME/caches/modules-2/files-2.1" ]; then
+    list_candidates "modules-2/files-2.1 (empty dirs, mtime > 30d)" \
+        find "$GRADLE_HOME/caches/modules-2/files-2.1" -mindepth 1 -type d -empty -mtime +30
+    if [ "$DRY_RUN" != "true" ]; then
+        find "$GRADLE_HOME/caches/modules-2/files-2.1" -mindepth 1 -type d -empty -mtime +30 -delete 2>/dev/null || true
+    fi
+fi
+
+echo ""
+AFTER_GB=$(df_free_gb)
+# `bc` is not guaranteed; use awk for portability
+RECOVERED=$(awk -v a="$AFTER_GB" -v b="$BEFORE_GB" 'BEGIN { printf "%.2f", a - b }')
+
+echo -e "${GREEN}=== Summary ===${NC}"
+echo "  Before:    ${BEFORE_GB} GB free"
+echo "  After:     ${AFTER_GB} GB free"
+echo "  Recovered: ${RECOVERED} GB"
+if [ "$DRY_RUN" = "true" ]; then
+    echo -e "  ${YELLOW}(dry-run — no actual deletions; re-run without --dry-run to apply)${NC}"
+fi

--- a/.claude/scripts/worktree-auto-prune.sh
+++ b/.claude/scripts/worktree-auto-prune.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# worktree-auto-prune.sh — safe GC for .claude/worktrees/*
+#
+# Why: orchestrator marathons leave behind worktrees from agents whose
+# PR has long since merged. Each worktree is ~1 GB. 16 stale worktrees
+# on 2026-05-14 dropped local disk below the 15 GB alert threshold.
+#
+# Safety contract:
+#   - NEVER removes the caller's own worktree (use --keep <path>).
+#   - NEVER removes a worktree whose branch is NOT fully merged on
+#     origin/main (ahead-count > 0 means unpushed/unmerged work).
+#   - Defaults to interactive prompt; --yes for non-interactive; --dry-run
+#     for preview without deletion.
+#
+# Usage:
+#   bash .claude/scripts/worktree-auto-prune.sh --dry-run --keep "$(git rev-parse --show-toplevel)"
+#   bash .claude/scripts/worktree-auto-prune.sh --yes  --keep "$(git rev-parse --show-toplevel)"
+#
+# Tracking: https://github.com/sceneview/sceneview/issues/1242
+#
+# Exit codes:
+#   0 = success (or no candidates)
+#   1 = unexpected error (not "user said no", that's still 0)
+
+set -euo pipefail
+
+DRY_RUN=false
+ASSUME_YES=false
+KEEP_PATH=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --yes)     ASSUME_YES=true; shift ;;
+        --keep)    KEEP_PATH="${2:-}"; shift 2 ;;
+        --keep=*)  KEEP_PATH="${1#--keep=}"; shift ;;
+        -h|--help)
+            sed -n '2,25p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Resolve the MAIN repo root (the original checkout, not whatever
+# linked worktree we're currently in). `git rev-parse --git-common-dir`
+# always points at the shared `.git/` directory; its parent is the main
+# working tree.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -z "$GIT_COMMON_DIR" ]; then
+    echo -e "${RED}Not inside a git repo.${NC}" >&2
+    exit 1
+fi
+# git-common-dir may be relative — normalise to absolute.
+GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
+
+# Normalise KEEP_PATH to an absolute path if provided.
+if [ -n "$KEEP_PATH" ]; then
+    KEEP_PATH="$(cd "$KEEP_PATH" 2>/dev/null && pwd || echo "$KEEP_PATH")"
+fi
+
+WORKTREES_DIR="$REPO_ROOT/.claude/worktrees"
+
+if [ ! -d "$WORKTREES_DIR" ]; then
+    echo -e "${YELLOW}No worktrees directory at $WORKTREES_DIR — nothing to do.${NC}"
+    exit 0
+fi
+
+echo -e "${CYAN}=== Worktree auto-prune ===${NC}"
+echo "Repo root:     $REPO_ROOT"
+echo "Worktrees dir: $WORKTREES_DIR"
+if [ -n "$KEEP_PATH" ]; then
+    echo "Keeping:       $KEEP_PATH"
+fi
+echo ""
+
+# Make sure origin/main is recent enough to compute ahead-count.
+git fetch --quiet origin main 2>/dev/null || \
+    echo -e "${YELLOW}Warning: couldn't fetch origin/main — using local refs.${NC}"
+
+CANDIDATES=()
+SKIPPED_UNMERGED=()
+SKIPPED_KEEP=()
+
+# Iterate worktrees registered with git (avoids stale dirs that aren't
+# real worktrees, and respects locked-state).
+# `git worktree list --porcelain` yields blocks separated by blank lines.
+while IFS= read -r line; do
+    case "$line" in
+        worktree\ *)
+            current_path="${line#worktree }"
+            ;;
+        branch\ *)
+            current_branch="${line#branch refs/heads/}"
+            ;;
+        "")
+            # End of a record — evaluate it.
+            if [ -n "${current_path:-}" ]; then
+                # Only consider worktrees under .claude/worktrees/
+                case "$current_path" in
+                    "$WORKTREES_DIR"/*)
+                        # Skip --keep path
+                        if [ -n "$KEEP_PATH" ] && [ "$current_path" = "$KEEP_PATH" ]; then
+                            SKIPPED_KEEP+=("$current_path")
+                        elif [ -n "${current_branch:-}" ]; then
+                            # ahead-count: commits in branch not yet on origin/main
+                            ahead=$(git rev-list --count "origin/main..$current_branch" 2>/dev/null || echo "unknown")
+                            if [ "$ahead" = "0" ]; then
+                                CANDIDATES+=("$current_path|$current_branch")
+                            else
+                                SKIPPED_UNMERGED+=("$current_path ($current_branch, ahead=$ahead)")
+                            fi
+                        else
+                            # Detached HEAD or no branch — treat as unmerged for safety
+                            SKIPPED_UNMERGED+=("$current_path (detached HEAD)")
+                        fi
+                        ;;
+                esac
+            fi
+            current_path=""
+            current_branch=""
+            ;;
+    esac
+done < <(git worktree list --porcelain; echo "")
+
+echo -e "${CYAN}--- Candidates (merged / ahead=0) ---${NC}"
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+    echo "  (none)"
+else
+    for entry in "${CANDIDATES[@]}"; do
+        path="${entry%%|*}"
+        branch="${entry#*|}"
+        size=$(du -sh "$path" 2>/dev/null | awk '{print $1}')
+        echo "  $path  [$branch]  $size"
+    done
+fi
+
+if [ "${#SKIPPED_UNMERGED[@]}" -gt 0 ]; then
+    echo ""
+    echo -e "${CYAN}--- Skipped (unmerged work — DO NOT delete) ---${NC}"
+    for entry in "${SKIPPED_UNMERGED[@]}"; do
+        echo "  $entry"
+    done
+fi
+
+if [ "${#SKIPPED_KEEP[@]}" -gt 0 ]; then
+    echo ""
+    echo -e "${CYAN}--- Skipped (--keep) ---${NC}"
+    for entry in "${SKIPPED_KEEP[@]}"; do
+        echo "  $entry"
+    done
+fi
+
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}Nothing to prune.${NC}"
+    exit 0
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo -e "${YELLOW}DRY RUN — no worktrees removed.${NC}"
+    exit 0
+fi
+
+if [ "$ASSUME_YES" != "true" ]; then
+    echo ""
+    printf "Remove %d worktree(s) listed above? [y/N] " "${#CANDIDATES[@]}"
+    read -r reply
+    case "$reply" in
+        y|Y|yes|YES) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+fi
+
+REMOVED=0
+FAILED=0
+for entry in "${CANDIDATES[@]}"; do
+    path="${entry%%|*}"
+    if git worktree remove --force "$path" 2>/dev/null; then
+        REMOVED=$((REMOVED + 1))
+        echo -e "  ${GREEN}removed${NC} $path"
+    else
+        FAILED=$((FAILED + 1))
+        echo -e "  ${RED}failed ${NC} $path"
+    fi
+done
+
+# Clean up any dangling refs in .git/worktrees/
+git worktree prune
+
+echo ""
+echo -e "${GREEN}=== Summary ===${NC}"
+echo "  Removed: $REMOVED"
+echo "  Failed:  $FAILED"


### PR DESCRIPTION
## Summary

Three helper scripts that automate the manual cleanup commands documented in `feedback_resource_hygiene.md`. The 2026-05-14 orchestrator marathon (5+ parallel `Agent(isolation=\"worktree\")` runs) drove free disk from 228 GB to 8.2 GB — well below the 15 GB alert threshold. These scripts are the programmatic version of the rule so the next marathon doesn't depend on operator vigilance.

Closes #1242.

## What's new

| Script | Purpose |
|---|---|
| `.claude/scripts/gradle-cache-cleanup.sh` | Bounded pruning of `~/.gradle/caches/{build-cache-1,transforms-*,modules-2/files-2.1}` by mtime/atime. Skips `./gradlew --stop` (unsafe with concurrent builds). Has `--dry-run`. |
| `.claude/scripts/worktree-auto-prune.sh` | Removes `.claude/worktrees/*` whose branch is fully merged on `origin/main` (ahead=0). NEVER touches unmerged work. Has `--dry-run`, `--yes`, `--keep <path>`. |
| `.claude/scripts/disk-gated-spawn-check.sh` | Pre-flight gate: exit 1 if free disk < `--min-gb` (default 15 GB). Emits `DISK_FREE_GB=<value>` to stdout for easy capture. |

## Recommended invocation pattern

```bash
if ! bash .claude/scripts/disk-gated-spawn-check.sh; then
    bash .claude/scripts/gradle-cache-cleanup.sh
    bash .claude/scripts/worktree-auto-prune.sh --yes \
        --keep \"\$(git rev-parse --show-toplevel)\"
    bash .claude/scripts/disk-gated-spawn-check.sh || exit 1
fi
# safe to spawn next batch
```

The memory file `feedback_resource_hygiene.md` now lists these scripts under an \"Automated tooling (v4.3.6+)\" section while keeping the manual commands as fallback.

## Future work

The issue suggested auto-executing the disk gate on `<task-notification>` events, but the harness does not currently expose a hook for that event. This is left as future work pending harness support. Tracked in the issue.

## Self-review (5 angles)

- **Safety** — `find -delete` paths are all scoped to `\$GRADLE_USER_HOME` (defaults to `\$HOME/.gradle`); cannot match repo files. `modules-2/files-2.1` deletes empty directories only (never JARs/AARs). `worktree-auto-prune` requires ahead=0 vs origin/main AND respects `--keep`. Validated with `--dry-run`.
- **Portability** — Uses BSD-compatible `find` flags (`-atime`, `-mtime`, `-empty`, `-type d`, `-mindepth`) tested on macOS. Avoids `bc` in favor of `awk` for float compare. `df -k` for portable disk parsing (no `-h` suffix differences).
- **Idempotency** — Second run on a clean cache finds 0 candidates and exits 0. No accumulating side effects.
- **Documentation** — Each script has a usage/why/safety header. Memory file updated with the new section. Local `.claude/handoff.md` updated (gitignored per CDI-safety scrub — local-only by design).
- **Cross-platform (orchestrator worktree)** — `worktree-auto-prune` resolves the main repo root via `git rev-parse --git-common-dir` (not `--show-toplevel`, which returns the linked worktree's root when called from inside one).

## Validation

- `shellcheck` on all 3 scripts: 0 warnings.
- `bash -n` syntax check: pass.
- `gradle-cache-cleanup.sh --dry-run` on this host: 0 candidates (host has no transforms-*).
- `worktree-auto-prune.sh --dry-run --keep ...` on this host: correctly identifies 4 merged worktrees as candidates (~4 GB), 3 unmerged worktrees as skipped, 1 `--keep` as protected.
- `disk-gated-spawn-check.sh --min-gb=1` → exit 0, `--min-gb=1000` → exit 1, default 15 GB → exit 1 on this host (we're at 9.6 GB free — exactly the scenario this PR addresses).

## Test plan

- [x] `shellcheck` clean on all 3 scripts
- [x] `bash -n` syntax check passes
- [x] `gradle-cache-cleanup.sh --dry-run` doesn't crash on a host with no transforms-*
- [x] `worktree-auto-prune.sh --dry-run` correctly skips unmerged and `--keep` worktrees
- [x] `disk-gated-spawn-check.sh` exits 0/1 correctly on threshold boundaries