### PR TITLE
docs(skill): nested Agent reviewer pattern fix (#1243)

### DIFF
--- a/.claude/commands/issue-batch.md
+++ b/.claude/commands/issue-batch.md
@@ -1,12 +1,17 @@
 ---
-description: "Rapporteur / Correcteur" workflow — parallel audit, toast-spawned batches per category, multi-agent reviews, mandatory visual QA.
+description: "Rapporteur / Correcteur" workflow — parallel audit, toast-spawned batches per category, Tier 1 child self-review + Tier 2 orchestrator post-merge audit, mandatory visual QA.
 ---
 
 # /issue-batch — SceneView batched issue workflow
 
 You are the **orchestrator** of the "Rapporteur / Correcteur" workflow. Your job is to dispatch — not to code. Treat each batch as a self-contained child session that you launch via `mcp__ccd_session__spawn_task` (toast notification). Each child session must auto-signal end-of-work so it can be closed.
 
-See memory file `feedback_issue_workflow.md` for the rationale and constraints.
+⛔ **Harness limitation (issue #1243)** — child agents launched via `spawn_task` or `Agent(isolation="worktree")` **cannot themselves spawn nested `Agent()` reviewers**. The harness silently rejects nested `Agent` calls and the child ends up self-reviewing. This means the multi-Agent parallel review **must happen at the orchestrator level (this session)**, not inside the child. The skill therefore splits review into two tiers:
+
+- **Tier 1 (pre-merge, inside child)** — child agent runs a single self-review pass against a 5-angle checklist (security, threading, API consistency, performance, docs). No nested Agent spawning.
+- **Tier 2 (post-merge, in orchestrator — Phase 3.5 below)** — orchestrator spawns 5-7 Opus reviewers in parallel via real top-level `Agent` calls, against the merged commit SHA. Any blocker found becomes a follow-up issue (PRs are atomic; no force-revert).
+
+See memory file `feedback_issue_workflow.md` for the rationale and `feedback_pr_review_workflow.md` for the Tier 1 / Tier 2 split details.
 
 ---
 
@@ -68,7 +73,13 @@ For each approved batch, call `mcp__ccd_session__spawn_task` with:
    a. Implémente le batch (refacto clean, breaking changes OK si justifié).
    b. Compile : `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` (+ iOS/Web si touché).
    c. Tests : `./gradlew :sceneview:test :arsceneview:testDebugUnitTest` (+ MCP si touché).
-   d. **5-7 reviewers Opus en parallèle**, angles différents (sécurité, threading, API consistency, perf, docs, cross-platform parity, visual QA). Voir `feedback_pr_review_workflow.md`.
+   d. **Tier 1 — Self-review pass with 5-angle checklist** (DO NOT attempt nested `Agent()` calls — the harness silently rejects them, cf. issue #1243):
+      - **Security** : input validation, secrets exposure, permission scopes, deserialization.
+      - **Threading** : Filament JNI on main thread, coroutine leaks, race conditions, lifecycle.
+      - **API consistency** : naming parity (Android/iOS/Web), KDoc, deprecation hygiene, signature stability.
+      - **Performance** : allocations in hot paths, draw-call counts, resource destroy order, regression vs baseline.
+      - **Docs** : `llms.txt`, KDoc, cheatsheet, migration notes, MCP examples up to date.
+      Document findings inline in the commit message or PR description. Fix anything actionable before merge. Real multi-Agent parallel review happens at Tier 2 (orchestrator post-merge audit).
    e. Triage 4-buckets : MERGE / FIX-MERGE / HOLD-COMMENT / FOLLOW-UP. Applique FIX-MERGE, file FOLLOW-UP en issues.
    f. **QA visuel obligatoire** avec interactions utilisateur réelles : Android emulator (`bash .claude/scripts/qa-android-demos.sh`), iOS simulator (`xcrun simctl` + computer-use tier "click"), Playwright/Chrome MCP pour web.
    g. Sync : `bash .claude/scripts/impact-check.sh` + update CLAUDE.md handoff + llms.txt + MCP + cheatsheet + version-bump si breaking.
@@ -97,25 +108,88 @@ Spawn parallel batches if they are truly independent (different modules, no merg
 
 ---
 
+## Phase 3.5 — Post-merge audit (Tier 2, orchestrator-side)
+
+Once a child session signals `✅ SESSION TERMINÉE` AND the merge to `main` is confirmed (commit SHA captured), **the orchestrator (this session) spawns 5-7 Opus reviewers in parallel** for real independent multi-agent review. This is where the multi-Agent pattern of `feedback_pr_review_workflow.md` actually executes — at the top level, not inside the child.
+
+Why post-merge: child agents cannot spawn nested `Agent()` (harness limitation, cf. issue #1243). Pre-merge multi-agent review would require the orchestrator to block on the child, defeating the toast/dispatch model. Post-merge audit accepts that PRs are atomic and trades pre-merge gating for post-merge follow-up issues.
+
+**How to spawn** (orchestrator-only — this is YOU, not the child):
+
+For each merged commit `<SHA>`, dispatch 5 parallel reviewers, each with a single angle:
+
+```
+Agent(
+  subagent_type="general-purpose",
+  model="opus",
+  run_in_background=true,
+  prompt="""
+You are a post-merge reviewer for SceneView commit <SHA> on main (batch <name>).
+Review angle: <Security|Threading|API consistency|Performance|Docs>.
+
+Read-only audit. Inspect:
+- `git show <SHA>` and `git diff <SHA>^..<SHA>`
+- Any file touched by the commit
+- Cross-platform parity if API surface changed
+
+Deliverable (<= 500 words, markdown):
+1. Verdict: 🟢 ship-as-is | 🟡 follow-up issue recommended | 🔴 hotfix required
+2. Concrete blockers (file:line citations) if any
+3. Suggested follow-up issue title + body if 🟡 or 🔴
+
+Do NOT push commits. Do NOT spawn nested agents. Report only.
+"""
+)
+```
+
+**Process the 5 outputs**:
+- 🟢 only → close batch, done.
+- 🟡 → file follow-up issue(s) on GitHub via `gh issue create`. Link the batch issues. No revert.
+- 🔴 → spawn a fresh `spawn_task` hotfix batch immediately (do NOT amend the merged commit — atomic PR principle).
+
+---
+
 ## Phase 4 — Closeout
 
 Main session monitors:
 - Pour chaque toast ouvert : attend le signal `✅ SESSION TERMINÉE`.
 - Collecte : commits SHAs, issues fermées, follow-ups filés.
-- Update `.claude/handoff.md` avec section "Cycle N : batches X-Y closed".
+- **Pour chaque SHA, confirme que Phase 3.5 (post-merge audit Tier 2) a tourné** et que les follow-up issues sont filées.
+- Update `.claude/handoff.md` avec section "Cycle N : batches X-Y closed" (inclut les follow-ups de Phase 3.5).
 - Update `MEMORY.md` metrics file (`metrics_<date>.md`) si fin de journée.
 - Décide : nouveau cycle Phase 1 OU pause.
+
+---
+
+## Workflow diagram
+
+```
+Phase 1 (Audit, Explore agents in parallel)
+   ↓
+Phase 2 (Batching table — Thomas approves order)
+   ↓
+Phase 3 (Execution — toast spawn_task per batch)
+   • Child does the work + Tier 1 self-review (5-angle checklist, NO nested Agent)
+   • Child signals ✅ SESSION TERMINÉE with SHA + issues closed
+   ↓
+Phase 3.5 (Post-merge audit — orchestrator-side Tier 2)
+   • Orchestrator spawns 5-7 Opus Agent reviewers in parallel against the merged SHA
+   • Findings → follow-up GitHub issues (no force-revert; PRs are atomic)
+   ↓
+Phase 4 (Closeout — handoff, metrics, decide next cycle)
+```
 
 ---
 
 ## Anti-patterns à éviter
 
 - ❌ Spawner un batch sans l'audit Phase 1 (= fait du flow-of-the-day)
-- ❌ Skipper les 5-7 reviewers Opus (= bugs en prod, cf. v4.1.0)
+- ❌ **Demander au child agent de spawn 5-7 reviewers Opus** (= no-op silencieux, cf. issue #1243). La multi-Agent review se fait **en Phase 3.5 côté orchestrateur**, jamais à l'intérieur du child.
+- ❌ Skipper la Phase 3.5 (post-merge audit Tier 2) sous prétexte que la Tier 1 self-review a tourné — les deux sont nécessaires (cf. `feedback_review_update_visual_triptych.md`).
 - ❌ Skipper la QA visuelle (= démos cassées, cf. v4.1.2 recovery)
 - ❌ Laisser sessions enfant tourner sans signal de fin (= zombies)
 - ❌ Burst de PRs externes (cf. `feedback_no_pr_burst.md`)
-- ❌ Self-evaluate (le rapporteur n'est pas le correcteur)
+- ❌ Self-evaluate (le rapporteur n'est pas le correcteur — mais la Tier 1 self-review reste OK, elle est complétée par Tier 2)
 
 ---
 


### PR DESCRIPTION
## Summary

Fix [#1243](https://github.com/sceneview/sceneview/issues/1243) — the `/issue-batch` skill instructed child agents (`mcp__ccd_session__spawn_task` / `Agent(isolation="worktree")`) to spawn "5-7 reviewers Opus en parallèle". The harness silently rejects nested `Agent()` calls from inside a child agent — confirmed across 5+ runs during the 2026-05-14 marathon (IOS-PARITY, I18N-MIGRATION, ISSUE-1157, STAGE2-AR-PHYSICS, V43[1-5]-CUT). Child agents end up self-reviewing instead.

This violates Pillar 1 of `feedback_review_update_visual_triptych.md` (multi-agent reviews mandatory).

## Fix — Tier 1 / Tier 2 split

- **Tier 1 — Pre-merge self-review (inside child)** : child agent runs a single self-review pass against a fixed 5-angle checklist (security, threading, API consistency, performance, docs). No nested `Agent` spawn.
- **Tier 2 — Post-merge orchestrator audit (Phase 3.5)** : once the child signals `✅ SESSION TERMINÉE` with the merged SHA, the orchestrator (main session) spawns 5-7 Opus `Agent`s in parallel via real top-level calls, one per angle, against the merged commit. 🟢 → close batch. 🟡 → file follow-up issues (atomic PRs, no force-revert). 🔴 → spawn fresh hotfix batch.

This preserves Pillar 1 — multi-agent reviews still happen, they just move from pre-merge (impossible at the child level) to post-merge (works at the top level).

## Changes (atomic, documentation-only)

- `.claude/commands/issue-batch.md`
  - Header: harness-limitation callout with Tier 1 / Tier 2 summary + cross-references.
  - Child prompt: "5-7 reviewers Opus en parallèle" replaced by "Tier 1 — Self-review pass with 5-angle checklist" with full criteria for each angle.
  - New Phase 3.5 (Post-merge audit) section between Phase 3 and Phase 4, with the orchestrator-side `Agent(subagent_type=general-purpose, model=opus, run_in_background=true, ...)` spawn template + 🟢/🟡/🔴 processing rules.
  - Workflow diagram updated.
  - Anti-patterns updated (new "Don't ask the child to spawn reviewers" entry).

Memory files updated in parallel (private, `~/.claude/projects/.../memory/`, not in repo):
- `feedback_pr_review_workflow.md` — new `## Harness limitation: Agent nesting (issue #1243)` section with Tier 1 / Tier 2 details + example spawn code.
- `feedback_issue_workflow.md` — existing harness-limitation note tightened with cross-link; Phase 3.5 added between Phase 3 and Phase 4.

No code touched in `sceneview/`, `arsceneview/`, `samples/`, etc.

## Test plan

- [x] `grep -nE "5.7? reviewers|5 reviewers|cinq reviewers" .claude/commands/issue-batch.md` matches only the orchestrator Phase 3.5 / anti-pattern contexts, never child-agent instruction.
- [x] Skill frontmatter still valid (`description:` line preserved).
- [x] Memory cross-references bidirectional and accurate.
- [x] English-only on public files (`.claude/commands/issue-batch.md`, PR body, commit message).
- [x] No code changes outside `.claude/commands/`.

Closes #1243