### PR TITLE
chore: fix 2 stale SPM refs 4.3.4 → 4.3.5 (post-v4.3.5 cut)

### DIFF
--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -212,7 +212,7 @@ I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old a
 **Answer:**
 [SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
+**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.5"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.4"`
+1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.5"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async


### PR DESCRIPTION
Pre-existing drift caught by `.claude/scripts/impact-check.sh` after I synced main post-#1251 merge. Two files in non-canonical directories (`pro/` and `marketing/`) sit outside the `sync-versions.sh` sweep, so the v4.3.5 release cut left them on 4.3.4.

Same pattern as [#1217](https://github.com/sceneview/sceneview/pull/1217) — single-line bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)