### PR TITLE
chore(ci): close the recurring SPM-drift gap (closes #1263)

### DIFF
--- a/.claude/scripts/impact-check.sh
+++ b/.claude/scripts/impact-check.sh
@@ -113,15 +113,22 @@ echo ""
 echo -e "${CYAN}--- SPM version consistency ---${NC}"
 
 GRADLE_VERSION=$(grep '^VERSION_NAME=' gradle.properties 2>/dev/null | cut -d= -f2)
+# Migration guides + changelogs legitimately quote the legacy
+# `sceneview-swift` mirror coordinate with an OLD version inside a diff
+# snippet (the whole point is to document the deprecation) — exclude them
+# so they're never flagged stale.
 SPM_STALE=$(grep -rl "sceneview-swift.*from.*\"[0-9]" --include='*.md' --include='*.txt' . 2>/dev/null | \
-    grep -v 'node_modules\|build/\|.git/\|docs/site/\|.claude/worktrees/\|.claude/plans/' | \
+    grep -vE 'node_modules|build/|\.git/|docs/site/|\.claude/worktrees/|\.claude/plans/|docs/docs/migration|CHANGELOG\.md|MIGRATION\.md' | \
     xargs grep -l "sceneview-swift" 2>/dev/null | \
     xargs grep -L "from.*\"$GRADLE_VERSION\"" 2>/dev/null || true)
 
 if [ -z "$SPM_STALE" ]; then
     check "SPM version refs match $GRADLE_VERSION" "PASS" ""
 else
-    check "SPM version refs stale" "FAIL" "$(echo "$SPM_STALE" | wc -l | tr -d ' ') file(s)"
+    # `printf | grep -c .` counts non-empty lines — `echo "" | wc -l`
+    # returns 1 for an empty string and would report a phantom "1 file".
+    STALE_COUNT=$(printf '%s\n' "$SPM_STALE" | grep -c .)
+    check "SPM version refs stale" "FAIL" "$STALE_COUNT file(s)"
 fi
 
 # ─── 5. Emulator build check ─────────────────────────────────────────────

--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -350,6 +350,11 @@ SPM_FILES=(
     website-static/playground.html
     .github/copilot-instructions.md
     gpt/system-prompt.md
+    # AI-assistant prompt surfaces in .gitignore'd dirs — tracked files
+    # that the release sweep kept missing (drift fixed by hand in #1217
+    # and again in #1262). Listed explicitly so `--fix` keeps them in sync.
+    pro/gpt-store/gpt-instructions.md
+    marketing/stackoverflow/qa-drafts.md
 )
 for spm_file in "${SPM_FILES[@]}"; do
     F="$REPO_ROOT/$spm_file"


### PR DESCRIPTION
The SPM `from:` version in `pro/gpt-store/gpt-instructions.md` and `marketing/stackoverflow/qa-drafts.md` drifts stale on every release cut — fixed by hand twice this cycle ([#1217](https://github.com/sceneview/sceneview/pull/1217), [#1262](https://github.com/sceneview/sceneview/pull/1262)). Both files live in `.gitignore`'d directories so they're tracked but were never in the release sweep.

## sync-versions.sh
Added both files to the `SPM_FILES` array → `--fix` keeps them in sync. Verified both now report `OK 4.3.5`.

## impact-check.sh — 2 bugs
1. **False positive on migration docs** — `docs/docs/migration.md` quotes the legacy `sceneview-swift` coordinate with `from: "4.0.0"` inside a `diff` snippet (intentional — it's a migration guide). Excluded `migration|CHANGELOG.md|MIGRATION.md` from the scan, mirroring `check-deprecated-api.sh`'s whitelist.
2. **Phantom "1 file(s)" count** — `echo "$SPM_STALE" | wc -l` returns `1` for an empty string. Switched to `printf '%s\n' … | grep -c .` (correct 0 when empty).

## Test
- [x] `impact-check.sh` SPM section PASSes on clean tree
- [x] `sync-versions.sh` lists both previously-missed files as `OK 4.3.5`

Closes #1263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)