### PR TITLE
fix(android-demo): i18n + a11y for SecondaryCameraDemo (#1256)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -22,7 +22,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.annotation.StringRes
 import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
 import io.github.sceneview.demo.DemoScaffold
@@ -90,7 +95,10 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
         title = stringResource(R.string.demo_secondary_camera_title),
         onBack = onBack,
         controls = {
-            Text("PiP Camera Angle", style = MaterialTheme.typography.labelLarge)
+            Text(
+                stringResource(R.string.demo_secondary_camera_chip_section),
+                style = MaterialTheme.typography.labelLarge
+            )
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -99,7 +107,7 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
                     FilterChip(
                         selected = cameraPreset == preset,
                         onClick = { cameraPreset = preset },
-                        label = { Text(preset.label) }
+                        label = { Text(stringResource(preset.labelRes)) }
                     )
                 }
             }
@@ -121,6 +129,10 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
             }
         }
 
+        val pipDescription = stringResource(
+            R.string.demo_secondary_camera_pip_cd,
+            stringResource(cameraPreset.labelRes)
+        )
         Box(
             modifier = Modifier
                 .align(Alignment.TopStart)
@@ -132,6 +144,14 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
                     MaterialTheme.colorScheme.outline,
                     RoundedCornerShape(12.dp)
                 )
+                // The PiP renders into a TextureView that TalkBack cannot
+                // introspect — describe it explicitly, and mark it a polite
+                // live region so the angle change is announced when the user
+                // picks a different chip.
+                .semantics {
+                    contentDescription = pipDescription
+                    liveRegion = LiveRegionMode.Polite
+                }
         ) {
             SceneView(
                 modifier = Modifier.fillMaxSize(),
@@ -155,11 +175,11 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
     }
 }
 
-private enum class CameraPreset(val label: String, val eye: Position) {
+private enum class CameraPreset(@StringRes val labelRes: Int, val eye: Position) {
     // Y=1.8 with X=0.01 to avoid a gimbal singularity in lookAt's up-vector
     // resolution when the camera sits exactly above the origin.
-    TOP("Top", Position(0.01f, 1.8f, 0f)),
-    SIDE("Side", Position(1.8f, 0.2f, 0f)),
-    FRONT("Front", Position(0f, 0.2f, 1.8f)),
-    CORNER("Corner", Position(1.3f, 0.9f, 1.3f)),
+    TOP(R.string.demo_secondary_camera_chip_top, Position(0.01f, 1.8f, 0f)),
+    SIDE(R.string.demo_secondary_camera_chip_side, Position(1.8f, 0.2f, 0f)),
+    FRONT(R.string.demo_secondary_camera_chip_front, Position(0f, 0.2f, 1.8f)),
+    CORNER(R.string.demo_secondary_camera_chip_corner, Position(1.3f, 0.9f, 1.3f)),
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -1,5 +1,6 @@
 package io.github.sceneview.demo.demos
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,12 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import androidx.annotation.StringRes
 import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
 import io.github.sceneview.demo.DemoScaffold

--- a/samples/android-demo/src/main/res/values-fr/strings.xml
+++ b/samples/android-demo/src/main/res/values-fr/strings.xml
@@ -234,6 +234,12 @@
     <string name="demo_reflection_probes_subtitle">Réflexions cubemap locales</string>
     <string name="demo_secondary_camera_title">Caméra secondaire (PiP)</string>
     <string name="demo_secondary_camera_subtitle">Vue caméra incrustée</string>
+    <string name="demo_secondary_camera_chip_section">Angle de la caméra PiP</string>
+    <string name="demo_secondary_camera_chip_top">Dessus</string>
+    <string name="demo_secondary_camera_chip_side">Côté</string>
+    <string name="demo_secondary_camera_chip_front">Face</string>
+    <string name="demo_secondary_camera_chip_corner">Coin</string>
+    <string name="demo_secondary_camera_pip_cd">Vue caméra incrustée : %1$s</string>
     <string name="demo_debug_overlay_title">Surcouche de débogage</string>
     <string name="demo_debug_overlay_subtitle">Surcouche de statistiques de performance</string>
     <string name="demo_ar_placement_title">Placer en tapant</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -228,6 +228,12 @@
     <string name="demo_reflection_probes_subtitle">Local cubemap reflections</string>
     <string name="demo_secondary_camera_title">Secondary Camera (PiP)</string>
     <string name="demo_secondary_camera_subtitle">Picture-in-picture camera view</string>
+    <string name="demo_secondary_camera_chip_section">PiP Camera Angle</string>
+    <string name="demo_secondary_camera_chip_top">Top</string>
+    <string name="demo_secondary_camera_chip_side">Side</string>
+    <string name="demo_secondary_camera_chip_front">Front</string>
+    <string name="demo_secondary_camera_chip_corner">Corner</string>
+    <string name="demo_secondary_camera_pip_cd">Picture-in-picture camera view: %1$s</string>
     <string name="demo_debug_overlay_title">Debug Overlay</string>
     <string name="demo_debug_overlay_subtitle">Performance stats overlay</string>
     <string name="demo_ar_placement_title">Tap to Place</string>


### PR DESCRIPTION
Partial fix for [#1256](https://github.com/sceneview/sceneview/issues/1256) — ships the two concrete code items. The "multi-camera demo: same model vs second model" design-discussion part stays open on the issue.

## i18n — chip labels were hard-coded English

`SecondaryCameraDemo.kt` had `Text("PiP Camera Angle")` + the four `CameraPreset.label` strings inlined in English while the demo title already used `stringResource`. In a French-localised app (`values-fr` ships per [#1099](https://github.com/sceneview/sceneview/issues/1099) / [#1160](https://github.com/sceneview/sceneview/pull/1160)) the section header + every chip rendered English regardless of device locale.

`CameraPreset` now carries `@StringRes val labelRes` instead of a raw `String`. Five keys added to both `values/strings.xml` + `values-fr/strings.xml`:

| key | EN | FR |
|---|---|---|
| `demo_secondary_camera_chip_section` | PiP Camera Angle | Angle de la caméra PiP |
| `demo_secondary_camera_chip_top` | Top | Dessus |
| `demo_secondary_camera_chip_side` | Side | Côté |
| `demo_secondary_camera_chip_front` | Front | Face |
| `demo_secondary_camera_chip_corner` | Corner | Coin |

## a11y — PiP overlay had no contentDescription

The PiP renders into a `TextureView` that TalkBack cannot introspect, so the top-start overlay was invisible to screen-reader users. The Box now carries `semantics { contentDescription = ...; liveRegion = Polite }`. The description includes the current angle ("Picture-in-picture camera view: Side") and the polite live-region mode makes TalkBack announce the change when the user picks a different chip. New format-string key `demo_secondary_camera_pip_cd` (`%1$s` = angle), translated in both locales.

## Test plan

- [x] `./gradlew :samples:android-demo:assembleDebug` — green (aapt validates every string-resource reference at build time)
- [ ] No visual device test — the Pixel 9's wireless adb dropped mid-session. The change touches zero rendering/camera logic, so compile + aapt resource validation is the meaningful gate.
- [x] `DemoInteractionTest.secondaryCamera_pipAngles` still matches the EN chip text on the default-locale CI emulator (the FR-locale fragility of that test is tracked separately in [#1257](https://github.com/sceneview/sceneview/issues/1257)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)