### PR TITLE
docs(recipes): add Blender → SceneView asset pipeline recipe (#1222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Cloud Anchor docs hotfix + `sceneview-swift` mirror retired
 
+### Added — `night_sky` environment preset ([#1219](https://github.com/sceneview/sceneview/issues/1219))
+
+- **New `night_sky` HDR environment** bundled across iOS and Android demos — a dramatic Milky Way starfield over a dark landscape (Poly Haven [`dikhololo_night`](https://polyhaven.com/a/dikhololo_night) by Greg Zaal, **CC0 1.0** public domain). iOS exposes it as `SceneEnvironment.nightSky` (added to `allPresets`, so it auto-surfaces in the demo's environment picker); Android adds a "Night Sky" chip to `EnvironmentDemo`. Pairs well with metallic PBR materials for chrome-mirror reflections. Web demo does not bundle HDRs and is unaffected.
+
 ### Fixed — iOS rendering
 
 - **`SceneEnvironment.showSkybox = true` now actually paints the HDR as the scene background ([PR #1215](https://github.com/sceneview/sceneview/pull/1215), ported from [@radcli14](https://github.com/radcli14)'s [sceneview-swift#1](https://github.com/sceneview/sceneview-swift/pull/1))** — `SceneView` previously loaded the HDR and applied it as IBL via `ImageBasedLightComponent`, but never assigned it to `RealityViewContent.environment`, so the scene rendered against the default neutral void regardless of which environment preset was selected. The new path caches the loaded `EnvironmentResource` in a `@State` and applies it via `content.environment = .skybox(resource)` in the `RealityView.update:` closure with a diff guard against the last applied resource (no per-frame ARC churn). The `.task(id:)` keys on `(name, showSkybox)` so toggling the flag on the same env re-runs the loader, and clears the cached resource at the start of every task tick so cross-env transitions don't show stale skyboxes under a new IBL.
@@ -25,6 +29,10 @@ Two regressions from `cd4034ff` (PR #1224) that the #1241 emulator QA sweep prov
 
 - **AR Instant Placement — "Initializing camera" pill alignment** ([#1265](https://github.com/sceneview/sceneview/issues/1265)): the scanning-indicator pill rendered bottom-left, overlapping the Clear All button, despite a `BoxScope.align(TopCenter)` set directly on its `AnimatedVisibility` wrapper. `AnimatedVisibility` introduces its own layout node for the enter/exit transition and the `align` modifier on that wrapper is not reliably honoured by the animated child. The alignment is now carried by a static `Box` that is a direct child of the outer `Box`, with `AnimatedVisibility` inside it handling only the fade — matching the structure of the working stats pill above. Pill stays pinned top-center, clear of the bottom Clear All button.
 - **Debug Overlay — invisible stress-test spheres** ([#1266](https://github.com/sceneview/sceneview/issues/1266)): the `SceneView` content block had no `LightNode` and the spheres were spawned with no `materialInstance`, so the default Filament material rendered black on the black background. Added a directional key light and a shared on-brand color material (created once via `remember`, so the stress test still measures pure geometry overhead). The earlier #1212 grid-centering fix already places the count == 1 sphere at origin; this completes the visibility fix.
+
+### Docs
+
+- **New recipe: Blender → SceneView asset pipeline ([#1222](https://github.com/sceneview/sceneview/issues/1222))** — `samples/recipes/blender-to-sceneview.md` and `docs/docs/recipes/blender-pipeline.md` walk contributors through authoring a custom 3D model in Blender and shipping it in a SceneView app: `.glb` is native on Android, while Apple platforms go `.glb` → Reality Converter → `.usdz` → Reality Composer Pro (Blender's own USDZ exporter produces broken materials). Adapted from [@radcli14](https://github.com/radcli14)'s [`blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) tutorial (MIT, 17⭐), with a SceneView-specific call-out on the Android Filament JNI main-thread rule. Cross-linked from both quickstarts and the API cheatsheet. Closes [#1222](https://github.com/sceneview/sceneview/issues/1222).
 
 ### Follow-ups (filed against the master polish-pipeline reference [#1218](https://github.com/sceneview/sceneview/issues/1218))
 

--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -214,6 +214,12 @@ environmentLoader.createKtxEnvironment("environments/studio.ktx")
 materialLoader.createColorInstance(Color.Red)
 ```
 
+### Custom 3D content
+
+Authoring your own model? See the [Blender pipeline recipe](recipes/blender-pipeline.md):
+export `.glb` from Blender for Android (native), or convert `.glb` → `.usdz` via Reality
+Converter + Reality Composer Pro for Apple platforms.
+
 ---
 
 ## Threading Rules

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -174,4 +174,5 @@ Point the camera at a flat surface, wait for plane detection, then tap to place 
 - **Try geometry** — Add shapes with `GeometryNode.cube(...)`, `GeometryNode.sphere(...)`, and `GeometryNode.cylinder(...)`.
 - **Add physics** — Use `PhysicsNode.dynamic(entity)` to make objects fall with gravity.
 - **Build for visionOS** — The same `SceneView` API works in immersive spaces on Apple Vision Pro.
+- **Need a custom 3D model?** — See the [Blender pipeline](recipes/blender-pipeline.md) for authoring a model in Blender and converting it to `.usdz`.
 - **Explore the Android SDK** — See the [Android Quickstart](quickstart.md) for the Compose equivalent of every API shown here.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -135,6 +135,7 @@ That is a production-quality, physically-based 3D viewer in under 30 lines of co
 
 - **Add HDR lighting** — Download a `.hdr` environment map and pass it via `rememberEnvironment(environmentLoader) { environmentLoader.createHDREnvironment("environments/sky_2k.hdr") ?: createEnvironment(environmentLoader) }` to the `environment` parameter of `SceneView`.
 - **Try AR** — Follow the [AR Compose codelab](codelabs/codelab-ar-compose.md) to place models in the real world using `ARSceneView`.
+- **Need a custom 3D model?** — See the [Blender pipeline](recipes/blender-pipeline.md) for authoring a model in Blender and exporting `.glb` for SceneView.
 - **Explore the samples** — The [samples page](samples.md) covers model animation, camera manipulation, cloud anchors, and more.
 - **Browse the API** — Read [`llms.txt`](https://github.com/sceneview/sceneview/blob/main/llms.txt) — the AI-first machine-readable reference covering every composable, node type, and loader.
 - **Building for Apple platforms?** — See the [Apple Quickstart](quickstart-ios.md) for iOS, macOS, and visionOS setup with SwiftUI and RealityKit.

--- a/docs/docs/recipes/blender-pipeline.md
+++ b/docs/docs/recipes/blender-pipeline.md
@@ -1,0 +1,207 @@
+---
+title: Blender → SceneView asset pipeline
+description: Author a custom 3D model in Blender and ship it in a SceneView app — glb on Android, glb → Reality Converter → usdz → Reality Composer Pro on Apple platforms.
+---
+
+# Blender → SceneView asset pipeline
+
+**Intent:** "I authored a 3D model in Blender — how do I get it into a SceneView app on iOS and Android?"
+
+!!! tip "Read the source tutorial first"
+    This recipe is adapted from [@radcli14](https://github.com/radcli14)'s comprehensive
+    Blender → RealityKit tutorial ([`radcli14/blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit),
+    MIT, 17⭐). **Read the original first** for the full Blender-side detail — modelling,
+    texturing, materials, displacement. This page is the **SceneView-specific adapter**:
+    it covers the Apple-tool and Android-tool steps and how to load the result through
+    the SceneView API.
+
+SceneView consumes two model formats:
+
+- **`.glb`** — glTF binary. Native on Android (and Web). The canonical interchange format.
+- **`.usdz`** — Universal Scene Description archive. Native on Apple (RealityKit).
+
+A single Blender model feeds both. The two platforms diverge only at the final
+conversion step.
+
+```
+                    ┌─────────────────────┐
+                    │   Blender model     │
+                    │  (textured, posed)  │
+                    └──────────┬──────────┘
+                               │  export glTF 2.0
+                               ▼
+                    ┌─────────────────────┐
+                    │       car.glb       │
+                    └────┬───────────┬────┘
+            Android      │           │      iOS / macOS / visionOS
+                         ▼           ▼
+              assets/models/   Reality Converter
+              car.glb               │  → car.usdz
+                         │           ▼
+                         │   Reality Composer Pro
+                         │   (fix materials + lighting)
+                         ▼           ▼
+              rememberModelInstance   ModelNode.load("car.usdz")
+```
+
+## Step 1 — Export `.glb` from Blender (both platforms)
+
+In Blender: **File → Export → glTF 2.0 (.glb/.gltf)**. Choose the **`glTF Binary (.glb)`**
+format so textures are embedded in a single file.
+
+!!! warning "Do not use Blender's USDZ exporter"
+    Blender can export `.usdz` directly, but the material round-trip is broken — PBR
+    inputs land on the wrong slots and the model renders untextured or flat-shaded in
+    RealityKit. Eliott's tutorial documents this in detail. The reliable path is
+    **glb → Reality Converter**, never **Blender → usdz**.
+
+This single `car.glb` is the source of truth for every platform.
+
+## Step 2a — Android: drop the `.glb` in and load it
+
+`.glb` is native on Android. There is **no Reality Converter step** — copy the file
+straight into the app's assets:
+
+```
+src/main/assets/models/car.glb
+```
+
+Load it in a composable with `rememberModelInstance`:
+
+```kotlin
+@Composable
+fun CarViewer() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val model = rememberModelInstance(modelLoader, "models/car.glb")
+
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        cameraManipulator = rememberCameraManipulator()
+    ) {
+        model?.let {
+            ModelNode(modelInstance = it, scaleToUnits = 1.0f)
+        }
+    }
+}
+```
+
+That's the whole Android path. The same `.glb` also works unchanged on the **Web** target
+(`sceneview-web`), which loads glTF via Filament.js.
+
+## Step 2b — iOS: convert `.glb` to `.usdz` with Reality Converter
+
+Apple's renderer (RealityKit) wants `.usdz`. Convert with the two free Apple tools from
+the [Apple AR tools page](https://developer.apple.com/augmented-reality/tools/):
+
+1. **[Reality Converter](https://developer.apple.com/augmented-reality/tools/)** —
+   drag `car.glb` into the window, inspect the preview, then **File → Export → USDZ**.
+   Reality Converter handles glTF → USD natively and is the tool Apple intends for this
+   job. It produces `car.usdz`.
+
+2. **[Reality Composer Pro](https://developer.apple.com/augmented-reality/tools/)** —
+   open `car.usdz` here to **clean up materials, lighting, and animations**. This is the
+   step that fixes anything the conversion didn't carry perfectly:
+    - Re-seat PBR texture maps if a slot looks wrong.
+    - Adjust metallic / roughness values.
+    - Bake or trim the lighting rig that ships inside the USD scene.
+    - Trim or rename animation clips.
+
+   Export the cleaned scene back to `car.usdz`.
+
+Drop the result into the iOS demo's bundle and load it in SwiftUI:
+
+```swift
+struct CarViewer: View {
+    @State private var model: ModelNode?
+
+    var body: some View {
+        SceneView { content in
+            if let model {
+                content.add(model.entity)
+            }
+        }
+        .cameraControls(.orbit)
+        .environment(.studio)
+        .task {
+            model = try? await ModelNode.load("car.usdz")?
+                .scaleToUnits(1.0)
+        }
+    }
+}
+```
+
+## Step 3 — PBR textures from iPhone photos (optional)
+
+For photorealistic surfaces you need a full PBR texture set: **albedo + roughness +
+normal + displacement**. Eliott's tutorial recommends [PolyCam](https://poly.cam/) —
+photograph a real surface with an iPhone and PolyCam generates the maps from the
+captured photos. Import those maps as image textures in Blender's Shader Editor before
+you export the `.glb`.
+
+## Pitfalls (from @radcli14's tutorial)
+
+| Pitfall | Fix |
+|---|---|
+| Blender's `.usdz` exporter produces broken materials | Export `.glb`, convert with **Reality Converter** instead. |
+| Conversion drops or mis-seats a material | Open the `.usdz` in **Reality Composer Pro** and re-seat the slots. |
+| Displacement maps don't survive the export | Displacement is **Blender-preview only** (Cycles + Subdivide Surface modifier). For shipped models, bake the detail into a **normal map** instead — normal maps survive both glTF and USD. |
+| Need realistic textures fast | Capture a real surface with [PolyCam](https://poly.cam/) → import the generated albedo / roughness / normal maps. |
+
+## SceneView gotcha — Android Filament threading
+
+This one is **not in Eliott's tutorial** — it's specific to SceneView's Android renderer.
+
+Filament (the Android rendering engine) is a JNI library, and its model/material calls
+**must run on the main thread**. Loading a model off a background coroutine directly
+will crash or corrupt the renderer:
+
+```kotlin
+// ❌ WRONG — Filament JNI call off the main thread
+viewModelScope.launch(Dispatchers.IO) {
+    val instance = modelLoader.createModelInstance("models/car.glb")
+}
+
+// ✅ CORRECT — rememberModelInstance marshals to the main thread for you
+@Composable
+fun CarViewer() {
+    val model = rememberModelInstance(modelLoader, "models/car.glb")
+    // ...
+}
+```
+
+`rememberModelInstance` (and `loadModelInstanceAsync` for imperative code) handle the
+thread hop correctly — always prefer them. The unsafe APIs are `modelLoader.createModel*`
+and any `materialLoader.*` call from a background thread.
+
+**iOS has no equivalent constraint** — RealityKit's `ModelNode.load(...)` is `async` and
+safely callable from any task; the renderer itself is thread-confined internally.
+
+## Key concepts
+
+| Concept | Android | iOS |
+|---|---|---|
+| Source format | Blender `.glb` export | Blender `.glb` export |
+| Conversion step | none — `.glb` is native | Reality Converter → `.usdz` |
+| Material cleanup | in Blender before export | Reality Composer Pro after conversion |
+| App location | `assets/models/car.glb` | app bundle, `car.usdz` |
+| Load API | `rememberModelInstance(loader, "models/car.glb")` | `ModelNode.load("car.usdz")` |
+| Threading | Filament JNI = main thread (handled by `remember*`) | no constraint |
+
+## See also
+
+- [`radcli14/blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) —
+  the full Blender-side tutorial this recipe adapts.
+- [`radcli14/DAE-to-RealityKit`](https://github.com/radcli14/DAE-to-RealityKit) and
+  [`radcli14/ModelIO-to-RealityKit`](https://github.com/radcli14/ModelIO-to-RealityKit) —
+  Eliott's converters for `.dae` and for `.stl` / `.obj` / `.ply` / `.abc` via Apple's ModelIO.
+- [Free 3D models](../free-3d-models.md) — where to source ready-made `.glb` / `.usdz` assets.
+- [Sketchfab streaming](sketchfab-streaming.md) — load models on demand instead of bundling them.
+
+---
+
+*This recipe is adapted from [@radcli14](https://github.com/radcli14)'s
+[`blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) tutorial
+(MIT licensed). Thanks to Eliott Radcliffe for the careful Blender-side write-up.*

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Nodes Reference: nodes.md
     - Recipes:
       - Overview: recipes.md
+      - Blender asset pipeline: recipes/blender-pipeline.md
       - Sketchfab streaming: recipes/sketchfab-streaming.md
       - Demo settings sheet: recipes/demo-settings-sheet.md
     - FAQ: faq.md

--- a/samples/recipes/blender-to-sceneview.md
+++ b/samples/recipes/blender-to-sceneview.md
@@ -1,0 +1,200 @@
+# Recipe: Blender → SceneView Asset Pipeline
+
+**Intent:** "Author a custom 3D model in Blender and ship it in a SceneView app on iOS and Android"
+
+> This recipe is adapted from [@radcli14](https://github.com/radcli14)'s comprehensive
+> Blender → RealityKit tutorial ([`radcli14/blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit),
+> MIT, 17⭐). **Read the original first** for the full Blender-side detail — modelling,
+> texturing, materials, displacement. This page is the **SceneView-specific adapter**:
+> it covers the Apple-tool and Android-tool steps and how to load the result through the
+> SceneView API.
+
+SceneView consumes two model formats:
+
+- **`.glb`** — glTF binary. Native on Android (and Web). The canonical interchange format.
+- **`.usdz`** — Universal Scene Description archive. Native on Apple (RealityKit).
+
+A single Blender model feeds both. The two platforms diverge only at the final
+conversion step.
+
+```
+                    ┌─────────────────────┐
+                    │   Blender model     │
+                    │  (textured, posed)  │
+                    └──────────┬──────────┘
+                               │  export glTF 2.0
+                               ▼
+                    ┌─────────────────────┐
+                    │       car.glb       │
+                    └────┬───────────┬────┘
+            Android      │           │      iOS / macOS / visionOS
+                         ▼           ▼
+              assets/models/   Reality Converter
+              car.glb               │  → car.usdz
+                         │           ▼
+                         │   Reality Composer Pro
+                         │   (fix materials + lighting)
+                         ▼           ▼
+              rememberModelInstance   ModelNode.load("car.usdz")
+```
+
+## Step 1 — Export `.glb` from Blender (both platforms)
+
+In Blender: **File → Export → glTF 2.0 (.glb/.gltf)**. Choose the **`glTF Binary (.glb)`**
+format so textures are embedded in a single file.
+
+> ⚠️ **Do NOT use Blender's USDZ exporter.** Blender can export `.usdz` directly, but the
+> material round-trip is broken — PBR inputs land on the wrong slots and the model renders
+> untextured or flat-shaded in RealityKit. Eliott's tutorial documents this in detail. The
+> reliable path is **glb → Reality Converter**, never **Blender → usdz**.
+
+This single `car.glb` is the source of truth for every platform.
+
+## Step 2a — Android: drop the `.glb` in and load it
+
+`.glb` is native on Android. There is **no Reality Converter step** — copy the file
+straight into the app's assets:
+
+```
+samples/android-demo/src/main/assets/models/car.glb
+```
+
+Load it in a composable with `rememberModelInstance`:
+
+```kotlin
+@Composable
+fun CarViewer() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val model = rememberModelInstance(modelLoader, "models/car.glb")
+
+    SceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        cameraManipulator = rememberCameraManipulator()
+    ) {
+        model?.let {
+            ModelNode(modelInstance = it, scaleToUnits = 1.0f)
+        }
+    }
+}
+```
+
+That's the whole Android path. The same `.glb` also works unchanged on the **Web** target
+(`sceneview-web`), which loads glTF via Filament.js.
+
+## Step 2b — iOS: convert `.glb` to `.usdz` with Reality Converter
+
+Apple's renderer (RealityKit) wants `.usdz`. Convert with the two free Apple tools from
+the [Apple AR tools page](https://developer.apple.com/augmented-reality/tools/):
+
+1. **[Reality Converter](https://developer.apple.com/augmented-reality/tools/)** —
+   drag `car.glb` into the window, inspect the preview, then **File → Export → USDZ**.
+   Reality Converter handles glTF → USD natively and is the tool Apple intends for this
+   job. It produces `car.usdz`.
+
+2. **[Reality Composer Pro](https://developer.apple.com/augmented-reality/tools/)** —
+   open `car.usdz` here to **clean up materials, lighting, and animations**. This is the
+   step that fixes anything the conversion didn't carry perfectly:
+   - Re-seat PBR texture maps if a slot looks wrong.
+   - Adjust metallic / roughness values.
+   - Bake or trim the lighting rig that ships inside the USD scene.
+   - Trim or rename animation clips.
+
+   Export the cleaned scene back to `car.usdz`.
+
+Drop the result into the iOS demo's bundle and load it in SwiftUI:
+
+```swift
+struct CarViewer: View {
+    @State private var model: ModelNode?
+
+    var body: some View {
+        SceneView { content in
+            if let model {
+                content.add(model.entity)
+            }
+        }
+        .cameraControls(.orbit)
+        .environment(.studio)
+        .task {
+            model = try? await ModelNode.load("car.usdz")?
+                .scaleToUnits(1.0)
+        }
+    }
+}
+```
+
+## Step 3 — PBR textures from iPhone photos (optional)
+
+For photorealistic surfaces you need a full PBR texture set: **albedo + roughness +
+normal + displacement**. Eliott's tutorial recommends [PolyCam](https://poly.cam/) —
+photograph a real surface with an iPhone and PolyCam generates the maps from the
+captured photos. Import those maps as image textures in Blender's Shader Editor before
+you export the `.glb`.
+
+## Pitfalls (from @radcli14's tutorial)
+
+| Pitfall | Fix |
+|---|---|
+| Blender's `.usdz` exporter produces broken materials | Export `.glb`, convert with **Reality Converter** instead. |
+| Conversion drops or mis-seats a material | Open the `.usdz` in **Reality Composer Pro** and re-seat the slots. |
+| Displacement maps don't survive the export | Displacement is **Blender-preview only** (Cycles + Subdivide Surface modifier). For shipped models, bake the detail into a **normal map** instead — normal maps survive both glTF and USD. |
+| Need realistic textures fast | Capture a real surface with [PolyCam](https://poly.cam/) → import the generated albedo / roughness / normal maps. |
+
+## SceneView gotcha — Android Filament threading
+
+This one is **not in Eliott's tutorial** — it's specific to SceneView's Android renderer.
+
+Filament (the Android rendering engine) is a JNI library, and its model/material calls
+**must run on the main thread**. Loading a model off a background coroutine directly
+will crash or corrupt the renderer:
+
+```kotlin
+// ❌ WRONG — Filament JNI call off the main thread
+viewModelScope.launch(Dispatchers.IO) {
+    val instance = modelLoader.createModelInstance("models/car.glb")
+}
+
+// ✅ CORRECT — rememberModelInstance marshals to the main thread for you
+@Composable
+fun CarViewer() {
+    val model = rememberModelInstance(modelLoader, "models/car.glb")
+    // ...
+}
+```
+
+`rememberModelInstance` (and `loadModelInstanceAsync` for imperative code) handle the
+thread hop correctly — always prefer them. The unsafe APIs are `modelLoader.createModel*`
+and any `materialLoader.*` call from a background thread.
+
+**iOS has no equivalent constraint** — RealityKit's `ModelNode.load(...)` is `async` and
+safely callable from any task; the renderer itself is thread-confined internally.
+
+## Key concepts
+
+| Concept | Android | iOS |
+|---|---|---|
+| Source format | Blender `.glb` export | Blender `.glb` export |
+| Conversion step | none — `.glb` is native | Reality Converter → `.usdz` |
+| Material cleanup | in Blender before export | Reality Composer Pro after conversion |
+| App location | `assets/models/car.glb` | app bundle, `car.usdz` |
+| Load API | `rememberModelInstance(loader, "models/car.glb")` | `ModelNode.load("car.usdz")` |
+| Threading | Filament JNI = main thread (handled by `remember*`) | no constraint |
+
+## See also
+
+- [`radcli14/blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) —
+  the full Blender-side tutorial this recipe adapts.
+- [`radcli14/DAE-to-RealityKit`](https://github.com/radcli14/DAE-to-RealityKit) and
+  [`radcli14/ModelIO-to-RealityKit`](https://github.com/radcli14/ModelIO-to-RealityKit) —
+  Eliott's converters for `.dae` and for `.stl` / `.obj` / `.ply` / `.abc` via Apple's ModelIO.
+- [Model Viewer recipe](model-viewer.md) — minimal orbit-camera viewer.
+- [Animated Model recipe](animated-model.md) — playing baked animations.
+
+---
+
+*This recipe is adapted from [@radcli14](https://github.com/radcli14)'s
+[`blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) tutorial
+(MIT licensed). Thanks to Eliott Radcliffe for the careful Blender-side write-up.*


### PR DESCRIPTION
## Summary

Adds a recipe walking contributors through authoring a custom 3D model in Blender and shipping it in a SceneView app — the most underserved tutorial gap in our docs.

- **New** `samples/recipes/blender-to-sceneview.md` (~200 lines) — iOS + Android paths, pitfalls, key-concepts table.
- **New** `docs/docs/recipes/blender-pipeline.md` — MkDocs mirror, added to the Recipes nav in `mkdocs.yml`.
- **Cross-linked** from `quickstart-ios.md`, `quickstart.md` (Android), and `cheatsheet.md` (new "Custom 3D content" subsection).
- **CHANGELOG** — new `### Docs` entry under `## Unreleased`.

### What the recipe covers

- **Single source of truth**: one Blender `.glb` export feeds every platform.
- **Android path**: `.glb` is native — drop into `assets/models/`, load via `rememberModelInstance`. No conversion step.
- **iOS path**: `.glb` → Reality Converter → `.usdz` → Reality Composer Pro (materials/lighting cleanup) → `ModelNode.load("car.usdz")`.
- **Counter-intuitive pitfall surfaced fast**: Blender's own USDZ exporter produces broken materials — the working path is glb → Reality Converter, never Blender → usdz.
- **SceneView-specific gotcha not in the source tutorial**: Android Filament JNI calls (`modelLoader.createModel*`, `materialLoader.*`) must run on the main thread; `rememberModelInstance` handles this. iOS RealityKit has no such constraint.

## Attribution

This recipe adapts [@radcli14](https://github.com/radcli14)'s comprehensive Blender → RealityKit tutorial ([`radcli14/blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit), MIT, 17⭐). The recipe links the original prominently as the authoritative Blender-side source and credits Eliott Radcliffe in a hat-tip header and attribution footer. Thanks Eliott!

## Test plan

- [ ] All internal links resolve (`model-viewer.md` / `animated-model.md` in `samples/recipes/`; `free-3d-models.md` / `sketchfab-streaming.md` in `docs/docs/recipes/`).
- [ ] MkDocs nav renders the new "Blender asset pipeline" entry under Recipes.
- [ ] `mkdocs build --strict` passes in CI (no local mkdocs available).
- [ ] Cross-links from both quickstarts and the cheatsheet render.

Docs-only change — no code, no binary assets.

Closes #1222