### PR TITLE
perf(android-demo): one GLB parse + shared IBL for SecondaryCameraDemo (#1255)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -17,11 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
@@ -32,13 +34,20 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.loaders.ModelLoader
 import io.github.sceneview.math.Position
+import io.github.sceneview.model.ModelInstance
 import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
-import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.utils.readBuffer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val HELMET_ASSET = "models/khronos_damaged_helmet.glb"
 
 /**
  * Secondary camera (picture-in-picture) demo.
@@ -53,12 +62,15 @@ import io.github.sceneview.rememberModelLoader
  *
  * Key correctness invariants — both ship-blockers if missed:
  *
- *  1. Each view loads its own [ModelInstance]. [ModelNode]'s wrapper entity is
+ *  1. Each view gets its OWN [ModelInstance]. [ModelNode]'s wrapper entity is
  *     `modelInstance.root`, so a single instance attached to two scenes would
  *     be destroyed twice on dispose (SIGABRT) and its child light / camera
- *     nodes reparented to whichever ModelNode was built last. The two
- *     `rememberModelInstance` calls are cheap — bytes are parsed once into
- *     the shared [io.github.sceneview.loaders.ModelLoader] cache.
+ *     nodes reparented to whichever ModelNode was built last. We get two
+ *     distinct instances from one `createInstancedModel(count = 2)` call —
+ *     the GLB is parsed ONCE and the two instances share the asset's mesh /
+ *     material / texture GPU resources, while each carries its own root
+ *     entity hierarchy, so the two ModelNodes destroy distinct roots and
+ *     never double-free. (See [rememberInstancedHelmet].)
  *
  *  2. The PiP SceneView passes `cameraManipulator = null`. Without it, the
  *     SceneView frame loop (`Scene.kt`) writes
@@ -66,6 +78,9 @@ import io.github.sceneview.rememberModelLoader
  *     clobbering whatever the LaunchedEffect just set on `pipCameraNode`.
  *     The chips would fire and the PiP would visually freeze at the
  *     manipulator's home position.
+ *
+ * Both views also share a single hoisted [rememberEnvironment] so the neutral
+ * IBL / skybox is built once rather than once per SceneView.
  *
  * The PiP uses [SurfaceType.TextureSurface] so it composites correctly over
  * the main [SurfaceType.Surface] view. Placed top-start so it never collides
@@ -80,8 +95,14 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
     val materialLoader = rememberMaterialLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
 
-    val mainInstance = rememberModelInstance(modelLoader, "models/khronos_damaged_helmet.glb")
-    val pipInstance = rememberModelInstance(modelLoader, "models/khronos_damaged_helmet.glb")
+    // One environment shared by both SceneViews — the neutral IBL is otherwise
+    // loaded + built twice (each SceneView defaults to its own rememberEnvironment).
+    val environment = rememberEnvironment(environmentLoader)
+
+    // One GLB parse, two resource-sharing instances — see invariant #1.
+    val instances = rememberInstancedHelmet(modelLoader, count = 2)
+    val mainInstance = instances.getOrNull(0)
+    val pipInstance = instances.getOrNull(1)
 
     var cameraPreset by rememberSaveable { mutableStateOf(CameraPreset.TOP) }
 
@@ -119,6 +140,7 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
             modelLoader = modelLoader,
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,
+            environment = environment,
         ) {
             mainInstance?.let { instance ->
                 ModelNode(
@@ -160,6 +182,7 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
                 modelLoader = modelLoader,
                 materialLoader = materialLoader,
                 environmentLoader = environmentLoader,
+                environment = environment,
                 cameraNode = pipCameraNode,
                 cameraManipulator = null,
             ) {
@@ -173,6 +196,31 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
             }
         }
     }
+}
+
+/**
+ * Loads the helmet GLB once and returns [count] resource-sharing
+ * [ModelInstance]s via `ModelLoader.createInstancedModel`.
+ *
+ * Mirrors the threading contract of `rememberModelInstance`: the asset bytes
+ * are read on [Dispatchers.IO], then `createInstancedModel` (a `@MainThread`
+ * Filament call) runs back on the composition's main dispatcher inside
+ * [produceState]. Returns an empty list while loading.
+ */
+@Composable
+private fun rememberInstancedHelmet(
+    modelLoader: ModelLoader,
+    count: Int,
+): List<ModelInstance> {
+    val context = LocalContext.current
+    return produceState(emptyList(), modelLoader, count) {
+        val buffer = withContext(Dispatchers.IO) {
+            runCatching { context.assets.readBuffer(HELMET_ASSET) }.getOrNull()
+        } ?: return@produceState
+        value = runCatching { modelLoader.createInstancedModel(buffer, count) }
+            .getOrNull()
+            .orEmpty()
+    }.value
 }
 
 private enum class CameraPreset(@StringRes val labelRes: Int, val eye: Position) {


### PR DESCRIPTION
Closes [#1255](https://github.com/sceneview/sceneview/issues/1255).

## One GLB parse instead of two

[PR #1213](https://github.com/sceneview/sceneview/pull/1213) fixed a double-destroy SIGABRT by giving each of the demo's two SceneViews its own `rememberModelInstance` — but that parses the ~3.5 MB `khronos_damaged_helmet.glb` twice and uploads two independent copies of every mesh / material / texture to the GPU.

New private `rememberInstancedHelmet` composable calls `ModelLoader.createInstancedModel(buffer, count = 2)`: the GLB is parsed **once** into a single `FilamentAsset`, and the two returned `ModelInstance`s share that asset's GPU resources. Each instance still carries its **own** root entity (`FilamentInstance.getRoot()` is distinct per instance), so the two `ModelNode`s wrap distinct `modelInstance.root` entities — the PR #1213 double-destroy invariant still holds, the SIGABRT cannot return.

Threading mirrors `rememberModelInstance`: bytes read on `Dispatchers.IO`, `createInstancedModel` (`@MainThread`) runs on the composition's main dispatcher inside `produceState`.

## One shared environment instead of two

Both SceneViews defaulted to their own `rememberEnvironment(environmentLoader)`, building the neutral IBL + skybox twice. Hoisted one `rememberEnvironment` and passed it to both via `environment =`.

## Net

One GLB parse (was 2), one IBL build (was 2), shared GPU mesh/material/texture. Functionally identical on screen.

## Review focus

The instancing-vs-disposal safety. The argument: `ModelNode` disposal destroys per-instance root entities exactly as it did with two separate non-instanced models in PR #1213 (merged, CI-green); instancing only adds asset-level resource sharing, which is what Filament's `createInstancedAsset` is designed for. Please scrutinise.

## Test plan

- [x] `./gradlew :samples:android-demo:assembleDebug` green
- [ ] No visual device test — the Pixel 9's wireless adb stayed disconnected this session. The loading-path change warrants an on-device check that both helmets still render + chip switching works; flagging explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)