### PR TITLE
fix(scripts): worktree-auto-prune dirty-tree guard + merged-PR detection (#1278)

### DIFF
--- a/.claude/scripts/worktree-auto-prune.sh
+++ b/.claude/scripts/worktree-auto-prune.sh
@@ -6,17 +6,28 @@
 # on 2026-05-14 dropped local disk below the 15 GB alert threshold.
 #
 # Safety contract:
-#   - NEVER removes the caller's own worktree (use --keep <path>).
-#   - NEVER removes a worktree whose branch is NOT fully merged on
-#     origin/main (ahead-count > 0 means unpushed/unmerged work).
+#   - NEVER removes a worktree with uncommitted changes (tracked OR
+#     untracked) — `git status --porcelain` must be empty. This is the
+#     primary data-loss guard: it protects a sibling session mid-edit.
+#   - NEVER removes the caller's own worktree(s) — pass --keep <path>
+#     once per running agent (the flag is repeatable).
+#   - Only removes a worktree whose branch is verifiably merged: either
+#     ahead-count is 0, or its PR is MERGED (squash-merge leaves
+#     ahead>0 forever, so the PR check is what actually reclaims them).
+#   - Uses plain `git worktree remove` (no --force) so a tree that turns
+#     dirty or locked between scan and removal fails safe.
 #   - Defaults to interactive prompt; --yes for non-interactive; --dry-run
 #     for preview without deletion.
 #
+# Note: `git worktree remove` deletes only the working-tree directory,
+# never the branch ref — committed work survives. Uncommitted work does
+# not, hence the porcelain guard above.
+#
 # Usage:
 #   bash .claude/scripts/worktree-auto-prune.sh --dry-run --keep "$(git rev-parse --show-toplevel)"
-#   bash .claude/scripts/worktree-auto-prune.sh --yes  --keep "$(git rev-parse --show-toplevel)"
+#   bash .claude/scripts/worktree-auto-prune.sh --yes --keep /path/a --keep /path/b
 #
-# Tracking: https://github.com/sceneview/sceneview/issues/1242
+# Tracking: https://github.com/sceneview/sceneview/issues/1242 (#1278)
 #
 # Exit codes:
 #   0 = success (or no candidates)
@@ -26,16 +37,16 @@ set -euo pipefail
 
 DRY_RUN=false
 ASSUME_YES=false
-KEEP_PATH=""
+KEEP_PATHS=()
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=true; shift ;;
         --yes)     ASSUME_YES=true; shift ;;
-        --keep)    KEEP_PATH="${2:-}"; shift 2 ;;
-        --keep=*)  KEEP_PATH="${1#--keep=}"; shift ;;
+        --keep)    KEEP_PATHS+=("${2:-}"); shift 2 ;;
+        --keep=*)  KEEP_PATHS+=("${1#--keep=}"); shift ;;
         -h|--help)
-            sed -n '2,25p' "$0"
+            sed -n '2,34p' "$0"
             exit 0
             ;;
         *)
@@ -64,10 +75,23 @@ fi
 GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
 REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
 
-# Normalise KEEP_PATH to an absolute path if provided.
-if [ -n "$KEEP_PATH" ]; then
-    KEEP_PATH="$(cd "$KEEP_PATH" 2>/dev/null && pwd || echo "$KEEP_PATH")"
-fi
+# Normalise every --keep path to absolute (so a relative arg still
+# matches the absolute paths reported by `git worktree list --porcelain`).
+KEEP_NORM=()
+for kp in "${KEEP_PATHS[@]:-}"; do
+    [ -z "$kp" ] && continue
+    KEEP_NORM+=("$(cd "$kp" 2>/dev/null && pwd || printf '%s' "$kp")")
+done
+KEEP_PATHS=("${KEEP_NORM[@]:-}")
+
+# Is $1 one of the --keep paths?
+path_is_kept() {
+    local p
+    for p in "${KEEP_PATHS[@]:-}"; do
+        [ -n "$p" ] && [ "$1" = "$p" ] && return 0
+    done
+    return 1
+}
 
 WORKTREES_DIR="$REPO_ROOT/.claude/worktrees"
 
@@ -79,9 +103,9 @@ fi
 echo -e "${CYAN}=== Worktree auto-prune ===${NC}"
 echo "Repo root:     $REPO_ROOT"
 echo "Worktrees dir: $WORKTREES_DIR"
-if [ -n "$KEEP_PATH" ]; then
-    echo "Keeping:       $KEEP_PATH"
-fi
+for kp in "${KEEP_PATHS[@]:-}"; do
+    [ -n "$kp" ] && echo "Keeping:       $kp"
+done
 echo ""
 
 # Make sure origin/main is recent enough to compute ahead-count.
@@ -90,6 +114,7 @@ git fetch --quiet origin main 2>/dev/null || \
 
 CANDIDATES=()
 SKIPPED_UNMERGED=()
+SKIPPED_DIRTY=()
 SKIPPED_KEEP=()
 
 # Iterate worktrees registered with git (avoids stale dirs that aren't
@@ -109,20 +134,33 @@ while IFS= read -r line; do
                 # Only consider worktrees under .claude/worktrees/
                 case "$current_path" in
                     "$WORKTREES_DIR"/*)
-                        # Skip --keep path
-                        if [ -n "$KEEP_PATH" ] && [ "$current_path" = "$KEEP_PATH" ]; then
+                        if path_is_kept "$current_path"; then
                             SKIPPED_KEEP+=("$current_path")
-                        elif [ -n "${current_branch:-}" ]; then
-                            # ahead-count: commits in branch not yet on origin/main
-                            ahead=$(git rev-list --count "origin/main..$current_branch" 2>/dev/null || echo "unknown")
-                            if [ "$ahead" = "0" ]; then
-                                CANDIDATES+=("$current_path|$current_branch")
-                            else
-                                SKIPPED_UNMERGED+=("$current_path ($current_branch, ahead=$ahead)")
-                            fi
-                        else
-                            # Detached HEAD or no branch — treat as unmerged for safety
+                        elif ! porcelain="$(git -C "$current_path" status --porcelain 2>/dev/null)"; then
+                            # `git status` failed — the directory is missing or
+                            # broken. Don't risk a remove; `git worktree prune`
+                            # at the end reaps the dangling registration.
+                            SKIPPED_UNMERGED+=("$current_path (unreadable — left for 'git worktree prune')")
+                        elif [ -n "$porcelain" ]; then
+                            # Uncommitted work (tracked OR untracked files).
+                            # This is the data-loss guard — NEVER a candidate.
+                            SKIPPED_DIRTY+=("$current_path (${current_branch:-detached HEAD} — uncommitted changes)")
+                        elif [ -z "${current_branch:-}" ]; then
+                            # Detached HEAD on a clean tree — unmerged for safety.
                             SKIPPED_UNMERGED+=("$current_path (detached HEAD)")
+                        else
+                            # ahead-count: commits in branch not yet on origin/main.
+                            ahead=$(git rev-list --count "origin/main..$current_branch" 2>/dev/null || echo "unknown")
+                            # Squash-merge leaves ahead>0 forever, so also accept a
+                            # MERGED PR as proof the branch's work is on main.
+                            pr_state=$(gh pr view "$current_branch" --json state --jq .state 2>/dev/null || echo "")
+                            if [ "$ahead" = "0" ] || [ "$pr_state" = "MERGED" ]; then
+                                reason="ahead=$ahead"
+                                [ "$pr_state" = "MERGED" ] && reason="$reason, PR MERGED"
+                                CANDIDATES+=("$current_path|$current_branch|$reason")
+                            else
+                                SKIPPED_UNMERGED+=("$current_path ($current_branch, ahead=$ahead, PR=${pr_state:-none})")
+                            fi
                         fi
                         ;;
                 esac
@@ -133,15 +171,25 @@ while IFS= read -r line; do
     esac
 done < <(git worktree list --porcelain; echo "")
 
-echo -e "${CYAN}--- Candidates (merged / ahead=0) ---${NC}"
+echo -e "${CYAN}--- Candidates (merged — safe to remove) ---${NC}"
 if [ "${#CANDIDATES[@]}" -eq 0 ]; then
     echo "  (none)"
 else
     for entry in "${CANDIDATES[@]}"; do
         path="${entry%%|*}"
-        branch="${entry#*|}"
+        rest="${entry#*|}"
+        branch="${rest%%|*}"
+        reason="${rest#*|}"
         size=$(du -sh "$path" 2>/dev/null | awk '{print $1}')
-        echo "  $path  [$branch]  $size"
+        echo "  $path  [$branch]  ${size:-?}  ($reason)"
+    done
+fi
+
+if [ "${#SKIPPED_DIRTY[@]}" -gt 0 ]; then
+    echo ""
+    echo -e "${CYAN}--- Skipped (uncommitted work — DATA-LOSS guard) ---${NC}"
+    for entry in "${SKIPPED_DIRTY[@]}"; do
+        echo "  $entry"
     done
 fi
 
@@ -187,12 +235,14 @@ REMOVED=0
 FAILED=0
 for entry in "${CANDIDATES[@]}"; do
     path="${entry%%|*}"
-    if git worktree remove --force "$path" 2>/dev/null; then
+    # Plain `git worktree remove` (no --force): if the tree turned dirty
+    # or locked between the scan above and now, this fails safe.
+    if remove_err=$(git worktree remove "$path" 2>&1); then
         REMOVED=$((REMOVED + 1))
         echo -e "  ${GREEN}removed${NC} $path"
     else
         FAILED=$((FAILED + 1))
-        echo -e "  ${RED}failed ${NC} $path"
+        echo -e "  ${RED}failed ${NC} $path — ${remove_err}"
     fi
 done
 


### PR DESCRIPTION
## Summary

Fixes the MAJOR data-loss risk in `.claude/scripts/worktree-auto-prune.sh` found by the Tier 2 post-merge audit of PR #1259.

The script decided a worktree was prunable from `ahead=0` alone, then ran `git worktree remove --force` — which destroys uncommitted edits. A sibling session mid-edit whose branch happens to show `ahead=0` (just merged main, or squash-merged) became a deletion candidate while still being worked on.

## Changes

- **Dirty-tree guard** — a worktree with uncommitted changes (tracked OR untracked, via `git status --porcelain`) is NEVER a candidate. Primary data-loss protection.
- **Drop `--force`** — plain `git worktree remove` fails safe if a tree turns dirty/locked between scan and removal; the git error is surfaced on failure.
- **Repeatable `--keep`** — an orchestrator can now protect every running agent's worktree, not just its own.
- **Merged-PR detection** — a `MERGED` PR (via `gh pr view`) counts as a merged signal alongside `ahead=0`, so squash-merged worktrees (which keep `ahead>0` forever) are actually reclaimed — fixes the opposite failure noted in the issue.

Note: `git worktree remove` only deletes the working-tree directory, never the branch ref — committed work survives. Uncommitted work does not, hence the porcelain guard.

## Test plan

- [x] `bash -n` syntax check passes
- [x] `shellcheck` clean
- [x] `--help` output intact
- [x] `--dry-run` on a host with a dirty parallel worktree — the dirty worktree is correctly listed under the new "DATA-LOSS guard" section and excluded from candidates; clean merged worktrees still listed as candidates; `--keep` path skipped

Closes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)