### PR TITLE
ci: hardening batch — sceneview-swift URL gate, sed portability, pinned pip (#1226 #1237 #1230 #1114 #1128)

### DIFF
--- a/.claude/scripts/check-sceneview-swift-urls.sh
+++ b/.claude/scripts/check-sceneview-swift-urls.sh
@@ -25,6 +25,7 @@
 #   - CHANGELOG.md                        — historical version entries (mirror retirement)
 #   - docs/docs/migration.md              — migration guide quoting the old mirror URL
 #   - .claude/scripts/check-sceneview-swift-urls.sh — this detector itself
+#   - .github/workflows/pr-check.yml      — the job comment that documents this detector
 #
 # Usage:
 #   bash .claude/scripts/check-sceneview-swift-urls.sh
@@ -44,7 +45,7 @@ cd "$ROOT"
 
 # Files where a historical `sceneview-swift` reference is allowed. Anchored
 # repo-root-relative paths, alternation joined with '|'.
-ALLOW='^(Package\.swift|\.github/workflows/release\.yml|CLAUDE\.md|SceneViewSwift/Sources/SceneViewSwift/SceneView\.swift|CHANGELOG\.md|docs/docs/migration\.md|\.claude/scripts/check-sceneview-swift-urls\.sh)$'
+ALLOW='^(Package\.swift|\.github/workflows/release\.yml|\.github/workflows/pr-check\.yml|CLAUDE\.md|SceneViewSwift/Sources/SceneViewSwift/SceneView\.swift|CHANGELOG\.md|docs/docs/migration\.md|\.claude/scripts/check-sceneview-swift-urls\.sh)$'
 
 # Grep only tracked files so build output / node_modules can't trip the gate.
 # `git grep` respects .gitignore by definition and is fast on large trees.

--- a/.claude/scripts/check-sceneview-swift-urls.sh
+++ b/.claude/scripts/check-sceneview-swift-urls.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# check-sceneview-swift-urls.sh — block PRs that reintroduce references to the
+# archived `sceneview/sceneview-swift` SPM mirror.
+#
+# The `sceneview/sceneview-swift` mirror was retired in PR #1215: SPM consumers
+# now resolve `SceneViewSwift` directly from the monorepo root `Package.swift`.
+# The mirror repo is archived read-only. Any NEW occurrence of the
+# `sceneview-swift` URL in docs / config / samples / generated bundles is a
+# bug — a stale paste from old docs or an AI-suggestion regression — and would
+# point users at a dead resolution path.
+#
+# This gate greps the tracked tree for `sceneview-swift` and fails on any hit
+# outside the historical / attribution allowlist below.
+#
+# ── Extending the allowlist ──────────────────────────────────────────────
+# If a NEW file legitimately needs a historical `sceneview-swift` mention
+# (e.g. a future changelog entry, a migration note, an attribution comment),
+# add its exact repo-root-relative path to the ALLOW regex below in the same
+# commit. Each allowed file is there for a documented reason:
+#   - Package.swift                       — comment explaining the monorepo SPM root
+#   - .github/workflows/release.yml       — comment about the retired mirror
+#   - CLAUDE.md                           — historical changelog narrative
+#   - SceneViewSwift/.../SceneView.swift   — "Ported from ... sceneview-swift PR #1" attribution
+#   - CHANGELOG.md                        — historical version entries (mirror retirement)
+#   - docs/docs/migration.md              — migration guide quoting the old mirror URL
+#   - .claude/scripts/check-sceneview-swift-urls.sh — this detector itself
+#
+# Usage:
+#   bash .claude/scripts/check-sceneview-swift-urls.sh
+#
+# Exit code: 0 if clean, 1 if a non-allowlisted reference is found.
+#
+# Closes #1237.
+
+set -u
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$ROOT" ]; then
+  echo "Not inside a git repo." >&2
+  exit 0
+fi
+cd "$ROOT"
+
+# Files where a historical `sceneview-swift` reference is allowed. Anchored
+# repo-root-relative paths, alternation joined with '|'.
+ALLOW='^(Package\.swift|\.github/workflows/release\.yml|CLAUDE\.md|SceneViewSwift/Sources/SceneViewSwift/SceneView\.swift|CHANGELOG\.md|docs/docs/migration\.md|\.claude/scripts/check-sceneview-swift-urls\.sh)$'
+
+# Grep only tracked files so build output / node_modules can't trip the gate.
+# `git grep` respects .gitignore by definition and is fast on large trees.
+HITS=$(git grep -l 'sceneview-swift' -- \
+         '*.md' '*.txt' '*.yml' '*.yaml' '*.swift' '*.kt' \
+         '*.json' '*.html' '*.js' '*.ts' \
+         2>/dev/null | grep -vE "$ALLOW" || true)
+
+if [ -n "$HITS" ]; then
+  echo "::error::Files reintroduced 'sceneview-swift' references — the SPM mirror is archived (#1237)."
+  echo ""
+  echo "  The 'sceneview/sceneview-swift' mirror was retired in PR #1215."
+  echo "  SPM consumers resolve SceneViewSwift from the monorepo root"
+  echo "  Package.swift — use 'https://github.com/sceneview/sceneview' instead."
+  echo ""
+  echo "  Offending file(s):"
+  echo "$HITS" | sed 's/^/    /'
+  echo ""
+  echo "  If a reference is genuinely historical, add the file path to the"
+  echo "  ALLOW regex in .claude/scripts/check-sceneview-swift-urls.sh."
+  exit 1
+fi
+
+echo "check-sceneview-swift-urls: OK — no non-historical mirror references."
+exit 0

--- a/.claude/scripts/quality-gate.sh
+++ b/.claude/scripts/quality-gate.sh
@@ -140,6 +140,19 @@ if [ -x ".claude/scripts/check-deprecated-api.sh" ]; then
     fi
 fi
 
+# Check for references to the archived `sceneview/sceneview-swift` SPM mirror.
+# The mirror was retired in PR #1215 — SceneViewSwift resolves from the
+# monorepo root Package.swift. A new mirror-URL reference points users at a
+# dead resolution path (#1237).
+if [ -x ".claude/scripts/check-sceneview-swift-urls.sh" ]; then
+    if bash .claude/scripts/check-sceneview-swift-urls.sh > /tmp/check-sceneview-swift-urls.log 2>&1; then
+        check "No archived sceneview-swift mirror URLs" "PASS" ""
+    else
+        SWIFT_URL_COUNT=$(grep -cE '^    [^ ]' /tmp/check-sceneview-swift-urls.log 2>/dev/null || echo "?")
+        check "Archived sceneview-swift mirror URLs" "FAIL" "$SWIFT_URL_COUNT file(s); see /tmp/check-sceneview-swift-urls.log"
+    fi
+fi
+
 echo ""
 
 # ─── 4a. SceneView Agent Skill Drift ───────────────────────────────────

--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -36,6 +36,19 @@ fi
 echo -e "Source of truth (gradle.properties): ${GREEN}$SOURCE_VERSION${NC}"
 echo ""
 
+# ─── Helper: portable in-place sed (BSD vs GNU) ──────────────────────────
+# BSD sed (macOS dev machines) requires `sed -i ''` — an explicit empty
+# backup suffix. GNU sed (Linux CI runners) treats `''` as a script and
+# errors. Detect which flavour is on PATH once and dispatch accordingly.
+# Usage: _sed_inplace "s/foo/bar/" path/to/file   (#1226)
+if sed --version >/dev/null 2>&1; then
+    # GNU sed — `--version` is GNU-only; BSD sed errors on it.
+    _sed_inplace() { sed -i "$@"; }
+else
+    # BSD/macOS sed — needs the empty backup-suffix argument.
+    _sed_inplace() { local script="$1"; shift; sed -i '' "$script" "$@"; }
+fi
+
 # ─── Helper: check a version ─────────────────────────────────────────────
 declare -a LOCATIONS=()
 declare -a VERSIONS=()
@@ -414,7 +427,7 @@ if [ "$FIX_MODE" = "--fix" ] && [ "$ERRORS" -gt 0 ]; then
         if [ -f "$PROPS" ]; then
             CURRENT=$(grep '^VERSION_NAME=' "$PROPS" | cut -d= -f2)
             if [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-                sed -i '' "s/^VERSION_NAME=.*/VERSION_NAME=$SOURCE_VERSION/" "$PROPS"
+                _sed_inplace "s/^VERSION_NAME=.*/VERSION_NAME=$SOURCE_VERSION/" "$PROPS"
                 echo -e "  Fixed: $module/gradle.properties ($CURRENT -> $SOURCE_VERSION)"
             fi
         fi
@@ -445,7 +458,7 @@ with open('$PKG_JSON', 'w') as f:
     if [ -f "$PUBSPEC" ]; then
         CURRENT=$(grep '^version:' "$PUBSPEC" | awk '{print $2}')
         if [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/^version: .*/version: $SOURCE_VERSION/" "$PUBSPEC"
+            _sed_inplace "s/^version: .*/version: $SOURCE_VERSION/" "$PUBSPEC"
             echo -e "  Fixed: flutter/sceneview_flutter/pubspec.yaml ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi
@@ -454,7 +467,7 @@ with open('$PKG_JSON', 'w') as f:
     if [ -f "$FLUTTER_ANDROID_GRADLE" ]; then
         CURRENT=$(grep "^version " "$FLUTTER_ANDROID_GRADLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)
         if [ -n "$CURRENT" ] && [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/^version '$CURRENT'/version '$SOURCE_VERSION'/" "$FLUTTER_ANDROID_GRADLE"
+            _sed_inplace "s/^version '$CURRENT'/version '$SOURCE_VERSION'/" "$FLUTTER_ANDROID_GRADLE"
             echo -e "  Fixed: flutter/.../android/build.gradle ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi
@@ -463,7 +476,7 @@ with open('$PKG_JSON', 'w') as f:
     if [ -f "$PODSPEC" ]; then
         CURRENT=$(grep "s\.version" "$PODSPEC" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)
         if [ -n "$CURRENT" ] && [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/s\.version *= *'$CURRENT'/s.version          = '$SOURCE_VERSION'/" "$PODSPEC"
+            _sed_inplace "s/s\.version *= *'$CURRENT'/s.version          = '$SOURCE_VERSION'/" "$PODSPEC"
             echo -e "  Fixed: flutter/.../ios/sceneview_flutter.podspec ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi
@@ -484,7 +497,7 @@ with open('$PKG_JSON', 'w') as f:
         for docfile in llms.txt README.md CLAUDE.md docs/docs/index.md docs/docs/quickstart.md docs/docs/llms-full.txt docs/docs/cheatsheet.md docs/docs/platforms.md docs/docs/migration.md docs/docs/android-xr.md; do
             F="$REPO_ROOT/$docfile"
             if [ -f "$F" ] && grep -q "io\.github\.sceneview:.*$OLD_V" "$F" 2>/dev/null; then
-                sed -i '' "s/io\.github\.sceneview:\([^:]*\):$OLD_V/io.github.sceneview:\1:$SOURCE_VERSION/g" "$F"
+                _sed_inplace "s/io\.github\.sceneview:\([^:]*\):$OLD_V/io.github.sceneview:\1:$SOURCE_VERSION/g" "$F"
                 echo -e "  Fixed: $docfile (artifact refs $OLD_V -> $SOURCE_VERSION)"
             fi
         done
@@ -495,7 +508,7 @@ with open('$PKG_JSON', 'w') as f:
         for OLD_V in $OLD_VERSIONS; do
             [ "$OLD_V" = "$SOURCE_VERSION" ] && continue
             if grep -q "$OLD_V" "$WEBSITE_INDEX" 2>/dev/null; then
-                sed -i '' "s/$OLD_V/$SOURCE_VERSION/g" "$WEBSITE_INDEX"
+                _sed_inplace "s/$OLD_V/$SOURCE_VERSION/g" "$WEBSITE_INDEX"
                 echo -e "  Fixed: website-static/index.html ($OLD_V -> $SOURCE_VERSION)"
             fi
         done
@@ -528,7 +541,7 @@ with open('$VERSION_JSON', 'w') as f:
     if [ -f "$WEB_DEMO_MAIN_KT" ]; then
         CURRENT=$(grep -E 'const val SDK_VERSION' "$WEB_DEMO_MAIN_KT" | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?"' | tr -d '"' | head -1 || echo "")
         if [ -n "$CURRENT" ] && [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/const val SDK_VERSION = \"$CURRENT\"/const val SDK_VERSION = \"$SOURCE_VERSION\"/" "$WEB_DEMO_MAIN_KT"
+            _sed_inplace "s/const val SDK_VERSION = \"$CURRENT\"/const val SDK_VERSION = \"$SOURCE_VERSION\"/" "$WEB_DEMO_MAIN_KT"
             echo -e "  Fixed: samples/web-demo Main.kt SDK_VERSION ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi
@@ -538,8 +551,8 @@ with open('$VERSION_JSON', 'w') as f:
     if [ -f "$WEB_DEMO_INDEX" ]; then
         CURRENT=$(grep -E "var BUILD_VERSION = '" "$WEB_DEMO_INDEX" | grep -oE "'[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?'" | tr -d "'" | head -1 || echo "")
         if [ -n "$CURRENT" ] && [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/var BUILD_VERSION = '$CURRENT'/var BUILD_VERSION = '$SOURCE_VERSION'/" "$WEB_DEMO_INDEX"
-            sed -i '' "s/v$CURRENT/v$SOURCE_VERSION/g" "$WEB_DEMO_INDEX"
+            _sed_inplace "s/var BUILD_VERSION = '$CURRENT'/var BUILD_VERSION = '$SOURCE_VERSION'/" "$WEB_DEMO_INDEX"
+            _sed_inplace "s/v$CURRENT/v$SOURCE_VERSION/g" "$WEB_DEMO_INDEX"
             echo -e "  Fixed: samples/web-demo index.html ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi
@@ -563,7 +576,7 @@ with open('$RN_DEMO_PKG', 'w') as f:
     if [ -f "$RN_DEMO_APP" ]; then
         CURRENT=$(grep -E "const VERSION = '" "$RN_DEMO_APP" | grep -oE "'[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?'" | tr -d "'" | head -1 || echo "")
         if [ -n "$CURRENT" ] && [ "$CURRENT" != "$SOURCE_VERSION" ]; then
-            sed -i '' "s/const VERSION = '$CURRENT'/const VERSION = '$SOURCE_VERSION'/" "$RN_DEMO_APP"
+            _sed_inplace "s/const VERSION = '$CURRENT'/const VERSION = '$SOURCE_VERSION'/" "$RN_DEMO_APP"
             echo -e "  Fixed: samples/react-native-demo App.tsx VERSION ($CURRENT -> $SOURCE_VERSION)"
         fi
     fi

--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -246,7 +246,9 @@ jobs:
           ASC_VERSION_STRING: ${{ startsWith(github.ref, 'refs/tags/v') && format('{0}', github.ref_name) || '' }}
         run: |
           python3 -m venv $RUNNER_TEMP/asc-venv
-          $RUNNER_TEMP/asc-venv/bin/pip install "PyJWT[crypto]" requests --quiet
+          # Pinned exact versions — this job runs with APP_STORE_CONNECT_API_KEY
+          # in env, so a compromised PyPI release must not be pullable here (#1230).
+          $RUNNER_TEMP/asc-venv/bin/pip install "PyJWT[crypto]==2.10.1" requests==2.32.3 --quiet
 
           # Wait for Apple to process the build
           echo "Waiting 120s for Apple to process the build..."

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -340,7 +340,9 @@ jobs:
           VERSION_NAME: ${{ needs.build.outputs.version_name }}
         run: |
           python3 -m venv /tmp/promote-venv
-          /tmp/promote-venv/bin/pip install --quiet google-auth requests
+          # Pinned exact versions — this job runs with PLAY_STORE_SERVICE_ACCOUNT_JSON
+          # in env, so a compromised PyPI release must not be pullable here (#1230).
+          /tmp/promote-venv/bin/pip install --quiet google-auth==2.38.0 requests==2.32.3
 
           /tmp/promote-venv/bin/python3 << 'PYEOF'
           import json, os, sys, requests
@@ -454,7 +456,8 @@ jobs:
           LISTING_DIR: samples/android-demo/distribution/play-store
         run: |
           python3 -m venv /tmp/listing-venv
-          /tmp/listing-venv/bin/pip install --quiet google-auth requests
+          # Pinned exact versions — credential-bearing job (#1230).
+          /tmp/listing-venv/bin/pip install --quiet google-auth==2.38.0 requests==2.32.3
 
           /tmp/listing-venv/bin/python3 << 'PYEOF'
           import json, os, sys, pathlib, requests

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -66,6 +66,23 @@ jobs:
         shell: bash
         run: bash .claude/scripts/check-sceneview-skill.sh
 
+  # ── Archived SPM mirror URL guard ───────────────────────────────────────
+  # The `sceneview/sceneview-swift` SPM mirror was archived in PR #1215 —
+  # SwiftViewSwift now resolves from the monorepo root Package.swift. Any
+  # NEW reference to the dead mirror URL (a stale paste or AI-suggestion
+  # regression) points users at a dead resolution path. This guard greps
+  # the tracked tree and fails on any hit outside the historical allowlist.
+  # Sub-second; no JDK or Gradle needed. Closes #1237.
+  check-sceneview-swift-urls:
+    name: Forbid archived sceneview-swift mirror URLs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run check-sceneview-swift-urls.sh
+        shell: bash
+        run: bash .claude/scripts/check-sceneview-swift-urls.sh
+
   # ── KMP core (all targets) ──────────────────────────────────────────────
   # ci.yml's `web-desktop` job compiles `:sceneview-core:jsMainClasses` but
   # not the full KMP `assemble` (which builds iosArm64/iosSimulatorArm64/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 - **`sceneview-swift` SPM mirror retired in favour of monorepo-direct package resolution ([PR #1215](https://github.com/sceneview/sceneview/pull/1215))** — every install snippet across docs, codelabs, GPT prompts, `.github/copilot-instructions.md`, `SceneViewSwift/README.md`, `llms.txt` (4 copies — root, docs, website-static, well-known), the website (`index.html` / `docs.html` / `playground.html`), the PWA manifest, the schema.org `sameAs` graph, and the bundled MCP `llms-txt.ts` now points at `https://github.com/sceneview/sceneview(.git)`. The `sceneview/sceneview-swift` mirror has been archived read-only; its frozen `v4.0.0` tag still resolves for SPM consumers pinned to the old URL, but no further releases will be cut there. Existing consumers should re-add the package in Xcode pointing at the monorepo URL — the root `Package.swift` (added in [PR #920](https://github.com/sceneview/sceneview/pull/920)) declares the `SceneViewSwift` product.
 
+### Changed — CI / scripts hardening
+
+- **CI/scripts hardening batch** ([#1226](https://github.com/sceneview/sceneview/issues/1226), [#1230](https://github.com/sceneview/sceneview/issues/1230), [#1237](https://github.com/sceneview/sceneview/issues/1237), [#1114](https://github.com/sceneview/sceneview/issues/1114)) — new `check-sceneview-swift-urls.sh` PR gate forbids reintroducing the archived `sceneview-swift` mirror URL; `sync-versions.sh` now uses a portable `_sed_inplace` helper (BSD/GNU); publish-time `pip install` calls in `play-store.yml` / `app-store.yml` are pinned to exact versions. CONTRIBUTING.md now documents that docs-only PRs skip the quality-gate + render-tests ([#1128](https://github.com/sceneview/sceneview/issues/1128)).
+
 ### Fixed — in-app update polish across all 6 sample platforms ([#1244](https://github.com/sceneview/sceneview/issues/1244)–[#1249](https://github.com/sceneview/sceneview/issues/1249))
 
 Follow-ups to [PR #1216](https://github.com/sceneview/sceneview/pull/1216) (in-app auto-update feature) — six small, platform-specific hardening fixes that bring the auto-update behaviour to parity across Android, Web, React Native, Flutter, iOS and macOS:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,10 +129,18 @@ After your changes are merged, the Discord bot will award you the **Contributor*
 
 **Docs-only PRs** — changes confined to `*.md`, `docs/**`, `website-static/**`,
 `marketing/**`, `branding/**`, `llms*.txt`, or `LICENSE` — skip the Android +
-MCP `quality-gate.yml`, `ci.yml`, and `render-tests.yml` checks by design.
-The diff cannot affect runtime behaviour, so spending 10-20 min of emulator
-time to re-render the same screenshots is pure noise. You will see fewer
-green checks than on a code PR; this is correct.
+MCP build and verification jobs by design. The diff cannot affect runtime
+behaviour, so spending 10-20 min of emulator time to re-build and re-render
+is pure noise. You will see fewer green checks than on a code PR; this is
+correct. Specifically:
+
+- **`quality-gate.yml`** and **`pr-check.yml`** carry a `paths-ignore` filter
+  for those paths, so neither triggers on a docs-only PR.
+- **`ci.yml`** carries an equivalent `paths-ignore` filter (it also ignores
+  `mcp*/**`, which `quality-gate.yml` deliberately does not).
+- **`render-tests.yml`** never runs on *any* pull request — it is push-to-main
+  + `workflow_dispatch` only — so docs-only PRs skip it for that reason rather
+  than via a path filter.
 
 If your docs PR needs to force a full CI run (for example, you suspect a
 markdown change has accidentally invalidated an example referenced from

--- a/marketing/awesome-lists/submissions.md
+++ b/marketing/awesome-lists/submissions.md
@@ -76,7 +76,7 @@ Ready-to-submit entries for major awesome lists. Each section is a PR-ready addi
 **Section:** Libraries / 3D & AR
 
 ```markdown
-- [SceneViewSwift](https://github.com/sceneview/sceneview-swift) - 3D & AR views for SwiftUI powered by RealityKit. iOS 17+, macOS 14+, visionOS 1+. Declarative scene graph matching Compose API on Android.
+- [SceneViewSwift](https://github.com/sceneview/sceneview) - 3D & AR views for SwiftUI powered by RealityKit. iOS 17+, macOS 14+, visionOS 1+. Declarative scene graph matching Compose API on Android.
 ```
 
 ---

--- a/marketing/stackoverflow/qa-drafts.md
+++ b/marketing/stackoverflow/qa-drafts.md
@@ -210,9 +210,9 @@ No ArFragment, no AndroidView wrapper. AR nodes are composables — they follow 
 I want to display a 3D USDZ model in a SwiftUI view on iOS. SceneKit feels old and RealityKit's API is complex. Is there a simple SwiftUI-native 3D viewer?
 
 **Answer:**
-[SceneViewSwift](https://github.com/sceneview/sceneview-swift) provides declarative 3D views for SwiftUI, powered by RealityKit:
+[SceneViewSwift](https://github.com/sceneview/sceneview) provides declarative 3D views for SwiftUI, powered by RealityKit:
 
-**SPM:** `https://github.com/sceneview/sceneview-swift.git` from: "4.3.5"`
+**SPM:** `https://github.com/sceneview/sceneview.git` from: "4.3.5"`
 
 ```swift
 import SceneViewSwift

--- a/pro/gpt-store/gpt-instructions.md
+++ b/pro/gpt-store/gpt-instructions.md
@@ -74,7 +74,7 @@ fun MyARScreen() {
 
 ## iOS Code Generation Rules
 
-1. **SPM**: `https://github.com/sceneview/sceneview-swift.git` from: "4.3.5"`
+1. **SPM**: `https://github.com/sceneview/sceneview.git` from: "4.3.5"`
 2. **Minimum**: iOS 17+, macOS 14+, visionOS 1+
 3. **Use `SceneView` for 3D, `ARSceneView` for AR** (SwiftUI views)
 4. **Load models**: `try await ModelNode.load("models/car.usdz")` — async


### PR DESCRIPTION
## Summary

A cohesive CI/scripts hardening batch — five small issues, one PR. None require a Gradle/Xcode build.

- **#1237 — `sceneview-swift` URL gate.** New `.claude/scripts/check-sceneview-swift-urls.sh` greps the tracked tree for the archived `sceneview/sceneview-swift` SPM mirror URL and fails on any hit outside a documented historical allowlist (`Package.swift`, `release.yml`, `CLAUDE.md`, `SceneView.swift` attribution lines, `CHANGELOG.md`, `migration.md`, the detector itself). Wired as a standalone job in `pr-check.yml` and into `quality-gate.sh`. Found and fixed **3 stale wrong references** — `marketing/awesome-lists/submissions.md`, `marketing/stackoverflow/qa-drafts.md`, `pro/gpt-store/gpt-instructions.md` were all telling users to install from the dead mirror; now point at the monorepo URL.
- **#1226 — `sync-versions.sh` BSD/GNU `sed` portability.** Added a `_sed_inplace()` helper that detects GNU vs BSD `sed` once and dispatches the right in-place form. Replaced all 10 `sed -i ''` call sites. The script ran clean on macOS (BSD sed) and is now Linux-CI-safe.
- **#1230 — pinned publish-time pip deps.** `play-store.yml` (promote + listing jobs) and `app-store.yml` now `pip install` exact pinned versions (`google-auth==2.38.0`, `requests==2.32.3`, `PyJWT[crypto]==2.10.1`) inside their credential-bearing venvs, so a compromised PyPI upstream can't land code in a job holding store secrets. `release.yml` has no `pip install` calls.
- **#1114 — workflow bashism lint.** Already implemented on `main` (`.claude/scripts/check-workflow-scripts.sh` + the `check-workflow-scripts` job in `pr-check.yml`, commit header says "Closes #1114"). Verified it runs clean against the current tree (2 `with.script:` blocks under `dash`, 99 `run:` blocks under shellcheck — 0 warnings). The issue is just closed by this batch; no new code needed.
- **#1128 — docs(contributing).** The `### CI on docs-only PRs` section already existed; corrected two inaccuracies — `render-tests.yml` never runs on *any* PR (push-to-main + `workflow_dispatch` only), and `pr-check.yml` also carries the same `paths-ignore` filter. Now states each workflow's behaviour precisely.

## Verification (no build)

- `bash -n` clean on all 3 touched shell scripts; `shellcheck -S error` clean on each.
- `python3 yaml.safe_load` clean on all 3 changed workflow files.
- `check-sceneview-swift-urls.sh` verified to **pass on clean `main`** and **fail on a planted violation** (`sceneview-swift` URL inserted in `README.md`).
- `check-workflow-scripts.sh` re-run after the workflow edits — confirms no bashisms introduced.
- `sync-versions.sh` ran to completion in check mode on macOS — 0 errors.
- `impact-check.sh` — PASS (one pre-existing unrelated Swift-only-nodes warning).

## Test plan

- [ ] `pr-check.yml` `check-sceneview-swift-urls` job goes green on this PR
- [ ] `pr-check.yml` `check-workflow-scripts` job stays green
- [ ] `quality-gate.yml` passes (new sceneview-swift gate wired into `quality-gate.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)