### PR TITLE
fix: web update-snackbar flush on init failure + FR-locale test helpers (#1279, #1282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Two regressions from `cd4034ff` (PR #1224) that the #1241 emulator QA sweep prov
 
 ### Fixed — tooling
 
+- **Web demo — deferred update snackbar stranded on engine-init failure** ([#1279](https://github.com/sceneview/sceneview/issues/1279)) — `flushPendingUpdateSnackbar()` (added in PR #1271 to defer the update snackbar past engine init) was only called in the `SceneView.modelViewer(...)` success path; an engine-init rejection left a deferred version stuck in `pendingUpdateVersion` forever. The `.catch()` path now flushes too — the snackbar is pure DOM and `flushPendingUpdateSnackbar()` nulls `pendingUpdateVersion`, so it can never double-show. `Closes #1279`.
+- **`DemoInteractionTest` — FR-locale gap in control helpers** ([#1282](https://github.com/sceneview/sceneview/issues/1282)) — `secondaryCamera_pipAngles` now resolves the PiP-angle chip labels from `R.string.demo_secondary_camera_chip_*` instead of hard-coded English literals, so the interaction test passes on a French-locale device. Demos that still inline English control labels in the composable need a per-demo resource-extraction sweep first (tracked separately). `Closes #1282`.
+
 - **`worktree-auto-prune.sh` no longer risks destroying a parallel session's uncommitted work** ([#1278](https://github.com/sceneview/sceneview/issues/1278)) — the script now skips any worktree with a non-empty `git status --porcelain`, uses plain `git worktree remove` (fail-safe) instead of `--force`, accepts repeatable `--keep` paths, and reclaims squash-merged worktrees via a `gh`-backed merged-PR check that degrades gracefully offline. `Closes #1278`.
 
 ### Docs

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/DemoInteractionTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/DemoInteractionTest.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.provider.MediaStore
+import io.github.sceneview.demo.R
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -667,16 +668,18 @@ class DemoInteractionTest {
         openDemo("secondary-camera")
         screenshot("53_secondaryCam_top_default")
 
-        tap("Side")
+        // Chip labels resolved from string resources (R.string.demo_secondary_camera_chip_*,
+        // added in PR #1270) so the tap matcher works on any device locale — see #1282.
+        tap(context.getString(R.string.demo_secondary_camera_chip_side))
         screenshot("54_secondaryCam_side")
 
-        tap("Front")
+        tap(context.getString(R.string.demo_secondary_camera_chip_front))
         screenshot("55_secondaryCam_front")
 
-        tap("Corner")
+        tap(context.getString(R.string.demo_secondary_camera_chip_corner))
         screenshot("56_secondaryCam_corner")
 
-        tap("Top")
+        tap(context.getString(R.string.demo_secondary_camera_chip_top))
         screenshot("57_secondaryCam_top_back")
     }
 

--- a/samples/web-demo/src/jsMain/resources/index.html
+++ b/samples/web-demo/src/jsMain/resources/index.html
@@ -919,6 +919,11 @@
           .catch(function(err) {
             console.error('SceneView init failed:', err);
             loadingOverlay.querySelector('.loading-text').textContent = 'Failed to initialize: ' + err.message;
+            // Engine init failed, but the update snackbar is pure DOM and not
+            // engine-dependent — flush any deferred version so it isn't stranded
+            // in pendingUpdateVersion forever. flushPendingUpdateSnackbar() nulls
+            // pendingUpdateVersion, so the success path can never double-show it.
+            flushPendingUpdateSnackbar();
           });
       }
 


### PR DESCRIPTION
## Summary

Two small platform follow-ups, one PR.

- **#1279 — web-demo: deferred update snackbar stranded on engine-init failure.** PR #1271 gated the update snackbar behind engine init via `pendingUpdateVersion` + `flushPendingUpdateSnackbar()`, but the flush was only called in the `SceneView.modelViewer(...)` success path. An engine-init rejection left a deferred version stuck in `pendingUpdateVersion` forever. The `.catch()` path now flushes too — the snackbar is pure DOM (not engine-dependent), and `flushPendingUpdateSnackbar()` nulls `pendingUpdateVersion` so it can never double-show.
- **#1282 — DemoInteractionTest: FR-locale gap in control helpers (PART 1).** `secondaryCamera_pipAngles` now resolves the PiP-angle chip labels from `R.string.demo_secondary_camera_chip_*` (added in PR #1270) instead of hard-coded English literals, so the interaction test passes on a French-locale device. Only `SecondaryCameraDemo`'s chips are resource-backed today — the remaining demos still inline English control labels in the composable and need a per-demo resource-extraction sweep first, filed as the deferred follow-up #1287.

## Test plan

- [x] `#1279` — extracted the inline `<script>` block and ran `node --check` → JS syntactically valid.
- [x] `#1282` — `./gradlew :samples:android-demo:compileDebugAndroidTestKotlin` → BUILD SUCCESSFUL (androidTest source set compiles). No test logic changed beyond label resolution; the full instrumented suite is intentionally not run for a label-resolution change.
- [x] `impact-check.sh` → PASS (only the pre-existing unrelated Swift-only-nodes parity warning).

Closes #1279
Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)