### PR TITLE
fix(ios): Stage 2 demo polish — AR clear-all, toggle honesty, error surfacing (#1280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ Six Android-only Sketchfab-streaming demos shipped by Stage 2 ([#1152](https://g
 - **`SamplesTab.swift`** — added Model Viewer / Multi-Model Park entries under Geometry, and promoted "AR Plane Placement" + "AR Instant Placement" from `Coming soon` to fully wired demos.
 - **`DemoDeepLinkRegistry.swift`** — `model-viewer` and `multi-model` ids no longer route to the `SceneGalleryDemo` placeholder; both land on the dedicated demos. `ar-placement` newly routed to `ARPlacementDemo`.
 
+### Fixed — iOS Stage 2 demo polish ([#1280](https://github.com/sceneview/sceneview/issues/1280))
+
+- `ARPlacementDemo` / `ARInstantPlacementDemo` gain a "Clear all placed models" control that tears down every placed anchor (placed anchors previously accumulated for the demo's lifetime); `ARInstantPlacementDemo`'s Instant/Plane toggle doc-comment + copy now honestly state both modes use the same `.estimatedPlane` raycast (the toggle only shows/hides the plane + coaching overlays); `ModelViewerDemo`'s "Surprise me" failures now surface a transient error banner instead of failing silently; and a confusing double-negation in `MultiModelDemo` was simplified.
+
 ### Fixed — pre-existing AppStoreUpdater build break
 
 - `AppStoreUpdater.swift:66` default parameter `currentVersion: @escaping () -> String? = AppStoreUpdater.bundleVersion` was losing the `@MainActor` global-actor isolation under Swift 6 strict concurrency, breaking the iOS demo build on main. Added `@MainActor` on both the parameter type and the stored field so the implicit `@MainActor` from the class scope propagates correctly. Surfaced while validating [#1194](https://github.com/sceneview/sceneview/issues/1194); the regression landed in [#1216](https://github.com/sceneview/sceneview/pull/1216) earlier today.

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
@@ -11,16 +11,27 @@ import SceneViewSwift
 /// which leverages ARCore's `Config.InstantPlacementMode.LOCAL_Y_UP`. On iOS,
 /// ARKit doesn't ship a 1:1 "instant placement" API — the closest equivalent is
 /// `ARView.raycast(...)` against `.estimatedPlane` alignment, which returns hits
-/// before plane geometry has fully converged. The pose is then promoted to a
-/// real `existingPlane` raycast result as ARKit gathers more features.
+/// before plane geometry has fully converged.
 ///
-/// The demo therefore exposes a single toggle:
+/// ### Honest-subset note — what the toggle actually does
 ///
-/// - **Instant Placement ON** (`existingOrEstimated` raycast) — taps land
-///   immediately at an approximate pose (~1 m in front when there's nothing
-///   tracked yet).
-/// - **Instant Placement OFF** (`existingPlane` raycast) — taps wait until a
-///   real plane is detected. Matches the Android `ARPlacementDemo` semantics.
+/// `ARSceneView`'s tap raycast (`ARSceneView.swift` `handleTap`) is hardcoded to
+/// `allowing: .estimatedPlane, alignment: .any`. It has no per-call hook to switch
+/// raycast alignment, so **both toggle positions place models through the same
+/// `.estimatedPlane` raycast** — taps always land before plane geometry has fully
+/// converged.
+///
+/// The toggle is therefore a *coaching/overlay* switch, not a raycast-mode switch:
+///
+/// - **Instant Placement ON** — no plane overlay, no coaching overlay. The UI
+///   encourages tapping straight away on the estimated-plane raycast.
+/// - **Instant Placement OFF** — plane overlay + coaching overlay are shown, so
+///   the user can wait for a converged plane before tapping. The raycast itself
+///   is identical; only the visual guidance differs.
+///
+/// A true per-mode `existingPlane` vs `estimatedPlane` switch would require an
+/// alignment parameter on `ARSceneView`'s tap raycast — tracked as a future API
+/// addition rather than faked at the demo layer.
 ///
 /// ### Streaming pipeline (Stage 2, issue #1152)
 ///
@@ -37,10 +48,24 @@ struct ARInstantPlacementDemo: View {
     ]
 
     @State private var instantEnabled: Bool = true
-    @State private var placedCount: Int = 0
     @State private var cycleIndex: Int = 0
     @State private var selectedSlug: SketchfabSlug?
     @State private var armedURL: URL?
+    /// Anchors placed by tapping. Retained so "Clear all placed models" can
+    /// tear them down — `placedCount` is always derived from this collection
+    /// so the two never drift apart.
+    @State private var placedAnchors: [AnchorEntity] = []
+    /// Weak handle on the live `ARView`, captured from the tap callback, so the
+    /// clear-all control can remove anchors from `arView.scene`.
+    @State private var arViewRef: ARViewBox = ARViewBox()
+
+    /// Reference box for the non-`Sendable`/non-`Equatable` `ARView` so it can
+    /// live in SwiftUI `@State` without triggering view-identity churn.
+    private final class ARViewBox {
+        weak var value: ARView?
+    }
+
+    private var placedCount: Int { placedAnchors.count }
 
     private let placementSlugs: [SketchfabSlug] = SampleAssets.byCategory["ar_placement"] ?? []
 
@@ -101,13 +126,29 @@ struct ARInstantPlacementDemo: View {
             let anchor = AnchorNode.world(position: worldPosition)
             anchor.add(node.entity)
             arView.scene.addAnchor(anchor.entity)
-            placedCount += 1
+            arViewRef.value = arView
+            placedAnchors.append(anchor.entity)
             #if os(iOS)
             HapticManager.lightTap()
             #endif
         } catch {
             // Silently keep the user in tap-to-retry mode (Android parity).
         }
+    }
+
+    /// Removes every placed anchor from the AR scene and resets the count.
+    /// Safe to call when nothing is placed — the loop simply does nothing.
+    @MainActor
+    private func clearAllPlacedModels() {
+        if let arView = arViewRef.value {
+            for anchor in placedAnchors {
+                arView.scene.removeAnchor(anchor)
+            }
+        }
+        placedAnchors.removeAll()
+        #if os(iOS)
+        HapticManager.mediumTap()
+        #endif
     }
 
     // MARK: - Controls sheet
@@ -120,8 +161,8 @@ struct ARInstantPlacementDemo: View {
                     Text(instantEnabled ? "Instant Placement ON" : "Instant Placement OFF")
                         .font(.subheadline.weight(.semibold))
                     Text(instantEnabled
-                         ? "Tap anywhere — ARKit approximates a pose immediately."
-                         : "Plane-based mode — wait for the overlay, then tap inside it.")
+                         ? "Overlays hidden — tap anywhere, ARKit approximates a pose immediately."
+                         : "Plane + coaching overlays shown — wait for a plane, then tap inside it.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
@@ -159,7 +200,15 @@ struct ARInstantPlacementDemo: View {
                     .foregroundStyle(.secondary)
             }
 
-            Text("iOS port note: ARKit doesn't expose ARCore's `InstantPlacementMode.LOCAL_Y_UP` directly. We approximate it via `.estimatedPlane` raycasts so taps land before planes fully converge — close enough for the demo's UX.")
+            Button(role: .destructive) {
+                clearAllPlacedModels()
+            } label: {
+                Label("Clear all placed models", systemImage: "trash")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .disabled(placedCount == 0)
+
+            Text("iOS port note: ARKit doesn't expose ARCore's `InstantPlacementMode.LOCAL_Y_UP` directly. Taps always use an `.estimatedPlane` raycast so they land before planes fully converge. The toggle here only shows/hides the plane + coaching overlays — it does not change the raycast alignment.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
@@ -46,7 +46,6 @@ struct ARPlacementDemo: View {
         ("animated_butterfly", "Butterfly"),
     ]
 
-    @State private var placedCount: Int = 0
     @State private var cycleIndex: Int = 0
     /// `nil` → bundled cycle mode. Non-nil → the user picked a streamed slug.
     @State private var selectedSlug: SketchfabSlug?
@@ -55,6 +54,21 @@ struct ARPlacementDemo: View {
     @State private var armedURL: URL?
     /// Lost-anchor / placement errors surfaced as a transient banner.
     @State private var lastError: String?
+    /// Anchors placed by tapping. Retained so "Clear all placed models" can
+    /// tear them down — `placedCount` is always derived from this collection
+    /// so the two never drift apart.
+    @State private var placedAnchors: [AnchorEntity] = []
+    /// Weak handle on the live `ARView`, captured from the tap callback, so the
+    /// clear-all control can remove anchors from `arView.scene`.
+    @State private var arViewRef: ARViewBox = ARViewBox()
+
+    /// Reference box for the non-`Sendable`/non-`Equatable` `ARView` so it can
+    /// live in SwiftUI `@State` without triggering view-identity churn.
+    private final class ARViewBox {
+        weak var value: ARView?
+    }
+
+    private var placedCount: Int { placedAnchors.count }
 
     private let placementSlugs: [SketchfabSlug] = SampleAssets.byCategory["ar_placement"] ?? []
 
@@ -122,7 +136,8 @@ struct ARPlacementDemo: View {
                 let anchor = AnchorNode.world(position: worldPosition)
                 anchor.add(node.entity)
                 arView.scene.addAnchor(anchor.entity)
-                placedCount += 1
+                arViewRef.value = arView
+                placedAnchors.append(anchor.entity)
                 #if os(iOS)
                 HapticManager.lightTap()
                 #endif
@@ -134,7 +149,8 @@ struct ARPlacementDemo: View {
             let anchor = AnchorNode.world(position: worldPosition)
             anchor.add(node.entity)
             arView.scene.addAnchor(anchor.entity)
-            placedCount += 1
+            arViewRef.value = arView
+            placedAnchors.append(anchor.entity)
             #if os(iOS)
             HapticManager.lightTap()
             #endif
@@ -142,6 +158,21 @@ struct ARPlacementDemo: View {
         } catch {
             lastError = "Could not place model: \(error.localizedDescription)"
         }
+    }
+
+    /// Removes every placed anchor from the AR scene and resets the count.
+    /// Safe to call when nothing is placed — the loop simply does nothing.
+    @MainActor
+    private func clearAllPlacedModels() {
+        if let arView = arViewRef.value {
+            for anchor in placedAnchors {
+                arView.scene.removeAnchor(anchor)
+            }
+        }
+        placedAnchors.removeAll()
+        #if os(iOS)
+        HapticManager.mediumTap()
+        #endif
     }
 
     // MARK: - Controls sheet
@@ -193,9 +224,13 @@ struct ARPlacementDemo: View {
                     .foregroundStyle(.secondary)
             }
 
-            // Clear-all isn't wired (placed anchors are owned by the ARView's
-            // scene at this layer); a future revision could expose
-            // arView.scene.anchors and tear them down here.
+            Button(role: .destructive) {
+                clearAllPlacedModels()
+            } label: {
+                Label("Clear all placed models", systemImage: "trash")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .disabled(placedCount == 0)
         }
     }
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -33,6 +33,9 @@ struct ModelViewerDemo: View {
     @State private var loadedNode: ModelNode?
     @State private var loadError: String?
     @State private var surpriseInFlight: Bool = false
+    /// Transient banner shown when a "Surprise me" roll fails (network error,
+    /// empty search result). Mirrors ``ARPlacementDemo``'s `lastError` capsule.
+    @State private var surpriseError: String?
     /// When non-nil, the demo is rendering a streamed pick instead of the
     /// bundled hero. We surface the title in the status pill so the user can
     /// tell which model is on screen right now.
@@ -45,6 +48,10 @@ struct ModelViewerDemo: View {
             sceneView
             VStack {
                 Spacer()
+                if let surpriseError {
+                    errorBanner(surpriseError)
+                        .padding(.bottom, 8)
+                }
                 if let name = streamedDisplayName {
                     sourcePill(text: "Streamed: \(name)")
                         .padding(.bottom, 8)
@@ -98,6 +105,15 @@ struct ModelViewerDemo: View {
             .padding(.vertical, 6)
             .background(.ultraThinMaterial, in: Capsule())
             .foregroundStyle(.primary)
+    }
+
+    private func errorBanner(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .background(Color.red.opacity(0.85), in: Capsule())
+            .foregroundStyle(.white)
     }
 
     private var surpriseButton: some View {
@@ -165,6 +181,7 @@ struct ModelViewerDemo: View {
     @MainActor
     private func rollSurpriseModel() async {
         surpriseInFlight = true
+        surpriseError = nil
         defer { surpriseInFlight = false }
 
         do {
@@ -187,7 +204,10 @@ struct ModelViewerDemo: View {
                     break
                 }
             }
-            guard let pick = picked else { return }
+            guard let pick = picked else {
+                surfaceTransientError("No surprise model available right now — try again.")
+                return
+            }
 
             // Download via the same service the resolver uses. We bypass the
             // resolver here because the result isn't in our curated
@@ -201,9 +221,22 @@ struct ModelViewerDemo: View {
             loadedNode = node
             streamedDisplayName = pick.name
         } catch {
-            // On failure we silently keep the hero on screen, matching Android.
-            // The button is re-enabled by the `defer` block above so the user
-            // can try again.
+            // Keep the current hero on screen, but surface a transient banner so
+            // a network failure isn't completely silent. The button is re-enabled
+            // by the `defer` block above so the user can try again.
+            surfaceTransientError("Couldn't roll a model: \(error.localizedDescription)")
+        }
+    }
+
+    /// Shows a transient error banner that auto-dismisses after a few seconds.
+    @MainActor
+    private func surfaceTransientError(_ message: String) {
+        surpriseError = message
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            if surpriseError == message {
+                surpriseError = nil
+            }
         }
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
@@ -97,7 +97,7 @@ struct MultiModelDemo: View {
             .ignoresSafeArea()
             .id("multi-model-spin-\(spinScene)")
 
-            if !loadedEntities.isEmpty == false && loadError == nil {
+            if loadedEntities.isEmpty && loadError == nil {
                 VStack(spacing: 12) {
                     ProgressView().tint(.white)
                     Text("Loading park scene…")


### PR DESCRIPTION
## Summary

Addresses the 4 polish items from the Tier 2 post-merge audit of PR #1261 (6 iOS Stage 2 Sketchfab demos). All non-blocking — small UX / honesty fixes under `samples/ios-demo/SceneViewDemo/Views/Demos/`.

- **`ARPlacementDemo` / `ARInstantPlacementDemo`** — add a "Clear all placed models" control. Placed anchors were never torn down (each tap accumulated an `AnchorEntity` + `ModelEntity` for the demo's lifetime). The placed count is now a *derived* property of the retained anchor collection, so the count and the scene can never drift apart. The button is disabled when nothing is placed.
- **`ARInstantPlacementDemo`** — the Instant/Plane toggle was cosmetic at the raycast layer: `ARSceneView`'s tap raycast (`handleTap`) is hardcoded to `allowing: .estimatedPlane, alignment: .any` with no per-call hook. Per `feedback_ios_mirror_android.md` (honesty over hidden gaps), the doc-comment, toggle copy and iOS port note now honestly state both modes use the same `.estimatedPlane` raycast — the toggle only shows/hides the plane + coaching overlays. A true per-mode switch is noted as a future `ARSceneView` API addition rather than faked.
- **`ModelViewerDemo`** — `rollSurpriseModel`'s empty `catch` swallowed network errors silently. Failures (and empty search results) now surface a transient error banner, reusing `ARPlacementDemo`'s existing `errorBanner` capsule pattern; it auto-dismisses after 4 s.
- **`MultiModelDemo`** — simplify the confusing `if !loadedEntities.isEmpty == false` double-negation to `if loadedEntities.isEmpty` (logically equivalent).

## Test plan

- [x] `xcodebuild -project samples/ios-demo/SceneViewDemo.xcodeproj -scheme SceneViewDemo -destination 'platform=iOS Simulator,name=iPhone 16e' build` → **BUILD SUCCEEDED**
- [x] `impact-check.sh` — PASS (only the pre-existing unrelated Swift-only-nodes warning)
- [x] Threading: all RealityKit mutations stay on `@MainActor`
- [ ] On-device AR smoke check of clear-all (AR demos can't run on the simulator — `#if !targetEnvironment(simulator)` gates the live `ARSceneView`)

Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)