### PR TITLE
ci(release): deploy Dokka to gh-pages + retry-wrap Dokka generation (#1252, #1127)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,11 @@ jobs:
   publish-api-docs:
     name: Publish API docs
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for the worst case: 3 Dokka retry attempts × `timeout_minutes:
+    # 10` (#1127) + checkout/setup-gradle + the gh-pages deploy step (#1252).
+    # The previous 15 would have killed the job mid-retry before the wrapper
+    # could exhaust its 3 attempts.
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -95,7 +99,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 3
-          timeout_minutes: 15
+          timeout_minutes: 10
           retry_on: error
           # Dokka 2.2.0 (bumped in gradle/libs.versions.toml#L59) removed V1
           # mode. The V1 task `dokkaHtml` now errors with "Cannot run Dokka
@@ -114,6 +118,75 @@ jobs:
             arsceneview/build/dokka/
           retention-days: 1
           if-no-files-found: ignore
+
+      # Arrange the just-generated Dokka HTML under a versioned tree so the
+      # gh-pages deploy below publishes it to a stable, browseable URL.
+      # Layout written into ./aggregated-dokka/ :
+      #   <version>/sceneview/index.html      ← :sceneview module API
+      #   <version>/arsceneview/index.html    ← :arsceneview module API
+      #   latest/sceneview/index.html         ← copy of the just-tagged version
+      #   latest/arsceneview/index.html
+      # Combined with `destination_dir: api/sceneview` + `keep_files: true`
+      # in the deploy step, this produces:
+      #   sceneview.github.io/api/sceneview/<version>/sceneview/
+      #   sceneview.github.io/api/sceneview/latest/sceneview/
+      # See #1252.
+      - name: Arrange Dokka HTML for gh-pages
+        id: arrange-dokka
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
+          else
+            VERSION=${GITHUB_REF_NAME#v}
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Dokka V2 (`dokkaGenerateHtml`) writes to `<module>/build/dokka/html/`.
+          SCENEVIEW_HTML="sceneview/build/dokka/html"
+          ARSCENEVIEW_HTML="arsceneview/build/dokka/html"
+          if [ ! -f "$SCENEVIEW_HTML/index.html" ] || [ ! -f "$ARSCENEVIEW_HTML/index.html" ]; then
+            echo "::error::Dokka HTML missing — expected $SCENEVIEW_HTML/index.html and $ARSCENEVIEW_HTML/index.html"
+            exit 1
+          fi
+          for slot in "$VERSION" latest; do
+            mkdir -p "aggregated-dokka/$slot/sceneview" "aggregated-dokka/$slot/arsceneview"
+            cp -r "$SCENEVIEW_HTML/." "aggregated-dokka/$slot/sceneview/"
+            cp -r "$ARSCENEVIEW_HTML/." "aggregated-dokka/$slot/arsceneview/"
+          done
+          echo "Arranged Dokka HTML for v$VERSION (+ latest/) under aggregated-dokka/"
+          find aggregated-dokka -maxdepth 2 -type d | sort
+
+      # Publish the versioned Dokka tree to the marketing-site repo
+      # `sceneview/sceneview.github.io` so `sceneview.github.io/api/sceneview/*`
+      # finally serves a browseable API reference (was 404 since v4.3.3).
+      #
+      # Auth: SSH `deploy_key` (secrets.PAGES_DEPLOY_KEY) — the SAME deploy key
+      # `deploy-website.yml` already uses for the cross-repo Pages push, so no
+      # new secret is required.
+      #
+      # `keep_files: true` is critical: the target repo also hosts the
+      # marketing site (deployed by deploy-website.yml) and previously-released
+      # API versions — without it, actions-gh-pages would wipe everything not
+      # in `publish_dir`. With `destination_dir: api/sceneview`, only that
+      # subtree is touched; the site root and other `/api/sceneview/<ver>/`
+      # folders are preserved across deploys.
+      #
+      # Only runs on real tag pushes — on workflow_dispatch the working tree
+      # may not match a published tag, so we skip to avoid mislabelling
+      # `latest/`.
+      - name: Deploy Dokka to sceneview.github.io
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          external_repository: sceneview/sceneview.github.io
+          publish_branch: main
+          publish_dir: ./aggregated-dokka
+          destination_dir: api/sceneview
+          keep_files: true
+          commit_message: "deploy: API docs for ${{ github.ref_name }}"
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
 
   # ── 3. Publish MCP to npm ──────────────────────────────────────────────────
   publish-mcp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Cloud Anchor docs hotfix + `sceneview-swift` mirror retired
 
+### Changed — CI
+
+- **`release.yml` now deploys the generated Dokka API docs to `sceneview.github.io/api/sceneview/<version>/` + `/latest/` and wraps Dokka generation in a 3× retry to tolerate transient Maven Central 503s ([#1252](https://github.com/sceneview/sceneview/issues/1252), [#1127](https://github.com/sceneview/sceneview/issues/1127)).**
+
 ### Added — Double Pendulum demo (shared KMP physics)
 
 - **New `DoublePendulum` simulation in `sceneview-core` ([Addresses #1221](https://github.com/sceneview/sceneview/issues/1221))** — a pure-Kotlin, platform-independent two-link (double) pendulum in `io.github.sceneview.physics`. `DoublePendulumState` holds two `DoublePendulumLink`s (length, mass, angle, angular velocity), a fixed `pivot`, `gravity` and `damping`; `DoublePendulum.step(state, dt)` advances it with a symplectic (semi-implicit) Euler integrator, sub-stepped at `1/240 s` so the chaotic motion stays numerically stable at any frame rate. Exposes `joint` / `tip` joint positions and a `totalEnergy` accessor; covered by 12 `commonTest` cases including energy-conservation (bounded energy band with `damping = 0`) and rest-state stability. Adapted from [@radcli14](https://github.com/radcli14)'s MIT-licensed [`twolinks`](https://github.com/radcli14/twolinks).

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,11 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
 
+**API reference (Dokka):** browse the full generated API docs at
+`https://sceneview.github.io/api/sceneview/latest/sceneview/` (3D) and
+`https://sceneview.github.io/api/sceneview/latest/arsceneview/` (AR). Each release
+is also archived under `/api/sceneview/<version>/`.
+
 ---
 
 ## Setup


### PR DESCRIPTION
## Summary

Two cohesive CI fixes to `release.yml`'s `publish-api-docs` job. One PR, no library code touched.

### #1252 — Deploy Dokka API docs to gh-pages (was 404 everywhere)
`publish-api-docs` built Dokka HTML and uploaded it as a 1-day CI artifact, but nothing published it to a browseable URL, so `sceneview.github.io/api/*` 404'd since v4.3.3.

- New **Arrange Dokka HTML** step stages the just-generated `sceneview` + `arsceneview` Dokka output under a versioned path *and* a `latest/` path:
  ```
  aggregated-dokka/<version>/sceneview/     aggregated-dokka/latest/sceneview/
  aggregated-dokka/<version>/arsceneview/   aggregated-dokka/latest/arsceneview/
  ```
- New **Deploy** step uses `peaceiris/actions-gh-pages@v4` → `external_repository: sceneview/sceneview.github.io`, `destination_dir: api/sceneview`, `keep_files: true`.
- **Auth reuses the existing `secrets.PAGES_DEPLOY_KEY`** SSH deploy key — the same key `deploy-website.yml` already uses for the cross-repo Pages push. **No new secret required.**
- `keep_files: true` + `destination_dir: api/sceneview` ensures the marketing-site root and previously-released `/api/sceneview/<ver>/` folders are preserved — only the `api/sceneview/` subtree is touched.
- Deploy step gated `if: startsWith(github.ref, 'refs/tags/v')` so a `workflow_dispatch` run can't mislabel `latest/`.
- `llms.txt` now documents the official API browse URL.

Resulting URLs after the next tagged release:
`https://sceneview.github.io/api/sceneview/<version>/sceneview/` and `.../latest/sceneview/` (+ `arsceneview`).

### #1127 — Retry-wrap Dokka generation (tolerate transient Maven Central 503s)
The Dokka generation step is wrapped in `nick-fields/retry@v3` (3 attempts) so a transient `repo.maven.apache.org` 503 during dependency resolution doesn't red the whole release.

- Per-attempt `timeout_minutes` lowered 15 → 10 (per the issue).
- Job `timeout-minutes` raised 15 → 45 so 3 retry attempts can actually run — the previous 15 would have killed the job mid-retry before the wrapper exhausted its attempts.
- **No `continue-on-error`** — a genuine Dokka failure after 3 attempts still surfaces as a workflow red X, preserving the #1116 correctness gate.
- Uses the current Dokka 2.2.0 V2 task `dokkaGenerateHtml` (verified against `gradle/libs.versions.toml` + commit `fa4cf31b`).

> Note: the retry wrapper itself was already present in `release.yml` (referencing #1127); this PR fixes its two latent timeout bugs (per-attempt 15→10, job ceiling 15→45) so it actually works under a real 3× retry.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — `release.yml` parses ✅
- `actionlint .github/workflows/release.yml` — 0 errors ✅
- `bash .claude/scripts/impact-check.sh` — PASS (1 pre-existing unrelated WARN) ✅
- Job graph intact: `create-release` still `needs: [..., publish-api-docs]`; gate unchanged.

**Only a real tag push (v4.3.6+) will exercise:** the actual gh-pages deploy to `sceneview.github.io` and the resulting 200 on `/api/sceneview/<version>/`. That cannot be tested without pushing a release tag.

**No new secret needed** — `secrets.PAGES_DEPLOY_KEY` already exists and is used by `deploy-website.yml`.

Closes #1252
Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)