### PR TITLE
test(samples): InAppUpdateManager DOWNLOADING coverage + TV Restart auto-focus (#1229, #1228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - **New `night_sky` HDR environment** bundled across iOS and Android demos — a dramatic Milky Way starfield over a dark landscape (Poly Haven [`dikhololo_night`](https://polyhaven.com/a/dikhololo_night) by Greg Zaal, **CC0 1.0** public domain). iOS exposes it as `SceneEnvironment.nightSky` (added to `allPresets`, so it auto-surfaces in the demo's environment picker); Android adds a "Night Sky" chip to `EnvironmentDemo`. Pairs well with metallic PBR materials for chrome-mirror reflections. Web demo does not bundle HDRs and is unaffected.
 
+### Changed — iOS demo
+
+- **The AR tab launcher now doubles as a discovery surface ([#1253](https://github.com/sceneview/sceneview/issues/1253))** — a 2×3 grid of headline AR demo cards under the "Start AR Camera" CTA (Plane Placement, Instant Placement, AR Lighting, AR Recording, Orbital AR, AR Debug), each opening the demo full-screen — closing the launcher-parity gap with Android's `ArLauncherScreen`. The AR tab's placed-model count is also derived from the live anchor collection so it can no longer drift.
+
 ### Fixed — iOS demo
 
 - **`AppStoreUpdater` snooze is now version-keyed instead of a 7-day TTL ([#1231](https://github.com/sceneview/sceneview/issues/1231))** — dismissing one release's update banner no longer hides a *newer* release's banner; a new App Store version invalidates the snooze automatically, matching the Web/Flutter/RN samples. The `SceneViewDemoTests` unit-test target is now wired into `SceneViewDemo.xcodeproj` so the `AppStoreUpdater` tests run in CI ([#1227](https://github.com/sceneview/sceneview/issues/1227)).
@@ -139,6 +143,10 @@ So the bug is Cloud-Console-side configuration drift, not an APK-side regression
 - **Secondary Camera demo — restore PiP overlay ([PR #1213](https://github.com/sceneview/sceneview/pull/1213))** — `SecondaryCameraDemo.kt` was renamed "Camera Presets" in commit `dfc241d5` and lost its picture-in-picture overlay; the chips ended up just snapping the main camera, defeating the "multi-camera" pitch even though the registry entry still ships the `PictureInPicture` icon + "Picture-in-picture camera view" subtitle. Two `SceneView`s now share the same engine/loaders and render the helmet simultaneously: the main view keeps the default orbital camera (user-interactive), and a small `SurfaceType.TextureSurface` PiP overlay top-start binds a dedicated `rememberCameraNode` driven by the Top / Side / Front / Corner chips via `LaunchedEffect(cameraPreset)`. Title restored to "Secondary Camera (PiP)" so `DemoInteractionTest.secondaryCamera_pipAngles` finds it again. Two correctness invariants doc'd inline: each `SceneView` gets its OWN `rememberModelInstance` (sharing one across views would double-destroy `modelInstance.root` on dispose — SIGABRT — and reparent child light/camera nodes off whichever ModelNode built last) and the PiP receives `cameraManipulator = null` (without it the SceneView frame loop writes `cameraNode.transform = manipulator.getTransform()` every frame, clobbering the `LaunchedEffect` preset writes). iOS gets the matching "Coming soon" placeholder under `.advanced` (`SamplesTab.swift`, `pip.fill` SF Symbol, v4.4) — `SceneView` Swift currently uses an internal `@State private var camera = CameraControls(mode:)` with no per-instance `cameraNode` binding, so a true RealityKit PiP needs new SceneViewSwift public API (tracked for v4.4).
 
 No library APIs change. No new releases of `:sceneview` / `:arsceneview` / `:sceneview-core` are required — the Cloud Anchor on-device fix is entirely Cloud Console configuration; the Secondary Camera fix is scoped to `samples/android-demo/`.
+
+### Changed — in-app update (samples)
+
+- **`InAppUpdateManagerTest` now covers the intermediate `DOWNLOADING` state + non-zero `downloadProgress` ([#1229](https://github.com/sceneview/sceneview/issues/1229)); `UpdateBanner` auto-focuses its "Restart" CTA on D-pad hosts ([#1228](https://github.com/sceneview/sceneview/issues/1228))** — the TV demo passes an optional `restartFocusRequester` so the Restart button grabs focus when an update reaches `READY_TO_INSTALL`; phone hosts leave it `null` and are unaffected.
 
 ## v4.3.5 — Pixel 9 production polish: AR demo UX fixes + FR i18n + CI dedup + iOS pull-to-refresh (2026-05-15)
 

--- a/samples/android-tv-demo/src/main/java/io/github/sceneview/sample/tv/TvModelViewerActivity.kt
+++ b/samples/android-tv-demo/src/main/java/io/github/sceneview/sample/tv/TvModelViewerActivity.kt
@@ -223,13 +223,16 @@ private fun TvModelViewerScreen(updateManager: InAppUpdateManager? = null) {
         )
 
         // Play in-app update banner — overlays the top of the screen during
-        // DOWNLOADING / READY_TO_INSTALL only (no-op otherwise). The Restart
-        // button is regular Material 3 — focusable via the D-pad without extra
-        // wiring. Tested by Google on Leanback; FLEXIBLE is the supported flow.
+        // DOWNLOADING / READY_TO_INSTALL only (no-op otherwise). On TV the
+        // Restart CTA must grab D-pad focus the moment the banner appears, so
+        // we hand UpdateBanner a FocusRequester it auto-requests on the
+        // READY_TO_INSTALL transition. FLEXIBLE is the supported Leanback flow.
+        val restartFocusRequester = remember { FocusRequester() }
         updateManager?.let { mgr ->
             UpdateBanner(
                 updateManager = mgr,
-                modifier = Modifier.align(Alignment.TopCenter)
+                modifier = Modifier.align(Alignment.TopCenter),
+                restartFocusRequester = restartFocusRequester
             )
         }
     }

--- a/samples/common/src/main/java/io/github/sceneview/sample/common/update/UpdateBanner.kt
+++ b/samples/common/src/main/java/io/github/sceneview/sample/common/update/UpdateBanner.kt
@@ -22,9 +22,12 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -39,9 +42,19 @@ import androidx.compose.ui.unit.dp
  * The banner is intentionally rounded + edge-aligned (24 dp radius, 16 dp inset)
  * so it overlays cleanly on top of any sample UI — including the full-bleed
  * SceneView surface — without competing with primary CTAs.
+ *
+ * @param restartFocusRequester optional [FocusRequester] for the "Restart" CTA.
+ * D-pad hosts (Android TV) should pass one in: when the install reaches
+ * `READY_TO_INSTALL` the button is focused automatically so the Leanback user
+ * can act without hunting for it. Phone hosts leave this `null` — touch users
+ * tap the button regardless, and an unsolicited focus request would be inert.
  */
 @Composable
-fun UpdateBanner(updateManager: InAppUpdateManager, modifier: Modifier = Modifier) {
+fun UpdateBanner(
+    updateManager: InAppUpdateManager,
+    modifier: Modifier = Modifier,
+    restartFocusRequester: FocusRequester? = null,
+) {
     val showBanner = updateManager.updateState == InAppUpdateManager.UpdateState.DOWNLOADING
             || updateManager.updateState == InAppUpdateManager.UpdateState.READY_TO_INSTALL
 
@@ -91,13 +104,28 @@ fun UpdateBanner(updateManager: InAppUpdateManager, modifier: Modifier = Modifie
                     }
 
                     if (updateManager.updateState == InAppUpdateManager.UpdateState.READY_TO_INSTALL) {
+                        // Auto-focus the Restart CTA for D-pad hosts. Keyed on
+                        // `updateState` so it fires exactly once on the
+                        // IDLE/DOWNLOADING -> READY_TO_INSTALL transition, not
+                        // on every recomposition. No-op for phone hosts, which
+                        // pass `restartFocusRequester == null`.
+                        if (restartFocusRequester != null) {
+                            LaunchedEffect(updateManager.updateState) {
+                                restartFocusRequester.requestFocus()
+                            }
+                        }
                         Spacer(modifier = Modifier.width(12.dp))
                         Button(
                             onClick = { updateManager.completeUpdate() },
                             shape = RoundedCornerShape(50),
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.primary
-                            )
+                            ),
+                            modifier = if (restartFocusRequester != null) {
+                                Modifier.focusRequester(restartFocusRequester)
+                            } else {
+                                Modifier
+                            }
                         ) {
                             Text("Restart")
                         }

--- a/samples/common/src/test/java/io/github/sceneview/sample/common/update/InAppUpdateManagerTest.kt
+++ b/samples/common/src/test/java/io/github/sceneview/sample/common/update/InAppUpdateManagerTest.kt
@@ -166,6 +166,31 @@ class InAppUpdateManagerTest {
     }
 
     @Test
+    fun `DOWNLOADING state surfaces with non-zero downloadProgress`() {
+        fake.setUpdateAvailable(42)
+        manager.checkForUpdate()
+        shadowOf(activity.mainLooper).idle()
+        fake.userAcceptsUpdate()
+        // `downloadStarts()` flips the fake into the DOWNLOADING phase and
+        // emits an InstallState with 0 bytes — that already drives the manager
+        // to `UpdateState.DOWNLOADING`.
+        fake.downloadStarts()
+        shadowOf(activity.mainLooper).idle()
+        assertEquals(InAppUpdateManager.UpdateState.DOWNLOADING, manager.updateState)
+
+        // `setBytesDownloaded` only re-fires the InstallStateUpdatedListener
+        // once the fake is in the DOWNLOADING phase AND the byte count fits
+        // inside `totalBytesToDownload`, so the total must be set first. The
+        // re-emitted DOWNLOADING event carries 500 / 2000 -> 0.25 progress.
+        fake.setTotalBytesToDownload(2000)
+        fake.setBytesDownloaded(500)
+        shadowOf(activity.mainLooper).idle()
+
+        assertEquals(InAppUpdateManager.UpdateState.DOWNLOADING, manager.updateState)
+        assertEquals(0.25f, manager.downloadProgress, 0.001f)
+    }
+
+    @Test
     fun `zero totalBytes does not crash progress computation`() {
         fake.setUpdateAvailable(42)
         manager.checkForUpdate()


### PR DESCRIPTION
## Summary

Two cohesive follow-ups to PR #1216 (in-app auto-update).

- **#1229** — `InAppUpdateManagerTest` gains a Robolectric test exercising the intermediate `DOWNLOADING` state and a non-zero `downloadProgress`. The test drives `FakeAppUpdateManager` through `downloadStarts()` -> `setTotalBytesToDownload(2000)` -> `setBytesDownloaded(500)` and asserts `updateState == DOWNLOADING` + `downloadProgress ≈ 0.25f` (float compare with `0.001f` tolerance). `triggerInstallStatusUpdate` does not exist in `app-update:2.1.0`; the fake only re-fires its `InstallStateUpdatedListener` from `setBytesDownloaded` once it is in the DOWNLOADING phase and the byte count fits inside the total — both preconditions are now satisfied and documented inline. Suite goes 9 -> 10 passing.

- **#1228** — `UpdateBanner` gains an optional `restartFocusRequester: FocusRequester? = null`. When non-null and the install reaches `READY_TO_INSTALL`, a `LaunchedEffect(updateManager.updateState)` requests focus on the "Restart" button so D-pad (Android TV) users land on it immediately. `TvModelViewerActivity` passes a `FocusRequester`; the phone host (`android-demo` `MainActivity`) passes nothing, so phone/touch behavior is provably unchanged. The `LaunchedEffect` is keyed on `updateState`, so it fires once on the transition into `READY_TO_INSTALL`, not on every recomposition.

`Closes #1229`
`Closes #1228`

## Test plan

- [x] `./gradlew :samples:common:testDebugUnitTest --tests "*InAppUpdateManager*"` — 10/10 pass, including the new `DOWNLOADING state surfaces with non-zero downloadProgress`.
- [x] `./gradlew :samples:android-tv-demo:compileDebugKotlin` — compiles.
- [x] Full `:samples:common:testDebugUnitTest` — green, no regression.
- [x] `bash .claude/scripts/impact-check.sh` — PASS (1 pre-existing unrelated Swift-only-nodes warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)