### PR TITLE
feat(ios): ARTab launcher polish — AR cards grid + anchor-derived placed count (#1253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - **New `night_sky` HDR environment** bundled across iOS and Android demos — a dramatic Milky Way starfield over a dark landscape (Poly Haven [`dikhololo_night`](https://polyhaven.com/a/dikhololo_night) by Greg Zaal, **CC0 1.0** public domain). iOS exposes it as `SceneEnvironment.nightSky` (added to `allPresets`, so it auto-surfaces in the demo's environment picker); Android adds a "Night Sky" chip to `EnvironmentDemo`. Pairs well with metallic PBR materials for chrome-mirror reflections. Web demo does not bundle HDRs and is unaffected.
 
+### Changed — iOS demo
+
+- **The AR tab launcher now doubles as a discovery surface ([#1253](https://github.com/sceneview/sceneview/issues/1253))** — a 2×3 grid of headline AR demo cards under the "Start AR Camera" CTA (Plane Placement, Instant Placement, AR Lighting, AR Recording, Orbital AR, AR Debug), each opening the demo full-screen — closing the launcher-parity gap with Android's `ArLauncherScreen`. The AR tab's placed-model count is also derived from the live anchor collection so it can no longer drift.
+
 ### Fixed — iOS demo
 
 - **`AppStoreUpdater` snooze is now version-keyed instead of a 7-day TTL ([#1231](https://github.com/sceneview/sceneview/issues/1231))** — dismissing one release's update banner no longer hides a *newer* release's banner; a new App Store version invalidates the snooze automatically, matching the Web/Flutter/RN samples. The `SceneViewDemoTests` unit-test target is now wired into `SceneViewDemo.xcodeproj` so the `AppStoreUpdater` tests run in CI ([#1227](https://github.com/sceneview/sceneview/issues/1227)).

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
@@ -13,12 +13,21 @@ import SceneViewSwift
 /// - Top-right: glass exit button to dismiss the tab
 /// - Bottom: floating glass action bar with FAB "Pick model", Reset, Screenshot
 struct ARTab: View {
-    @State private var placedCount = 0
+    /// Anchors placed by tapping a detected plane. The count shown in the
+    /// status pill is *derived* from this collection (`placedCount`) so the
+    /// two can never drift — previously a bare `placedCount: Int` could fall
+    /// out of sync with the real ARKit anchor set (issue #1253 item 4,
+    /// matching the `placedAnchors` pattern already used by `ARPlacementDemo`).
+    @State private var placedAnchors: [AnchorEntity] = []
     @State private var selectedModelIndex = 0
     @State private var errorMessage: String?
     @State private var showError = false
     @State private var showModelPicker = false
     @State private var arViewID = UUID()
+
+    /// Live count of placed models, derived from `placedAnchors` so it stays
+    /// authoritative — never a separately-mutated `Int`.
+    private var placedCount: Int { placedAnchors.count }
     /// Mirrors Android's `sessionStarted` gate on `ArViewTabContent` — the
     /// AR tab opens to a static launcher screen (icon + tagline + "Start
     /// AR Camera" CTA) instead of jumping straight to the live ARKit
@@ -31,6 +40,12 @@ struct ARTab: View {
     /// long as the scene is alive, so plain `@State` already matches that
     /// scope.
     @State private var sessionStarted = false
+
+    /// AR demo presented from the launcher's discovery grid (issue #1253
+    /// item 1). The launcher mirrors Android's `ArLauncherScreen`, which is
+    /// both an entry gate *and* a discovery surface — a 2×3 grid of headline
+    /// AR demos. Tapping a card opens the demo full-screen above the AR tab.
+    @State private var presentedDemo: FeaturedARDemo?
 
     /// Whether the current device has the ARKit world-tracking config we
     /// need (front-facing AR planes + camera passthrough). Computed once
@@ -48,7 +63,7 @@ struct ARTab: View {
     /// We rebuild because there's no public `removeAllAnchors` on the wrapper.
     private func resetScene() {
         arViewID = UUID()
-        placedCount = 0
+        placedAnchors.removeAll()
         HapticManager.mediumTap()
     }
 
@@ -59,7 +74,7 @@ struct ARTab: View {
     /// for in-session resets). We DO close any open sheets / alerts so
     /// the user lands on a clean launcher instead of an orphan modal.
     private func exitArSession() {
-        placedCount = 0
+        placedAnchors.removeAll()
         showModelPicker = false
         showError = false
         sessionStarted = false
@@ -89,10 +104,17 @@ struct ARTab: View {
             if sessionStarted {
                 liveARView
             } else {
-                ARLauncherScreen(arSupported: arSupported) {
-                    sessionStarted = true
-                    HapticManager.lightTap()
-                }
+                ARLauncherScreen(
+                    arSupported: arSupported,
+                    onStartArSession: {
+                        sessionStarted = true
+                        HapticManager.lightTap()
+                    },
+                    onDemoTap: { demo in
+                        presentedDemo = demo
+                        HapticManager.lightTap()
+                    }
+                )
             }
         }
         .alert("AR Error", isPresented: $showError) {
@@ -106,6 +128,18 @@ struct ARTab: View {
                 .presentationBackground(.regularMaterial)
                 .presentationCornerRadius(28)
                 .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(item: $presentedDemo) { demo in
+            NavigationStack {
+                demo.destination
+                    .navigationTitle(demo.title)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { presentedDemo = nil }
+                        }
+                    }
+            }
         }
     }
 
@@ -178,7 +212,9 @@ struct ARTab: View {
                         anchor.add(modelNode.entity)
                         arView.scene.addAnchor(anchor.entity)
 
-                        placedCount += 1
+                        // Track the anchor itself — the status-pill count is
+                        // derived from `placedAnchors`, never mutated directly.
+                        placedAnchors.append(anchor.entity)
                         HapticManager.mediumTap()
                     } catch {
                         errorMessage = error.localizedDescription
@@ -434,17 +470,90 @@ private enum ARLauncherState {
     case cameraDenied
 }
 
+/// One headline AR demo surfaced on the launcher's discovery grid. Each
+/// entry carries the SwiftUI destination so a card tap can present the demo
+/// full-screen — mirroring Android's `FEATURED_AR_DEMOS` list on
+/// `ArViewTab.kt`, where every card routes to a real demo screen.
+///
+/// Only AR demos with a *working* iOS port are listed — the launcher is a
+/// discovery surface, not a "coming soon" teaser wall (the Samples tab
+/// already shows the full catalogue including not-yet-ported demos).
+///
+/// `@MainActor`-isolated: the erased `AnyView` destination is built from
+/// SwiftUI views, which are themselves main-actor-isolated, so the type and
+/// its static `all` catalogue live on the main actor (it's UI-only data).
+@MainActor
+struct FeaturedARDemo: Identifiable {
+    /// `nonisolated` so it satisfies `Identifiable`'s non-isolated `id`
+    /// requirement even though the enclosing type is `@MainActor`.
+    nonisolated let id: String
+    let title: String
+    let subtitle: String
+    let icon: String
+    /// Builds the demo view to present. `@ViewBuilder`-erased so heterogeneous
+    /// demo types share one collection.
+    let destination: AnyView
+
+    /// The six headline AR demos shown on the launcher grid. Picked to mirror
+    /// Android's launcher card set as closely as the iOS port allows — all of
+    /// these have a real, shipping iOS destination.
+    static let all: [FeaturedARDemo] = [
+        FeaturedARDemo(
+            id: "ar-placement",
+            title: "Plane Placement",
+            subtitle: "Tap a detected surface to place a model",
+            icon: "arkit",
+            destination: AnyView(ARPlacementDemo())
+        ),
+        FeaturedARDemo(
+            id: "ar-instant-placement",
+            title: "Instant Placement",
+            subtitle: "Place models without waiting for plane detection",
+            icon: "bolt.fill",
+            destination: AnyView(ARInstantPlacementDemo())
+        ),
+        FeaturedARDemo(
+            id: "ar-lighting",
+            title: "AR Lighting",
+            subtitle: "Compare main / fill light modifier presets",
+            icon: "lightbulb.max.fill",
+            destination: AnyView(ARLightingDemo())
+        ),
+        FeaturedARDemo(
+            id: "ar-recording",
+            title: "AR Recording",
+            subtitle: "Capture the AR session as a screen video",
+            icon: "record.circle",
+            destination: AnyView(ARRecorderDemo())
+        ),
+        FeaturedARDemo(
+            id: "ar-orbital",
+            title: "Orbital AR",
+            subtitle: "Models orbit around you in AR",
+            icon: "circle.dotted",
+            destination: AnyView(OrbitalARDemo())
+        ),
+        FeaturedARDemo(
+            id: "ar-rerun",
+            title: "AR Debug (Rerun)",
+            subtitle: "Stream camera pose & planes to the Rerun viewer",
+            icon: "antenna.radiowaves.left.and.right",
+            destination: AnyView(RerunDebugDemo())
+        ),
+    ]
+}
+
 /// Static launcher shown when the AR tab is opened, before the user explicitly
 /// starts the camera session. Mirrors Android's `ArLauncherScreen` on
-/// `ArViewTab.kt` (#1211 item 3): hero icon + tagline + "Start AR Camera" CTA.
-///
-/// On Android the launcher also surfaces a row of AR demo cards (Cloud
-/// Anchor, Streetscape, etc.) — iOS skips that for now since the AR demos
-/// live under the Samples tab and the launcher is meant as a soft entry
-/// point, not a discovery surface (tracked in #1253).
+/// `ArViewTab.kt` (#1211 item 3): hero icon + tagline + "Start AR Camera" CTA,
+/// followed by a 2×3 grid of headline AR demo cards so the launcher doubles
+/// as a discovery surface (issue #1253 item 1) — every card routes to a real
+/// demo screen presented full-screen above the AR tab.
 private struct ARLauncherScreen: View {
     let arSupported: Bool
     let onStartArSession: () -> Void
+    /// Invoked when one of the discovery-grid cards is tapped.
+    let onDemoTap: (FeaturedARDemo) -> Void
 
     /// Re-read on scene-foreground so a user who tapped "Open Settings",
     /// flipped the camera switch and returned sees the CTA recover to
@@ -521,71 +630,77 @@ private struct ARLauncherScreen: View {
     }
 
     var body: some View {
-        VStack(spacing: 20) {
-            // Hero icon — same gradient + corner radius idiom as the Android
-            // launcher's 56dp box.
-            ZStack {
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color.accentColor.opacity(0.85),
-                                .blue.opacity(0.55),
-                                .purple.opacity(0.45),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
+        ScrollView {
+            VStack(spacing: 20) {
+                // Hero icon — same gradient + corner radius idiom as the Android
+                // launcher's 56dp box.
+                ZStack {
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.accentColor.opacity(0.85),
+                                    .blue.opacity(0.55),
+                                    .purple.opacity(0.45),
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
                         )
-                    )
-                    .frame(width: 96, height: 96)
-                Image(systemName: "arkit")
-                    .font(.system(size: 44, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .accessibilityHidden(true)
-            }
-            .padding(.top, 32)
+                        .frame(width: 96, height: 96)
+                    Image(systemName: "arkit")
+                        .font(.system(size: 44, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .accessibilityHidden(true)
+                }
+                .padding(.top, 32)
 
-            VStack(spacing: 8) {
-                Text("AR Experiences")
-                    .font(.title.weight(.bold))
-                    // Bump VoiceOver focus order so the title gets read
-                    // first then the CTA — without this the screen reader
-                    // walks the Spacer / hero / etc before reaching the
-                    // action.
-                    .accessibilitySortPriority(2)
-                Text("Place 3D models in your space, scan faces, anchor to terrain.")
-                    .font(.subheadline)
+                VStack(spacing: 8) {
+                    Text("AR Experiences")
+                        .font(.title.weight(.bold))
+                        // Bump VoiceOver focus order so the title gets read
+                        // first then the CTA — without this the screen reader
+                        // walks the Spacer / hero / etc before reaching the
+                        // action.
+                        .accessibilitySortPriority(2)
+                    Text("Place 3D models in your space, scan faces, anchor to terrain.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                }
+
+                Button(action: onCtaTap) {
+                    Label(ctaTitle, systemImage: ctaIcon)
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(.tint, in: Capsule())
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 24)
+                .disabled(state == .unsupported)
+                .opacity(state == .unsupported ? 0.5 : 1.0)
+                .accessibilityLabel(ctaTitle)
+                .accessibilitySortPriority(1)
+
+                Text(caption)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 24)
+
+                // Discovery grid — mirrors Android's `FEATURED_AR_DEMOS` 2×3
+                // card grid on `ArLauncherScreen`. Gives the user something
+                // to explore even before (or instead of) starting the live
+                // camera session. Each card opens a real AR demo full-screen.
+                demoGrid
+                    .padding(.top, 8)
             }
-
-            Spacer(minLength: 8)
-
-            Button(action: onCtaTap) {
-                Label(ctaTitle, systemImage: ctaIcon)
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(.tint, in: Capsule())
-                    .foregroundStyle(.white)
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 24)
-            .disabled(state == .unsupported)
-            .opacity(state == .unsupported ? 0.5 : 1.0)
-            .accessibilityLabel(ctaTitle)
-            .accessibilitySortPriority(1)
-
-            Text(caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
-
-            Spacer(minLength: 24)
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, 24)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onChange(of: scenePhase) { _, phase in
             // Re-sync the CTA when the app returns to the foreground — the
             // user may have flipped the camera switch in Settings.
@@ -594,13 +709,95 @@ private struct ARLauncherScreen: View {
             }
         }
     }
+
+    // MARK: - Discovery grid
+
+    private var demoGrid: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Try an AR demo")
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+                .padding(.horizontal, 24)
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 12),
+                    GridItem(.flexible(), spacing: 12),
+                ],
+                spacing: 12
+            ) {
+                ForEach(FeaturedARDemo.all) { demo in
+                    Button {
+                        onDemoTap(demo)
+                    } label: {
+                        ARDemoCard(demo: demo)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(demo.title): \(demo.subtitle)")
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+}
+
+/// A single discovery-grid card on the AR launcher. Visually mirrors the
+/// Samples-tab card idiom (gradient icon header + title + subtitle) so the
+/// two surfaces feel like one app, matching Android's `ArDemoCard`.
+private struct ARDemoCard: View {
+    let demo: FeaturedARDemo
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ZStack {
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.green.opacity(0.32),
+                                Color.green.opacity(0.14),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                Image(systemName: demo.icon)
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(.green)
+                    .accessibilityHidden(true)
+            }
+            .frame(height: 56)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(demo.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(demo.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 150, alignment: .top)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
 }
 
 #Preview("Launcher — supported") {
-    ARLauncherScreen(arSupported: true, onStartArSession: {})
+    ARLauncherScreen(arSupported: true, onStartArSession: {}, onDemoTap: { _ in })
 }
 
 #Preview("Launcher — unsupported") {
-    ARLauncherScreen(arSupported: false, onStartArSession: {})
+    ARLauncherScreen(arSupported: false, onStartArSession: {}, onDemoTap: { _ in })
 }
 #endif


### PR DESCRIPTION
## Summary

Closes #1253 — the two remaining open follow-ups from the 3-agent review of PR #1251. Items 2 (camera-permission denial recovery), 5 (status pill keeps model name) and 6 (`isNewer` nonisolated) already shipped in #1277; item 3 (return-user launcher skip) was closed as won't-fix to preserve Android parity.

- **Item 1 — AR demo cards on the iOS launcher.** The AR-tab launcher was a dead-end gate (hero + CTA only). It now doubles as a discovery surface, mirroring Android's `ArLauncherScreen` 2×3 `FEATURED_AR_DEMOS` grid: six headline AR demo cards (Plane Placement, Instant Placement, AR Lighting, AR Recording, Orbital AR, AR Debug) sit under the CTA, each opening its real iOS demo full-screen. Only demos with a working iOS port are listed — no "coming soon" teasers on the launcher (the Samples tab still shows the full catalogue).
- **Item 4 — `placedCount` Int → derived from anchor collection.** `ARTab`'s separately-mutated `placedCount: Int` is replaced by a computed count over `@State placedAnchors: [AnchorEntity]`, so the status pill can never drift from the real anchor set. Matches the pattern already used by `ARPlacementDemo`.

## Test plan

- [x] Clean `xcodebuild` on iPhone 16e simulator (`** BUILD SUCCEEDED **`)
- [x] Simulator smoke check — launcher renders the "Try an AR demo" grid; tapping a card routes into the demo full-screen (verified `ARPlacementDemo`); Close returns to the launcher
- [x] CTA still adapts to capability/permission state (shows "AR not supported" disabled on simulator)
- [x] `impact-check.sh` passes (only the pre-existing unrelated Swift-only-nodes WARN)
- [ ] On-device AR camera flow (cannot run on simulator — launcher UI + permission states checkable, AR session is not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)