### PR TITLE
ci: scope workflows with path filters so trivial PRs skip irrelevant builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - 'docs/**'
       - 'marketing/**'
       - 'mcp*/**'
+      - 'telemetry-worker/**'
+      - 'branding/**'
+      - '.claude/**'
+      - 'tools/**'
       - '*.md'
       - 'llms*.txt'
       - 'LICENSE'
@@ -18,6 +22,10 @@ on:
       - 'docs/**'
       - 'marketing/**'
       - 'mcp*/**'
+      - 'telemetry-worker/**'
+      - 'branding/**'
+      - '.claude/**'
+      - 'tools/**'
       - '*.md'
       - 'llms*.txt'
       - 'LICENSE'
@@ -32,8 +40,74 @@ permissions:
   contents: read
 
 jobs:
+  # ── Path-filter gate ─────────────────────────────────────────────────────
+  # Computes which areas of the repo a PR touched so the three build jobs
+  # below can each skip when nothing in their scope changed. The
+  # workflow-level `paths-ignore` above already drops pure docs/website/mcp
+  # PRs; this finer per-job gate stops, for example, a Flutter-only change
+  # from rebuilding the Android libraries or a web-only change from
+  # rebuilding the Flutter demo. See #1295.
+  #
+  # A job that gets `if:`-skipped reports the "skipped" conclusion, which
+  # GitHub treats as success for branch-protection required checks — the
+  # same guarantee the repo already relies on for the workflow-level
+  # `paths` filters in ios.yml / build-apks.yml / telemetry-ci.yml. No
+  # check is renamed, so branch protection is unaffected.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+      web: ${{ steps.filter.outputs.web }}
+      flutter: ${{ steps.filter.outputs.flutter }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Conservative bias (#1295): when unsure whether a path is in
+          # scope, INCLUDE it — a needless rebuild is cheaper than a
+          # skipped-but-needed test. `sceneview-core/**` is shared KMP
+          # logic, so it intentionally appears in BOTH `android` and
+          # `web`. The workflow file + its composite actions are listed
+          # under every filter so a CI change always re-runs every job.
+          # `push` events (branch `main`) have no PR diff base — the
+          # action falls back to comparing against the previous commit;
+          # the workflow-level `paths-ignore` is the real gate there.
+          filters: |
+            shared: &shared
+              - '.github/workflows/ci.yml'
+              - '.github/actions/setup-gradle/**'
+              - 'gradle/**'
+              - 'build.gradle*'
+              - 'settings.gradle*'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+            android:
+              - *shared
+              - 'sceneview/**'
+              - 'arsceneview/**'
+              - 'sceneview-core/**'
+              - 'samples/android-demo/**'
+              - 'samples/android-tv-demo/**'
+              - 'samples/common/**'
+            web:
+              - *shared
+              - 'sceneview-core/**'
+              - 'sceneview-web/**'
+              - 'samples/web-demo/**'
+              - 'samples/desktop-demo/**'
+            flutter:
+              - *shared
+              - 'flutter/**'
+              - 'samples/flutter-demo/**'
+
   build:
     name: Build & lint
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -131,6 +205,8 @@ jobs:
   # ── Web & Desktop modules (Kotlin/JS + Compose Desktop) ──────────────────
   web-desktop:
     name: Build web & desktop
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -175,6 +251,8 @@ jobs:
   # only shows up the next time someone runs `flutter build apk`.
   flutter-demo:
     name: Build flutter-demo APK
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,17 +1,22 @@
 name: iOS CI
 
 on:
+  # `sceneview-core/**` is shared KMP logic consumed by the Apple
+  # (RealityKit) renderer, so an iOS-affecting core change must re-run
+  # iOS CI — it also triggers Android CI in ci.yml's path filter. See #1295.
   push:
     branches: [main]
     paths:
       - 'SceneViewSwift/**'
       - 'samples/ios-demo/**'
+      - 'sceneview-core/**'
       - '.github/workflows/ios.yml'
   pull_request:
     branches: [main]
     paths:
       - 'SceneViewSwift/**'
       - 'samples/ios-demo/**'
+      - 'sceneview-core/**'
       - '.github/workflows/ios.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Closes #1295.

## Problem

`ci.yml` was one monolithic workflow whose three jobs — Android library + demo APKs, web/desktop, Flutter demo APK — shared a single coarse `paths-ignore`. So a web-only change still rebuilt Android + Flutter, a Flutter-only change still rebuilt the Android libraries, and a `.claude/**` / `tools/**` edit triggered all three (~20-30 min of wall-clock + CI minutes wasted per trivial PR).

`ios.yml` also had a false negative: it filtered on `SceneViewSwift/**` + `samples/ios-demo/**` but **not** `sceneview-core/**` — the shared KMP core is consumed by the Apple renderer, so an iOS-affecting core change skipped iOS CI.

The other PR-irrelevant workflows are already fine: `render-tests.yml`, `build-apks.yml`, `deploy-website.yml`, `docs.yml`, `app-store.yml`, `play-store.yml`, `release.yml` are push/tag/schedule-only (don't run on PRs at all); `telemetry-ci.yml` is already scoped to `telemetry-worker/**`.

## Changes

- **`ci.yml`** — add a `dorny/paths-filter` `changes` job and gate `build` / `web-desktop` / `flutter-demo` with precise per-job `if:` conditions:
  - `build` → `sceneview/**`, `arsceneview/**`, `sceneview-core/**`, `samples/android*/**`, `samples/common/**`, gradle files, the workflow + composite action.
  - `web-desktop` → `sceneview-core/**`, `sceneview-web/**`, `samples/web-demo/**`, `samples/desktop-demo/**`, gradle files, the workflow.
  - `flutter-demo` → `flutter/**`, `samples/flutter-demo/**`, gradle files, the workflow.
  - Extend the workflow-level `paths-ignore` with `.claude/**`, `tools/**`, `branding/**`, `telemetry-worker/**` so non-code PRs don't even spin up the `changes` job.
- **`ios.yml`** — add `sceneview-core/**` to its `paths:` (false-negative fix).

`sceneview-core/**` intentionally appears in **both** the `android` and `web` filters **and** in `ios.yml` — shared KMP logic must re-run every renderer.

## Required-check safety

No check is renamed. A job that gets `if:`-skipped reports the `skipped` conclusion, which GitHub treats as **success** for branch-protection required checks — the exact guarantee the repo already relies on for the workflow-level `paths` filters in `ios.yml` / `build-apks.yml` / `telemetry-ci.yml`. The new `changes` job always runs and succeeds, so no required check can be stuck permanently pending.

## 3-scenario trace (before vs after)

| Scenario | Before | After |
|---|---|---|
| (a) `.claude/scripts/foo.sh` edit | `ci.yml` runs fully (Android + web + flutter, ~30 min) + `pr-check.yml` + `quality-gate.yml` | `ci.yml` **skipped entirely** (`.claude/**` in `paths-ignore`); `pr-check.yml` + `quality-gate.yml` still run (correct — `check-workflow-scripts` validates the script). ~30 min saved. |
| (b) `samples/ios-demo/**` edit | `ios.yml` runs; `ci.yml` runs fully (Android + web + flutter) | `ios.yml` runs; `ci.yml` `changes` runs (~1 min) then `build` / `web-desktop` / `flutter-demo` all **skipped**. ~30 min saved. |
| (c) `sceneview/**` library edit | `ci.yml` runs fully (Android + web + flutter); `ios.yml` skipped | `ci.yml` `build` runs (Android in scope); `web-desktop` + `flutter-demo` **skipped**; `ios.yml` still skipped (correct — `sceneview/**` is Android-only). web + flutter rebuild saved. |

## Verification

- YAML: `python3 -c "import yaml; yaml.safe_load(...)"` — both changed files parse.
- `actionlint .github/workflows/ci.yml .github/workflows/ios.yml` — 0 errors. (Pre-existing shellcheck `SC2086` style findings in `app-store.yml` / `play-store.yml` / etc. are untouched and out of scope.)
- `dorny/paths-filter` YAML anchor (`&shared` / `*shared`) verified to resolve correctly — the action supports nested-list filter rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)