### PR TITLE
chore: recurring-tasks audit — migrate to android-CLI / skill pattern (#1084)

### DIFF
--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -89,6 +89,45 @@ If a newer stable version exists, note it for a potential PR.
 - Check for TODO/FIXME: `git log --since="1 day ago" -p | grep "+.*TODO\|+.*FIXME"`
 - Run detekt if configured: `./gradlew detekt`
 
+## 5b. AI-first tooling health (android-CLI / agent skill)
+
+SceneView's QA workflows depend on Google's `android` CLI and the published
+`agents/sceneview/` agent skill. Drift here silently degrades every
+agent-driven QA run, so check it daily.
+
+### Agent skill drift
+```bash
+bash .claude/scripts/check-sceneview-skill.sh
+```
+Catches hallucinated APIs, dead demo refs, and stale `last-updated`
+frontmatter in `agents/sceneview/`. If it fails, update the skill from real
+demos / `llms.txt` (don't just bump the date).
+
+### android CLI version drift
+```bash
+android --version 2>/dev/null || echo "android CLI not installed"
+```
+CLAUDE.md pins the tested baseline (currently **v0.7.15411012**). If the
+installed CLI is materially newer, sanity-check that `android layout`,
+`android screen capture`, and `android run` still behave as the helper
+(`.claude/scripts/lib/android-cli.sh`) expects, and bump the documented
+baseline if the new version is adopted.
+
+### AR emulator (AVD) health
+```bash
+bash .claude/scripts/setup-ar-emulator.sh --check
+```
+Read-only inspection of the reusable `Pixel_7a` ARCore AVD. If it reports a
+missing AVD, missing ARCore APK, or storage degradation (see
+`project_emulator_storage_degradation.md` — viewports go black after ~6 QA
+runs), run `setup-ar-emulator.sh --clean` to wipe and recreate it.
+
+### Dev-env sanity
+```bash
+bash .claude/scripts/android-env-check.sh
+```
+Use `--fix` to auto-install the `android` CLI and re-sync the SceneView skill.
+
 ## 6. Cross-platform API parity
 
 ```bash

--- a/.claude/scripts/pre-push-check.sh
+++ b/.claude/scripts/pre-push-check.sh
@@ -16,7 +16,7 @@ echo "  SceneView Pre-Push Quality Gate"
 echo "═══════════════════════════════════════════"
 
 # 1. Android compilation
-echo -e "\n${YELLOW}[1/8] Compiling sceneview...${NC}"
+echo -e "\n${YELLOW}[1/10] Compiling sceneview...${NC}"
 if ./gradlew :sceneview:compileReleaseKotlin --quiet 2>/dev/null; then
     echo -e "${GREEN}  ✓ sceneview compiles${NC}"
 else
@@ -24,7 +24,7 @@ else
     ERRORS=$((ERRORS + 1))
 fi
 
-echo -e "${YELLOW}[2/8] Compiling arsceneview...${NC}"
+echo -e "${YELLOW}[2/10] Compiling arsceneview...${NC}"
 if ./gradlew :arsceneview:compileReleaseKotlin --quiet 2>/dev/null; then
     echo -e "${GREEN}  ✓ arsceneview compiles${NC}"
 else
@@ -33,7 +33,7 @@ else
 fi
 
 # 2. Unit tests
-echo -e "\n${YELLOW}[3/8] Running sceneview unit tests...${NC}"
+echo -e "\n${YELLOW}[3/10] Running sceneview unit tests...${NC}"
 if ./gradlew :sceneview:test --quiet 2>/dev/null; then
     echo -e "${GREEN}  ✓ sceneview tests pass${NC}"
 else
@@ -41,7 +41,7 @@ else
     ERRORS=$((ERRORS + 1))
 fi
 
-echo -e "${YELLOW}[4/8] Running arsceneview unit tests...${NC}"
+echo -e "${YELLOW}[4/10] Running arsceneview unit tests...${NC}"
 if ./gradlew :arsceneview:testDebugUnitTest --quiet 2>/dev/null; then
     echo -e "${GREEN}  ✓ arsceneview tests pass${NC}"
 else
@@ -50,7 +50,7 @@ else
 fi
 
 # 3. Screenshot tests (Roborazzi — Android, JVM, no emulator)
-echo -e "\n${YELLOW}[5/8] Verifying Android screenshot goldens...${NC}"
+echo -e "\n${YELLOW}[5/10] Verifying Android screenshot goldens...${NC}"
 SNAPSHOTS_DIR="samples/android-demo/src/test/snapshots"
 if [ -d "$SNAPSHOTS_DIR" ] && [ "$(ls -A $SNAPSHOTS_DIR 2>/dev/null)" ]; then
     if ./gradlew :samples:android-demo:verifyRoborazziDebug --quiet 2>/dev/null; then
@@ -64,7 +64,7 @@ else
 fi
 
 # 4. Screenshot tests iOS (Pillow pixel comparison against simulator goldens)
-echo -e "${YELLOW}[6/8] Verifying iOS screenshot goldens...${NC}"
+echo -e "${YELLOW}[6/10] Verifying iOS screenshot goldens...${NC}"
 IOS_GOLDENS="samples/ios-demo/goldens"
 if xcrun simctl list devices | grep -q "Booted" 2>/dev/null; then
     if [ -d "$IOS_GOLDENS" ] && [ "$(ls -A $IOS_GOLDENS/*.png 2>/dev/null)" ]; then
@@ -82,7 +82,7 @@ else
 fi
 
 # 5. Version sync
-echo -e "\n${YELLOW}[7/8] Checking version sync...${NC}"
+echo -e "\n${YELLOW}[7/10] Checking version sync...${NC}"
 MISMATCHES=$(bash .claude/scripts/sync-versions.sh 2>/dev/null | grep "MISMATCH" | grep -v "migration.md" | grep -v "Errors" | wc -l | tr -d ' ')
 if [ "$MISMATCHES" = "0" ]; then
     echo -e "${GREEN}  ✓ All versions aligned${NC}"
@@ -92,7 +92,7 @@ else
 fi
 
 # 6. Website JS syntax
-echo -e "\n${YELLOW}[8/9] Validating website JS...${NC}"
+echo -e "\n${YELLOW}[8/10] Validating website JS...${NC}"
 NODE_CMD=$(which node 2>/dev/null || which /opt/homebrew/bin/node 2>/dev/null || which /usr/local/bin/node 2>/dev/null || echo "")
 if [ -n "$NODE_CMD" ]; then
     if "$NODE_CMD" -c website-static/js/sceneview.js 2>/dev/null; then
@@ -109,7 +109,7 @@ fi
 # Scans every samples/* for broken bundled paths or dead CDN URLs so the
 # class of bugs fixed in session 34 (TV demo pointing at non-existent
 # models/*.glb, web-demo pointing at 404 CDN URLs) cannot come back.
-echo -e "\n${YELLOW}[9/9] Validating demo app asset references...${NC}"
+echo -e "\n${YELLOW}[9/10] Validating demo app asset references...${NC}"
 # --no-cdn to keep pre-push fast; CI runs the full check with CDN hits.
 if bash .claude/scripts/validate-demo-assets.sh --no-cdn > /tmp/validate-demo-assets.log 2>&1; then
     echo -e "${GREEN}  ✓ All demo asset refs resolve${NC}"
@@ -117,6 +117,25 @@ else
     echo -e "${RED}  ✗ Demo apps reference assets that don't exist:${NC}"
     tail -30 /tmp/validate-demo-assets.log | sed 's/^/      /'
     ERRORS=$((ERRORS + 1))
+fi
+
+# 8. SceneView agent skill drift
+# Catches the case where a library API was renamed/removed without updating
+# `agents/sceneview/` (the published android-CLI agent skill). The same check
+# runs in quality-gate.sh, pr-check.yml and daily via maintenance.yml — but
+# the lighter pre-push gate skipped it, so a skill-only push could land drift
+# without ever hitting quality-gate.sh. Invoke it directly here too.
+echo -e "\n${YELLOW}[10/10] Checking agent skill drift...${NC}"
+if [ -f .claude/scripts/check-sceneview-skill.sh ]; then
+    if bash .claude/scripts/check-sceneview-skill.sh > /tmp/skill-drift.log 2>&1; then
+        echo -e "${GREEN}  ✓ agents/sceneview/ in sync with library source${NC}"
+    else
+        echo -e "${RED}  ✗ Agent skill drift — agents/sceneview/ out of sync:${NC}"
+        tail -30 /tmp/skill-drift.log | sed 's/^/      /'
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo -e "${YELLOW}  ⚠ check-sceneview-skill.sh not found, skipping${NC}"
 fi
 
 # Summary


### PR DESCRIPTION
## Summary

Audit of recurring/maintenance tasks against the android-CLI / agent-skill pattern (PR #1068, #1072), per #1084. Two clear low-risk improvements applied here; larger items deferred to follow-up issues.

### Acted now
- **`pre-push-check.sh`** — new step 10 invokes `check-sceneview-skill.sh` directly. Agent-skill drift previously only ran via `quality-gate.sh` / `pr-check.yml` / `maintenance.yml`, so a skill-only push could land drift without ever hitting `quality-gate.sh`. Step labels renumbered to `/10`.
- **`/maintain` skill** — new section 5b "AI-first tooling health": agent skill drift (`check-sceneview-skill.sh`), `android` CLI version drift vs the CLAUDE.md baseline, AR-emulator AVD health (`setup-ar-emulator.sh --check`), and dev-env sanity.

### Deferred → follow-up issues
- #1301 — `release.yml`: validate APK/bundle with `android describe` before Play Store upload
- #1302 — `cross-platform-check.sh`: cross-check exposed activities via `android describe` APK manifest
- #1303 — `maintenance.yml`: run the `/maintain` skill as a structured CI report (needs a Claude-Code-in-CI runner — architectural)

### Skipped
- `sync-versions.sh` auto-bumping `SKILL.md` `last-updated:` — that field is a content-freshness marker; bumping it on every version sync would falsely mark the skill "fresh". It should reflect real skill-content edits only.
- Filament `.filamat` recompile invariant — no android-CLI lever (matc is a build toolchain, not a device CLI); stays a CONTRIBUTING.md / reviewer-discipline item.

Full audit table posted on #1084.

Side-finding: `tools/try-demo.sh` was flagged in older notes as still using raw `adb` — verified already migrated (`android run` primary via the helper, adb only as documented fallback). No action needed.

## Test plan
- [x] `bash -n .claude/scripts/pre-push-check.sh` — passes
- [x] `shellcheck -S warning` — clean
- [x] CI/script-doc-only change — no Kotlin/gradle/YAML touched
- [ ] CI green

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)