### PR TITLE
fix(scene): 3D rendering quality — DefaultCameraNode 3/4-view default framing (#1074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Removed the French localization from the sample apps — sample apps are English-only by design ([#1294](https://github.com/sceneview/sceneview/issues/1294)).** Deleted `samples/android-demo/.../res/values-fr/strings.xml`; the default English resources remain the single source of truth.
 
+### Fixed — 3D rendering quality umbrella ([#1074](https://github.com/sceneview/sceneview/issues/1074))
+
+- **`DefaultCameraNode` now starts at a framed 3/4 view** — the default 3D camera placement moved from `(0, 0, 1)` (1 m dead-ahead of the world origin, flat front-on, under-framing anything but a tiny object) to `(0, 0.3, 2)` looking at the origin. This frames a typical 0.3–1 m model placed at origin correctly out of the box and mirrors iOS RealityKit's `look(at: .zero, from: [0, 0.3, 2])` default, so the same scene frames identically on Android and iOS. The position is exposed as `DefaultCameraNode.DEFAULT_Y` / `DEFAULT_Z` and pinned in `SceneFactoriesTest`. This is a visual behavior change — demos that supply their own `cameraNode` are unaffected. The remaining umbrella items (IBL intensity 30k→10k, PostProcessingDemo SSAO toggle, light/material leaks, render-quality clobber, `indirectLightApply` threading, PhysicsDemo light retune) already shipped in [#1079](https://github.com/sceneview/sceneview/pull/1079), [#1088](https://github.com/sceneview/sceneview/pull/1088), [#1089](https://github.com/sceneview/sceneview/pull/1089), [#1092](https://github.com/sceneview/sceneview/pull/1092) and [#1147](https://github.com/sceneview/sceneview/pull/1147).
+
 ### Changed — CI
 
 - **`release.yml` now deploys the generated Dokka API docs to `sceneview.github.io/api/sceneview/<version>/` + `/latest/` and wraps Dokka generation in a 3× retry to tolerate transient Maven Central 503s ([#1252](https://github.com/sceneview/sceneview/issues/1252), [#1127](https://github.com/sceneview/sceneview/issues/1127)).**

--- a/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
@@ -228,7 +228,16 @@ fun createCollisionSystem(view: View) = CollisionSystem(view)
 
 class DefaultCameraNode(engine: Engine) : CameraNode(engine) {
     init {
-        transform = io.github.sceneview.math.Transform(position = Position(0.0f, 0.0f, 1.0f))
+        // 3/4 view: slightly elevated and pulled back so a typical 0.3–1 m model placed
+        // at the world origin is fully framed and centered (#1080). The previous
+        // `(0, 0, 1)` placement sat the camera 1 m dead-ahead of origin — too close for
+        // anything but a tiny object and, with no Y elevation, produced a flat,
+        // under-framed front-on view. `(0, DEFAULT_Y, DEFAULT_Z)` + `lookAt(origin)`
+        // mirrors iOS RealityKit's `look(at: .zero, from: [0, 0.3, 2])` default
+        // (`SceneViewSwift/.../SceneView.swift`) so the same scene frames identically
+        // on both platforms. Pinned in `SceneFactoriesTest.defaultCameraNodePositionIsPinned()`.
+        position = Position(0.0f, DEFAULT_Y, DEFAULT_Z)
+        lookAt(Position(0.0f, 0.0f, 0.0f))
         // Neutral, less photographic exposure.
         // The previous setting (`f/16, 1/125 s, ISO 100` ≈ EV 15) is "sunny-16" — a real-world
         // outdoor exposure that makes Filament renders look much darker than the iOS
@@ -241,6 +250,18 @@ class DefaultCameraNode(engine: Engine) : CameraNode(engine) {
     }
 
     companion object {
+        /**
+         * Default camera Y elevation. Small positive lift gives a natural 3/4 angle
+         * looking slightly down on origin-placed content. Matches iOS `[0, 0.3, 2]`.
+         */
+        const val DEFAULT_Y = 0.3f
+
+        /**
+         * Default camera Z distance from origin. Pulls the camera back far enough to
+         * frame a typical 0.3–1 m model. Matches iOS `[0, 0.3, 2]`.
+         */
+        const val DEFAULT_Z = 2.0f
+
         /** Aperture (f-stop). AR mirrors via `ARDefaultCameraNode.DEFAULT_APERTURE`. */
         const val DEFAULT_APERTURE = 12.0f
 

--- a/sceneview/src/test/java/io/github/sceneview/SceneFactoriesTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/SceneFactoriesTest.kt
@@ -48,6 +48,26 @@ class SceneFactoriesTest {
     }
 
     @Test
+    fun defaultCameraNodePositionIsPinned() {
+        // Pin #1080 — DefaultCameraNode 3/4-view default placement. `(0, 0.3, 2)` frames a
+        // typical 0.3–1 m origin-placed model and mirrors iOS RealityKit's
+        // `look(at: .zero, from: [0, 0.3, 2])`. The pre-#1080 `(0, 0, 1)` placement was too
+        // close and flat. Changing these is a BREAKING visual + cross-platform-parity change.
+        assertEquals(
+            "DefaultCameraNode.DEFAULT_Y must stay 0.3 — matches iOS [0, 0.3, 2] (#1080).",
+            0.3f,
+            DefaultCameraNode.DEFAULT_Y,
+            0.0f,
+        )
+        assertEquals(
+            "DefaultCameraNode.DEFAULT_Z must stay 2.0 — matches iOS [0, 0.3, 2] (#1080).",
+            2.0f,
+            DefaultCameraNode.DEFAULT_Z,
+            0.0f,
+        )
+    }
+
+    @Test
     fun defaultCameraNodeExposureValuesArePinned() {
         // Pin #1067 — 3D DefaultCameraNode exposure. ARDefaultCameraNode mirrors
         // these via the `arsceneview` module's companion constants; the cross-


### PR DESCRIPTION
## Summary

Closes out the [#1074](https://github.com/sceneview/sceneview/issues/1074) **3D rendering quality umbrella** (twin of the AR-side #1061). An independent audit found 10 bugs in the Android `sceneview/` pipeline. **8 of the 9 actionable bugs (1-9) were already fixed and merged on `main`** via prior PRs — this PR lands the last remaining one (bug 6, `DefaultCameraNode` framing) and defers the P3 reactivity-parity item (bug 10) to a follow-up.

## Bug-by-bug status

| # | Sev | Bug | Status |
|---|---|---|---|
| 1 | P0 | IBL ships at 30k lux → 3× the v4.1.0 main light, washed-out | ✅ already merged — #1079 (`DEFAULT_IBL_INTENSITY = 10_000`) |
| 2 | P0 | PostProcessingDemo `ssaoEnabled = false` contradicts library default | ✅ already merged — #1079 (now `mutableStateOf(true)`) |
| 3 | P1 | `isOpaque = false` broken — `uiHelper.isOpaque` + `view.blendMode` unwired | ✅ already merged — #1092 |
| 4 | P1 | `mainLightNode`/`fillLightNode` leak into shared `Scene` on dispose | ✅ already merged — #1147 (`DisposableEffect` cleanup, mirrors cameraNode #1143) |
| 5 | P1 | `applyRenderQuality` clobbers user `colorGrading`/`bloomOptions` every recomposition | ✅ already merged — #1089 (keyed `LaunchedEffect(view, renderQuality)`) |
| 6 | P1 | `DefaultCameraNode` position `(0,0,1)` under-frames typical 0.3 m models | ✅ **this PR** |
| 7 | P1 | `createHDREnvironment` overloads drop `indirectLightApply` | ✅ already merged — #1147 (threaded through file/asset/rawRes) |
| 8 | P1 | `RenderableNode.destroy()` leaks bound `MaterialInstance`s | ✅ already merged (`destroyMaterialsOnDispose` opt-in flag, propagated through `GeometryNode`) |
| 9 | P2 | PhysicsDemo stacks an extra 100k lux light | ✅ already retuned — PhysicsDemo light is now `5_000f` |
| 10 | P3 | Android `mainLight` mutations ignored after first composition (parity gap) | ⏭️ deferred → **#1306** |

## This PR — bug 6

`DefaultCameraNode` moved from `(0, 0, 1)` — 1 m dead-ahead of the world origin, flat front-on, under-framing anything but a tiny object — to `(0, 0.3, 2)` looking at the origin:

- Frames a typical 0.3-1 m model placed at origin correctly out of the box.
- Mirrors iOS RealityKit's `look(at: .zero, from: [0, 0.3, 2])` default (`SceneViewSwift/Sources/SceneViewSwift/SceneView.swift`) — same scene now frames **identically on Android and iOS**, closing the cross-platform gap noted in iOS #1051 / #1026.
- The default `rememberCameraManipulator` derives `orbitHomePosition` from `cameraNode.worldPosition` and orbits around the unset (origin) `targetPosition` — so the orbit radius (~2.02) and home both follow the new placement, no manipulator changes needed.
- Demos that supply their own `cameraNode` (ModelViewer, Physics, DoublePendulum, …) are unaffected. Demos relying on the bare default (`GeometryDemo`, `CameraControlsDemo`, `AnimationDemo`, `ReflectionProbesDemo`) get the improved framing for free.

Position exposed as `DefaultCameraNode.DEFAULT_Y` / `DEFAULT_Z`.

## Tests

- New `SceneFactoriesTest.defaultCameraNodePositionIsPinned()` — pins `DEFAULT_Y`/`DEFAULT_Z` (pure-JVM; render-output tests are `@Ignore`'d on SwiftShader CI). Pattern matches the existing IBL-intensity pins.
- `:sceneview:test` + `:arsceneview:testDebugUnitTest` — all green incl. the new pin (4/4 in `SceneFactoriesTest`).

## Verification

- `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` ✅
- `./gradlew :sceneview:test :arsceneview:testDebugUnitTest` ✅
- `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- **Visual QA** on the reusable Pixel_7a ARCore emulator — Geometry Primitives renders centered with the new `(0, 0.3, 2)` 3/4 view + soft PBR shading from the rebalanced 10k IBL; Model Viewer hero (Damaged Helmet) shows correct, non-washed-out PBR. Screenshots at `tools/qa-screenshots/android/issue-1074/`.

## Cross-platform

iOS is already correct for all umbrella bugs (`provisionLightSlot` reactivity, `AREnvironmentProbeAnchor` ambient, set-once `colorGrading`, `[0, 0.3, 2]` camera). This PR brings the Android camera default **to** iOS — no iOS mirror needed. Bug 10 (#1306) is the one remaining Android-vs-iOS parity gap.

## Test plan

- [ ] CI green (compile + unit tests)
- [ ] Default-camera demos (Geometry Primitives, Camera Controls) frame content centered out of the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)