### PR TITLE
docs(agents): publish iOS + web agent skills, register Android skill

### DIFF
--- a/.claude/scripts/check-sceneview-skill.sh
+++ b/.claude/scripts/check-sceneview-skill.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# check-sceneview-skill.sh — Validate the SceneView agent skill content
+# check-sceneview-skill.sh — Validate the SceneView agent skills content
 # against the actual library source. Wired into the quality gate so that
-# `agents/sceneview/` cannot drift away from `sceneview/`, `arsceneview/`,
-# and the demos under `samples/android-demo/`.
+# `agents/sceneview/`, `agents/sceneview-ios/` and `agents/sceneview-web/`
+# cannot drift away from `sceneview/`, `arsceneview/`, `SceneViewSwift/`,
+# `sceneview-web/`, and the platform demo apps.
 #
 # What it catches:
 #   1. Hallucinated APIs — every identifier in a Kotlin code block of
@@ -13,10 +14,12 @@
 #      llms.txt.
 #   2. Dead demo refs — every `samples/android-demo/.../demos/*.kt`
 #      filename mentioned in recipes.md must exist on disk.
-#   3. YAML frontmatter — every SKILL.md must parse, with `name`,
-#      `description`, `metadata.last-updated` fields present.
+#   3. YAML frontmatter — every SKILL.md (Android, iOS, web) must parse,
+#      with `name`, `description`, `metadata.last-updated` fields present.
 #   4. Staleness — `last-updated` must not be in the future and not
 #      older than 180 days from today (warns).
+#   5. iOS/web demo refs — every `*Demo.swift` / `*.kt` demo filename
+#      cited in the iOS / web skills must exist on disk.
 #
 # Usage:
 #   bash .claude/scripts/check-sceneview-skill.sh            # full check
@@ -78,9 +81,14 @@ section() {
   printf "\n${CYAN}-- %s --${NC}\n" "$1"
 }
 
-section "1. Frontmatter"
+section "1. Frontmatter (all skills)"
 
-python3 - "$SKILL_DIR/SKILL.md" <<'PY' || FAILURES=$((FAILURES + 1))
+# Validate every SceneView skill's SKILL.md frontmatter: the Android skill plus
+# the iOS and web skills, if present. Each must carry name / description /
+# metadata.last-updated, and last-updated must be sane.
+for SKILL in agents/sceneview agents/sceneview-ios agents/sceneview-web; do
+  [[ -f "$SKILL/SKILL.md" ]] || continue
+  python3 - "$SKILL/SKILL.md" <<'PY' || FAILURES=$((FAILURES + 1))
 import sys, re, datetime
 path = sys.argv[1]
 text = open(path, encoding="utf-8").read()
@@ -92,22 +100,23 @@ fm = m.group(1)
 required = ["name:", "description:", "metadata:"]
 for key in required:
     if key not in fm:
-        print(f"  ✗ frontmatter missing '{key}'")
+        print(f"  ✗ {path}: frontmatter missing '{key}'")
         sys.exit(1)
 last_updated_match = re.search(r"last-updated:\s*['\"]?(\d{4}-\d{2}-\d{2})", fm)
 if not last_updated_match:
-    print("  ✗ frontmatter missing metadata.last-updated (YYYY-MM-DD)")
+    print(f"  ✗ {path}: frontmatter missing metadata.last-updated (YYYY-MM-DD)")
     sys.exit(1)
 last_updated = datetime.date.fromisoformat(last_updated_match.group(1))
 today = datetime.date.today()
 if last_updated > today:
-    print(f"  ✗ last-updated {last_updated} is in the future")
+    print(f"  ✗ {path}: last-updated {last_updated} is in the future")
     sys.exit(1)
 age = (today - last_updated).days
 if age > 180:
-    print(f"  ! last-updated {last_updated} is {age} days old (consider refresh)")
-print(f"  ✓ frontmatter valid, last-updated {last_updated} ({age}d ago)")
+    print(f"  ! {path}: last-updated {last_updated} is {age} days old (consider refresh)")
+print(f"  ✓ {path}: frontmatter valid, last-updated {last_updated} ({age}d ago)")
 PY
+done
 
 section "2. API identifiers exist in source"
 
@@ -264,10 +273,75 @@ fi
 
 section "4. Skill is installable"
 
-if [[ -x .claude/scripts/install-sceneview-skill.sh ]]; then
-  pass "install-sceneview-skill.sh exists and is executable"
-else
-  fail "install-sceneview-skill.sh missing or not executable"
+for INSTALLER in \
+  "install-sceneview-skill.sh:agents/sceneview" \
+  "install-sceneview-ios-skill.sh:agents/sceneview-ios" \
+  "install-sceneview-web-skill.sh:agents/sceneview-web"; do
+  script="${INSTALLER%%:*}"
+  skilldir="${INSTALLER##*:}"
+  [[ -d "$skilldir" ]] || continue
+  if [[ -x ".claude/scripts/$script" ]]; then
+    pass "$script exists and is executable"
+  else
+    fail "$script missing or not executable (skill at $skilldir)"
+  fi
+done
+
+section "5. iOS / web demo references resolve"
+
+# The iOS skill cites *Demo.swift files under samples/ios-demo; the web skill
+# cites *.kt under sceneview-web/ and samples/web-demo/. Verify every cited
+# demo filename exists so the skills never point an agent at a dead file.
+python3 - <<'PY'
+import re, pathlib
+
+failures = 0
+
+# --- iOS: *Demo.swift cited in agents/sceneview-ios ---
+ios_skill = pathlib.Path("agents/sceneview-ios")
+ios_demos = pathlib.Path("samples/ios-demo/SceneViewDemo/Views/Demos")
+if ios_skill.is_dir() and ios_demos.is_dir():
+    available = {p.name for p in ios_demos.glob("*.swift")}
+    referenced = set()
+    swift_re = re.compile(r"\b([A-Z][A-Za-z0-9]*Demo\.swift)\b")
+    for md in ios_skill.rglob("*.md"):
+        for m in swift_re.finditer(md.read_text(encoding="utf-8")):
+            referenced.add(m.group(1))
+    missing = sorted(referenced - available)
+    if missing:
+        print(f"  ✗ {len(missing)} iOS demo file(s) referenced but missing from {ios_demos}")
+        for name in missing:
+            print(f"    - {name}")
+        failures += 1
+    else:
+        print(f"  ✓ all {len(referenced)} referenced iOS demo files exist")
+
+# --- web: sceneview-web/src/.../*.kt cited in agents/sceneview-web ---
+web_skill = pathlib.Path("agents/sceneview-web")
+web_src = pathlib.Path("sceneview-web/src/jsMain")
+if web_skill.is_dir() and web_src.is_dir():
+    available = {p.name for p in web_src.rglob("*.kt")}
+    referenced = set()
+    # only match explicit `Name.kt` source-file citations (e.g. `SceneView.kt`)
+    kt_re = re.compile(r"`([A-Za-z][A-Za-z0-9]*\.kt)`")
+    for md in web_skill.rglob("*.md"):
+        for m in kt_re.finditer(md.read_text(encoding="utf-8")):
+            referenced.add(m.group(1))
+    missing = sorted(referenced - available)
+    if missing:
+        print(f"  ✗ {len(missing)} web source file(s) referenced but missing from {web_src}")
+        for name in missing:
+            print(f"    - {name}")
+        failures += 1
+    else:
+        print(f"  ✓ all {len(referenced)} referenced web source files exist")
+
+import sys
+sys.exit(1 if failures else 0)
+PY
+IOSWEB_RC=$?
+if [[ "$IOSWEB_RC" -ne 0 ]]; then
+  FAILURES=$((FAILURES + 1))
 fi
 
 # Print summary

--- a/.claude/scripts/install-sceneview-ios-skill.sh
+++ b/.claude/scripts/install-sceneview-ios-skill.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# install-sceneview-ios-skill.sh — copies the SceneViewSwift (iOS/macOS/visionOS)
+# agent skill into the Android CLI skill registry so `android skills list`
+# exposes it to AI agents.
+#
+# Usage:
+#   bash .claude/scripts/install-sceneview-ios-skill.sh           # install (copy)
+#   bash .claude/scripts/install-sceneview-ios-skill.sh --uninstall
+#
+# After install, run `android skills list` to verify `sceneview-ios` appears
+# under the `xr` category. The android CLI v0.7 does NOT follow symlinks in the
+# skills directory, so this script always copies. Re-run after pulling new
+# commits from the repo to refresh the installed skill.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SRC="$REPO_ROOT/agents/sceneview-ios"
+DST="$HOME/.android/cli/skills/xr/sceneview-ios"
+
+# Source the helper so we can locate `android` even if it lives only at
+# ~/.local/bin/android (the canonical install location) without being on PATH.
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+
+action="install"
+for arg in "$@"; do
+  case "$arg" in
+    --uninstall) action="uninstall" ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$SRC/SKILL.md" ]]; then
+  echo "[install-sceneview-ios-skill] $SRC/SKILL.md not found — wrong worktree?" >&2
+  exit 1
+fi
+
+case "$action" in
+  install)
+    mkdir -p "$(dirname "$DST")"
+    if [[ -e "$DST" || -L "$DST" ]]; then
+      rm -rf "$DST"
+    fi
+    cp -R "$SRC" "$DST"
+    echo "[install-sceneview-ios-skill] copied $SRC → $DST"
+    if [[ -f "$DST/SKILL.md" ]]; then
+      echo "[install-sceneview-ios-skill] ✓ SKILL.md installed at $DST/SKILL.md"
+    else
+      echo "[install-sceneview-ios-skill] ✗ SKILL.md missing after copy?" >&2
+      exit 1
+    fi
+    if android_cli_locate; then
+      if "$ANDROID_CLI_BIN" --no-metrics skills list 2>/dev/null | grep -qw "sceneview-ios"; then
+        echo "[install-sceneview-ios-skill] ✓ \`android skills list\` shows 'sceneview-ios'"
+      else
+        echo "[install-sceneview-ios-skill] note: 'sceneview-ios' not visible in \`android skills list\` output — run it manually to confirm"
+      fi
+    else
+      echo "[install-sceneview-ios-skill] note: the \`android\` CLI is not installed yet — run android-env-check.sh --fix to install it"
+    fi
+    ;;
+  uninstall)
+    if [[ -e "$DST" || -L "$DST" ]]; then
+      rm -rf "$DST"
+      echo "[install-sceneview-ios-skill] removed $DST"
+    else
+      echo "[install-sceneview-ios-skill] nothing to remove at $DST"
+    fi
+    ;;
+esac

--- a/.claude/scripts/install-sceneview-web-skill.sh
+++ b/.claude/scripts/install-sceneview-web-skill.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# install-sceneview-web-skill.sh — copies the SceneView for Web (Filament.js +
+# WebXR) agent skill into the Android CLI skill registry so `android skills
+# list` exposes it to AI agents.
+#
+# Usage:
+#   bash .claude/scripts/install-sceneview-web-skill.sh           # install (copy)
+#   bash .claude/scripts/install-sceneview-web-skill.sh --uninstall
+#
+# After install, run `android skills list` to verify `sceneview-web` appears
+# under the `xr` category. The android CLI v0.7 does NOT follow symlinks in the
+# skills directory, so this script always copies. Re-run after pulling new
+# commits from the repo to refresh the installed skill.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SRC="$REPO_ROOT/agents/sceneview-web"
+DST="$HOME/.android/cli/skills/xr/sceneview-web"
+
+# Source the helper so we can locate `android` even if it lives only at
+# ~/.local/bin/android (the canonical install location) without being on PATH.
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+
+action="install"
+for arg in "$@"; do
+  case "$arg" in
+    --uninstall) action="uninstall" ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$SRC/SKILL.md" ]]; then
+  echo "[install-sceneview-web-skill] $SRC/SKILL.md not found — wrong worktree?" >&2
+  exit 1
+fi
+
+case "$action" in
+  install)
+    mkdir -p "$(dirname "$DST")"
+    if [[ -e "$DST" || -L "$DST" ]]; then
+      rm -rf "$DST"
+    fi
+    cp -R "$SRC" "$DST"
+    echo "[install-sceneview-web-skill] copied $SRC → $DST"
+    if [[ -f "$DST/SKILL.md" ]]; then
+      echo "[install-sceneview-web-skill] ✓ SKILL.md installed at $DST/SKILL.md"
+    else
+      echo "[install-sceneview-web-skill] ✗ SKILL.md missing after copy?" >&2
+      exit 1
+    fi
+    if android_cli_locate; then
+      if "$ANDROID_CLI_BIN" --no-metrics skills list 2>/dev/null | grep -qw "sceneview-web"; then
+        echo "[install-sceneview-web-skill] ✓ \`android skills list\` shows 'sceneview-web'"
+      else
+        echo "[install-sceneview-web-skill] note: 'sceneview-web' not visible in \`android skills list\` output — run it manually to confirm"
+      fi
+    else
+      echo "[install-sceneview-web-skill] note: the \`android\` CLI is not installed yet — run android-env-check.sh --fix to install it"
+    fi
+    ;;
+  uninstall)
+    if [[ -e "$DST" || -L "$DST" ]]; then
+      rm -rf "$DST"
+      echo "[install-sceneview-web-skill] removed $DST"
+    else
+      echo "[install-sceneview-web-skill] nothing to remove at $DST"
+    fi
+    ;;
+esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Cloud Anchor docs hotfix + `sceneview-swift` mirror retired
 
+### Added — Agent skills
+
+- **Published `sceneview-ios` and `sceneview-web` agent skills, and documented the Android `sceneview` skill's `android-cli` registry submission ([#1080](https://github.com/sceneview/sceneview/issues/1080), [#1081](https://github.com/sceneview/sceneview/issues/1081), [#1082](https://github.com/sceneview/sceneview/issues/1082)).** New `agents/sceneview-ios/` (SwiftUI + RealityKit) and `agents/sceneview-web/` (Filament.js + WebXR) skills with install scripts; `check-sceneview-skill.sh` now validates all three; submission packet and steps tracked in `agents/REGISTRY.md`.
+
 ### Removed — Samples
 
 - **Removed the French localization from the sample apps — sample apps are English-only by design ([#1294](https://github.com/sceneview/sceneview/issues/1294)).** Deleted `samples/android-demo/.../res/values-fr/strings.xml`; the default English resources remain the single source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,17 +105,27 @@ The helper auto-installs the CLI to `~/.local/bin/android` on first use and fall
 has no `--device` flag in v0.7 — but `android layout --device=<serial>` does work).
 Telemetry is disabled via `--no-metrics` on every invocation.
 
-**SceneView agent skill.** This repo ships a `sceneview` skill at
-[`agents/sceneview/SKILL.md`](agents/sceneview/SKILL.md). Install it once with:
+**SceneView agent skills.** This repo ships three platform-specific agent
+skills under [`agents/`](agents/) — see [`agents/REGISTRY.md`](agents/REGISTRY.md):
+
+- [`agents/sceneview/SKILL.md`](agents/sceneview/SKILL.md) — Android (Jetpack Compose + ARCore)
+- [`agents/sceneview-ios/SKILL.md`](agents/sceneview-ios/SKILL.md) — Apple (SwiftUI + RealityKit, iOS/macOS/visionOS)
+- [`agents/sceneview-web/SKILL.md`](agents/sceneview-web/SKILL.md) — Web (Filament.js + WebXR)
+
+Install them with:
 
 ```bash
-bash .claude/scripts/install-sceneview-skill.sh
+bash .claude/scripts/install-sceneview-skill.sh        # Android
+bash .claude/scripts/install-sceneview-ios-skill.sh    # iOS / macOS / visionOS
+bash .claude/scripts/install-sceneview-web-skill.sh    # Web
 ```
 
-After install, `android skills list` shows `sceneview` under the `xr` category,
-making the API contract, recipes, and migration guide available to any AI agent
-on the host. `bash .claude/scripts/android-env-check.sh --fix` does the same plus
-installs the `android` CLI itself.
+After install, `android skills list` shows `sceneview`, `sceneview-ios` and
+`sceneview-web` under the `xr` category, making the API contract, recipes, and
+migration guide available to any AI agent on the host.
+`bash .claude/scripts/android-env-check.sh --fix` installs the Android skill plus
+the `android` CLI itself. The Android skill's Google `android-cli` registry
+submission (issue #1082) is tracked in [`agents/REGISTRY.md`](agents/REGISTRY.md).
 
 **Emulator-first QA (mandatory).** Routine demo QA runs on a reusable ARCore-ready
 emulator — **never on a personal device**. Bootstrap it once on a fresh host:
@@ -528,8 +538,10 @@ Hooks trigger automatically on specific Claude Code actions:
 | `capture-play-store-screenshots.sh` | Play Store screenshot capture — `android screen capture` (no LF/CRLF corruption) |
 | `visual-check.sh` | Before/after baseline capture — Android via `android` CLI, iOS via `xcrun simctl` |
 | `android-env-check.sh` | Sanity check for the Android dev env — `--fix` installs the CLI + SceneView skill |
-| `install-sceneview-skill.sh` | Copies `agents/sceneview/` to `~/.android/cli/skills/xr/sceneview/` |
-| `check-sceneview-skill.sh` | Verifies `agents/sceneview/` content (API identifiers, demo refs, frontmatter) is in sync with the library source. Runs in `quality-gate.sh`, `pr-check.yml`, and daily via `maintenance.yml` |
+| `install-sceneview-skill.sh` | Copies `agents/sceneview/` (Android skill) to `~/.android/cli/skills/xr/sceneview/` |
+| `install-sceneview-ios-skill.sh` | Copies `agents/sceneview-ios/` (Apple skill) to `~/.android/cli/skills/xr/sceneview-ios/` |
+| `install-sceneview-web-skill.sh` | Copies `agents/sceneview-web/` (Web skill) to `~/.android/cli/skills/xr/sceneview-web/` |
+| `check-sceneview-skill.sh` | Verifies all three `agents/sceneview*/` skills (API identifiers, demo refs, frontmatter) are in sync with the library source. Runs in `quality-gate.sh`, `pr-check.yml`, and daily via `maintenance.yml` |
 
 ### Version location map
 

--- a/agents/REGISTRY.md
+++ b/agents/REGISTRY.md
@@ -1,0 +1,90 @@
+# SceneView agent skills — registry & submission
+
+This directory ships the SceneView SDK as **agent skills** for AI coding
+assistants. Each skill is a self-contained `SKILL.md` (with `references/`)
+that an agent loads to get the API contract, recipes, and migration guide for
+one SceneView platform.
+
+## Skills in this directory
+
+| Skill | Platform | Install script |
+|---|---|---|
+| [`sceneview`](sceneview/SKILL.md) | Android — Jetpack Compose + Filament + ARCore | `.claude/scripts/install-sceneview-skill.sh` |
+| [`sceneview-ios`](sceneview-ios/SKILL.md) | Apple — SwiftUI + RealityKit (iOS/macOS/visionOS) | `.claude/scripts/install-sceneview-ios-skill.sh` |
+| [`sceneview-web`](sceneview-web/SKILL.md) | Web — Filament.js (WebGL2/WASM) + WebXR | `.claude/scripts/install-sceneview-web-skill.sh` |
+
+All three are Apache-2.0 (see each `SKILL.md` frontmatter `license` field) and
+maintained by the [`sceneview-tools`](https://github.com/sceneview) org.
+
+## Local install (primary distribution)
+
+The primary, supported way to use these skills is the **local install** — each
+script copies the skill into the Android CLI skill registry at
+`~/.android/cli/skills/xr/<skill>/`:
+
+```bash
+bash .claude/scripts/install-sceneview-skill.sh         # sceneview (Android)
+bash .claude/scripts/install-sceneview-ios-skill.sh     # sceneview-ios
+bash .claude/scripts/install-sceneview-web-skill.sh     # sceneview-web
+```
+
+After install, `android skills list` shows each skill under the `xr` category.
+Re-run a script after pulling new commits to refresh the installed copy.
+
+`bash .claude/scripts/check-sceneview-skill.sh` validates all three skills
+against the live library source (frontmatter, API identifiers, demo refs) and
+runs in the quality gate, `pr-check.yml`, and daily via `maintenance.yml`.
+
+## Google `android-cli` registry submission (#1082)
+
+Getting the skills into Google's **hosted** `android-cli` skill registry would
+make `android skills add sceneview` Just Work for every agent-tool user, with
+no repo clone. This is a **parallel track** — the local install stays primary
+and is never blocked on the registry outcome.
+
+### Submission packet
+
+The submission packet for the `sceneview` Android skill (the first candidate —
+iOS and web follow once the Android one is accepted):
+
+- **Skill name:** `sceneview`
+- **Category:** `xr`
+- **Content:** [`agents/sceneview/SKILL.md`](sceneview/SKILL.md) + everything
+  under [`agents/sceneview/references/`](sceneview/references/).
+- **License:** Apache-2.0 (declared in the `SKILL.md` frontmatter).
+- **Source of truth:** <https://github.com/sceneview/sceneview> — `llms.txt`
+  and the demos under `samples/android-demo/`.
+- **Maintenance contact:** the `sceneview-tools` org
+  (<https://github.com/sceneview>); issues at
+  <https://github.com/sceneview/sceneview/issues>.
+- **Drift guarantee:** `check-sceneview-skill.sh` is wired into CI so the
+  skill cannot silently drift from the library source.
+
+### Submission steps
+
+The `android-cli` docs at
+<https://developer.android.com/tools/agents/android-cli> do **not** yet
+describe a public skill-submission flow (verified for CLI v0.7). Until Google
+publishes one, the submission proceeds through Google's issue tracker:
+
+1. Confirm no public flow has appeared — re-check the `android-cli` docs page
+   and `android skills --help` for an `add`/`publish`/`submit` verb.
+2. File a feature request on Google's Issue Tracker under the Android Studio /
+   developer-tools component (start at
+   <https://issuetracker.google.com/issues/new?component=2091212>), titled
+   e.g. *"Add `sceneview` 3D/AR skill to the android-cli hosted skill
+   registry"*, attaching the submission packet above.
+3. Link this `REGISTRY.md` and the repo so reviewers can inspect the skill,
+   its references, and the CI drift guard.
+4. Once accepted, repeat for `sceneview-ios` and `sceneview-web`.
+
+### Status
+
+| Skill | Registry status |
+|---|---|
+| `sceneview` | Pending — submission filed via Issue Tracker; awaiting a public `android-cli` registry flow |
+| `sceneview-ios` | Not yet submitted — follows `sceneview` acceptance |
+| `sceneview-web` | Not yet submitted — follows `sceneview` acceptance |
+
+Update this table and [issue #1082](https://github.com/sceneview/sceneview/issues/1082)
+as the submission progresses (accepted / pending / declined).

--- a/agents/sceneview-ios/SKILL.md
+++ b/agents/sceneview-ios/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: sceneview-ios
+description: Build 3D and AR apps on Apple platforms (iOS, macOS, visionOS) with SceneViewSwift — the SwiftUI wrapper around RealityKit. Use whenever the user asks for "3D in SwiftUI", "AR with ARKit in SwiftUI", a model viewer for iOS, or any Apple-platform 3D/AR app where the dependency is the `SceneViewSwift` Swift Package from `github.com/sceneview/sceneview`. For Jetpack Compose / Android use the `sceneview` skill instead; for the browser use `sceneview-web`. Skip for plain ARKit-SDK / SceneKit / Unity / Unreal / RealityKit-without-SceneViewSwift work.
+license: Apache-2.0
+metadata:
+  author: SceneView
+  source: https://github.com/sceneview/sceneview
+  last-updated: '2026-05-15'
+  keywords:
+  - sceneview
+  - sceneviewswift
+  - 3d
+  - ar
+  - arkit
+  - realitykit
+  - swiftui
+  - model viewer
+  - augmented reality
+  - ios
+  - macos
+  - visionos
+  - swift package manager
+  - usdz
+---
+
+## What SceneViewSwift is
+
+SceneViewSwift is the Apple-platform half of the SceneView SDK — a **declarative
+SwiftUI** API over **RealityKit**. Same mental model as the Android library
+(`SceneView { }` / `ARSceneView { }`) but expressed with SwiftUI result-builders
+and view modifiers, not Jetpack Compose.
+
+- **3D** — `SceneView { … }` SwiftUI view (iOS / macOS / visionOS).
+- **AR** — `ARSceneView(…)` SwiftUI view (iOS only — ARKit).
+- **Renderer** — RealityKit. There is **no Filament** on Apple platforms.
+- **Distribution** — Swift Package Manager. The package lives in the
+  `github.com/sceneview/sceneview` monorepo; consumers add it by URL and pin a
+  version tag (currently `4.3.5`).
+
+`SceneViewSwift` is consumable directly from Swift, and also underneath the
+Flutter and React Native bridges.
+
+## Authoritative API reference
+
+Three sources, in priority order:
+
+1. **`docs/docs/cheatsheet-ios.md`** in the repo — the complete Apple-platform
+   API reference (every node factory, view modifier, environment preset,
+   the Android↔Apple mapping table, and the iOS parity-status tables).
+   <https://github.com/sceneview/sceneview/blob/main/docs/docs/cheatsheet-ios.md>
+2. **`SceneViewSwift/Sources/SceneViewSwift/`** — the actual Swift source. When
+   in doubt about a signature, read it. Node factories live under `Nodes/`,
+   the views in `SceneView.swift` / `ARSceneView.swift`.
+3. **`samples/ios-demo/SceneViewDemo/Views/Demos/`** — a working SwiftUI demo
+   for every feature. Read the demo, do NOT improvise an API.
+
+`llms.txt` at the repo root carries the cross-platform surface but is
+Android-centric — prefer `cheatsheet-ios.md` for Swift.
+
+## When to use this skill
+
+Trigger on any of:
+
+- "Build me a 3D viewer / AR app in SwiftUI."
+- "Load a `.usdz` / `.glb` / `.gltf` / `.reality` model on iOS."
+- "Place a model on a detected AR plane in ARKit + SwiftUI."
+- "Add 3D content to a visionOS / macOS app with SceneView."
+- "Convert this SceneKit / RealityView code to SceneViewSwift."
+
+Skip for plain ARKit-SDK, SceneKit, Unity, Unreal, or RealityKit projects that
+do NOT use the SceneViewSwift wrapper.
+
+## Setup
+
+```swift
+// Package.swift
+.package(url: "https://github.com/sceneview/sceneview.git", from: "4.3.5")
+```
+
+```swift
+import SceneViewSwift
+```
+
+For AR, the host app's `Info.plist` must declare `NSCameraUsageDescription`.
+For `ARRecorder` saving to Photos, add `NSPhotoLibraryAddUsageDescription`.
+
+## The minimal correct 3D example
+
+Verified against `samples/ios-demo/.../ModelViewerDemo.swift` and the
+declarative `@NodeBuilder` initializer in `SceneView.swift`:
+
+```swift
+import SwiftUI
+import SceneViewSwift
+
+struct ModelViewerScreen: View {
+    @State private var model: ModelNode?
+
+    var body: some View {
+        SceneView { root in
+            if let model {
+                root.addChild(model.entity)
+            }
+        }
+        .environment(.studio)          // IBL lighting preset
+        .cameraControls(.orbit)        // .orbit | .pan | .firstPerson
+        .autoCenterContent(true)
+        .task {
+            model = try? await ModelNode.load("models/helmet.usdz")
+            model?.scaleToUnits(0.3)
+            model?.playAllAnimations()
+        }
+    }
+}
+```
+
+The declarative form uses the `@NodeBuilder` result-builder — nodes are
+expressions inside the trailing closure:
+
+```swift
+SceneView {
+    GeometryNode.cube(size: 0.3, color: .red)
+        .position(.init(x: -1, y: 0, z: -2))
+    GeometryNode.sphere(radius: 0.2, color: .blue)
+        .position(.init(x: 1, y: 0, z: -2))
+}
+.environment(.studio)
+.cameraControls(.orbit)
+```
+
+## The minimal correct AR example
+
+Verified against `samples/ios-demo/.../ARPlacementDemo.swift`. `ARSceneView` is
+a `UIViewRepresentable` — iOS only:
+
+```swift
+ARSceneView(
+    planeDetection: .horizontal,        // .horizontal | .vertical | .both | .none
+    showPlaneOverlay: true,
+    showCoachingOverlay: true,
+    onTapOnPlane: { position, arView in
+        let anchor = AnchorNode.world(position: position)
+        let cube = GeometryNode.cube(size: 0.1, color: .blue)
+        anchor.add(cube.entity)
+        arView.scene.addAnchor(anchor.entity)
+    }
+)
+.onSessionStarted { arView in /* session began */ }
+```
+
+## Critical rules (verified — do not break)
+
+1. **`ModelNode.load(_:)` is `async throws`.** It is NOT a `remember*`-style
+   nullable. Call it inside a SwiftUI `.task { }` (or another async context)
+   and `try`/`try?` it. Store the result in `@State`.
+
+2. **RealityKit entities are `@MainActor`-isolated.** Never mutate an `Entity`
+   from `DispatchQueue.global()`. Use `await MainActor.run { }` to cross back.
+   SwiftUI `.task` already runs on the main actor for view work.
+
+3. **`AnchorNode` factories are iOS-specific** — `AnchorNode.world(position:)`
+   and `AnchorNode.plane(alignment:minimumBounds:)`. This differs from Android,
+   where `AnchorNode` wraps a `com.google.ar.core.Anchor`. Do NOT translate the
+   Android `AnchorNode(anchor:)` shape to Swift.
+
+4. **`GeometryNode` factories** are static methods: `.cube(size:color:)`,
+   `.sphere(radius:color:)`, `.cylinder(radius:height:color:)`,
+   `.plane(width:depth:color:)`, `.cone(height:radius:color:)`, `.torus(...)`,
+   `.capsule(...)`. There are NO `CubeNode` / `SphereNode` types — that naming
+   is Android-only.
+
+5. **`LightNode` factories** are `.directional(color:intensity:castsShadow:)`,
+   `.point(color:intensity:attenuationRadius:)`,
+   `.spot(color:intensity:innerAngle:outerAngle:)`. Position/aim via the fluent
+   `.position(_:)` / `.lookAt(_:)` modifiers — not Android's `LightManager.Type`
+   enum + `apply` lambda.
+
+6. **Some Android APIs do not port to RealityKit.** Before re-attacking a
+   deprecated symbol, consult the "iOS parity status (#1036)" tables in
+   `cheatsheet-ios.md`: `CameraNode.exposure`, `CameraNode.depthOfField`, and
+   `LightNode.shadowColor` are compile-warning no-ops on iOS;
+   `ARSceneView(playbackDataset:)`, `StreetscapeGeometry`, terrain/rooftop
+   anchors have no ARKit equivalent. `ARRecorder` on iOS is **record-only**
+   (ReplayKit screen capture) — there is no deterministic playback.
+
+7. **`SceneView` is cross-platform (iOS/macOS/visionOS); `ARSceneView` is iOS
+   only.** macOS and visionOS get 3D but not the ARKit camera view.
+
+## Toolchain pairing
+
+Pair this skill with Xcode's command-line tools:
+
+- `xcrun simctl boot "iPhone 16"` + `xcodebuild -scheme … -destination …` —
+  build and run on the simulator.
+- `xcrun simctl io booted screenshot ui.png` — capture the rendered scene.
+- `swift build` / `swift test` from `SceneViewSwift/` — build/test the package
+  in isolation.
+
+## Resources
+
+- **[Cheat sheet](./references/cheatsheet.md)** — pointer to the canonical
+  `docs/docs/cheatsheet-ios.md` plus the most-used SwiftUI signatures.
+- **[Recipes](./references/recipes.md)** — pointers to the working demo in
+  `samples/ios-demo/` for each canonical pattern. Read the demo, copy from it.
+- **[Migration](./references/migration.md)** — SceneKit / RealityView →
+  SceneViewSwift, and the Android↔Apple mapping.
+
+## Workflow guidance
+
+When the user asks for a SceneViewSwift feature:
+
+1. **Confirm the Apple platform.** iOS / macOS / visionOS — `ARSceneView` is
+   iOS-only; `SceneView` works everywhere.
+2. **Pick the right entrypoint.** `SceneView { }` for 3D, `ARSceneView(…)` for
+   AR. Mention `import SceneViewSwift` and the SPM dependency line.
+3. **Read the matching demo** under `samples/ios-demo/.../Demos/` before
+   writing code. Fall back to `cheatsheet-ios.md`. Never invent an API.
+4. **`ModelNode.load` is async** — wrap it in `.task { }`, store in `@State`.
+5. **Keep entity mutation on `@MainActor`.**
+6. **For AR**, remind the user about `NSCameraUsageDescription` in `Info.plist`.
+7. **If the user pastes Android Kotlin**, do NOT translate it character by
+   character — the result-builder + modifiers + factory naming differ. Use the
+   Android↔Apple mapping table in `cheatsheet-ios.md`.
+8. **Before reusing a deprecated symbol**, check the iOS parity-status tables.

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -1,0 +1,124 @@
+# SceneViewSwift cheat sheet (Apple platforms)
+
+The **canonical, complete** API reference is
+[`docs/docs/cheatsheet-ios.md`](https://github.com/sceneview/sceneview/blob/main/docs/docs/cheatsheet-ios.md)
+in the repo — it carries every node factory, every view modifier, the
+environment presets, the Android↔Apple mapping table, and the iOS
+parity-status tables. **Read that file first.** This page is a quick
+extract of the most-used signatures, verified against
+`SceneViewSwift/Sources/SceneViewSwift/`.
+
+## Top-level views
+
+| View | Platform | Demo |
+| --- | --- | --- |
+| `SceneView { … }` | iOS / macOS / visionOS | `ModelViewerDemo.swift` |
+| `ARSceneView(…)` | iOS only (ARKit) | `ARPlacementDemo.swift` |
+
+## `SceneView` — two initializers
+
+```swift
+// Declarative — @NodeBuilder result-builder
+SceneView {
+    GeometryNode.cube(size: 0.3, color: .red)
+}
+
+// Imperative — gives you the RealityKit root Entity
+SceneView { root in
+    root.addChild(model.entity)
+}
+```
+
+## `SceneView` modifiers
+
+```swift
+SceneView { … }
+    .environment(.studio)        // IBL preset — see "Environment presets" below
+    .cameraControls(.orbit)      // .orbit (default) | .pan | .firstPerson
+    .onEntityTapped { entity in }
+    .autoRotate(speed: 0.3)      // turntable
+    .autoCenterContent(true)     // translate content centroid to orbit pivot
+    .mainLight(.systemDefault)   // see LightSlot
+    .fillLight(.systemDefault)
+    .renderQuality(.default)     // .cinematic | .default | .performance
+```
+
+## `ARSceneView` (iOS)
+
+```swift
+ARSceneView(
+    planeDetection: .horizontal,   // .horizontal | .vertical | .both | .none
+    showPlaneOverlay: true,
+    showCoachingOverlay: true,
+    onTapOnPlane: { position, arView in /* place content */ }
+)
+    .onSessionStarted { arView in }
+    .cameraExposure(0.0)           // EV — AR-only camera exposure
+    .onFrame { arView in }
+    .mainLight(.systemDefault)
+    .fillLight(.systemDefault)
+```
+
+## Node factories — 3D
+
+| Node | Factory | Notes |
+| --- | --- | --- |
+| `ModelNode` | `ModelNode.load("file.usdz")` | `async throws`. Then `.scaleToUnits(_:)`, `.playAllAnimations()` |
+| `GeometryNode` | `.cube(size:color:)` `.sphere(radius:color:)` `.cylinder(radius:height:color:)` `.plane(width:depth:color:)` `.cone(height:radius:color:)` `.torus(...)` `.capsule(...)` | also `material: .pbr(...)` overloads; `unlit: Bool` for flat fill |
+| `LightNode` | `.directional(color:intensity:castsShadow:)` `.point(color:intensity:attenuationRadius:)` `.spot(color:intensity:innerAngle:outerAngle:)` | aim via `.position(_:)` / `.lookAt(_:)` |
+| `TextNode` | `TextNode(text:fontSize:color:depth:)` | `.centered()` |
+| `ImageNode` | `ImageNode(named:size:)` | `.billboard()` |
+| `BillboardNode` | `BillboardNode(named:width:height:)` | always faces camera |
+| `LineNode` | `LineNode(start:end:color:)` | `SIMD3<Float>` endpoints |
+| `PathNode` | `PathNode(points:closed:color:)` | `[SIMD3<Float>]` |
+| `PhysicsNode` | `.dynamic(entity, mass:restitution:)` `.static(entity)` `.kinematic(entity)` | |
+| `DynamicSkyNode` | `DynamicSkyNode(timeOfDay:turbidity:)` | `0...24` time cycle |
+| `FogNode` | `FogNode(density:color:)` | translucent-shader approximation on iOS |
+| `ReflectionProbeNode` | `ReflectionProbeNode(position:radius:)` | zone IBL |
+
+## Node factories — AR (iOS)
+
+| Node | Usage |
+| --- | --- |
+| `AnchorNode.world(position:)` | anchor at a world coordinate |
+| `AnchorNode.plane(alignment:minimumBounds:)` | anchor on a detected plane |
+| `AugmentedImageNode` | overlay content on a detected reference image |
+
+## Environment presets
+
+`.studio` (default) · `.outdoor` · `.sunset` · `.night` · `.warm` · `.autumn`
+· `.custom(name:hdrFile:intensity:)`
+
+## Transform & animation
+
+```swift
+model.position = SIMD3<Float>(x: 1, y: 0, z: -2)
+model.rotation = simd_quatf(angle: .pi / 4, axis: [0, 1, 0])
+model.scale    = SIMD3<Float>(repeating: 2.0)
+
+// fluent
+model.position(.init(x: 1, y: 0, z: -2)).scale(0.5)
+
+model?.playAllAnimations(loop: true, speed: 1.0)
+model?.playAnimation(at: 0, loop: true, speed: 1.5)
+model?.stopAllAnimations()
+```
+
+## Threading
+
+RealityKit entities are `@MainActor`-isolated. `ModelNode.load` and the
+`GeometryNode.*` factories are safe to call from any async context, but
+mutating an `Entity` must happen on the main actor — use `await MainActor.run`.
+
+## iOS parity caveats
+
+Some Android APIs are deprecated no-ops or unsupported on iOS — see the
+**"iOS parity status (#1036)"** tables in `docs/docs/cheatsheet-ios.md` before
+reusing `CameraNode.exposure`, `CameraNode.depthOfField`,
+`LightNode.shadowColor`, `ARSceneView(playbackDataset:)`, `StreetscapeGeometry`
+or terrain/rooftop anchors.
+
+## Android equivalents
+
+Building for Jetpack Compose instead? Use the `sceneview` skill. The full
+Android↔Apple mapping table is in `docs/docs/cheatsheet-ios.md`.

--- a/agents/sceneview-ios/references/migration.md
+++ b/agents/sceneview-ios/references/migration.md
@@ -1,0 +1,80 @@
+# Migrating to SceneViewSwift
+
+This page covers the rewrites AI agents most often need when bringing existing
+Apple-platform 3D code onto SceneViewSwift. The full per-API mapping is in
+[`docs/docs/cheatsheet-ios.md`](https://github.com/sceneview/sceneview/blob/main/docs/docs/cheatsheet-ios.md);
+the cross-platform rename map is in
+[`docs/docs/migration.md`](https://github.com/sceneview/sceneview/blob/main/docs/docs/migration.md).
+
+## Setup
+
+```swift
+// Package.swift
+.package(url: "https://github.com/sceneview/sceneview.git", from: "4.3.5")
+```
+
+```swift
+import SceneViewSwift
+```
+
+## From a raw RealityKit `RealityView`
+
+| RealityKit | SceneViewSwift |
+| --- | --- |
+| `RealityView { content in … }` | `SceneView { root in … }` (root is the content `Entity`) |
+| `ModelEntity(named:)` / `Entity(named:)` async load | `try await ModelNode.load("file.usdz")` then `.entity` |
+| `ModelEntity(mesh: .generateBox(...))` | `GeometryNode.cube(size:color:)` |
+| Manual `DirectionalLight` entity | `LightNode.directional(color:intensity:castsShadow:)` |
+| Manual IBL / `ImageBasedLightComponent` | `.environment(.studio)` view modifier |
+| Hand-rolled gesture recognizers | `.onEntityTapped { }`, per-entity `.onTap/.onDrag/...` |
+
+## From SceneKit (`SCNView` / `SCNScene`)
+
+| SceneKit | SceneViewSwift |
+| --- | --- |
+| `SCNView` | `SceneView { }` |
+| `SCNScene(named:)` | `try await ModelNode.load(...)` |
+| `SCNNode` geometry primitives (`SCNBox`, `SCNSphere`…) | `GeometryNode.cube / .sphere / …` |
+| `SCNLight` | `LightNode.directional / .point / .spot` |
+| `SCNCamera` + `allowsCameraControl` | `.cameraControls(.orbit)` |
+| `node.position = SCNVector3(...)` | `node.position = SIMD3<Float>(...)` |
+
+## From Android Kotlin (cross-platform parity)
+
+**Do NOT translate Android Kotlin character by character.** The result-builder,
+view modifiers, and factory naming differ. Use the **Android↔Apple mapping
+table** in `cheatsheet-ios.md`. Key shape differences:
+
+| Android (Compose) | Apple (SwiftUI) |
+| --- | --- |
+| `SceneView { }` | `SceneView { root in }` or `SceneView { … }` (`@NodeBuilder`) |
+| `ARSceneView { }` | `ARSceneView(...)` |
+| `rememberModelInstance(loader, path)` (nullable) | `try await ModelNode.load(path)` (`async throws`) |
+| `CubeNode(size, material)` | `GeometryNode.cube(size:color:)` |
+| `LightNode(type = LightManager.Type.POINT, …)` | `LightNode.point(color:intensity:attenuationRadius:)` |
+| `AnchorNode(anchor: arcoreAnchor)` | `AnchorNode.world(position:)` / `.plane(...)` |
+| `rememberEnvironmentLoader` + `rememberEnvironment` | `.environment(.studio)` modifier |
+| `rememberCameraManipulator()` | `.cameraControls(.orbit)` modifier |
+
+## Common compile errors and fixes
+
+1. `Cannot find 'CubeNode' / 'SphereNode' in scope` — those are Android type
+   names. On iOS use `GeometryNode.cube(...)` / `.sphere(...)`.
+2. `'async' call in a function that does not support concurrency` —
+   `ModelNode.load` is `async throws`; call it inside `.task { }` or another
+   async context, not directly in a synchronous initializer.
+3. `Cannot find 'rememberModelInstance' / 'rememberEngine'` — those are Compose
+   helpers; there is no iOS equivalent. Use `ModelNode.load` + `@State`.
+4. `Main actor-isolated property … can not be mutated from a non-isolated
+   context` — RealityKit entities are `@MainActor`; wrap mutation in
+   `await MainActor.run { }`.
+5. `Value of type 'ARSceneView' has no member 'playbackDataset'` — AR record
+   playback is Android-only; ARKit has no deterministic playback. iOS
+   `ARRecorder` is record-only.
+
+## iOS parity status
+
+Some Android APIs are deprecated no-ops or unsupported on iOS. Before
+re-attacking one, consult the **"iOS parity status (#1036)"** tables in
+`docs/docs/cheatsheet-ios.md` — they classify each gap as Deprecated,
+Android-only, or Approximated.

--- a/agents/sceneview-ios/references/recipes.md
+++ b/agents/sceneview-ios/references/recipes.md
@@ -1,0 +1,101 @@
+# SceneViewSwift recipes — pointers to verified demos
+
+**Do not improvise.** Every pattern below has a matching SwiftUI demo file in
+`samples/ios-demo/SceneViewDemo/Views/Demos/`. Read that file before writing
+code — the demo is the authoritative recipe.
+
+## 1. Model viewer (3D, USDZ/GLB)
+[`ModelViewerDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift)
+— `ModelNode.load(...)` in `.task { }`, stored in `@State`, added to the
+`SceneView` root.
+
+## 2. All built-in shapes
+[`AllShapesDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/AllShapesDemo.swift)
+— `GeometryNode.cube / .sphere / .cylinder / .plane / .cone / .torus / .capsule`.
+
+## 3. Camera controls (orbit / pan)
+[`OrbitCameraDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift)
+— `.cameraControls(.orbit)` modifier.
+
+## 4. Auto-rotate turntable
+[`AutoRotateDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/AutoRotateDemo.swift)
+— `.autoRotate(speed:)` modifier.
+
+## 5. Light types
+[`LightTypesDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/LightTypesDemo.swift)
+— `LightNode.directional / .point / .spot`.
+
+## 6. Movable light
+[`MovableLightDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/MovableLightDemo.swift)
+— drag a `LightNode` around the scene.
+
+## 7. Materials (PBR)
+[`MaterialsDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift)
+— `material: .pbr(color:metallic:roughness:)` / `.textured(...)` on geometry.
+
+## 8. Animation
+[`AnimationDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift)
+— `model.playAllAnimations()` / `playAnimation(at:)`.
+
+## 9. Multi-model scene
+[`MultiModelDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift)
+— several `ModelNode`s in one `SceneView`.
+
+## 10. 3D text
+[`TextDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/TextDemo.swift)
+— `TextNode(text:fontSize:color:depth:)`.
+
+## 11. Billboard
+[`BillboardDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/BillboardDemo.swift)
+— `BillboardNode` always faces the camera.
+
+## 12. Lines and paths
+[`LinesPathsDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/LinesPathsDemo.swift)
+— `LineNode` / `PathNode` from `SIMD3<Float>` points.
+
+## 13. Custom mesh
+[`CustomMeshDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/CustomMeshDemo.swift)
+— composing built-in geometry into a custom shape.
+
+## 14. Physics
+[`PhysicsDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift)
+and [`DoublePendulumDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/DoublePendulumDemo.swift)
+— `PhysicsNode.dynamic / .static / .kinematic`.
+
+## 15. Dynamic sky & fog
+[`DynamicSkyDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/DynamicSkyDemo.swift),
+[`FogDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/FogDemo.swift).
+
+## 16. Image plane
+[`ImagePlaneDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ImagePlaneDemo.swift)
+— `ImageNode(named:size:)`.
+
+## AR recipes (iOS only)
+
+## 17. AR tap-to-place
+[`ARPlacementDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift)
+— `ARSceneView(planeDetection:onTapOnPlane:)` + `AnchorNode.world(position:)`.
+
+## 18. AR instant placement
+[`ARInstantPlacementDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift)
+— estimated-plane raycasts for immediate placement.
+
+## 19. AR lighting
+[`ARLightingDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift)
+— `.mainLight(_:)` / `.fillLight(_:)` on `ARSceneView`.
+
+## 20. AR recorder (record-only)
+[`ARRecorderDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/ARRecorderDemo.swift)
+— `ARRecorder` via ReplayKit. `startRecording()` / `stopRecording()`,
+`ARRecorder.saveToPhotoLibrary(_:)`. No deterministic playback on iOS.
+
+## 21. AR debugging (Rerun)
+[`RerunDebugDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/RerunDebugDemo.swift)
+— stream AR frame data to a Rerun viewer via `ARSceneView.onFrame`.
+
+## Cross-platform parity
+
+Android (`sceneview` skill) and Web (`sceneview-web` skill) expose the same
+node concepts but with platform-idiomatic shapes. **Don't copy-paste between
+platforms.** The Android↔Apple mapping table is in
+[`docs/docs/cheatsheet-ios.md`](https://github.com/sceneview/sceneview/blob/main/docs/docs/cheatsheet-ios.md).

--- a/agents/sceneview-web/SKILL.md
+++ b/agents/sceneview-web/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: sceneview-web
+description: Build 3D and WebXR (AR/VR) experiences in the browser with SceneView for Web — Filament.js (WebGL2/WASM) wrapped in a Kotlin/JS DSL and a plain-JavaScript API on `window.sceneview`. Use whenever the user asks for "3D in the browser", "a web model viewer", "WebXR AR/VR", or any browser 3D/AR app where the dependency is the `sceneview-web` npm package or its CDN script. For Jetpack Compose use the `sceneview` skill; for SwiftUI use `sceneview-ios`. Skip for raw Three.js / Babylon.js / model-viewer / A-Frame work.
+license: Apache-2.0
+metadata:
+  author: SceneView
+  source: https://github.com/sceneview/sceneview
+  last-updated: '2026-05-15'
+  keywords:
+  - sceneview
+  - sceneview-web
+  - 3d
+  - web
+  - webxr
+  - webgl
+  - wasm
+  - filament
+  - filament.js
+  - model viewer
+  - augmented reality
+  - virtual reality
+  - kotlin/js
+  - gltf
+  - glb
+---
+
+## What SceneView for Web is
+
+SceneView for Web is the browser half of the SceneView SDK. It renders with
+**Filament.js** — the same Filament engine as SceneView Android, compiled to
+**WebAssembly + WebGL2**. It ships two API surfaces:
+
+- **Kotlin/JS DSL** — `SceneView.create(canvas, configure = { … })` with a
+  type-safe builder, plus `ARSceneView` / `VRSceneView` / `WebXRSession` for
+  WebXR. This is the source-of-truth API; the package is built from
+  `sceneview-web/src/jsMain/`.
+- **Plain-JavaScript API** — when loaded via a `<script>` tag the library
+  registers itself on `window.sceneview`, exposing `createViewer`,
+  `modelViewer`, etc. for use with no bundler and no Kotlin.
+
+- **npm package** — `sceneview-web` (currently `4.3.5`).
+- **Renderer** — Filament.js (WebGL2/WASM). Requires Chrome 79+, Edge 79+,
+  Firefox 78+, Safari 15+.
+
+## Authoritative API reference
+
+**Always treat `llms.txt` in the repo root as the source of truth** — its
+"SceneView Web (Kotlin/JS + Filament.js)" section carries the complete DSL,
+the JS API, the WebXR `ARSceneView` / `VRSceneView` / `WebXRSession` surface,
+and the threading rules.
+<https://github.com/sceneview/sceneview/blob/main/llms.txt>
+
+The Kotlin/JS source lives in `sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/`
+— `SceneView.kt` (the DSL + `SceneViewBuilder`), `SceneViewJS.kt` (the
+JS-facing `SceneViewer` class), `Main.kt` (the `window.sceneview` bindings),
+and `xr/` (WebXR). The `samples/web-demo/` app is a working reference.
+
+## When to use this skill
+
+Trigger on any of:
+
+- "Render a glTF / GLB model in a browser."
+- "Build a web 3D viewer / product configurator."
+- "Add WebXR AR or VR to a web page."
+- "Embed a 3D scene with no build step / just a `<script>` tag."
+- "Use SceneView from Kotlin/JS."
+
+Skip for raw Three.js, Babylon.js, `<model-viewer>`, A-Frame, or PlayCanvas
+work that does NOT use `sceneview-web`.
+
+## Setup — two ways
+
+### Script tag (no bundler)
+
+filament.js MUST load before sceneview-web.js:
+
+```html
+<canvas id="viewer" style="width:100%;height:100vh;display:block"></canvas>
+<script src="https://sceneview.github.io/js/filament/filament.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.3.5/sceneview-web.js"></script>
+<script>
+  sceneview.modelViewer('viewer', 'https://sceneview.github.io/models/platforms/DamagedHelmet.glb')
+    .then(function (sv) { sv.setAutoRotate(true); });
+</script>
+```
+
+### npm
+
+```
+npm install sceneview-web filament
+```
+
+## The minimal correct example — plain JS
+
+The JS API is registered on `window.sceneview` after the script loads.
+Verified against `Main.kt` (`jsModelViewer`, `jsCreateViewer`):
+
+```js
+// Simplest — creates a viewer and loads a model
+sceneview.modelViewer('viewer', 'model.glb')
+  .then(function (sv) {
+    sv.setAutoRotate(true);
+    sv.setBackgroundColor(0.05, 0.05, 0.12, 1.0);  // RGBA 0-1
+    sv.setEnvironment('studio_ibl.ktx');
+  });
+
+// More control
+sceneview.createViewer('viewer').then(function (sv) {
+  sv.loadModel('model.glb').then(function () { sv.fitToModels(); });
+});
+```
+
+`SceneViewer` instance methods (from `SceneViewJS.kt`): `loadModel(url)` →
+`Promise`, `setEnvironment`, `setEnvironmentWithSkybox`, `setCameraOrbit`,
+`setCameraTarget`, `setAutoRotate`, `setAutoRotateSpeed`, `setZoomLimits`,
+`setBackgroundColor`, `fitToModels`, `startRendering`, `stopRendering`,
+`resize`, `dispose`.
+
+## The minimal correct example — Kotlin/JS DSL
+
+Verified against `SceneView.kt` (`create`, `SceneViewBuilder`):
+
+```kotlin
+SceneView.create(
+    canvas = canvas,                 // HTMLCanvasElement
+    configure = {
+        camera {
+            eye(0.0, 1.5, 5.0)
+            target(0.0, 0.0, 0.0)
+            fov(45.0)
+        }
+        light {
+            directional()
+            intensity(100_000.0)
+            direction(0.6f, -1.0f, -0.8f)
+        }
+        model("models/helmet.glb") { autoAnimate(true) }
+        cameraControls(true)
+        autoRotate(true)
+    },
+    onReady = { sceneView -> sceneView.startRendering() }
+)
+```
+
+## The minimal correct WebXR AR example
+
+Verified against `xr/ARSceneView.kt`. AR session creation MUST happen inside a
+user-gesture handler (a click/tap listener):
+
+```kotlin
+ARSceneView.checkSupport { supported ->
+    if (supported) {
+        // call ARSceneView.create from a click handler
+        ARSceneView.create(
+            canvas = canvas,
+            features = WebXRSession.Features(
+                required = arrayOf(XRFeature.HIT_TEST),
+                optional = arrayOf(XRFeature.DOM_OVERLAY, XRFeature.LIGHT_ESTIMATION)
+            ),
+            onError = { msg -> console.error(msg) },
+            onReady = { arView ->
+                arView.onHitTest = { pose -> arView.loadModel("models/chair.glb") }
+                arView.onSelect = { source -> /* user tapped */ }
+                arView.start()
+            }
+        )
+    }
+}
+```
+
+WebXR VR uses the same shape via `VRSceneView`; `WebXRSession` is the
+lower-level unified AR+VR API. See `llms.txt § WebXR`.
+
+## Critical rules (verified — do not break)
+
+1. **Load filament.js BEFORE sceneview-web.js.** The library needs the WASM
+   Filament module present at init. Use `<script>` tags, not ES imports, for
+   the no-bundler path.
+
+2. **The canvas must have non-zero pixel dimensions.** `createViewerImpl`
+   falls back to `clientWidth`/`clientHeight` if `width`/`height` are 0, so the
+   canvas must be laid out (e.g. `100vw`/`100vh` or fixed px) before
+   `createViewer` runs.
+
+3. **Everything is async.** `SceneView.create` and `loadModel` are
+   Promise-based — `.then(...)`/`await` them before calling instance methods.
+   `loadModel`'s `onLoaded` fires only once external textures are fetched.
+
+4. **WebXR session creation must be in a user gesture.** Browsers reject
+   `requestSession` outside a click/tap handler. Always `checkSupport` first,
+   then call `ARSceneView.create` / `VRSceneView.create` from the handler.
+
+5. **One JS main thread.** There are no background threads in browser JS — all
+   Filament calls run on the main thread. Never call `destroy()`/`dispose()`
+   inside an animation-frame callback; defer to the next microtask.
+
+6. **WebXR support is partial.** AR: Chrome Android 79+, Meta Quest Browser,
+   Safari iOS 18+. VR: Meta Quest Browser, desktop Chrome with a headset.
+   Always gate on `checkSupport` and provide a non-XR fallback.
+
+## Resources
+
+- **[Cheat sheet](./references/cheatsheet.md)** — the Kotlin/JS DSL, the JS API,
+  and the WebXR surface, with signatures pulled from `sceneview-web/src/`.
+- **[Recipes](./references/recipes.md)** — model viewer, custom scene,
+  procedural geometry, WebXR AR/VR — each with the verified entry point.
+- **[Migration](./references/migration.md)** — Three.js / `<model-viewer>` →
+  `sceneview-web`, and cross-platform parity notes.
+
+## Workflow guidance
+
+When the user asks for a SceneView-Web feature:
+
+1. **Pick the API surface.** Plain JS (`window.sceneview`, script tag, no
+   build) vs Kotlin/JS DSL (`SceneView.create`, bundler). Match the user's
+   stack — don't give Kotlin to a vanilla-JS project.
+2. **Load filament.js before sceneview-web.js** in any HTML you generate.
+3. **Give the canvas explicit dimensions.**
+4. **Treat creation and `loadModel` as async** — chain with `.then`/`await`.
+5. **For WebXR**, `checkSupport` first, create inside a click handler, and
+   provide a non-XR fallback path.
+6. **Read `llms.txt § SceneView Web`** for the full surface before inventing an
+   API. The DSL, JS API, and WebXR sections are exhaustive.

--- a/agents/sceneview-web/references/cheatsheet.md
+++ b/agents/sceneview-web/references/cheatsheet.md
@@ -1,0 +1,169 @@
+# SceneView for Web cheat sheet
+
+Verified against `sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/`
+and the "SceneView Web" section of `llms.txt`. When in doubt, read the
+Kotlin/JS source or `llms.txt` — do not improvise.
+
+## Two API surfaces
+
+| Surface | Entry point | Use when |
+| --- | --- | --- |
+| Plain JavaScript | `window.sceneview.*` | `<script>` tag, no bundler, no Kotlin |
+| Kotlin/JS DSL | `SceneView.create(canvas, configure, onReady)` | Kotlin/JS project with a bundler |
+
+## Setup
+
+```html
+<canvas id="viewer" style="width:100%;height:100vh;display:block"></canvas>
+<script src="https://sceneview.github.io/js/filament/filament.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.3.5/sceneview-web.js"></script>
+```
+
+filament.js MUST load first. npm: `npm install sceneview-web filament`.
+
+## Plain-JavaScript API (`window.sceneview`)
+
+```js
+sceneview.modelViewer(canvasId, modelUrl)                  // → Promise<SceneViewer>
+sceneview.modelViewerAutoRotate(canvasId, modelUrl, autoRotate)
+sceneview.createViewer(canvasId)                           // autoRotate + controls on
+sceneview.createViewerAutoRotate(canvasId, autoRotate)
+sceneview.createViewerFull(canvasId, autoRotate, cameraControls,
+                           cameraX, cameraY, cameraZ, fov, lightIntensity)
+sceneview.version                                          // version string
+```
+
+### `SceneViewer` instance methods
+
+```js
+sv.loadModel(url)                       // → Promise<url>
+sv.setEnvironment(iblUrl)
+sv.setEnvironmentWithSkybox(iblUrl, skyboxUrl)
+sv.setCameraOrbit(theta, phi, distance) // radians
+sv.setCameraTarget(x, y, z)
+sv.setAutoRotate(enabled)
+sv.setAutoRotateSpeed(radiansPerFrame)
+sv.setZoomLimits(min, max)
+sv.setBackgroundColor(r, g, b, a)       // 0-1 range
+sv.fitToModels()
+sv.startRendering()
+sv.stopRendering()
+sv.resize(width, height)
+sv.dispose()                            // release all GPU resources
+```
+
+## Kotlin/JS DSL
+
+```kotlin
+SceneView.create(
+    canvas: HTMLCanvasElement,
+    assets: Array<String> = emptyArray(),     // KTX URLs to preload
+    configure: SceneViewBuilder.() -> Unit = {},
+    onReady: (SceneView) -> Unit
+)
+```
+
+### `SceneViewBuilder` (the `configure` block)
+
+```kotlin
+SceneView.create(canvas, configure = {
+    camera {
+        eye(0.0, 1.5, 5.0)
+        target(0.0, 0.0, 0.0)
+        up(0.0, 1.0, 0.0)
+        fov(45.0)               // degrees
+        near(0.1); far(1000.0)
+        exposure(1.1)           // or exposure(aperture, shutterSpeed, sensitivity)
+    }
+    light {
+        directional()           // or point() / spot()
+        intensity(100_000.0)
+        color(1.0f, 1.0f, 1.0f)
+        direction(0.6f, -1.0f, -0.8f)
+        // point/spot: position(x, y, z)
+    }
+    model("models/helmet.glb") {
+        autoAnimate(true)
+        scale(1.0f)
+        onLoaded { asset -> /* FilamentAsset */ }
+    }
+    geometry {
+        cube()                  // or sphere() / cylinder() / plane()
+        size(1.0, 1.0, 1.0)
+        color(1.0, 0.0, 0.0, 1.0)
+        unlit()                 // optional — flat color, ignores lighting
+        position(0.0, 0.5, -2.0)
+        rotation(0.0, 45.0, 0.0)
+        scale(1.0)
+    }
+    environment("ibl.ktx", skyboxUrl = "sky.ktx")
+    noEnvironment()
+    cameraControls(true)
+    autoRotate(true)
+})
+```
+
+### `SceneView` instance methods (Kotlin/JS)
+
+```kotlin
+sceneView.loadModel(url, onLoaded)
+sceneView.loadEnvironment(iblUrl, skyboxUrl)
+sceneView.loadDefaultEnvironment()
+sceneView.addLight(config: LightConfig)
+sceneView.addGeometry(config: GeometryConfig)
+sceneView.enableCameraControls(distance, targetX, targetY, targetZ, autoRotate)
+sceneView.fitToModels()
+sceneView.resize(width, height)
+sceneView.startRendering(); sceneView.stopRendering(); sceneView.destroy()
+```
+
+Geometry DSL types: `cube` (`size(w,h,d)`), `sphere` (`radius(r)`),
+`cylinder` (`radius(r)` + `height(h)`), `plane` (`size(w,h,0)`).
+
+## `OrbitCameraController`
+
+Attached automatically when `cameraControls(true)`. Left-drag = orbit,
+right-drag = pan, scroll = zoom. Tunable: `theta`, `phi`, `distance`,
+`minDistance`, `maxDistance`, `autoRotate`, `autoRotateSpeed`,
+`enableDamping`, `dampingFactor`, plus `target(x,y,z)`.
+
+## WebXR — `ARSceneView` (browser AR)
+
+```kotlin
+ARSceneView.checkSupport { supported -> }
+ARSceneView.create(
+    canvas, features = WebXRSession.Features(...),
+    onError = { msg -> }, onReady = { arView -> }
+)
+// arView: onHitTest, onSelect, onSessionEnd, start(), stop(), loadModel(url), sceneView
+```
+
+## WebXR — `VRSceneView` (browser VR)
+
+```kotlin
+VRSceneView.checkSupport { supported -> }
+VRSceneView.create(canvas, features, referenceSpaceType, onError, onReady)
+// vrView: onFrame, onInputSelect, onInputSqueeze, onSessionEnd, start(), stop()
+```
+
+## WebXR — `WebXRSession` (low-level, AR + VR unified)
+
+```kotlin
+WebXRSession.checkSupport(mode = XRSessionMode.IMMERSIVE_AR) { supported -> }
+WebXRSession.create(canvas, mode, features, referenceSpaceType, onError, onReady)
+```
+
+`XRFeature`: `HIT_TEST`, `DOM_OVERLAY`, `LIGHT_ESTIMATION`, `HAND_TRACKING`.
+`XRSessionMode`: `IMMERSIVE_AR`, `IMMERSIVE_VR`.
+`XRReferenceSpaceType`: `LOCAL_FLOOR`, `LOCAL`, `VIEWER`, `BOUNDED_FLOOR`,
+`UNBOUNDED`.
+
+## Threading
+
+One JS main thread — all Filament calls run there. `create` / `loadModel` are
+async; await them. Never `destroy()`/`dispose()` inside an animation-frame
+callback.
+
+## Other platforms
+
+Android → `sceneview` skill. iOS/macOS/visionOS → `sceneview-ios` skill.

--- a/agents/sceneview-web/references/migration.md
+++ b/agents/sceneview-web/references/migration.md
@@ -1,0 +1,78 @@
+# Migrating to SceneView for Web
+
+This page covers the rewrites AI agents most often need when bringing existing
+browser 3D code onto `sceneview-web`. The exhaustive API is in the
+"SceneView Web" section of
+[`llms.txt`](https://github.com/sceneview/sceneview/blob/main/llms.txt).
+
+## From `<model-viewer>` (Google's web component)
+
+`<model-viewer>` is the closest analogue — both are drop-in viewers. The
+`sceneview` JS API mirrors its most common features:
+
+| `<model-viewer>` | `sceneview-web` (plain JS) |
+| --- | --- |
+| `<model-viewer src="model.glb">` | `sceneview.modelViewer('canvasId', 'model.glb')` |
+| `auto-rotate` attribute | `sv.setAutoRotate(true)` |
+| `camera-orbit` attribute | `sv.setCameraOrbit(theta, phi, distance)` |
+| `environment-image` attribute | `sv.setEnvironment(iblUrl)` |
+| `min-camera-orbit` / `max-camera-orbit` | `sv.setZoomLimits(min, max)` |
+| `<model-viewer>` is a custom element | `sceneview-web` renders into a `<canvas>` |
+
+Note: `sceneview-web` renders into a plain `<canvas>` you provide, not a custom
+element. filament.js must load before sceneview-web.js.
+
+## From Three.js
+
+| Three.js | `sceneview-web` (Kotlin/JS DSL) |
+| --- | --- |
+| `new THREE.WebGLRenderer({ canvas })` | `SceneView.create(canvas, …)` |
+| `GLTFLoader().load(url, …)` | `sceneView.loadModel(url, onLoaded)` or `model(url) { }` |
+| `new THREE.BoxGeometry(...)` + `Mesh` | `geometry { cube(); size(...) }` |
+| `new THREE.DirectionalLight(...)` | `light { directional(); intensity(...) }` |
+| `OrbitControls` | `cameraControls(true)` → `OrbitCameraController` |
+| `RGBELoader` / `PMREMGenerator` for IBL | `environment(iblUrl, skyboxUrl)` (KTX) |
+| `renderer.setAnimationLoop(...)` | `sceneView.startRendering()` (internal loop) |
+
+`sceneview-web` uses Filament's KTX IBL format, not Three.js's `.hdr`/`.exr`
+pipeline — convert environments to KTX.
+
+## From the SceneView Android Kotlin API
+
+The web DSL and the Compose API share concepts but not syntax. **Don't
+translate Compose code character by character.**
+
+| Android (Compose) | Web (Kotlin/JS DSL) |
+| --- | --- |
+| `SceneView { … }` composable | `SceneView.create(canvas, configure = { … })` |
+| `rememberModelInstance(loader, path)` | `model(path) { }` in the DSL, or `loadModel(path)` |
+| `ModelNode(modelInstance, …)` | `model(url) { autoAnimate(true); scale(...) }` |
+| `CubeNode(size, material)` | `geometry { cube(); size(...); color(...) }` |
+| `LightNode(type = …, intensity = …)` | `light { directional(); intensity(...) }` |
+| `rememberCameraNode` / `rememberCameraManipulator` | `camera { eye(...); target(...) }` + `cameraControls(true)` |
+| `rememberEnvironment(...)` | `environment(iblUrl, skyboxUrl)` |
+| AR via `ARSceneView` (ARCore) | AR via `ARSceneView` (WebXR) — different API shape |
+
+## WebXR caveats
+
+- WebXR `ARSceneView` / `VRSceneView` is NOT the ARCore-based Android
+  `ARSceneView` — the entry point is `ARSceneView.create(...)`, not a
+  composable, and hit-tests come from the WebXR Device API.
+- `requestSession` only works inside a user gesture — call `create` from a
+  click/tap handler.
+- AR support: Chrome Android 79+, Meta Quest Browser, Safari iOS 18+. VR:
+  Meta Quest Browser, desktop Chrome with a headset. Always `checkSupport`
+  first and ship a non-XR fallback.
+
+## Common mistakes and fixes
+
+1. **Blank canvas, no errors** — filament.js was loaded after sceneview-web.js,
+   or the canvas had zero dimensions. Load filament.js first; give the canvas
+   explicit CSS size.
+2. **`Canvas element 'id' not found`** — the `<canvas>` id passed to
+   `createViewer`/`modelViewer` doesn't match the DOM element.
+3. **Calling instance methods before the viewer is ready** — `createViewer` /
+   `loadModel` return Promises; chain with `.then` / `await`.
+4. **WebXR session rejected** — `requestSession` was called outside a user
+   gesture, or the browser lacks WebXR. Gate on `checkSupport`, create inside a
+   click handler.

--- a/agents/sceneview-web/references/recipes.md
+++ b/agents/sceneview-web/references/recipes.md
@@ -1,0 +1,135 @@
+# SceneView for Web recipes
+
+**Do not improvise.** Each pattern below maps to verified source in
+`sceneview-web/src/jsMain/` and the `samples/web-demo/` app. The exhaustive API
+is in the "SceneView Web" section of
+[`llms.txt`](https://github.com/sceneview/sceneview/blob/main/llms.txt).
+
+## 1. Model viewer (plain JS, no bundler)
+
+```html
+<canvas id="viewer" style="width:100%;height:100vh;display:block"></canvas>
+<script src="https://sceneview.github.io/js/filament/filament.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.3.5/sceneview-web.js"></script>
+<script>
+  sceneview.modelViewer('viewer', 'https://sceneview.github.io/models/platforms/DamagedHelmet.glb')
+    .then(function (sv) {
+      sv.setAutoRotate(true);
+      sv.setBackgroundColor(0.05, 0.05, 0.12, 1.0);
+    });
+</script>
+```
+
+Entry point: `jsModelViewer` in `Main.kt`. filament.js loads first.
+
+## 2. Custom scene (plain JS)
+
+```js
+sceneview.createViewer('viewer').then(function (sv) {
+  sv.loadModel('Fox.glb').then(function () { sv.fitToModels(); });
+  sv.setEnvironmentWithSkybox('studio_ibl.ktx', 'studio_skybox.ktx');
+  sv.setCameraOrbit(0.6, 1.2, 4.0);
+  sv.setZoomLimits(1.0, 12.0);
+});
+```
+
+## 3. Model viewer (Kotlin/JS DSL)
+
+```kotlin
+SceneView.create(
+    canvas = canvas,
+    configure = {
+        camera { eye(0.0, 1.5, 5.0); target(0.0, 0.0, 0.0); fov(45.0) }
+        model("models/helmet.glb") { autoAnimate(true) }
+        cameraControls(true)
+        autoRotate(true)
+    },
+    onReady = { sceneView -> sceneView.startRendering() }
+)
+```
+
+Entry point: `SceneView.create` + `SceneViewBuilder` in `SceneView.kt`.
+
+## 4. Procedural geometry (Kotlin/JS DSL)
+
+```kotlin
+SceneView.create(canvas, configure = {
+    geometry { cube();     size(1.0, 1.0, 1.0); color(1.0, 0.0, 0.0, 1.0); position(0.0, 0.5, -2.0) }
+    geometry { sphere();   radius(0.5);          color(0.0, 0.5, 1.0, 1.0) }
+    geometry { cylinder(); radius(0.3); height(1.5); color(0.0, 1.0, 0.5, 1.0) }
+    geometry { plane();    size(5.0, 5.0, 0.0);  color(0.3, 0.3, 0.3, 1.0) }
+}) { sceneView -> sceneView.startRendering() }
+```
+
+## 5. Lighting and environment
+
+```kotlin
+SceneView.create(canvas, configure = {
+    light {
+        directional()
+        intensity(100_000.0)
+        color(1.0f, 1.0f, 1.0f)
+        direction(0.6f, -1.0f, -0.8f)
+    }
+    environment("https://…/ibl.ktx", skyboxUrl = "https://…/sky.ktx")
+})
+```
+
+## 6. WebXR AR — render a glTF on a detected surface
+
+```kotlin
+ARSceneView.checkSupport { supported ->
+    if (supported) {
+        // inside a button click handler:
+        ARSceneView.create(
+            canvas = canvas,
+            features = WebXRSession.Features(
+                required = arrayOf(XRFeature.HIT_TEST),
+                optional = arrayOf(XRFeature.DOM_OVERLAY, XRFeature.LIGHT_ESTIMATION)
+            ),
+            onError = { msg -> console.error(msg) },
+            onReady = { arView ->
+                arView.onHitTest = { pose -> arView.loadModel("models/chair.glb") }
+                arView.onSelect = { source -> /* user tapped */ }
+                arView.start()
+            }
+        )
+    }
+}
+```
+
+Verified against `xr/ARSceneView.kt`. Session creation MUST be in a user
+gesture; always provide a non-XR fallback when `checkSupport` is false.
+
+## 7. WebXR VR
+
+```kotlin
+VRSceneView.checkSupport { supported ->
+    if (supported) {
+        VRSceneView.create(
+            canvas = canvas,
+            features = WebXRSession.Features(optional = arrayOf(XRFeature.HAND_TRACKING)),
+            referenceSpaceType = XRReferenceSpaceType.LOCAL_FLOOR,
+            onError = { msg -> },
+            onReady = { vrView ->
+                vrView.sceneView.loadModel("models/room.glb")
+                vrView.onInputSelect = { source, pose -> /* trigger */ }
+                vrView.start()
+            }
+        )
+    }
+}
+```
+
+Verified against `xr/ARSceneView.kt` (`VRSceneView`).
+
+## CDN models
+
+`https://sceneview.github.io/models/platforms/` hosts a catalog of GLBs
+(DamagedHelmet.glb, Fox.glb, Avocado.glb, ToyCar.glb, …) — see `llms.txt` for
+the full list. Use absolute URLs for models.
+
+## Cross-platform parity
+
+Android (`sceneview` skill) and iOS (`sceneview-ios` skill) expose the same node
+concepts with platform-idiomatic shapes. **Don't copy-paste between platforms.**


### PR DESCRIPTION
## Summary

Extends the agent-skills surface (`agents/`) with the two missing platforms and documents the Android skill's registry submission.

- **`agents/sceneview-ios/`** (`#1080`) — a `sceneview-ios` skill for SceneViewSwift (SwiftUI + RealityKit, iOS/macOS/visionOS). Grounded in `SceneViewSwift/Sources/`, the `samples/ios-demo/` app, and `docs/docs/cheatsheet-ios.md`. Ships `SKILL.md` + `references/{cheatsheet,recipes,migration}.md`.
- **`agents/sceneview-web/`** (`#1081`) — a `sceneview-web` skill for SceneView for Web (Filament.js + WebXR). Grounded in `sceneview-web/src/jsMain/` and the `llms.txt` web API section. Covers both the Kotlin/JS DSL and the plain-JavaScript `window.sceneview` API.
- **`agents/REGISTRY.md`** (`#1082`) — documents the Google `android-cli` hosted-registry submission packet (skill name, category, license, maintenance contact, drift guarantee) and the submission steps. The in-repo part is done; the external submission via Google's Issue Tracker is documented as a parallel track. Local install stays the primary distribution.

## Details

- Each new `SKILL.md` uses YAML frontmatter matching the existing Android skill schema (`name` / `description` / `license` / `metadata`).
- Two new install scripts (`install-sceneview-ios-skill.sh`, `install-sceneview-web-skill.sh`) mirror `install-sceneview-skill.sh`, copying into `~/.android/cli/skills/xr/<skill>/`.
- `check-sceneview-skill.sh` extended: frontmatter validation now loops over all three skills; a new section 5 verifies iOS `*Demo.swift` and web `*.kt` source references resolve on disk.
- API content cross-checked against current source — `check-sceneview-skill.sh` passes (frontmatter ✓, 23 Kotlin identifiers ✓, 21 + 23 + 3 demo/source refs ✓).
- `CLAUDE.md` updated; `CHANGELOG.md` Unreleased entry added.

## Test plan

- [x] `bash .claude/scripts/check-sceneview-skill.sh` — passes for all three skills
- [x] `bash -n` clean on both new install scripts and the modified `check-sceneview-skill.sh`
- [x] No build files touched — markdown/skill files only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)