### PR TITLE
ci: path-gate pr-check.yml, dedup compile-kmp, upgrade Gradle cache (#1311)

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -22,7 +22,18 @@ runs:
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
-        cache: gradle
+
+    # Build-cache-aware Gradle setup. Replaces the lightweight
+    # `cache: gradle` shortcut on setup-java (wrapper + deps only) with the
+    # official gradle/actions/setup-gradle@v6, which also caches the Gradle
+    # build cache (compiled task outputs) for richer hit rates across
+    # ci/pr-check/build-apks/render-tests. Mirrors quality-gate.yml.
+    # `cache-read-only` on every non-push event so PRs (incl. forks) read
+    # but never write the cache; pushes to main repopulate it.
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: ${{ github.event_name != 'push' }}
 
     # Verify the checked-in gradle-wrapper.jar matches the SHA of a known-good
     # Gradle distribution. A malicious PR can otherwise sneak a tampered

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -15,6 +15,12 @@ on:
   issues:
     types: [opened]
 
+# One notification run per triggering event; a duplicate webhook delivery
+# (e.g. an issue edited-then-reopened storm) cancels the stale in-flight run.
+concurrency:
+  group: discord-notify-${{ github.event.release.id || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,6 +21,15 @@ on:
       - 'docs/**'
       - 'marketing/**'
       - 'branding/**'
+      # `.claude/**` (scripts/skill/plans) and `tools/**` (build utilities)
+      # are not exercised by any job here — the repo-hygiene gates read
+      # `.claude/scripts/*.sh` but a *change* to those scripts is validated
+      # by quality-gate.yml, not pr-check.yml. Mirrors ci.yml's ignore list
+      # so a scripts-only PR (the PR #1304 profile) no longer spins up the
+      # ~5 min KMP compile. Closes #1311 gap #1.
+      # ⛔ Do NOT add `.github/workflows/**` — a CI change must re-run CI.
+      - '.claude/**'
+      - 'tools/**'
       - '*.md'
       - 'llms*.txt'
       - 'LICENSE'
@@ -127,12 +136,62 @@ jobs:
         shell: bash
         run: bash .claude/scripts/validate-demo-assets.sh
 
-  # ── KMP core (all targets) ──────────────────────────────────────────────
-  # ci.yml's `web-desktop` job compiles `:sceneview-core:jsMainClasses` but
-  # not the full KMP `assemble` (which builds iosArm64/iosSimulatorArm64/
-  # iosX64/jvm too). Keep this job to protect every KMP target on PR.
+  # ── Path-filter gate ────────────────────────────────────────────────────
+  # Computes whether a PR touched any code that affects the Kotlin/Native
+  # compilation of `sceneview-core`. The workflow-level `paths-ignore` above
+  # already drops pure docs/website/scripts PRs; this finer per-job gate
+  # stops, for example, a Flutter-only or iOS-demo-only PR from running the
+  # ~5 min KMP compile below. Reuses the `dorny/paths-filter` pattern from
+  # ci.yml's `changes` job. Closes #1311 gap #2.
+  #
+  # A job that gets `if:`-skipped reports the "skipped" conclusion, which
+  # GitHub treats as success — `main` has no required-check list, so this is
+  # safe and no check hangs pending.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      kmp: ${{ steps.filter.outputs.kmp }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `kmp` covers everything that affects Kotlin/Native compilation of
+          # sceneview-core: the KMP module itself, the Android consumers that
+          # share its source set, sceneview-web, and the Gradle build files.
+          # The workflow + its composite action are listed so a CI change
+          # always re-runs this job. `push` events have no PR diff base —
+          # the action falls back to the previous commit; pr-check.yml only
+          # triggers on pull_request anyway.
+          filters: |
+            kmp:
+              - '.github/workflows/pr-check.yml'
+              - '.github/actions/setup-gradle/**'
+              - 'sceneview-core/**'
+              - 'arsceneview/**'
+              - 'sceneview/**'
+              - 'sceneview-web/**'
+              - 'gradle/**'
+              - 'build.gradle*'
+              - 'settings.gradle*'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+
+  # ── KMP core (iOS-only native targets) ──────────────────────────────────
+  # ci.yml already builds the JVM/JS KMP targets: `web-desktop` compiles
+  # `:sceneview-core:jsMainClasses` and runs `:sceneview-core:jsTest`, and
+  # `build` consumes the JVM/Android target via `assembleDebug`. The ONLY
+  # KMP targets nothing else exercises on PR are the iOS Kotlin/Native ones
+  # (`ios.yml` builds the Swift package, not the KMP native targets), so
+  # this job is narrowed to them — the unique PR-time guard on Kotlin/Native
+  # compilation. Closes #1311 gaps #3 + #4.
   compile-kmp:
     name: Compile KMP core
+    needs: changes
+    if: needs.changes.outputs.kmp == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -141,9 +200,10 @@ jobs:
 
       - uses: ./.github/actions/setup-gradle
 
-      - name: Compile KMP core (all targets)
-        run: ./gradlew :sceneview-core:assemble --stacktrace
-
-      - name: KMP unit tests (JS)
-        continue-on-error: true
-        run: ./gradlew :sceneview-core:jsTest --stacktrace
+      - name: Compile KMP core (iOS Kotlin/Native targets)
+        run: |
+          ./gradlew \
+            :sceneview-core:compileKotlinIosArm64 \
+            :sceneview-core:compileKotlinIosSimulatorArm64 \
+            :sceneview-core:compileKotlinIosX64 \
+            --stacktrace

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -130,7 +130,9 @@ jobs:
       - name: Install Android CLI
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/android \
+          # --retry guards against cold-CDN flake on dl.google.com.
+          curl -fsSL --retry 3 --retry-delay 5 \
+            https://dl.google.com/android/cli/latest/linux_x86_64/android \
             -o "$HOME/.local/bin/android"
           chmod +x "$HOME/.local/bin/android"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary

Implements the highest-impact gaps from CI performance umbrella **#1311** — finishes the `pr-check.yml` path-gating left unfinished by #1296, de-dups `compile-kmp` against `ci.yml`, and upgrades Gradle caching for every Gradle job at once.

## Done (gaps #1-5, #8, #9)

| # | Workflow | Change |
|---|----------|--------|
| #1 | `pr-check.yml` | Added `.claude/**` + `tools/**` to `paths-ignore` — a scripts-only PR (the PR #1304 profile) now skips the whole workflow. `.github/workflows/**` deliberately NOT ignored. |
| #2 | `pr-check.yml` | New `changes` gate job (`dorny/paths-filter@v3`, same pattern as `ci.yml`). `compile-kmp` now has `if: needs.changes.outputs.kmp == 'true'` on `sceneview-core/** + arsceneview/** + sceneview/** + sceneview-web/** + gradle/build files` (+ the workflow & composite action so CI changes always re-run). |
| #3 | `pr-check.yml:compile-kmp` | Narrowed from `:sceneview-core:assemble` (all targets) to the iOS-only Kotlin/Native targets: `compileKotlinIosArm64` / `compileKotlinIosSimulatorArm64` / `compileKotlinIosX64`. The JVM/JS targets are already built by `ci.yml` (`build` + `web-desktop`). **iOS native targets kept** — they are the only PR-time guard on Kotlin/Native compilation. |
| #4 | `pr-check.yml:compile-kmp` | Dropped the duplicate `:sceneview-core:jsTest` step (runs in `ci.yml:web-desktop` too, both `continue-on-error`). |
| #5 | `.github/actions/setup-gradle/action.yml` | Swapped `actions/setup-java@v5` `cache: gradle` for `gradle/actions/setup-gradle@v6` with `cache-read-only: ${{ github.event_name != 'push' }}` — build-cache-aware caching for `ci` / `pr-check` / `build-apks` / `render-tests` at once. Mirrors `quality-gate.yml`. |
| #8 | `render-tests.yml` | Added `--retry 3 --retry-delay 5` to the Android-CLI `curl` from `dl.google.com` (cold-CDN flake guard). |
| #9 | `discord-notify.yml` | Added a `concurrency:` group. `timeout-minutes: 5` was already present on both jobs. |

## Deferred (stay in umbrella #1311)

- **#6** — `ci.yml:build` sharding into parallel `build`/`unit-test`/`lint` jobs. Real runner-cost tradeoff (more runner-minutes for ~3 min wall-clock) — needs a deliberate call, not bundled here.
- **#7** — `quality-gate.yml` vs `pr-check.yml` hygiene-check de-dup. Low priority (~10-20s), intentional 2-tier fast-fail.
- **#10** — `quality-gate.yml fetch-depth: 0` shallowing. Needs verification that `quality-gate.sh` doesn't need full history before changing.

**#1311 stays OPEN** — this PR closes the core gaps; #6/#7/#10 remain tracked there.

## Trace (path-gating behaviour)

- **Scripts-only PR** (`.claude/scripts/foo.sh`) — `pr-check.yml` skipped entirely by `paths-ignore`. `ci.yml` + `quality-gate.yml` also already ignore `.claude/**`. ✅
- **Flutter-only PR** (`flutter/**`, `samples/flutter-demo/**`) — `pr-check.yml` runs (not in `paths-ignore`); `repo-hygiene` runs, `changes.kmp` is `false` → `compile-kmp` **skipped** (reports "skipped" = success). `ci.yml:flutter-demo` still runs. ✅
- **`sceneview-core/**` change** — `changes.kmp` is `true` → `compile-kmp` runs the iOS Kotlin/Native targets. `ci.yml`: `changes.android` + `changes.web` both `true` → `build` (Android) + `web-desktop` run. `ios.yml` builds the Swift package. Full coverage. ✅

Skipped jobs report the `skipped` conclusion (GitHub treats it as success). `main` has no branch protection / rulesets, so no required-check realignment needed and no check hangs pending.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on all 4 changed files — valid.
- `actionlint` on `pr-check.yml` + `render-tests.yml` — 0 errors. `discord-notify.yml` reports only a pre-existing `github.event.issue.title` script-injection warning (present on `origin/main`, line shifted by the new `concurrency` block, not introduced here) — filed as a follow-up.
- iOS KMP task names confirmed against `sceneview-core/build.gradle.kts` (`iosArm64()` / `iosSimulatorArm64()` / `iosX64()` all declared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)