### PR TITLE
fix(agents): repoint iOS skill recipe after CameraControls rename (#1055)

### DIFF
--- a/agents/sceneview-ios/references/recipes.md
+++ b/agents/sceneview-ios/references/recipes.md
@@ -14,7 +14,7 @@ code — the demo is the authoritative recipe.
 — `GeometryNode.cube / .sphere / .cylinder / .plane / .cone / .torus / .capsule`.
 
 ## 3. Camera controls (orbit / pan)
-[`OrbitCameraDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitCameraDemo.swift)
+[`CameraControlsDemo.swift`](https://github.com/sceneview/sceneview/blob/main/samples/ios-demo/SceneViewDemo/Views/Demos/CameraControlsDemo.swift)
 — `.cameraControls(.orbit)` modifier.
 
 ## 4. Auto-rotate turntable


### PR DESCRIPTION
## Summary

Follow-up to #1310. The iOS-demo file rename `OrbitCameraDemo.swift` → `CameraControlsDemo.swift` ([#1055](https://github.com/sceneview/sceneview/issues/1055)) landed in #1310, but `agents/sceneview-ios/references/recipes.md` still linked the old `OrbitCameraDemo.swift` path. `check-sceneview-skill.sh` (run by `quality-gate` and the `Repo hygiene checks` PR gate) flags this as skill drift on `main`.

Repoints the recipe link to `CameraControlsDemo.swift`.

## Test plan

- [x] `bash .claude/scripts/check-sceneview-skill.sh` — passes (was: `1 iOS demo file(s) referenced but missing — OrbitCameraDemo.swift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)