### PR TITLE
ci: add CI Gate aggregator job + require it via branch protection (#1314)

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,134 @@
+name: CI Gate
+
+# Single always-on aggregator status check for branch protection.
+#
+# WHY THIS EXISTS (#1314)
+# ----------------------
+# `main` is merged fire-and-forget (`gh pr merge --squash --auto`). For
+# auto-merge to actually gate on CI, branch protection must require a
+# status check. But the repo's real CI workflows (ci.yml, pr-check.yml,
+# quality-gate.yml, ios.yml, telemetry-ci.yml) all use workflow-level
+# `paths`/`paths-ignore` filters — so a docs-only or scripts-only PR runs
+# ZERO of their jobs. Requiring any of those checks directly would leave
+# such a PR stuck on "Expected — waiting for status" forever.
+#
+# DESIGN CHOICE
+# -------------
+# A GitHub job can only `needs:` jobs in its OWN workflow, and the repo
+# has FIVE PR-triggered workflows with different path filters — a single
+# `needs:`-based gate cannot see across them. A `workflow_run`-triggered
+# gate is unreliable as a required check (its check run attaches to the
+# branch, not the PR head SHA, so the PR merge box never sees it).
+#
+# So this is a dedicated workflow with a `pull_request` trigger and NO
+# path filter — it therefore runs on EVERY PR and ALWAYS reports the
+# `CI Gate` status. Its single job polls the GitHub Checks API for the
+# PR head SHA, waits for every OTHER check run to finish, and:
+#   - FAILS  if any other check concluded `failure`/`cancelled`/`timed_out`
+#   - PASSES if every other check is `success`, `skipped`, or `neutral`
+# A path-filtered-out workflow simply produces no check runs for that SHA
+# (or its `if:`-skipped jobs report `skipped`) — either way the gate is
+# green, so docs/scripts/CI-only PRs merge without jamming.
+#
+# Branch protection on `main` requires ONLY this `CI Gate` check.
+
+on:
+  pull_request:
+    branches: [main]
+    # ⛔ Intentionally NO paths / paths-ignore filter. This workflow MUST
+    # run on every PR so the `CI Gate` status is always reported — that
+    # is the whole point of the aggregator pattern (#1314).
+  workflow_dispatch:
+
+concurrency:
+  group: ci-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Aggregate all PR check conclusions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          # This job's own check run name — excluded from the aggregation
+          # so the gate never waits on itself.
+          SELF_CHECK: CI Gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # workflow_dispatch has no PR context — nothing to aggregate.
+          if [ -z "${HEAD_SHA:-}" ]; then
+            echo "No pull_request context (manual dispatch) — nothing to gate."
+            exit 0
+          fi
+
+          echo "Aggregating check runs for $REPO @ $HEAD_SHA"
+
+          # Poll until every non-self check run for this SHA has finished.
+          # GitHub registers a workflow's check runs within a few seconds
+          # of the PR event, so we wait briefly before the first read to
+          # avoid a false "all green" on an empty list.
+          deadline=$(( $(date +%s) + 25 * 60 ))
+          sleep 30
+
+          while :; do
+            # All check runs for the head commit (handles >100 via paging).
+            runs=$(gh api --paginate \
+              "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+              --jq '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion}')
+
+            # Drop this gate's own check run from consideration.
+            others=$(echo "$runs" | jq -c --arg self "$SELF_CHECK" 'select(.name != $self)')
+
+            if [ -z "$others" ]; then
+              echo "No other check runs reported for this SHA yet."
+            fi
+
+            pending=$(echo "$others" | jq -r 'select(.status != "completed") | .name')
+            if [ -z "$pending" ]; then
+              break
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for CI checks to complete:"
+              echo "$pending" | sort -u | while IFS= read -r n; do echo "  - $n"; done
+              exit 1
+            fi
+
+            echo "Waiting for checks to finish:"
+            echo "$pending" | sort -u | while IFS= read -r n; do echo "  - $n"; done
+            sleep 20
+          done
+
+          echo ""
+          echo "All other check runs completed. Conclusions:"
+          echo "$others" | jq -r '"  - \(.name): \(.conclusion)"' | sort -u
+
+          # A real failure flips the gate red. `skipped`/`neutral`/`success`
+          # all pass — path-filtered-out jobs report `skipped`.
+          failed=$(echo "$others" \
+            | jq -r 'select(.conclusion == "failure"
+                          or .conclusion == "cancelled"
+                          or .conclusion == "timed_out"
+                          or .conclusion == "action_required"
+                          or .conclusion == "stale") | .name')
+
+          if [ -n "$failed" ]; then
+            echo ""
+            echo "::error::One or more required CI checks failed:"
+            echo "$failed" | sort -u | while IFS= read -r n; do echo "  - $n"; done
+            exit 1
+          fi
+
+          echo ""
+          echo "CI Gate passed — every CI check succeeded or was skipped."


### PR DESCRIPTION
## Summary

Adds a dedicated **`ci-gate.yml`** workflow with a single `CI Gate` job — an always-on aggregator status check so branch protection on `main` can gate fire-and-forget auto-merges on CI without the "path-filtered required check hangs the PR" trap.

Branch protection on `main` has been enabled, requiring **only** the `CI Gate` check.

Closes #1314

## Design choice — why a dedicated polling workflow, not `needs:` or `workflow_run`

A GitHub job can only `needs:` jobs in its **own** workflow. The repo has **five** PR-triggered workflows with differing path filters (`ci.yml`, `pr-check.yml`, `quality-gate.yml`, `ios.yml`, `telemetry-ci.yml`), so a single `needs:`-based gate cannot see across all of them.

A `workflow_run`-triggered gate is **unreliable as a required check** — its check run attaches to the branch ref, not the PR head SHA, so the PR merge box never recognizes it.

So `ci-gate.yml`:
- triggers on `pull_request` with **NO path filter** → it runs on *every* PR and *always* reports the `CI Gate` status (this is the whole point — a required check that is never reported jams the PR forever).
- its job polls the Checks API for the PR head SHA, waits for every *other* check run to complete, then aggregates: **red** if any concluded `failure`/`cancelled`/`timed_out`/`action_required`/`stale`; **green** if all are `success`/`skipped`/`neutral`.

This is correct over elegant: it reflects ALL five workflows regardless of their individual path filters.

## Trace

- **Docs-only PR** (e.g. a `README.md` change): `ci.yml` / `pr-check.yml` / `quality-gate.yml` are `paths-ignore`'d → they produce no check runs; `ios.yml` / `telemetry-ci.yml` `paths`-filter out → no check runs. `CI Gate` finds no other checks → **green** → docs PR merges. No jam.
- **Code PR, all jobs pass**: every check run concludes `success`, path-filtered-out jobs report `skipped` → `CI Gate` **green** → auto-merge proceeds.
- **Code PR with a failing job**: that check run concludes `failure` → `CI Gate` **red** → auto-merge blocked.

## Branch protection

After this PR's own `CI Gate` ran green once, branch protection was enabled via:

```
gh api -X PUT repos/sceneview/sceneview/branches/main/protection \
  --input - <<'JSON'
{"required_status_checks":{"strict":false,"contexts":["CI Gate"]},
 "enforce_admins":false,"required_pull_request_reviews":null,"restrictions":null}
JSON
```

Only `CI Gate` is required — no path-filtered check (`Quality gate (full)`, `Repo hygiene checks`, `compile-kmp`, etc.), so docs/scripts-only PRs never hang.

## Verification

- `actionlint` clean on `ci-gate.yml`; YAML parses; repo's own `check-workflow-scripts.sh` (dash + shellcheck) passes.
- This PR's `CI Gate` confirmed green before protection was enabled, so this PR itself remains mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)