### PR TITLE
ci: make App Store deploy tag-only — fixes Apple upload-limit failures

### DIFF
--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -13,21 +13,7 @@ name: Deploy iOS App to App Store
 
 on:
   push:
-    branches: [main]
     tags: ['v*']
-    # The `paths` filter applies to BOTH branch and tag pushes — i.e. a tag
-    # push must also touch one of these paths to trigger. Every release
-    # commit in this repo bumps `gradle.properties:VERSION_NAME` and adds an
-    # entry to `CHANGELOG.md` (per the Version Location Map in CLAUDE.md), so
-    # those two paths act as a "release commit always touches at least one
-    # of these" anchor that guarantees every clean release tag fires the
-    # workflow even if the iOS source itself didn't change in that PR.
-    paths:
-      - 'SceneViewSwift/**'
-      - 'samples/ios-demo/**'
-      - '.github/workflows/app-store.yml'
-      - 'gradle.properties'
-      - 'CHANGELOG.md'
   workflow_dispatch:
     inputs:
       submit_for_review:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Changed — CI
 
 - **`release.yml` now deploys the generated Dokka API docs to `sceneview.github.io/api/sceneview/<version>/` + `/latest/` and wraps Dokka generation in a 3× retry to tolerate transient Maven Central 503s ([#1252](https://github.com/sceneview/sceneview/issues/1252), [#1127](https://github.com/sceneview/sceneview/issues/1127)).**
+- `Deploy iOS App to App Store` is now tag-only — fixes Apple upload-limit failures on every main merge ([#1318](https://github.com/sceneview/sceneview/issues/1318)).
 
 ### Changed — MCP
 


### PR DESCRIPTION
## Problem

`.github/workflows/app-store.yml` ("Deploy iOS App to App Store") was triggered on `push: branches: [main]`, so it uploaded the iOS demo to App Store Connect on **every merge to main**. Apple rate-limits TestFlight uploads daily, so the workflow now fails on every run:

```
error: exportArchive Validation failed. Upload limit reached. The upload limit
for your application has been reached. Please wait 1 day and try again.
```

The IPA build / sign / export all **succeed** — the only failure is the upload frequency. This makes main CI red and blocks the **v4.4.0 release**.

## Fix

Per the release-checkpoint policy (already used by `release.yml`), App Store deploys must fire only on `vX.Y.Z` release tags, never per-merge:

- `on:` trigger is now **tag-only**: `push: tags: ['v*']`.
- Removed the `branches: [main]` line.
- Removed the now-obsolete `paths:` filter and its explanatory comment block — a release tag should always deploy regardless of which files changed.
- Kept `workflow_dispatch:` (manual trigger).

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` confirms valid YAML.
- Self-reviewed: trigger is genuinely tag-only, no `branches:` left, comment block consistent with new behavior.
- `quality-gate` on the latest non-cancelled main runs is green — the "flake" mentioned in #1318 appears already resolved (cancelled runs are rapid-merge cancellation noise, not real failures).

## Follow-up

`play-store.yml` also runs on every `push: main`. The Play Store has no comparable hard daily limit so it is not breaking CI — only wasteful. Filed separately as #1321 to keep this PR scoped to `app-store.yml`.

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)