### PR TITLE
feat(scene): library-level autoCenterContent for Android (port of iOS #1026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@ Two regressions from `cd4034ff` (PR #1224) that the #1241 emulator QA sweep prov
 
 - **New recipe: Blender → SceneView asset pipeline ([#1222](https://github.com/sceneview/sceneview/issues/1222))** — `samples/recipes/blender-to-sceneview.md` and `docs/docs/recipes/blender-pipeline.md` walk contributors through authoring a custom 3D model in Blender and shipping it in a SceneView app: `.glb` is native on Android, while Apple platforms go `.glb` → Reality Converter → `.usdz` → Reality Composer Pro (Blender's own USDZ exporter produces broken materials). Adapted from [@radcli14](https://github.com/radcli14)'s [`blender-to-realitykit`](https://github.com/radcli14/blender-to-realitykit) tutorial (MIT, 17⭐), with a SceneView-specific call-out on the Android Filament JNI main-thread rule. Cross-linked from both quickstarts and the API cheatsheet. Closes [#1222](https://github.com/sceneview/sceneview/issues/1222).
 
+### Added — Android library-level `autoCenterContent` ([#1051](https://github.com/sceneview/sceneview/issues/1051))
+
+- **`SceneView(autoCenterContent = true)`** — port of the iOS `autoCenterContent` feature ([#1026](https://github.com/sceneview/sceneview/issues/1026) / [PR #1038](https://github.com/sceneview/sceneview/pull/1038)). DSL `content` nodes are parented to an intermediate content-root node which the library translates once — on the first frame their union bounding box is non-empty — so the content centroid lands at the orbit pivot and renders centred without per-node `ModelNode(centerOrigin = …)`. Lights / camera are `SceneView` parameters (never DSL children) so they stay put. Opt out with `autoCenterContent = false` for intentional off-centre composition.
+
 ### Follow-ups (filed against the master polish-pipeline reference [#1218](https://github.com/sceneview/sceneview/issues/1218))
 
 - [#1219](https://github.com/sceneview/sceneview/issues/1219) — Bundle ambientCG NightSkyHDRI008 (CC0) as `night_sky` env preset (iOS + Android + Web)

--- a/llms.txt
+++ b/llms.txt
@@ -69,12 +69,15 @@ fun SceneView(
     permissionHandler: ARPermissionHandler? = /* auto from ComponentActivity */,
     lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
     renderQuality: RenderQuality = RenderQuality.Default,   // Cinematic / Default / Performance — see "Render Quality"
+    autoCenterContent: Boolean = true,   // library-level auto-center — see note below
     onFrame: ((frameTimeNanos: Long) -> Unit)? = null,
     content: (@Composable SceneScope.() -> Unit)? = null
 )
 ```
 
 **Defaults changed in v4.0.10+:** shadows ON (mainLight + fillLight), SSAO + bloom enabled, neutral exposure (~1.0), dual-light setup out-of-the-box. No more "flat-lit chrome look" — drop a model in and it renders cinematic by default.
+
+**`autoCenterContent` (default `true`):** all DSL `content` nodes are parented to an intermediate content-root node which the library translates once — on the first frame their union bounding box is non-empty — so the content centroid lands at the orbit pivot and renders centred without per-node `ModelNode(centerOrigin = …)`. Lights / camera are `SceneView` parameters (never DSL children) so they stay put. Pass `autoCenterContent = false` for scenes with intentional off-centre placement. Mirrors the iOS `autoCenterContent` modifier.
 
 Minimal usage:
 ```kotlin

--- a/sceneview/src/main/java/io/github/sceneview/Scene.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Scene.kt
@@ -118,6 +118,14 @@ import io.github.sceneview.node.findActivity
  * @param isOpaque              Whether the render target is opaque. Default `true`.
  * @param renderQuality         One-line preset applied to `view` ([RenderQuality.Default],
  *                              [RenderQuality.Cinematic], or [RenderQuality.Performance]).
+ * @param autoCenterContent     When `true` (default), the library translates all DSL [content]
+ *                              nodes once — on the first frame their union bounding box is
+ *                              non-empty — so the content centroid lands at the orbit pivot and
+ *                              renders centred in the viewport without each node needing
+ *                              `ModelNode(centerOrigin = …)`. Lights / camera are passed as
+ *                              separate parameters, never DSL children, so they are unaffected.
+ *                              Mirrors the iOS `autoCenterContent` feature (#1026). Pass `false`
+ *                              for scenes with intentional off-centre placement.
  * @param renderer              Filament [Renderer]. Use [rememberRenderer].
  * @param scene                 Filament [Scene] graph, shareable across views. Use [rememberScene].
  * @param environment           IBL + skybox environment. Use [rememberEnvironment].
@@ -181,6 +189,14 @@ fun SceneView(
      * preset is applied.
      */
     renderQuality: RenderQuality = RenderQuality.Default,
+    /**
+     * When `true` (default), all DSL [content] nodes are parented to an intermediate content-root
+     * node which is translated once — on the first frame the content's union bounding box is
+     * non-empty — so the content centroid lands at the orbit pivot and renders centred. Mirrors
+     * the iOS library-level `autoCenterContent` feature (#1026 / PR #1038). Pass `false` to keep
+     * strict per-node placement semantics for scenes with intentional off-centre composition.
+     */
+    autoCenterContent: Boolean = true,
     /**
      * A [Renderer] instance represents an operating system's window.
      * Typically, applications create a [Renderer] per window.
@@ -320,15 +336,49 @@ fun SceneView(
         }
     }
 
+    // ── Auto-center content (#1026 — port of the iOS library-level autoCenterContent) ────────────
+    //
+    // Intermediate content-root node. When `autoCenterContent` is on, every DSL `content` node is
+    // parented to it instead of being added to the Filament scene directly — the `nodeManager`
+    // propagates the children automatically via its `onChildAdded` hook. Translating this single
+    // node once recentres the whole scene without touching lights / camera (those are separate
+    // `SceneView` parameters, never DSL children, so they stay put — exactly like iOS keeping
+    // lights on `entities.root` rather than `contentRoot`). When `autoCenterContent` is off the
+    // content root is unused and nodes register directly, preserving pre-#1051 behaviour.
+
+    val contentRoot = remember(engine) { Node(engine) }
+    val autoCenterState = remember { SceneAutoCenterState() }
+
+    DisposableEffect(autoCenterContent, contentRoot) {
+        if (autoCenterContent) {
+            nodeManager.addNode(contentRoot)
+        }
+        onDispose {
+            if (autoCenterContent) {
+                nodeManager.removeNode(contentRoot)
+            }
+        }
+    }
+
     // ── DSL nodes → Filament scene sync ──────────────────────────────────────────────────────────
 
     val childNodesRef = remember { AtomicReference(emptyList<Node>()) }
 
-    LaunchedEffect(nodeManager) {
+    LaunchedEffect(nodeManager, autoCenterContent, contentRoot) {
         var prevNodes = emptyList<Node>()
         snapshotFlow { scopeChildNodes.toList() }.collect { newNodes ->
-            (prevNodes - newNodes.toSet()).forEach { nodeManager.removeNode(it) }
-            (newNodes - prevNodes.toSet()).forEach { nodeManager.addNode(it) }
+            if (autoCenterContent) {
+                // Parent / unparent under the content root — `nodeManager` follows via onChildAdded.
+                (prevNodes - newNodes.toSet()).forEach { node ->
+                    if (node.parent == contentRoot) node.parent = null
+                }
+                (newNodes - prevNodes.toSet()).forEach { node -> node.parent = contentRoot }
+                // Content changed — re-run the one-shot centering on the next non-empty frame.
+                autoCenterState.reset()
+            } else {
+                (prevNodes - newNodes.toSet()).forEach { nodeManager.removeNode(it) }
+                (newNodes - prevNodes.toSet()).forEach { nodeManager.addNode(it) }
+            }
             prevNodes = newNodes
             childNodesRef.set(newNodes)
         }
@@ -456,6 +506,10 @@ fun SceneView(
     // never moves. Reading through a state ref here makes the frame loop pick up
     // every recomposition without restarting.
     val currentCameraManipulator = rememberUpdatedState(cameraManipulator)
+    // Read through a state ref so toggling `autoCenterContent` at runtime is picked up by the
+    // frame loop without restarting it (the loop's LaunchedEffect is keyed on engine/renderer/
+    // view/scene only).
+    val currentAutoCenterContent = rememberUpdatedState(autoCenterContent)
 
     LaunchedEffect(engine, renderer, view, scene) {
         while (true) {
@@ -467,6 +521,14 @@ fun SceneView(
                 sceneRenderer.renderFrame(frameTimeNanos) {
                     modelLoader.updateLoad()
                     childNodesRef.get().forEach { it.onFrame(frameTimeNanos) }
+
+                    // Library-level auto-center (#1026). One-shot: no-op once the content has been
+                    // centred, and skipped while the content bounds are still empty (async model
+                    // loads not finished). Runs here so it sees post-`updateLoad` geometry, on the
+                    // main render thread — Filament transform / renderable reads require it.
+                    if (currentAutoCenterContent.value) {
+                        autoCenterState.maybeCenter(contentRoot)
+                    }
 
                     currentCameraManipulator.value?.let { manipulator ->
                         val lastTime = lastFrameTimeNanosRef.get().takeIf { it != 0L }
@@ -1313,6 +1375,7 @@ fun Scene(
     view: View = rememberView(engine),
     isOpaque: Boolean = true,
     renderQuality: RenderQuality = RenderQuality.Default,
+    autoCenterContent: Boolean = true,
     renderer: Renderer = rememberRenderer(engine),
     scene: Scene = rememberScene(engine),
     environment: Environment = rememberEnvironment(environmentLoader, isOpaque = isOpaque),
@@ -1340,6 +1403,7 @@ fun Scene(
     view = view,
     isOpaque = isOpaque,
     renderQuality = renderQuality,
+    autoCenterContent = autoCenterContent,
     renderer = renderer,
     scene = scene,
     environment = environment,

--- a/sceneview/src/main/java/io/github/sceneview/SceneAutoCenter.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneAutoCenter.kt
@@ -1,0 +1,211 @@
+package io.github.sceneview
+
+import com.google.android.filament.Box
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Transform
+import io.github.sceneview.math.times
+import io.github.sceneview.math.toPosition
+import io.github.sceneview.node.Node
+import io.github.sceneview.node.RenderableNode
+
+/**
+ * Library-level auto-centering of `SceneView` content — the Android counterpart of the iOS
+ * `autoCenterContent` feature shipped in v4.3.0 ([#1026], [PR #1038]).
+ *
+ * iOS introduces an intermediate `contentRoot` `Entity`; on the first frame where the content's
+ * `visualBounds` is non-empty the library translates `contentRoot` so the content centroid lands
+ * at the orbit pivot. Android mirrors that here: every node declared inside the `SceneView { }`
+ * DSL block is parented to a single intermediate [Node] (the "content root"), and once the union
+ * of every renderable's bounding box is non-degenerate the content root is translated by minus
+ * the centroid. Lights and the camera are passed to `SceneView` as separate parameters — they are
+ * never DSL children — so they are unaffected by the translation, exactly like iOS keeping lights
+ * on `entities.root` rather than `contentRoot`.
+ *
+ * The math here is intentionally split from the Compose / Filament plumbing so it can be unit
+ * tested in pure JVM — see `SceneAutoCenterTest`.
+ *
+ * @see io.github.sceneview.SceneView
+ */
+
+/**
+ * Smallest mesh extent (in metres) the auto-centre pass accepts as "content has loaded enough to
+ * be centred". Below this threshold the bounds are assumed to come from an async model load that
+ * has not populated yet, so the pass is deferred to the next frame. Mirrors the iOS
+ * `minVisualExtent` constant in `SceneView.swift`.
+ */
+const val AUTO_CENTER_MIN_VISUAL_EXTENT: Float = 0.001f
+
+/**
+ * An axis-aligned bounding box expressed as a centre / half-extent pair, mirroring Filament's
+ * [Box] convention. Used by the auto-centring pass to union the bounds of every renderable in the
+ * scene without touching Filament's mutable [Box] type — keeping the union math pure and testable.
+ */
+data class Aabb(
+    val center: Position = Position(0f, 0f, 0f),
+    val halfExtent: Position = Position(0f, 0f, 0f)
+) {
+    /** Minimum corner of the box. */
+    val min: Position get() = center - halfExtent
+
+    /** Maximum corner of the box. */
+    val max: Position get() = center + halfExtent
+
+    /** Full side lengths of the box along x / y / z. */
+    val extents: Position get() = halfExtent * 2.0f
+
+    /**
+     * `true` when this box carries no measurable volume — either a freshly created zero box or
+     * one whose extents are non-finite (Filament reports an empty renderable AABB as
+     * `min = +∞ / max = -∞`).
+     */
+    val isEmpty: Boolean
+        get() = !halfExtent.x.isFinite() || !halfExtent.y.isFinite() || !halfExtent.z.isFinite() ||
+            (halfExtent.x <= 0f && halfExtent.y <= 0f && halfExtent.z <= 0f)
+
+    /** Returns the smallest box that contains both `this` and [other]. */
+    fun union(other: Aabb): Aabb {
+        if (other.isEmpty) return this
+        if (this.isEmpty) return other
+        val minCorner = Position(
+            minOf(min.x, other.min.x),
+            minOf(min.y, other.min.y),
+            minOf(min.z, other.min.z)
+        )
+        val maxCorner = Position(
+            maxOf(max.x, other.max.x),
+            maxOf(max.y, other.max.y),
+            maxOf(max.z, other.max.z)
+        )
+        return fromMinMax(minCorner, maxCorner)
+    }
+
+    companion object {
+        /** Builds an [Aabb] from an explicit min / max corner pair. */
+        fun fromMinMax(min: Position, max: Position): Aabb = Aabb(
+            center = (min + max) * 0.5f,
+            halfExtent = (max - min) * 0.5f
+        )
+    }
+}
+
+/**
+ * Unions an arbitrary collection of [Aabb]s, skipping empty boxes. Returns an empty [Aabb] when
+ * the input is empty or every box is degenerate.
+ */
+fun Iterable<Aabb>.union(): Aabb = fold(Aabb()) { acc, box -> acc.union(box) }
+
+/**
+ * Computes the union AABB of every renderable found in the subtree rooted at [node], expressed in
+ * the local space of [relativeTo]. Empty / not-yet-loaded renderables contribute nothing.
+ *
+ * Walks [Node.childNodes] recursively. For each [RenderableNode] — including the renderable child
+ * nodes a `ModelNode` exposes for its meshes — the per-renderable Filament AABB is transformed
+ * into [relativeTo]-local space via the renderable's world transform and the inverse world
+ * transform of [relativeTo], so the result is invariant of any rotation / scale the camera
+ * manipulator applies to the scene root on each frame.
+ *
+ * **Threading:** reads Filament `RenderableManager` / `TransformManager` state, so it must run on
+ * the main (render) thread — `SceneView`'s frame loop satisfies this.
+ *
+ * @param node       Subtree root to measure.
+ * @param relativeTo Node whose local space the resulting bounds are expressed in.
+ */
+fun computeContentBounds(node: Node, relativeTo: Node): Aabb {
+    val relativeToWorldInverse = relativeTo.worldToLocal
+    val acc = ArrayList<Aabb>()
+    fun visit(n: Node) {
+        if (!n.isVisible) return
+        renderableAabbsRelativeTo(n, relativeToWorldInverse, acc)
+        n.childNodes.forEach { visit(it) }
+    }
+    visit(node)
+    return acc.union()
+}
+
+/**
+ * Appends the world-space AABB of the renderable owned by [node] — re-expressed in the local
+ * space implied by [relativeToWorldInverse] — into [out]. `ModelNode`s expose their meshes as
+ * child `RenderableNode`s, so the recursive `childNodes` walk in [computeContentBounds] already
+ * covers them — this only reads the renderable component a node carries itself.
+ */
+private fun renderableAabbsRelativeTo(
+    node: Node,
+    relativeToWorldInverse: Transform,
+    out: MutableList<Aabb>
+) {
+    if (node !is RenderableNode) return
+    val filamentBox: Box = runCatching { node.axisAlignedBoundingBox }.getOrNull() ?: return
+    val localCenter = filamentBox.center.toPosition()
+    val localHalf = filamentBox.halfExtent.toPosition()
+    if (Aabb(localCenter, localHalf).isEmpty) return
+    // Transform the 8 corners of the renderable-local AABB into `relativeTo`-local space, then
+    // re-fit an axis-aligned box around them. Going corner-by-corner (rather than just the
+    // centre) keeps the box correct under rotation.
+    val nodeToRelativeTo = relativeToWorldInverse * node.worldTransform
+    var min = Position(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+    var max = Position(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY)
+    for (sx in intArrayOf(-1, 1)) {
+        for (sy in intArrayOf(-1, 1)) {
+            for (sz in intArrayOf(-1, 1)) {
+                val corner = Position(
+                    localCenter.x + sx * localHalf.x,
+                    localCenter.y + sy * localHalf.y,
+                    localCenter.z + sz * localHalf.z
+                )
+                val world = nodeToRelativeTo * corner
+                min = Position(
+                    minOf(min.x, world.x),
+                    minOf(min.y, world.y),
+                    minOf(min.z, world.z)
+                )
+                max = Position(
+                    maxOf(max.x, world.x),
+                    maxOf(max.y, world.y),
+                    maxOf(max.z, world.z)
+                )
+            }
+        }
+    }
+    out += Aabb.fromMinMax(min, max)
+}
+
+/**
+ * Mutable holder for the one-shot auto-centring pass. Lives in a Compose `remember` so the
+ * "already centred" flag survives recomposition. Mirrors the iOS `didCenterContent` `@State`.
+ */
+class SceneAutoCenterState {
+    /** `true` once [maybeCenter] has translated the content root. */
+    var didCenter: Boolean = false
+        private set
+
+    /**
+     * Runs the centring pass against [contentRoot]. No-op once [didCenter] is `true`, or while the
+     * content bounds are still empty / degenerate (async loads not finished). On success the
+     * content root is translated so the content centroid lands at its parent origin, and
+     * [didCenter] flips to `true`.
+     *
+     * **Threading:** must run on the main thread — it reads and writes Filament transforms.
+     *
+     * @return `true` if this call performed the centring translation.
+     */
+    fun maybeCenter(contentRoot: Node): Boolean {
+        if (didCenter) return false
+        // Bounds in content-root-local space so they are invariant of any rotation / scale the
+        // camera manipulator applies to the scene each frame.
+        val bounds = computeContentBounds(contentRoot, relativeTo = contentRoot)
+        if (bounds.isEmpty) return false
+        val maxExtent = maxOf(bounds.extents.x, bounds.extents.y, bounds.extents.z)
+        if (!maxExtent.isFinite() || maxExtent <= AUTO_CENTER_MIN_VISUAL_EXTENT) return false
+        contentRoot.position = -bounds.center
+        didCenter = true
+        return true
+    }
+
+    /**
+     * Resets the one-shot flag so the next frame re-runs the centring pass. Call this when the
+     * scene content changes (a new content-hash) so newly loaded models get re-centred.
+     */
+    fun reset() {
+        didCenter = false
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/SceneAutoCenterTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/SceneAutoCenterTest.kt
@@ -1,0 +1,122 @@
+package io.github.sceneview
+
+import io.github.sceneview.math.Position
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM pins for the auto-centring bounding-box math used by `SceneView`'s library-level
+ * `autoCenterContent` feature ([SceneAutoCenter.kt]) — the Android port of iOS #1026 / PR #1038.
+ *
+ * The Filament / Compose plumbing (the content-root node, the frame-loop hook) is exercised on
+ * device; this suite locks the pure [Aabb] union math that decides *where* content is recentred.
+ */
+class SceneAutoCenterTest {
+
+    private fun assertPositionEquals(expected: Position, actual: Position, delta: Float = 1e-5f) {
+        assertEquals("x", expected.x, actual.x, delta)
+        assertEquals("y", expected.y, actual.y, delta)
+        assertEquals("z", expected.z, actual.z, delta)
+    }
+
+    @Test
+    fun freshAabbIsEmpty() {
+        assertTrue("a default-constructed Aabb carries no volume", Aabb().isEmpty)
+    }
+
+    @Test
+    fun infiniteAabbIsEmpty() {
+        // Filament reports an empty renderable AABB as min = +∞ / max = -∞ — half-extent
+        // becomes non-finite and must be treated as empty.
+        val box = Aabb(
+            center = Position(0f, 0f, 0f),
+            halfExtent = Position(Float.POSITIVE_INFINITY, 1f, 1f)
+        )
+        assertTrue(box.isEmpty)
+    }
+
+    @Test
+    fun nonDegenerateAabbIsNotEmpty() {
+        assertFalse(
+            Aabb(center = Position(0f, 0f, 0f), halfExtent = Position(0.5f, 0.5f, 0.5f)).isEmpty
+        )
+    }
+
+    @Test
+    fun fromMinMaxComputesCenterAndHalfExtent() {
+        val box = Aabb.fromMinMax(
+            min = Position(-1f, -2f, -3f),
+            max = Position(3f, 2f, 1f)
+        )
+        assertPositionEquals(Position(1f, 0f, -1f), box.center)
+        assertPositionEquals(Position(2f, 2f, 2f), box.halfExtent)
+        assertPositionEquals(Position(4f, 4f, 4f), box.extents)
+    }
+
+    @Test
+    fun unionWithEmptyReturnsTheNonEmptyOperand() {
+        val box = Aabb(center = Position(5f, 5f, 5f), halfExtent = Position(1f, 1f, 1f))
+        assertPositionEquals(box.center, box.union(Aabb()).center)
+        assertPositionEquals(box.center, Aabb().union(box).center)
+    }
+
+    @Test
+    fun unionOfTwoBoxesIsTheirEnclosingBox() {
+        // Box A: [-1,-1,-1] .. [1,1,1]  — Box B: [1,1,1] .. [3,3,3]
+        val a = Aabb.fromMinMax(Position(-1f, -1f, -1f), Position(1f, 1f, 1f))
+        val b = Aabb.fromMinMax(Position(1f, 1f, 1f), Position(3f, 3f, 3f))
+        val union = a.union(b)
+        assertPositionEquals(Position(-1f, -1f, -1f), union.min)
+        assertPositionEquals(Position(3f, 3f, 3f), union.max)
+        assertPositionEquals(Position(1f, 1f, 1f), union.center)
+    }
+
+    @Test
+    fun iterableUnionFoldsAllBoxesAndSkipsEmpties() {
+        val boxes = listOf(
+            Aabb.fromMinMax(Position(0f, 0f, 0f), Position(2f, 2f, 2f)),
+            Aabb(), // empty — contributes nothing
+            Aabb.fromMinMax(Position(-2f, -2f, -2f), Position(0f, 0f, 0f))
+        )
+        val union = boxes.union()
+        assertPositionEquals(Position(-2f, -2f, -2f), union.min)
+        assertPositionEquals(Position(2f, 2f, 2f), union.max)
+        assertPositionEquals(Position(0f, 0f, 0f), union.center)
+    }
+
+    @Test
+    fun iterableUnionOfOnlyEmptyBoxesStaysEmpty() {
+        assertTrue(listOf(Aabb(), Aabb()).union().isEmpty)
+        assertTrue(emptyList<Aabb>().union().isEmpty)
+    }
+
+    @Test
+    fun offCenterContentCentroidGivesTheExpectedTranslation() {
+        // A model placed at z = -2 with a 1 m cube extent — the auto-centre pass translates the
+        // content root by minus this centroid so the centroid lands at the orbit pivot (origin).
+        val contentBounds = Aabb.fromMinMax(
+            min = Position(-0.5f, -0.5f, -2.5f),
+            max = Position(0.5f, 0.5f, -1.5f)
+        )
+        val translation = -contentBounds.center
+        assertPositionEquals(Position(0f, 0f, 2f), translation)
+    }
+
+    @Test
+    fun alreadyCenteredContentTranslatesByZero() {
+        // Idempotency pin: content already at origin (the 11 demos using per-node centerOrigin)
+        // must not be moved — the centring translation is exactly zero.
+        val centered = Aabb.fromMinMax(Position(-0.5f, -0.5f, -0.5f), Position(0.5f, 0.5f, 0.5f))
+        assertPositionEquals(Position(0f, 0f, 0f), -centered.center)
+    }
+
+    @Test
+    fun minVisualExtentThresholdIsPositiveAndSmall() {
+        // The gate that defers centring until an async model load has populated. Must be > 0 so a
+        // zero-extent placeholder is rejected, and small enough not to reject real small meshes.
+        assertTrue(AUTO_CENTER_MIN_VISUAL_EXTENT > 0f)
+        assertTrue(AUTO_CENTER_MIN_VISUAL_EXTENT < 0.01f)
+    }
+}


### PR DESCRIPTION
## Summary

Ports the iOS library-level `autoCenterContent` feature ([#1026](https://github.com/sceneview/sceneview/issues/1026) / [PR #1038](https://github.com/sceneview/sceneview/pull/1038)) to the Android `sceneview/` Filament library. Closes [#1051](https://github.com/sceneview/sceneview/issues/1051).

`SceneView` gains an `autoCenterContent: Boolean = true` parameter. When enabled, every node declared in the `SceneView { }` DSL `content` block is parented to an intermediate **content-root node**. On the first frame the union bounding box of all content renderables is non-empty, the library translates the content root once by minus the centroid — so loaded models render visually centred at the orbit pivot without each demo calling `ModelNode(centerOrigin = …)`.

- **Lights / camera unaffected** — they are `SceneView` parameters, never DSL children, so the content-root translation does not move them. Mirrors iOS keeping lights on `entities.root` rather than `contentRoot`.
- **One-shot + first-stable-frame gated** — the centering pass is skipped while bounds are empty / degenerate (async model loads not finished), gated by `AUTO_CENTER_MIN_VISUAL_EXTENT`, and runs at most once per content change. No jitter, no centering before content loads.
- **Builds on PR #1307** — `DefaultCameraNode` sits at `(0, 0.3, 2)` looking at world origin; centering content to origin aligns with both the camera default and the default manipulator's orbit pivot. This feature is the complementary half (centering the *content*, not just the camera).
- **Opt-out** — `autoCenterContent = false` preserves the exact pre-#1051 behavior (nodes register directly, no content root).

## Cross-platform parity

| Platform | API | Status |
|---|---|---|
| iOS | `.autoCenterContent(_:)` modifier | shipped v4.3.0 (#1026 / #1038) |
| **Android** | **`SceneView(autoCenterContent =)` param** | **this PR (#1051)** |
| Web | `autoCenterContent` | tracked #1052 |

Semantics match iOS: intermediate content root, centroid-of-content-bounds translation on the first non-empty frame, opt-out flag.

## Implementation

- New `SceneAutoCenter.kt` — pure-Kotlin `Aabb` (center/half-extent) with union math, `computeContentBounds()` walking the node tree, and a one-shot `SceneAutoCenterState`. The math is split from the Compose/Filament plumbing so it is JVM-testable.
- `Scene.kt` — adds the `autoCenterContent` param, a remembered `contentRoot` node, parents DSL nodes to it, and runs `maybeCenter()` in the main-thread frame loop after `modelLoader.updateLoad()`.
- Filament JNI (transform/renderable reads, content-root translation) all run on the main render thread — per the `CLAUDE.md` threading rule.

## Test plan

- [x] `./gradlew :sceneview:compileReleaseKotlin` — compiles
- [x] `./gradlew :sceneview:testReleaseUnitTest` — green incl. 11 new `SceneAutoCenterTest` cases pinning the AABB union / centroid math (off-centre translation, idempotency on already-centered content, empty/infinite-bounds rejection)
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — demo compiles
- [x] Visual QA on the ARCore Pixel 7a emulator — Model Viewer (helmet) and Geometry Primitives (multi-shape row) both render with content centred in the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)