### PR TITLE
ci: lighten main CI — tag-only Play Store, path-gate website + render/APK builds

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -6,6 +6,11 @@ on:
   # every PR before this slimming pass). This workflow now only produces
   # the artifact-uploaded + release-attached APKs on main and tag pushes,
   # which is the only unique value vs ci.yml's build.
+  #
+  # Strictly path-gated (#1311, #1321): SKIPPED on doc-only, CI-only
+  # (`.github/**`), and `mcp/`-only merges — none of those change the
+  # built APKs. Still runs on every real code/build-script change to
+  # `main` so squash-merged integration regressions are caught.
   push:
     branches: [main]
     paths:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,22 @@
 name: Deploy website + docs
 
 on:
+  # Path-gated so a pure-code merge to main does NOT redeploy the
+  # website + docs (#1311, #1321). The repo runs a continuous
+  # high-merge-rate cycle — a Pages rebuild only adds value when
+  # documentation or website content actually changes.
+  #   - `**/*.md` covers CHANGELOG.md / MIGRATION.md / CONTRIBUTING.md
+  #     (synced into the MkDocs site) plus marketing/codelabs/*.md.
+  #   - the workflow file itself is listed so changes to the deploy
+  #     logic re-run it.
   push:
     branches: [main]
     paths:
-      - 'website-static/**'
       - 'docs/**'
-      - 'marketing/**'
-      - 'samples/web-demo/**'
-      - 'sceneview-web/**'
+      - 'website-static/**'
       - 'llms.txt'
-      - 'CHANGELOG.md'
-      - 'MIGRATION.md'
-      - 'CONTRIBUTING.md'
+      - '**/*.md'
+      - '.github/workflows/docs.yml'
   release:
     types: [published]
   workflow_call:

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -1,35 +1,31 @@
 name: Deploy Demo to Play Store
 
-# Canary pattern with snapshot/release split.
+# Release-checkpoint deploy — tag-only.
 #
 # Trigger             → tracks
 # ─────────────────────────────────────────────────────────────────────
-# push to main        → internal only (snapshots like 4.0.2-abcdef0)
 # push of v* tag      → internal + production (clean release like 4.0.2)
 # manual dispatch     → user chooses
 #
-# Why this shape:
+# Why tag-only (#1321):
 #
-# - Internal is always the freshest — every push to main lands there
-#   within ~1 hour, no Google review. Thomas + the team eat the
-#   snapshot before real users do.
-# - Production is reserved for **stable releases** (semver tags). No
-#   more "4.0.2-133df8ff" snapshots leaking onto the public store —
-#   only "4.0.2", "4.0.3", … hit production.
+# - The repo runs a continuous high-merge-rate issue cycle (dozens of
+#   merges/day). Building + uploading an AAB on every push to main
+#   spent ~12 min of runner time per merge and churned the internal
+#   track with snapshots nobody installed.
+# - Production is reserved for **stable releases** (semver tags) and a
+#   tag push targets BOTH internal AND production, so internal testers
+#   still get the clean release the moment the tag lands — they no
+#   longer lag, they just no longer get a snapshot per merge.
+# - Mirrors `app-store.yml` (tag-only after #1318) and `release.yml`.
 # - A tag push runs through Google review (1-3 days) and replaces the
-#   previous public build. Internal still gets the same AAB so testers
-#   never lag behind production.
+#   previous public build.
+#
+# To deploy an interim build between releases, use `workflow_dispatch`
+# below and pick the desired track.
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'sceneview/**'
-      - 'arsceneview/**'
-      - 'sceneview-core/**'
-      - 'samples/android-demo/**'
-      - 'samples/android-demo-assets/**'
-      - 'samples/common/**'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -8,11 +8,18 @@ on:
   # on every push to main, so post-merge regressions surface in the
   # Actions tab without burning ~30 min × multiple PRs per day. Trigger
   # manually via workflow_dispatch when you want to vet a feature branch.
+  #
+  # Strictly path-gated (#1311, #1321): runs only when render-affecting
+  # source actually changes. SKIPPED on doc-only, CI-only (`.github/**`),
+  # and `mcp/`-only merges — none of those can change a rendered frame.
+  # squash-merge means `main` HEAD differs from every PR commit, so this
+  # main-push run still catches integration regressions a PR build can't.
   push:
     branches: [main]
     paths:
       - 'sceneview/src/**'
       - 'arsceneview/src/**'
+      - 'sceneview-core/src/**'
       - 'samples/**'
       - 'SceneViewSwift/**'
       - 'gradle/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - **`release.yml` now deploys the generated Dokka API docs to `sceneview.github.io/api/sceneview/<version>/` + `/latest/` and wraps Dokka generation in a 3× retry to tolerate transient Maven Central 503s ([#1252](https://github.com/sceneview/sceneview/issues/1252), [#1127](https://github.com/sceneview/sceneview/issues/1127)).**
 - `Deploy iOS App to App Store` is now tag-only — fixes Apple upload-limit failures on every main merge ([#1318](https://github.com/sceneview/sceneview/issues/1318)).
+- Lighter `main` CI: `Deploy Demo to Play Store` is now tag-only ([#1321](https://github.com/sceneview/sceneview/issues/1321)), `Deploy website + docs` is path-gated to docs/website/markdown changes, and `Render Tests` / `Build sample APKs` path filters were tightened to skip doc-only, CI-only and `mcp/`-only merges ([#1311](https://github.com/sceneview/sceneview/issues/1311)).
 
 ### Changed — MCP
 


### PR DESCRIPTION
## Summary

The repo runs a continuous high-merge-rate issue cycle (dozens of merges/day). Several heavy workflows did release-type work on **every** merge to `main`. This PR lightens them so that work only happens when it adds value.

`Closes #1321`. Overlaps the CI-performance umbrella #1311 (path-gating theme).

## Workflows changed

| Workflow | Before | After |
|---|---|---|
| `play-store.yml` — Deploy Demo to Play Store | `push: main` (path-gated) **+** `v*` tags + dispatch | **`v*` tags only** + dispatch. No more ~12-min AAB build + internal-track upload per merge. Mirrors `app-store.yml` (tag-only after #1318). |
| `docs.yml` — Deploy website + docs | `push: main` gated on `website-static/`, `docs/`, `marketing/`, `samples/web-demo/`, `sceneview-web/`, `llms.txt`, `CHANGELOG.md`, `MIGRATION.md`, `CONTRIBUTING.md` | `push: main` gated on `docs/**`, `website-static/**`, `llms.txt`, `**/*.md`, `.github/workflows/docs.yml`. A pure-code merge no longer redeploys GitHub Pages. (`release: published` + `workflow_call` + `workflow_dispatch` unchanged.) |
| `render-tests.yml` — Render Tests | `push: main` gated on `sceneview/src/`, `arsceneview/src/`, `samples/`, `SceneViewSwift/`, `gradle/` | Same, **+ `sceneview-core/src/**`**. Now provably skips doc-only, CI-only and `mcp/`-only merges. |
| `build-apks.yml` — Build sample APKs | `push: main` (path-gated) + `v*` tags + dispatch | Path filter unchanged (already strict); comment clarified to confirm it skips doc-only / CI-only / `mcp/`-only merges. |

## CI Gate correctness

Branch protection requires the `CI Gate` aggregator (#1314). It is **`pull_request`-triggered** and aggregates check runs for the PR head SHA, treating `skipped`/`neutral`/`success` as passing. The four workflows changed here are **push-triggered** (`push: main` / `push: tags`) — they produce **zero** check runs on a PR head SHA, so path-gating them does not interact with the gate at all. Doc-only PRs and code PRs both resolve `CI Gate` exactly as before.

Trigger trace:
- **Doc-only PR / code PR** → unaffected; `CI Gate` resolves via the unchanged `pull_request` workflows (`ci.yml`, `pr-check.yml`, …).
- **Doc-only merge to main** → `docs.yml` runs; `render-tests`/`build-apks`/`play-store` skip.
- **Code merge to main** → `render-tests`/`build-apks` run; `docs.yml`/`play-store` skip.
- **Release `vX.Y.Z` tag** → `play-store.yml` + `build-apks.yml` + `release.yml` + `app-store.yml` all fire; `docs.yml` runs on `release: published`. All deploy targets still ship on tags.

## Relation to #1311

This completes the **push-time** half of #1311's path-gating theme (its numbered gaps #1–#10 target PR-time `pr-check.yml`/`ci.yml`, left for separate work). #1311 gap #8's `--retry` on the Android-CLI `curl` is already present in `render-tests.yml`.

## Follow-up

No nightly full-CI safety-net run exists today (`maintenance.yml` is a dependency-version checker, not a validation run). Filed as #1324 rather than expanding this PR.

## Verification

- All four edited YAML files validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- `actionlint` run — no new findings; pre-existing shellcheck `info`/`warning` items are inside untouched script bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)