### PR TITLE
fix(ci): discord-notify.yml — fix GitHub Actions script injection (#1313)

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -33,15 +33,19 @@ jobs:
       - name: Post release to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # User-controlled fields — passed via env, never interpolated into the
+          # inline script, to prevent GitHub Actions shell script injection.
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_WEBHOOK_URL secret is not set — skipping notification."
             exit 0
           fi
 
-          PRERELEASE="${{ github.event.release.prerelease }}"
-
-          if [ "$PRERELEASE" = "true" ]; then
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
             EMOJI="🧪"
             LABEL="Pre-release"
           else
@@ -50,9 +54,9 @@ jobs:
           fi
 
           PAYLOAD=$(jq -n \
-            --arg title "$EMOJI $LABEL: ${{ github.event.release.tag_name }}" \
-            --arg name "${{ github.event.release.name }}" \
-            --arg url "${{ github.event.release.html_url }}" \
+            --arg title "$EMOJI $LABEL: $RELEASE_TAG_NAME" \
+            --arg name "$RELEASE_NAME" \
+            --arg url "$RELEASE_URL" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{embeds: [{title: $title, description: ("**" + $name + "**\n\n[View release notes](" + $url + ")"), color: 3447003, footer: {text: "SceneView — 3D & AR SDK"}, timestamp: $ts}]}')
 
@@ -74,6 +78,12 @@ jobs:
       - name: Post new issue to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # User-controlled fields — passed via env, never interpolated into the
+          # inline script, to prevent GitHub Actions shell script injection.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_WEBHOOK_URL secret is not set — skipping notification."
@@ -81,10 +91,10 @@ jobs:
           fi
 
           PAYLOAD=$(jq -n \
-            --arg title "🐛 New Issue #${{ github.event.issue.number }}" \
-            --arg issue_title "${{ github.event.issue.title }}" \
-            --arg url "${{ github.event.issue.html_url }}" \
-            --arg author "${{ github.event.issue.user.login }}" \
+            --arg title "🐛 New Issue #$ISSUE_NUMBER" \
+            --arg issue_title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg author "$ISSUE_AUTHOR" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{embeds: [{title: $title, description: ("**" + $issue_title + "**\n\nOpened by [" + $author + "](https://github.com/" + $author + ")\n[View issue](" + $url + ")"), color: 15105570, footer: {text: "SceneView — 3D & AR SDK"}, timestamp: $ts}]}')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed — CI security
+
+- **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Fixed — AR recording resolution ([#1065](https://github.com/sceneview/sceneview/issues/1065))


### PR DESCRIPTION
## Summary

`actionlint` flagged `.github/workflows/discord-notify.yml`: user-controlled `github.event.*` fields were interpolated directly via `${{ }}` into the `jq -n` inline shell scripts — a GitHub Actions **script-injection** vulnerability. A crafted issue title (or release name) could execute arbitrary shell in the runner.

## Fix

Move every user-controlled field into the step `env:` block and reference it as a quoted shell variable inside `run:`:

- **notify-issue**: `issue.title`, `issue.user.login`, `issue.number`, `issue.html_url`
- **notify-release**: `release.name`, `release.tag_name`, `release.prerelease`, `release.html_url`

No `${{ github.event.* }}` interpolation remains inside any `run:` script. The only remaining reference is in `concurrency.group:` — a key context (not a shell script) using numeric IDs only, not injectable.

Behavior is unchanged for legitimate titles. YAML validated; `actionlint` now clean.

Closes #1313