### PR TITLE
refactor(samples): migrate remaining demos to rememberMaterialInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed — Samples
+
+- **Migrated the remaining `samples/android-demo` demos to the `rememberMaterialInstance` / `rememberUnlitMaterialInstance` helpers ([#971](https://github.com/sceneview/sceneview/issues/971)).** `CollisionDemo`, `LightingDemo`, `VideoDemo`, `ARStreetscapeDemo`, `GeometryDemo`, `DebugOverlayDemo`, `PhysicsDemo` and the shared `Axes3DNode` no longer allocate `MaterialInstance` handles via raw `materialLoader.create*` without disposal — the helpers own the lifecycle. Behaviour-preserving.
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Fixed — AR recording resolution ([#1065](https://github.com/sceneview/sceneview/issues/1065))

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/Axes3DNode.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/Axes3DNode.kt
@@ -1,12 +1,12 @@
 package io.github.sceneview.demo.common
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import io.github.sceneview.SceneScope
 import io.github.sceneview.loaders.MaterialLoader
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
 
 /**
  * Blender-style 3D axes gizmo at the origin (0, 0, 0).
@@ -51,19 +51,14 @@ fun SceneScope.Axes3DNode(
     colorY: Color = Color.Green,
     colorZ: Color = Color.Blue,
 ) {
-    // Materials are minted once per (loader, colour) pair — `remember` ensures we don't
-    // leak a fresh MaterialInstance on every recomposition. Unlit so the gizmo keeps the
-    // requested colour regardless of scene lighting (it's a debug reference, not part of
-    // the rendered world).
-    val materialX = remember(materialLoader, colorX) {
-        materialLoader.createUnlitColorInstance(color = colorX)
-    }
-    val materialY = remember(materialLoader, colorY) {
-        materialLoader.createUnlitColorInstance(color = colorY)
-    }
-    val materialZ = remember(materialLoader, colorZ) {
-        materialLoader.createUnlitColorInstance(color = colorZ)
-    }
+    // Materials are minted once per (loader, colour) pair and disposed when the
+    // composition leaves — `rememberUnlitMaterialInstance` owns the MaterialInstance
+    // lifecycle so the gizmo never leaks a JNI handle. Unlit so it keeps the requested
+    // colour regardless of scene lighting (it's a debug reference, not part of the
+    // rendered world).
+    val materialX = rememberUnlitMaterialInstance(materialLoader, colorX)
+    val materialY = rememberUnlitMaterialInstance(materialLoader, colorY)
+    val materialZ = rememberUnlitMaterialInstance(materialLoader, colorZ)
 
     // X axis — cylinder lies along native +Y, rotate -90° around Z to point along +X.
     CylinderNode(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARStreetscapeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARStreetscapeDemo.kt
@@ -49,6 +49,7 @@ import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 
 private const val TAG = "ARStreetscapeDemo"
 
@@ -230,14 +231,13 @@ fun ARStreetscapeDemo(onBack: () -> Unit) {
     // Semi-transparent material for streetscape geometry overlays — SceneView TintLight at
     // low alpha so the real camera feed of buildings/sidewalks stays readable through the
     // overlay mesh.
-    val buildingMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(
-            color = SceneViewColors.LandscapeOverlay,
-            metallic = 0.1f,
-            roughness = 0.9f,
-            reflectance = 0.1f
-        )
-    }
+    val buildingMaterial = rememberMaterialInstance(
+        materialLoader,
+        color = SceneViewColors.LandscapeOverlay,
+        metallic = 0.1f,
+        roughness = 0.9f,
+        reflectance = 0.1f,
+    )
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_streetscape_title),

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CollisionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CollisionDemo.kt
@@ -30,6 +30,7 @@ import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberOnGestureListener
 import io.github.sceneview.rememberView
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
 
 /**
  * Demonstrates collision-based hit testing.
@@ -52,12 +53,8 @@ fun CollisionDemo(onBack: () -> Unit) {
     // On-brand: Primary blue by default, Accent purple when a shape is hit — same hero
     // gradient as the product identity. Unlit so the hit/no-hit colour flip stays
     // legible regardless of scene lighting (the colour itself IS the signal here).
-    val defaultMaterial = remember(materialLoader) {
-        materialLoader.createUnlitColorInstance(color = SceneViewColors.Primary)
-    }
-    val highlightedMaterial = remember(materialLoader) {
-        materialLoader.createUnlitColorInstance(color = SceneViewColors.Accent)
-    }
+    val defaultMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Primary)
+    val highlightedMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Accent)
 
     // Node layout: 3 cubes and 2 spheres in a row.
     data class ShapeSpec(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
@@ -55,6 +55,7 @@ import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 import io.github.sceneview.utils.rememberDebugStats
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -115,9 +116,7 @@ fun DebugOverlayDemo(onBack: () -> Unit) {
     // background (no light, no IBL) and made the demo look empty (#1266). A single
     // shared color instance keeps the per-node cost at zero extra material allocations,
     // so the stress test still measures pure geometry + draw-call overhead.
-    val sphereMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(SceneViewColors.Primary)
-    }
+    val sphereMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Primary)
 
     // Rolling FPS history — 120 samples (~2 s of real-world data at 60 fps, but the
     // sparkline width matters more than wall-clock time so we just show the most recent

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GeometryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GeometryDemo.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import io.github.sceneview.sample.LifecycleAwareLaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -37,8 +36,6 @@ import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.demo.theme.SceneViewDemoTheme
-import io.github.sceneview.material.setMetallic
-import io.github.sceneview.material.setRoughness
 import io.github.sceneview.math.Direction
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -47,6 +44,7 @@ import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
  * Shows the four built-in geometry primitives: Cube, Sphere, Cylinder, Plane.
@@ -86,10 +84,12 @@ fun GeometryDemo(onBack: () -> Unit) {
 
     // On-brand ramp — Primary blue, Accent purple, light blue, soft purple — so the four
     // primitives stay visually distinct while all reading as SceneView.
-    val cubeMaterial = remember(materialLoader) { materialLoader.createColorInstance(SceneViewColors.Ramp4[0]) }
-    val sphereMaterial = remember(materialLoader) { materialLoader.createColorInstance(SceneViewColors.Ramp4[1]) }
-    val cylinderMaterial = remember(materialLoader) { materialLoader.createColorInstance(SceneViewColors.Ramp4[2]) }
-    val planeMaterial = remember(materialLoader) { materialLoader.createColorInstance(SceneViewColors.Ramp4[3]) }
+    // metallic / roughness are pushed into each instance by rememberMaterialInstance
+    // itself (via a paired DisposableEffect) — no extra slider-sync LaunchedEffect needed.
+    val cubeMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[0], metallic, roughness)
+    val sphereMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[1], metallic, roughness)
+    val cylinderMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[2], metallic, roughness)
+    val planeMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[3], metallic, roughness)
 
     // Continuous Y-axis spin shared by all primitives. withFrameNanos drives the
     // angle off the Choreographer so it runs at the display's refresh rate without
@@ -119,14 +119,6 @@ fun GeometryDemo(onBack: () -> Unit) {
                 lastNanos = nanos
             }
         }
-    }
-
-    // Apply metallic/roughness to all 4 materials whenever the sliders change.
-    LaunchedEffect(metallic, roughness) {
-        cubeMaterial.setMetallic(metallic); cubeMaterial.setRoughness(roughness)
-        sphereMaterial.setMetallic(metallic); sphereMaterial.setRoughness(roughness)
-        cylinderMaterial.setMetallic(metallic); cylinderMaterial.setRoughness(roughness)
-        planeMaterial.setMetallic(metallic); planeMaterial.setRoughness(roughness)
     }
 
     DemoScaffold(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
@@ -44,6 +44,7 @@ import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
  * Demonstrates directional, point, and spot lights with interactive controls.
@@ -94,23 +95,21 @@ fun LightingDemo(onBack: () -> Unit) {
     // the same way because the helmet alone gets fully lit by any of them. The wall
     // makes the light's *shape in space* visible: directional = uniform wash, point
     // = radial gradient (1/r²), spot = sharp circular disc with cone edge.
-    val backdropMaterial = remember(materialLoader) {
-        materialLoader.createColorInstance(
-            color = Color(0xFF424448),
-            metallic = 0.0f,
-            roughness = 0.85f,
-        )
-    }
-    val sourceMaterial = remember(materialLoader, selectedColor) {
-        // Bright unlit-looking ball to mark the light position. PBR can't be true
-        // self-emissive without an emissive material, but a low-roughness saturated
-        // colour with the IBL fallback reads convincingly as a glowing source.
-        materialLoader.createColorInstance(
-            color = selectedColor.color,
-            metallic = 0.0f,
-            roughness = 0.0f,
-        )
-    }
+    val backdropMaterial = rememberMaterialInstance(
+        materialLoader,
+        color = Color(0xFF424448),
+        metallic = 0.0f,
+        roughness = 0.85f,
+    )
+    // Bright unlit-looking ball to mark the light position. PBR can't be true
+    // self-emissive without an emissive material, but a low-roughness saturated
+    // colour with the IBL fallback reads convincingly as a glowing source.
+    val sourceMaterial = rememberMaterialInstance(
+        materialLoader,
+        color = selectedColor.color,
+        metallic = 0.0f,
+        roughness = 0.0f,
+    )
 
     // Camera orbits the helmet; the model itself stays fixed so the directional /
     // point / spot light hits the exact same surface every frame — otherwise the

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
@@ -213,9 +213,14 @@ fun PhysicsDemo(onBack: () -> Unit) {
                 val groundMaterial = rememberMaterialInstance(
                     materialLoader, SceneViewColors.SurfaceDim
                 )
-                val sphereMaterials = remember(materialLoader) {
-                    SceneViewColors.Ramp4.map { materialLoader.createColorInstance(it) }
-                }
+                // Ramp4 is a fixed 4-colour list — call the helper once per slot so
+                // each MaterialInstance gets the same disposal hygiene as the rest.
+                val sphereMaterials = listOf(
+                    rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[0]),
+                    rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[1]),
+                    rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[2]),
+                    rememberMaterialInstance(materialLoader, SceneViewColors.Ramp4[3]),
+                )
 
                 // Ground plane — must use Size(x, y=0, z) for a HORIZONTAL floor
                 PlaneNode(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/VideoDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/VideoDemo.kt
@@ -51,6 +51,7 @@ import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.sample.rememberMaterialInstance
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -251,16 +252,15 @@ fun VideoDemo(onBack: () -> Unit) {
                         // (not behind, where the plane would occlude it). The cube
                         // is large enough (1.0 m) to read at any camera distance,
                         // and slightly tilted so the IBL highlights catch the eye.
-                        val chromeMaterial = remember(materialLoader) {
-                            materialLoader.createColorInstance(
-                                color = androidx.compose.ui.graphics.Color(
-                                    0.92f, 0.92f, 0.95f, 1f
-                                ),
-                                metallic = 1f,
-                                roughness = 0.12f,
-                                reflectance = 0.8f,
-                            )
-                        }
+                        val chromeMaterial = rememberMaterialInstance(
+                            materialLoader,
+                            color = androidx.compose.ui.graphics.Color(
+                                0.92f, 0.92f, 0.95f, 1f
+                            ),
+                            metallic = 1f,
+                            roughness = 0.12f,
+                            reflectance = 0.8f,
+                        )
                         CubeNode(
                             size = Size(1.0f, 1.0f, 1.0f),
                             materialInstance = chromeMaterial,
@@ -274,16 +274,15 @@ fun VideoDemo(onBack: () -> Unit) {
                         // (5×5 m) to fill the lower half of every camera angle. The
                         // very low roughness + high metallic gives a near-mirror
                         // bounce of the video and the IBL.
-                        val floorMaterial = remember(materialLoader) {
-                            materialLoader.createColorInstance(
-                                color = androidx.compose.ui.graphics.Color(
-                                    0.04f, 0.04f, 0.05f, 1f
-                                ),
-                                metallic = 1f,
-                                roughness = 0.06f,
-                                reflectance = 0.95f,
-                            )
-                        }
+                        val floorMaterial = rememberMaterialInstance(
+                            materialLoader,
+                            color = androidx.compose.ui.graphics.Color(
+                                0.04f, 0.04f, 0.05f, 1f
+                            ),
+                            metallic = 1f,
+                            roughness = 0.06f,
+                            reflectance = 0.95f,
+                        )
                         PlaneNode(
                             size = Size(5f, 0.001f, 5f),
                             materialInstance = floorMaterial,


### PR DESCRIPTION
## Summary

Completes the `rememberMaterialInstance` migration started in #937. The remaining `samples/android-demo` demos that still allocated `MaterialInstance` handles via raw `materialLoader.createColorInstance` / `createUnlitColorInstance` (with no disposal) now use the lifecycle-owning helpers:

- `CollisionDemo`, `LightingDemo`, `VideoDemo`, `ARStreetscapeDemo`, `GeometryDemo`, `DebugOverlayDemo`, `PhysicsDemo` (leftover `Ramp4.map` allocation)
- The shared `Axes3DNode` composable (same manual pattern)

The helpers own the MaterialInstance lifecycle via a `DisposableEffect`-backed `onDispose`, so home → demo → home navigation cycles no longer leak JNI handles.

`GeometryDemo`'s separate `LaunchedEffect(metallic, roughness)` slider-sync is removed — the helper performs the equivalent `setMetallic` / `setRoughness` in its paired `DisposableEffect`. The PBR-key safety pattern is respected: `color` is the only `remember` key, so 60 Hz slider ticks never churn allocate/destroy the instance.

Behaviour-preserving — no visual change. Scoped entirely to `samples/android-demo/`.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — passes
- [x] `bash .claude/scripts/impact-check.sh` — PASS (1 pre-existing unrelated warning)
- [ ] Visual smoke test of the 7 migrated demos on an emulator

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)