### PR TITLE
ci: revert render-tests 3-shard matrix to single job (#1119)

### DIFF
--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -2,7 +2,7 @@ name: Render Tests
 
 on:
   # Render tests no longer run on PRs — they are non-blocking
-  # (`continue-on-error: true`), spin up 3 KVM-accelerated emulator shards
+  # (`continue-on-error: true`), spin up a KVM-accelerated emulator
   # + an iOS Simulator + Playwright web, and the screenshots they produce
   # were rarely consulted by PR reviewers. The signal is still captured
   # on every push to main, so post-merge regressions surface in the
@@ -44,21 +44,13 @@ jobs:
     # status check.  Individual job status still visible in the Actions tab.
     continue-on-error: true
 
-    # Shard render tests across 3 parallel emulator jobs (#1119). The
-    # `class=` testInstrumentationRunnerArguments accepts a comma-separated
-    # list, so a "group" can bundle 2+ classes that exercise similar code
-    # paths. Wall-clock drops from ~20 min sequential to ~8 min parallel.
-    strategy:
-      fail-fast: false
-      matrix:
-        api-level: [30]
-        test-group:
-          - name: demo-parameters
-            classes: io.github.sceneview.render.DemoParametersRenderTest
-          - name: visual-geometry
-            classes: io.github.sceneview.render.VisualVerificationTest,io.github.sceneview.render.GeometryRenderTest
-          - name: smoke-lighting
-            classes: io.github.sceneview.render.RenderSmokeTest,io.github.sceneview.render.LightingRenderTest
+    # The 3-shard emulator matrix (#1119, PR #1145) was REVERTED to a single
+    # job: all 5 render-test classes are class-level `@Ignore`'d on
+    # SwiftShader CI (Filament `readPixels` crash, tracked in #803), so
+    # sharding boots 3 emulators to run 0 tests — strictly more CI cost for
+    # the same 0 coverage. Re-apply the matrix scaffold (DemoParameters
+    # alone; Visual+Geometry paired; Smoke+Lighting paired) once #803 lifts
+    # the `@Ignore`s and real per-class wall-clocks justify the parallelism.
 
     steps:
       - uses: actions/checkout@v6
@@ -78,15 +70,15 @@ jobs:
       - name: Run render tests on emulator
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.api-level }}
+          api-level: 30
           target: google_apis
           arch: x86_64
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           disable-animations: true
           script: |
-            # Run this shard's class list only. The `class=` arg accepts a
-            # comma-separated list, so a "group" can bundle related classes.
-            ./gradlew :sceneview:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=${{ matrix.test-group.classes }} --stacktrace
+            # Run the whole render-test suite in one emulator. Every target
+            # class is currently `@Ignore`'d (#803), so this completes fast.
+            ./gradlew :sceneview:connectedDebugAndroidTest --stacktrace
 
             # Pull rendered screenshots from device for visual inspection
             mkdir -p render-output
@@ -96,7 +88,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: android-library-render-results-${{ matrix.test-group.name }}
+          name: android-library-render-results
           path: sceneview/build/reports/androidTests/
           if-no-files-found: ignore
 
@@ -104,7 +96,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: android-library-render-screenshots-${{ matrix.test-group.name }}
+          name: android-library-render-screenshots
           path: render-output/
           if-no-files-found: ignore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.
 
+### Changed — CI
+
+- **`render-tests.yml` reverted from a 3-shard emulator matrix back to a single job ([#1119](https://github.com/sceneview/sceneview/issues/1119)).** All 5 render-test classes are class-level `@Ignore`'d on SwiftShader CI (#803), so the shard matrix booted 3 emulators to run 0 tests — strictly more CI cost for the same coverage. The matrix scaffold can be re-applied once #803 lifts the ignores.
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Fixed — AR recording resolution ([#1065](https://github.com/sceneview/sceneview/issues/1065))


### PR DESCRIPTION
## Summary

The render-test sharding requested in #1119 was already implemented in PR #1145 (`beb625a3`): `render-tests.yml` gained a 3-shard `test-group` emulator matrix (`demo-parameters` / `visual-geometry` / `smoke-lighting`).

But the CI-SWEEP HOLD verdict in #1119's comments flagged a BLOCKER: **all 5 render-test classes are class-level `@Ignore`'d** on SwiftShader CI (`DemoParametersRenderTest`, `GeometryRenderTest`, `LightingRenderTest`, `RenderSmokeTest`, `VisualVerificationTest` — Filament `readPixels` crash, tracked in #803). So the shard matrix boots **3 emulators to run 0 tests** — strictly more CI cost for the same 0 coverage than a single job.

This PR reverts the matrix to a single job per the HOLD recommendation:

- Removed `strategy: matrix: test-group:` and the per-shard `class=` filter — the single job runs the whole `androidTest` suite (currently all `@Ignore`'d, so it completes fast).
- Restored single (non-suffixed) artifact upload names (`android-library-render-results`, `android-library-render-screenshots`).
- Added a YAML comment noting the matrix was removed pending #803 and can be re-sharded once the render tests are un-`@Ignore`'d.
- Cuts emulator boots from 3 → 1 per run.

## Untouched

- Path-gating and `push`-only trigger (set by PR #1325) — left exactly as-is.
- `render-tests.yml` remains NOT part of the `pull_request` `CI Gate` aggregator (`ci-gate.yml`) — confirmed.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] `actionlint` clean
- [x] `impact-check.sh` passes (only the pre-existing unrelated cross-platform warning)

Closes #1119