### PR TITLE
fix(sceneview): retry ViewNode off-screen attach on owner-View attach (#984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.
 
+### Fixed — ViewNode rendering
+
+- **`ViewNode` no longer renders as a permanent black rectangle after a background → foreground cycle ([#984](https://github.com/sceneview/sceneview/issues/984)).** `ViewNode.WindowManager` now retries the off-screen window attach via an owner-View attach listener when the owner is not yet attached at resume time, instead of silently dropping the attach.
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Fixed — AR recording resolution ([#1065](https://github.com/sceneview/sceneview/issues/1065))

--- a/sceneview/src/androidTest/java/io/github/sceneview/node/ViewNodeTest.kt
+++ b/sceneview/src/androidTest/java/io/github/sceneview/node/ViewNodeTest.kt
@@ -280,4 +280,86 @@ class ViewNodeTest {
             wm.destroy() // calling twice must not throw
         }
     }
+
+    // ── Retry-on-attach (sceneview/sceneview#984) ─────────────────────────────
+
+    /**
+     * Regression for #984: when `resume()` is called with an owner View that is not yet
+     * attached to a window, the WindowManager must register an attach listener on it so the
+     * off-screen attach is retried automatically — not silently dropped. A detached owner
+     * View must therefore have an [View.OnAttachStateChangeListener] registered after
+     * `resume()`, and that listener must be removed again on `pause()`.
+     */
+    @Test
+    fun windowManager_resume_withDetachedOwner_registersAttachListener() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        lateinit var wm: ViewNode.WindowManager
+        lateinit var detachedOwner: AttachTrackingView
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            wm = ViewNode.WindowManager(ctx)
+            // A bare View built from a Context is not attached to any window.
+            detachedOwner = AttachTrackingView(ctx)
+            wm.resume(detachedOwner)
+        }
+        // resume() posts its work to the owner View — let the main looper drain it.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            assertTrue(
+                "resume() with a detached owner must register an attach listener for retry",
+                detachedOwner.listenerCount > 0
+            )
+
+            wm.pause()
+            assertEquals(
+                "pause() must remove the pending attach listener",
+                0, detachedOwner.listenerCount
+            )
+
+            wm.destroy()
+        }
+    }
+
+    /**
+     * Regression for #984: `destroy()` must also clear the pending attach listener so the
+     * WindowManager does not keep a reference to (and re-attach via) a stale owner View.
+     */
+    @Test
+    fun windowManager_destroy_clearsPendingAttachListener() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        lateinit var wm: ViewNode.WindowManager
+        lateinit var detachedOwner: AttachTrackingView
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            wm = ViewNode.WindowManager(ctx)
+            detachedOwner = AttachTrackingView(ctx)
+            wm.resume(detachedOwner)
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            wm.destroy()
+            assertEquals(
+                "destroy() must remove the pending attach listener",
+                0, detachedOwner.listenerCount
+            )
+        }
+    }
+
+    /** A [View] that counts how many [OnAttachStateChangeListener]s are currently registered. */
+    private class AttachTrackingView(ctx: android.content.Context) : View(ctx) {
+        var listenerCount = 0
+            private set
+
+        override fun addOnAttachStateChangeListener(listener: OnAttachStateChangeListener) {
+            super.addOnAttachStateChangeListener(listener)
+            listenerCount++
+        }
+
+        override fun removeOnAttachStateChangeListener(listener: OnAttachStateChangeListener) {
+            super.removeOnAttachStateChangeListener(listener)
+            if (listenerCount > 0) listenerCount--
+        }
+    }
 }

--- a/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ViewNode.kt
@@ -263,6 +263,29 @@ class ViewNode(
 
         private var destroyed = false
 
+        // The owner View we are currently waiting on to become attached to a window so we can
+        // retry the off-screen attach. Non-null only between a failed `resume()` and the moment
+        // the owner View finally attaches (or `pause()`/`destroy()` cancels the wait).
+        private var pendingAttachOwner: View? = null
+
+        // Re-runs the off-screen attach the instant the owner View becomes attached to a window.
+        // This is the fix for sceneview/sceneview#984: on a background → foreground cycle the
+        // owner SurfaceView/TextureView re-attaches *after* `onResume` fires, so the `post`ed
+        // attach in `resume()` runs while the owner is still detached and would otherwise be
+        // silently dropped — leaving the ViewNode as a black rectangle until the next process
+        // restart.
+        private val onOwnerAttachListener = object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                if (!destroyed) tryAttachingView()
+            }
+
+            override fun onViewDetachedFromWindow(v: View) {
+                // Owner window is gone — drop the off-screen window so it is not leaked, and keep
+                // waiting on this owner for the next attach.
+                tryDetachingView()
+            }
+        }
+
         val layout by lazy {
             FrameLayout(context).also {
                 context.findActivity()?.let { activity ->
@@ -282,8 +305,12 @@ class ViewNode(
 
         /**
          * An owner View can only be added to the WindowManager after the activity has finished
-         * resuming.
-         * Therefore, we must use post to ensure that the window is only added after resume is finished.
+         * resuming **and** the owner View itself is attached to a window.
+         *
+         * If the owner View is not yet attached when we try (common on a background → foreground
+         * cycle, where the SurfaceView re-attaches after `onResume`), we register an
+         * [View.OnAttachStateChangeListener] so the attach is retried automatically the moment the
+         * owner View becomes attached, instead of being silently dropped (sceneview/sceneview#984).
          */
         fun resume(ownerView: View) {
             if (destroyed) return
@@ -293,8 +320,13 @@ class ViewNode(
                 // Recheck after the post: destroy() may have run while we were queued — without this
                 // guard the layout would be re-attached to the system WindowManager *after* it was
                 // explicitly torn down, leaking the window for the lifetime of the process.
-                if (!destroyed && ownerView.isAttachedToWindow) {
+                if (destroyed) return@post
+                if (ownerView.isAttachedToWindow) {
+                    clearPendingAttach()
                     tryAttachingView()
+                } else {
+                    // Owner not attached yet — wait for it instead of dropping the attach.
+                    awaitOwnerAttach(ownerView)
                 }
             }
         }
@@ -304,34 +336,55 @@ class ViewNode(
          * the window will be leaked. Therefore we add/remove the ownerView in resume/pause.
          */
         fun pause() {
+            clearPendingAttach()
             tryDetachingView()
         }
 
         fun destroy() {
             destroyed = true
+            clearPendingAttach()
             tryDetachingView()
         }
 
+        /** Registers [onOwnerAttachListener] on [ownerView] so the attach retries once it attaches. */
+        private fun awaitOwnerAttach(ownerView: View) {
+            if (pendingAttachOwner === ownerView) return
+            clearPendingAttach()
+            pendingAttachOwner = ownerView
+            ownerView.addOnAttachStateChangeListener(onOwnerAttachListener)
+        }
+
+        /** Stops waiting on the pending owner View, if any. */
+        private fun clearPendingAttach() {
+            pendingAttachOwner?.removeOnAttachStateChangeListener(onOwnerAttachListener)
+            pendingAttachOwner = null
+        }
+
         private fun tryAttachingView() {
+            if (destroyed || layout.parent != null) return
             try {
-                if (layout.parent == null) {
-                    windowManager.addView(layout, LayoutParams(
-                        LayoutParams.WRAP_CONTENT,
-                        LayoutParams.WRAP_CONTENT,
-                        LayoutParams.TYPE_APPLICATION_PANEL,
-                        LayoutParams.FLAG_NOT_FOCUSABLE
-                                or LayoutParams.FLAG_LAYOUT_NO_LIMITS
-                                or LayoutParams.FLAG_NOT_TOUCHABLE
-                                or LayoutParams.FLAG_HARDWARE_ACCELERATED,
-                        PixelFormat.TRANSLUCENT
-                    ).apply {
-                        title = "ViewNodeWindowManager"
-                    })
-                }
+                windowManager.addView(layout, LayoutParams(
+                    LayoutParams.WRAP_CONTENT,
+                    LayoutParams.WRAP_CONTENT,
+                    LayoutParams.TYPE_APPLICATION_PANEL,
+                    LayoutParams.FLAG_NOT_FOCUSABLE
+                            or LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                            or LayoutParams.FLAG_NOT_TOUCHABLE
+                            or LayoutParams.FLAG_HARDWARE_ACCELERATED,
+                    PixelFormat.TRANSLUCENT
+                ).apply {
+                    title = "ViewNodeWindowManager"
+                })
+                // Attached successfully — stop waiting on any pending owner View.
+                clearPendingAttach()
             } catch (t: Throwable) {
-                Log.e(
+                // Attach failed despite the owner View being attached (e.g. a transient bad
+                // window token). This is the rare retry path, hence Log.w rather than Log.e:
+                // the attach is retried on the next resume()/owner-attach callback rather than
+                // leaving the ViewNode permanently black.
+                Log.w(
                     "ViewNode",
-                    "Failed to attach ViewNode layout to system WindowManager — view will render as black rectangle",
+                    "ViewNode layout attach to system WindowManager failed — will retry on next resume",
                     t
                 )
             }


### PR DESCRIPTION
## Summary

`ViewNode` renders a permanent black rectangle after a background → foreground cycle. The root cause: `ViewNode.WindowManager.resume()` posts the off-screen window attach to the owner View, but on a background → foreground cycle the owner `SurfaceView`/`TextureView` re-attaches to the window *after* `onResume` fires. The posted attach therefore runs while the owner is still detached, hits the `isAttachedToWindow` gate, and is **silently dropped with no retry** — the backing `Layout` is never added to `android.view.WindowManager`, so `onLayout` never fires and the `SurfaceTexture` stays 0×0.

A prior PR (`233416e6`, v4.1.0) only added a `Log.e` so the failure was visible; the library-level fix was timeboxed out. This delivers the actual fix.

## Fix

- When the owner View is not attached at resume time, `WindowManager` registers a `View.OnAttachStateChangeListener` so the off-screen attach **retries automatically** the instant the owner View attaches.
- On owner detach, the off-screen window is dropped (no leak).
- `resume()` / `pause()` / `destroy()` clear the pending listener so no stale owner reference survives.
- The `Log.e` from `233416e6` is downgraded to `Log.w` — the attach is now a rare retry path, not a permanent failure.

All changes are confined to private internals of `ViewNode.WindowManager`; the public API is unchanged.

## Test plan

- [x] `:sceneview:compileReleaseKotlin` — green
- [x] `:sceneview:compileDebugAndroidTestSources` — green
- [x] `:sceneview:test` — green
- [x] `impact-check.sh` — pass (1 pre-existing known false-positive)
- [x] Two new `ViewNodeTest` regression cases assert the retry listener is registered on a detached owner and cleared on `pause()`/`destroy()`
- [ ] Device QA: background/foreground the ViewNode demo and confirm the Compose content reappears (instrumentation `androidTest` requires a device/emulator — not run in this CI-less worktree)

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)