### PR TITLE
ci: add nightly full-validation safety-net workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ on:
       - 'llms*.txt'
       - 'LICENSE'
   workflow_dispatch:
+  # Allows nightly-ci.yml to invoke this workflow as a reusable workflow so
+  # the scheduled full-validation run reuses these job definitions instead
+  # of copy-pasting them. See #1324.
+  workflow_call:
+    inputs:
+      force-all:
+        description: >-
+          Run every build job regardless of the path filter. The nightly
+          full-CI safety-net sets this so a path-gated-out regression still
+          gets compiled/tested/built within 24h.
+        type: boolean
+        default: false
 
 # Cancel in-progress runs for the same branch/PR to save resources
 concurrency:
@@ -107,7 +119,7 @@ jobs:
   build:
     name: Build & lint
     needs: changes
-    if: needs.changes.outputs.android == 'true'
+    if: inputs.force-all || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -206,7 +218,7 @@ jobs:
   web-desktop:
     name: Build web & desktop
     needs: changes
-    if: needs.changes.outputs.web == 'true'
+    if: inputs.force-all || needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -252,7 +264,7 @@ jobs:
   flutter-demo:
     name: Build flutter-demo APK
     needs: changes
-    if: needs.changes.outputs.flutter == 'true'
+    if: inputs.force-all || needs.changes.outputs.flutter == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,111 @@
+name: Nightly full CI
+
+# WHY THIS EXISTS (#1324)
+# ----------------------
+# After the main-CI slimming pass (#1311 / #1321), several heavy workflows
+# are strictly path-gated on `main`:
+#   - `CI`               — per-job path filter; skips jobs whose scope is untouched.
+#   - `Render Tests`     — runs only on render-affecting source changes.
+#   - `Build sample APKs`— runs only on real code/build-script changes.
+#   - `Deploy ... Play Store` — tag-only.
+# That is the right trade-off for the high-merge-rate cycle, but it means
+# NO single scheduled run exercises the full validation surface end-to-end.
+# `maintenance.yml` runs daily but only checks dependency versions — it does
+# not compile, test, or build APKs.
+#
+# This workflow closes that gap: once a night it runs the FULL heavy suite
+# against `main` HEAD (compile + KMP/web/flutter builds + unit tests +
+# JaCoCo + render tests + quality gate) so a path-gated-out regression that
+# slipped through still surfaces within 24h.
+#
+# It REUSES the existing workflows via `workflow_call` instead of
+# duplicating their job bodies — `ci.yml` is invoked with `force-all: true`
+# so its per-job path filter is bypassed.
+#
+# It is deliberately NOT part of the `CI Gate` aggregator and is NOT a
+# required check — it is a scheduled safety net, not a PR gate.
+
+on:
+  schedule:
+    # 04:00 UTC daily — low-traffic, and distinct from maintenance.yml (07:00).
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-ci
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Full CI build/lint/test (path filter bypassed) ────────────────────────
+  full-ci:
+    name: Full CI (forced)
+    uses: ./.github/workflows/ci.yml
+    with:
+      force-all: true
+    secrets: inherit
+
+  # ── Quality gate (version sync, security, asset/website rules, MCP tests) ─
+  quality-gate:
+    name: Quality gate
+    uses: ./.github/workflows/quality-gate.yml
+    secrets: inherit
+
+  # ── Render tests (emulator + iOS Simulator + Playwright web) ──────────────
+  render-tests:
+    name: Render tests
+    uses: ./.github/workflows/render-tests.yml
+    secrets: inherit
+
+  # ── Failure surfacing ─────────────────────────────────────────────────────
+  # If any of the reused workflows fail, open (or update) a tracking issue so
+  # the regression is visible without anyone watching the Actions tab.
+  # `render-tests` jobs are `continue-on-error` internally, so a reused
+  # render-test failure does not by itself flip this job — that is intended:
+  # SwiftShader render flake should not spam issues. A genuine compile/test
+  # regression in `full-ci` or `quality-gate` does flip it.
+  report-failure:
+    name: Report nightly failure
+    needs: [full-ci, quality-gate, render-tests]
+    if: always() && (needs.full-ci.result == 'failure' || needs.quality-gate.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FULL_CI_RESULT: ${{ needs.full-ci.result }}
+          QG_RESULT: ${{ needs.quality-gate.result }}
+        run: |
+          set -euo pipefail
+          BODY=$(printf '%s\n' \
+            "The nightly full-CI safety-net run failed against \`main\` HEAD." \
+            "" \
+            "| Reused workflow | Result |" \
+            "|---|---|" \
+            "| Full CI (forced) | $FULL_CI_RESULT |" \
+            "| Quality gate | $QG_RESULT |" \
+            "" \
+            "Run: $RUN_URL" \
+            "" \
+            "A path-gated-out regression may have reached \`main\` between per-push CI runs. Investigate the failing job above.")
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "Nightly full CI failed in:title" \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$EXISTING" ]; then
+            gh issue create --repo "$REPO" \
+              --title "Nightly full CI failed — $(date -u +%Y-%m-%d)" \
+              --body "$BODY" \
+              --label "ci" \
+              || echo "::warning::Could not create nightly-failure issue"
+          else
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY" \
+              || echo "::warning::Could not comment on existing nightly-failure issue #$EXISTING"
+          fi

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -40,6 +40,9 @@ on:
       - 'llms*.txt'
       - 'LICENSE'
   workflow_dispatch:
+  # Invoked by nightly-ci.yml so the scheduled full-validation run reuses
+  # this quality-gate definition rather than duplicating it. See #1324.
+  workflow_call:
 
 # One run per ref; cancel older in-progress runs to save resources.
 concurrency:

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -24,6 +24,9 @@ on:
       - 'SceneViewSwift/**'
       - 'gradle/**'
   workflow_dispatch:
+  # Invoked by nightly-ci.yml so the scheduled full-validation run reuses
+  # this render-test definition rather than duplicating it. See #1324.
+  workflow_call:
 
 concurrency:
   group: render-tests-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added — CI
+
+- **Nightly full-CI safety-net workflow ([#1324](https://github.com/sceneview/sceneview/issues/1324)).** `nightly-ci.yml` runs the full heavy validation surface (compile + builds + unit tests + render tests + quality gate) against `main` HEAD once a night, reusing the existing workflows via `workflow_call`, so a path-gated-out regression still surfaces within 24h. Not a PR gate.
+
 ### Fixed — CI security
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.


### PR DESCRIPTION
## Summary

After the `main`-CI slimming pass (#1311 / #1321), the heavy workflows are strictly path-gated: `Render Tests` and `Build sample APKs` run only on render/code-affecting changes, `Deploy website + docs` only on docs changes, and `Deploy Demo to Play Store` is tag-only. That is the right trade-off for the high-merge-rate cycle, but it leaves **no single scheduled run that exercises the full validation surface** — `maintenance.yml` only checks dependency versions.

This adds `nightly-ci.yml` ("Nightly full CI"):

- Triggers on a `schedule:` cron (`0 4 * * *` UTC — low-traffic, distinct from `maintenance.yml`'s `0 7`) plus `workflow_dispatch:` for manual runs.
- Runs the full heavy validation against `main` HEAD: compile + KMP/web/flutter builds + unit tests + JaCoCo + render tests + quality gate.
- **Reuses** the existing `ci.yml`, `quality-gate.yml` and `render-tests.yml` via `workflow_call` — no job bodies are copy-pasted. `ci.yml` gains a tiny `force-all` boolean input so the nightly run bypasses its per-job path filter (a path-gated-out regression, e.g. an uncovered build-script change, still gets built/tested within 24h).
- On a genuine `full-ci` / `quality-gate` failure, opens or updates a `ci`-labelled tracking issue so the regression is visible without watching the Actions tab. Render-test flake (SwiftShader, `continue-on-error` internally) intentionally does not spam issues.
- **Not** part of the `CI Gate` aggregator and **not** a required check — it is a scheduled safety net, not a PR gate.

The `workflow_call` triggers and the `inputs.force-all ||` guards are additive and non-breaking: `inputs.force-all` is `null` on `push`/`pull_request`/`workflow_dispatch`, and `null || X` evaluates to `X`, so existing CI behaviour is unchanged.

## Test plan

- [x] YAML validated for all 4 touched workflow files
- [x] `actionlint` clean on all 4 files
- [x] `impact-check.sh` passes (pre-existing Swift-only-nodes warning unrelated)
- [ ] First scheduled `Nightly full CI` run appears in the Actions tab

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)