### PR TITLE
fix(android-demo): loading scrim hides cold-start black viewport (#1022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.
 
+### Fixed — Android demo
+
+- **Demo viewports no longer flash black for 5–12 s on cold start ([#1022](https://github.com/sceneview/sceneview/issues/1022)).** `DemoScaffold` now shows a surface-tinted loading scrim over the 3D viewport until the SceneView presents its first Filament frame, wired via the new `rememberFirstFrameState()` helper.
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Fixed — AR recording resolution ([#1065](https://github.com/sceneview/sceneview/issues/1065))

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -69,6 +69,46 @@ fun LoadingScrim(loading: Boolean, label: String = "Loading…") {
 }
 
 /**
+ * First-frame signal for the [DemoScaffold] loading scrim.
+ *
+ * Cold-starting a SceneView demo leaves the viewport jet-black for 5–12 s while
+ * Filament compiles shaders and uploads buffers — it reads as a crash to a
+ * first-time user (#1022). [rememberFirstFrameState] returns this pair so a demo
+ * can flip the scrim off exactly when the first Filament frame is presented:
+ *
+ * ```kotlin
+ * val firstFrame = rememberFirstFrameState()
+ * DemoScaffold(title = …, onBack = onBack, firstFrameRendered = firstFrame.rendered) {
+ *     SceneView(onFrame = firstFrame.onFrame, …) { … }
+ * }
+ * ```
+ *
+ * @property rendered Read in the scaffold — `false` until the first frame, then `true`.
+ * @property onFrame Pass straight to `SceneView(onFrame = …)`. Cheap after the first call.
+ */
+class FirstFrameState internal constructor(
+    private val renderedState: androidx.compose.runtime.MutableState<Boolean>,
+) {
+    val rendered: androidx.compose.runtime.State<Boolean> get() = renderedState
+
+    val onFrame: (frameTimeNanos: Long) -> Unit = {
+        if (!renderedState.value) renderedState.value = true
+    }
+}
+
+/**
+ * Remembers a [FirstFrameState] for wiring the [DemoScaffold] loading scrim to a
+ * SceneView's first presented frame. See [FirstFrameState] for the usage pattern.
+ */
+@Composable
+fun rememberFirstFrameState(): FirstFrameState {
+    val rendered = androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf(false)
+    }
+    return androidx.compose.runtime.remember { FirstFrameState(rendered) }
+}
+
+/**
  * Idle auto-orbit state for a camera that sweeps slowly around a target.
  *
  * Returns a [OrbitState] whose [yaw][OrbitState.yaw] advances from 0° to 360° in

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -110,6 +111,13 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
  * The sheet content is rendered inside a vertically-scrolling Column so the same
  * `controls = { ... }` blocks that worked with the v1 side-panel work unchanged
  * — 35 demo call-sites stay byte-identical.
+ *
+ * - `firstFrameRendered != null` → a surface-tinted scrim covers the 3D viewport
+ *   until the first Filament frame is presented, hiding the 5–12 s cold-start
+ *   black viewport that reads as a crash to users (#1022). Wire it with
+ *   [rememberFirstFrameState] + `SceneView(onFrame = …)`. A defensive 12 s
+ *   timeout dismisses the scrim even if `onFrame` never fires. Demos that load
+ *   models can still layer their own [LoadingScrim] spinner on top.
  */
 @Composable
 fun DemoScaffold(
@@ -117,6 +125,7 @@ fun DemoScaffold(
     onBack: () -> Unit,
     controls: (@Composable ColumnScope.() -> Unit)? = null,
     assetSource: AssetSourceState? = null,
+    firstFrameRendered: androidx.compose.runtime.State<Boolean>? = null,
     scene: @Composable BoxScope.() -> Unit
 ) {
     val haptic = LocalHapticFeedback.current
@@ -178,6 +187,10 @@ fun DemoScaffold(
         ) {
             Box(modifier = Modifier.fillMaxSize(), content = scene)
 
+            if (firstFrameRendered != null) {
+                FirstFrameScrim(firstFrameRendered = firstFrameRendered)
+            }
+
             if (assetSource != null) {
                 AssetSourceChip(state = assetSource)
             }
@@ -234,6 +247,65 @@ private fun BoxScope.AssetSourceChip(state: AssetSourceState) {
 }
 
 /**
+ * Surface-tinted scrim that covers the 3D viewport until the SceneView presents
+ * its first Filament frame (#1022). Without it, 13 of the demos render a black
+ * viewport for 5–12 s on a cold start while shaders compile — which reads as a
+ * crash to a first-time user.
+ *
+ * The scrim is an opaque [MaterialTheme.colorScheme.surface] fill (light + dark
+ * both covered by the theme token) carrying a small centred progress indicator.
+ * Once [firstFrameRendered] flips true it cross-fades out over 350 ms (the
+ * `DESIGN.md` `duration-medium` token), revealing the rendered scene underneath.
+ *
+ * Defensive timeout: if `onFrame` never fires (a broken demo, a viewport that
+ * never composes a SceneView) the scrim still dismisses after 12 s so the
+ * controls are never permanently blocked.
+ */
+@Composable
+private fun BoxScope.FirstFrameScrim(
+    firstFrameRendered: androidx.compose.runtime.State<Boolean>,
+) {
+    // Defensive fallback: dismiss even if the first frame is never reported.
+    var timedOut by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(FIRST_FRAME_SCRIM_TIMEOUT_MS)
+        timedOut = true
+    }
+    val dismissed = firstFrameRendered.value || timedOut
+    // Cross-fade out on the M3 `duration-medium` (350 ms) — the surface fades to
+    // reveal the rendered scene, never the reverse, so it can't imply readiness
+    // and then flash black again (see #1022 rejected-timeout note).
+    val alpha by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = if (dismissed) 0f else 1f,
+        animationSpec = androidx.compose.animation.core.tween(durationMillis = 350),
+        label = "first-frame-scrim",
+    )
+    if (alpha <= 0f) return
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(alpha)
+            .background(MaterialTheme.colorScheme.surface)
+            // Swallow touches while the scrim is opaque so a stray tap can't
+            // reach the (not-yet-rendered) scene; lets them through once fading.
+            .then(
+                if (dismissed) Modifier
+                else Modifier.pointerInput(Unit) { detectTapGestures { } }
+            )
+            .testTag(DemoScaffoldTestTags.FIRST_FRAME_SCRIM),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.material3.CircularProgressIndicator(
+            modifier = Modifier.size(40.dp),
+            color = MaterialTheme.colorScheme.primary,
+            strokeWidth = 4.dp,
+        )
+    }
+}
+
+private const val FIRST_FRAME_SCRIM_TIMEOUT_MS = 12_000L
+
+/**
  * Stable test tags consumed by `DemoInteractionTest` and any future visual smoke
  * tooling so the controls sheet can be opened deterministically without relying
  * on accessibility-tree heuristics. Kept in the public surface of this file so
@@ -245,6 +317,7 @@ object DemoScaffoldTestTags {
     const val SETTINGS_SHEET = "demo-settings-sheet"
     const val QA_PILL = "demo-qa-pill"
     const val ASSET_SOURCE_CHIP = "demo-asset-source-chip"
+    const val FIRST_FRAME_SCRIM = "demo-first-frame-scrim"
 }
 
 /**

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/BillboardDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/BillboardDemo.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Scale
 import io.github.sceneview.rememberCameraManipulator
@@ -49,9 +50,12 @@ fun BillboardDemo(onBack: () -> Unit) {
         createLabelBitmap("Fixed", 0xFF6446CD.toInt())  // SceneView Accent
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_billboard_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Visible Nodes", style = MaterialTheme.typography.labelLarge)
             Row(
@@ -75,6 +79,7 @@ fun BillboardDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             // Dolly closer so both 0.55 m-wide panels read comfortably — at default

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CollisionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CollisionDemo.kt
@@ -20,6 +20,7 @@ import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Size
 import io.github.sceneview.node.Node
@@ -95,9 +96,12 @@ fun CollisionDemo(onBack: () -> Unit) {
         }
     )
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_collision_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text(
                 "Tap a shape to highlight it",
@@ -114,6 +118,7 @@ fun CollisionDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
@@ -26,6 +26,7 @@ import dev.romainguy.kotlin.math.Float3
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.rememberPausableHeroYaw
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -61,9 +62,12 @@ fun CustomMeshDemo(onBack: () -> Unit) {
         trigger = rotating, durationMillis = 8_000, staticYaw = 0f,
     )
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_custom_mesh_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Row(
                 modifier = Modifier
@@ -89,6 +93,7 @@ fun CustomMeshDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             // Dolly closer — molecule spans ±0.6 m and renders at scale 0.5–2.5x, so at

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DebugOverlayDemo.kt
@@ -49,6 +49,7 @@ import io.github.sceneview.createDefaultCameraManipulator
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.rememberEngine
@@ -192,9 +193,12 @@ fun DebugOverlayDemo(onBack: () -> Unit) {
         }
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_debug_overlay_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -310,6 +314,7 @@ fun DebugOverlayDemo(onBack: () -> Unit) {
                 cameraNode = cameraNode,
                 cameraManipulator = cameraManipulator,
                 onFrame = { frameTimeNanos ->
+                    firstFrame.onFrame(frameTimeNanos)
                     stats.onFrame(frameTimeNanos, nodeCount = currentCount)
                     // Push the just-computed FPS into the ring buffer. We read
                     // stats.fps after onFrame() so we get the freshest value.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DynamicSkyDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DynamicSkyDemo.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.node.DynamicSkyNode
 import io.github.sceneview.rememberCameraManipulator
@@ -71,9 +72,12 @@ fun DynamicSkyDemo(onBack: () -> Unit) {
         else                    -> "🌙 Night"
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_dynamic_sky),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text(
                 "Time of Day: %.1f h  ·  $periodLabel".format(timeOfDay),
@@ -98,6 +102,7 @@ fun DynamicSkyDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             modelLoader = modelLoader,
             environmentLoader = environmentLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GeometryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GeometryDemo.kt
@@ -33,6 +33,7 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoPreviewPlaceholder
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.demo.demos.internal.DemoMath
@@ -129,9 +130,12 @@ fun GeometryDemo(onBack: () -> Unit) {
         planeMaterial.setMetallic(metallic); planeMaterial.setRoughness(roughness)
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_geometry_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             // Controls extracted into a separate composable so a Roborazzi snapshot
             // test can capture the panel layout in pure JVM (no Filament, no SceneView).
@@ -148,6 +152,7 @@ fun GeometryDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GestureEditingDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/GestureEditingDemo.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.common.Axes3DNode
 import io.github.sceneview.math.Position
 import io.github.sceneview.node.ModelNode
@@ -157,9 +158,12 @@ fun GestureEditingDemo(onBack: () -> Unit) {
         derivedStateOf { editable && (positionEditable || rotationEditable || scaleEditable) }
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_gesture_editing_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Row(
                 modifier = Modifier
@@ -245,6 +249,7 @@ fun GestureEditingDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             modelLoader = modelLoader,
             materialLoader = materialLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Scale
 import io.github.sceneview.rememberCameraManipulator
@@ -31,9 +32,12 @@ fun ImageDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_image_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text(
                 "Scale: ${"%.1f".format(scaleFactor)}x",
@@ -48,6 +52,7 @@ fun ImageDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             cameraManipulator = rememberCameraManipulator()

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LinesPathsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LinesPathsDemo.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberCameraManipulator
@@ -49,9 +50,12 @@ fun LinesPathsDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_lines_paths_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Visibility", style = MaterialTheme.typography.labelLarge)
             Row(
@@ -86,6 +90,7 @@ fun LinesPathsDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             cameraManipulator = rememberCameraManipulator()

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
@@ -30,6 +30,7 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
 import io.github.sceneview.demo.sketchfab.SketchfabSlug
@@ -120,9 +121,12 @@ fun PhysicsDemo(onBack: () -> Unit) {
         lookAt(Position(0f, 0f, 0f))
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_physics_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Bodies: $bodyCount", style = MaterialTheme.typography.labelLarge)
             Row(
@@ -198,6 +202,7 @@ fun PhysicsDemo(onBack: () -> Unit) {
                 materialLoader = materialLoader,
                 environmentLoader = environmentLoader,
                 cameraNode = cameraNode,
+                onFrame = firstFrame.onFrame,
                 cameraManipulator = rememberCameraManipulator(
                     orbitHomePosition = cameraNode.worldPosition
                 )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -34,6 +34,7 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.loaders.ModelLoader
 import io.github.sceneview.math.Position
 import io.github.sceneview.model.ModelInstance
@@ -112,9 +113,12 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
         pipCameraNode.lookAt(Position(0f, 0f, 0f))
     }
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_secondary_camera_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text(
                 stringResource(R.string.demo_secondary_camera_chip_section),
@@ -141,6 +145,7 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,
             environment = environment,
+            onFrame = firstFrame.onFrame,
         ) {
             mainInstance?.let { instance ->
                 ModelNode(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ShapeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ShapeDemo.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.sample.rememberMaterialInstance
 import io.github.sceneview.math.Position
@@ -90,9 +91,12 @@ fun ShapeDemo(onBack: () -> Unit) {
         "Hexagon" to hexagonPath,
     )
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_shape_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Shape", style = MaterialTheme.typography.labelLarge)
             Row(
@@ -111,6 +115,7 @@ fun ShapeDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             // Dolly closer — shape sits at z = -1 with radius ≤ 0.5 m, default camera

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/TextDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/TextDemo.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
@@ -36,10 +37,12 @@ fun TextDemo(onBack: () -> Unit) {
 
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
+    val firstFrame = rememberFirstFrameState()
 
     DemoScaffold(
         title = stringResource(R.string.demo_text_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Text Content", style = MaterialTheme.typography.labelLarge)
             OutlinedTextField(
@@ -62,6 +65,7 @@ fun TextDemo(onBack: () -> Unit) {
             modifier = Modifier.fillMaxSize(),
             engine = engine,
             materialLoader = materialLoader,
+            onFrame = firstFrame.onFrame,
             // Dolly the camera closer — 3 stacked 0.18 m-tall labels at the origin read
             // cramped at the default z = 4. z = 1.2 fills the portrait viewport.
             cameraManipulator = rememberCameraManipulator(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/VideoDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/VideoDemo.kt
@@ -40,6 +40,7 @@ import dev.romainguy.kotlin.math.lookAt
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.gesture.CameraGestureDetector
 import io.github.sceneview.math.Position
@@ -145,9 +146,12 @@ fun VideoDemo(onBack: () -> Unit) {
         cinematic = cinematic,
     )
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_video_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             Text("Playback", style = MaterialTheme.typography.labelLarge)
             Spacer(modifier = Modifier.height(8.dp))
@@ -220,6 +224,7 @@ fun VideoDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ViewNodeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ViewNodeDemo.kt
@@ -30,6 +30,7 @@ import dev.romainguy.kotlin.math.Float3
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.rememberPausableHeroYaw
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -88,9 +89,12 @@ fun ViewNodeDemo(onBack: () -> Unit) {
         onScroll = { _, _, _, _ -> onHeroGesture() },
     )
 
+    val firstFrame = rememberFirstFrameState()
+
     DemoScaffold(
         title = stringResource(R.string.demo_view_node_title),
         onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
         controls = {
             // Wrap the whole row in Modifier.toggleable so the row itself is the
             // click target — tapping anywhere on "Visible" (label or switch) flips
@@ -113,6 +117,7 @@ fun ViewNodeDemo(onBack: () -> Unit) {
     ) {
         SceneView(
             modifier = Modifier.fillMaxSize(),
+            onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,


### PR DESCRIPTION
## Summary

13 of 25 non-AR demos rendered a jet-black viewport for 5–12 s on a cold start while Filament compiled shaders and uploaded buffers — looks like a crash to a first-time user.

- `DemoScaffold` gains an optional `firstFrameRendered: State<Boolean>` param. When set, a surface-tinted Material 3 scrim with a centred progress indicator covers the 3D viewport until the SceneView presents its first Filament frame, then cross-fades out over 350 ms (`DESIGN.md` `duration-medium`). The `surface` theme token covers light + dark.
- New `rememberFirstFrameState()` helper in `DemoHelpers.kt` returns a `FirstFrameState` pairing the scrim state with an `onFrame` lambda — 2-line wiring per demo.
- A defensive 12 s timeout dismisses the scrim even if `onFrame` never fires.
- Wired into the 15 affected demos: Geometry, Text, LinesPaths, Image, Billboard, Video, GestureEditing, Collision, ViewNode, Physics, CustomMesh, Shape, SecondaryCamera, DebugOverlay, DynamicSky.
- Demos that load models keep their own `LoadingScrim` spinner on top.

The scrim fades only to *reveal* the rendered scene (never the reverse), avoiding the rejected timeout heuristic noted in the issue where a premature fade implied readiness and the subsequent black read as a crash.

## Test plan

- [x] `:samples:android-demo:compileDebugKotlin` passes
- [x] `impact-check.sh` passes
- [ ] Emulator audit: no demo's first viewport screenshot at `t = 1.0 s` is jet-black

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)