### PR TITLE
fix(ios): true look-around firstPerson camera — no teleport, no pivot drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed — iOS true look-around camera ([#1236](https://github.com/sceneview/sceneview/issues/1236))
+
+- **iOS `.firstPerson` now rotates the perspective camera in place instead of orbiting the scene root, so switching orbit ↔ firstPerson no longer teleports the camera; new `recentersTargetOnOrbit(_:)` modifier + `CameraControls.recenterTarget()` fix pan→orbit pivot drift.** `Closes #1236`.
+
 ### Fixed — CI security
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.

--- a/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
@@ -23,18 +23,17 @@ public enum CameraControlMode: Sendable {
     /// rather than expecting 2-finger detection.
     case pan
 
-    /// First-person look-around. Drag rotates the scene content around the
-    /// world origin (the default perspective camera at `[0, 0.3, 2]` stays
-    /// fixed); pinch adjusts the camera's field of view — mirrors
-    /// Android's `FovZoomCameraManipulator`.
+    /// First-person look-around. Drag yaws / pitches the perspective
+    /// camera **about its own position** — the camera stands still and
+    /// looks around, it does not orbit and does not move the scene root.
+    /// Pinch adjusts the camera's field of view — mirrors Android's
+    /// `FovZoomCameraManipulator`.
     ///
-    /// **Limitation (#1034)**: true first-person look — rotating the
-    /// camera *about its own position* instead of rotating world content —
-    /// is not yet implemented because the orbit pivot is shared with
-    /// ``orbit`` mode. The visual effect is a tight orbit at radius `2`
-    /// rather than a stationary look-around; this is good enough for
-    /// inspection demos but not for FPS-style navigation. Tracked as a
-    /// v4.4.0 follow-up.
+    /// Entering ``firstPerson`` keeps the camera at whatever world-space
+    /// position it had in ``orbit`` / ``pan`` (no teleport): the look-around
+    /// pivots around that fixed eye. Switching back to ``orbit`` re-derives
+    /// the orbit angles from the look direction, so the transition is
+    /// continuous in both directions. Closes #1236 / #1034.
     case firstPerson
 }
 
@@ -205,6 +204,90 @@ public struct CameraControls: Sendable {
         let yaw = simd_quatf(angle: -azimuth, axis: [0, 1, 0])
         let pitch = simd_quatf(angle: -elevation, axis: [1, 0, 0])
         return yaw * pitch
+    }
+
+    /// Fixed world-space eye position for ``CameraControlMode/firstPerson``.
+    ///
+    /// `nil` until the first time ``firstPerson`` is entered. While in
+    /// firstPerson the camera stays pinned at this point and only its
+    /// orientation changes (true "stand still and look around"). It is
+    /// captured from the current orbit camera position at the mode switch
+    /// so there is no teleport. Closes #1236.
+    public var firstPersonEye: SIMD3<Float>? = nil
+
+    /// World-space orientation of the perspective camera for the current
+    /// look angles.
+    ///
+    /// RealityKit cameras look down their local `-Z`. A yaw of `azimuth`
+    /// about `+Y` followed by a pitch of `elevation` about the camera's
+    /// local `+X` reproduces the same forward vector that
+    /// ``cameraPosition()`` / ``cameraTransform()`` look toward in orbit
+    /// mode, so deriving orbit angles back from this orientation is exact
+    /// (no drift across orbit ↔ firstPerson switches).
+    public func lookOrientation() -> simd_quatf {
+        let yaw = simd_quatf(angle: azimuth, axis: [0, 1, 0])
+        let pitch = simd_quatf(angle: -elevation, axis: [1, 0, 0])
+        return yaw * pitch
+    }
+
+    /// Unit forward vector (the direction the camera looks) for the
+    /// current ``azimuth`` / ``elevation``.
+    public func lookForward() -> SIMD3<Float> {
+        let cosElev = cos(elevation)
+        // -Z forward, consistent with `cameraPosition()`: in orbit the
+        // camera sits at `+radius` along this axis and looks back at the
+        // target, so the look direction is the negated offset.
+        return SIMD3<Float>(
+            -cosElev * sin(azimuth),
+            -sin(elevation),
+            -cosElev * cos(azimuth)
+        )
+    }
+
+    /// Captures the current orbit camera position as the fixed
+    /// ``firstPersonEye``. Call this when entering ``firstPerson`` so the
+    /// look-around pivots around exactly where the camera already is —
+    /// switching orbit → firstPerson never teleports. Idempotent within a
+    /// firstPerson session: only the first call (when `firstPersonEye` is
+    /// `nil`) takes effect.
+    public mutating func enterFirstPerson() {
+        guard firstPersonEye == nil else { return }
+        firstPersonEye = cameraPosition()
+    }
+
+    /// Re-derives the orbit ``target`` from the fixed firstPerson eye and
+    /// the current look direction, then clears ``firstPersonEye``. Call
+    /// this when leaving ``firstPerson`` so orbit resumes around a pivot
+    /// directly in front of the camera — the orbit camera position
+    /// recomputed from `(target, azimuth, elevation, orbitRadius)` equals
+    /// the firstPerson eye exactly, so the transition is continuous.
+    public mutating func exitFirstPerson() {
+        if let eye = firstPersonEye {
+            // The camera looks *toward* the target, so the pivot sits one
+            // `orbitRadius` ahead of the eye along the look direction.
+            // `cameraPosition()` recomputed from this target then lands
+            // back exactly on `eye` (the orbit offset is `-lookForward()`).
+            target = eye + lookForward() * orbitRadius
+        }
+        firstPersonEye = nil
+    }
+
+    /// Resets the orbit ``target`` (pivot) to the given world point —
+    /// typically the content centroid.
+    ///
+    /// Pan moves ``target`` laterally; over repeated pan-then-orbit cycles
+    /// the pivot drifts away from the content centroid (#1236 limitation 2).
+    /// Call this — e.g. from a "recenter" affordance — to snap the orbit
+    /// pivot back. The camera keeps its current ``azimuth`` / ``elevation``
+    /// / ``orbitRadius`` so only the framing recenters, not the viewing
+    /// angle.
+    ///
+    /// - Parameter centroid: World-space point to orbit around. Defaults
+    ///   to the world origin, which is where ``SceneView``'s auto-centering
+    ///   places the content centroid (#1026).
+    public mutating func recenterTarget(_ centroid: SIMD3<Float> = .zero) {
+        target = centroid
+        firstPersonEye = nil
     }
 
     // MARK: - Gesture Handling

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -100,6 +100,12 @@ public struct SceneView: View {
     // `.autoCenterContent(false)`. Closes #1026.
     var autoCenterContentEnabled: Bool = true
 
+    // When true, switching back to `.orbit` resets the orbit pivot to the
+    // content centroid (world origin under auto-centering) so repeated
+    // pan-then-orbit cycles don't drift the centroid out of frame.
+    // Default `false` — pan-then-orbit keeps the panned pivot. Closes #1236.
+    var recentersTargetOnOrbit: Bool = false
+
     /// Creates a 3D scene with imperative content setup.
     ///
     /// - Parameter content: A closure that populates the scene. Receives a root
@@ -140,7 +146,8 @@ public struct SceneView: View {
             mainLightSlot: mainLightSlot,
             fillLightSlot: fillLightSlot,
             renderQualityPreset: renderQualityPreset,
-            autoCenterContentEnabled: autoCenterContentEnabled
+            autoCenterContentEnabled: autoCenterContentEnabled,
+            recentersTargetOnOrbit: recentersTargetOnOrbit
         )
     }
 
@@ -157,6 +164,28 @@ public struct SceneView: View {
     public func cameraControls(_ mode: CameraControlMode) -> SceneView {
         var copy = self
         copy.cameraControlMode = mode
+        return copy
+    }
+
+    /// Controls whether switching back to ``CameraControlMode/orbit`` resets
+    /// the orbit pivot to the content centroid. Default `false`.
+    ///
+    /// ``CameraControlMode/pan`` translates the orbit target laterally;
+    /// over repeated pan-then-orbit cycles the pivot drifts away from the
+    /// content centroid and the model can creep out of frame (#1236
+    /// limitation 2). Pass `true` to snap the orbit pivot back to the
+    /// centroid — the world origin under ``autoCenterContent(_:)`` — every
+    /// time orbit mode is (re-)entered. The camera keeps its current
+    /// azimuth / elevation / radius, so only the framing recenters.
+    ///
+    /// ```swift
+    /// SceneView { /* ... */ }
+    ///   .cameraControls(mode)
+    ///   .recentersTargetOnOrbit(true)   // pan → orbit re-pivots on centroid
+    /// ```
+    public func recentersTargetOnOrbit(_ enabled: Bool) -> SceneView {
+        var copy = self
+        copy.recentersTargetOnOrbit = enabled
         return copy
     }
 
@@ -331,6 +360,10 @@ private struct SceneViewRepresentation: View {
     /// `entities.contentRoot` so the scene's centroid lands at the orbit
     /// pivot. Closes #1026.
     let autoCenterContentEnabled: Bool
+
+    /// When true, re-entering `.orbit` resets the orbit pivot to the
+    /// content centroid so repeated pan→orbit cycles don't drift. Closes #1236.
+    let recentersTargetOnOrbit: Bool
 
     /// Default `CameraControls(mode: .orbit)` — uses the struct's own
     /// `orbitRadius = 2.0` public default, which matches the camera-
@@ -712,16 +745,33 @@ private struct SceneViewRepresentation: View {
         // camera state is `@State` — without this, calling
         // `.cameraControls(.pan)` would be silently ignored. Closes #1034.
         if camera.mode != cameraControlMode {
+            let previousMode = camera.mode
             camera.mode = cameraControlMode
-            // Reset the pinched FOV back to baseline when LEAVING firstPerson,
-            // so the next firstPerson entry starts at 60° rather than at the
-            // last clamped value. Without this guard, a user who pinches FOV
-            // down to 30° in firstPerson then switches to orbit sees the
-            // 30° stick around (visible as a stuck zoom-in); switching back
-            // to firstPerson would then resume at 30° instead of resetting.
-            // R3 MAJOR finding.
-            if camera.mode != .firstPerson && camera.fov != Self.baselineFov {
-                camera.fov = Self.baselineFov
+            if camera.mode == .firstPerson {
+                // ENTERING firstPerson: pin the camera at exactly its
+                // current orbit/pan world position so the mode switch
+                // does not teleport (#1236 limitation 1). The look-around
+                // then yaws / pitches the camera in place around this eye.
+                camera.enterFirstPerson()
+            } else if previousMode == .firstPerson {
+                // LEAVING firstPerson: re-derive the orbit pivot from the
+                // fixed eye + current look direction so orbit resumes
+                // continuously (the recomputed orbit camera position
+                // equals the firstPerson eye). Then reset the pinched FOV
+                // back to baseline — a user who pinched FOV down to 30°
+                // in firstPerson then switched to orbit must not keep the
+                // 30° zoom (R3 MAJOR — FOV bleed).
+                camera.exitFirstPerson()
+                if camera.fov != Self.baselineFov {
+                    camera.fov = Self.baselineFov
+                }
+            }
+            // Opt-in pivot recentre on (re-)entering orbit so repeated
+            // pan→orbit cycles don't drift the centroid out of frame
+            // (#1236 limitation 2). The content centroid is the world
+            // origin under `.autoCenterContent(true)` (#1026).
+            if camera.mode == .orbit && recentersTargetOnOrbit {
+                camera.recenterTarget()
             }
         }
 
@@ -777,35 +827,45 @@ private struct SceneViewRepresentation: View {
             #endif
 
         case .firstPerson:
-            // First-person inspection: pinch mutates FOV (see pinchGesture)
-            // rather than the orbit radius. Currently rotates the scene
-            // root around world origin while the camera stays at a fixed
-            // eye — visually a tight orbit at radius `2`. NOT a true
-            // "stand still and look around" camera-orientation rotation;
-            // tracked as a v4.4.0 follow-up in ``CameraControlMode/firstPerson``.
+            // True look-around (#1236 / #1034): the perspective camera
+            // stands still at a fixed eye and only its ORIENTATION yaws /
+            // pitches — it does not orbit and does not rotate the scene
+            // root. The eye was captured (`enterFirstPerson()`) from the
+            // exact orbit/pan camera position at the mode switch, so
+            // entering firstPerson never teleports. Pinch mutates FOV
+            // (see pinchGesture) rather than the orbit radius.
             //
-            // KNOWN LIMITATION (R3 MAJOR, deferred to v4.4.0): switching
-            // orbit → firstPerson teleports the perspective camera from
-            // its last orbit position to `[0, 0.3, 2]` without
-            // interpolation. The "true look-around" rewrite tracked under
-            // #1034 will resolve this by rotating the camera entity in
-            // place instead of repositioning it on mode entry.
-            let yaw = simd_quatf(angle: -camera.azimuth, axis: [0, 1, 0])
-            let pitch = simd_quatf(angle: -camera.elevation, axis: [1, 0, 0])
-            entities.root.orientation = yaw * pitch
+            // The scene root stays at identity for ALL three modes — the
+            // skybox therefore wraps correctly and content never moves
+            // under the camera.
+            entities.root.orientation = simd_quatf(angle: 0, axis: [0, 1, 0])
             entities.root.scale = SIMD3<Float>(repeating: 1)
             entities.root.position = .zero
             #if os(iOS) || os(macOS)
-            // Pin the camera at a fixed eye and reset to look at origin
-            // so a mode switch from orbit doesn't strand the camera at
-            // the last orbit position. Sync FOV to the controls state —
-            // this is the ONLY mode that mirrors `camera.fov` so pinch
-            // can dolly without affecting orbit's baseline (see orbit/pan
-            // case above for the corresponding non-write).
-            entities.perspCamera.look(at: .zero, from: [0, 0.3, 2], relativeTo: nil)
+            // Eye is normally set by `enterFirstPerson()` on the orbit→
+            // firstPerson switch. When firstPerson is the INITIAL mode no
+            // such switch ever fires, so capture it once here from the
+            // current orbit position — otherwise dragging would re-derive
+            // a moving `cameraPosition()` each frame (the old orbit bug).
+            if camera.firstPersonEye == nil {
+                camera.enterFirstPerson()
+            }
+            let eye = camera.firstPersonEye ?? camera.cameraPosition()
+            entities.perspCamera.position = eye
+            // Rotate the camera in place — `lookOrientation()` reproduces
+            // the same forward vector orbit looks along, so orbit↔first-
+            // person is continuous in both directions.
+            entities.perspCamera.orientation = camera.lookOrientation()
+            // firstPerson is the ONLY mode that mirrors `camera.fov` so
+            // pinch can zoom without affecting orbit's baseline (see the
+            // orbit/pan case above for the corresponding non-write).
             if entities.perspCamera.camera.fieldOfViewInDegrees != camera.fov {
                 entities.perspCamera.camera.fieldOfViewInDegrees = camera.fov
             }
+            #else
+            // visionOS fallback: no manual camera entity (the headset is
+            // the camera). Rotate the scene root to simulate look-around.
+            entities.root.orientation = camera.sceneRotation()
             #endif
         }
     }

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/CameraLookAroundTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/CameraLookAroundTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+import simd
+@testable import SceneViewSwift
+
+#if os(iOS) || os(visionOS) || os(macOS)
+/// Pins the true look-around `firstPerson` camera math — closes #1236.
+///
+/// Covers the two regressions called out in the issue:
+/// 1. orbit → firstPerson teleport (the camera must stay where it was), and
+/// 2. pan → orbit pivot drift (`recenterTarget()` must snap the pivot back).
+///
+/// Test classes run on the main actor: their RealityKit node factories are
+/// `@MainActor` (#1054).
+@MainActor
+final class CameraLookAroundTests: XCTestCase {
+
+    private let eps: Float = 1e-4
+
+    private func assertClose(
+        _ a: SIMD3<Float>, _ b: SIMD3<Float>,
+        _ msg: String, accuracy: Float = 1e-3,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(a.x, b.x, accuracy: accuracy, msg, file: file, line: line)
+        XCTAssertEqual(a.y, b.y, accuracy: accuracy, msg, file: file, line: line)
+        XCTAssertEqual(a.z, b.z, accuracy: accuracy, msg, file: file, line: line)
+    }
+
+    // MARK: - Limitation 1: orbit → firstPerson must NOT teleport
+
+    func testEnterFirstPerson_pinsEyeAtCurrentOrbitPosition() {
+        var c = CameraControls(mode: .orbit)
+        c.azimuth = .pi / 4          // 45°
+        c.elevation = .pi / 3        // 60°
+        c.orbitRadius = 4
+        let orbitEye = c.cameraPosition()
+
+        c.mode = .firstPerson
+        c.enterFirstPerson()
+
+        XCTAssertNotNil(c.firstPersonEye)
+        assertClose(c.firstPersonEye!, orbitEye,
+                    "entering firstPerson must pin the eye at the exact orbit position — no teleport")
+    }
+
+    func testEnterFirstPerson_isIdempotentWithinSession() {
+        var c = CameraControls(mode: .firstPerson)
+        c.orbitRadius = 4
+        c.enterFirstPerson()
+        let firstEye = c.firstPersonEye!
+
+        // Look around, then a stray re-entry call must NOT recapture.
+        c.handleDrag(CGSize(width: 300, height: 0))
+        c.enterFirstPerson()
+
+        assertClose(c.firstPersonEye!, firstEye,
+                    "the eye must stay fixed while looking around")
+    }
+
+    func testLookAround_keepsEyeFixed_onlyOrientationChanges() {
+        var c = CameraControls(mode: .firstPerson)
+        c.enterFirstPerson()
+        let eye = c.firstPersonEye!
+        let orientationBefore = c.lookOrientation()
+
+        c.handleDrag(CGSize(width: 200, height: 80))
+
+        assertClose(c.firstPersonEye!, eye, "look-around must not move the eye")
+        let orientationAfter = c.lookOrientation()
+        XCTAssertNotEqual(orientationBefore.vector, orientationAfter.vector,
+                          "look-around must change the camera orientation")
+    }
+
+    // MARK: - orbit ↔ firstPerson is continuous (no teleport either way)
+
+    func testExitFirstPerson_orbitPositionEqualsFirstPersonEye() {
+        var c = CameraControls(mode: .orbit)
+        c.azimuth = .pi / 5
+        c.elevation = .pi / 8
+        c.orbitRadius = 3.5
+
+        // orbit → firstPerson
+        c.mode = .firstPerson
+        c.enterFirstPerson()
+        let eye = c.firstPersonEye!
+
+        // look around in place — the eye must stay set throughout
+        c.handleDrag(CGSize(width: 150, height: -40))
+        XCTAssertNotNil(c.firstPersonEye, "eye stays set while looking around")
+
+        // firstPerson → orbit
+        c.mode = .orbit
+        c.exitFirstPerson()
+
+        XCTAssertNil(c.firstPersonEye, "leaving firstPerson must clear the eye")
+        // The recomputed orbit camera position must land back on the eye —
+        // this is what makes the firstPerson → orbit switch teleport-free.
+        assertClose(c.cameraPosition(), eye,
+                    "orbit position after exitFirstPerson must equal the firstPerson eye")
+    }
+
+    func testRoundTrip_orbitFirstPersonOrbit_isStable() {
+        var c = CameraControls(mode: .orbit)
+        c.azimuth = 0.6
+        c.elevation = 0.4
+        c.orbitRadius = 5
+        let eye0 = c.cameraPosition()
+
+        c.mode = .firstPerson
+        c.enterFirstPerson()
+        c.mode = .orbit
+        c.exitFirstPerson()
+
+        assertClose(c.cameraPosition(), eye0,
+                    "a no-look round trip orbit→firstPerson→orbit must be a no-op")
+    }
+
+    // MARK: - look math consistency
+
+    func testLookForward_matchesOrbitForward() {
+        var c = CameraControls(mode: .orbit)
+        c.azimuth = 0.9
+        c.elevation = -0.3
+        c.orbitRadius = 2
+
+        // In orbit the camera looks from cameraPosition() toward target.
+        let orbitForward = simd_normalize(c.target - c.cameraPosition())
+        assertClose(c.lookForward(), orbitForward, "lookForward must equal the orbit look direction")
+    }
+
+    func testLookOrientation_minusZMapsToLookForward() {
+        var c = CameraControls(mode: .firstPerson)
+        c.azimuth = 1.1
+        c.elevation = 0.2
+
+        let q = c.lookOrientation()
+        let rotatedMinusZ = q.act(SIMD3<Float>(0, 0, -1))
+        assertClose(rotatedMinusZ, c.lookForward(),
+                    "the camera's local -Z must map to the look-forward vector", accuracy: 1e-4)
+    }
+
+    // MARK: - Limitation 2: pan → orbit pivot drift
+
+    func testRecenterTarget_snapsPivotToOrigin() {
+        var c = CameraControls(mode: .pan)
+        // Simulate repeated panning that drifted the target.
+        c.target = SIMD3<Float>(2, 0.5, -1)
+
+        c.recenterTarget()  // default centroid = origin
+
+        assertClose(c.target, .zero, "recenterTarget() must snap the pivot back to the centroid")
+    }
+
+    func testRecenterTarget_acceptsExplicitCentroid() {
+        var c = CameraControls(mode: .orbit)
+        c.target = SIMD3<Float>(5, 5, 5)
+        let centroid = SIMD3<Float>(1, 2, 3)
+
+        c.recenterTarget(centroid)
+
+        assertClose(c.target, centroid, "recenterTarget(_:) must honour an explicit centroid")
+    }
+
+    func testRecenterTarget_preservesViewingAngleAndRadius() {
+        var c = CameraControls(mode: .orbit)
+        c.azimuth = 0.7
+        c.elevation = 0.3
+        c.orbitRadius = 4
+        c.target = SIMD3<Float>(3, 0, 0)
+
+        c.recenterTarget()
+
+        XCTAssertEqual(c.azimuth, 0.7, accuracy: eps, "recenter must keep azimuth")
+        XCTAssertEqual(c.elevation, 0.3, accuracy: eps, "recenter must keep elevation")
+        XCTAssertEqual(c.orbitRadius, 4, accuracy: eps, "recenter must keep radius")
+    }
+
+    func testRecenterTarget_clearsFirstPersonEye() {
+        var c = CameraControls(mode: .firstPerson)
+        c.enterFirstPerson()
+        XCTAssertNotNil(c.firstPersonEye)
+
+        c.recenterTarget()
+
+        XCTAssertNil(c.firstPersonEye, "recenterTarget() must drop a stale firstPerson eye")
+    }
+
+    func testPanThenRecenter_pivotDriftEliminated() {
+        // Repeated pan-then-orbit workflow from the issue: target drifts,
+        // recenterTarget() brings the pivot back to the content centroid.
+        var c = CameraControls(mode: .pan)
+        for _ in 0..<5 {
+            c.handleDrag(CGSize(width: 100, height: 0))  // drift the pivot
+        }
+        XCTAssertGreaterThan(abs(c.target.x), 0.5, "panning must have drifted the pivot")
+
+        c.mode = .orbit
+        c.recenterTarget()
+
+        assertClose(c.target, .zero, "after recenter the orbit pivot is back on the centroid")
+    }
+}
+#endif

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -43,7 +43,8 @@ SceneView { root in
     root.addChild(model.entity)
 }
 .environment(.studio)              // IBL lighting preset
-.cameraControls(.orbit)            // .orbit (default) | .pan | .firstPerson (v4.3.0+)
+.cameraControls(.orbit)            // .orbit (default) | .pan | .firstPerson (v4.3.0+; firstPerson is true in-place look-around v4.4.0+)
+.recentersTargetOnOrbit(true)      // v4.4.0+ — re-pivot on content centroid when returning to orbit (default false)
 .onEntityTapped { entity in }      // tap handler
 .autoRotate(speed: 0.3)            // turntable auto-rotation
 .autoCenterContent(true)           // v4.3.0+ — library translates content centroid to orbit pivot (default true; pass false to keep explicit placements)

--- a/llms.txt
+++ b/llms.txt
@@ -3108,6 +3108,7 @@ View modifiers (chainable):
 ```swift
 .environment(_ environment: SceneEnvironment) -> SceneView  // IBL lighting
 .cameraControls(_ mode: CameraControlMode) -> SceneView     // .orbit (default), .pan, .firstPerson
+.recentersTargetOnOrbit(_ enabled: Bool) -> SceneView       // v4.4.0+ — re-pivot on content centroid when (re-)entering orbit; default false
 .onEntityTapped(_ handler: @escaping (Entity) -> Void) -> SceneView   // real entity hit-test (v4.2.0+)
 .autoRotate(speed: Float = 0.3) -> SceneView                // radians/s, default 0.3
 .mainLight(_ slot: LightSlot) -> SceneView                  // v4.2.0+ — see LightSlot below
@@ -3559,7 +3560,7 @@ public protocol EntityProvider {
 public enum CameraControlMode: Sendable {
     case orbit         // drag rotates the scene around the orbit pivot, pinch dollies (default)
     case pan           // drag translates the target laterally, pinch dollies
-    case firstPerson   // drag rotates the view (no orbit translation), pinch adjusts FOV
+    case firstPerson   // v4.4.0+ true look-around: drag yaws/pitches the camera IN PLACE (no orbit, no teleport on mode switch), pinch adjusts FOV
 }
 
 public struct CameraControls: Sendable {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/CameraControlsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/CameraControlsDemo.swift
@@ -7,8 +7,16 @@ import SceneViewSwift
 /// Users can switch between ``CameraControlMode/orbit``, ``CameraControlMode/pan``,
 /// and ``CameraControlMode/firstPerson`` to feel the difference in gesture
 /// handling. Closes #1034 (last #928 silent-stub item).
+///
+/// The mode switcher also exercises the v4.4.0 follow-up #1236: switching
+/// orbit ↔ firstPerson keeps the camera in place (true look-around, no
+/// teleport), and the "Recenter on orbit" toggle re-pivots a panned scene
+/// when you return to orbit mode.
 struct CameraControlsDemo: View {
     @State private var mode: CameraControlMode = .orbit
+    /// When on, returning to `.orbit` snaps the orbit pivot back to the
+    /// scene centroid so repeated pan→orbit cycles don't drift (#1236).
+    @State private var recenterOnOrbit = false
 
     var body: some View {
         sceneContent
@@ -60,6 +68,7 @@ struct CameraControlsDemo: View {
                 root.addChild(zLabel.entity)
             }
             .cameraControls(mode)
+            .recentersTargetOnOrbit(recenterOnOrbit)
             .ignoresSafeArea()
         }
         .background(Color.black)
@@ -79,6 +88,13 @@ struct CameraControlsDemo: View {
             VStack(spacing: 8) {
                 instructionRow(icon: gestureIconForMode, text: dragHintForMode)
                 instructionRow(icon: "hand.pinch.fill", text: pinchHintForMode)
+            }
+
+            // #1236: opt-in pivot recentre so pan-then-orbit doesn't drift
+            // the model out of frame on repeated cycles.
+            Toggle(isOn: $recenterOnOrbit) {
+                Label("Recenter pivot on orbit", systemImage: "scope")
+                    .font(.caption)
             }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up from #1215 (R3 MAJOR, deferred to v4.4.0). Fixes the two iOS camera regressions in #1236.

- **Limitation 1 — orbit → firstPerson teleport.** `.firstPerson` now rotates the perspective camera *in place* (yaws/pitches its orientation around a fixed eye) instead of rotating the scene root. The eye is captured from the exact orbit/pan camera world position at the mode switch (`enterFirstPerson()`), so entering firstPerson never teleports. Leaving firstPerson (`exitFirstPerson()`) re-derives the orbit pivot from the eye + look direction so the reverse switch is equally continuous — the recomputed orbit camera position lands back exactly on the eye. The scene root now stays at identity for all three modes (orbit/pan/firstPerson), so the skybox wraps correctly and content never moves under the camera.
- **Limitation 2 — pan → orbit pivot drift.** New `CameraControls.recenterTarget(_:)` API + a `.recentersTargetOnOrbit(_:)` `SceneView` modifier. When enabled, returning to `.orbit` snaps the orbit pivot back to the content centroid (world origin under `.autoCenterContent`), so repeated pan-then-orbit cycles don't drift the model out of frame.
- FOV/pinch state isolation from #1215 preserved — firstPerson FOV resets to baseline on exit.
- visionOS retains the rotate-root fallback (no manual camera entity — the headset is the camera).

## Test plan

- [x] `swift build` — SceneViewSwift compiles clean
- [x] `swift test` — full 615-test suite green (2 pre-existing skips)
- [x] 12 new `CameraLookAroundTests` covering teleport-free orbit↔firstPerson round-trips, look-orientation/forward math consistency, and `recenterTarget` pivot-drift elimination
- [x] `CameraControlsDemo` extended with a "Recenter pivot on orbit" toggle exercising all 3 modes + pan + orbit transitions
- [x] `impact-check.sh` — PASS (1 pre-existing unrelated warning)
- [ ] On-device: switch orbit↔firstPerson at a steep orbit angle, confirm no camera jump; pan then re-orbit with the toggle on, confirm re-pivot

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)