### PR TITLE
ci: extract publish-time pip deps to requirements.txt for Dependabot tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,18 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(web)"
+
+  # pip — Python deps installed inside CI/publish workflows.
+  # The deps live in .github/workflows/requirements/*.txt (one file per
+  # workflow); the workflows `pip install -r` them. Dependabot's `pip`
+  # ecosystem only scans requirements files, never inline `pip install x==y`
+  # lines in workflow YAML — so this entry restores automated bumps (#1286).
+  - package-ecosystem: "pip"
+    directory: "/.github/workflows/requirements"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -234,7 +234,8 @@ jobs:
           python3 -m venv $RUNNER_TEMP/asc-venv
           # Pinned exact versions — this job runs with APP_STORE_CONNECT_API_KEY
           # in env, so a compromised PyPI release must not be pullable here (#1230).
-          $RUNNER_TEMP/asc-venv/bin/pip install "PyJWT[crypto]==2.10.1" requests==2.32.3 --quiet
+          # Deps live in a requirements file so Dependabot can track/bump them (#1286).
+          $RUNNER_TEMP/asc-venv/bin/pip install -r .github/workflows/requirements/app-store.txt --quiet
 
           # Wait for Apple to process the build
           echo "Waiting 120s for Apple to process the build..."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,9 +57,10 @@ jobs:
 
       - name: Install MkDocs
         run: |
-          pip install mkdocs-material
+          # Deps live in requirements files so Dependabot can track/bump them (#1286).
+          pip install -r .github/workflows/requirements/docs.txt
           # mkdocs-material[imaging] enables social card previews (optional, needs Cairo)
-          pip install "mkdocs-material[imaging]" 2>/dev/null || true
+          pip install -r .github/workflows/requirements/docs-imaging.txt 2>/dev/null || true
 
       - name: Sync content into docs
         run: |

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -338,7 +338,8 @@ jobs:
           python3 -m venv /tmp/promote-venv
           # Pinned exact versions — this job runs with PLAY_STORE_SERVICE_ACCOUNT_JSON
           # in env, so a compromised PyPI release must not be pullable here (#1230).
-          /tmp/promote-venv/bin/pip install --quiet google-auth==2.38.0 requests==2.32.3
+          # Deps live in a requirements file so Dependabot can track/bump them (#1286).
+          /tmp/promote-venv/bin/pip install --quiet -r .github/workflows/requirements/play-store.txt
 
           /tmp/promote-venv/bin/python3 << 'PYEOF'
           import json, os, sys, requests
@@ -453,7 +454,8 @@ jobs:
         run: |
           python3 -m venv /tmp/listing-venv
           # Pinned exact versions — credential-bearing job (#1230).
-          /tmp/listing-venv/bin/pip install --quiet google-auth==2.38.0 requests==2.32.3
+          # Deps live in a requirements file so Dependabot can track/bump them (#1286).
+          /tmp/listing-venv/bin/pip install --quiet -r .github/workflows/requirements/play-store.txt
 
           /tmp/listing-venv/bin/python3 << 'PYEOF'
           import json, os, sys, pathlib, requests

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -116,7 +116,8 @@ jobs:
             sudo apt-get install -y -qq shellcheck
           fi
           # PyYAML — already in the runner image, but assert.
-          python3 -c "import yaml" || pip install --quiet pyyaml
+          # Fallback deps live in a requirements file so Dependabot tracks them (#1286).
+          python3 -c "import yaml" || pip install --quiet -r .github/workflows/requirements/pr-check.txt
 
       - name: Validate workflow shell blocks (dash + shellcheck)
         if: always()

--- a/.github/workflows/requirements/app-store.txt
+++ b/.github/workflows/requirements/app-store.txt
@@ -1,0 +1,6 @@
+# Python deps for .github/workflows/app-store.yml (App Store Connect upload/verify).
+# Pinned exact versions — this job runs with APP_STORE_CONNECT_API_KEY in env,
+# so a compromised PyPI release must not be pullable here (#1230).
+# Tracked by Dependabot via the `pip` entry in .github/dependabot.yml.
+PyJWT[crypto]==2.10.1
+requests==2.32.3

--- a/.github/workflows/requirements/docs-imaging.txt
+++ b/.github/workflows/requirements/docs-imaging.txt
@@ -1,0 +1,5 @@
+# Optional imaging extra for .github/workflows/docs.yml — enables MkDocs Material
+# social card previews (needs Cairo at runtime). Installed best-effort; the docs
+# build does not fail if this install fails.
+# Tracked by Dependabot via the `pip` entry in .github/dependabot.yml.
+mkdocs-material[imaging]==9.7.6

--- a/.github/workflows/requirements/docs.txt
+++ b/.github/workflows/requirements/docs.txt
@@ -1,0 +1,3 @@
+# Python deps for .github/workflows/docs.yml (MkDocs site build).
+# Tracked by Dependabot via the `pip` entry in .github/dependabot.yml.
+mkdocs-material==9.7.6

--- a/.github/workflows/requirements/play-store.txt
+++ b/.github/workflows/requirements/play-store.txt
@@ -1,0 +1,6 @@
+# Python deps for .github/workflows/play-store.yml (Play Store promote + listing sync).
+# Pinned exact versions — these jobs run with PLAY_STORE_SERVICE_ACCOUNT_JSON in env,
+# so a compromised PyPI release must not be pullable here (#1230).
+# Tracked by Dependabot via the `pip` entry in .github/dependabot.yml.
+google-auth==2.38.0
+requests==2.32.3

--- a/.github/workflows/requirements/pr-check.txt
+++ b/.github/workflows/requirements/pr-check.txt
@@ -1,0 +1,4 @@
+# Python deps for .github/workflows/pr-check.yml (workflow YAML lint helper).
+# PyYAML is normally already in the runner image; this is the fallback install.
+# Tracked by Dependabot via the `pip` entry in .github/dependabot.yml.
+pyyaml==6.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed — CI
 
+- **CI/publish workflows' inline `pip install` deps moved into per-workflow `.github/workflows/requirements/*.txt` files so Dependabot's `pip` ecosystem tracks and bumps them ([#1286](https://github.com/sceneview/sceneview/issues/1286)).** Same packages, same pinned versions installed — Dependabot just cannot see inline `pip install x==y` lines in workflow YAML, so the pins would have gone stale silently.
+
 - **`render-tests.yml` reverted from a 3-shard emulator matrix back to a single job ([#1119](https://github.com/sceneview/sceneview/issues/1119)).** All 5 render-test classes are class-level `@Ignore`'d on SwiftShader CI (#803), so the shard matrix booted 3 emulators to run 0 tests — strictly more CI cost for the same coverage. The matrix scaffold can be re-applied once #803 lifts the ignores.
 
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)


### PR DESCRIPTION
## Summary

Follow-up to #1230 / #1285. CI and publish-time workflows installed Python deps via inline `pip install x==y` lines in `run:` blocks. Dependabot's `pip` ecosystem only scans `requirements.txt` / `pyproject.toml` — it never sees inline workflow YAML — so those pins would go stale silently with no automated bump PRs.

This extracts each workflow's Python deps into per-workflow files under `.github/workflows/requirements/`, has the workflows `pip install -r` them, and adds a `pip` entry to `.github/dependabot.yml` so Dependabot tracks and bumps them.

## Changes

- New `.github/workflows/requirements/{app-store,play-store,docs,docs-imaging,pr-check}.txt` — same packages, same pinned versions.
- `app-store.yml`, `play-store.yml` (×2), `docs.yml`, `pr-check.yml` now `pip install -r` the requirement files instead of inline package lists.
- `.github/dependabot.yml` gains a `pip` ecosystem entry pointing at `/.github/workflows/requirements`.

No behavior change: identical packages at identical versions are installed. Previously-unpinned deps (`mkdocs-material`, `pyyaml`) are now pinned to current latest known-good.

## Test plan

- [x] YAML validated for every touched workflow + `dependabot.yml`
- [x] `actionlint` clean on edited lines (pre-existing shellcheck findings on untouched lines only)

Closes #1286