### PR TITLE
test(ar): regression pins for 3 untested fixes from 2026-05-14 batch (#1120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Tests
+
+- **Regression pins for three untested AR rendering fixes from the 2026-05-14 batch ([#1120](https://github.com/sceneview/sceneview/issues/1120)).** New JVM tests pin the `environmentalHdrSpecularFilter = true` default (#1086), the no-double-close hoisted cubemap upload callback (#1091), and the 7 `@Volatile` `LightEstimator` toggles (#1095).
+
 ### Added — CI
 
 - **Nightly full-CI safety-net workflow ([#1324](https://github.com/sceneview/sceneview/issues/1324)).** `nightly-ci.yml` runs the full heavy validation surface (compile + builds + unit tests + render tests + quality gate) against `main` HEAD once a night, reusing the existing workflows via `workflow_call`, so a path-gated-out regression still surfaces within 24h. Not a PR gate.

--- a/arsceneview/src/test/java/io/github/sceneview/ar/light/LightEstimatorTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/light/LightEstimatorTest.kt
@@ -227,4 +227,80 @@ class LightEstimatorTest {
             assertEquals("component[$i] mismatch", reference[i], converted[i], 1e-6f)
         }
     }
+
+    // ── Source-level regression pins (#1120) ─────────────────────────────────
+    //
+    // `LightEstimator`'s instance fields can only be observed by constructing the
+    // class, which needs a real Filament `Engine` + `IBLPrefilter` (JNI, not
+    // shadowed by Robolectric). The established repo pattern for that situation
+    // — see `ARCompletenessDefaultsTest` — is to pin the source declaration with
+    // a regex so a revert fails the build. These pins fill the test gap left by
+    // PRs #1086 and #1091 (post-merge audit batch on `ce1f4a79`, see #1120).
+
+    private val lightEstimatorSource: String by lazy {
+        val f = java.io.File(
+            "src/main/java/io/github/sceneview/ar/light/LightEstimator.kt"
+        )
+        assertTrue(
+            "Expected ${f.absolutePath} — JVM test must run from arsceneview module root.",
+            f.exists(),
+        )
+        f.readText()
+    }
+
+    @Test
+    fun `environmentalHdrSpecularFilter defaults to true (#1086)`() {
+        // PR #1086 flipped the default false → true (#1064): Filament's
+        // `IndirectLight.reflections()` expects a roughness-prefiltered mip
+        // chain, so a raw cubemap makes every reflection mirror-like at any
+        // roughness. A future "default-off for perf" PR would silently revert
+        // this without a test catching it (#1120).
+        val pattern = Regex(
+            """var\s+environmentalHdrSpecularFilter\s*=\s*true"""
+        )
+        assertTrue(
+            "LightEstimator.environmentalHdrSpecularFilter MUST default to `true` " +
+                "(#1086 / #1064). Source did not match $pattern.",
+            pattern.containsMatchIn(lightEstimatorSource),
+        )
+    }
+
+    @Test
+    fun `cubemap upload callback is the hoisted no-double-close uploadCompletedCallback (#1091)`() {
+        // PR #1091 (#1090) removed the inline callback that double-closed the
+        // already-`use {}`-closed ARCore Images. CORR-B (#1094) then restored a
+        // *synchronisation-only* callback, hoisted by #1102 to the instance-scoped
+        // `uploadCompletedCallback`. Pin BOTH facets of the evolved contract:
+        //   1. the callback handed to `PixelBufferDescriptor` is the hoisted ref;
+        //   2. that hoisted ref's body is a pure flag flip — it must NEVER close
+        //      `arImages` again (the #1091 double-close regression).
+        val src = lightEstimatorSource
+        // Strip Kotlin line comments — the call site carries an inline comment
+        // between `null,` and `uploadCompletedCallback` explaining the #1102 hoist.
+        val codeOnly = src.lineSequence()
+            .map { it.substringBefore("//") }
+            .joinToString("\n")
+        assertTrue(
+            "The `Texture.PixelBufferDescriptor` callback MUST be the hoisted " +
+                "`uploadCompletedCallback` (#1091 double-close fix + #1102 hoist).",
+            Regex("""1,\s*0,\s*0,\s*0,\s*null,\s*uploadCompletedCallback""")
+                .containsMatchIn(codeOnly),
+        )
+        val callbackDecl = Regex(
+            """uploadCompletedCallback\s*=\s*Runnable\s*\{[^}]*}"""
+        ).find(codeOnly)?.value
+        requireNotNull(callbackDecl) {
+            "Could not find the `uploadCompletedCallback` Runnable declaration."
+        }
+        assertTrue(
+            "uploadCompletedCallback body must be the pure flag flip " +
+                "`uploadInFlight = false` (#1094). Saw: $callbackDecl",
+            Regex("""uploadInFlight\s*=\s*false""").containsMatchIn(callbackDecl),
+        )
+        assertFalse(
+            "uploadCompletedCallback MUST NOT close `arImages` — that is the " +
+                "#1090/#1091 double-close regression. Saw: $callbackDecl",
+            callbackDecl.contains("arImages"),
+        )
+    }
 }

--- a/arsceneview/src/test/java/io/github/sceneview/ar/light/LightEstimatorVolatileTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/light/LightEstimatorVolatileTest.kt
@@ -1,0 +1,53 @@
+package io.github.sceneview.ar.light
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Modifier
+
+/**
+ * Regression pin for PR [#1095](https://github.com/sceneview/sceneview/pull/1095)
+ * (#1094) — `@Volatile` on [LightEstimator]'s 7 cross-thread toggles.
+ *
+ * The Filament `PixelBufferDescriptor` upload callback fires on Filament's
+ * render thread, while the public `environmentalHdr*` toggles + `isEnabled`
+ * are flipped from the AR / UI thread. Without `@Volatile` the render thread
+ * could observe a stale toggle value indefinitely (Java Memory Model: no
+ * happens-before edge between an ordinary write and a read on another thread).
+ *
+ * A Kotlin `@Volatile` property compiles to the JVM `volatile` modifier on the
+ * backing field, so this concurrency invariant is observable by pure-JVM
+ * reflection — no Filament `Engine` instance required. A future contributor who
+ * "cleans up" one of these annotations away gets caught here (#1120).
+ *
+ * Scope note: #1120 explicitly flags the reflection-based `@Volatile` check as
+ * acceptable. Keeping it pins the invariant cheaply.
+ */
+class LightEstimatorVolatileTest {
+
+    /**
+     * The 7 fields PR #1095 annotated `@Volatile`. Names are the Kotlin
+     * property names; the backing field carries the same name.
+     */
+    private val volatileFields = listOf(
+        "isEnabled",
+        "environmentalHdrReflections",
+        "environmentalHdrSphericalHarmonics",
+        "environmentalHdrSpecularFilter",
+        "environmentalHdrMainLightDirection",
+        "environmentalHdrMainLightIntensity",
+        "uploadInFlight",
+    )
+
+    @Test
+    fun `LightEstimator cross-thread toggles carry @Volatile (#1095)`() {
+        volatileFields.forEach { name ->
+            val field = LightEstimator::class.java.getDeclaredField(name)
+            assertTrue(
+                "LightEstimator.$name MUST be `@Volatile` — it is written and read " +
+                    "from different threads (AR/UI thread vs Filament render thread). " +
+                    "Dropping `@Volatile` re-introduces the #1094 stale-read race (#1095).",
+                Modifier.isVolatile(field.modifiers),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The 4-cluster post-merge audit of the 2026-05-14 15-PR rendering batch (issue #1120) found that 4 fixes shipped without JVM regression-pin tests. This PR adds focused, genuine regression pins.

## Which fixes are now pinned

| PR | Fix | Pin added |
|---|---|---|
| #1086 | `environmentalHdrSpecularFilter = true` default | `LightEstimatorTest.environmentalHdrSpecularFilter defaults to true (#1086)` — source pin; a "default-off for perf" revert now fails the build |
| #1091 | cubemap upload callback no double-close | `LightEstimatorTest.cubemap upload callback is the hoisted no-double-close uploadCompletedCallback (#1091)` — pins the **evolved** contract (CORR-B #1094 + #1102 hoist): callback is the hoisted `uploadCompletedCallback`, body is a pure `uploadInFlight = false` flip, never closes `arImages` again |
| #1095 | 7× `@Volatile` on `LightEstimator` toggles | new `LightEstimatorVolatileTest` — reflection asserts `Modifier.isVolatile` on all 7 cross-thread fields |
| #1088 | `ARDefaultCameraNode` EV11.6 | **already pinned** by the existing `ARDefaultCameraNodeTest.kt` (5 tests) — no new test needed |

The 3D-cluster rows #1077/#1078 in the issue table do not exist as PRs (GraphQL resolve failure), so they are out of scope here.

## Notes

- Test-only change — **no production code touched**. `LightEstimator` cannot be constructed in pure JVM (needs a real Filament `Engine`/`IBLPrefilter`, JNI not shadowed by Robolectric), so #1086/#1091 use the established source-regex pin pattern from `ARCompletenessDefaultsTest`; #1095 uses pure reflection.
- All test names follow the `…(#NNNN)` convention.

## Test plan

- [x] `./gradlew :arsceneview:testDebugUnitTest --tests "*LightEstimatorTest" --tests "*LightEstimatorVolatileTest"` — BUILD SUCCESSFUL
- [x] `impact-check.sh` — PASS (only the pre-existing Swift-only-nodes parity warning)

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)