### PR TITLE
fix(android-demo): TalkBack a11y for SecondaryCameraDemo camera-angle controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - **`discord-notify.yml` no longer interpolates user-controlled `github.event.*` fields into inline shell scripts ([#1313](https://github.com/sceneview/sceneview/issues/1313)).** Issue title/author and release name/tag now pass through `env:` and are referenced as quoted shell variables, closing a GitHub Actions script-injection vector.
 
+### Fixed — Samples
+
+- **`SecondaryCameraDemo` camera-angle controls are now TalkBack-friendly ([#1256](https://github.com/sceneview/sceneview/issues/1256)).** The section label is exposed as a heading and the selected `FilterChip` carries an explicit "Selected camera angle" state description.
+
 ### Changed — CI
 
 - **`render-tests.yml` reverted from a 3-shard emulator matrix back to a single job ([#1119](https://github.com/sceneview/sceneview/issues/1119)).** All 5 render-test classes are class-level `@Ignore`'d on SwiftShader CI (#803), so the shard matrix booted 3 emulators to run 0 tests — strictly more CI cost for the same coverage. The matrix scaffold can be re-applied once #803 lifts the ignores.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -27,8 +27,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
@@ -116,19 +118,31 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
         title = stringResource(R.string.demo_secondary_camera_title),
         onBack = onBack,
         controls = {
+            // Mark the section label as a heading so TalkBack users can
+            // navigate to it and understand the chip row that follows.
             Text(
                 stringResource(R.string.demo_secondary_camera_chip_section),
-                style = MaterialTheme.typography.labelLarge
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.semantics { heading() }
             )
+            val selectedStateDescription =
+                stringResource(R.string.demo_secondary_camera_chip_selected)
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 CameraPreset.entries.forEach { preset ->
+                    val selected = cameraPreset == preset
                     FilterChip(
-                        selected = cameraPreset == preset,
+                        selected = selected,
                         onClick = { cameraPreset = preset },
-                        label = { Text(stringResource(preset.labelRes)) }
+                        label = { Text(stringResource(preset.labelRes)) },
+                        // FilterChip exposes a selected toggle to TalkBack, but
+                        // the default state announcement ("on"/"off") is vague
+                        // for a camera-angle picker — spell out "selected".
+                        modifier = Modifier.semantics {
+                            if (selected) stateDescription = selectedStateDescription
+                        }
                     )
                 }
             }

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@
     <string name="demo_secondary_camera_chip_front">Front</string>
     <string name="demo_secondary_camera_chip_corner">Corner</string>
     <string name="demo_secondary_camera_pip_cd">Picture-in-picture camera view: %1$s</string>
+    <string name="demo_secondary_camera_chip_selected">Selected camera angle</string>
     <string name="demo_debug_overlay_title">Debug Overlay</string>
     <string name="demo_debug_overlay_subtitle">Performance stats overlay</string>
     <string name="demo_ar_placement_title">Tap to Place</string>


### PR DESCRIPTION
## Summary

Polish for `SecondaryCameraDemo`, addressing the actionable scope of #1256.

- **a11y semantics on the camera-angle controls** — the PiP camera-angle picker had no semantic structure for TalkBack. The section label was decorative text and the `FilterChip`s only announced the default `"on"`/`"off"` toggle state.
  - Section label is now exposed as a `heading()` so TalkBack users can navigate to it and understand the chip row that follows.
  - The selected `FilterChip` carries an explicit `"Selected camera angle"` `stateDescription`, replacing the vague default toggle announcement.
- The PiP `Box` already had a `contentDescription` + polite `liveRegion` from #1256's first round (commit `733fddee`); this PR completes the interactive-control side.

## Scope notes

- **Part (a) "i18n chip labels" — dropped, stale.** The chip labels are already clean English `string` resources, and the sample apps are English-only by design since #1294 removed all localization. No `values-fr` added.
- **Part (c) "multi-camera design discussion" — left on the issue.** It is an open design question with no consensus; a design comment is posted on #1256. This PR stays scoped to the concrete a11y work.

## Test plan

- [x] `:samples:android-demo:compileDebugKotlin` passes
- [x] `impact-check.sh` passes (1 unrelated Swift-only-node warning)
- [ ] TalkBack: section label announces as a heading; selecting a chip announces "Selected camera angle"

Addresses #1256 (a11y + label cleanup). The multi-camera design discussion stays open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)