### PR TITLE
ci: split ci.yml build/lint/test + shallow quality-gate checkout (#1311 gaps #6/#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,17 @@ jobs:
               - 'flutter/**'
               - 'samples/flutter-demo/**'
 
+  # ── Android build / test / lint ──────────────────────────────────────────
+  # Gap #6 (#1311): the former single "Build & lint" job ran assembleDebug +
+  # 2 demo APKs + JaCoCo unit tests + lint sequentially (~8.5 min long pole).
+  # It is now split into three jobs that run in parallel on separate runners
+  # and share the same Gradle build cache (the `setup-gradle` composite action
+  # is `cache-read-only` on non-push, so the cache is consistent across them).
+  # Trades a few extra runner-minutes for ~3 min wall-clock. All three are
+  # picked up automatically by the `CI Gate` aggregator (#1314), which polls
+  # every check run for the head SHA rather than using a static `needs:` list.
   build:
-    name: Build & lint
+    name: Build libraries & samples
     needs: changes
     if: inputs.force-all || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
@@ -138,6 +147,43 @@ jobs:
             :samples:android-demo:assembleDebug \
             :samples:android-tv-demo:assembleDebug \
             --stacktrace
+
+  lint:
+    name: Lint
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Lint
+        run: ./gradlew :sceneview:lintDebug :arsceneview:lintDebug --stacktrace
+
+      - name: Upload lint reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lint-reports
+          path: |
+            sceneview/build/reports/lint-results-debug.html
+            arsceneview/build/reports/lint-results-debug.html
+          if-no-files-found: ignore
+
+  unit-test:
+    name: Unit tests + coverage
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-gradle
 
       - name: Unit tests + JaCoCo coverage
         # Single invocation: jacocoTestReport depends on testDebugUnitTest so
@@ -200,19 +246,6 @@ jobs:
             sceneview/build/reports/jacoco/jacocoTestReport/
             arsceneview/build/reports/jacoco/jacocoTestReport/
           if-no-files-found: warn
-
-      - name: Lint
-        run: ./gradlew :sceneview:lintDebug :arsceneview:lintDebug --stacktrace
-
-      - name: Upload lint reports
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: lint-reports
-          path: |
-            sceneview/build/reports/lint-results-debug.html
-            arsceneview/build/reports/lint-results-debug.html
-          if-no-files-found: ignore
 
   # ── Web & Desktop modules (Kotlin/JS + Compose Desktop) ──────────────────
   web-desktop:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -61,11 +61,13 @@ jobs:
 
     steps:
       - name: Checkout
+        # Gap #10 (#1311): the default shallow checkout (fetch-depth: 1) is
+        # sufficient. quality-gate.sh only runs `git diff HEAD`,
+        # `git diff --cached`, `git ls-files` and `git branch --show-current`
+        # — all of which resolve against the working tree / HEAD, never an
+        # older commit. sync-versions.sh compares files with plain `diff`, no
+        # git history. Dropping `fetch-depth: 0` skips cloning full history.
         uses: actions/checkout@v6
-        with:
-          # Full history so quality-gate.sh can run git diff/ls-files against
-          # main and so version checks can resolve historical refs.
-          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -100,9 +102,9 @@ jobs:
         env:
           # Optional. Demo runtime disables Geospatial when unset.
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
-          # ci.yml's `build` job already runs `assembleDebug` + the same
-          # unit-test set + JaCoCo coverage in parallel with this gate.
-          # Skipping the duplicate Android build/test work here keeps the
+          # ci.yml's `build` / `unit-test` jobs already run `assembleDebug`
+          # + the same unit-test set + JaCoCo coverage in parallel with this
+          # gate. Skipping the duplicate Android build/test work here keeps the
           # gate focused on what it owns uniquely: version sync, security
           # scans, asset CDN integrity, website rules, MCP tests, agent
           # skill drift. Trims ~5 min from every PR and push. The full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed — CI
 
+- **`ci.yml`'s "Build & lint" job split into parallel `build` / `lint` / `unit-test` jobs, and `quality-gate.yml` switched to a shallow checkout ([#1311](https://github.com/sceneview/sceneview/issues/1311)).** The three Android jobs share the Gradle cache and run concurrently (~3 min wall-clock saved); the quality gate drops `fetch-depth: 0` since its scripts only diff against the working tree / HEAD.
 - **`render-tests.yml` reverted from a 3-shard emulator matrix back to a single job ([#1119](https://github.com/sceneview/sceneview/issues/1119)).** All 5 render-test classes are class-level `@Ignore`'d on SwiftShader CI (#803), so the shard matrix booted 3 emulators to run 0 tests — strictly more CI cost for the same coverage. The matrix scaffold can be re-applied once #803 lifts the ignores.
 
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)


### PR DESCRIPTION
## Summary

Completes the remaining `#1311` CI-performance gaps after PR #1312 (gaps #1-5, #8, #9).

- **Gap #6 (P2)** — `ci.yml`'s single `Build & lint` job (~8.5 min long pole: `assembleDebug` + 2 demo APKs + JaCoCo unit tests + lint, all sequential) is split into three parallel jobs: `build` / `lint` / `unit-test`. Each reuses the `setup-gradle` composite action, so they share one Gradle cache (`cache-read-only` on non-push — no double-write race). ~3 min wall-clock saved, traded for a few extra runner-minutes.
- **Gap #10 (P2)** — `quality-gate.yml` drops `fetch-depth: 0`. Verified `quality-gate.sh` only uses `git diff HEAD`, `git diff --cached`, `git ls-files`, `git branch --show-current` (all working-tree / HEAD-relative) and `sync-versions.sh` compares files with plain `diff` — no history beyond HEAD is needed, so the default shallow checkout is sufficient.

## Gaps already done / skipped

- **Gap #9** — `discord-notify.yml` already has both `concurrency:` (added by PR #1312) and `timeout-minutes: 5` (predates this work). Nothing to change; file untouched.
- **Gap #7** — intentionally skipped. The issue itself marks it low-priority (~10-20s CPU dup); not worth the churn.

## CI Gate

The `CI Gate` aggregator (#1314) polls every check run for the PR head SHA — it has no static `needs:` list — so the three new `build` / `lint` / `unit-test` jobs are aggregated automatically. No gate change required.

## Validation

- YAML parse + `actionlint` clean on all three workflows.
- Every former step still runs exactly once across the three jobs; no step dropped or duplicated.
- `impact-check.sh` passes (pre-existing unrelated Swift-only-nodes warning).

Closes #1311