### PR TITLE
docs(sceneview-core): KDoc for collision API (#965 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added — Documentation
+
+- **KDoc for the `sceneview-core` collision API ([#965](https://github.com/sceneview/sceneview/issues/965)).** Documented previously-undocumented public declarations in the collision module (`Box`, `Sphere`, `Plane`, `Ray`, `RayHit`, `Vector3`, `Quaternion`, `Capsule`, `MeshCollider`, `ChangeId`, `TransformProvider`) plus the `Easing` curve set and the cross-platform `logWarning` logger.
+
 ### Added — CI
 
 - **Nightly full-CI safety-net workflow ([#1324](https://github.com/sceneview/sceneview/issues/1324)).** `nightly-ci.yml` runs the full heavy validation surface (compile + builds + unit tests + render tests + quality gate) against `main` HEAD once a night, reusing the existing workflows via `workflow_call`, so a path-gated-out regression still surfaces within 24h. Not a PR gate.

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/animation/Interpolation.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/animation/Interpolation.kt
@@ -14,6 +14,13 @@ import kotlin.math.sqrt
 // ── Easing functions ────────────────────────────────────────────────────────────
 // Each takes a fraction in [0..1] and returns a curved fraction in [0..1].
 
+/**
+ * Standard animation easing curves.
+ *
+ * Every entry is a function mapping a linear progress fraction in `[0, 1]` to a curved
+ * fraction (also nominally in `[0, 1]`, though `Back` and `Elastic` curves overshoot
+ * slightly). Pass one of these to an animation driver to shape its timing.
+ */
 object Easing {
     /** No curve — constant speed. */
     val Linear: (Float) -> Float = { it }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Box.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Box.kt
@@ -20,8 +20,15 @@ class Box : CollisionShape {
     /** Create a box with a center of (0,0,0) and a size of (1,1,1). */
     constructor()
 
+    /** Create an axis-aligned box centered at (0,0,0) with the given full [size]. */
     constructor(size: Vector3) : this(size, Vector3.zero())
 
+    /**
+     * Create a box with the given [size] and [center].
+     *
+     * @param size Full extents along each axis (not half-extents).
+     * @param center Box center in local space.
+     */
     constructor(size: Vector3, center: Vector3) {
         Preconditions.checkNotNull(center, "Parameter \"center\" was null.")
         Preconditions.checkNotNull(size, "Parameter \"size\" was null.")
@@ -29,40 +36,70 @@ class Box : CollisionShape {
         setSize(size)
     }
 
+    /**
+     * Sets the box center and notifies listeners that the shape changed.
+     *
+     * @param center New center in local space. The vector is copied, not retained.
+     */
     fun setCenter(center: Vector3) {
         Preconditions.checkNotNull(center, "Parameter \"center\" was null.")
         this.center.set(center)
         onChanged()
     }
 
+    /** Returns a copy of the box center. Mutating it does not affect the box. */
     fun getCenter(): Vector3 = Vector3(center)
 
+    /**
+     * Sets the full box size and notifies listeners that the shape changed.
+     *
+     * @param size Full extents along each axis (not half-extents).
+     */
     fun setSize(size: Vector3) {
         Preconditions.checkNotNull(size, "Parameter \"size\" was null.")
         this.size.set(size)
         onChanged()
     }
 
+    /** Returns a copy of the full box size (extents along each axis). */
     fun getSize(): Vector3 = Vector3(size)
 
+    /** Returns the box half-extents (half the full size along each axis). */
     fun getExtents(): Vector3 = getSize().scaled(0.5f)
 
+    /**
+     * Sets the box orientation, turning it into an oriented bounding box.
+     *
+     * @param rotation Orientation of the box relative to its parent space.
+     */
     fun setRotation(rotation: Quaternion) {
         Preconditions.checkNotNull(rotation, "Parameter \"rotation\" was null.")
         rotationMatrix.makeRotation(rotation)
         onChanged()
     }
 
+    /** Returns the current box orientation as a quaternion. */
     fun getRotation(): Quaternion {
         val result = Quaternion()
         rotationMatrix.extractQuaternion(result)
         return result
     }
 
+    /** Returns an independent copy of this box with the same size and center. */
     override fun makeCopy(): Box = Box(getSize(), getCenter())
 
     internal fun getRawRotationMatrix(): Matrix = rotationMatrix
 
+    /**
+     * Tests whether [ray] intersects this oriented box and, if so, fills [result] with the hit.
+     *
+     * Uses the slab method against the box's three local axes. The nearest non-negative
+     * intersection is reported; if the ray origin is inside the box, the exit point is used.
+     *
+     * @param ray Ray in the same space as the box.
+     * @param result Mutated in place with the hit distance and point when an intersection occurs.
+     * @return `true` if the ray intersects the box, `false` otherwise.
+     */
     override fun rayIntersection(ray: Ray, result: RayHit): Boolean {
         Preconditions.checkNotNull(ray, "Parameter \"ray\" was null.")
         Preconditions.checkNotNull(result, "Parameter \"result\" was null.")
@@ -156,17 +193,25 @@ class Box : CollisionShape {
         return true
     }
 
+    /** Returns `true` if this box overlaps [shape] (dispatches by the shape's concrete type). */
     override fun shapeIntersection(shape: CollisionShape): Boolean {
         Preconditions.checkNotNull(shape, "Parameter \"shape\" was null.")
         return shape.boxIntersection(this)
     }
 
+    /** Returns `true` if this box overlaps [sphere]. */
     override fun sphereIntersection(sphere: Sphere): Boolean =
         Intersections.sphereBoxIntersection(sphere, this)
 
+    /** Returns `true` if this box overlaps [box]. */
     override fun boxIntersection(box: Box): Boolean =
         Intersections.boxBoxIntersection(this, box)
 
+    /**
+     * Returns a new box obtained by applying [transformProvider]'s transform to this one.
+     *
+     * Position, size (scaled per-axis) and rotation are all carried through.
+     */
     override fun transform(transformProvider: TransformProvider): CollisionShape {
         Preconditions.checkNotNull(transformProvider, "Parameter \"transformProvider\" was null.")
         val result = Box()
@@ -174,6 +219,13 @@ class Box : CollisionShape {
         return result
     }
 
+    /**
+     * Applies [transformProvider]'s transform to this box, writing into [result].
+     *
+     * @param result Must be a [Box] and must not be this same instance; otherwise the call
+     *   is a no-op (wrong type) or throws (self).
+     * @throws IllegalArgumentException if [result] is this same box instance.
+     */
     override fun transform(transformProvider: TransformProvider, result: CollisionShape) {
         Preconditions.checkNotNull(transformProvider, "Parameter \"transformProvider\" was null.")
         Preconditions.checkNotNull(result, "Parameter \"result\" was null.")

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Capsule.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Capsule.kt
@@ -41,27 +41,34 @@ class Capsule : CollisionShape {
         this.center.set(center)
     }
 
+    /** Sets the capsule center and notifies listeners that the shape changed. The vector is copied. */
     fun setCenter(center: Vector3) {
         this.center.set(center)
         onChanged()
     }
 
+    /** Returns a copy of the capsule center. */
     fun getCenter(): Vector3 = Vector3(center)
 
+    /** Sets the capsule radius and notifies listeners that the shape changed. */
     fun setRadius(radius: Float) {
         this.radius = radius
         onChanged()
     }
 
+    /** Returns the capsule radius. */
     fun getRadius(): Float = radius
 
+    /** Sets the full capsule height (including the hemispherical caps) and notifies listeners. */
     fun setHeight(height: Float) {
         this.height = height
         onChanged()
     }
 
+    /** Returns the full capsule height, including the hemispherical caps. */
     fun getHeight(): Float = height
 
+    /** Sets the capsule orientation and notifies listeners that the shape changed. */
     fun setRotation(rotation: Quaternion) {
         rotationMatrix.makeRotation(rotation)
         onChanged()
@@ -83,12 +90,23 @@ class Capsule : CollisionShape {
         return Pair(bottom, top)
     }
 
+    /** Returns an independent copy of this capsule with the same dimensions and orientation. */
     override fun makeCopy(): Capsule {
         val copy = Capsule(radius, height, getCenter())
         copy.rotationMatrix.set(rotationMatrix)
         return copy
     }
 
+    /**
+     * Tests whether [ray] intersects this capsule and, if so, fills [result] with the nearest hit.
+     *
+     * The capsule is tested as an infinite cylinder body plus two hemispherical caps;
+     * the closest non-negative intersection across all parts is reported.
+     *
+     * @param ray Ray in the same space as the capsule.
+     * @param result Mutated in place with the hit distance and point when an intersection occurs.
+     * @return `true` if the ray intersects the capsule.
+     */
     override fun rayIntersection(ray: Ray, result: RayHit): Boolean {
         // Ray-capsule intersection: test ray against the infinite cylinder,
         // then against the two hemispherical caps
@@ -160,6 +178,11 @@ class Capsule : CollisionShape {
         return false
     }
 
+    /**
+     * Returns `true` if this capsule overlaps [shape].
+     *
+     * Supports [Sphere], [Box] and [Capsule]; any other shape type returns `false`.
+     */
     override fun shapeIntersection(shape: CollisionShape): Boolean {
         return when (shape) {
             is Sphere -> capsuleSphereIntersection(this, shape)
@@ -169,22 +192,35 @@ class Capsule : CollisionShape {
         }
     }
 
+    /** Returns `true` if this capsule overlaps [sphere]. */
     override fun sphereIntersection(sphere: Sphere): Boolean =
         capsuleSphereIntersection(this, sphere)
 
+    /** Returns `true` if this capsule overlaps [box]. */
     override fun boxIntersection(box: Box): Boolean =
         capsuleBoxIntersection(this, box)
 
-    /** Test whether this capsule intersects another [Capsule]. */
+    /** Returns `true` if this capsule overlaps another [Capsule]. */
     fun capsuleIntersection(other: Capsule): Boolean =
         capsuleCapsuleIntersection(this, other)
 
+    /**
+     * Returns a new capsule obtained by applying [transformProvider]'s transform to this one.
+     *
+     * Position, orientation, radius (scaled by the larger radial scale) and height are carried through.
+     */
     override fun transform(transformProvider: TransformProvider): CollisionShape {
         val result = Capsule()
         transform(transformProvider, result)
         return result
     }
 
+    /**
+     * Applies [transformProvider]'s transform to this capsule, writing into [result].
+     *
+     * @param result Must be a [Capsule] and must not be this same instance.
+     * @throws IllegalArgumentException if [result] is this same capsule instance.
+     */
     override fun transform(transformProvider: TransformProvider, result: CollisionShape) {
         if (result !is Capsule) {
             logWarning(TAG, "Cannot pass CollisionShape of a type other than Capsule into Capsule.transform.")

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/ChangeId.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/ChangeId.kt
@@ -10,17 +10,27 @@ package io.github.sceneview.collision
  */
 class ChangeId {
     companion object {
+        /** The id value that represents "never changed yet". */
         const val EMPTY_ID = 0
     }
 
     private var id = EMPTY_ID
 
+    /** Returns the current change id. Store it and later pass it to [checkChanged] to detect mutations. */
     fun get(): Int = id
 
+    /** Returns `true` if no change has been recorded yet (the id is still [EMPTY_ID]). */
     fun isEmpty(): Boolean = id == EMPTY_ID
 
+    /**
+     * Returns `true` if the object has changed since the snapshot [id] was taken.
+     *
+     * @param id A previously captured value from [get].
+     * @return `false` if no change has ever occurred, otherwise whether the id differs.
+     */
     fun checkChanged(id: Int): Boolean = this.id != id && !isEmpty()
 
+    /** Records a change by advancing the id. Skips [EMPTY_ID] on wrap-around. */
     fun update() {
         id++
 

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/MeshCollider.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/MeshCollider.kt
@@ -150,12 +150,14 @@ data class AABB(
     val min: Vector3,
     val max: Vector3
 ) {
+    /** The geometric center (midpoint of [min] and [max]). */
     val center: Vector3 get() = Vector3(
         (min.x + max.x) / 2f,
         (min.y + max.y) / 2f,
         (min.z + max.z) / 2f
     )
 
+    /** The full extents of the box along each axis (`max - min`). */
     val size: Vector3 get() = Vector3(
         max.x - min.x,
         max.y - min.y,

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Plane.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Plane.kt
@@ -3,7 +3,10 @@ package io.github.sceneview.collision
 import kotlin.math.abs
 
 /**
- * Mathematical representation of a plane with an infinite size. Used for intersection tests.
+ * Mathematical representation of an infinite plane. Used for ray intersection tests.
+ *
+ * @param center A point lying on the plane.
+ * @param normal The plane's surface normal. Stored normalized.
  */
 class Plane(center: Vector3, normal: Vector3) {
     private val center = Vector3()
@@ -18,20 +21,34 @@ class Plane(center: Vector3, normal: Vector3) {
         setNormal(normal)
     }
 
+    /** Sets a point lying on the plane. The vector is copied, not retained. */
     fun setCenter(center: Vector3) {
         Preconditions.checkNotNull(center, "Parameter \"center\" was null.")
         this.center.set(center)
     }
 
+    /** Returns a copy of the plane's reference point. */
     fun getCenter(): Vector3 = Vector3(center)
 
+    /** Sets the plane's surface normal. The value is normalized before being stored. */
     fun setNormal(normal: Vector3) {
         Preconditions.checkNotNull(normal, "Parameter \"normal\" was null.")
         this.normal.set(normal.normalized())
     }
 
+    /** Returns a copy of the plane's (normalized) surface normal. */
     fun getNormal(): Vector3 = Vector3(normal)
 
+    /**
+     * Tests whether [ray] intersects this plane and, if so, fills [result] with the hit.
+     *
+     * Only forward intersections (distance >= 0) are reported. A ray parallel to the
+     * plane never intersects.
+     *
+     * @param ray Ray in the same space as the plane.
+     * @param result Mutated in place with the hit distance and point when an intersection occurs.
+     * @return `true` if the ray intersects the plane in front of its origin.
+     */
     fun rayIntersection(ray: Ray, result: RayHit): Boolean {
         Preconditions.checkNotNull(ray, "Parameter \"ray\" was null.")
         Preconditions.checkNotNull(result, "Parameter \"result\" was null.")

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Quaternion.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Quaternion.kt
@@ -11,14 +11,20 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
- * A Sceneform quaternion class for floats.
+ * A mutable float quaternion representing a 3D rotation.
  *
  * Quaternion operations are Hamiltonian using the right-hand-rule convention.
+ * Components are stored normalized — most setters re-normalize automatically.
+ * The identity quaternion `(0, 0, 0, 1)` represents no rotation.
  */
 class Quaternion {
+    /** The X component of the rotation axis (imaginary part). */
     var x: Float
+    /** The Y component of the rotation axis (imaginary part). */
     var y: Float
+    /** The Z component of the rotation axis (imaginary part). */
     var z: Float
+    /** The scalar (real) component. */
     var w: Float
 
     /** Construct Quaternion and set to Identity */
@@ -130,14 +136,26 @@ class Quaternion {
         return true
     }
 
+    /** Returns a normalized (unit-length) copy of this quaternion, leaving this one unchanged. */
     fun normalized(): Quaternion {
         val result = Quaternion(this)
         result.normalize()
         return result
     }
 
+    /**
+     * Returns the inverse rotation as a new quaternion (the conjugate, valid for unit quaternions).
+     *
+     * Applying this rotation after the original cancels it out.
+     */
     fun inverted(): Quaternion = Quaternion(-this.x, -this.y, -this.z, this.w)
 
+    /**
+     * Returns a new quaternion with all components negated.
+     *
+     * This represents the *same* rotation as the original (q and -q are equivalent),
+     * but is useful for taking the shortest interpolation path.
+     */
     fun negated(): Quaternion = Quaternion(-this.x, -this.y, -this.z, -this.w)
 
     override fun toString(): String = "[x=$x, y=$y, z=$z, w=$w]"
@@ -171,6 +189,11 @@ class Quaternion {
         return result
     }
 
+    /**
+     * Returns this rotation as Euler angles in degrees (pitch, yaw, roll) on the X, Y, Z axes.
+     *
+     * @return A [Vector3] where x/y/z hold the rotation about each axis in degrees.
+     */
     fun getEulerAngles(): Vector3 {
         val xRadians = atan2((2.0f * (y * z + w * x)).toDouble(), (w * w - x * x - y * y + z * z).toDouble())
         val yRadians = asin((-2.0f * (x * z - w * y)).toDouble())
@@ -185,6 +208,7 @@ class Quaternion {
     companion object {
         private const val SLERP_THRESHOLD = 0.9995f
 
+        /** Rotates [src] by quaternion [q] and returns the rotated vector. */
         fun rotateVector(q: Quaternion, src: Vector3): Vector3 {
             val result = Vector3()
             val w2 = q.w * q.w
@@ -215,6 +239,7 @@ class Quaternion {
             return result
         }
 
+        /** Rotates [src] by the inverse of quaternion [q] and returns the rotated vector. */
         fun inverseRotateVector(q: Quaternion, src: Vector3): Vector3 {
             val result = Vector3()
             val w2 = q.w * q.w
@@ -245,6 +270,10 @@ class Quaternion {
             return result
         }
 
+        /**
+         * Returns the Hamilton product `lhs * rhs` — the rotation that applies [rhs] first,
+         * then [lhs]. Quaternion multiplication is not commutative.
+         */
         fun multiply(lhs: Quaternion, rhs: Quaternion): Quaternion {
             val lx = lhs.x
             val ly = lhs.y
@@ -263,6 +292,12 @@ class Quaternion {
             )
         }
 
+        /**
+         * Returns the component-wise sum of [lhs] and [rhs].
+         *
+         * Note: the result is *not* a normalized rotation — addition is only meaningful
+         * as an intermediate step in interpolation (see [slerp]).
+         */
         fun add(lhs: Quaternion, rhs: Quaternion): Quaternion {
             val result = Quaternion()
             result.x = lhs.x + rhs.x
@@ -282,6 +317,14 @@ class Quaternion {
             MathHelper.lerp(a.w, b.w, ratio)
         )
 
+        /**
+         * Spherical linear interpolation between rotations [start] and [end].
+         *
+         * Always takes the shortest path and falls back to linear interpolation for
+         * nearly-parallel rotations to avoid numerical instability.
+         *
+         * @param t Interpolation factor; 0 returns [start], 1 returns [end].
+         */
         fun slerp(start: Quaternion, end: Quaternion, t: Float): Quaternion {
             val orientation0 = start.normalized()
             var orientation1 = end.normalized()
@@ -308,6 +351,12 @@ class Quaternion {
             return result.normalized()
         }
 
+        /**
+         * Builds a rotation of [degrees] around the given [axis].
+         *
+         * @param axis Rotation axis. Need not be normalized — the result is normalized internally.
+         * @param degrees Rotation angle in degrees (right-hand rule).
+         */
         fun axisAngle(axis: Vector3, degrees: Float): Quaternion {
             val dest = Quaternion()
             val angle = degrees.toDouble() * (PI / 180.0)
@@ -321,6 +370,12 @@ class Quaternion {
             return dest
         }
 
+        /**
+         * Builds a rotation from Euler angles in degrees.
+         *
+         * @param eulerAngles Rotation about the X, Y and Z axes in degrees. Composed as
+         *   intrinsic ZYX (extrinsic XYZ), matching [getEulerAngles].
+         */
         fun eulerAngles(eulerAngles: Vector3): Quaternion {
             val qX = Quaternion(Vector3.right(), eulerAngles.x)
             val qY = Quaternion(Vector3.up(), eulerAngles.y)
@@ -329,6 +384,11 @@ class Quaternion {
             return multiply(multiply(qZ, qY), qX)
         }
 
+        /**
+         * Returns the shortest-arc rotation that turns direction [start] into direction [end].
+         *
+         * Both inputs are normalized internally. Handles the antiparallel case (180° rotation).
+         */
         fun rotationBetweenVectors(start: Vector3, end: Vector3): Quaternion {
             val startN = start.normalized()
             val endN = end.normalized()
@@ -359,6 +419,13 @@ class Quaternion {
             )
         }
 
+        /**
+         * Builds a rotation that orients the local forward axis along [forwardInWorld]
+         * while keeping the local up axis as close as possible to [desiredUpInWorld].
+         *
+         * @param forwardInWorld Desired forward (look) direction in world space.
+         * @param desiredUpInWorld Desired up direction in world space (used to resolve roll).
+         */
         fun lookRotation(forwardInWorld: Vector3, desiredUpInWorld: Vector3): Quaternion {
             val rotateForwardToDesiredForward = rotationBetweenVectors(Vector3.forward(), forwardInWorld)
 
@@ -371,6 +438,10 @@ class Quaternion {
             return multiply(rotateNewUpToUpwards, rotateForwardToDesiredForward)
         }
 
+        /**
+         * Returns `true` if [lhs] and [rhs] represent the same rotation within floating-point
+         * tolerance. `q` and `-q` are treated as equal since they encode the same orientation.
+         */
         fun equals(lhs: Quaternion, rhs: Quaternion): Boolean {
             // Use abs(dot) to handle both q and -q representing the same rotation.
             // Compare abs(1.0 - abs(dot)) <= epsilon to tolerate float precision
@@ -379,6 +450,7 @@ class Quaternion {
             return kotlin.math.abs(1.0f - dotVal) <= MathHelper.FLT_EPSILON * 10f
         }
 
+        /** Returns the identity quaternion `(0, 0, 0, 1)` — no rotation. */
         fun identity(): Quaternion = Quaternion()
     }
 }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Ray.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Ray.kt
@@ -23,20 +23,30 @@ class Ray {
         setDirection(direction)
     }
 
+    /** Sets the ray origin. The vector is copied, not retained. */
     fun setOrigin(origin: Vector3) {
         Preconditions.checkNotNull(origin, "Parameter \"origin\" was null.")
         this.origin.set(origin)
     }
 
+    /** Returns a copy of the ray origin. Mutating it does not affect the ray. */
     fun getOrigin(): Vector3 = Vector3(origin)
 
+    /** Sets the ray direction. The value is normalized before being stored. */
     fun setDirection(direction: Vector3) {
         Preconditions.checkNotNull(direction, "Parameter \"direction\" was null.")
         this.direction.set(direction.normalized())
     }
 
+    /** Returns a copy of the (normalized) ray direction. */
     fun getDirection(): Vector3 = Vector3(direction)
 
+    /**
+     * Returns the point along the ray at the given [distance] from the origin.
+     *
+     * Computed as `origin + direction * distance`. Since the direction is normalized,
+     * [distance] is in the same units as the origin.
+     */
     fun getPoint(distance: Float): Vector3 = Vector3.add(origin, direction.scaled(distance))
 
     override fun toString(): String = "[Origin:$origin, Direction:$direction]"

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/RayHit.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/RayHit.kt
@@ -9,6 +9,7 @@ open class RayHit {
     private var distance = Float.MAX_VALUE
     private val point = Vector3()
 
+    /** Sets the distance along the ray at which the hit occurred. */
     fun setDistance(distance: Float) {
         this.distance = distance
     }
@@ -20,6 +21,7 @@ open class RayHit {
      */
     fun getDistance(): Float = distance
 
+    /** Sets the world-space position where the ray hit the collision shape. The vector is copied. */
     fun setPoint(point: Vector3) {
         Preconditions.checkNotNull(point, "Parameter \"point\" was null.")
         this.point.set(point)
@@ -39,6 +41,7 @@ open class RayHit {
      */
     fun getWorldPosition(): Float3 = getPoint().let { Float3(it.x, it.y, it.z) }
 
+    /** Copies the distance and point from [other] into this hit. */
     fun set(other: RayHit) {
         Preconditions.checkNotNull(other, "Parameter \"other\" was null.")
 
@@ -46,6 +49,7 @@ open class RayHit {
         setPoint(other.point)
     }
 
+    /** Resets this hit to its empty state — distance back to [Float.MAX_VALUE] and point to the origin. */
     open fun reset() {
         distance = Float.MAX_VALUE
         point.set(0f, 0f, 0f)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Sphere.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Sphere.kt
@@ -17,31 +17,62 @@ class Sphere : CollisionShape {
     /** Create a sphere with a center of (0,0,0) and a radius of 1. */
     constructor()
 
+    /** Create a sphere centered at (0,0,0) with the given [radius]. */
     constructor(radius: Float) : this(radius, Vector3.zero())
 
+    /**
+     * Create a sphere with the given [radius] and [center].
+     *
+     * @param radius Sphere radius in local units. Must be positive.
+     * @param center Sphere center in local space.
+     */
     constructor(radius: Float, center: Vector3) {
         Preconditions.checkNotNull(center, "Parameter \"center\" was null.")
         setCenter(center)
         setRadius(radius)
     }
 
+    /**
+     * Sets the center of the sphere and notifies listeners that the shape changed.
+     *
+     * @param center New center in local space. The vector is copied, not retained.
+     */
     fun setCenter(center: Vector3) {
         Preconditions.checkNotNull(center, "Parameter \"center\" was null.")
         this.center.set(center)
         onChanged()
     }
 
+    /** Returns a copy of the sphere center. Mutating it does not affect the sphere. */
     fun getCenter(): Vector3 = Vector3(center)
 
+    /**
+     * Sets the radius of the sphere and notifies listeners that the shape changed.
+     *
+     * @param radius New radius in local units.
+     */
     fun setRadius(radius: Float) {
         this.radius = radius
         onChanged()
     }
 
+    /** Returns the sphere radius in local units. */
     fun getRadius(): Float = radius
 
+    /** Returns an independent copy of this sphere with the same center and radius. */
     override fun makeCopy(): Sphere = Sphere(getRadius(), getCenter())
 
+    /**
+     * Tests whether [ray] intersects this sphere and, if so, fills [result] with the hit.
+     *
+     * The nearest non-negative intersection along the ray is reported. If the ray
+     * origin is inside the sphere, the exit point is returned instead.
+     *
+     * @param ray Ray in the same space as the sphere.
+     * @param result Mutated in place with the hit distance and point when an intersection occurs.
+     * @return `true` if the ray intersects the sphere, `false` otherwise. [result] is left
+     *   unchanged when `false` is returned.
+     */
     override fun rayIntersection(ray: Ray, result: RayHit): Boolean {
         Preconditions.checkNotNull(ray, "Parameter \"ray\" was null.")
         Preconditions.checkNotNull(result, "Parameter \"result\" was null.")
@@ -76,17 +107,26 @@ class Sphere : CollisionShape {
         return true
     }
 
+    /** Returns `true` if this sphere overlaps [shape] (dispatches by the shape's concrete type). */
     override fun shapeIntersection(shape: CollisionShape): Boolean {
         Preconditions.checkNotNull(shape, "Parameter \"shape\" was null.")
         return shape.sphereIntersection(this)
     }
 
+    /** Returns `true` if this sphere overlaps [sphere]. */
     override fun sphereIntersection(sphere: Sphere): Boolean =
         Intersections.sphereSphereIntersection(this, sphere)
 
+    /** Returns `true` if this sphere overlaps [box]. */
     override fun boxIntersection(box: Box): Boolean =
         Intersections.sphereBoxIntersection(this, box)
 
+    /**
+     * Returns a new sphere obtained by applying [transformProvider]'s transform to this one.
+     *
+     * The center is transformed by the model matrix and the radius is scaled by the
+     * largest absolute component of the decomposed world scale (keeping the result a sphere).
+     */
     override fun transform(transformProvider: TransformProvider): CollisionShape {
         Preconditions.checkNotNull(transformProvider, "Parameter \"transformProvider\" was null.")
         val result = Sphere()
@@ -94,6 +134,11 @@ class Sphere : CollisionShape {
         return result
     }
 
+    /**
+     * Applies [transformProvider]'s transform to this sphere, writing into [result].
+     *
+     * @param result Must be a [Sphere]; otherwise the call is a no-op and a warning is logged.
+     */
     override fun transform(transformProvider: TransformProvider, result: CollisionShape) {
         Preconditions.checkNotNull(transformProvider, "Parameter \"transformProvider\" was null.")
         Preconditions.checkNotNull(result, "Parameter \"result\" was null.")

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/TransformProvider.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/TransformProvider.kt
@@ -1,8 +1,12 @@
 package io.github.sceneview.collision
 
 /**
- * Interface for providing information about a 3D transformation.
+ * Supplies the world transformation matrix used to transform collision shapes.
+ *
+ * Typically implemented by a scene node so that its collision shape can be moved
+ * into world space for intersection tests.
  */
 fun interface TransformProvider {
+    /** Returns the current 4×4 world transformation matrix. */
     fun getTransformationMatrix(): Matrix
 }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Vector3.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/collision/Vector3.kt
@@ -7,11 +7,18 @@ import kotlin.math.min
 import kotlin.math.sqrt
 
 /**
- * A Vector with 3 floats.
+ * A mutable 3-component vector (x, y, z).
+ *
+ * Used throughout the collision system for positions, directions, scales and extents.
+ * Instances are mutable: methods like [set] modify the receiver in place, while operations
+ * such as [scaled] or the [Companion] arithmetic helpers return new instances.
  */
 class Vector3 {
+    /** The X component. */
     var x: Float
+    /** The Y component. */
     var y: Float
+    /** The Z component. */
     var z: Float
 
     /** Construct a Vector3 and assign zero to all values */
@@ -81,8 +88,10 @@ class Vector3 {
         set(-1f, 0f, 0f)
     }
 
+    /** Returns the squared length (magnitude) of this vector. Cheaper than [length] — avoids the square root. */
     fun lengthSquared(): Float = x * x + y * y + z * z
 
+    /** Returns the Euclidean length (magnitude) of this vector. */
     fun length(): Float = sqrt(lengthSquared())
 
     override fun toString(): String = "[x=$x, y=$y, z=$z]"
@@ -127,18 +136,23 @@ class Vector3 {
     }
 
     companion object {
+        /** Returns the component-wise sum `lhs + rhs` as a new vector. */
         fun add(lhs: Vector3, rhs: Vector3): Vector3 =
             Vector3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z)
 
+        /** Returns the component-wise difference `lhs - rhs` as a new vector. */
         fun subtract(lhs: Vector3, rhs: Vector3): Vector3 =
             Vector3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
 
+        /** Returns the component-wise (Hadamard) product `lhs * rhs` as a new vector. */
         fun multiply(lhs: Vector3, rhs: Vector3): Vector3 =
             Vector3(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z)
 
+        /** Returns the dot product of [lhs] and [rhs]. */
         fun dot(lhs: Vector3, rhs: Vector3): Float =
             lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z
 
+        /** Returns the cross product `lhs × rhs` — a vector perpendicular to both inputs. */
         fun cross(lhs: Vector3, rhs: Vector3): Vector3 {
             val lhsX = lhs.x
             val lhsY = lhs.y
@@ -151,9 +165,11 @@ class Vector3 {
             )
         }
 
+        /** Returns the component-wise minimum of [lhs] and [rhs]. */
         fun min(lhs: Vector3, rhs: Vector3): Vector3 =
             Vector3(min(lhs.x, rhs.x), min(lhs.y, rhs.y), min(lhs.z, rhs.z))
 
+        /** Returns the component-wise maximum of [lhs] and [rhs]. */
         fun max(lhs: Vector3, rhs: Vector3): Vector3 =
             Vector3(max(lhs.x, rhs.x), max(lhs.y, rhs.y), max(lhs.z, rhs.z))
 
@@ -161,6 +177,12 @@ class Vector3 {
 
         internal fun componentMin(a: Vector3): Float = min(min(a.x, a.y), a.z)
 
+        /**
+         * Linearly interpolates between [a] and [b].
+         *
+         * @param t Interpolation factor; 0 returns [a], 1 returns [b]. Values outside
+         *   `[0, 1]` extrapolate.
+         */
         fun lerp(a: Vector3, b: Vector3, t: Float): Vector3 = Vector3(
             MathHelper.lerp(a.x, b.x, t), MathHelper.lerp(a.y, b.y, t), MathHelper.lerp(a.z, b.z, t)
         )
@@ -184,6 +206,7 @@ class Vector3 {
             return (angleRadians * (180.0 / PI)).toFloat()
         }
 
+        /** Returns `true` if [lhs] and [rhs] are equal component-wise within floating-point tolerance. */
         fun equals(lhs: Vector3, rhs: Vector3): Boolean {
             var result = true
             result = result and MathHelper.almostEqualRelativeAndAbs(lhs.x, rhs.x)
@@ -192,13 +215,28 @@ class Vector3 {
             return result
         }
 
+        /** Returns a new zero vector `(0, 0, 0)`. */
         fun zero(): Vector3 = Vector3()
+
+        /** Returns a new vector with all components set to 1 — the unit scale. */
         fun one(): Vector3 = Vector3(1f, 1f, 1f)
+
+        /** Returns the forward direction `(0, 0, -1)` (SceneView faces down -Z). */
         fun forward(): Vector3 = Vector3(0f, 0f, -1f)
+
+        /** Returns the backward direction `(0, 0, 1)`. */
         fun back(): Vector3 = Vector3(0f, 0f, 1f)
+
+        /** Returns the up direction `(0, 1, 0)`. */
         fun up(): Vector3 = Vector3(0f, 1f, 0f)
+
+        /** Returns the down direction `(0, -1, 0)`. */
         fun down(): Vector3 = Vector3(0f, -1f, 0f)
+
+        /** Returns the right direction `(1, 0, 0)`. */
         fun right(): Vector3 = Vector3(1f, 0f, 0f)
+
+        /** Returns the left direction `(-1, 0, 0)`. */
         fun left(): Vector3 = Vector3(-1f, 0f, 0f)
     }
 }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/logging/Log.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/logging/Log.kt
@@ -1,3 +1,12 @@
 package io.github.sceneview.logging
 
+/**
+ * Logs a warning-level message using the host platform's logging facility.
+ *
+ * Cross-platform `expect` function — each target supplies its own implementation
+ * (Android `java.util.logging`, iOS `NSLog`, JS `console.warn`).
+ *
+ * @param tag Short category/source label for the message.
+ * @param message The warning text to log.
+ */
 expect fun logWarning(tag: String, message: String)


### PR DESCRIPTION
## Summary

Adds KDoc to previously-undocumented public declarations in the `sceneview-core` collision module, a scoped chunk of [#965](https://github.com/sceneview/sceneview/issues/965) (2705 undocumented declarations across three modules).

Documented:
- **collision**: `Box`, `Sphere`, `Plane`, `Ray`, `RayHit`, `Vector3`, `Quaternion`, `Capsule`, `MeshCollider` (AABB accessors), `ChangeId`, `TransformProvider`
- **animation**: the `Easing` curve set
- **logging**: the cross-platform `logWarning` `expect` function

KDoc focuses on AI-first usefulness — units, nullability/return contracts, parameter meaning, mutate-in-place vs return-new behavior — not filler.

## Scope

This is **partial** work on #965 — the `sceneview-core` module only. The `sceneview/` and `arsceneview/` modules are tracked separately; this PR does **not** close #965.

## Notes

- Comment-only change — **no code behavior changed**, no test files touched.
- `:sceneview-core:compileKotlinMetadata` (commonMain) compiles clean.
- `impact-check.sh` passes (one pre-existing unrelated cross-platform parity warning).

## Test plan

- [x] `./gradlew :sceneview-core:compileKotlinMetadata` succeeds
- [x] `bash .claude/scripts/impact-check.sh` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)