### PR TITLE
fix(arsceneview): ARRecorder restores camera config after stop() (#1358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 - **`render-tests.yml` reverted from a 3-shard emulator matrix back to a single job ([#1119](https://github.com/sceneview/sceneview/issues/1119)).** All 5 render-test classes are class-level `@Ignore`'d on SwiftShader CI (#803), so the shard matrix booted 3 emulators to run 0 tests — strictly more CI cost for the same coverage. The matrix scaffold can be re-applied once #803 lifts the ignores.
 
+### Fixed — arsceneview
+
+- **`ARRecorder.start(recordingResolution=…)` now restores the session's camera config on `stop()` ([#1358](https://github.com/sceneview/sceneview/issues/1358)).** The higher-resolution CPU image stream raised for a recording no longer silently persists for the rest of the AR session — the prior config is captured before the swap and restored on `stop()` (and on a failed `start()`).
+
 ## v4.4.0 — iOS skybox renders + true-orbit camera + iOS Stage 2 demo parity + Double Pendulum physics demo + `sceneview-swift` mirror retired (2026-05-15)
 
 ### Changed — AR `LightEstimator` allocation & robustness refactor ([#1105](https://github.com/sceneview/sceneview/issues/1105))

--- a/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt
@@ -89,6 +89,14 @@ public class ARRecorder {
 
     private val sessionRef = AtomicReference<Session?>(null)
 
+    /**
+     * The session's camera config captured immediately before [start] swapped in a
+     * higher-resolution one for `recordingResolution`. `null` when no swap happened — [stop]
+     * only restores the config if this is non-null, so a [start] without `recordingResolution`
+     * (or one where no matching config was found) leaves the session untouched on [stop].
+     */
+    private val previousCameraConfig = AtomicReference<CameraConfig?>(null)
+
     private var _state by mutableStateOf(State.IDLE)
     private var _recordingFile by mutableStateOf<File?>(null)
     private var _errorMessage by mutableStateOf<String?>(null)
@@ -236,7 +244,15 @@ public class ARRecorder {
             // the session has been created and configured by ARSceneView); applying it just
             // before startRecording() is the valid window.
             recordingResolution?.let { requested ->
-                selectCameraConfig(session, requested)?.let { session.cameraConfig = it }
+                selectCameraConfig(session, requested)?.let { newConfig ->
+                    // Remember the config in effect BEFORE the swap so stop() can restore it —
+                    // otherwise the higher-res CPU image stream (and its perf cost) silently
+                    // persists for the rest of the AR session (#1358). Captured via runCatching
+                    // because Session.getCameraConfig is JNI-backed and must never abort the
+                    // recording; on failure we just skip the restore.
+                    previousCameraConfig.set(runCatching { session.cameraConfig }.getOrNull())
+                    session.cameraConfig = newConfig
+                }
             }
             val config = RecordingConfig(session)
                 .setMp4DatasetFilePath(file.absolutePath)
@@ -249,11 +265,16 @@ public class ARRecorder {
             true
         } catch (e: RecordingFailedException) {
             logWarning("startRecording failed: ${e.message}")
+            // The camera-config swap happens before startRecording() — if the start fails,
+            // restore the prior config so a failed recording doesn't leak the high-res
+            // stream (#1358).
+            restoreCameraConfig(session)
             _errorMessage = e.message ?: "RecordingFailedException"
             _state = State.ERROR
             false
         } catch (e: Exception) {
             logWarning("start failed: ${e.message}")
+            restoreCameraConfig(session)
             _errorMessage = e.message ?: e::class.java.simpleName
             _state = State.ERROR
             false
@@ -263,6 +284,10 @@ public class ARRecorder {
     /**
      * Stop the current recording. Returns the file that was written, or `null` if no
      * recording was active. Safe to call when idle — it's a no-op.
+     *
+     * If [start] swapped the session's camera config to satisfy a `recordingResolution`
+     * request, the prior config is restored here so the higher-res CPU image stream does not
+     * outlive the recording (#1358).
      */
     public fun stop(): File? {
         val session = sessionRef.get() ?: run {
@@ -283,6 +308,27 @@ public class ARRecorder {
             _errorMessage = e.message ?: e::class.java.simpleName
             _state = State.ERROR
             null
+        } finally {
+            // Restore the camera config even if stopRecording() threw — leaking the
+            // higher-res CPU image stream for the rest of the session is worse than the
+            // stop failure itself (#1358).
+            restoreCameraConfig(session)
+        }
+    }
+
+    /**
+     * Restore the camera config captured by [start] before it swapped in a higher-resolution
+     * one for `recordingResolution`. No-op when no swap happened (the [AtomicReference] holds
+     * `null`). The swapped-out config is cleared so a subsequent recording without
+     * `recordingResolution` does not erroneously restore a stale config.
+     *
+     * Wrapped in `runCatching` because [Session.setCameraConfig] is JNI-backed; a failure to
+     * restore must not surface as a recording error — the recording has already stopped.
+     */
+    private fun restoreCameraConfig(session: Session) {
+        previousCameraConfig.getAndSet(null)?.let { prior ->
+            runCatching { session.cameraConfig = prior }
+                .onFailure { logWarning("restoring camera config failed: ${it.message}") }
         }
     }
 

--- a/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecorderTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecorderTest.kt
@@ -545,6 +545,129 @@ class ARRecorderTest {
         assertEquals(ARRecorder.State.RECORDING, recorder.state)
     }
 
+    // ── recordingResolution camera-config restore after stop() (#1358) ───────
+
+    @Test
+    fun `stop restores the camera config that start swapped out for recordingResolution`() {
+        // #1358: start(recordingResolution=…) swaps the session's cameraConfig to a higher-res
+        // one. After stop(), the original config MUST be restored so the higher-res CPU image
+        // stream does not outlive the recording.
+        val originalConfig = fakeCameraConfig(640, 480)
+        val highResConfig = fakeCameraConfig(1920, 1080)
+        val recorder = ARRecorder()
+        val session = FakeSession(
+            supportedCameraConfigs = listOf(originalConfig, highResConfig),
+            initialCameraConfig = originalConfig,
+        )
+        recorder.attach(session)
+
+        assertTrue(recorder.start(outFile, recordingResolution = Size(1920, 1080)))
+        // The swap happened.
+        assertSame(highResConfig, session.cameraConfig)
+
+        recorder.stop()
+
+        // The prior config is back.
+        assertSame("stop() must restore the pre-recording camera config", originalConfig, session.cameraConfig)
+        assertEquals(ARRecorder.State.IDLE, recorder.state)
+    }
+
+    @Test
+    fun `stop does not touch the camera config when start requested no recordingResolution`() {
+        // No swap → nothing to restore. stop() must not call setCameraConfig at all.
+        val originalConfig = fakeCameraConfig(640, 480)
+        val recorder = ARRecorder()
+        val session = FakeSession(
+            supportedCameraConfigs = listOf(originalConfig),
+            initialCameraConfig = originalConfig,
+        )
+        recorder.attach(session)
+
+        assertTrue(recorder.start(outFile, recordingResolution = null))
+        recorder.stop()
+
+        assertNull("no swap happened — setCameraConfig must never be called", session.lastSetCameraConfig)
+    }
+
+    @Test
+    fun `stop does not touch the camera config when the device exposed no matching config`() {
+        // recordingResolution requested but getSupportedCameraConfigs returned empty — no swap
+        // occurred, so stop() must not attempt a restore.
+        val recorder = ARRecorder()
+        val session = FakeSession(supportedCameraConfigs = emptyList())
+        recorder.attach(session)
+
+        assertTrue(recorder.start(outFile, recordingResolution = Size(1920, 1080)))
+        recorder.stop()
+
+        assertNull("no swap happened — setCameraConfig must never be called", session.lastSetCameraConfig)
+    }
+
+    @Test
+    fun `a second recordingResolution recording restores the config from its own start`() {
+        // The captured config must be cleared on each stop() so a later recording restores
+        // the config in effect at ITS start, not a stale one.
+        val originalConfig = fakeCameraConfig(640, 480)
+        val highResConfig = fakeCameraConfig(1920, 1080)
+        val recorder = ARRecorder()
+        val session = FakeSession(
+            supportedCameraConfigs = listOf(originalConfig, highResConfig),
+            initialCameraConfig = originalConfig,
+        )
+        recorder.attach(session)
+
+        assertTrue(recorder.start(outFile, recordingResolution = Size(1920, 1080)))
+        recorder.stop()
+        assertSame(originalConfig, session.cameraConfig)
+
+        // Second recording with no resolution swap — stop() must NOT re-apply a stale config.
+        assertTrue(recorder.start(outFile, recordingResolution = null))
+        recorder.stop()
+        assertSame("stale config must not be restored on a no-swap recording", originalConfig, session.cameraConfig)
+    }
+
+    @Test
+    fun `stop restores the camera config even when stopRecording throws`() {
+        // A failed stopRecording() must not leak the higher-res config — the restore runs
+        // in a finally block.
+        val originalConfig = fakeCameraConfig(640, 480)
+        val highResConfig = fakeCameraConfig(1920, 1080)
+        val recorder = ARRecorder()
+        val session = FakeSession(
+            supportedCameraConfigs = listOf(originalConfig, highResConfig),
+            initialCameraConfig = originalConfig,
+            stopRecordingException = lazy { RecordingFailedException("io issue") },
+        )
+        recorder.attach(session)
+
+        assertTrue(recorder.start(outFile, recordingResolution = Size(1920, 1080)))
+        recorder.stop()
+
+        assertSame("config must be restored despite the stopRecording failure", originalConfig, session.cameraConfig)
+        assertEquals(ARRecorder.State.ERROR, recorder.state)
+    }
+
+    @Test
+    fun `a failed start restores the camera config it swapped before startRecording threw`() {
+        // The swap happens before startRecording(). If start fails, the prior config must be
+        // restored — a failed recording must not leak the high-res stream.
+        val originalConfig = fakeCameraConfig(640, 480)
+        val highResConfig = fakeCameraConfig(1920, 1080)
+        val recorder = ARRecorder()
+        val session = FakeSession(
+            supportedCameraConfigs = listOf(originalConfig, highResConfig),
+            initialCameraConfig = originalConfig,
+            startRecordingException = lazy { RecordingFailedException("disk full") },
+            failOnStartRecordingFromCall = 1,
+        )
+        recorder.attach(session)
+
+        assertFalse(recorder.start(outFile, recordingResolution = Size(1920, 1080)))
+
+        assertSame("a failed start must restore the pre-swap config", originalConfig, session.cameraConfig)
+        assertEquals(ARRecorder.State.ERROR, recorder.state)
+    }
+
     // ── Test doubles ─────────────────────────────────────────────────────────
 
     /** [CameraConfig] test double — stubs only the image size the selector reads. */
@@ -575,6 +698,8 @@ class ARRecorderTest {
         private val supportedCameraConfigs: List<CameraConfig> = emptyList(),
         /** When true, [getSupportedCameraConfigs] throws — simulates a JNI failure. */
         private val getSupportedCameraConfigsThrows: Boolean = false,
+        /** The config in effect before recording — what a `recordingResolution` swap must restore. */
+        initialCameraConfig: CameraConfig? = null,
     ) : Session() {
 
         var startRecordingCount: Int = 0
@@ -586,6 +711,8 @@ class ARRecorderTest {
         /** The last config passed to [setCameraConfig], or `null` if it was never called. */
         var lastSetCameraConfig: CameraConfig? = null
             private set
+        /** The session's current camera config — readable by [getCameraConfig], mutated by [setCameraConfig]. */
+        private var currentCameraConfig: CameraConfig? = initialCameraConfig
 
         override fun getPlaybackStatus(): PlaybackStatus = playbackStatus
 
@@ -613,7 +740,11 @@ class ARRecorderTest {
 
         override fun setCameraConfig(cameraConfig: CameraConfig?) {
             lastSetCameraConfig = cameraConfig
+            currentCameraConfig = cameraConfig
         }
+
+        override fun getCameraConfig(): CameraConfig =
+            currentCameraConfig ?: throw IllegalStateException("no camera config set")
     }
 
     /**


### PR DESCRIPTION
## Summary

`ARRecorder.start(recordingResolution=…)` swaps the ARCore session's `cameraConfig` to raise the recording's CPU-image resolution but never restored the previous config after `stop()`. The higher-res camera stream — and its per-frame perf cost — silently persisted for the rest of the AR session.

## Fix

- Capture `session.cameraConfig` (the prior config) **before** the swap in `start(recordingResolution=…)`, stored in an `AtomicReference`.
- Restore it in `stop()` via a `finally` block, so the config is restored even if `stopRecording()` throws.
- Also restore on a **failed `start()`** — the swap happens before `startRecording()`, so a failed start would otherwise leak the high-res config.
- Only restore when a swap actually occurred: `start()` without `recordingResolution`, or one where the device exposed no matching config, leaves the session untouched. The captured config is cleared on each restore so a later no-swap recording does not re-apply a stale config.
- `Session.getCameraConfig` / `setCameraConfig` calls are wrapped in `runCatching` (JNI-backed, must never abort/leak through the recording).

## Test plan

- [x] `:arsceneview:compileReleaseKotlin` passes
- [x] `:arsceneview:testDebugUnitTest --tests "io.github.sceneview.ar.recording.*"` passes — 6 new regression tests in `ARRecorderTest` cover: restore after `stop()`, no-op when no `recordingResolution`, no-op on degenerate device, no stale-config restore on a second recording, restore despite `stopRecording()` throwing, and restore after a failed `start()`.
- [x] `impact-check.sh` clean (pre-existing parity warning only)

Closes #1358