### PR TITLE
fix(ios): GeometryNode/ShapeNode unlit:true returns UnlitMaterial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Fixed
 
+- **iOS `GeometryNode` / `ShapeNode` `unlit: true` now returns a flat `UnlitMaterial` ([#1359](https://github.com/sceneview/sceneview/issues/1359)).** The `unlit:` parameter previously produced a lit `SimpleMaterial` that still reacted to scene lighting, contradicting the KDoc contract — it now yields an `UnlitMaterial`, matching `ImageNode` and `GeometryMaterial.unlit`.
+
 - **`SceneView` main/fill light mutations are now reactive ([#1306](https://github.com/sceneview/sceneview/issues/1306)).** `rememberMainLightNode` / `rememberFillLightNode` re-run their `apply` block on every recomposition (via `SideEffect`), so Compose-state-driven light properties (intensity, direction, color) propagate to the Filament scene without re-keying the `remember` — matching the iOS `RealityView.update:` reactive light contract.
 
 ### Changed — Samples

--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/GeometryNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/GeometryNode.swift
@@ -56,15 +56,18 @@ public struct GeometryNode: Sendable {
     /// (the HDR environment that `SceneView` wires by default). This is the single
     /// biggest visual-quality jump over RealityKit's unlit-flat `SimpleMaterial`.
     ///
-    /// Pass `unlit: true` to opt back into the legacy flat-fill `SimpleMaterial`
-    /// look — useful for debug visualizations and overlays that should not react
-    /// to scene lighting.
+    /// Pass `unlit: true` to opt into a flat-fill `UnlitMaterial` look — useful
+    /// for debug visualizations and overlays that should not react to scene
+    /// lighting.
     static func defaultMaterial(
         color: SimpleMaterial.Color,
         unlit: Bool = false
     ) -> any RealityKit.Material {
         if unlit {
-            return SimpleMaterial(color: color, isMetallic: false)
+            // UnlitMaterial renders a flat fill that ignores IBL/scene lighting.
+            // SimpleMaterial(isMetallic: false) is still lit, so it would
+            // contradict the `unlit` contract.
+            return UnlitMaterial(color: color)
         }
         var pbr = PhysicallyBasedMaterial()
         pbr.baseColor = .init(tint: color)

--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/ShapeNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/ShapeNode.swift
@@ -83,8 +83,9 @@ public struct ShapeNode: Sendable {
     ///     flat shape. Default 0.
     ///   - color: Material color. Default white.
     ///   - isMetallic: Whether the material is metallic. Default false.
-    ///   - unlit: When `true`, uses a flat unlit material instead of the default
-    ///     physically-based material. Default `false`.
+    ///     Ignored when `unlit` is `true`.
+    ///   - unlit: When `true`, uses a flat unlit material (no lighting response)
+    ///     instead of the default physically-based material. Default `false`.
     public init(
         points: [SIMD2<Float>],
         extrusionDepth: Float = 0,
@@ -96,7 +97,10 @@ public struct ShapeNode: Sendable {
 
         let material: any RealityKit.Material
         if unlit {
-            material = SimpleMaterial(color: color, isMetallic: isMetallic)
+            // UnlitMaterial renders a flat fill that ignores scene lighting,
+            // honouring the `unlit` contract. `isMetallic` has no meaning for
+            // an unlit material and is intentionally ignored on this path.
+            material = UnlitMaterial(color: color)
         } else {
             var pbr = PhysicallyBasedMaterial()
             pbr.baseColor = .init(tint: color)

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/GeometryNodeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/GeometryNodeTests.swift
@@ -69,6 +69,51 @@ final class GeometryNodeTests: XCTestCase {
         XCTAssertEqual(sphere.entity.model?.materials.count, 1)
     }
 
+    // MARK: - `unlit:` parameter (#1359)
+
+    /// `unlit: true` must produce an `UnlitMaterial` — a flat fill that does
+    /// not respond to image-based lighting — not a lit `SimpleMaterial`.
+    func testCubeUnlitParameterYieldsUnlitMaterial() {
+        let cube = GeometryNode.cube(size: 1.0, color: .red, unlit: true)
+        let material = cube.entity.model?.materials.first
+        XCTAssertNotNil(material)
+        XCTAssertTrue(
+            material is UnlitMaterial,
+            "unlit: true must yield an UnlitMaterial (no lighting response), got \(type(of: material))"
+        )
+        XCTAssertFalse(material is SimpleMaterial, "unlit material must not be a lit SimpleMaterial")
+    }
+
+    /// The default (`unlit: false`) path stays physically-based so shapes
+    /// react to scene lighting.
+    func testCubeDefaultParameterYieldsPBRMaterial() {
+        let cube = GeometryNode.cube(size: 1.0, color: .red)
+        let material = cube.entity.model?.materials.first
+        XCTAssertTrue(
+            material is PhysicallyBasedMaterial,
+            "default material must be physically-based, got \(type(of: material))"
+        )
+    }
+
+    /// Every procedural primitive honours the `unlit:` contract identically.
+    func testAllPrimitivesUnlitParameterYieldsUnlitMaterial() {
+        let nodes: [GeometryNode] = [
+            .cube(size: 1.0, unlit: true),
+            .sphere(radius: 0.5, unlit: true),
+            .cylinder(radius: 0.3, height: 1.0, unlit: true),
+            .plane(width: 1.0, depth: 1.0, unlit: true),
+            .cone(height: 1.0, radius: 0.5, unlit: true),
+            .torus(unlit: true),
+            .capsule(unlit: true)
+        ]
+        for node in nodes {
+            XCTAssertTrue(
+                node.entity.model?.materials.first is UnlitMaterial,
+                "unlit: true must yield an UnlitMaterial for every primitive"
+            )
+        }
+    }
+
     // MARK: - Transform helpers
 
     func testPositionSetsEntityPosition() {

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ShapeNodeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ShapeNodeTests.swift
@@ -1,6 +1,7 @@
 #if os(iOS) || os(macOS) || os(visionOS)
 import XCTest
 import simd
+import RealityKit
 @testable import SceneViewSwift
 
 // Test classes run on the main actor: their RealityKit node factories
@@ -155,6 +156,47 @@ final class ShapeNodeTests: XCTestCase {
         let shape = ShapeNode.regularPolygon(sides: 6, radius: 0.3)
         XCTAssertNotNil(shape.sceneEntity)
         XCTAssert(shape.sceneEntity === shape.entity)
+    }
+
+    // MARK: - `unlit:` parameter (#1359)
+
+    private static let triangle: [SIMD2<Float>] = [
+        SIMD2<Float>(0, 0.5),
+        SIMD2<Float>(-0.5, -0.5),
+        SIMD2<Float>(0.5, -0.5)
+    ]
+
+    /// `unlit: true` must produce an `UnlitMaterial` — a flat fill that does
+    /// not respond to image-based lighting — not a lit `SimpleMaterial`.
+    func testUnlitParameterYieldsUnlitMaterial() {
+        let shape = ShapeNode(points: Self.triangle, color: .red, unlit: true)
+        let material = shape.entity.model?.materials.first
+        XCTAssertNotNil(material)
+        XCTAssertTrue(
+            material is UnlitMaterial,
+            "unlit: true must yield an UnlitMaterial (no lighting response), got \(type(of: material))"
+        )
+        XCTAssertFalse(material is SimpleMaterial, "unlit material must not be a lit SimpleMaterial")
+    }
+
+    /// The `unlit:` contract holds for extruded shapes too.
+    func testExtrudedUnlitParameterYieldsUnlitMaterial() {
+        let shape = ShapeNode(
+            points: Self.triangle,
+            extrusionDepth: 0.1,
+            color: .red,
+            unlit: true
+        )
+        XCTAssertTrue(shape.entity.model?.materials.first is UnlitMaterial)
+    }
+
+    /// The default (`unlit: false`) path stays physically-based.
+    func testDefaultParameterYieldsPBRMaterial() {
+        let shape = ShapeNode(points: Self.triangle, color: .red)
+        XCTAssertTrue(
+            shape.entity.model?.materials.first is PhysicallyBasedMaterial,
+            "default material must be physically-based"
+        )
     }
 
     // MARK: - Concave polygon


### PR DESCRIPTION
## Summary

The iOS `unlit: true` parameter on procedural nodes returned a **lit** `SimpleMaterial` instead of an `UnlitMaterial`, contradicting the KDoc promise of a flat material that does not react to scene lighting (regression from #1274).

- `GeometryNode.defaultMaterial(unlit: true)` returned `SimpleMaterial(isMetallic: false)` (lit).
- `ShapeNode.init(... unlit: true)` had the same defect.

Both now return `UnlitMaterial(color:)` — matching how `ImageNode` and `GeometryMaterial.unlit` already correctly handle the unlit path. `isMetallic` is intentionally ignored on `ShapeNode`'s unlit path since it has no meaning for an unlit material (doc updated).

## Test plan

- [x] New `GeometryNodeTests` cases assert `unlit: true` yields `UnlitMaterial` (all 7 primitives) and the default path stays `PhysicallyBasedMaterial`.
- [x] New `ShapeNodeTests` cases assert flat + extruded `unlit: true` yields `UnlitMaterial`, default stays PBR.
- [x] Scoped to `SceneViewSwift/` only; no public API signature change.

Closes #1359