### PR TITLE
ci: adopt changelog.d/ fragment system to end CHANGELOG merge conflicts

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -56,23 +56,29 @@ If not using /version-bump, manually update:
 ### MCP source
 24. `mcp/src/index.ts` — version string in server info
 
-## Step 2: Update CHANGELOG.md
+## Step 2: Collate the CHANGELOG
 
-Add a new section at the top:
-```markdown
-## X.Y.Z — YYYY-MM-DD
+Changelog entries no longer live under a manually-edited `## Unreleased` anchor —
+each PR drops a fragment in `changelog.d/` (see `changelog.d/README.md`). Collate
+them into a new release section in one command:
 
-### New
-- ...
-
-### Improved
-- ...
-
-### Fixed
-- ...
+```bash
+bash .claude/scripts/collate-changelog.sh X.Y.Z
 ```
 
-Pull from recent git log: `git log <last-tag>..HEAD --oneline`
+This reads every `changelog.d/*.md` fragment, groups the bullets by category
+(`### Added` / `### Changed` / `### Fixed` / `### Removed` / `### Tests` /
+`### Docs`), prepends a `## vX.Y.Z — <date>` section to `CHANGELOG.md`, folds in
+any legacy `## Unreleased` entries, deletes the consumed fragments, and leaves an
+empty `## Unreleased` placeholder. Pass `--dry-run` first to preview, or
+`--date YYYY-MM-DD` to override the date.
+
+After collation, review `git diff CHANGELOG.md` and hand-edit the
+`## vX.Y.Z — <date>` title to add the thematic summary (the format
+`release.yml` extracts and publishes as the GitHub Release body), then
+reorder/merge bullets if needed.
+
+Cross-check against recent git log: `git log <last-tag>..HEAD --oneline`
 
 ## Step 3: Rebuild MCP
 

--- a/.claude/scripts/collate-changelog.sh
+++ b/.claude/scripts/collate-changelog.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# collate-changelog.sh — Collate changelog.d/ fragments into CHANGELOG.md
+#
+# Reads every fragment in `changelog.d/*.md` (towncrier-style), groups the
+# bullets by category, prepends a new `## vX.Y.Z — <date>` section to
+# `CHANGELOG.md`, and deletes the consumed fragments.
+#
+# Any entries still living under the legacy `## Unreleased` section are folded
+# into the same new release section, and an empty `## Unreleased` placeholder
+# is left in place for backward compatibility.
+#
+# Usage:
+#   ./collate-changelog.sh <version> [--date YYYY-MM-DD] [--dry-run]
+#   Example: ./collate-changelog.sh 4.5.0
+#
+# Exit 0 on success, non-zero on error.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo -e "${RED}Error:${NC} version argument required."
+    echo "Usage: $0 <version> [--date YYYY-MM-DD] [--dry-run]"
+    exit 1
+fi
+shift || true
+
+# Strip a leading 'v' if the caller passed a tag-style version.
+VERSION="${VERSION#v}"
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo -e "${RED}Error:${NC} '$VERSION' is not a valid X.Y.Z version."
+    exit 1
+fi
+
+DATE="$(date +%Y-%m-%d)"
+DRY_RUN=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --date) DATE="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        *) echo -e "${RED}Error:${NC} unknown argument '$1'"; exit 1 ;;
+    esac
+done
+
+FRAG_DIR="changelog.d"
+CHANGELOG="CHANGELOG.md"
+
+[ -f "$CHANGELOG" ] || { echo -e "${RED}Error:${NC} $CHANGELOG not found."; exit 1; }
+[ -d "$FRAG_DIR" ]   || { echo -e "${RED}Error:${NC} $FRAG_DIR/ not found."; exit 1; }
+
+# Collect fragment files (skip README.md and .gitkeep).
+FRAGMENTS=()
+for f in "$FRAG_DIR"/*.md; do
+    [ -e "$f" ] || continue
+    case "$(basename "$f")" in
+        README.md) continue ;;
+    esac
+    FRAGMENTS+=("$f")
+done
+
+if [ "${#FRAGMENTS[@]}" -eq 0 ]; then
+    echo -e "${YELLOW}No fragments in $FRAG_DIR/${NC} — only legacy ## Unreleased entries will be collated."
+fi
+
+# Canonical category order. "Changed" is the fallback bucket.
+CATEGORIES=(Added Changed Fixed Removed Tests Docs)
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+for cat in "${CATEGORIES[@]}"; do : > "$TMP_DIR/$cat"; done
+
+# Strip leading and trailing blank lines from stdin (portable: awk, no sed).
+trim_blank_lines() {
+    awk '
+        { lines[NR] = $0 }
+        END {
+            start = 1
+            while (start <= NR && lines[start] ~ /^[[:space:]]*$/) start++
+            end = NR
+            while (end >= start && lines[end] ~ /^[[:space:]]*$/) end--
+            for (i = start; i <= end; i++) print lines[i]
+        }
+    '
+}
+
+# Map an arbitrary category string to a canonical bucket.
+canonical_category() {
+    local raw
+    raw="$(echo "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    case "$raw" in
+        added|new)            echo "Added" ;;
+        fixed|fix|bugfix)     echo "Fixed" ;;
+        removed|remove)       echo "Removed" ;;
+        tests|test)           echo "Tests" ;;
+        docs|doc|documentation) echo "Docs" ;;
+        changed|change|improved|*) echo "Changed" ;;
+    esac
+}
+
+# ─── 1. Parse fragments ──────────────────────────────────────────────────
+for f in "${FRAGMENTS[@]}"; do
+    category="Changed"
+    body=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Category tag line: <!-- category: Fixed -->  (anywhere in the file)
+        if [[ "$line" =~ ^[[:space:]]*\<!--[[:space:]]*category:[[:space:]]*([A-Za-z]+)[[:space:]]*--\>[[:space:]]*$ ]]; then
+            category="$(canonical_category "${BASH_REMATCH[1]}")"
+            continue
+        fi
+        body+="$line"$'\n'
+    done < "$f"
+    # Trim leading/trailing blank lines from the body.
+    body="$(printf '%s' "$body" | trim_blank_lines)"
+    if [ -n "$body" ]; then
+        printf '%s\n' "$body" >> "$TMP_DIR/$category"
+        echo -e "  ${GREEN}+${NC} $(basename "$f") → ${CYAN}$category${NC}"
+    fi
+done
+
+# ─── 2. Carry over legacy ## Unreleased entries ──────────────────────────
+# Everything between '## Unreleased' and the next '## ' header is preserved.
+UNRELEASED_BODY="$(awk '
+    /^## Unreleased[[:space:]]*$/ { found=1; next }
+    found && /^## / { exit }
+    found { print }
+' "$CHANGELOG")"
+# Trim blank padding.
+UNRELEASED_BODY="$(printf '%s' "$UNRELEASED_BODY" | trim_blank_lines)"
+HAS_UNRELEASED=false
+if [ -n "$UNRELEASED_BODY" ]; then
+    HAS_UNRELEASED=true
+fi
+
+# ─── 3. Build the new release section ───────────────────────────────────
+NEW_SECTION="$TMP_DIR/new_section"
+{
+    echo "## v$VERSION — $DATE"
+    echo ""
+    HAD_CONTENT=false
+    for cat in "${CATEGORIES[@]}"; do
+        if [ -s "$TMP_DIR/$cat" ]; then
+            echo "### $cat"
+            echo ""
+            cat "$TMP_DIR/$cat"
+            echo ""
+            HAD_CONTENT=true
+        fi
+    done
+    if [ "$HAS_UNRELEASED" = true ]; then
+        # The legacy block already carries its own ### sub-headers — append verbatim.
+        printf '%s\n\n' "$UNRELEASED_BODY"
+        HAD_CONTENT=true
+    fi
+    if [ "$HAD_CONTENT" = false ]; then
+        echo "_No user-facing changes._"
+        echo ""
+    fi
+} > "$NEW_SECTION"
+
+# ─── 4. Splice into CHANGELOG.md ────────────────────────────────────────
+# Result layout:
+#   # Changelog
+#   <blank>
+#   ## Unreleased        <- emptied placeholder, kept for backward-compat
+#   <blank>
+#   ## vX.Y.Z — <date>   <- new collated section
+#   ...
+#   ## v<previous> ...
+RESULT="$TMP_DIR/changelog_new"
+{
+    # Preamble: everything up to and including the '# Changelog' title line.
+    awk 'NR==1{print; if ($0 ~ /^# /) {print ""; exit}}' "$CHANGELOG"
+    # Empty Unreleased placeholder.
+    echo "## Unreleased"
+    echo ""
+    # New release section.
+    cat "$NEW_SECTION"
+    # All pre-existing release sections (first '## v...' onward), verbatim.
+    awk '/^## v[0-9]/ { found=1 } found { print }' "$CHANGELOG"
+} > "$RESULT"
+
+if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo -e "${CYAN}=== DRY RUN — new CHANGELOG.md head ===${NC}"
+    head -40 "$RESULT"
+    echo -e "${CYAN}=== (fragments NOT deleted) ===${NC}"
+    exit 0
+fi
+
+mv "$RESULT" "$CHANGELOG"
+
+# ─── 5. Delete consumed fragments ───────────────────────────────────────
+for f in "${FRAGMENTS[@]}"; do
+    rm -f "$f"
+done
+
+echo ""
+echo -e "${GREEN}✓${NC} Collated ${#FRAGMENTS[@]} fragment(s) into ${CYAN}## v$VERSION — $DATE${NC}"
+[ "$HAS_UNRELEASED" = true ] && echo -e "${GREEN}✓${NC} Folded legacy ## Unreleased entries into the new section"
+echo -e "${GREEN}✓${NC} Emptied ## Unreleased placeholder kept for backward-compat"
+echo -e "  Review the result:  git diff $CHANGELOG"

--- a/.claude/scripts/release-checklist.sh
+++ b/.claude/scripts/release-checklist.sh
@@ -127,10 +127,17 @@ echo ""
 echo -e "${CYAN}--- CHANGELOG ---${NC}"
 
 if [ -f "CHANGELOG.md" ]; then
-    CL_V=$(grep -m1 '^## ' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "MISSING")
-    [ "$CL_V" = "$TARGET_VERSION" ] && check "CHANGELOG entry" "PASS" "" || check "CHANGELOG entry" "FAIL" "Latest entry is $CL_V"
+    # First versioned section (## vX.Y.Z ...), skipping the ## Unreleased placeholder.
+    CL_V=$(grep -m1 '^## v[0-9]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "MISSING")
+    [ "$CL_V" = "$TARGET_VERSION" ] && check "CHANGELOG entry" "PASS" "" || check "CHANGELOG entry" "FAIL" "Latest entry is $CL_V — run collate-changelog.sh $TARGET_VERSION"
 else
     check "CHANGELOG.md exists" "FAIL" "File not found"
+fi
+
+# changelog.d/ fragments must be collated into CHANGELOG.md before tagging.
+if [ -d "changelog.d" ]; then
+    PENDING=$(find changelog.d -maxdepth 1 -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
+    [ "$PENDING" -eq 0 ] && check "changelog.d/ fragments collated" "PASS" "" || check "changelog.d/ fragments collated" "FAIL" "$PENDING pending — run collate-changelog.sh $TARGET_VERSION"
 fi
 echo ""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,17 @@ One unified showcase app per platform — all features integrated into tabs.
 | `buildSrc/` | Gradle build logic + detekt config |
 | `.github/` | CI workflows + community docs (CoC, Security, Support, Governance, Sponsors, Privacy) |
 
+## Changelog entries
+
+**Changelog entries go in `changelog.d/`, not `CHANGELOG.md`.** Each PR adds one
+fragment file `changelog.d/<issue-or-pr>-<slug>.md` with its release-note
+bullet(s) and a `<!-- category: Fixed -->` tag (Added/Changed/Fixed/Removed/
+Tests/Docs). Distinct filenames mean parallel PRs never conflict on the
+changelog. At release time `bash .claude/scripts/collate-changelog.sh X.Y.Z`
+collates every fragment into a new `## vX.Y.Z` section and deletes them. Never
+hand-edit the `## Unreleased` anchor — it is kept empty for backward-compat.
+See [`changelog.d/README.md`](changelog.d/README.md).
+
 ## Version Location Map
 
 **Source of truth:** `gradle.properties` -> `VERSION_NAME=X.Y.Z`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,24 @@ for full API context in any chat:
 
 Contributions to any part of the project are welcome — Android (`sceneview/`, `arsceneview/`), iOS (`SceneViewSwift/`), shared KMP core (`sceneview-core/`), samples, documentation, or the MCP server.
 
+### Changelog entries
+
+**Do not edit `CHANGELOG.md` directly.** Changelog entries go in `changelog.d/`
+as a small fragment file — one per PR. Add a file named
+`changelog.d/<issue-or-pr-number>-<short-slug>.md` containing your release-note
+bullet(s), prefixed with a category tag:
+
+```markdown
+<!-- category: Fixed -->
+- **Short headline ([#1234](https://github.com/sceneview/sceneview/issues/1234)).** What changed and why.
+```
+
+Recognised categories: `Added`, `Changed`, `Fixed`, `Removed`, `Tests`, `Docs`.
+Distinct filenames mean parallel PRs never conflict on the changelog. At release
+time `.claude/scripts/collate-changelog.sh` collates all fragments into a new
+`## vX.Y.Z` section. See [`changelog.d/README.md`](changelog.d/README.md) for
+the full convention.
+
 After your changes are merged, the Discord bot will award you the **Contributor** role.
 
 ### CI on docs-only PRs

--- a/changelog.d/1337-changelog-fragments.md
+++ b/changelog.d/1337-changelog-fragments.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- **Adopted a towncrier-style fragment changelog ([#1337](https://github.com/sceneview/sceneview/issues/1337)).** PRs now drop a small file in `changelog.d/` instead of editing `CHANGELOG.md`'s `## Unreleased` anchor, so parallel PRs no longer conflict on the changelog. `.claude/scripts/collate-changelog.sh X.Y.Z` collates the fragments into a new `## vX.Y.Z` section at release time. `Closes #1337`.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,54 @@
+# `changelog.d/` — changelog fragments
+
+This directory holds **changelog fragments**: one small Markdown file per pull
+request. At release time the fragments are collated into `CHANGELOG.md` by
+`.claude/scripts/collate-changelog.sh`, then deleted.
+
+## Why
+
+In the high-merge-rate continuous cycle, nearly every parallel PR used to add a
+one-line entry under `CHANGELOG.md`'s `## Unreleased` section. Because they all
+inserted at the same anchor, the 2nd..Nth PRs of a wave reliably hit a merge
+conflict the moment one of them merged — even though the entries never
+semantically conflict.
+
+A fragment is a **distinct file** named after the PR/issue, so two PRs never
+touch the same path. Zero conflicts.
+
+## How to add a changelog entry
+
+When you open a PR, **do not edit `CHANGELOG.md`**. Instead create one file:
+
+```
+changelog.d/<issue-or-pr-number>-<short-slug>.md
+```
+
+Examples: `changelog.d/1337-changelog-fragments.md`,
+`changelog.d/1408-arrecorder-camera-restore.md`.
+
+### Fragment format
+
+Each fragment is plain Markdown — the bullet(s) exactly as they should appear in
+the release notes. Prefix the file with a **category tag line** so the
+collation script can group it:
+
+```markdown
+<!-- category: Fixed -->
+- **Short headline ([#1408](https://github.com/sceneview/sceneview/issues/1408)).** One- or two-sentence description of the change.
+```
+
+Recognised categories (case-insensitive): `Added`, `Changed`, `Fixed`,
+`Removed`, `Tests`, `Docs`. If the tag line is omitted the entry is filed under
+`Changed`.
+
+You may include more than one bullet in a single fragment if the PR genuinely
+ships several related changes, but keep it to one PR's worth of notes.
+
+## At release time
+
+`.claude/scripts/collate-changelog.sh X.Y.Z` reads every `*.md` fragment here
+(ignoring `README.md` and `.gitkeep`), groups bullets by category, prepends a
+new `## vX.Y.Z — <date>` section to `CHANGELOG.md`, and deletes the consumed
+fragments. The `## Unreleased` section in `CHANGELOG.md` is preserved for
+backward compatibility — any entries still living there are merged into the new
+release section too.


### PR DESCRIPTION
## Summary

Parallel PRs in the continuous high-merge-rate cycle all inserted their release-note line at the same `## Unreleased` anchor in `CHANGELOG.md`, so the 2nd..Nth PR of every wave reliably went `DIRTY` and needed a dedicated rebase-sweep agent to union-resolve.

This adopts a towncrier-style **fragment changelog**:

- **`changelog.d/`** holds one small Markdown fragment per PR — `changelog.d/<issue-or-pr>-<slug>.md`. Distinct filenames mean parallel PRs never touch the same path → zero conflicts.
- **`.claude/scripts/collate-changelog.sh <version>`** reads all fragments, groups bullets by category tag (`Added`/`Changed`/`Fixed`/`Removed`/`Tests`/`Docs`), prepends a `## vX.Y.Z — <date>` section to `CHANGELOG.md`, folds in any legacy `## Unreleased` entries, deletes consumed fragments, and keeps an empty `## Unreleased` placeholder for backward-compat.
- **Release flow wired**: `/release` Step 2 now calls the script; `release-checklist.sh` fails if fragments remain uncollated at tag time.
- **Convention documented** in `changelog.d/README.md`, `CONTRIBUTING.md`, and `CLAUDE.md`.

## Conflict-safety

`CHANGELOG.md` itself is **intentionally untouched** — this PR adds only new infrastructure, so it does not conflict with the ~15 in-flight PRs still editing `## Unreleased` the old way. This PR's own changelog entry is dogfooded as a `changelog.d/` fragment.

## Verification

- Collation dry-run + real run verified: produces a valid `## vX.Y.Z — <date>` section matching the exact `^## v$VERSION` awk extractor in `release.yml` (the GitHub Release body source).
- All 23 prior `## v` sections preserved; no content lost.
- `impact-check.sh` passes (only the pre-existing Swift-only-nodes warning).

## Test plan

- [ ] `bash .claude/scripts/collate-changelog.sh X.Y.Z --dry-run` previews a valid section
- [ ] A second PR adding a `changelog.d/*.md` fragment merges with no conflict
- [ ] Next release collates fragments and the GitHub Release body renders correctly

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)