### PR TITLE
fix(ios): FogNode heightFalloff honestly documented as RealityKit parity gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Fixed
 
+- **iOS `FogNode.heightFalloff` / `heightBased` are now honestly documented as a RealityKit parity gap ([#1380](https://github.com/sceneview/sceneview/issues/1380)).** the height gradient was a silent no-op — a uniform translucent sphere cannot vary opacity by world height; the parameter is kept for Android parity but now clearly documents that height-based fog renders identically to exponential fog on iOS ([#1373](https://github.com/sceneview/sceneview/issues/1373)).
+
 - **iOS `GeometryNode` / `ShapeNode` `unlit: true` now returns a flat `UnlitMaterial` ([#1359](https://github.com/sceneview/sceneview/issues/1359)).** The `unlit:` parameter previously produced a lit `SimpleMaterial` that still reacted to scene lighting, contradicting the KDoc contract — it now yields an `UnlitMaterial`, matching `ImageNode` and `GeometryMaterial.unlit`.
 
 - **`SceneView` main/fill light mutations are now reactive ([#1306](https://github.com/sceneview/sceneview/issues/1306)).** `rememberMainLightNode` / `rememberFillLightNode` re-run their `apply` block on every recomposition (via `SideEffect`), so Compose-state-driven light properties (intensity, direction, color) propagate to the Filament scene without re-keying the `remember` — matching the iOS `RealityView.update:` reactive light contract.

--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/FogNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/FogNode.swift
@@ -14,6 +14,11 @@ import AppKit
 /// fog API, `FogNode` places a translucent sphere around the camera origin to
 /// approximate the effect.
 ///
+/// - Note: The ``heightBased(density:height:color:)`` factory and ``heightFalloff``
+///   property are kept for Android API parity, but the height gradient itself is
+///   **not rendered on iOS** — a uniform translucent sphere cannot vary opacity by
+///   world height. On iOS, height-based fog looks identical to exponential fog.
+///
 /// ```swift
 /// SceneView { content in
 ///     let fog = FogNode.linear(start: 1.0, end: 20.0)
@@ -58,10 +63,22 @@ public struct FogNode: Sendable {
         }
     }
 
-    /// Height falloff in world-space meters. Fog is denser below this height.
+    /// Height falloff in world-space meters, mirroring Android's `FogNode.heightFalloff`.
+    ///
+    /// - Important: **The height gradient is not rendered on iOS.** On Android, fog
+    ///   uses Filament's native `View.setFog` which exposes a true per-pixel
+    ///   `heightFalloff`. RealityKit has no native fog API, so `FogNode` approximates
+    ///   fog with a single uniform translucent sphere (see ``makeFog(density:start:end:heightFalloff:color:)``).
+    ///   A uniform-color `UnlitMaterial` cannot vary opacity by world height — that
+    ///   would require a custom `ShaderGraphMaterial`. The value is stored and kept
+    ///   for Android API parity, but height-based fog renders identically to
+    ///   exponential fog on iOS. See ``heightBased(density:height:color:)``.
     public var heightFalloff: Float {
         get { _heightFalloff }
         set {
+            // Stored for Android API parity only — see the property doc-comment.
+            // RealityKit's UnlitMaterial cannot render a height gradient, so no
+            // rebuildMaterial()/updateScale() call is intentional here (not a bug).
             _heightFalloff = newValue
         }
     }
@@ -133,11 +150,18 @@ public struct FogNode: Sendable {
         return makeFog(density: density, start: 0.5, end: 40.0, heightFalloff: 0, color: color)
     }
 
-    /// Creates height-based fog that is denser below the given height.
+    /// Creates height-based fog, mirroring Android's `FogNode.heightBased`.
+    ///
+    /// - Important: **The height gradient is not rendered on iOS.** RealityKit has no
+    ///   native fog API, so `FogNode` approximates fog with a uniform translucent
+    ///   sphere that cannot vary opacity by world height. On iOS this factory behaves
+    ///   identically to ``exponential(density:color:)`` — the `height` argument is
+    ///   stored on ``heightFalloff`` for Android API parity only. Use Android for
+    ///   true height-based fog (Filament's native `View.setFog`). See ``heightFalloff``.
     ///
     /// - Parameters:
     ///   - density: Fog density in [0.0, 1.0]. Default 0.05.
-    ///   - height: Height falloff in meters. Fog is denser below this height. Default 1.0.
+    ///   - height: Height falloff in meters (stored, not rendered on iOS). Default 1.0.
     ///   - color: Fog color. Default `.white`.
     /// - Returns: A configured `FogNode`.
     public static func heightBased(

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/FogNodeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/FogNodeTests.swift
@@ -151,6 +151,11 @@ final class FogNodeTests: XCTestCase {
 
     // MARK: - Height-based specific
 
+    // `heightFalloff` is stored for Android API parity but the height gradient is
+    // not rendered on iOS (RealityKit has no native fog API; a uniform translucent
+    // sphere cannot vary opacity by world height). See FogNode.heightFalloff docs
+    // and issue #1380. These tests pin the documented store-only behavior.
+
     func testHeightBasedFogSetsHeightFalloff() {
         let fog = FogNode.heightBased(density: 0.1, height: 5.0)
         XCTAssertEqual(fog.heightFalloff, 5.0, accuracy: 0.001)
@@ -160,6 +165,31 @@ final class FogNodeTests: XCTestCase {
         var fog = FogNode.heightBased(density: 0.1, height: 1.0)
         fog.heightFalloff = 3.0
         XCTAssertEqual(fog.heightFalloff, 3.0, accuracy: 0.001)
+    }
+
+    /// Height-based fog renders identically to exponential fog on iOS: the height
+    /// gradient is a documented RealityKit parity gap (#1380). Verifies that
+    /// changing `heightFalloff` does not alter the rendered material/mesh, so the
+    /// API is honestly a store-only no-op rather than silently pretending.
+    func testHeightFalloffDoesNotAffectRenderedMaterial() {
+        let exponential = FogNode.exponential(density: 0.1)
+        let heightBased = FogNode.heightBased(density: 0.1, height: 5.0)
+
+        // Same density -> same translucent-sphere approximation on iOS.
+        XCTAssertEqual(
+            exponential.entity.model?.materials.count,
+            heightBased.entity.model?.materials.count
+        )
+        XCTAssertEqual(exponential.endDistance, heightBased.endDistance, accuracy: 0.001)
+        XCTAssertEqual(exponential.startDistance, heightBased.startDistance, accuracy: 0.001)
+
+        // Mutating heightFalloff must not change the entity scale (no updateScale call).
+        var fog = heightBased
+        let scaleBefore = fog.entity.scale
+        fog.heightFalloff = 42.0
+        XCTAssertEqual(fog.entity.scale.x, scaleBefore.x, accuracy: 0.001)
+        XCTAssertEqual(fog.entity.scale.y, scaleBefore.y, accuracy: 0.001)
+        XCTAssertEqual(fog.entity.scale.z, scaleBefore.z, accuracy: 0.001)
     }
 
     // MARK: - Material


### PR DESCRIPTION
## Summary

Fixes the silent no-op API reported in #1380 (part of #1373 iOS demo QA v4.4.0).

`FogNode.heightFalloff` and `FogNode.heightBased(density:height:color:)` stored the height value but never rendered a gradient. `FogNode` approximates fog with a single uniform translucent sphere (RealityKit has no native fog API), and a uniform-color `UnlitMaterial` cannot vary opacity by world height. So height-based fog rendered identically to exponential fog while the docs and demo advertised "height fog" — a #928-class dishonesty regression.

## Fix

A real height gradient would require a custom `ShaderGraphMaterial` (a `.rkassets` shader bundle, out of scope for this module). Following the existing honest-deprecation pattern in `CameraNode.exposure` / `depthOfField`:

- The `heightFalloff` parameter is **kept for Android API parity** (Android's `FogNode` uses Filament's native `View.setFog` which has a real `heightFalloff`).
- The type-level doc, the `heightFalloff` property doc, and the `heightBased` factory doc now clearly state the height gradient is **not rendered on iOS** and height-based fog renders identically to exponential fog.
- The `heightFalloff` setter intentionally does not call `rebuildMaterial()`/`updateScale()`, now documented as deliberate (not a bug).
- Added a test pinning the documented store-only behavior — `heightFalloff` does not alter the rendered material or entity scale.

No public API surface change, so cross-platform code keeps compiling unchanged.

## Test plan

- [x] `swift build` — succeeds
- [x] `swift test` — 622 tests pass (621 baseline + 1 new), 2 skipped, 0 failures

Refs #1380 #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)