### PR TITLE
chore(scripts): reusable claude/* branch + worktree cleanup task

### DIFF
--- a/.claude/scripts/cleanup-branches-worktrees.sh
+++ b/.claude/scripts/cleanup-branches-worktrees.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# cleanup-branches-worktrees.sh — reusable GC for stale claude/* branches
+# and stale .claude/worktrees/* directories.
+#
+# Why: an orchestrator marathon leaves behind dozens of `claude/*` local
+# branches, the same on `origin`, and one ~1 GB worktree per spawned agent.
+# Disk pressure builds; the remote ref list gets unwieldy. This is the one
+# command to reclaim all three at once, safely.
+#
+# What it does (in order):
+#   1. `git fetch origin --prune` so every ref is current.
+#   2. Deletes MERGED local `claude/*` branches — "merged" means
+#      `git rev-list --count origin/main..<branch> == 0` (zero commits the
+#      branch carries that origin/main doesn't). Never the current branch.
+#   3. Deletes MERGED remote `claude/*` branches on `origin` in a SINGLE
+#      `git push origin --delete b1 b2 ...` call (one API operation — a
+#      loop of pushes looks bot-ish and is ban-risky, see
+#      feedback_no_pr_burst). A branch with an OPEN PR is never deleted.
+#   4. Removes stale worktrees under `.claude/worktrees/` by delegating to
+#      the sibling `worktree-auto-prune.sh` (which already handles the
+#      dirty-tree / unmerged / squash-merged-PR cases).
+#
+# Safety contract:
+#   - NEVER touches the current branch or the current worktree.
+#   - NEVER deletes a branch that is ahead>0 vs origin/main (unmerged work)
+#     UNLESS its PR is MERGED on GitHub (squash-merge: ahead stays >0).
+#   - NEVER deletes a branch whose PR is OPEN on GitHub.
+#   - NEVER deletes anything passed via --keep.
+#   - Defaults to DRY-RUN: prints what it would delete and stops. Pass
+#     --yes to actually delete (matches worktree-auto-prune.sh's --yes,
+#     but here --yes is *required* for any destructive action — there is
+#     no interactive prompt, so CI and humans behave identically).
+#
+# Usage:
+#   bash .claude/scripts/cleanup-branches-worktrees.sh                 # dry-run
+#   bash .claude/scripts/cleanup-branches-worktrees.sh --dry-run       # explicit dry-run
+#   bash .claude/scripts/cleanup-branches-worktrees.sh --yes           # actually delete
+#   bash .claude/scripts/cleanup-branches-worktrees.sh --yes \
+#        --keep claude/my-wip --keep "$(git rev-parse --show-toplevel)"
+#   bash .claude/scripts/cleanup-branches-worktrees.sh --yes --no-worktrees
+#
+# Flags:
+#   --dry-run        Preview only (default when --yes is absent).
+#   --yes            Perform deletions. Without it, nothing is deleted.
+#   --keep <ref>     Branch name OR worktree path to spare. Repeatable.
+#   --no-worktrees   Skip the worktree-prune step (branches only).
+#   -h, --help       Show this header.
+#
+# Exit codes:
+#   0 = success (including "nothing to clean")
+#   1 = unexpected error
+
+set -euo pipefail
+
+DRY_RUN=true
+DO_WORKTREES=true
+KEEP=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)      DRY_RUN=true; shift ;;
+        --yes)          DRY_RUN=false; shift ;;
+        --no-worktrees) DO_WORKTREES=false; shift ;;
+        --keep)         KEEP+=("${2:-}"); shift 2 ;;
+        --keep=*)       KEEP+=("${1#--keep=}"); shift ;;
+        -h|--help)      sed -n '2,52p' "$0"; exit 0 ;;
+        *)              echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# --- locate the main repo root (works from a linked worktree too) ----------
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -z "$GIT_COMMON_DIR" ]; then
+    echo -e "${RED}Not inside a git repo.${NC}" >&2
+    exit 1
+fi
+GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+# is_kept <ref> — true if the ref matches any --keep argument (verbatim).
+is_kept() {
+    local ref="$1" k
+    for k in "${KEEP[@]:-}"; do
+        [ -n "$k" ] && [ "$ref" = "$k" ] && return 0
+    done
+    return 1
+}
+
+# gh availability — only used for the open-PR safety signal. The script
+# works fully offline / without `gh`; without it, a branch is considered
+# deletable purely on the ahead=0 signal (still safe — ahead=0 = merged).
+GH_AVAILABLE=false
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    GH_AVAILABLE=true
+fi
+
+# pr_state <branch> — echoes the PR state (OPEN / MERGED / CLOSED) or "" if
+# none / gh unavailable. Degrades safely on any failure.
+pr_state() {
+    local branch="$1"
+    [ "$GH_AVAILABLE" = "true" ] || { echo ""; return 0; }
+    gh pr view "$branch" --json state --jq .state 2>/dev/null || echo ""
+}
+
+echo -e "${CYAN}=== Branch + worktree cleanup ===${NC}"
+echo "Repo root:      $REPO_ROOT"
+echo "Current branch: ${CURRENT_BRANCH:-<detached>}"
+if [ "$DRY_RUN" = "true" ]; then
+    echo -e "Mode:           ${YELLOW}DRY RUN${NC} (pass --yes to delete)"
+else
+    echo -e "Mode:           ${RED}DELETE${NC}"
+fi
+[ "$GH_AVAILABLE" = "true" ] && echo "GitHub:         gh authenticated (open-PR guard active)" \
+                             || echo "GitHub:         gh unavailable (ahead=0 guard only)"
+echo ""
+
+# --- 1. refresh refs -------------------------------------------------------
+echo -e "${CYAN}--- Fetching origin --prune ---${NC}"
+git -C "$REPO_ROOT" fetch origin --prune --quiet 2>/dev/null \
+    || echo -e "${YELLOW}Warning: fetch failed — working from local refs.${NC}"
+echo ""
+
+# ===========================================================================
+# 2. MERGED LOCAL claude/* branches
+# ===========================================================================
+echo -e "${CYAN}--- Local claude/* branches ---${NC}"
+LOCAL_DELETE=()
+LOCAL_SKIP=()
+
+while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    if [ "$branch" = "$CURRENT_BRANCH" ]; then
+        LOCAL_SKIP+=("$branch (current branch)")
+        continue
+    fi
+    if is_kept "$branch"; then
+        LOCAL_SKIP+=("$branch (--keep)")
+        continue
+    fi
+    ahead=$(git -C "$REPO_ROOT" rev-list --count "origin/main..$branch" 2>/dev/null || echo "unknown")
+    if [ "$ahead" = "0" ]; then
+        LOCAL_DELETE+=("$branch")
+    elif [ "$(pr_state "$branch")" = "MERGED" ]; then
+        # Squash-merge case: the branch's commits stay distinct (ahead>0)
+        # but its PR is MERGED on GitHub → the work is safely on main.
+        LOCAL_DELETE+=("$branch")
+    else
+        LOCAL_SKIP+=("$branch (ahead=$ahead — unmerged work)")
+    fi
+done < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/heads/claude/*')
+
+if [ "${#LOCAL_DELETE[@]}" -eq 0 ]; then
+    echo "  (no merged local claude/* branches)"
+else
+    for b in "${LOCAL_DELETE[@]}"; do echo -e "  ${GREEN}delete${NC}  $b"; done
+fi
+for s in "${LOCAL_SKIP[@]:-}"; do [ -n "$s" ] && echo -e "  ${YELLOW}keep${NC}    $s"; done
+echo ""
+
+# ===========================================================================
+# 3. MERGED REMOTE origin/claude/* branches
+# ===========================================================================
+echo -e "${CYAN}--- Remote origin/claude/* branches ---${NC}"
+REMOTE_DELETE=()
+REMOTE_SKIP=()
+
+while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    branch="${ref#origin/}"
+    # Never delete the remote tracking branch of the branch we're on.
+    if [ "$branch" = "$CURRENT_BRANCH" ]; then
+        REMOTE_SKIP+=("$branch (current branch)")
+        continue
+    fi
+    if is_kept "$branch"; then
+        REMOTE_SKIP+=("$branch (--keep)")
+        continue
+    fi
+    ahead=$(git -C "$REPO_ROOT" rev-list --count "origin/main..$ref" 2>/dev/null || echo "unknown")
+    state="$(pr_state "$branch")"
+    # Never delete a branch with an OPEN PR — that PR carries live work.
+    if [ "$state" = "OPEN" ]; then
+        REMOTE_SKIP+=("$branch (open PR)")
+        continue
+    fi
+    if [ "$ahead" != "0" ] && [ "$state" != "MERGED" ]; then
+        # ahead>0 and no merged PR — genuine unmerged work, keep it.
+        # (ahead>0 + MERGED PR = squash-merge; the work is on main → ok.)
+        REMOTE_SKIP+=("$branch (ahead=$ahead — unmerged work)")
+        continue
+    fi
+    REMOTE_DELETE+=("$branch")
+done < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/claude/*')
+
+if [ "${#REMOTE_DELETE[@]}" -eq 0 ]; then
+    echo "  (no merged remote claude/* branches)"
+else
+    for b in "${REMOTE_DELETE[@]}"; do echo -e "  ${GREEN}delete${NC}  origin/$b"; done
+fi
+for s in "${REMOTE_SKIP[@]:-}"; do [ -n "$s" ] && echo -e "  ${YELLOW}keep${NC}    $s"; done
+echo ""
+
+# ===========================================================================
+# Execute (or stop here on dry-run)
+# ===========================================================================
+if [ "$DRY_RUN" = "true" ]; then
+    echo -e "${YELLOW}DRY RUN — nothing deleted.${NC}"
+    echo "  Local branches that would be deleted:  ${#LOCAL_DELETE[@]}"
+    echo "  Remote branches that would be deleted: ${#REMOTE_DELETE[@]}"
+    echo ""
+else
+    if [ "${#LOCAL_DELETE[@]}" -gt 0 ]; then
+        echo -e "${CYAN}--- Deleting local branches ---${NC}"
+        # -D (not -d): ahead=0 already proves merged-into-origin/main; -d
+        # can still refuse if the local branch lacks an upstream merge ref.
+        for b in "${LOCAL_DELETE[@]}"; do
+            if git -C "$REPO_ROOT" branch -D "$b" >/dev/null 2>&1; then
+                echo -e "  ${GREEN}deleted${NC} $b"
+            else
+                echo -e "  ${RED}failed ${NC} $b"
+            fi
+        done
+        echo ""
+    fi
+
+    if [ "${#REMOTE_DELETE[@]}" -gt 0 ]; then
+        echo -e "${CYAN}--- Deleting remote branches (single push) ---${NC}"
+        # One git push --delete with every branch — a single API operation,
+        # NOT a loop of pushes (bot-burst / ban risk, feedback_no_pr_burst).
+        if git -C "$REPO_ROOT" push origin --delete "${REMOTE_DELETE[@]}"; then
+            echo -e "  ${GREEN}deleted ${#REMOTE_DELETE[@]} remote branch(es).${NC}"
+        else
+            echo -e "  ${RED}remote delete failed — see git output above.${NC}"
+        fi
+        echo ""
+    fi
+fi
+
+# ===========================================================================
+# 4. Stale worktrees — delegate to worktree-auto-prune.sh
+# ===========================================================================
+if [ "$DO_WORKTREES" = "true" ]; then
+    PRUNE="$REPO_ROOT/.claude/scripts/worktree-auto-prune.sh"
+    if [ -f "$PRUNE" ]; then
+        echo -e "${CYAN}--- Worktrees (delegating to worktree-auto-prune.sh) ---${NC}"
+        PRUNE_ARGS=()
+        [ "$DRY_RUN" = "true" ] && PRUNE_ARGS+=(--dry-run) || PRUNE_ARGS+=(--yes)
+        # Always spare the current worktree, plus any --keep paths.
+        PRUNE_ARGS+=(--keep "$(git rev-parse --show-toplevel)")
+        for k in "${KEEP[@]:-}"; do
+            [ -n "$k" ] && [ -d "$k" ] && PRUNE_ARGS+=(--keep "$k")
+        done
+        bash "$PRUNE" "${PRUNE_ARGS[@]}" || echo -e "${YELLOW}worktree-auto-prune.sh exited non-zero.${NC}"
+        echo ""
+    else
+        echo -e "${YELLOW}worktree-auto-prune.sh not found — skipping worktree cleanup.${NC}"
+        echo ""
+    fi
+fi
+
+echo -e "${GREEN}=== Done ===${NC}"
+exit 0

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -196,3 +196,32 @@ jobs:
           else
             echo "CI health OK ($FAILURES/7 failures)"
           fi
+
+  # ── 5. Stale claude/* branch cleanup ──────────────────────────────────────
+  # An orchestrator marathon leaves dozens of merged `claude/*` branches on
+  # `origin`. This job deletes the ones that are provably dead — fully merged
+  # into origin/main (ahead=0) OR carrying a MERGED PR (squash-merge case) —
+  # in a SINGLE `git push --delete` call. Branches with an OPEN PR or genuine
+  # unmerged commits are never touched. Worktrees are skipped (they only
+  # exist on local checkouts, not in CI).
+  branch-cleanup:
+    name: Prune merged claude/* branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write       # git push --delete
+      pull-requests: read   # gh pr view (open-PR guard)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0    # full history — ahead-count needs all refs
+
+      - name: Prune merged remote branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # --yes  : perform the deletion (merged == dead, safe to act).
+          # --no-worktrees : CI has no .claude/worktrees/ checkouts.
+          # The script's own guards (current branch, ahead>0, open PR)
+          # protect every branch that still carries live work.
+          bash .claude/scripts/cleanup-branches-worktrees.sh --yes --no-worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,8 @@ Hooks trigger automatically on specific Claude Code actions:
 | `install-sceneview-ios-skill.sh` | Copies `agents/sceneview-ios/` (Apple skill) to `~/.android/cli/skills/xr/sceneview-ios/` |
 | `install-sceneview-web-skill.sh` | Copies `agents/sceneview-web/` (Web skill) to `~/.android/cli/skills/xr/sceneview-web/` |
 | `check-sceneview-skill.sh` | Verifies all three `agents/sceneview*/` skills (API identifiers, demo refs, frontmatter) are in sync with the library source. Runs in `quality-gate.sh`, `pr-check.yml`, and daily via `maintenance.yml` |
+| `worktree-auto-prune.sh` | Safe GC for `.claude/worktrees/*` — removes worktrees whose branch is merged (`--dry-run`, `--yes`, `--keep <path>`). Never touches dirty or unmerged trees |
+| `cleanup-branches-worktrees.sh` | One-shot GC for stale `claude/*` branches **and** worktrees: deletes merged local + remote branches (single `git push --delete`, no bot-burst) and delegates worktree pruning to `worktree-auto-prune.sh`. Defaults to dry-run; `--yes` to act, `--keep <branch\|path>`, `--no-worktrees`. Current-branch / unmerged / open-PR guarded. Runs daily in `maintenance.yml` |
 
 ### Version location map
 

--- a/changelog.d/1-cleanup-branches-worktrees.md
+++ b/changelog.d/1-cleanup-branches-worktrees.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **Reusable branch + worktree cleanup task.** New `.claude/scripts/cleanup-branches-worktrees.sh` deletes merged local and remote `claude/*` branches (single `git push --delete`, no bot-burst) and prunes stale `.claude/worktrees/*` directories, with current-branch / unmerged / open-PR safety guards and a `--dry-run` default. A daily `branch-cleanup` job in `maintenance.yml` prunes merged remote branches automatically.


### PR DESCRIPTION
## Summary

A reusable cleanup task for the three things an orchestrator marathon accumulates: stale local `claude/*` branches, stale remote `claude/*` branches on `origin`, and stale `.claude/worktrees/*` directories. Builds on the existing `worktree-auto-prune.sh` rather than duplicating it.

- **New `.claude/scripts/cleanup-branches-worktrees.sh`** — `git fetch origin --prune`, then:
  - deletes merged **local** `claude/*` branches (`ahead=0` vs `origin/main`, or a MERGED PR for the squash-merge case) — never the current branch
  - deletes merged **remote** `claude/*` branches in a **single** `git push origin --delete b1 b2 ...` call (one API operation — not a loop of pushes, which is bot-ish / ban-risky)
  - prunes stale worktrees by **delegating** to `worktree-auto-prune.sh`
  - safety: dry-run by default (`--yes` to act), `--keep <branch|path>`, `--no-worktrees`; never touches the current branch/worktree, a branch with unmerged commits, or one with an OPEN PR
- **`maintenance.yml`** gains a daily `branch-cleanup` job that prunes merged remote branches automatically (merged == dead; worktrees skipped — CI has none). Open-PR / unmerged guards still protect live work.
- **CLAUDE.md** Scripts table documents the new script (and `worktree-auto-prune.sh`).

## Test plan

- [x] `shellcheck` clean on the new script
- [x] `--dry-run` correctly lists 67 merged remote branches, keeps the current branch, keeps the one branch with an open PR, keeps genuinely-unmerged branches
- [x] `check-workflow-scripts.sh` passes (`maintenance.yml` reference validated)
- [x] `maintenance.yml` YAML validates
- [ ] First scheduled `branch-cleanup` run prunes merged remote branches without touching live work

🤖 Generated with [Claude Code](https://claude.com/claude-code)