### PR TITLE
test(ci): JaCoCo delta-coverage gate + committed baseline

### DIFF
--- a/.claude/data/jacoco-baseline.txt
+++ b/.claude/data/jacoco-baseline.txt
@@ -1,0 +1,33 @@
+# JaCoCo coverage baseline — issue #973
+#
+# Per-module LINE coverage recorded at the time the delta-coverage gate
+# landed. The CI `Coverage delta gate` step (see `.github/workflows/ci.yml`)
+# runs `jacocoTestReport` for both modules, reads the freshly generated XML,
+# and FAILS the build if any module's line coverage drops more than the
+# allowed threshold below this baseline.
+#
+# WHY A DELTA GATE (not a hard 60% floor)
+# ---------------------------------------
+# Absolute coverage is intentionally low (7-10%); raising it to 60% is a
+# multi-week test-writing project. A delta gate gives the same "no
+# regression" property at near-zero cost — the baseline can ratchet upward
+# from here as tests land.
+#
+# HOW TO UPDATE THIS FILE
+# -----------------------
+# When a PR legitimately raises coverage, bump the matching `<module>=<pct>`
+# line so the new floor is locked in (one-way ratchet — never lower it).
+# `.claude/scripts/jacoco-delta-check.sh --update` rewrites the percentages
+# from the current reports for you.
+#
+# Format: one `module=percentage` line per gated module. Percentage is
+# LINE coverage to 2 decimal places. Blank lines and `#` comments ignored.
+#
+# Allowed regression threshold (percentage points). The gate fails when
+#   baseline_pct - current_pct > threshold_pp
+# Override at runtime with the JACOCO_DELTA_THRESHOLD env var.
+threshold_pp=0.5
+
+# Measured 2026-05-15 from ci.yml run 25941488163 (commit 11713a74).
+sceneview=7.59
+arsceneview=9.64

--- a/.claude/scripts/jacoco-delta-check.sh
+++ b/.claude/scripts/jacoco-delta-check.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# jacoco-delta-check.sh — JaCoCo delta-coverage gate (issue #973)
+#
+# Compares the LINE coverage of each gated module against the committed
+# baseline in `.claude/data/jacoco-baseline.txt` and fails if any module
+# regressed by more than the allowed threshold.
+#
+# This is a "no regression" gate, not an absolute-floor gate: the headline
+# numbers are low by design (~7-10%) and the baseline ratchets upward as
+# tests land — it must never be lowered.
+#
+# PREREQUISITE
+#   The JaCoCo XML reports must already exist. Generate them with:
+#     ./gradlew :sceneview:jacocoTestReport :arsceneview:jacocoTestReport
+#
+# USAGE
+#   .claude/scripts/jacoco-delta-check.sh            # check (gate)
+#   .claude/scripts/jacoco-delta-check.sh --update   # rewrite baseline %s
+#   .claude/scripts/jacoco-delta-check.sh --report-only   # never exit non-zero
+#
+# ENV
+#   JACOCO_DELTA_THRESHOLD   override the allowed regression in pp
+#                            (default: `threshold_pp` from the baseline file)
+#
+# EXIT
+#   0  every module within threshold (or --update / --report-only)
+#   1  a module regressed beyond threshold, or a report was missing
+#   2  usage / setup error
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BASELINE_FILE=".claude/data/jacoco-baseline.txt"
+MODULES=(sceneview arsceneview)
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+MODE="check"
+case "${1:-}" in
+    --update)      MODE="update" ;;
+    --report-only) MODE="report" ;;
+    "")            MODE="check" ;;
+    *) echo -e "${RED}Error:${NC} unknown argument '$1'"; exit 2 ;;
+esac
+
+[ -f "$BASELINE_FILE" ] || { echo -e "${RED}Error:${NC} $BASELINE_FILE not found."; exit 2; }
+
+report_path() {
+    echo "$1/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+}
+
+# Parse LINE coverage from a JaCoCo XML report. Echoes a single line
+# "<pct> <covered>/<total>" (pct to 2 d.p.), or nothing + exit 1 if the
+# report is missing or unparseable.
+line_coverage() {
+    local xml="$1"
+    [ -f "$xml" ] || return 1
+    python3 - "$xml" <<'PY'
+import sys, xml.etree.ElementTree as ET
+try:
+    root = ET.parse(sys.argv[1]).getroot()
+except Exception:
+    sys.exit(1)
+# The report-level LINE counter is a top-level <counter> child.
+for c in root.findall("counter"):
+    if c.get("type") == "LINE":
+        cov = int(c.get("covered")); miss = int(c.get("missed"))
+        total = cov + miss
+        pct = (100.0 * cov / total) if total else 0.0
+        print(f"{pct:.2f} {cov}/{total}")
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# Read a key from the baseline file (`module=pct` or `threshold_pp=...`).
+baseline_get() {
+    grep -E "^$1=" "$BASELINE_FILE" | head -1 | cut -d= -f2 | tr -d '[:space:]'
+}
+
+THRESHOLD="${JACOCO_DELTA_THRESHOLD:-$(baseline_get threshold_pp)}"
+[ -n "$THRESHOLD" ] || THRESHOLD="0.5"
+
+# Float maths via python, passing values through the environment so no
+# user-controlled string is ever interpolated into the python source.
+# Echoes "<delta> <regressed 0|1> <sign-text>" for the given baseline.
+delta_eval() {
+    JD_BASE="$1" JD_CUR="$2" JD_THR="$3" python3 - <<'PY'
+import os
+base = float(os.environ["JD_BASE"])
+cur = float(os.environ["JD_CUR"])
+thr = float(os.environ["JD_THR"])
+delta = base - cur                       # positive == regression
+regressed = 1 if delta > thr else 0
+if delta < 0:
+    sign = "improved +%.2fpp" % (-delta)
+elif delta == 0:
+    sign = "held"
+else:
+    sign = "within tolerance -%.2fpp" % delta
+print(f"{delta:.2f} {regressed} {sign}")
+PY
+}
+
+# Echo the larger of two percentages (one-way ratchet for --update).
+max_pct() {
+    JD_A="$1" JD_B="$2" python3 - <<'PY'
+import os
+a = float(os.environ["JD_A"]); b = float(os.environ["JD_B"])
+print("%.2f" % (a if a > b else b))
+PY
+}
+
+echo -e "${CYAN}JaCoCo delta-coverage gate${NC} (issue #973)"
+echo "Allowed regression: ${THRESHOLD} pp   baseline: $BASELINE_FILE"
+echo
+
+FAILED=0
+MISSING=0
+# Portable (bash 3.2) parallel arrays in place of an associative array:
+# NEW_PCT_KEYS / NEW_PCT_VALS hold the freshly-measured percentages.
+NEW_PCT_KEYS=""
+NEW_PCT_VALS=""
+
+# Look up a measured percentage by module name from the parallel arrays.
+# Word-splitting on the (space-separated) lists keeps the indices aligned.
+new_pct_get() {
+    local target="$1" k v
+    # shellcheck disable=SC2086
+    set -- $NEW_PCT_VALS
+    local idx=1
+    for k in $NEW_PCT_KEYS; do
+        if [ "$k" = "$target" ]; then
+            eval "v=\${$idx}"
+            echo "$v"
+            return 0
+        fi
+        idx=$((idx + 1))
+    done
+    return 1
+}
+
+for mod in "${MODULES[@]}"; do
+    xml="$(report_path "$mod")"
+    base="$(baseline_get "$mod")"
+
+    cov_line="$(line_coverage "$xml" || true)"
+    if [ -z "$cov_line" ]; then
+        echo -e "  ${RED}✗ $mod${NC}: report missing — $xml"
+        echo -e "    run \`./gradlew :$mod:jacocoTestReport\` first."
+        MISSING=1
+        continue
+    fi
+    current="${cov_line%% *}"
+    ratio="${cov_line##* }"
+    NEW_PCT_KEYS="$NEW_PCT_KEYS $mod"
+    NEW_PCT_VALS="$NEW_PCT_VALS $current"
+
+    if [ -z "$base" ]; then
+        echo -e "  ${YELLOW}? $mod${NC}: ${current}% ($ratio) — no baseline entry, skipping."
+        continue
+    fi
+
+    # delta = baseline - current  (positive delta == a regression)
+    eval_line="$(delta_eval "$base" "$current" "$THRESHOLD")"
+    delta="${eval_line%% *}"
+    rest="${eval_line#* }"
+    regressed="${rest%% *}"
+    sign="${rest#* }"
+
+    if [ "$regressed" = "1" ]; then
+        echo -e "  ${RED}✗ $mod${NC}: ${current}% ($ratio)  baseline ${base}%  Δ -${delta}pp  ${RED}> ${THRESHOLD}pp REGRESSION${NC}"
+        FAILED=1
+    else
+        echo -e "  ${GREEN}✓ $mod${NC}: ${current}% ($ratio)  baseline ${base}%  ($sign)"
+    fi
+done
+
+echo
+
+if [ "$MODE" = "update" ]; then
+    tmp="$(mktemp)"
+    cp "$BASELINE_FILE" "$tmp"
+    for mod in "${MODULES[@]}"; do
+        new="$(new_pct_get "$mod" || true)"
+        [ -n "$new" ] || continue
+        # Only ratchet upward — never lower a baseline on --update.
+        base="$(baseline_get "$mod")"
+        keep="$(max_pct "$new" "${base:-0}")"
+        python3 - "$tmp" "$mod" "$keep" <<'PY'
+import sys
+path, mod, val = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).read().splitlines()
+out = []
+for ln in lines:
+    if ln.startswith(f"{mod}="):
+        out.append(f"{mod}={val}")
+    else:
+        out.append(ln)
+open(path, "w").write("\n".join(out) + "\n")
+PY
+    done
+    cp "$tmp" "$BASELINE_FILE"
+    rm -f "$tmp"
+    echo -e "${GREEN}Baseline updated${NC} (ratcheted upward only) → $BASELINE_FILE"
+    exit 0
+fi
+
+if [ "$MISSING" = "1" ]; then
+    echo -e "${RED}One or more JaCoCo reports were missing.${NC}"
+    [ "$MODE" = "report" ] && exit 0
+    exit 1
+fi
+
+if [ "$FAILED" = "1" ]; then
+    echo -e "${RED}Coverage regressed beyond the ${THRESHOLD}pp threshold.${NC}"
+    echo    "If the drop is intentional, lower nothing — add tests, or in a"
+    echo    "deliberate ratchet PR re-measure and justify the new baseline."
+    [ "$MODE" = "report" ] && { echo -e "${YELLOW}(--report-only: not failing)${NC}"; exit 0; }
+    exit 1
+fi
+
+echo -e "${GREEN}Coverage delta gate passed.${NC}"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,37 @@ jobs:
                       f.write(f"- {r}\n")
           PY
 
+      - name: Coverage delta gate
+        if: always()
+        # Compares this PR's line coverage against the committed baseline in
+        # `.claude/data/jacoco-baseline.txt` and reports whether any module
+        # dropped more than `threshold_pp` (0.5pp default). See #973.
+        #
+        # `continue-on-error: true` keeps it INFORMATIONAL for now — a real
+        # regression is logged loudly and surfaced in the job step summary,
+        # but the step failure does not flip the `unit-test` job (and
+        # therefore the `CI Gate` aggregator) red. Promote it to a hard gate
+        # by deleting this `continue-on-error` line once it has been green
+        # for two consecutive weeks (the #973 follow-up ratchet step).
+        continue-on-error: true
+        run: |
+          set +e
+          bash .claude/scripts/jacoco-delta-check.sh 2>&1 | tee /tmp/jacoco-delta.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## JaCoCo coverage delta gate"
+            echo ""
+            echo '```'
+            sed 's/\x1b\[[0-9;]*m//g' /tmp/jacoco-delta.log
+            echo '```'
+            if [ "$status" -ne 0 ]; then
+              echo ""
+              echo "> :warning: Coverage regressed beyond the allowed threshold."
+              echo "> This check is currently **informational** (non-blocking)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/changelog.d/973-jacoco-delta-gate.md
+++ b/changelog.d/973-jacoco-delta-gate.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **JaCoCo coverage delta gate ([#973](https://github.com/sceneview/sceneview/issues/973)).** A committed baseline (`.claude/data/jacoco-baseline.txt`) records per-module line coverage, and `.claude/scripts/jacoco-delta-check.sh` fails when a PR drops coverage more than the configurable `threshold_pp` (0.5pp default). Wired into the `unit-test` CI job as an informational, non-blocking step for now — promoting it to a hard gate once it has been green for two consecutive weeks is the `#973` follow-up.


### PR DESCRIPTION
## Summary

Implements the #964 follow-up requested in #973: a **delta-coverage gate** so
JaCoCo line coverage cannot silently drift downward as untested code lands.
The issue deliberately rejects chasing an absolute 60% floor (a multi-week
test-writing project) in favour of a cheap "no regression" property that can
ratchet upward from the current 7-10% headline.

## Changes

- **`.claude/data/jacoco-baseline.txt`** — committed per-module line-coverage
  baseline: `sceneview` **7.59%**, `arsceneview` **9.64%** (measured from
  `ci.yml` run `25941488163`, commit `11713a74`). Carries a configurable
  `threshold_pp` (0.5pp default).
- **`.claude/scripts/jacoco-delta-check.sh`** — reads the freshly generated
  JaCoCo XML reports, compares LINE coverage against the baseline, and fails
  when a module regressed more than the threshold.
  - `--update` ratchets the baseline upward only (never down).
  - `--report-only` never exits non-zero.
  - `JACOCO_DELTA_THRESHOLD` env overrides the threshold.
  - Float maths run through python with values passed via the environment
    (no string interpolation); portable to bash 3.2.
- **`ci.yml` `unit-test` job** — new *Coverage delta gate* step runs the check
  and writes a step-summary table. `continue-on-error: true` keeps it
  **informational / non-blocking** for now, so it never flips the `CI Gate`
  aggregator red. Promoting it to a hard gate is a one-line change
  (delete `continue-on-error`) once it has been green for two weeks — that,
  plus bumping the absolute `violationRules` floor, is the #973 step-3
  follow-up.

## Test plan

- [x] `bash -n` + `shellcheck` clean on the new script
- [x] Script exercised against real JaCoCo reports downloaded from CI run
      `25941488163`: pass (equal), regression (tampered XML), improvement,
      missing-report, `--report-only`, `--update` all behave correctly
- [x] `python3 -c yaml.safe_load` + `actionlint` clean on `ci.yml`
- [x] `.claude/scripts/check-workflow-scripts.sh` passes (new script referenced)
- [x] `CI Gate` aggregator untouched — no new job, no `needs:` change
- [ ] CI run on this PR shows the informational *Coverage delta gate* step
      green in the `unit-test` job step summary

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)