### PR TITLE
fix(ci): resolve aapt2 from build-tools + non-blocking AAB validation (#1413)

### DIFF
--- a/.claude/scripts/lib/android-cli.sh
+++ b/.claude/scripts/lib/android-cli.sh
@@ -194,14 +194,54 @@ sys.exit(1)
 PY
 }
 
+# android_cli_locate_aapt2
+# Resolves the `aapt2` binary and echoes its path on stdout. Returns 0 on
+# success, 1 if it genuinely cannot be found.
+#
+# `aapt2` is NOT on PATH on most CI runners — it ships *inside* the Android SDK
+# at `<sdk>/build-tools/<version>/aapt2`, not in `<sdk>/platform-tools` (which
+# IS the dir that gets added to PATH). So:
+#   1. Try a bare `aapt2` on PATH first (covers dev machines that symlink it).
+#   2. Otherwise walk `${ANDROID_SDK_ROOT:-$ANDROID_HOME}/build-tools/*` and
+#      pick the newest version directory that contains an executable `aapt2`.
+android_cli_locate_aapt2() {
+  if command -v aapt2 >/dev/null 2>&1; then
+    command -v aapt2
+    return 0
+  fi
+  local sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+  if [[ -n "$sdk" && -d "$sdk/build-tools" ]]; then
+    local bt
+    # `sort -V` orders build-tools dirs by semantic version; `tail` → newest.
+    # The loop walks newest→oldest so a partially-installed newest dir without
+    # an `aapt2` falls through to the next-newest instead of failing outright.
+    while IFS= read -r bt; do
+      [[ -z "$bt" ]] && continue
+      if [[ -x "$bt/aapt2" ]]; then
+        echo "$bt/aapt2"
+        return 0
+      fi
+    done < <(find "$sdk/build-tools" -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
+             | sort -Vr)
+  fi
+  return 1
+}
+
 # android_cli_describe <apk-or-aab>
 # Echoes the artifact's manifest metadata (package / versionName / versionCode …)
-# on stdout so callers can grep it. Returns non-zero if the artifact can't be read.
+# on stdout so callers can grep it.
+#
+# Return codes are meaningful to callers (validate-release-artifact.sh):
+#   0  → artifact introspected OK, metadata on stdout
+#   1  → the artifact itself is unreadable / corrupt / unsupported
+#   2  → the TOOLING (`aapt2`) is unavailable — distinct from a bad artifact so
+#        a validation guard can warn+skip instead of hard-failing a release.
 #
 # NOTE on tooling: the `android` CLI's `describe` subcommand (v0.7) analyzes a
 # *project directory*, not a built artifact — it has no artifact-introspection
 # mode. The correct tool for reading a built `.apk` / `.aab` manifest is
-# `aapt2`, which ships with the Android SDK build-tools the runner already has.
+# `aapt2`, which ships with the Android SDK build-tools the runner already has
+# (resolved via `android_cli_locate_aapt2` — it is NOT on PATH).
 # This helper therefore uses `aapt2`:
 #   - `.apk` → `aapt2 dump badging` reads it directly.
 #   - `.aab` → the protobuf `base/manifest/AndroidManifest.xml` is unzipped and
@@ -212,9 +252,11 @@ android_cli_describe() {
     echo "[android-cli] describe: artifact not found: $artifact" >&2
     return 1
   fi
-  if ! command -v aapt2 >/dev/null 2>&1; then
-    echo "[android-cli] describe: aapt2 not on PATH (expected in Android SDK build-tools)" >&2
-    return 1
+  local aapt2
+  if ! aapt2="$(android_cli_locate_aapt2)"; then
+    echo "[android-cli] describe: aapt2 not found — not on PATH and not under" \
+         "\${ANDROID_SDK_ROOT:-\$ANDROID_HOME}/build-tools/*" >&2
+    return 2
   fi
   case "$artifact" in
     *.aab)
@@ -224,7 +266,7 @@ android_cli_describe() {
       if command -v unzip >/dev/null 2>&1 \
          && unzip -o -q "$artifact" "base/manifest/AndroidManifest.xml" -d "$tmp" 2>/dev/null \
          && [[ -f "$tmp/base/manifest/AndroidManifest.xml" ]]; then
-        aapt2 dump xmltree --file "base/manifest/AndroidManifest.xml" "$tmp/base"
+        "$aapt2" dump xmltree --file "base/manifest/AndroidManifest.xml" "$tmp/base"
         local rc=$?
         rm -rf "$tmp"
         return $rc
@@ -234,7 +276,7 @@ android_cli_describe() {
       return 1
       ;;
     *)
-      aapt2 dump badging "$artifact"
+      "$aapt2" dump badging "$artifact"
       ;;
   esac
 }

--- a/.claude/scripts/validate-release-artifact.sh
+++ b/.claude/scripts/validate-release-artifact.sh
@@ -25,11 +25,25 @@
 # `android_cli_describe` therefore wraps `aapt2` (badging for `.apk`, xmltree of
 # the protobuf base manifest for `.aab`).
 #
+# ⛔ A pre-upload *validation guard* must NEVER block a release because of its
+# OWN missing tooling. So this script draws a hard line between two failure
+# kinds:
+#
+#   * "the artifact is wrong"  → exit 1 (BLOCK the release — that is the point)
+#   * "the validation tooling
+#      is unavailable"          → exit 0 (WARN + SKIP — a release must not be
+#                                 blocked because `aapt2` couldn't be located)
+#
+# The `android_cli_describe` helper signals these apart: it returns 2 when
+# `aapt2` itself is missing, and 1 when the artifact genuinely can't be read.
+#
 # Usage:
 #   validate-release-artifact.sh <artifact> <expected-package> \
 #       <expected-version-name> <expected-version-code>
 #
-# Exit codes: 0 = artifact OK; 1 = mismatch / unreadable artifact / bad args.
+# Exit codes:
+#   0 = artifact OK, OR validation skipped because tooling is unavailable
+#   1 = genuine mismatch (wrong package / versionName / versionCode) or bad args
 
 set -euo pipefail
 
@@ -49,15 +63,38 @@ EXPECT_CODE="$4"
 
 fail() {
   # `::error::` so the message is surfaced as a GitHub Actions annotation.
+  # Used ONLY for genuine artifact problems — these MUST block the release.
   echo "::error::$*" >&2
   exit 1
+}
+
+skip() {
+  # `::warning::` so the message is surfaced as a GitHub Actions annotation
+  # without failing the job. Used when the *validation tooling* is unavailable —
+  # a guard must never block a release because of its own missing tooling.
+  echo "::warning::$*" >&2
+  echo "[validate-artifact] SKIPPED — validation tooling unavailable, not blocking the release." >&2
+  exit 0
 }
 
 [[ -f "$ARTIFACT" ]] || fail "release artifact not found: $ARTIFACT"
 
 echo "[validate-artifact] describing $ARTIFACT"
-DESC="$(android_cli_describe "$ARTIFACT")" \
-  || fail "could not read $ARTIFACT — 'aapt2' could not introspect the artifact"
+# `android_cli_describe` exit codes: 0 = OK, 1 = artifact unreadable,
+# 2 = `aapt2` tooling unavailable. `set -e` would abort on any non-zero, so
+# capture the status explicitly and branch: tooling failure → warn+skip,
+# artifact failure → hard fail.
+DESC=""
+DESCRIBE_RC=0
+DESC="$(android_cli_describe "$ARTIFACT")" || DESCRIBE_RC=$?
+if [[ "$DESCRIBE_RC" -eq 2 ]]; then
+  skip "AAB manifest validation skipped — 'aapt2' could not be located" \
+       "(not on PATH, not under \$ANDROID_SDK_ROOT/build-tools). This is a" \
+       "tooling gap, not an artifact problem; the upload proceeds unvalidated."
+elif [[ "$DESCRIBE_RC" -ne 0 ]]; then
+  fail "could not introspect $ARTIFACT — the artifact appears corrupt or is" \
+       "an unsupported format. Refusing to upload an unverifiable release."
+fi
 
 echo "$DESC"
 

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -192,8 +192,13 @@ jobs:
       # AAB before it reaches the Play Store. Asserts the built bundle's
       # package / versionName / versionCode match what gradle was told to build,
       # so a misconfigured artifact is caught here (~1 s) instead of as a Play
-      # Console rejection minutes later. `aapt2` is on PATH via the Android SDK
-      # build-tools that `setup-gradle` provisions.
+      # Console rejection minutes later.
+      #
+      # `aapt2` is NOT on PATH — it lives under
+      # `$ANDROID_SDK_ROOT/build-tools/<version>/`; the script resolves it from
+      # there. A pre-upload guard must never block a release because of its own
+      # tooling: if `aapt2` cannot be found the script WARNS and exits 0 (skip),
+      # and it only exits non-zero on a genuine manifest mismatch (#1413).
       - name: Validate AAB manifest before upload
         env:
           EXPECT_PKG: io.github.sceneview.demo

--- a/changelog.d/1413-aapt2-path-hotfix.md
+++ b/changelog.d/1413-aapt2-path-hotfix.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Play Store deploy no longer blocked by AAB manifest validation ([#1413](https://github.com/sceneview/sceneview/issues/1413)).** `validate-release-artifact.sh` now resolves `aapt2` from `$ANDROID_SDK_ROOT/build-tools/<newest>/` instead of relying on `PATH` (where it never is), and the pre-upload guard now warns and skips instead of hard-failing when the validation tooling itself is unavailable — only a genuine manifest mismatch blocks a release.


### PR DESCRIPTION
## Summary

Fixes the critical v4.6.0 Play Store regression from #1410: the `Validate AAB manifest before upload` step in `play-store.yml` hard-failed because `aapt2` is not on `PATH` — it lives at `$ANDROID_SDK_ROOT/build-tools/<version>/aapt2`. That failed the entire `Deploy Demo to Play Store` job, so the demo app never reached the Play Store.

## Changes

- **Locate `aapt2` properly.** New `android_cli_locate_aapt2` helper in `lib/android-cli.sh` tries a bare `aapt2` on `PATH` first, then walks `${ANDROID_SDK_ROOT:-$ANDROID_HOME}/build-tools/*` newest-first and picks the first dir with an executable `aapt2`.
- **Non-blocking on tooling failure.** A pre-upload validation guard must never block a release because of its *own* missing tooling. `android_cli_describe` now returns a distinct exit code `2` for "aapt2 unavailable" vs `1` for "artifact unreadable". `validate-release-artifact.sh` warns + `exit 0` (skip) on a tooling gap, but still `exit 1` (block) on a genuine `package` / `versionName` / `versionCode` mismatch.
- Corrected the stale "aapt2 is on PATH" comment in `play-store.yml`.
- Added `changelog.d/1413-aapt2-path-hotfix.md` fragment.

## Test plan

- [x] `bash -n` + `shellcheck -x` clean on both scripts (no new warnings vs main).
- [x] `python3` YAML validation of `play-store.yml`.
- [x] Traced `android_cli_locate_aapt2`: found-on-PATH / found-under-build-tools (picks newest) / genuinely-absent.
- [x] Traced `validate-release-artifact.sh` end-to-end: aapt2 found + match → exit 0; aapt2 found + mismatch → exit 1 (block); aapt2 not findable → warn + exit 0 (skip).

Closes #1413