### PR TITLE
fix(android-demo): stop Demo Settings sheet dismissing itself instantly

### DIFF
--- a/changelog.d/1420-settings-sheet.md
+++ b/changelog.d/1420-settings-sheet.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Demo Settings sheet no longer dismisses itself instantly ([#1420](https://github.com/sceneview/sceneview/issues/1420)).** The `DemoSettingsLayer` bottom sheet treated its initial `SheetValue.Hidden` state as a dismissal, slamming the panel shut before it could animate open — making the Settings controls dead in every demo. `Hidden` is now only honoured as a dismiss once the sheet has actually settled in a shown detent.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -431,14 +431,27 @@ private fun BoxScope.DemoSettingsLayer(
         }
 
         // Medium-tick haptic when the user moves between detents.
+        //
+        // `rememberModalBottomSheetState` starts at `SheetValue.Hidden`, so this
+        // effect fires once with `Hidden` *before* the sheet has animated open.
+        // Treating that initial value as a dismiss would slam `expanded = false`
+        // and kill the sheet on every demo (#1420). Only honour `Hidden` as a
+        // dismiss after the sheet has actually settled in a shown detent at
+        // least once — the actual outside-tap / back-gesture dismiss is already
+        // handled by `onDismissRequest`, this branch just keeps `expanded` in
+        // sync if the sheet collapses by any other path.
+        var hasShown by remember { mutableStateOf(false) }
         LaunchedEffect(sheetState.currentValue) {
             when (sheetState.currentValue) {
                 SheetValue.Expanded,
                 SheetValue.PartiallyExpanded -> {
+                    hasShown = true
                     haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                 }
                 SheetValue.Hidden -> {
-                    expanded = false
+                    if (hasShown) {
+                        expanded = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes the highest-impact bug in the demo app: the Settings bottom-sheet (`DemoSettingsLayer` in `DemoScaffold.kt`) dismissed itself instantly in all ~30 demos, leaving every demo's controls dead.
- Root cause: `rememberModalBottomSheetState` starts at `SheetValue.Hidden`, so `LaunchedEffect(sheetState.currentValue)` fired once with `Hidden` and hit the `Hidden -> expanded = false` branch before the sheet could animate open.
- Fix: track a `hasShown` flag set when the sheet settles in a shown detent (`Expanded`/`PartiallyExpanded`), and only honour `Hidden` as a dismiss after that. The genuine outside-tap / back-gesture dismiss is still driven by `onDismissRequest`.

Closes #1420

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: open the Settings sheet on several demos (3D + AR) and confirm it animates open and stays open, and that outside-tap / back still dismiss it

🤖 Generated with [Claude Code](https://claude.com/claude-code)