### PR TITLE
fix(android-demo): Light Types demo renders an empty black scene

### DIFF
--- a/changelog.d/1421-light-types.md
+++ b/changelog.d/1421-light-types.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Light Types demo no longer renders an empty black scene ([#1421](https://github.com/sceneview/sceneview/issues/1421)).** The demo composes a helmet, an off-centre backdrop wall, and a light-source marker; `autoCenterContent` centred the union of all three, shifting the helmet far off the hero camera's fixed orbit pivot. The demo now passes `autoCenterContent = false` so each node keeps its authored position and the camera frames the lit helmet as intended.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
@@ -198,6 +198,14 @@ fun LightingDemo(onBack: () -> Unit) {
                 // is always somewhat visible (neutral_ibl.ktx), and the user's LightNode
                 // adds its directional / point / spot contribution on top.
                 mainLightNode = null,
+                // This demo intentionally composes three nodes off-centre: the helmet at
+                // origin, a 3 × 2.4 m backdrop wall behind it, and a light-source marker
+                // up-and-forward. With the default autoCenterContent the union bounding
+                // box of those three is centred — which shifts the helmet far off the
+                // HeroOrbit camera's fixed (0,0,0) pivot, leaving the viewport black
+                // (#1421). Disable it so each node keeps its authored world position and
+                // the camera orbits the helmet exactly as intended.
+                autoCenterContent = false,
                 cameraManipulator = cameraManipulator,
             ) {
                 modelInstance?.let { instance ->


### PR DESCRIPTION
## Summary

The **Light Types** demo (Lighting & Environment section of `samples/android-demo`) showed a fully black viewport — no model, no lights — while sibling demos rendered fine.

**Root cause:** Light Types is the only `HeroOrbitCameraManipulator` demo that composes more than one node. Besides the helmet at origin it adds a 3 × 2.4 m backdrop wall (offset back at z=-1.3) and a light-source marker sphere (up-and-forward at y=1.4, z=1.0). `SceneView`'s default `autoCenterContent = true` centres the *union bounding box* of all three nodes — which translates the content root so the helmet lands far off the camera's fixed `(0,0,0)` orbit pivot, pushing it out of frame.

Sibling demos (Materials, Fog, Environment, ReflectionProbes, PostProcessing, ModelViewer, SceneGallery) only ever add a single centred `ModelNode`, so `autoCenterContent` agrees with the orbit pivot for them — which is why only Light Types broke.

**Fix:** the demo opts out with `autoCenterContent = false` — the documented escape hatch for "scenes with intentional off-centre composition". Each node keeps its authored world position and the hero camera orbits the helmet exactly as the demo's code comments describe.

Closes #1421

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] On-device QA: open Light Types demo, confirm a lit helmet renders against the backdrop and the directional/point/spot chips visibly change the lighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)