### PR TITLE
fix(samples): Scene Gallery chips render distinct models (#1433)

### DIFF
--- a/changelog.d/1433-scene-gallery.md
+++ b/changelog.d/1433-scene-gallery.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Scene Gallery demo no longer appears stuck in a loop ([#1433](https://github.com/sceneview/sceneview/issues/1433)).** The four gallery chips carried unverified placeholder Sketchfab uids, so every chip fell back to a bundled model — and two chips ("Reading Lamp" + "Wooden Chair") shared the *same* fallback GLB, making the chips look inert. Each gallery entry now points at a distinct bundled model with an honest label, so switching chips visibly changes the rendered model.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
@@ -116,33 +116,41 @@ object SampleAssets {
         ),
 
         // ── Gallery (SceneGalleryDemo) ─────────────────────────────────────
-        // 4 themed bundles. Stage 2 will fan out to ~10 via Sketchfab search.
+        // 4 variety-pack bundles. The Sketchfab uids below are still Stage 1
+        // placeholders (`GET /v3/models/<uid>` returns 404), so until a Stage 2
+        // PR verifies real downloadable uids the resolver always serves the
+        // `fallbackBundledPath`. Each gallery chip MUST therefore point at a
+        // *distinct* bundled GLB — otherwise two chips render the identical
+        // model and the demo reads as "stuck in a loop / chips do nothing"
+        // (#1433). `displayName` / `author` describe the bundled fallback that
+        // actually renders so the chip label, the credits byline and the
+        // on-screen model stay honest and consistent offline.
         SketchfabSlug(
             uid = "92f1d1eea16d422d8593f1e8c3e0ee37",
-            displayName = "Vintage Cassette",
-            author = "Stefano-Tax",
+            displayName = "Toy Car",
+            author = "Khronos Group",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
             fallbackBundledPath = "models/khronos_toy_car.glb",
             scaleToUnits = 0.12f,
             hasBakedAnimation = false,
             category = "gallery",
-            tags = listOf("retro", "audio"),
+            tags = listOf("retro", "vehicle"),
         ),
         SketchfabSlug(
             uid = "5cf2d5dd1a40451595dcc0fef5dcb6a8",
-            displayName = "Polly the Parrot",
-            author = "lambertcommercial",
+            displayName = "Low-Poly Fox",
+            author = "Khronos Group",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
             fallbackBundledPath = "models/khronos_fox.glb",
             scaleToUnits = 0.40f,
             hasBakedAnimation = false,
             category = "gallery",
-            tags = listOf("animal", "bird"),
+            tags = listOf("animal", "low-poly"),
         ),
         SketchfabSlug(
             uid = "61bd9ee5e30946fab26d3f8e7ef9da4f",
             displayName = "Reading Lamp",
-            author = "ArtIntellect",
+            author = "Khronos Group",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
             fallbackBundledPath = "models/khronos_lantern.glb",
             scaleToUnits = 0.45f,
@@ -152,14 +160,14 @@ object SampleAssets {
         ),
         SketchfabSlug(
             uid = "ac4e6b6f6e7a4f9da4e62fadcf9eaece",
-            displayName = "Wooden Chair",
-            author = "EvgenyRodygin",
+            displayName = "Damaged Helmet",
+            author = "Khronos Group",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
-            fallbackBundledPath = "models/khronos_lantern.glb",
+            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
             scaleToUnits = 0.85f,
             hasBakedAnimation = false,
             category = "gallery",
-            tags = listOf("furniture"),
+            tags = listOf("hard-surface", "pbr"),
         ),
 
         // ── Animation (AnimationDemo) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1433 — the **Scene Gallery** demo (`samples/android-demo`) appeared "stuck in a loop" with an unclear purpose during the 2026-05-16 on-device QA session.

**Root cause.** `SceneGalleryDemo` shows four chips. Each resolves through `SketchfabAssetResolver`, but the four `gallery` slugs in `SampleAssets.kt` still carry **unverified Stage 1 placeholder Sketchfab uids** (the file's own header says so). `GET /v3/models/<placeholder-uid>/download` always returns 404, so the resolver falls back to the bundled GLB for every chip — both with and without a `SKETCHFAB_API_KEY`. Two of the four chips ("Reading Lamp" + "Wooden Chair") shared the **same** `khronos_lantern.glb` fallback, so tapping different chips rendered the identical model. With the hero camera orbiting forever and the chips appearing inert, the demo read as a loop with no clear point.

**Fix.** Each `gallery` slug now points at a **distinct** bundled GLB (`khronos_toy_car.glb`, `khronos_fox.glb`, `khronos_lantern.glb`, `khronos_damaged_helmet.glb`), and `displayName`/`author` honestly describe the bundled fallback that actually renders offline. Switching chips now visibly changes the model and the demo reaches a clear, usable state. The streamed-when-keyed path is unchanged; uids are untouched so a Stage 2 PR can still swap in verified uids later.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — passes
- [x] `:samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.sketchfab.*"` — `SampleAssetsTest` + `SketchfabAssetResolverTest` green (CC-BY/author/scale/uid invariants still hold)
- [ ] On-device: open Scene Gallery, tap each of the 4 chips, confirm 4 different models render

🤖 Generated with [Claude Code](https://claude.com/claude-code)