### PR TITLE
fix(android-demo): keep Custom Mesh auto-rotate continuous (#1431)

### DIFF
--- a/changelog.d/1431-auto-rotate.md
+++ b/changelog.d/1431-auto-rotate.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Custom Mesh auto-rotate no longer stops on a stray tap ([#1431](https://github.com/sceneview/sceneview/issues/1431)).** The "Auto-Rotate" molecule demo silently paused its spin the first time the viewport was touched, so it looked like the rotation stopped on its own. Rotation is now continuous and controlled solely by the explicit Auto-Rotate switch.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomMeshDemo.kt
@@ -33,7 +33,6 @@ import io.github.sceneview.math.Rotation
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
-import io.github.sceneview.rememberOnGestureListener
 import io.github.sceneview.sample.rememberMaterialInstance
 
 /**
@@ -56,9 +55,12 @@ fun CustomMeshDemo(onBack: () -> Unit) {
     val sphereMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Primary)
     val bondMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Accent)
 
-    // Hero yaw auto-pauses on first camera gesture so orbit/pinch don't fight the spin.
-    // Triggered by the user's Auto-Rotate switch.
-    val (rotationY, onHeroGesture) = rememberPausableHeroYaw(
+    // The molecule spins on its own node, independently of the camera, so it's driven
+    // purely by the explicit Auto-Rotate switch — toggling off freezes it at the current
+    // pose, toggling on resumes from there. We deliberately do NOT auto-pause on a stray
+    // camera gesture: the spin and the orbit don't fight (different transforms), and a
+    // silent pause-on-tap made the demo look like it "stopped on its own" (#1431).
+    val (rotationY, _) = rememberPausableHeroYaw(
         trigger = rotating, durationMillis = 8_000, staticYaw = 0f,
     )
 
@@ -102,11 +104,6 @@ fun CustomMeshDemo(onBack: () -> Unit) {
             cameraManipulator = rememberCameraManipulator(
                 orbitHomePosition = Position(0f, 0.1f, 2f),
                 targetPosition = Position(0f, 0f, 0f),
-            ),
-            onGestureListener = rememberOnGestureListener(
-                onSingleTapUp = { _, _ -> onHeroGesture() },
-                onDoubleTap = { _, _ -> onHeroGesture() },
-                onScroll = { _, _, _, _ -> onHeroGesture() },
             ),
         ) {
             // Molecule-like structure: center atom + 4 outer atoms connected by bonds.


### PR DESCRIPTION
Clean re-roll of the #1431 fix — the original PR #1447 got cross-contaminated with other commits during a worktree-isolation glitch in the QA wave; this PR contains only the #1431 fix, cherry-picked onto a fresh branch off `main`.

Fixes the Auto-Rotate / Custom Mesh demo stopping its spin on the first viewport touch: the demo wired `onUserGesture` (which permanently sets `paused = true`) into tap/scroll listeners, so any tap froze the rotation silently. The molecule rotates its own node independently of the camera manipulator, so a camera gesture had no reason to kill the spin. Rotation is now driven solely by the explicit "Auto-Rotate" switch.

Closes #1431

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>