### PR TITLE
fix(samples): edge-to-edge insets — Samples header gap + clipped update banner

### DIFF
--- a/changelog.d/1425-edge-to-edge.md
+++ b/changelog.d/1425-edge-to-edge.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Edge-to-edge insets in the Android demo ([#1425](https://github.com/sceneview/sceneview/issues/1425)).** Removed the large empty gap above the "Samples" tab header — the nested `LargeTopAppBar` no longer double-counts the status-bar inset already applied by the root `Scaffold`. The in-app "Update ready / Restart" banner is now z-ordered above every screen and inset below the status bar, so it is no longer clipped behind a demo's top app bar.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -95,6 +96,13 @@ fun DemoListScreen(
                     }
                 },
                 scrollBehavior = scrollBehavior,
+                // This Scaffold is nested inside RootScreen's Scaffold, which
+                // already consumes the status-bar inset as top content padding.
+                // Letting LargeTopAppBar apply its default status-bar inset too
+                // double-counts it — that was the large empty gap above the
+                // "Samples" header (#1425). Zero the bar's own insets so the
+                // header sits flush below the status bar.
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.largeTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                     scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -102,6 +110,9 @@ fun DemoListScreen(
                 ),
             )
         },
+        // The inherited status-bar inset arrives via the outer RootScreen
+        // Scaffold; consuming it again here would re-introduce the #1425 gap.
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     ) { padding ->
         LazyVerticalGrid(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -67,7 +67,10 @@ import io.github.sceneview.demo.ui.RootScreen
 import io.github.sceneview.sample.common.update.InAppUpdateManager
 import io.github.sceneview.sample.common.update.UpdateBanner
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
@@ -179,13 +182,6 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun SceneViewDemoApp(activity: MainActivity? = null) {
     val navController = rememberNavController()
-    // Compose the update banner above the NavHost so a downloaded-and-ready Play
-    // update is visible from any screen (#890). The banner is a no-op when state
-    // is IDLE / CHECKING / UP_TO_DATE — it only renders during DOWNLOADING /
-    // READY_TO_INSTALL so it doesn't take screen real estate from demos.
-    activity?.updateManager?.let { mgr ->
-        UpdateBanner(updateManager = mgr)
-    }
 
     // Watch for deep-link intents. On a non-null id we either navigate
     // directly (the demo list is the start destination, so navigate adds
@@ -210,32 +206,53 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
         activity?.consumePendingDemo()
     }
 
-    NavHost(
-        navController = navController,
-        startDestination = if (initialDemo != null) "demo/$initialDemo" else "list",
-        enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
-        exitTransition = { slideOutHorizontally(targetOffsetX = { -it / 4 }) + fadeOut() },
-        popEnterTransition = { slideInHorizontally(initialOffsetX = { -it / 4 }) + fadeIn() },
-        popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() }
-    ) {
-        composable("list") {
-            // New 4-tab root (Explore / AR View / Samples / About). The legacy
-            // category-grouped DemoListScreen lives untouched inside the
-            // "Samples" tab so existing deep-link flows (`adb am start ... --es
-            // demo <id>`) and the in-app update banner remain wired up.
-            RootScreen(onDemoClick = { id -> navController.navigate("demo/$id") })
+    // Wrap the NavHost and the in-app update banner in an explicit Box so the
+    // banner is z-ordered ON TOP of every screen (#1425). Previously the banner
+    // and the NavHost were sibling root composables — the demo screens' own
+    // TopAppBar then drew over the banner, clipping the "Update ready / Restart"
+    // chrome. Drawing the banner last in the Box guarantees it stays visible.
+    Box(modifier = Modifier.fillMaxSize()) {
+        NavHost(
+            navController = navController,
+            startDestination = if (initialDemo != null) "demo/$initialDemo" else "list",
+            enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
+            exitTransition = { slideOutHorizontally(targetOffsetX = { -it / 4 }) + fadeOut() },
+            popEnterTransition = { slideInHorizontally(initialOffsetX = { -it / 4 }) + fadeIn() },
+            popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() }
+        ) {
+            composable("list") {
+                // New 4-tab root (Explore / AR View / Samples / About). The legacy
+                // category-grouped DemoListScreen lives untouched inside the
+                // "Samples" tab so existing deep-link flows (`adb am start ... --es
+                // demo <id>`) and the in-app update banner remain wired up.
+                RootScreen(onDemoClick = { id -> navController.navigate("demo/$id") })
+            }
+            composable("demo/{id}") { backStackEntry ->
+                val id = backStackEntry.arguments?.getString("id") ?: return@composable
+                val onBack: () -> Unit = { navController.popBackStack() }
+                DemoRouter(id = id, onBack = onBack)
+            }
+            // Note: the legacy `composable("about") { AboutScreen(...) }` route was
+            // removed (alongside `AboutScreen.kt`) because RootScreen's bottom-tab
+            // `RootTab.About → AboutTabContent()` is the only About surface — no
+            // caller ever navigated to "about". Deletion verified via grep:
+            // 0 `navigate("about")` calls anywhere. The @Ignore'd ScreenshotTest
+            // for AboutScreen stays disabled per its own comment.
         }
-        composable("demo/{id}") { backStackEntry ->
-            val id = backStackEntry.arguments?.getString("id") ?: return@composable
-            val onBack: () -> Unit = { navController.popBackStack() }
-            DemoRouter(id = id, onBack = onBack)
+
+        // The update banner is a no-op when state is IDLE / CHECKING /
+        // UP_TO_DATE — it only renders during DOWNLOADING / READY_TO_INSTALL so
+        // it doesn't take screen real estate from demos (#890). The status-bar
+        // inset keeps it clear of the system bar so the banner is never clipped
+        // behind the status bar or a demo's top app bar (#1425).
+        activity?.updateManager?.let { mgr ->
+            UpdateBanner(
+                updateManager = mgr,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .windowInsetsPadding(WindowInsets.statusBars),
+            )
         }
-        // Note: the legacy `composable("about") { AboutScreen(...) }` route was
-        // removed (alongside `AboutScreen.kt`) because RootScreen's bottom-tab
-        // `RootTab.About → AboutTabContent()` is the only About surface — no
-        // caller ever navigated to "about". Deletion verified via grep:
-        // 0 `navigate("about")` calls anywhere. The @Ignore'd ScreenshotTest
-        // for AboutScreen stays disabled per its own comment.
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the two edge-to-edge inset bugs reported in #1425 (2026-05-16 on-device QA pass).

- **Empty gap above the "Samples" header.** `DemoListScreen` nests a `Scaffold` + `LargeTopAppBar` inside `RootScreen`'s `Scaffold`, which already consumes the status-bar inset as top content padding. `LargeTopAppBar` then re-applied its own status-bar inset → the inset was counted twice, pushing the header far down. Fix: zero the nested `Scaffold`'s `contentWindowInsets` and the `LargeTopAppBar`'s `windowInsets` so the header sits flush below the status bar. Explore / AR View tabs are unaffected — they still receive the outer Scaffold's top inset.
- **Update banner clipped behind the top app bar.** `UpdateBanner` was a root sibling of the `NavHost` with no layout container, so a demo screen's `TopAppBar` drew over it, clipping the "Update ready / Restart" chrome. Fix: wrap `NavHost` + banner in an explicit `Box` with the banner drawn last (top z-order) and `windowInsetsPadding(statusBars)` so it clears the system bar.

Closes #1425

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: Samples tab header sits flush below the status bar (no gap)
- [ ] On-device: trigger an in-app update — banner renders fully above any demo's top app bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)