### PR TITLE
fix(sceneview): re-tune default camera distance + gesture sensitivity

### DIFF
--- a/changelog.d/1427-camera-feel.md
+++ b/changelog.d/1427-camera-feel.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Camera feel re-tuned across 3D model demos ([#1427](https://github.com/sceneview/sceneview/issues/1427)).** The default camera now sits further back (`DefaultCameraNode` Z `2.0` → `2.75`, Y `0.3` → `0.4`) so origin-placed models are no longer framed too tight. Orbit/pan sensitivity is reduced (`orbitSpeed` `0.005` → `0.003`) so finger drag tracks the model more calmly, and pinch-zoom is made more responsive (`DEFAULT_PINCH_ZOOM_SPEED` `1/30` → `1/18`) so zooming no longer feels sluggish.

--- a/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneFactories.kt
@@ -229,13 +229,15 @@ fun createCollisionSystem(view: View) = CollisionSystem(view)
 class DefaultCameraNode(engine: Engine) : CameraNode(engine) {
     init {
         // 3/4 view: slightly elevated and pulled back so a typical 0.3–1 m model placed
-        // at the world origin is fully framed and centered (#1080). The previous
-        // `(0, 0, 1)` placement sat the camera 1 m dead-ahead of origin — too close for
-        // anything but a tiny object and, with no Y elevation, produced a flat,
-        // under-framed front-on view. `(0, DEFAULT_Y, DEFAULT_Z)` + `lookAt(origin)`
-        // mirrors iOS RealityKit's `look(at: .zero, from: [0, 0.3, 2])` default
-        // (`SceneViewSwift/.../SceneView.swift`) so the same scene frames identically
-        // on both platforms. Pinned in `SceneFactoriesTest.defaultCameraNodePositionIsPinned()`.
+        // at the world origin is fully framed and centered (#1080, re-tuned in #1427).
+        // The original `(0, 0, 1)` placement sat the camera 1 m dead-ahead of origin —
+        // too close for anything but a tiny object and, with no Y elevation, produced a
+        // flat, under-framed front-on view. The #1080 `(0, 0.3, 2)` placement was still
+        // "beaucoup trop zoomé" in the 2026-05-16 on-device QA, so #1427 pulls the camera
+        // further back to `(0, DEFAULT_Y, DEFAULT_Z)` + `lookAt(origin)` for more headroom.
+        // iOS RealityKit still uses `[0, 0.3, 2]` (`SceneViewSwift/.../SceneView.swift`) —
+        // a matching iOS bump is tracked alongside the auto-framing work (#1439). Pinned
+        // in `SceneFactoriesTest.defaultCameraNodePositionIsPinned()`.
         position = Position(0.0f, DEFAULT_Y, DEFAULT_Z)
         lookAt(Position(0.0f, 0.0f, 0.0f))
         // Neutral, less photographic exposure.
@@ -252,15 +254,18 @@ class DefaultCameraNode(engine: Engine) : CameraNode(engine) {
     companion object {
         /**
          * Default camera Y elevation. Small positive lift gives a natural 3/4 angle
-         * looking slightly down on origin-placed content. Matches iOS `[0, 0.3, 2]`.
+         * looking slightly down on origin-placed content. Re-tuned in #1427 from `0.3`
+         * to keep the 3/4 angle proportional to the larger [DEFAULT_Z] dolly-back.
          */
-        const val DEFAULT_Y = 0.3f
+        const val DEFAULT_Y = 0.4f
 
         /**
          * Default camera Z distance from origin. Pulls the camera back far enough to
-         * frame a typical 0.3–1 m model. Matches iOS `[0, 0.3, 2]`.
+         * frame a typical 0.3–1 m model with comfortable headroom. Re-tuned in #1427
+         * from `2.0` — the pre-#1427 value framed origin-placed models too tight
+         * ("beaucoup trop zoomé", 2026-05-16 on-device QA).
          */
-        const val DEFAULT_Z = 2.0f
+        const val DEFAULT_Z = 2.75f
 
         /** Aperture (f-stop). AR mirrors via `ARDefaultCameraNode.DEFAULT_APERTURE`. */
         const val DEFAULT_APERTURE = 12.0f

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
@@ -67,10 +67,11 @@ open class CameraGestureDetector(
      *                           a sensible default ORBIT-mode manipulator.
      * @param pinchZoomSpeed     Per-pixel zoom multiplier applied to the inter-finger separation
      *                           delta during a pinch gesture. Lower values = smoother zoom. The
-     *                           default `1/30` (≈ 0.033) was tuned in v4.0.x after Pixel 9 review
-     *                           feedback that the previous `1/10` value felt too abrupt and made
-     *                           the camera lurch through the target during fast pinches. Set to a
-     *                           higher value (e.g. `1/5`) to restore the legacy fast-zoom feel.
+     *                           default `1/18` (≈ 0.056) was re-tuned in #1427: the v4.0.x `1/30`
+     *                           value felt too sluggish on-device ("hyper lent"), while the
+     *                           pre-v4.0.x `1/10` lurched the camera through the target during
+     *                           fast pinches. `1/18` sits between the two. Set to a higher value
+     *                           (e.g. `1/5`) to restore the legacy fast-zoom feel.
      * @param pinchZoomDamping   Non-linear damping exponent applied to the zoom delta. Values < 1
      *                           soften large pinches without sacrificing small-pinch precision
      *                           (sqrt-style curve). The default `0.7` is a gentle knee; set to
@@ -94,7 +95,10 @@ open class CameraGestureDetector(
                     orbitHomePosition?.let { orbitHomePosition(it) }
                     targetPosition?.let { targetPosition(it) }
                 }
-                .orbitSpeed(0.005f, 0.005f)
+                // Re-tuned in #1427: orbit/pan felt "beaucoup trop vite" on-device
+                // (2026-05-16 Pixel 9 QA). 0.005 → 0.003 makes finger drag track the
+                // model more calmly without feeling sluggish.
+                .orbitSpeed(0.003f, 0.003f)
                 .zoomSpeed(0.05f)
                 .build(Manipulator.Mode.ORBIT),
             pinchZoomSpeed,
@@ -143,10 +147,13 @@ open class CameraGestureDetector(
 
         companion object {
             /**
-             * Default per-pixel zoom multiplier. Tuned in v4.0.x — was `1/10` previously, which
-             * felt too abrupt on dense screens. See [pinchZoomSpeed] kdoc for tuning advice.
+             * Default per-pixel zoom multiplier. Tuned in v4.0.x from `1/10` down to `1/30`
+             * (felt too abrupt on dense screens), then re-tuned in #1427 from `1/30` up to
+             * `1/18` — the `1/30` value made pinch-zoom feel "hyper lent" in the 2026-05-16
+             * on-device QA. `1/18` restores a responsive pinch while staying well short of
+             * the abrupt legacy `1/10`. See [pinchZoomSpeed] kdoc for tuning advice.
              */
-            const val DEFAULT_PINCH_ZOOM_SPEED: Float = 1f / 30f
+            const val DEFAULT_PINCH_ZOOM_SPEED: Float = 1f / 18f
 
             /**
              * Default damping exponent for pinch deltas. Sub-1 values create a sqrt-like response

--- a/sceneview/src/test/java/io/github/sceneview/SceneFactoriesTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/SceneFactoriesTest.kt
@@ -49,19 +49,21 @@ class SceneFactoriesTest {
 
     @Test
     fun defaultCameraNodePositionIsPinned() {
-        // Pin #1080 — DefaultCameraNode 3/4-view default placement. `(0, 0.3, 2)` frames a
-        // typical 0.3–1 m origin-placed model and mirrors iOS RealityKit's
-        // `look(at: .zero, from: [0, 0.3, 2])`. The pre-#1080 `(0, 0, 1)` placement was too
-        // close and flat. Changing these is a BREAKING visual + cross-platform-parity change.
+        // Pin #1080 / re-tuned #1427 — DefaultCameraNode 3/4-view default placement.
+        // #1080 set `(0, 0.3, 2)`; the 2026-05-16 on-device QA found it still framed
+        // origin-placed models too tight, so #1427 pulled the camera back to
+        // `(0, 0.4, 2.75)`. iOS RealityKit still uses `[0, 0.3, 2]` — a matching iOS
+        // bump is tracked alongside the auto-framing work (#1439). Changing these is a
+        // BREAKING visual change.
         assertEquals(
-            "DefaultCameraNode.DEFAULT_Y must stay 0.3 — matches iOS [0, 0.3, 2] (#1080).",
-            0.3f,
+            "DefaultCameraNode.DEFAULT_Y must stay 0.4 — re-tuned in #1427.",
+            0.4f,
             DefaultCameraNode.DEFAULT_Y,
             0.0f,
         )
         assertEquals(
-            "DefaultCameraNode.DEFAULT_Z must stay 2.0 — matches iOS [0, 0.3, 2] (#1080).",
-            2.0f,
+            "DefaultCameraNode.DEFAULT_Z must stay 2.75 — re-tuned in #1427.",
+            2.75f,
             DefaultCameraNode.DEFAULT_Z,
             0.0f,
         )

--- a/sceneview/src/test/java/io/github/sceneview/gesture/CameraGestureMathTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/gesture/CameraGestureMathTest.kt
@@ -50,7 +50,8 @@ class CameraGestureMathTest {
     }
 
     @Test fun pinchZoomDelta_defaultConstants_haveExpectedValues() {
-        assertEquals(1f / 30f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED, 1e-6f)
+        // DEFAULT_PINCH_ZOOM_SPEED re-tuned in #1427: 1/30 → 1/18 (pinch felt "hyper lent").
+        assertEquals(1f / 18f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED, 1e-6f)
         assertEquals(0.7f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_DAMPING, 1e-6f)
     }
 


### PR DESCRIPTION
## Summary

On-device QA (2026-05-16, Pixel 9) gave consistent feedback across every model demo: the default camera is too zoomed-in, orbit/pan is too fast, and pinch-zoom is too slow. This re-tunes the camera-feel constants.

- **Default camera pulled back** — `DefaultCameraNode` Z `2.0` → `2.75`, Y `0.3` → `0.4`, so origin-placed models are framed with comfortable headroom instead of "beaucoup trop zoomé".
- **Orbit/pan calmer** — `DefaultCameraManipulator` `orbitSpeed` `0.005` → `0.003` so finger drag tracks the model less frantically.
- **Pinch-zoom more responsive** — `DEFAULT_PINCH_ZOOM_SPEED` `1/30` → `1/18` (still well short of the abrupt legacy `1/10`), fixing the "hyper lent" zoom.

Scope is gesture-feel + default distance only. Model-bounds auto-framing is tracked separately (#1439), as is the matching iOS camera bump. Pinned-value tests (`SceneFactoriesTest`, `CameraGestureMathTest`) updated to match.

## Test plan

- [x] `./gradlew :sceneview:compileReleaseKotlin` passes
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [x] `./gradlew :sceneview:test` passes (updated pinned tests)
- [ ] On-device re-check of camera feel across model demos

Closes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)