### PR TITLE
fix(android-demo): Physics demo simulation never runs + ground plane off-center

### DIFF
--- a/changelog.d/1463-physics-demo.md
+++ b/changelog.d/1463-physics-demo.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- Physics demo: the rigid-body simulation now actually runs — the `SphereNode` composable no longer re-pushes `position`/`rotation`/`scale` to the node on every recomposition, which was clobbering the per-frame position written by `PhysicsBody` (the same fix already applied to the bare `Node` composable). Spheres now drop, bounce, and settle as intended ([#1463](https://github.com/sceneview/sceneview/issues/1463)).
+- Physics demo: re-framed the camera so the grey ground plane is vertically centred in the viewport instead of being shoved into the bottom third with its near edge clipped.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PhysicsDemo.kt
@@ -115,10 +115,14 @@ fun PhysicsDemo(onBack: () -> Unit) {
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
-    // Camera slightly above scene, angled down so the floor + falling bodies are both framed.
+    // Camera above and back from the scene, angled down. The look-at target sits between
+    // the floor (y = -0.5) and the spheres' rest height (y ≈ -0.42) rather than the scene
+    // origin, so the 1.6 m ground plane is vertically centred in the viewport instead of
+    // being shoved into the bottom third with its near edge clipped (#1463). Pulled back to
+    // z = 4 so the full plane depth fits with headroom for the drop column above it.
     val cameraNode = rememberCameraNode(engine) {
-        position = Position(0f, 1.5f, 3f)
-        lookAt(Position(0f, 0f, 0f))
+        position = Position(0f, 2f, 4f)
+        lookAt(Position(0f, -0.35f, 0f))
     }
 
     val firstFrame = rememberFirstFrameState()

--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -533,9 +533,24 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 node.setMaterialInstanceAt(0, materialInstance)
                 prevSphereMaterial.value = materialInstance
             }
-            node.position = position
-            node.rotation = rotation
-            node.scale = scale
+        }
+        // Push declarative transform props ONLY when they actually change — never on every
+        // recomposition. A bare `SideEffect { node.position = position }` re-runs after each
+        // successful recomposition and clobbers any position a frame-loop driver
+        // (PhysicsBody, animations, camera follow) wrote via `node.onFrame` in between, so
+        // PhysicsDemo spheres never appeared to move. Component-wise keys (not the Float3
+        // wrapper — `dev.romainguy.kotlin.math.Float3` uses reference equality, so a freshly
+        // allocated `Position(x = …)` always `!=` the previous instance) let
+        // `DisposableEffect` stay idle while a frame driver owns the node. Mirrors the fix
+        // already applied to the bare `Node` composable above.
+        DisposableEffect(node, position.x, position.y, position.z) {
+            node.position = position; onDispose {}
+        }
+        DisposableEffect(node, rotation.x, rotation.y, rotation.z) {
+            node.rotation = rotation; onDispose {}
+        }
+        DisposableEffect(node, scale.x, scale.y, scale.z) {
+            node.scale = scale; onDispose {}
         }
         NodeLifecycle(node, content)
     }


### PR DESCRIPTION
## Summary

Fixes #1463. In the Physics demo of `samples/android-demo`, the spheres stayed perfectly static and the grey ground plane was shoved into the bottom third of the viewport with its near edge clipped.

- **Simulation never ran** — `SceneScope.SphereNode` re-pushed `position`/`rotation`/`scale` to the underlying node on every recomposition through a bare `SideEffect`, clobbering the per-frame position written by `PhysicsBody` via `node.onFrame`. This is the exact failure mode already documented and fixed for the bare `Node` composable — `SphereNode` was simply left behind. Transform props now go through component-keyed `DisposableEffect`s, so a frame-loop driver can own the node without being fought.
- **Bad framing** — the demo camera now looks near the floor (`y = -0.35`) instead of the scene origin and is pulled back to `z = 4`, so the 1.6 m ground plane is vertically centred with headroom for the falling drop column.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin :sceneview:compileReleaseKotlin` — passes
- [x] `./gradlew :sceneview:test` — passes
- [ ] On-device: open Advanced -> Physics, confirm spheres drop/bounce/settle and the ground plane is centred

Closes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)