### PR TITLE
fix(android-demo): stand the helmet upright in AR placement demos (#1477)

### DIFF
--- a/changelog.d/1475-helmet-orientation.md
+++ b/changelog.d/1475-helmet-orientation.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **AR placement demos no longer drop the helmet face-down ([#1477](https://github.com/sceneview/sceneview/issues/1477)).** The bundled Khronos *DamagedHelmet* GLB ships a residual +90° X root rotation from its Blender export, which landed it nose-into-the-floor when placed under an ARCore plane anchor. The Cloud Anchor, Tap to Place, and Depth Occlusion demos now apply a shared `-90°` X correcting rotation at placement time so the helmet stands upright, visor forward. Other bundled cycle models are unaffected.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
@@ -39,6 +39,7 @@ import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.CloudAnchorNode as CloudAnchorNodeImpl
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
@@ -263,7 +264,11 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
                             ModelNode(
                                 modelInstance = instance,
                                 scaleToUnits = 0.3f,
-                                centerOrigin = Position(0f, 0f, 0f)
+                                centerOrigin = Position(0f, 0f, 0f),
+                                // The bundled DamagedHelmet GLB carries a residual +90° X
+                                // root rotation that lands it face-down on the plane —
+                                // correct it at placement time. See #1477.
+                                rotation = DemoMath.placementRotationFor(DemoMath.HELMET_ASSET)
                             )
                         }
                     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
@@ -42,6 +42,7 @@ import io.github.sceneview.ar.createARCameraStream
 import io.github.sceneview.ar.rememberARCameraStream
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.math.Position
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
@@ -269,7 +270,11 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
                                 ModelNode(
                                     modelInstance = instance,
                                     scaleToUnits = 0.3f,
-                                    centerOrigin = Position(0.0f, 0.0f, 0.0f)
+                                    centerOrigin = Position(0.0f, 0.0f, 0.0f),
+                                    // The bundled DamagedHelmet GLB carries a residual +90° X
+                                    // root rotation that lands it face-down on the plane —
+                                    // correct it at placement time. See #1477.
+                                    rotation = DemoMath.placementRotationFor(DemoMath.HELMET_ASSET)
                                 )
                             }
                         }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -44,6 +44,7 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.demo.AssetSourceState
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.demo.sketchfab.SketchfabConfig
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.sketchfab.SampleAssets
@@ -346,6 +347,11 @@ fun ARPlacementDemo(onBack: () -> Unit) {
                                     modelInstance = it,
                                     scaleToUnits = 0.3f,
                                     centerOrigin = Position(0.0f, 0.0f, 0.0f),
+                                    // The bundled DamagedHelmet GLB carries a residual +90° X
+                                    // root rotation that lands it face-down on the plane.
+                                    // Keyed to the placed asset path so only the helmet is
+                                    // corrected; the other cycle models stay upright. See #1477.
+                                    rotation = DemoMath.placementRotationFor(placed.assetLocation),
                                     isEditable = true
                                 )
                             }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
@@ -1,5 +1,6 @@
 package io.github.sceneview.demo.demos.internal
 
+import io.github.sceneview.math.Rotation
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -48,6 +49,37 @@ internal object DemoMath {
     }
 
     private fun Float.wrapTo360(): Float = ((this % 360f) + 360f) % 360f
+
+    /**
+     * Asset path of the bundled Khronos *DamagedHelmet* GLB. The helmet is the hero
+     * model for the AR placement demos (Cloud Anchor, Tap to Place, Depth Occlusion).
+     */
+    const val HELMET_ASSET = "models/khronos_damaged_helmet.glb"
+
+    /**
+     * Default placement rotation to apply to a bundled model the moment it is dropped
+     * onto an AR plane. See [#1477](https://github.com/sceneview/sceneview/issues/1477).
+     *
+     * The Khronos *DamagedHelmet* GLB ships with a root-node quaternion of
+     * `(0.7071, 0, 0, 0.7071)` — a +90° rotation about X — left over from its
+     * Blender Z-up export. When the model is placed under an ARCore plane
+     * `AnchorNode` (whose local frame is already Y-up), that residual pitch lands
+     * the helmet **face-down**, nose into the floor, with the gold exhaust nozzle
+     * pointing at the ceiling.
+     *
+     * Rather than re-author the shared bundled asset — several non-AR demos also
+     * load it and frame it correctly in their own way — every AR placement demo
+     * applies this single correcting rotation at placement time so the helmet
+     * stands upright, visor forward. All other bundled cycle models (fox, lantern,
+     * toy car, shiba) are authored upright and get the identity rotation.
+     *
+     * @param assetPath The bundled asset path passed to `rememberModelInstance`.
+     * @return The local Euler rotation (degrees) to pass to `ModelNode(rotation = …)`.
+     */
+    fun placementRotationFor(assetPath: String): Rotation = when (assetPath) {
+        HELMET_ASSET -> Rotation(x = -90f)
+        else -> Rotation(x = 0f)
+    }
 
     /**
      * Tabletop-display rotation used by [io.github.sceneview.demo.demos.MultiModelDemo].

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
@@ -169,4 +169,42 @@ class DemoMathTest {
         assertEquals(pos.first, neg.first, eps)
         assertEquals(-pos.second, neg.second, eps)
     }
+
+    // ── placementRotationFor (#1477) ────────────────────────────────────────
+
+    @Test
+    fun `placementRotationFor corrects the bundled helmet by minus 90 degrees X`() {
+        // The DamagedHelmet GLB ships a residual +90° X root rotation that lands it
+        // face-down on an AR plane — the placement demos undo it with -90° X.
+        val rotation = DemoMath.placementRotationFor(DemoMath.HELMET_ASSET)
+        assertEquals(-90f, rotation.x, eps)
+        assertEquals(0f, rotation.y, eps)
+        assertEquals(0f, rotation.z, eps)
+    }
+
+    @Test
+    fun `placementRotationFor returns identity for other bundled models`() {
+        // Fox, lantern, toy car, shiba are authored upright — no correction.
+        for (path in listOf(
+            "models/khronos_fox.glb",
+            "models/khronos_lantern.glb",
+            "models/khronos_toy_car.glb",
+            "models/shiba.glb",
+        )) {
+            val rotation = DemoMath.placementRotationFor(path)
+            assertEquals("$path x", 0f, rotation.x, eps)
+            assertEquals("$path y", 0f, rotation.y, eps)
+            assertEquals("$path z", 0f, rotation.z, eps)
+        }
+    }
+
+    @Test
+    fun `placementRotationFor returns identity for streamed file URIs`() {
+        // ARPlacementDemo can place streamed Sketchfab models whose assetLocation is a
+        // `file://` URI — those must never be hit by the helmet-specific correction.
+        val rotation = DemoMath.placementRotationFor("file:///data/user/0/app/cache/streamed.glb")
+        assertEquals(0f, rotation.x, eps)
+        assertEquals(0f, rotation.y, eps)
+        assertEquals(0f, rotation.z, eps)
+    }
 }


### PR DESCRIPTION
## Summary
- The bundled Khronos *DamagedHelmet* GLB ships a residual `+90°` X root rotation (quaternion `(0.7071, 0, 0, 0.7071)`) left over from its Blender Z-up export. Placed under an ARCore plane `AnchorNode` (already Y-up), that residual pitch landed the helmet **face-down** — nose into the floor, gold exhaust nozzle up — in the Cloud Anchor, Tap to Place, and Depth Occlusion demos.
- Adds a shared `DemoMath.placementRotationFor(assetPath)` helper returning a `-90°` X correcting rotation for the helmet and identity for every other bundled model, wired into all three affected demos at placement time.
- `ARPlacementDemo` keys the lookup on the placed asset path so its other cycle models (fox, lantern, toy car, shiba) and streamed Sketchfab `file://` URIs stay upright. The shared bundled asset is left untouched.

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [x] `./gradlew :samples:android-demo:testDebugUnitTest --tests DemoMathTest` passes (3 new tests for `placementRotationFor`)
- [ ] On-device: helmet stands upright, visor forward, in Cloud Anchor / Tap to Place / Depth Occlusion

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)