### PR TITLE
fix(ci): Play Store listing-sync is best-effort, never blocks a deploy (#1386)

### DIFF
--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -461,6 +461,15 @@ jobs:
     needs: [build, publish]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Best-effort: the listing-text sync is NOT a release gate. The AAB
+    # rollout (build + publish) is the release; this job only refreshes the
+    # store-listing copy. `continue-on-error: true` means a failure here
+    # (notably a 403 Forbidden on `edits:commit` when the deploy service
+    # account lacks the Play Console 'Edit store listing' permission —
+    # tracked in #1386) is TOLERATED and must never mark a green deploy red.
+    # The real fix is granting that permission in the Play Console, which is
+    # a separate manual maintainer task.
+    continue-on-error: true
     # Match `vX.Y.0` exactly — drops `4.0.0-rc.1` (pre-release), `4.3.1`
     # (patch), AND `4.3.10` (would slip past a naive `endsWith('.0')`
     # check). The gate is computed via bash regex on `VERSION_NAME` in
@@ -549,9 +558,30 @@ jobs:
               r = sess.post(f"{BASE}/edits/{edit_id}:commit")
               r.raise_for_status()
               print(f"[listing] commit OK")
-          except Exception:
+          except requests.HTTPError as e:
               # Best-effort rollback — abandon the edit so we don't leave a
               # dangling Edit ID in Play Console.
+              try:
+                  sess.delete(f"{BASE}/edits/{edit_id}")
+              except Exception:
+                  pass
+              status = e.response.status_code if e.response is not None else None
+              if status == 403:
+                  # The deploy service account lacks the Play Console
+                  # 'Edit store listing' permission (#1386). The app deploy
+                  # already succeeded — a listing-sync 403 is best-effort and
+                  # must not fail the release. Warn and exit cleanly; the
+                  # job is also `continue-on-error: true` as a safety net.
+                  print(
+                      "::warning::Play Store listing sync got 403 Forbidden — "
+                      "the deploy service account lacks the 'Edit store "
+                      "listing' permission. Listing copy NOT updated; the app "
+                      "deploy is unaffected. Grant the permission in the Play "
+                      "Console to enable listing sync (see #1386)."
+                  )
+                  sys.exit(0)
+              raise
+          except Exception:
               try:
                   sess.delete(f"{BASE}/edits/{edit_id}")
               except Exception:

--- a/changelog.d/1386-listing-sync-nonblocking.md
+++ b/changelog.d/1386-listing-sync-nonblocking.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Play Store listing sync no longer marks a successful deploy red ([#1386](https://github.com/sceneview/sceneview/issues/1386)).** The `Sync Play Store listing (en-US)` job in `play-store.yml` is now `continue-on-error: true` and swallows a `403 Forbidden` (missing 'Edit store listing' permission) with a warning. The AAB build/publish jobs stay strict, so the listing-text sync is best-effort and can never block a release.


### PR DESCRIPTION
## Summary
The `Sync Play Store listing (en-US)` job in `play-store.yml` fails with `403 Forbidden` on the Android Publisher `edits:commit` endpoint because the deploy service account lacks the Play Console **'Edit store listing'** permission. The actual app deploy (`Build release AAB` + `Publish to production` + `Publish to internal`) succeeds — but the listing-sync 403 marked every `Deploy Demo to Play Store` run RED despite a clean deploy (recurred on the v4.7.0 release).

This PR fixes the **CI-noise half** of #1386:

- `sync-listing` job is now `continue-on-error: true` — its failure can never fail the workflow. The strict AAB build/publish jobs are untouched.
- The listing script catches a `403 HTTPError`, rolls back the Edit, emits a `::warning::`, and exits 0 — clear logs instead of a stack trace.
- Added a YAML comment documenting the best-effort rationale and the #1386 link.

## Note for the maintainer
The **permission grant is a separate manual Play Console task** (not code): grant the deploy service account the 'Edit store listing' permission, or drop the listing-sync job if CI-managed listings aren't wanted. Until then, this PR ensures a 403 there is tolerated and never blocks a release.

## Test plan
- [x] `yaml.safe_load` parses `play-store.yml`
- [x] `actionlint` — no new findings (pre-existing shellcheck infos only, in unrelated steps)
- [x] Strict app-deploy jobs (`build`, `publish`) unchanged
- [x] `impact-check.sh` passes

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)