### PR TITLE
fix(sceneview): VideoNode.destroy() teardown ordering — drain frame pipeline before freeing external texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`VideoNode.destroy()` no longer risks a native SIGABRT ([#1497](https://github.com/sceneview/sceneview/issues/1497)).** `destroy()` freed the external `Texture`/`Stream` immediately after destroying the `MaterialInstance` that referenced them — the exact ordering that triggers Filament's `Invalid texture still bound to MaterialInstance` abort, since MaterialInstance reclamation is coupled to the render loop rather than to the `destroy()` call site. Teardown now drains the frame pipeline (`Engine.drainFramePipeline()`) between destroying the MaterialInstance and freeing the external texture/stream, mirroring the safe pattern documented on the sibling `ImageNode`. Adds `VideoNodeTest` pinning the teardown ordering.
+
 ## v4.7.0 — Bridge expansion, slimmer APK & demo-app polish (2026-05-16)
 
 ### Added

--- a/sceneview/src/androidTest/java/io/github/sceneview/node/VideoNodeTest.kt
+++ b/sceneview/src/androidTest/java/io/github/sceneview/node/VideoNodeTest.kt
@@ -1,0 +1,121 @@
+package io.github.sceneview.node
+
+import android.media.MediaPlayer
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.filament.Filament
+import com.google.android.filament.gltfio.Gltfio
+import com.google.android.filament.utils.Utils
+import io.github.sceneview.createEglContext
+import io.github.sceneview.createEngine
+import io.github.sceneview.loaders.MaterialLoader
+import io.github.sceneview.safeDestroy
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression coverage for #1497.
+ *
+ * Before the fix, [VideoNode.destroy] destroyed the [com.google.android.filament.MaterialInstance]
+ * and then immediately freed the external [com.google.android.filament.Texture] / [Stream] — the
+ * exact ordering that triggers a native SIGABRT
+ * (`Invalid texture still bound to MaterialInstance`), because MaterialInstance reclamation is
+ * coupled to the render loop, not to the `destroy()` call site.
+ *
+ * The fix drains the frame pipeline between destroying the MaterialInstance and freeing the
+ * external texture/stream, so the MI is fully reclaimed first. These tests pin that ordering by
+ * exercising the real teardown path against a live Filament [com.google.android.filament.Engine].
+ */
+@RunWith(AndroidJUnit4::class)
+class VideoNodeTest {
+
+    private lateinit var engine: com.google.android.filament.Engine
+    private lateinit var materialLoader: MaterialLoader
+
+    @Before
+    fun setup() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            Gltfio.init(); Filament.init(); Utils.init()
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val eglContext = createEglContext()
+            engine = createEngine(eglContext)
+            materialLoader = MaterialLoader(engine, context)
+        }
+    }
+
+    @After
+    fun teardown() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            materialLoader.destroy()
+            engine.safeDestroy()
+        }
+    }
+
+    /**
+     * A freshly created [VideoNode] must tear down without a native SIGABRT — i.e. the external
+     * texture must not be freed while its MaterialInstance is still GPU-bound.
+     */
+    @Test
+    fun destroy_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val player = MediaPlayer()
+            val node = VideoNode(materialLoader = materialLoader, player = player)
+            node.destroy() // must not SIGABRT
+            player.release()
+        }
+    }
+
+    /**
+     * Rapid add/destroy churn must stay crash-free and leave no MaterialInstance tracked by
+     * [MaterialLoader] — otherwise the `materialLoader.destroy()` in teardown would double-free.
+     */
+    @Test
+    fun destroy_rapidCycle_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val player = MediaPlayer()
+            repeat(20) {
+                val node = VideoNode(materialLoader = materialLoader, player = player)
+                node.destroy()
+            }
+            player.release()
+        }
+    }
+
+    /**
+     * A node created with an explicit fixed [io.github.sceneview.math.Size] must also destroy
+     * cleanly (the auto-size code path is skipped, but teardown ordering is identical).
+     */
+    @Test
+    fun destroy_withExplicitSize_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val player = MediaPlayer()
+            val node = VideoNode(
+                materialLoader = materialLoader,
+                player = player,
+                size = io.github.sceneview.math.Size(0.5f, 0.5f)
+            )
+            node.destroy()
+            player.release()
+        }
+    }
+
+    /**
+     * A node configured with a chroma-key colour (a distinct material variant) must destroy
+     * cleanly — exercising the green-screen MaterialInstance path through the same teardown.
+     */
+    @Test
+    fun destroy_withChromaKey_doesNotCrash() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val player = MediaPlayer()
+            val node = VideoNode(
+                materialLoader = materialLoader,
+                player = player,
+                chromaKeyColor = 0xFF00FF00.toInt()
+            )
+            node.destroy()
+            player.release()
+        }
+    }
+}

--- a/sceneview/src/main/java/io/github/sceneview/node/VideoNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/VideoNode.kt
@@ -8,6 +8,7 @@ import com.google.android.filament.RenderableManager
 import com.google.android.filament.Stream
 import com.google.android.filament.Texture
 import dev.romainguy.kotlin.math.normalize
+import io.github.sceneview.drainFramePipeline
 import io.github.sceneview.geometries.Plane
 import io.github.sceneview.loaders.MaterialLoader
 import io.github.sceneview.math.Direction
@@ -139,12 +140,34 @@ open class VideoNode(
         this.player = player
     }
 
+    /**
+     * Tears the node down in an order that is safe for Filament's external-stream pipeline.
+     *
+     * The [texture] is an external [Texture] bound to [materialInstance]; destroying it while
+     * the MaterialInstance is still GPU-bound triggers a native SIGABRT
+     * (`Invalid texture still bound to MaterialInstance`) — MaterialInstance reclamation is
+     * coupled to the render loop, not to this call (see the sibling [ImageNode] for the same
+     * hazard). Unlike [ImageNode], a [VideoNode] also owns native [Stream]/[SurfaceTexture]
+     * resources that must be released, so the texture cannot simply be leaked.
+     *
+     * The sequence below therefore:
+     * 1. destroys the [MaterialInstance] first (un-references the texture),
+     * 2. calls [Engine.drainFramePipeline] so any in-flight frame still holding the
+     *    MaterialInstance is flushed and the MI is actually reclaimed,
+     * 3. only then destroys the external [Texture] and [Stream].
+     *
+     * Must run on the main thread — all Filament JNI calls do.
+     */
     override fun destroy() {
         val mi = materialInstance
         super.destroy()
         player.setOnVideoSizeChangedListener(null)
         surface.release()
         materialLoader.destroyMaterialInstance(mi)
+        // Flush the render pipeline so the just-destroyed MaterialInstance is reclaimed before
+        // its external texture is freed — otherwise Filament SIGABRTs ("Invalid texture still
+        // bound to MaterialInstance"). See KDoc above.
+        materialLoader.engine.drainFramePipeline()
         materialLoader.engine.safeDestroyTexture(texture)
         materialLoader.engine.safeDestroyStream(stream)
         surfaceTexture.release()


### PR DESCRIPTION
## Summary

`VideoNode.destroy()` (`sceneview/src/main/java/io/github/sceneview/node/VideoNode.kt`) destroyed the `MaterialInstance` and then *immediately* freed the external `Texture` / `Stream` that it referenced. This is the exact ordering the sibling `ImageNode` KDoc warns triggers a native **SIGABRT** (`Invalid texture still bound to MaterialInstance`) — Filament's MaterialInstance reclamation is coupled to the render loop, not to the `destroy()` call site.

## Fix

- Teardown now calls `Engine.drainFramePipeline()` between destroying the `MaterialInstance` and freeing the external `Texture`/`Stream`, so any in-flight frame still holding the MI is flushed and the MI is reclaimed *first*.
- Unlike `ImageNode` (which deliberately leaks its texture because it owns no `Stream`), `VideoNode` owns native `Stream`/`SurfaceTexture` resources that **must** be released — so draining the pipeline, rather than leaking, is the safe equivalent of `ImageNode`'s documented pattern.
- KDoc on `destroy()` documents the hazard and the ordering, cross-referencing `ImageNode`.
- No public API change; all Filament JNI stays on the main thread.

## Test plan

- [x] `:sceneview:compileReleaseKotlin` passes
- [x] `:sceneview:testDebugUnitTest` passes
- [x] `:sceneview:compileDebugAndroidTestKotlin` passes (new `VideoNodeTest`)
- [ ] New `VideoNodeTest` (androidTest, modeled on `ImageNodeTest`) pins teardown ordering against a live Filament Engine — fresh node, rapid add/destroy cycle, explicit size, and chroma-key variant all must destroy without SIGABRT

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)