### PR TITLE
fix(android-demo): reconcile Scene Gallery asset-source status

### DIFF
--- a/changelog.d/1465-gallery-status.md
+++ b/changelog.d/1465-gallery-status.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Scene Gallery demo no longer shows contradictory status labels: the top-right asset-source chip now stays "Streaming…" until the model is fully loaded, matching the centre loading overlay, instead of flipping to "Streamed (cached)" the moment the file path resolves (#1465).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
@@ -113,12 +113,16 @@ fun SceneGalleryDemo(onBack: () -> Unit) {
 
     // Per-demo offline indicator chip (#1152 Stage 3). When no API key is
     // configured we know up-front the resolver will fall back to bundled
-    // GLBs; while a slug is selected and `resolvedPath` is still null we
-    // surface a "Streaming…" pill; otherwise "Streamed (cached)".
+    // GLBs; otherwise the chip mirrors the centre LoadingScrim exactly so the
+    // two never contradict each other (#1465): it stays "Streaming…" until the
+    // model is fully parsed into a `ModelInstance` — not merely while the file
+    // path resolves — and only then flips to "Streamed (cached)". Gating on
+    // `modelInstance` (the same signal the LoadingScrim uses) keeps the chip
+    // and the spinner in lockstep.
     val assetSource = when {
         slugs.isEmpty() -> null
         SketchfabConfig.apiKey == null -> AssetSourceState.Bundled
-        resolvedPath == null -> AssetSourceState.Streaming
+        modelInstance == null -> AssetSourceState.Streaming
         else -> AssetSourceState.Streamed
     }
 


### PR DESCRIPTION
## Summary
- Scene Gallery demo showed two mutually-exclusive states at once: the top-right `AssetSourceState` chip read 'Streamed (cached)' while the centre `LoadingScrim` overlay still read 'Streaming model…'.
- Root cause: the chip was gated on `resolvedPath` (true as soon as the file path resolves on disk), but the overlay is gated on `modelInstance` (true only after the GLB is fully parsed into a `ModelInstance`). The window between the two produced the contradiction.
- Fix: gate the chip on `modelInstance` — the same signal the `LoadingScrim` uses — so the chip stays 'Streaming…' until the model is fully loaded and both indicators stay in lockstep.

Closes #1465

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: open Scene Gallery, observe chip and overlay never contradict during model load

🤖 Generated with [Claude Code](https://claude.com/claude-code)