### PR TITLE
fix(android-demo): re-scale Light Types backdrop wall so the helmet is centered

### DIFF
--- a/changelog.d/1466-lighttypes-plane.md
+++ b/changelog.d/1466-lighttypes-plane.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Light Types demo:** re-scaled the backdrop wall from 3 × 2.4 m down to 1.6 × 1.2 m and re-centred it on the helmet. The oversized quad previously filled ~⅔ of the viewport with a hard diagonal top edge, cramming the model into the lower-left corner (#1466).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingDemo.kt
@@ -199,7 +199,7 @@ fun LightingDemo(onBack: () -> Unit) {
                 // adds its directional / point / spot contribution on top.
                 mainLightNode = null,
                 // This demo intentionally composes three nodes off-centre: the helmet at
-                // origin, a 3 × 2.4 m backdrop wall behind it, and a light-source marker
+                // origin, a backdrop wall behind it, and a light-source marker
                 // up-and-forward. With the default autoCenterContent the union bounding
                 // box of those three is centred — which shifts the helmet far off the
                 // HeroOrbit camera's fixed (0,0,0) pivot, leaving the viewport black
@@ -215,15 +215,18 @@ fun LightingDemo(onBack: () -> Unit) {
                     )
                 }
 
-                // Backdrop wall — see [backdropMaterial] for the rationale. Sized 3 ×
-                // 2.4 m so the helmet appears against a continuous surface from any
-                // orbit angle the hero camera reaches; offset back so it never clips
-                // into the model.
+                // Backdrop wall — see [backdropMaterial] for the rationale. Sized
+                // 1.6 × 1.2 m: large enough to fill the backdrop behind the
+                // 0.5 m helmet from every hero-orbit angle, small enough that it
+                // never crams the helmet into a corner (#1466 — the old 3 × 2.4 m
+                // quad filled ~⅔ of the viewport with a hard diagonal top edge).
+                // Centred on the helmet (y = 0) and pushed back so it never clips
+                // into the model while staying inside the orbit radius.
                 PlaneNode(
                     materialInstance = backdropMaterial,
-                    size = Float3(3f, 2.4f, 0f),
+                    size = Float3(1.6f, 1.2f, 0f),
                     normal = Direction(z = 1f),
-                    position = Position(0f, 0.4f, -1.3f),
+                    position = Position(0f, 0f, -0.9f),
                 )
 
                 // Tiny ball at the light source position — only for Point/Spot since
@@ -253,7 +256,7 @@ fun LightingDemo(onBack: () -> Unit) {
                 apply = {
                     // Spot: very narrow cone (≈11° outer) so the disc on the wall
                     // reads as a sharp circle, not a wide wash. Falloff 4 m keeps
-                    // the cone visible against the 1.3 m-deep wall.
+                    // the cone visible all the way to the backdrop wall.
                     // Point: aggressive 2 m falloff so the wall shows the radial
                     // gradient (helmet front bright, wall corners dark).
                     if (selectedType.type == LightManager.Type.FOCUSED_SPOT) {


### PR DESCRIPTION
## Summary
- The **Light Types** demo (`LightingDemo`) backdrop wall was sized 3 × 2.4 m — far too large for the 0.5 m helmet orbited by the hero camera at radius 2.0. From most orbit angles the oversized quad filled ~⅔ of the viewport with a hard diagonal top edge, cramming the helmet into the lower-left corner.
- Shrink the wall to 1.6 × 1.2 m, re-centre it on the helmet (y = 0), and pull it forward to z = -0.9 so it reads as a proportional backdrop while keeping the helmet centered and well-framed.
- Builds on the merged #1421 `autoCenterContent = false` fix; stale wall-size/depth comments updated.

Closes #1466

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: open Light Types demo, confirm helmet is centered and the backdrop reads as a proportional wall across the full hero-orbit (Directional / Point / Spot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)