### PR TITLE
fix(android-demo): re-frame Text Nodes demo so top label is not clipped

### DIFF
--- a/changelog.d/1470-text-clip.md
+++ b/changelog.d/1470-text-clip.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Text Nodes demo: pulled the camera back so the top "Hello SceneView" label is no longer clipped at the top viewport edge in the default framing.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/TextDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/TextDemo.kt
@@ -67,16 +67,18 @@ fun TextDemo(onBack: () -> Unit) {
             materialLoader = materialLoader,
             onFrame = firstFrame.onFrame,
             // Dolly the camera closer — 3 stacked 0.18 m-tall labels at the origin read
-            // cramped at the default z = 4. z = 1.2 fills the portrait viewport.
+            // cramped at the default z = 4. z = 1.5 fills the portrait viewport while
+            // keeping enough vertical room for the top label (#1470: z = 1.2 framed the
+            // top 'Hello SceneView' card past the top viewport edge at rest).
             cameraManipulator = rememberCameraManipulator(
-                orbitHomePosition = Position(0f, 0f, 1.2f),
+                orbitHomePosition = Position(0f, 0f, 1.5f),
                 targetPosition = Position(0f, 0f, 0f),
             ),
         ) {
             // Three labels stacked vertically at x=0 so all three fit inside the default
             // camera framing on a phone portrait viewport. y=±0.22 keeps the top and
-            // bottom labels fully inside the viewport (y=±0.32 still cropped the top
-            // label on the portrait FOV).
+            // bottom labels' card edges (y reaching ±0.31 with the 0.18 m height) fully
+            // inside the viewport at the pulled-back z = 1.5 framing — see #1470.
             //
             // Each label's quad material is marked double-sided: TextNode does not face
             // the camera on its own (no cameraPositionProvider is wired here), so when


### PR DESCRIPTION
## Summary
- The Text Nodes demo (`samples/android-demo`) framed the camera at `z = 1.2`, placing the top "Hello SceneView" label's card past the top viewport edge on a phone portrait FOV before any user gesture.
- Dolly the camera back to `z = 1.5` so all three stacked labels (y = +0.22 / 0 / -0.22, each 0.18 m tall) are fully visible at rest.

Focused change: `orbitHomePosition` z only; label layout unchanged.

Closes #1470

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] Visual: open the Text Nodes demo, confirm the top label card is fully inside the viewport at rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)