### PR TITLE
fix(android-demo): inset AR Record REC pill below system bars

### DIFF
--- a/changelog.d/1474-rec-pill.md
+++ b/changelog.d/1474-rec-pill.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- AR Record & Playback demo: the "REC" elapsed-time pill is now inset below the system bars so it no longer overlaps the status bar / notch / camera cutout.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -548,13 +551,15 @@ private fun RecordOverlay(
     onStop: () -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
-        // Elapsed-time pill, top-center, only while recording.
+        // Elapsed-time pill, top-center, only while recording. Inset below the
+        // system bars so it never overlaps the status bar / notch / camera cutout.
         AnimatedVisibility(
             visible = recorder.state == ARRecorder.State.RECORDING,
             enter = fadeIn(),
             exit = fadeOut(),
             modifier = Modifier
                 .align(Alignment.TopCenter)
+                .windowInsetsPadding(WindowInsets.systemBars)
                 .padding(top = 8.dp)
         ) {
             Surface(


### PR DESCRIPTION
## Summary
- The red "REC 00:02" elapsed-time pill in the AR Record & Playback demo rendered flush against the top of the viewport, partially overlapping the system status bar / notch / camera cutout.
- Added `windowInsetsPadding(WindowInsets.systemBars)` to the pill's `AnimatedVisibility` modifier so it is inset below the safe area (the existing `padding(top = 8.dp)` is preserved on top).

Closes #1474

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: start a recording, confirm the REC pill sits below the status bar / notch

🤖 Generated with [Claude Code](https://claude.com/claude-code)