### PR TITLE
fix(android-demo): camera-init scrim on AR demos instead of black viewport (#1473)

### DIFF
--- a/changelog.d/1473-ar-camera-init.md
+++ b/changelog.d/1473-ar-camera-init.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Android demo: AR demos (Record & Playback, Terrain Anchors) now show a "Starting camera…" spinner overlay while ARCore initializes the camera, instead of a bare black viewport that read as a frozen/broken screen. The overlay clears on the first delivered AR frame.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -69,6 +69,68 @@ fun LoadingScrim(loading: Boolean, label: String = "Loading…") {
 }
 
 /**
+ * Camera-initialising scrim for AR demos.
+ *
+ * An [io.github.sceneview.ar.ARSceneView] paints its surface jet-black until ARCore
+ * opens the camera and delivers the first frame — on a cold start that can take
+ * several seconds. With no overlay the viewport reads as a frozen or crashed screen
+ * (#1473). [ARCameraInitScrim] covers the viewport with a centred spinner and a
+ * "Starting camera…" label until [initializing] flips to false, at which point
+ * Compose drops the Box from the tree and the live camera feed shows through.
+ *
+ * Drive [initializing] off the demo's first `onSessionUpdated` callback — the first
+ * invocation means ARCore has delivered a camera frame:
+ *
+ * ```kotlin
+ * var cameraReady by remember { mutableStateOf(false) }
+ * Box(Modifier.fillMaxSize()) {
+ *     ARSceneView(
+ *         onSessionUpdated = { _, _ -> cameraReady = true /* … */ },
+ *         …
+ *     ) { … }
+ *     ARCameraInitScrim(initializing = !cameraReady)
+ * }
+ * ```
+ *
+ * Place it as the last child of the [Box] that wraps the `ARSceneView` so it draws
+ * on top of the still-black viewport but below any other status overlays.
+ */
+@Composable
+fun ARCameraInitScrim(
+    initializing: Boolean,
+    label: String = "Starting camera…",
+) {
+    if (!initializing) return
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.92f))
+                .padding(horizontal = 28.dp, vertical = 22.dp),
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(44.dp),
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = 4.dp,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
  * First-frame signal for the [DemoScaffold] loading scrim.
  *
  * Cold-starting a SceneView demo leaves the viewport jet-black for 5–12 s while

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
@@ -59,6 +59,7 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.recording.ARRecorder
 import io.github.sceneview.ar.recording.rememberARRecorder
+import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.math.Position
@@ -395,6 +396,11 @@ private fun ModeContent(
     var latestFrame by remember { mutableStateOf<Frame?>(null) }
     var isTracking by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
+    // Flipped true on the first onSessionUpdated — i.e. once ARCore has opened the
+    // camera (or started replaying the dataset) and delivered a frame. Until then the
+    // ARSceneView surface is bare black, so we cover it with ARCameraInitScrim rather
+    // than leave a viewport that reads as frozen/broken (#1473).
+    var cameraReady by remember { mutableStateOf(false) }
 
     val recorder = rememberARRecorder()
     // The file we passed to recorder.start() — kept so we can hand it back to the
@@ -453,6 +459,7 @@ private fun ModeContent(
             config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
         },
         onSessionUpdated = { session: Session, frame: Frame ->
+            cameraReady = true
             latestFrame = frame
             isTracking = frame.camera.trackingState == TrackingState.TRACKING
             // Stateless side-channel pattern (#876) — recordFrame publishes the
@@ -537,6 +544,14 @@ private fun ModeContent(
     if (!isTracking) {
         TrackingFailureBanner(reason = trackingFailureReason)
     }
+
+    // Cover the still-black ARSceneView surface until ARCore delivers its first frame —
+    // either the live camera feed, or the first replayed frame in PLAYBACK mode — so the
+    // entry doesn't read as a frozen screen with a dimmed record button (#1473).
+    ARCameraInitScrim(
+        initializing = !cameraReady,
+        label = if (mode == Mode.PLAYBACK) "Starting playback…" else "Starting camera…",
+    )
 }
 
 @Composable

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARTerrainAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARTerrainAnchorDemo.kt
@@ -40,6 +40,7 @@ import com.google.ar.core.TrackingState
 import dev.romainguy.kotlin.math.Quaternion
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.TerrainAnchorNode
+import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.math.Position
@@ -148,6 +149,10 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
     }
 
     var arSession by remember { mutableStateOf<Session?>(null) }
+    // Flipped true on the first onSessionUpdated — i.e. once ARCore has opened the
+    // camera and delivered a frame. Until then the ARSceneView surface is bare black,
+    // so we cover it with ARCameraInitScrim instead of leaving a frozen-looking screen.
+    var cameraReady by remember { mutableStateOf(false) }
     var isTracking by remember { mutableStateOf(false) }
     var earthTracking by remember { mutableStateOf(false) }
     // Tracked alongside `earthTracking` because `Earth.resolveAnchorOnTerrainAsync`
@@ -343,6 +348,7 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
                     sessionError = exception.message ?: exception.javaClass.simpleName
                 },
                 onSessionUpdated = { session: Session, frame: Frame ->
+                    cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
                     val earth = session.earth
                     earthTracking = earth?.trackingState == TrackingState.TRACKING
@@ -404,6 +410,10 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
                     )
                     .padding(horizontal = 20.dp, vertical = 10.dp)
             )
+
+            // Cover the still-black ARSceneView surface until ARCore delivers its
+            // first camera frame, so the entry doesn't read as a frozen screen (#1473).
+            ARCameraInitScrim(initializing = !cameraReady && sessionError == null)
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1473.

Several AR demos showed a fully black viewport for several seconds on entry while ARCore opened the camera, with no progress feedback — reading as a frozen/broken screen. **Record & Playback** showed a black screen + dimmed record button; **Terrain Anchors** stayed black behind a static "Initializing camera…" banner.

- Add a shared `ARCameraInitScrim` composable to `DemoHelpers.kt` — an opaque black scrim with a centred spinner and a "Starting camera…" label.
- Drive it off the first `onSessionUpdated` callback (the first delivered AR frame). Until then the `ARSceneView` surface is bare black; once a frame arrives the scrim is dropped and the live camera feed shows through.
- Applied to **Terrain Anchors** (`ARTerrainAnchorDemo`) and **Record & Playback** (`ARRecordPlaybackDemo`). In playback mode the label reads "Starting playback…". The scrim does not hide an explicit session-error state.

Focused change — demo app only, no `arsceneview` library changes.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: enter Record & Playback — spinner shows, clears on first camera frame
- [ ] On-device: enter Terrain Anchors — spinner shows, clears on first camera frame
- [ ] Playback mode shows "Starting playback…" then clears on first replayed frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)