### PR TITLE
fix(arsceneview): AR Face Mesh never tracked — front camera was never selected

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
@@ -907,6 +907,47 @@ fun highestResolutionCameraConfig(session: Session): CameraConfig =
         }
     }.getOrNull() ?: session.cameraConfig
 
+/**
+ * Picks a FRONT-facing [CameraConfig] for the [session].
+ *
+ * **Required for Augmented Faces.** Passing `Session.Feature.FRONT_CAMERA` to the ARCore
+ * [Session] constructor only makes the front camera *eligible* — it does NOT switch the camera.
+ * ARCore keeps the session on its default BACK config until [Session.setCameraConfig] is called
+ * with a config whose [CameraConfig.getFacingDirection] is
+ * [FRONT][CameraConfig.FacingDirection.FRONT]. [ARSceneView]'s default `sessionCameraConfig` is
+ * [highestResolutionCameraConfig], which is **BACK-facing** — so an Augmented Faces scene that
+ * only sets `sessionFeatures = setOf(Session.Feature.FRONT_CAMERA)` ends up running the back
+ * camera, `AugmentedFaceMode.MESH3D` produces no trackables, and no face mesh ever appears.
+ *
+ * Pass this helper as `sessionCameraConfig` whenever the session enables the front camera:
+ *
+ * ```kotlin
+ * ARSceneView(
+ *     sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
+ *     sessionCameraConfig = ::frontCameraConfig,
+ *     sessionConfiguration = { _, config ->
+ *         config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
+ *     },
+ * )
+ * ```
+ *
+ * Falls back to the session's current [CameraConfig][Session.getCameraConfig] when ARCore
+ * exposes no FRONT-facing config (e.g. a device without a front camera) or when
+ * [Session.getSupportedCameraConfigs] throws — the call must never crash session creation.
+ *
+ * @param session The ARCore [Session] being configured. Must have been created with
+ *                [Session.Feature.FRONT_CAMERA] for a FRONT config to be available.
+ * @return The chosen FRONT-facing [CameraConfig]; never throws.
+ */
+fun frontCameraConfig(session: Session): CameraConfig =
+    runCatching {
+        val filter = CameraConfigFilter(session)
+            .setFacingDirection(CameraConfig.FacingDirection.FRONT)
+        session.getSupportedCameraConfigs(filter).maxByOrNull {
+            it.imageSize.width.toLong() * it.imageSize.height.toLong()
+        }
+    }.getOrNull() ?: session.cameraConfig
+
 // ── Remember helpers ──────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
@@ -389,9 +389,15 @@ class ARSceneScope internal constructor(
      * [AugmentedFace] tracking is active. Requires the session to be configured with
      * `AugmentedFaceMode.MESH3D` and the front camera.
      *
+     * **Both `sessionFeatures` and `sessionCameraConfig` must be set.** `FRONT_CAMERA` only
+     * makes the front camera eligible; the session stays on the default BACK camera until
+     * `sessionCameraConfig = ::frontCameraConfig` actually selects a FRONT-facing config —
+     * without it `AugmentedFaceMode.MESH3D` yields no trackables and no mesh ever appears.
+     *
      * ```kotlin
      * ARSceneView(
      *     sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
+     *     sessionCameraConfig = ::frontCameraConfig,
      *     sessionConfiguration = { _, config ->
      *         config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
      *     },

--- a/changelog.d/1436-ar-features.md
+++ b/changelog.d/1436-ar-features.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- AR Face Mesh demo: the face mesh now actually tracks. `Session.Feature.FRONT_CAMERA` only makes the front camera *eligible* — the session stayed on the default BACK camera config, so `AugmentedFaceMode.MESH3D` produced zero trackables and no mesh ever appeared. The demo now passes `sessionCameraConfig = ::frontCameraConfig` so ARCore opens the selfie camera. Added a public `frontCameraConfig(session)` helper in `arsceneview` for any Augmented Faces consumer (#1436).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -1949,6 +1949,10 @@ fun ARFaceTracking() {
 
     ARSceneView(
         sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
+        // REQUIRED: FRONT_CAMERA alone only makes the front camera eligible — the session
+        // stays on the default BACK camera until sessionCameraConfig selects a FRONT config.
+        // Without ::frontCameraConfig, AugmentedFaceMode.MESH3D yields no faces and no mesh.
+        sessionCameraConfig = ::frontCameraConfig,
         sessionConfiguration = { _, config ->
             config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
         },

--- a/llms.txt
+++ b/llms.txt
@@ -1949,6 +1949,10 @@ fun ARFaceTracking() {
 
     ARSceneView(
         sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
+        // REQUIRED: FRONT_CAMERA alone only makes the front camera eligible — the session
+        // stays on the default BACK camera until sessionCameraConfig selects a FRONT config.
+        // Without ::frontCameraConfig, AugmentedFaceMode.MESH3D yields no faces and no mesh.
+        sessionCameraConfig = ::frontCameraConfig,
         sessionConfiguration = { _, config ->
             config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
         },

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
@@ -25,6 +25,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
+import io.github.sceneview.ar.frontCameraConfig
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
@@ -40,6 +41,11 @@ import io.github.sceneview.sample.rememberUnlitMaterialInstance
  * detect face meshes. When a face is detected, an [AugmentedFaceNode] renders a translucent
  * unlit-blue mesh overlay on the user's face — alpha 0.4 so the user's actual facial features
  * remain visible underneath the fitted topology.
+ *
+ * Augmented Faces needs **two** session settings, not one: `sessionFeatures` must include
+ * [Session.Feature.FRONT_CAMERA] *and* `sessionCameraConfig` must select a FRONT-facing
+ * [com.google.ar.core.CameraConfig] via `::frontCameraConfig`. The feature flag alone leaves
+ * the session on the default BACK camera and the mesh never tracks (#1436).
  *
  * Requires a device with a front-facing camera and ARCore face mesh support.
  */
@@ -81,6 +87,15 @@ fun ARFaceDemo(onBack: () -> Unit) {
                 materialLoader = materialLoader,
                 planeRenderer = false,
                 sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
+                // CRITICAL for Augmented Faces (#1436). `sessionFeatures = FRONT_CAMERA`
+                // only makes the front camera *eligible* — it does NOT switch the camera.
+                // ARSceneView's default `sessionCameraConfig` is `highestResolutionCameraConfig`,
+                // which is hardwired to `FacingDirection.BACK`. So without this override the
+                // session runs the BACK camera, `AugmentedFaceMode.MESH3D` yields zero
+                // trackables, and the face mesh never appears — exactly the "j'ai jamais vu
+                // marcher ça" symptom. `frontCameraConfig` selects a FRONT-facing CameraConfig
+                // so ARCore actually opens the selfie camera and the face mesh can track.
+                sessionCameraConfig = ::frontCameraConfig,
                 // No `cameraExposure` override — issue #1179. The previous
                 // `cameraExposure = -1.5f` rendered the entire scene fully black on
                 // Pixel 9 v4.3.0 production.


### PR DESCRIPTION
## Summary

Investigation of the #1436 umbrella (Face Mesh / Cloud Anchor / Streetscape). One confirmed code-level root cause, fixed here.

- **Face Mesh bug:** `Session.Feature.FRONT_CAMERA` only makes the front camera *eligible* — ARCore keeps the session on its default `CameraConfig` until `setCameraConfig()` is called with a FRONT-facing config. `ARSceneView`'s default `sessionCameraConfig` is `highestResolutionCameraConfig`, hardwired to `FacingDirection.BACK`. So `ARFaceDemo` ran the back camera, `AugmentedFaceMode.MESH3D` produced zero trackables, and no mesh ever appeared on device.
- **Fix:** new public `frontCameraConfig(session)` helper in `arsceneview`; `ARFaceDemo` now passes `sessionCameraConfig = ::frontCameraConfig`. Updated `AugmentedFaceNode` KDoc + both `llms.txt` examples so AI-generated code is correct.
- **Cloud Anchor & Streetscape:** audited — code paths are correct and they already fail gracefully when the ARCore Cloud API key is absent (buttons disabled, clear status banner). Those are environmental (API key / billing / VPS coverage), no code change. See findings comment on #1436.

References #1436 — only the Face Mesh sub-issue is code-fixable; the umbrella should stay open for the Geospatial/Cloud provisioning items.

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin :samples:android-demo:compileDebugKotlin` — passes
- [ ] On-device: launch Face Mesh demo, confirm the selfie camera opens and a blue mesh tracks a real face (no emulator coverage for Augmented Faces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)