### PR TITLE
feat(android-demo): idle-resume option for hero auto-rotate

### DIFF
--- a/changelog.d/1440-idle-rotate.md
+++ b/changelog.d/1440-idle-rotate.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- `rememberPausableHeroYaw` gained an opt-in `idleResumeMillis` parameter: after the user stops interacting with the viewport, the hero auto-rotation gently resumes once the idle timeout elapses. Each gesture restarts the countdown, so the spin only comes back when interaction has truly stopped. Demos that omit the parameter keep the original pause-forever behaviour. Wired into the View Node demo. (#1440)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -223,6 +223,22 @@ fun rememberAutoOrbit(
  * ```
  *
  * Or just call `onUserGesture()` from `onTouchEvent` for the broadest coverage.
+ *
+ * ### Idle-resume (opt-in)
+ *
+ * Pass a non-null [idleResumeMillis] to make the rotation *gently resume* once the
+ * user has been idle for that long, instead of staying paused forever. Each gesture
+ * restarts the idle countdown, so the rotation only comes back when the user has
+ * truly stopped interacting. Demos that don't pass it keep the original
+ * pause-forever behaviour, so existing callers are unaffected.
+ *
+ * ```kotlin
+ * // Resume the hero spin 3 s after the last gesture.
+ * val (yaw, onUserGesture) = rememberPausableHeroYaw(
+ *     trigger = modelInstance != null,
+ *     idleResumeMillis = 3_000L,
+ * )
+ * ```
  */
 data class HeroYawController(val yaw: Float, val onUserGesture: () -> Unit)
 
@@ -231,10 +247,28 @@ fun rememberPausableHeroYaw(
     trigger: Boolean,
     durationMillis: Int = 20_000,
     staticYaw: Float = 45f,
+    idleResumeMillis: Long? = null,
 ): HeroYawController {
     val pausedState = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     val paused = pausedState.value
     val anim = androidx.compose.runtime.remember { androidx.compose.animation.core.Animatable(0f) }
+    // Bumped on every gesture; the idle-resume effect keys off it so each new
+    // gesture cancels the in-flight countdown and starts a fresh one.
+    val gestureTick = androidx.compose.runtime.remember { androidx.compose.runtime.mutableIntStateOf(0) }
+
+    // Opt-in: when idle-resume is enabled, wait out the idle window after the last
+    // gesture, then lift the pause. Keyed on gestureTick so a gesture mid-countdown
+    // restarts the timer; the coroutine is cancelled cleanly by Compose on each
+    // re-key (and on dispose / qaMode toggle), so no timer ever leaks.
+    if (idleResumeMillis != null) {
+        androidx.compose.runtime.LaunchedEffect(gestureTick.intValue, DemoSettings.qaMode) {
+            if (pausedState.value && !DemoSettings.qaMode) {
+                kotlinx.coroutines.delay(idleResumeMillis)
+                pausedState.value = false
+            }
+        }
+    }
+
     androidx.compose.runtime.LaunchedEffect(trigger, DemoSettings.qaMode, paused) {
         if (trigger && !DemoSettings.qaMode && !paused) {
             // Resume from current yaw if previously paused — no snap.
@@ -262,7 +296,14 @@ fun rememberPausableHeroYaw(
         }
     }
     val yaw = if (DemoSettings.qaMode) staticYaw else anim.value
-    return HeroYawController(yaw = yaw, onUserGesture = { pausedState.value = true })
+    return HeroYawController(
+        yaw = yaw,
+        onUserGesture = {
+            pausedState.value = true
+            // Restart the idle countdown (no-op when idle-resume is disabled).
+            gestureTick.intValue++
+        },
+    )
 }
 
 /**

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ViewNodeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ViewNodeDemo.kt
@@ -70,11 +70,13 @@ fun ViewNodeDemo(onBack: () -> Unit) {
     // back card (at rotation+180°) reveals itself — makes the "Compose-in-3D" story
     // unmistakable instead of looking like a flat HUD sticker. `trigger = true`
     // because the ViewNode itself needs no asset load — the animation can run
-    // immediately. Pauses on first gesture so users can grab and inspect the cards.
+    // immediately. Pauses on gesture so users can grab and inspect the cards, then
+    // gently resumes the spin once they've been idle for 3 s (#1440).
     val (heroYaw, onHeroGesture) = rememberPausableHeroYaw(
         trigger = true,
         durationMillis = 14_000,
         staticYaw = 20f,
+        idleResumeMillis = 3_000L,
     )
 
     val gestureListener = rememberOnGestureListener(


### PR DESCRIPTION
## Summary
Closes #1440.

Adds an opt-in `idleResumeMillis` parameter to `rememberPausableHeroYaw`. After the user stops interacting with the camera/viewport, the hero auto-rotation gently resumes once the idle timeout elapses — addressing the QA note "quand on arrête de bouger le camera manipulator, que ça se remette à tourner".

- Each gesture restarts the idle countdown via a tick-keyed `LaunchedEffect`, so Compose cancels the in-flight `delay` cleanly and the spin only comes back when interaction has truly stopped (no leaked timers, cancels on dispose / QA-mode toggle).
- Fully opt-in: callers that omit the parameter keep the original pause-forever behaviour, so existing demos are unaffected.
- Wired into the View Node demo (3 s idle window) as a representative case.

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On-device: touch the View Node demo, stop, confirm the card spin resumes ~3 s later with no snap
- [ ] Confirm a gesture mid-countdown restarts the timer (spin does not resume early)

🤖 Generated with [Claude Code](https://claude.com/claude-code)