### PR TITLE
fix(android-demo): polish demo-grid contrast, Image Planes & Billboard staging (#1443)

### DIFF
--- a/changelog.d/1443-demo-polish.md
+++ b/changelog.d/1443-demo-polish.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Android demo polish (#1443): demo-grid cards now carry a hairline `outlineVariant` border so their boundaries stay visible against the dark ParticleBackground; the Image Planes demo is staged as a three-picture wall gallery (framed procedural landscapes at varying depth and angle) instead of a single floating logo; the Billboard demo plants its billboard and fixed signs on a ground plane with an angled camera and explanatory caption so the orbit-time difference between the two node types is obvious.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
@@ -227,6 +227,15 @@ private fun DemoCard(
         shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 1.dp,
+        // Hairline outline so the card boundary stays visible. In dark mode
+        // `surfaceContainer` sits only a few luminance steps above the near-black
+        // ParticleBackground, so without a stroke the cards bled into the page
+        // and the grid looked like floating text (#1443). `outlineVariant` is the
+        // M3 token for exactly this low-emphasis container divider.
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant,
+        ),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxSize()) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/BillboardDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/BillboardDemo.kt
@@ -18,21 +18,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
+import io.github.sceneview.math.Rotation
 import io.github.sceneview.math.Scale
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 
 /**
- * Demonstrates BillboardNode (always faces the camera) vs a regular ImageNode
- * (stays fixed in world space). Toggle billboard mode on/off to compare.
+ * Demonstrates [BillboardNode] (always faces the camera, like a map pin or
+ * AR label) vs a regular [ImageNode] (fixed in world space).
+ *
+ * The two are staged on a shared "ground" plane as if they were signs planted
+ * in a scene: a **billboard label** that stays squarely readable from every
+ * angle, and a **fixed signboard** that rotates with the world and turns
+ * edge-on — nearly invisible — as the user orbits past it. Orbiting the camera
+ * is what makes the difference obvious, so the demo invites it explicitly.
  */
 @Composable
 fun BillboardDemo(onBack: () -> Unit) {
@@ -42,12 +48,17 @@ fun BillboardDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
-    // Create simple colored bitmaps for the billboard and fixed image
+    // A neutral "ground" so the two signs read as planted in a scene rather
+    // than floating in the void — sells the 3D staging.
+    val groundBitmap = remember { createGroundBitmap() }
+    // Billboard label — pin-style, with a "FACING YOU" caption that stays true
+    // because the node always rotates to face the camera.
     val billboardBitmap = remember {
-        createLabelBitmap("Billboard", 0xFF005BC1.toInt())  // SceneView Primary
+        createSignBitmap("Billboard", "always faces you", 0xFF005BC1.toInt())
     }
+    // Fixed signboard — caption warns it turns edge-on as you orbit.
     val fixedBitmap = remember {
-        createLabelBitmap("Fixed", 0xFF6446CD.toInt())  // SceneView Accent
+        createSignBitmap("Fixed sign", "turns away as you orbit", 0xFF6446CD.toInt())
     }
 
     val firstFrame = rememberFirstFrameState()
@@ -57,6 +68,11 @@ fun BillboardDemo(onBack: () -> Unit) {
         onBack = onBack,
         firstFrameRendered = firstFrame.rendered,
         controls = {
+            Text(
+                "Orbit the scene — the billboard stays readable, the fixed sign turns edge-on.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Text("Visible Nodes", style = MaterialTheme.typography.labelLarge)
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -82,31 +98,43 @@ fun BillboardDemo(onBack: () -> Unit) {
             onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
-            // Dolly closer so both 0.55 m-wide panels read comfortably — at default
-            // camera z = 4 they looked small. z = 1 puts them at 2.2 m.
+            // Slightly raised, angled camera so the ground plane reads as a
+            // floor receding into the scene — sells the "two planted signs"
+            // staging instead of two panels on a flat backdrop.
             cameraManipulator = rememberCameraManipulator(
-                orbitHomePosition = Position(0f, 0f, 1f),
-                targetPosition = Position(0f, 0f, -1.2f),
+                orbitHomePosition = Position(0f, 0.55f, 1.5f),
+                targetPosition = Position(0f, -0.05f, -0.8f),
             )
         ) {
-            // BillboardNode: always faces the camera. Made larger + closer so the
-            // contrast with the fixed image is obvious (the fixed image rotates / shrinks
-            // as the user orbits, the billboard stays facing them).
+            // Ground plane the two signs are "planted" on. Laid flat (rotated
+            // -90° about X) and pushed down so the signs rise out of it.
+            ImageNode(
+                bitmap = groundBitmap,
+                position = Position(x = 0f, y = -0.42f, z = -0.8f),
+                rotation = Rotation(x = -90f),
+                scale = Scale(2.4f)
+            )
+
+            // BillboardNode: always faces the camera. As the user orbits, this
+            // stays square-on and fully legible — the "FACING YOU" caption
+            // never lies.
             if (showBillboard) {
                 BillboardNode(
                     bitmap = billboardBitmap,
-                    widthMeters = 0.55f,
-                    heightMeters = 0.28f,
-                    position = Position(x = -0.4f, y = 0f, z = -1.2f)
+                    widthMeters = 0.62f,
+                    heightMeters = 0.40f,
+                    position = Position(x = -0.5f, y = -0.05f, z = -0.8f)
                 )
             }
 
-            // Regular ImageNode: stays fixed in world space
+            // Regular ImageNode: fixed in world space. Orbiting the camera
+            // swings it edge-on so it nearly vanishes — the visible contrast
+            // with the billboard.
             if (showFixed) {
                 ImageNode(
                     bitmap = fixedBitmap,
-                    position = Position(x = 0.4f, y = 0f, z = -1.2f),
-                    scale = Scale(0.55f)
+                    position = Position(x = 0.5f, y = -0.05f, z = -0.8f),
+                    scale = Scale(0.62f)
                 )
             }
         }
@@ -114,30 +142,65 @@ fun BillboardDemo(onBack: () -> Unit) {
 }
 
 /**
- * Creates a simple bitmap with a colored background and centered white text label.
+ * A pin-style sign bitmap: a rounded card with a bold [title], a smaller
+ * [caption], and a short "post" beneath so it reads as planted signage.
  */
-private fun createLabelBitmap(label: String, bgColor: Int): Bitmap {
-    val width = 256
-    val height = 128
+private fun createSignBitmap(title: String, caption: String, bgColor: Int): Bitmap {
+    val width = 320
+    val height = 200
     val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
 
-    // Background
-    val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = bgColor
-        style = Paint.Style.FILL
-    }
-    canvas.drawRoundRect(RectF(0f, 0f, width.toFloat(), height.toFloat()), 16f, 16f, bgPaint)
+    // Sign post.
+    val postPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFF6B5B4A.toInt() }
+    canvas.drawRect(width / 2f - 8f, 150f, width / 2f + 8f, height.toFloat(), postPaint)
 
-    // Text
-    val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+    // Sign card.
+    val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = bgColor }
+    canvas.drawRoundRect(RectF(12f, 12f, width - 12f, 156f), 20f, 20f, bgPaint)
+
+    // Title.
+    val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = android.graphics.Color.WHITE
-        textSize = 40f
+        textSize = 44f
         textAlign = Paint.Align.CENTER
         typeface = android.graphics.Typeface.DEFAULT_BOLD
     }
-    val textY = height / 2f - (textPaint.descent() + textPaint.ascent()) / 2f
-    canvas.drawText(label, width / 2f, textY, textPaint)
+    canvas.drawText(title, width / 2f, 78f, titlePaint)
 
+    // Caption.
+    val captionPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFFE8E8F4.toInt()
+        textSize = 26f
+        textAlign = Paint.Align.CENTER
+    }
+    canvas.drawText(caption, width / 2f, 122f, captionPaint)
+
+    return bitmap
+}
+
+/**
+ * A subtle checkered "ground" bitmap so the signs read as planted in a scene
+ * rather than floating in empty space.
+ */
+private fun createGroundBitmap(): Bitmap {
+    val size = 256
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(0xFF2A2E3A.toInt())
+    val tilePaint = Paint().apply { color = 0xFF353A4A.toInt() }
+    val tiles = 8
+    val tile = size / tiles
+    for (row in 0 until tiles) {
+        for (col in 0 until tiles) {
+            if ((row + col) % 2 == 0) {
+                canvas.drawRect(
+                    (col * tile).toFloat(), (row * tile).toFloat(),
+                    ((col + 1) * tile).toFloat(), ((row + 1) * tile).toFloat(),
+                    tilePaint
+                )
+            }
+        }
+    }
     return bitmap
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
@@ -1,5 +1,13 @@
 package io.github.sceneview.demo.demos
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RadialGradient
+import android.graphics.RectF
+import android.graphics.Shader
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -16,14 +24,21 @@ import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
+import io.github.sceneview.math.Rotation
 import io.github.sceneview.math.Scale
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 
 /**
- * Demonstrates ImageNode composable displaying a drawable resource as a flat
- * textured plane in 3D space. A scale slider controls the node's uniform scale.
+ * Demonstrates [ImageNode] — a flat, textured plane positioned in 3D space.
+ *
+ * Rather than a single logo floating in the void (which reads as a flat 2D
+ * sticker), the demo stages a small **photo gallery**: three framed pictures
+ * hung at different depths and angles, like a wall display. The depth offset,
+ * the perspective foreshortening as the camera orbits, and the framed
+ * thumbnails together make it obvious the images are real 3D planes — not a
+ * HUD overlay. A scale slider grows / shrinks the whole gallery in unison.
  */
 @Composable
 fun ImageDemo(onBack: () -> Unit) {
@@ -31,6 +46,13 @@ fun ImageDemo(onBack: () -> Unit) {
 
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
+
+    // Three distinct photographic-style bitmaps generated once. Procedural
+    // rather than bundled JPEGs so the demo ships no extra binary assets and
+    // still reads as real photos (sky gradient, sun, layered hills).
+    val sunsetPhoto = remember { createScenePhoto(Scene.SUNSET) }
+    val noonPhoto = remember { createScenePhoto(Scene.NOON) }
+    val nightPhoto = remember { createScenePhoto(Scene.NIGHT) }
 
     val firstFrame = rememberFirstFrameState()
 
@@ -40,13 +62,13 @@ fun ImageDemo(onBack: () -> Unit) {
         firstFrameRendered = firstFrame.rendered,
         controls = {
             Text(
-                "Scale: ${"%.1f".format(scaleFactor)}x",
+                "Gallery scale: ${"%.1f".format(scaleFactor)}x",
                 style = MaterialTheme.typography.labelLarge
             )
             Slider(
                 value = scaleFactor,
                 onValueChange = { scaleFactor = it },
-                valueRange = 0.2f..3f
+                valueRange = 0.4f..2f
             )
         }
     ) {
@@ -57,11 +79,134 @@ fun ImageDemo(onBack: () -> Unit) {
             materialLoader = materialLoader,
             cameraManipulator = rememberCameraManipulator()
         ) {
+            // Centre picture — hung flat, facing the camera.
             ImageNode(
-                imageFileLocation = "textures/sceneview_logo.png",
-                position = Position(x = 0f, y = 0f, z = 0f),
-                scale = Scale(scaleFactor)
+                bitmap = noonPhoto,
+                position = Position(x = 0f, y = 0.1f, z = 0f),
+                scale = Scale(0.8f * scaleFactor)
+            )
+            // Left picture — pushed back and angled inward so its perspective
+            // foreshortening is visible from the default camera. Orbiting the
+            // scene swings it through a clear depth arc.
+            ImageNode(
+                bitmap = sunsetPhoto,
+                position = Position(x = -0.85f, y = -0.05f, z = -0.45f),
+                rotation = Rotation(y = 32f),
+                scale = Scale(0.62f * scaleFactor)
+            )
+            // Right picture — also recessed and angled the opposite way.
+            ImageNode(
+                bitmap = nightPhoto,
+                position = Position(x = 0.85f, y = -0.05f, z = -0.45f),
+                rotation = Rotation(y = -32f),
+                scale = Scale(0.62f * scaleFactor)
             )
         }
+    }
+}
+
+/** Time-of-day variants for the generated photo. */
+private enum class Scene(
+    val skyTop: Int,
+    val skyBottom: Int,
+    val sun: Int,
+    val sunY: Float,
+    val hillFront: Int,
+    val hillBack: Int,
+) {
+    SUNSET(0xFF1B2A52.toInt(), 0xFFF4A259.toInt(), 0xFFFFE3A3.toInt(), 0.62f, 0xFF1E2A38.toInt(), 0xFF3A4A63.toInt()),
+    NOON(0xFF2F6FB8.toInt(), 0xFFBFE3F5.toInt(), 0xFFFFFFFF.toInt(), 0.30f, 0xFF2F5D3A.toInt(), 0xFF4C8455.toInt()),
+    NIGHT(0xFF05060F.toInt(), 0xFF1E2747.toInt(), 0xFFEDEFF7.toInt(), 0.26f, 0xFF0A1019.toInt(), 0xFF1A2436.toInt()),
+}
+
+/**
+ * Renders a small photographic-looking landscape (gradient sky, sun/moon glow,
+ * two layered hill silhouettes) inside a neutral photo frame, so an
+ * [ImageNode] reads as a hung picture rather than an icon.
+ */
+private fun createScenePhoto(scene: Scene): Bitmap {
+    val w = 512
+    val h = 384
+    val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    // Frame border.
+    val frameInset = 18f
+    canvas.drawColor(0xFFEAE6DE.toInt())
+
+    val photo = RectF(frameInset, frameInset, w - frameInset, h - frameInset)
+    canvas.save()
+    canvas.clipRect(photo)
+
+    // Sky gradient.
+    val skyPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        shader = LinearGradient(
+            0f, photo.top, 0f, photo.bottom,
+            scene.skyTop, scene.skyBottom, Shader.TileMode.CLAMP
+        )
+    }
+    canvas.drawRect(photo, skyPaint)
+
+    // Sun / moon glow.
+    val sunX = photo.left + photo.width() * 0.68f
+    val sunY = photo.top + photo.height() * scene.sunY
+    val sunRadius = photo.width() * 0.16f
+    val glowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        shader = RadialGradient(
+            sunX, sunY, sunRadius * 2.4f,
+            intArrayOf(scene.sun, scene.sun and 0x00FFFFFF),
+            floatArrayOf(0f, 1f), Shader.TileMode.CLAMP
+        )
+    }
+    canvas.drawCircle(sunX, sunY, sunRadius * 2.4f, glowPaint)
+    canvas.drawCircle(sunX, sunY, sunRadius, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = scene.sun
+    })
+
+    // Back hill silhouette.
+    canvas.drawPath(hillPath(photo, 0.62f, 0.10f), Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = scene.hillBack
+    })
+    // Front hill silhouette.
+    canvas.drawPath(hillPath(photo, 0.78f, 0.16f), Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = scene.hillFront
+    })
+
+    canvas.restore()
+
+    // Thin inner mat line so the frame reads as a real picture frame.
+    canvas.drawRect(photo, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = 3f
+        color = 0x33000000
+    })
+
+    return bitmap
+}
+
+/**
+ * Builds a rolling-hill silhouette filling the lower part of [photo].
+ *
+ * @param baseY    Hill crest height as a fraction of the photo (0 = top).
+ * @param amplitude Crest undulation as a fraction of the photo height.
+ */
+private fun hillPath(photo: RectF, baseY: Float, amplitude: Float): Path {
+    val crest = photo.top + photo.height() * baseY
+    val amp = photo.height() * amplitude
+    return Path().apply {
+        moveTo(photo.left, photo.bottom)
+        lineTo(photo.left, crest)
+        cubicTo(
+            photo.left + photo.width() * 0.30f, crest - amp,
+            photo.left + photo.width() * 0.55f, crest + amp,
+            photo.left + photo.width() * 0.78f, crest - amp * 0.4f
+        )
+        cubicTo(
+            photo.left + photo.width() * 0.90f, crest - amp * 0.9f,
+            photo.right, crest,
+            photo.right, crest
+        )
+        lineTo(photo.right, photo.bottom)
+        close()
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ImageDemo.kt
@@ -50,9 +50,9 @@ fun ImageDemo(onBack: () -> Unit) {
     // Three distinct photographic-style bitmaps generated once. Procedural
     // rather than bundled JPEGs so the demo ships no extra binary assets and
     // still reads as real photos (sky gradient, sun, layered hills).
-    val sunsetPhoto = remember { createScenePhoto(Scene.SUNSET) }
-    val noonPhoto = remember { createScenePhoto(Scene.NOON) }
-    val nightPhoto = remember { createScenePhoto(Scene.NIGHT) }
+    val sunsetPhoto = remember { createScenePhoto(ImageScene.SUNSET) }
+    val noonPhoto = remember { createScenePhoto(ImageScene.NOON) }
+    val nightPhoto = remember { createScenePhoto(ImageScene.NIGHT) }
 
     val firstFrame = rememberFirstFrameState()
 
@@ -106,7 +106,7 @@ fun ImageDemo(onBack: () -> Unit) {
 }
 
 /** Time-of-day variants for the generated photo. */
-private enum class Scene(
+private enum class ImageScene(
     val skyTop: Int,
     val skyBottom: Int,
     val sun: Int,
@@ -124,7 +124,7 @@ private enum class Scene(
  * two layered hill silhouettes) inside a neutral photo frame, so an
  * [ImageNode] reads as a hung picture rather than an icon.
  */
-private fun createScenePhoto(scene: Scene): Bitmap {
+private fun createScenePhoto(scene: ImageScene): Bitmap {
     val w = 512
     val h = 384
     val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)


### PR DESCRIPTION
## Summary

Three independent items from the [#1443](https://github.com/sceneview/sceneview/issues/1443) Android demo polish umbrella. The umbrella stays **open** — this PR addresses three of the remaining items.

### Items done in this PR
- **Dark mode: demo-grid card contrast** — `DemoCard` now carries a hairline `outlineVariant` border. In dark mode `surfaceContainer` sits only a few luminance steps above the near-black ParticleBackground, so without a stroke the card boundaries were invisible. Uses the M3 `outlineVariant` token (the low-emphasis container divider).
- **Image Planes** — staged as a three-picture **wall gallery**: framed procedural landscape photos (gradient sky, sun/moon glow, layered hill silhouettes) hung at varying depth and angle, replacing the single flat logo floating in the void. Depth offsets + perspective foreshortening on orbit make the planes read as real 3D. No new binary assets — bitmaps are generated procedurally.
- **Billboard** — billboard and fixed signs are now planted on a ground plane with an angled, raised camera and an explanatory caption. As the user orbits, the `BillboardNode` stays square-on and legible while the fixed `ImageNode` turns edge-on, making the difference between the two node types obvious.

### Items still open in #1443
Settings affordance dedupe, Text Nodes depth, Lines & Paths, Video clip, Gesture axes (done by #1521), Physics polish, PostProcessing visibility, AR demo content, ViewNode Compose layout (already polished), Secondary Camera clarity (already well-built), general use-case staging. (Note: several were already fixed by prior PRs — #1519, #1521, #1522, #1523, #1505.)

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] Visual QA on emulator — demo grid in dark mode, Image Planes gallery, Billboard orbit behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)