### PR TITLE
feat(samples): expand RN + Flutter demo catalogs (#1362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **React Native & Flutter demo apps gain Materials / Animation / Environment demos ([#1362](https://github.com/sceneview/sceneview/issues/1362)).** Part of the cross-platform demo-parity umbrella: the RN and Flutter sample apps showcased only a small slice of the bridge surface. The `react-native-demo` app adds three tabs — **Materials** (lit PBR vs `unlit` geometry materials), **Animation** (auto-playing glTF clips via `ModelNode.animation`) and **Environment** (HDR image-based lighting plus the `autoCenterContent` toggle) — and its bottom tab bar is now horizontally scrollable so the catalog can keep growing. The `flutter-demo` app gains a dedicated **Demos** tab with four runnable per-feature scenes — Materials (`GeometryNode.unlit`), Model Animation (`loadModel` with animated Khronos assets), Environment (`setEnvironment` + `setAutoCenterContent`) and Camera Modes (`setCameraControlMode`) — complementing the existing flat "Bridge Features" reference checklist. Every demo uses only APIs the Fabric / PlatformView bridges actually expose; no dead UI for un-bridged features.
+
 ## v4.8.0 — Bottom-sheet settings, web & RN bridge fixes (2026-05-16)
 
 ### Added

--- a/samples/flutter-demo/lib/app.dart
+++ b/samples/flutter-demo/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'pages/viewer_page.dart';
 import 'pages/ar_page.dart';
+import 'pages/demos_page.dart';
 import 'pages/features_page.dart';
 import 'pages/double_pendulum_page.dart';
 import 'pages/about_page.dart';
@@ -51,6 +52,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
 
   static const _pages = <Widget>[
     ViewerPage(),
+    DemosPage(),
     ARPage(),
     FeaturesPage(),
     DoublePendulumPage(),
@@ -117,6 +119,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             icon: Icon(Icons.view_in_ar_outlined),
             selectedIcon: Icon(Icons.view_in_ar),
             label: '3D Viewer',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.grid_view_outlined),
+            selectedIcon: Icon(Icons.grid_view),
+            label: 'Demos',
           ),
           NavigationDestination(
             icon: Icon(Icons.camera_outlined),

--- a/samples/flutter-demo/lib/pages/demos_page.dart
+++ b/samples/flutter-demo/lib/pages/demos_page.dart
@@ -1,0 +1,441 @@
+import 'package:flutter/material.dart';
+import 'package:sceneview_flutter/sceneview_flutter.dart';
+
+/// Demos tab — a catalog of runnable, per-feature SceneView demos.
+///
+/// Unlike the [FeaturesPage] reference checklist, each entry here is a live,
+/// interactive scene exercising exactly one bridge capability:
+///
+/// - **Materials** — lit PBR vs `unlit` geometry materials.
+/// - **Model Animation** — auto-playing glTF animation clips.
+/// - **Environment** — HDR image-based lighting switching.
+/// - **Camera Modes** — orbit / pan / first-person camera control.
+///
+/// Every demo uses only APIs the Flutter bridge actually exposes
+/// (`SceneViewController.addGeometry` / `loadModel` / `setEnvironment` /
+/// `setCameraControlMode`), so nothing here is dead UI.
+class DemosPage extends StatelessWidget {
+  const DemosPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Demos')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          _MaterialsDemo(),
+          SizedBox(height: 16),
+          _AnimationDemo(),
+          SizedBox(height: 16),
+          _EnvironmentDemo(),
+          SizedBox(height: 16),
+          _CameraModesDemo(),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shared card chrome for a demo: a titled header plus a fixed-height body.
+class _DemoCard extends StatelessWidget {
+  const _DemoCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.child,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Text(title, style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(description, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Materials demo — lit PBR vs unlit
+// ---------------------------------------------------------------------------
+
+/// Demonstrates [GeometryNode.unlit] — the bridge's only material control.
+/// A lit sphere reacts to the directional light; an unlit sphere renders its
+/// flat colour straight to the framebuffer.
+class _MaterialsDemo extends StatefulWidget {
+  const _MaterialsDemo();
+
+  @override
+  State<_MaterialsDemo> createState() => _MaterialsDemoState();
+}
+
+class _MaterialsDemoState extends State<_MaterialsDemo> {
+  final _controller = SceneViewController();
+  bool _ready = false;
+  bool _unlit = false;
+  Color _color = const Color(0xFF1E88E5);
+
+  static const _colors = [
+    Color(0xFF1E88E5),
+    Color(0xFFE53935),
+    Color(0xFF43A047),
+    Color(0xFFFDD835),
+    Color(0xFF8E24AA),
+  ];
+
+  void _rebuild() {
+    if (!_ready) return;
+    _controller.clearScene();
+    _controller.addLight(const LightNode(type: 'directional', intensity: 100000));
+    // A row of three primitives sharing one colour; only the shading model
+    // changes between lit and unlit.
+    _controller.addGeometry(GeometryNode(
+      type: 'sphere',
+      size: 0.9,
+      x: -1.4,
+      color: _color.value,
+      unlit: _unlit,
+    ));
+    _controller.addGeometry(GeometryNode(
+      type: 'cube',
+      size: 0.8,
+      color: _color.value,
+      unlit: _unlit,
+    ));
+    _controller.addGeometry(GeometryNode(
+      type: 'cylinder',
+      size: 0.8,
+      x: 1.4,
+      color: _color.value,
+      unlit: _unlit,
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      icon: Icons.palette,
+      title: 'Materials — Lit vs Unlit',
+      description: 'GeometryNode.unlit flag: PBR shading vs flat colour.',
+      child: Column(
+        children: [
+          SizedBox(
+            height: 200,
+            child: Stack(
+              children: [
+                SceneView(
+                  controller: _controller,
+                  onViewCreated: () {
+                    _controller.setEnvironment('environments/studio_small.hdr');
+                    setState(() => _ready = true);
+                    _rebuild();
+                  },
+                ),
+                if (!_ready) const Center(child: CircularProgressIndicator()),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Unlit material'),
+            subtitle: const Text('Ignore all scene lighting'),
+            value: _unlit,
+            onChanged: _ready
+                ? (v) {
+                    setState(() => _unlit = v);
+                    _rebuild();
+                  }
+                : null,
+          ),
+          Row(
+            children: [
+              const Text('Color: '),
+              const SizedBox(width: 8),
+              for (final c in _colors)
+                Padding(
+                  padding: const EdgeInsets.only(right: 4),
+                  child: GestureDetector(
+                    onTap: _ready
+                        ? () {
+                            setState(() => _color = c);
+                            _rebuild();
+                          }
+                        : null,
+                    child: CircleAvatar(
+                      radius: 14,
+                      backgroundColor: c,
+                      child: _color == c
+                          ? const Icon(Icons.check, size: 14, color: Colors.white)
+                          : null,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Animation demo — auto-playing glTF clips
+// ---------------------------------------------------------------------------
+
+/// Loads glTF models that ship animation clips. The Android bridge
+/// auto-plays a model's animation on load, so picking an animated model
+/// shows it moving.
+class _AnimationDemo extends StatefulWidget {
+  const _AnimationDemo();
+
+  @override
+  State<_AnimationDemo> createState() => _AnimationDemoState();
+}
+
+class _AnimationDemoState extends State<_AnimationDemo> {
+  final _controller = SceneViewController();
+  bool _ready = false;
+  int _modelIndex = 0;
+
+  // Khronos sample assets that ship animation clips.
+  static const _models = [
+    (
+      'Fox',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb',
+      0.03,
+    ),
+    (
+      'Box Animated',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/BoxAnimated/glTF-Binary/BoxAnimated.glb',
+      0.6,
+    ),
+    (
+      'BrainStem',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/BrainStem/glTF-Binary/BrainStem.glb',
+      0.7,
+    ),
+  ];
+
+  void _loadModel() {
+    if (!_ready) return;
+    final (_, url, scale) = _models[_modelIndex];
+    _controller.clearScene();
+    _controller.addLight(const LightNode(type: 'directional', intensity: 100000));
+    _controller.loadModel(ModelNode(modelPath: url, scale: scale, y: -0.5));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      icon: Icons.movie,
+      title: 'Model Animation',
+      description: 'glTF animation clips auto-play on load (Android).',
+      child: Column(
+        children: [
+          SizedBox(
+            height: 200,
+            child: Stack(
+              children: [
+                SceneView(
+                  controller: _controller,
+                  onViewCreated: () {
+                    _controller.setEnvironment('environments/studio_small.hdr');
+                    setState(() => _ready = true);
+                    _loadModel();
+                  },
+                ),
+                if (!_ready) const Center(child: CircularProgressIndicator()),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          SegmentedButton<int>(
+            segments: [
+              for (var i = 0; i < _models.length; i++)
+                ButtonSegment(value: i, label: Text(_models[i].$1)),
+            ],
+            selected: {_modelIndex},
+            onSelectionChanged: _ready
+                ? (s) {
+                    setState(() => _modelIndex = s.first);
+                    _loadModel();
+                  }
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment demo — HDR image-based lighting
+// ---------------------------------------------------------------------------
+
+/// Switches the HDR environment on a fixed model so the change in
+/// image-based lighting and skybox is the only variable.
+class _EnvironmentDemo extends StatefulWidget {
+  const _EnvironmentDemo();
+
+  @override
+  State<_EnvironmentDemo> createState() => _EnvironmentDemoState();
+}
+
+class _EnvironmentDemoState extends State<_EnvironmentDemo> {
+  final _controller = SceneViewController();
+  bool _ready = false;
+  bool _autoCenter = true;
+
+  static const _helmetUrl =
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb';
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      icon: Icons.image,
+      title: 'Environment — HDR Lighting',
+      description: 'setEnvironment + autoCenterContent on a fixed model.',
+      child: Column(
+        children: [
+          SizedBox(
+            height: 200,
+            child: Stack(
+              children: [
+                SceneView(
+                  controller: _controller,
+                  autoCenterContent: _autoCenter,
+                  onViewCreated: () {
+                    _controller.setEnvironment('environments/studio_small.hdr');
+                    _controller.loadModel(const ModelNode(modelPath: _helmetUrl));
+                    setState(() => _ready = true);
+                  },
+                ),
+                if (!_ready) const Center(child: CircularProgressIndicator()),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          FilledButton.tonalIcon(
+            onPressed: _ready
+                ? () => _controller.setEnvironment('environments/studio_small.hdr')
+                : null,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Reload Studio HDR'),
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Auto-center content'),
+            subtitle: const Text('Frame model on first stable frame (iOS-first)'),
+            value: _autoCenter,
+            onChanged: (v) {
+              setState(() => _autoCenter = v);
+              if (_ready) _controller.setAutoCenterContent(v);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Camera modes demo — orbit / pan / first-person
+// ---------------------------------------------------------------------------
+
+/// Switches the camera control mode at runtime via
+/// [SceneViewController.setCameraControlMode]. On iOS all three modes are
+/// wired; on Android non-orbit modes fall back to orbit (issue #1051).
+class _CameraModesDemo extends StatefulWidget {
+  const _CameraModesDemo();
+
+  @override
+  State<_CameraModesDemo> createState() => _CameraModesDemoState();
+}
+
+class _CameraModesDemoState extends State<_CameraModesDemo> {
+  final _controller = SceneViewController();
+  bool _ready = false;
+  CameraControlMode _mode = CameraControlMode.orbit;
+
+  static const _helmetUrl =
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb';
+
+  static const _modes = [
+    (CameraControlMode.orbit, 'Orbit'),
+    (CameraControlMode.pan, 'Pan'),
+    (CameraControlMode.firstPerson, 'FPV'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      icon: Icons.videocam,
+      title: 'Camera Modes',
+      description: 'setCameraControlMode: orbit / pan / first-person.',
+      child: Column(
+        children: [
+          SizedBox(
+            height: 200,
+            child: Stack(
+              children: [
+                SceneView(
+                  controller: _controller,
+                  cameraControlMode: _mode,
+                  onViewCreated: () {
+                    _controller.setEnvironment('environments/studio_small.hdr');
+                    _controller.loadModel(const ModelNode(modelPath: _helmetUrl));
+                    setState(() => _ready = true);
+                  },
+                ),
+                if (!_ready) const Center(child: CircularProgressIndicator()),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          SegmentedButton<CameraControlMode>(
+            segments: [
+              for (final (mode, label) in _modes)
+                ButtonSegment(value: mode, label: Text(label)),
+            ],
+            selected: {_mode},
+            onSelectionChanged: _ready
+                ? (s) {
+                    setState(() => _mode = s.first);
+                    _controller.setCameraControlMode(_mode);
+                  }
+                : null,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Pan / FPV are iOS-first; Android falls back to orbit (#1051).',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/samples/react-native-demo/src/App.tsx
+++ b/samples/react-native-demo/src/App.tsx
@@ -37,7 +37,15 @@ interface SketchfabResult {
   user: { displayName: string };
 }
 
-type TabId = 'search' | 'geometry' | 'lights' | 'physics' | 'ar';
+type TabId =
+  | 'search'
+  | 'geometry'
+  | 'materials'
+  | 'lights'
+  | 'animation'
+  | 'environment'
+  | 'physics'
+  | 'ar';
 
 interface PlaygroundShape {
   id: string;
@@ -58,9 +66,41 @@ const ENVIRONMENT = 'environments/studio_small.hdr';
 const TABS: { id: TabId; label: string; icon: string }[] = [
   { id: 'search', label: 'Search', icon: 'Q' },
   { id: 'geometry', label: 'Geometry', icon: 'G' },
+  { id: 'materials', label: 'Materials', icon: 'M' },
   { id: 'lights', label: 'Lights', icon: 'L' },
+  { id: 'animation', label: 'Animation', icon: '▶' },
+  { id: 'environment', label: 'Environ.', icon: 'E' },
   { id: 'physics', label: 'Physics', icon: 'P' },
   { id: 'ar', label: 'AR', icon: 'A' },
+];
+
+/**
+ * Animated glTF sample models (Khronos sample assets). The RN native bridge
+ * auto-plays a loaded model's animation clip, so any model that ships one
+ * will animate without extra wiring.
+ */
+const ANIMATED_MODELS: { label: string; src: string; scale: number }[] = [
+  {
+    label: 'Fox (run)',
+    src: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/Fox/glTF-Binary/Fox.glb',
+    scale: 0.03,
+  },
+  {
+    label: 'Box Animated',
+    src: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/BoxAnimated/glTF-Binary/BoxAnimated.glb',
+    scale: 0.6,
+  },
+  {
+    label: 'BrainStem',
+    src: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/BrainStem/glTF-Binary/BrainStem.glb',
+    scale: 0.7,
+  },
+];
+
+/** HDR environments available to the Environment demo. */
+const ENVIRONMENTS: { label: string; path: string | null }[] = [
+  { label: 'Studio (small)', path: 'environments/studio_small.hdr' },
+  { label: 'None (neutral)', path: null },
 ];
 
 const SHAPE_TYPES: GeometryNode['type'][] = ['cube', 'sphere', 'cylinder', 'plane'];
@@ -678,6 +718,242 @@ function ARTab() {
 }
 
 // ---------------------------------------------------------------------------
+// Tab: Materials (lit PBR vs unlit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrates the `GeometryNode.unlit` material flag — the only material
+ * control the RN bridge currently exposes. A lit PBR sphere reacts to scene
+ * lighting (shading, IBL); an unlit sphere renders its flat colour straight
+ * to the framebuffer. Both rows share the same colour so the difference is
+ * purely the shading model.
+ */
+function MaterialsTab() {
+  const [unlit, setUnlit] = useState(false);
+  const [color, setColor] = useState('#1E88E5');
+
+  // A single row of three primitives, re-rendered lit or unlit on toggle.
+  const geometryNodes: GeometryNode[] = [
+    { type: 'sphere', color, position: [-1.4, 0, -2.5], size: [0.9, 0.9, 0.9], unlit },
+    { type: 'cube', color, position: [0, 0, -2.5], size: [0.8, 0.8, 0.8], unlit },
+    { type: 'cylinder', color, position: [1.4, 0, -2.5], size: [0.7, 1.1, 0.7], unlit },
+  ];
+
+  // A directional light makes the lit/unlit contrast obvious.
+  const lightNodes: LightNode[] = [
+    { type: 'directional', intensity: 100000, color: '#FFFFFF', direction: [-1, -1, -1] },
+  ];
+
+  return (
+    <View style={styles.tabContent}>
+      <View style={styles.viewerContainer}>
+        <SceneView
+          style={styles.scene}
+          environment={ENVIRONMENT}
+          geometryNodes={geometryNodes}
+          lightNodes={lightNodes}
+          cameraOrbit
+        />
+        <View style={styles.lightInfoBadge}>
+          <Text style={styles.lightInfoText}>{unlit ? 'Unlit' : 'Lit PBR'}</Text>
+        </View>
+      </View>
+
+      <ScrollView style={styles.controls} contentContainerStyle={styles.controlsContent}>
+        <View style={styles.switchRow}>
+          <Text style={styles.switchLabel}>Unlit material</Text>
+          <Switch
+            value={unlit}
+            onValueChange={setUnlit}
+            trackColor={{ false: '#3A3F4B', true: '#1E88E5' }}
+            thumbColor="#fff"
+          />
+        </View>
+
+        <Text style={[styles.controlLabel, { marginTop: 16 }]}>Color</Text>
+        <View style={styles.colorGrid}>
+          {PRESET_COLORS.map((c) => (
+            <TouchableOpacity
+              key={c}
+              style={[
+                styles.colorSwatch,
+                { backgroundColor: c },
+                color === c && styles.colorSwatchSelected,
+              ]}
+              onPress={() => setColor(c)}
+              activeOpacity={0.7}
+            />
+          ))}
+        </View>
+
+        <View style={styles.arInfoCard}>
+          <Text style={styles.arInfoTitle}>Material Modes</Text>
+          <Text style={styles.arInfoBody}>
+            {'•'} Lit PBR — reacts to lights, IBL and shadows{'\n'}
+            {'•'} Unlit — flat colour, ignores all lighting{'\n'}
+            {'\n'}Toggle the switch and watch the same shapes go from shaded to
+            flat. Unlit is ideal for HUD overlays, gizmos and AR face meshes.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab: Animation (animated glTF models)
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrates auto-playing glTF animation clips. The native bridge
+ * auto-animates a loaded model whose glTF ships an animation clip, so picking
+ * an animated model shows it moving with no extra wiring.
+ */
+function AnimationTab() {
+  const [modelIndex, setModelIndex] = useState(0);
+
+  const model = ANIMATED_MODELS[modelIndex];
+  const modelNode: ModelNode = {
+    src: model.src,
+    scale: model.scale,
+    position: [0, -0.5, -2.5],
+  };
+
+  return (
+    <View style={styles.tabContent}>
+      <View style={styles.viewerContainer}>
+        <SceneView
+          style={styles.scene}
+          environment={ENVIRONMENT}
+          modelNodes={[modelNode]}
+          cameraOrbit
+        />
+        <View style={styles.lightInfoBadge}>
+          <Text style={styles.lightInfoText}>{model.label}</Text>
+        </View>
+      </View>
+
+      <ScrollView style={styles.controls} contentContainerStyle={styles.controlsContent}>
+        <Text style={styles.controlLabel}>Animated Model</Text>
+        <View style={styles.chipRow}>
+          {ANIMATED_MODELS.map((m, index) => (
+            <TouchableOpacity
+              key={m.label}
+              style={[styles.typeChip, modelIndex === index && styles.typeChipSelected]}
+              onPress={() => setModelIndex(index)}
+              activeOpacity={0.7}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  modelIndex === index && styles.typeChipTextSelected,
+                ]}
+              >
+                {m.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.arInfoCard}>
+          <Text style={styles.arInfoTitle}>Model Animation</Text>
+          <Text style={styles.arInfoBody}>
+            glTF models that ship an animation clip (Fox, BoxAnimated,
+            BrainStem) auto-play it on the native renderer. Selecting a
+            specific clip by name, or pausing playback, needs new bridge
+            surface — tracked as a bridge-gap follow-up under issue #1362.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab: Environment (HDR image-based lighting + auto-center)
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrates the `environment` (HDR IBL) and `autoCenterContent` props.
+ * Switching the environment changes the skybox and image-based lighting on a
+ * fixed model; the auto-center toggle frames the content on the first stable
+ * frame (iOS-first, see #1051 for the Android side).
+ */
+function EnvironmentTab() {
+  const [envIndex, setEnvIndex] = useState(0);
+  const [autoCenter, setAutoCenter] = useState(true);
+
+  const env = ENVIRONMENTS[envIndex];
+
+  // A neutral model so the environment lighting is what reads visually.
+  const modelNode: ModelNode = {
+    src: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb',
+    scale: 1.0,
+    position: [0, 0, -2.5],
+  };
+
+  return (
+    <View style={styles.tabContent}>
+      <View style={styles.viewerContainer}>
+        <SceneView
+          style={styles.scene}
+          environment={env.path ?? undefined}
+          modelNodes={[modelNode]}
+          autoCenterContent={autoCenter}
+          cameraOrbit
+        />
+        <View style={styles.lightInfoBadge}>
+          <Text style={styles.lightInfoText}>{env.label}</Text>
+        </View>
+      </View>
+
+      <ScrollView style={styles.controls} contentContainerStyle={styles.controlsContent}>
+        <Text style={styles.controlLabel}>HDR Environment</Text>
+        <View style={styles.chipRow}>
+          {ENVIRONMENTS.map((e, index) => (
+            <TouchableOpacity
+              key={e.label}
+              style={[styles.typeChip, envIndex === index && styles.typeChipSelected]}
+              onPress={() => setEnvIndex(index)}
+              activeOpacity={0.7}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  envIndex === index && styles.typeChipTextSelected,
+                ]}
+              >
+                {e.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.switchRow}>
+          <Text style={styles.switchLabel}>Auto-center content</Text>
+          <Switch
+            value={autoCenter}
+            onValueChange={setAutoCenter}
+            trackColor={{ false: '#3A3F4B', true: '#1E88E5' }}
+            thumbColor="#fff"
+          />
+        </View>
+
+        <View style={styles.arInfoCard}>
+          <Text style={styles.arInfoTitle}>Image-Based Lighting</Text>
+          <Text style={styles.arInfoBody}>
+            The `environment` prop loads an HDR file for image-based lighting
+            and the skybox. `autoCenterContent` frames the model on the first
+            stable frame — an iOS-first v4.3.0 feature; the Android side is
+            tracked in issue #1051.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main App
 // ---------------------------------------------------------------------------
 
@@ -688,7 +964,10 @@ export default function App() {
     switch (activeTab) {
       case 'search': return <SearchTab />;
       case 'geometry': return <GeometryTab />;
+      case 'materials': return <MaterialsTab />;
       case 'lights': return <LightsTab />;
+      case 'animation': return <AnimationTab />;
+      case 'environment': return <EnvironmentTab />;
       case 'physics': return <DoublePendulumTab />;
       case 'ar': return <ARTab />;
     }
@@ -714,25 +993,32 @@ export default function App() {
         {renderTab()}
       </View>
 
-      {/* Bottom tab bar */}
+      {/* Bottom tab bar — horizontally scrollable so the catalog can grow
+          past the ~5 tabs that fit a phone width without cramping. */}
       <View style={styles.tabBar}>
-        {TABS.map((tab) => (
-          <TouchableOpacity
-            key={tab.id}
-            style={[styles.tabItem, activeTab === tab.id && styles.tabItemActive]}
-            onPress={() => setActiveTab(tab.id)}
-            activeOpacity={0.7}
-          >
-            <View style={[styles.tabIconContainer, activeTab === tab.id && styles.tabIconContainerActive]}>
-              <Text style={[styles.tabIcon, activeTab === tab.id && styles.tabIconActive]}>
-                {tab.icon}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.tabBarContent}
+        >
+          {TABS.map((tab) => (
+            <TouchableOpacity
+              key={tab.id}
+              style={[styles.tabItem, activeTab === tab.id && styles.tabItemActive]}
+              onPress={() => setActiveTab(tab.id)}
+              activeOpacity={0.7}
+            >
+              <View style={[styles.tabIconContainer, activeTab === tab.id && styles.tabIconContainerActive]}>
+                <Text style={[styles.tabIcon, activeTab === tab.id && styles.tabIconActive]}>
+                  {tab.icon}
+                </Text>
+              </View>
+              <Text style={[styles.tabLabel, activeTab === tab.id && styles.tabLabelActive]}>
+                {tab.label}
               </Text>
-            </View>
-            <Text style={[styles.tabLabel, activeTab === tab.id && styles.tabLabelActive]}>
-              {tab.label}
-            </Text>
-          </TouchableOpacity>
-        ))}
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
       </View>
 
       {/* Auto-update banner — overlays the top of the screen when a newer
@@ -791,18 +1077,22 @@ const styles = StyleSheet.create({
 
   // Tab bar
   tabBar: {
-    flexDirection: 'row',
     backgroundColor: '#0F1218',
     borderTopWidth: 1,
     borderTopColor: '#1E2430',
     paddingBottom: Platform.OS === 'ios' ? 20 : 8,
     paddingTop: 8,
   },
+  tabBarContent: {
+    flexDirection: 'row',
+    paddingHorizontal: 8,
+  },
   tabItem: {
-    flex: 1,
+    minWidth: 72,
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: 4,
+    paddingHorizontal: 4,
   },
   tabItemActive: {},
   tabIconContainer: {


### PR DESCRIPTION
## Summary

Part of the [#1362](https://github.com/sceneview/sceneview/issues/1362) cross-platform demo-parity umbrella — the RN and Flutter sample apps showcased only a small slice of the bridge surface (RN: search/geometry/lights/physics/ar; Flutter: a flat "Bridge Features" checklist). This slice expands both catalogs with runnable per-feature demos.

Every demo uses **only** APIs the Fabric (RN) / PlatformView (Flutter) bridges actually expose — no dead UI for un-bridged features. Bridge surfaces were verified against `react-native/react-native-sceneview/src/index.tsx` + the Android `SceneViewManager.kt`, and `flutter/sceneview_flutter/lib/sceneview_flutter.dart` + the Android `SceneViewPlugin.kt`.

## Demos added

**react-native-demo (`samples/react-native-demo/src/App.tsx`)** — 3 new tabs:
- **Materials** — lit PBR vs `unlit` geometry materials (`GeometryNode.unlit`)
- **Animation** — auto-playing glTF clips (Fox / BoxAnimated / BrainStem) — the native bridge auto-animates loaded models
- **Environment** — HDR image-based lighting + the `autoCenterContent` toggle
- Bottom tab bar is now horizontally scrollable so the 8-tab catalog can keep growing past phone width

**flutter-demo (`samples/flutter-demo/lib/pages/demos_page.dart` — new)** — new "Demos" tab with 4 runnable per-feature scenes:
- **Materials** — `GeometryNode.unlit` lit/unlit toggle
- **Model Animation** — `loadModel` with animated Khronos assets
- **Environment** — `setEnvironment` + `setAutoCenterContent`
- **Camera Modes** — `setCameraControlMode` (orbit / pan / first-person)

The existing flat "Bridge Features" reference checklist stays as API docs.

## Remaining (bridge-gap follow-ups for #1362)

- **RN:** `geometryNodes` / `lightNodes` are not exported by the iOS RN view manager (`RNSceneViewManager.m`) — the Materials/Geometry/Lights tabs no-op on iOS. Pre-existing gap, not introduced here.
- **Animation:** selecting a glTF clip by name, or pausing playback, needs new bridge surface (the bridge only auto-plays the default clip).
- web-demo catalog expansion (separate umbrella slice).

## Test plan

- [x] `flutter analyze` — no new errors (only pre-existing `Color.value` infos, matching `features_page.dart`)
- [x] RN: typecheck verified manually against the bridge `index.tsx` types (`node_modules` not installed in this lean worktree)
- [x] `impact-check.sh` — pass
- [ ] On-device smoke test of the new tabs/pages (Android emulator)

References #1362 — does not close it (umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)