### PR TITLE
docs(samples): reconcile README + recipes with actual repo state

### DIFF
--- a/changelog.d/1542-samples-docs.md
+++ b/changelog.d/1542-samples-docs.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- Docs: reconciled `samples/README.md` with the actual `DemoRegistry` — corrected the android-demo demo count (now 42: 28 non-AR + 14 AR), fixed the tab list (Explore, AR View, Samples, About), and removed rows advertising demos that don't exist (`gltf-camera`, `ar-point-cloud`, `autopilot-demo`).
+- Docs: fixed HDR asset paths across `samples/recipes/` (`environment-lighting.md`, `multi-model.md`, `editable-model.md`) to match the bundled `environments/*_2k.hdr` files, and corrected the Flutter `features_page.dart` snippet to reference the real `environments/studio_small.hdr` asset.

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,7 +11,6 @@ This directory contains sample apps demonstrating SceneView capabilities across 
 | Show a 3D model with orbit camera | `model-viewer` | `SceneView { ModelNode(modelInstance) }` |
 | Place a model in AR on a surface | `ar-model-viewer` | `ARSceneView { AnchorNode { ModelNode() } }` |
 | Control camera orbit/pan/zoom | `camera-manipulator` | `rememberCameraManipulator()` |
-| Use cameras from a glTF file | `gltf-camera` | `CameraNode(camera = gltfCamera)` |
 | Draw lines and curves | `line-path` | `LineNode(start, end)`, `PathNode(points)` |
 | Add text labels in 3D | `text-labels` | `TextNode(text = "Label")` |
 | Procedural sky + fog atmosphere | `dynamic-sky` | `DynamicSkyNode`, `FogNode` |
@@ -20,8 +19,7 @@ This directory contains sample apps demonstrating SceneView capabilities across 
 | Local reflections / IBL zones | `reflection-probe` | `ReflectionProbeNode` |
 | Detect real-world images in AR | `ar-augmented-image` | `AugmentedImageNode(image)` |
 | Share AR anchors across devices | `ar-cloud-anchor` | `CloudAnchorNode(anchor)` |
-| Visualize AR feature points | `ar-point-cloud` | ARCore point cloud rendering |
-| Build a full demo app | `android-demo` | 4-tab Material 3 app (3D, AR, Samples, About) |
+| Build a full demo app | `android-demo` | 4-tab Material 3 app (Explore, AR View, Samples, About) |
 
 ## Samples by category
 
@@ -31,14 +29,12 @@ This directory contains sample apps demonstrating SceneView capabilities across 
 |---|---|---|
 | `model-viewer` | Load a glTF/GLB model, HDR environment, orbit camera, animations | Beginner |
 | `camera-manipulator` | Orbit, pan, zoom camera with gesture and collision hit-testing | Beginner |
-| `gltf-camera` | Import and use camera nodes from glTF files | Intermediate |
 | `line-path` | LineNode, PathNode, procedural curves, animated sine waves | Intermediate |
 | `text-labels` | World-space text labels with face-to-camera constraints | Intermediate |
 | `dynamic-sky` | Procedural sky + fog atmosphere, real-time parameter sliders | Advanced |
 | `physics-demo` | Tap-to-spawn spheres with gravity, bounce, Euler integration | Advanced |
 | `post-processing` | Bloom, Depth of Field, SSAO, fog — all post-processing effects | Advanced |
 | `reflection-probe` | ReflectionProbeNode, zone-based IBL switching | Advanced |
-| `autopilot-demo` | Procedural geometry scene + HUD overlay — no model files needed | Showcase |
 
 ### Augmented Reality
 
@@ -47,13 +43,12 @@ This directory contains sample apps demonstrating SceneView capabilities across 
 | `ar-model-viewer` | Tap-to-place on planes, model picker, pinch/rotate | Beginner |
 | `ar-augmented-image` | Image detection, overlay 3D content on real images | Intermediate |
 | `ar-cloud-anchor` | Persistent cross-device anchors via Google Cloud | Advanced |
-| `ar-point-cloud` | ARCore feature point visualization | Intermediate |
 
 ### Showcase
 
 | Sample | Description |
 |---|---|
-| `android-demo` | Play Store demo app — 3D, AR, Samples, About tabs (37 demos: 24 3D + 13 AR, Material 3) |
+| `android-demo` | Play Store demo app — Explore, AR View, Samples, About tabs (42 demos: 28 non-AR + 14 AR, Material 3) |
 
 ## Common recipes (copy-paste ready)
 

--- a/samples/flutter-demo/lib/pages/features_page.dart
+++ b/samples/flutter-demo/lib/pages/features_page.dart
@@ -106,7 +106,7 @@ class _FeaturesPageState extends State<FeaturesPage> {
 
 // After onViewCreated:
 controller.loadModel(ModelNode(modelPath: url));
-controller.setEnvironment('environments/studio.hdr');
+controller.setEnvironment('environments/studio_small.hdr');
 controller.addLight(LightNode(type: 'directional'));
 controller.addGeometry(GeometryNode(type: 'cube'));
 controller.clearScene();''',

--- a/samples/recipes/editable-model.md
+++ b/samples/recipes/editable-model.md
@@ -15,7 +15,7 @@ fun EditableModelViewer() {
         modifier = Modifier.fillMaxSize(),
         engine = engine,
         modelLoader = modelLoader,
-        environment = rememberEnvironment(engine, "envs/studio.hdr"),
+        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
         cameraManipulator = rememberCameraManipulator()
     ) {
         model?.let {

--- a/samples/recipes/environment-lighting.md
+++ b/samples/recipes/environment-lighting.md
@@ -16,7 +16,7 @@ fun ModelWithEnvironment() {
         engine = engine,
         modelLoader = modelLoader,
         // HDR environment provides both indirect lighting (IBL) and skybox
-        environment = rememberEnvironment(engine, "envs/studio.hdr"),
+        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
         cameraManipulator = rememberCameraManipulator()
     ) {
         model?.let {
@@ -77,18 +77,24 @@ struct MyApp: App {
 
 ## Available Environments
 
+These are the HDR files bundled with `android-demo` under
+`src/main/assets/environments/`:
+
 | Environment | Description | Best for |
 |---|---|---|
-| `studio.hdr` | Neutral studio lighting | Product shots, model viewers |
-| `outdoor.hdr` | Outdoor daylight | Architectural scenes |
-| `sunset.hdr` | Warm golden hour | Atmospheric scenes |
-| `night.hdr` | Dark environment | Dramatic lighting |
+| `studio_2k.hdr` | Neutral studio lighting | Product shots, model viewers |
+| `studio_warm_2k.hdr` | Warm studio lighting | Product shots with a warmer tone |
+| `outdoor_cloudy_2k.hdr` | Overcast outdoor daylight | Architectural scenes |
+| `chinese_garden_2k.hdr` | Outdoor garden | Natural / scenic scenes |
+| `sunset_2k.hdr` | Warm golden hour | Atmospheric scenes |
+| `rooftop_night_2k.hdr` | City rooftop at night | Dramatic urban lighting |
+| `night_sky_2k.hdr` | Dark night sky | Dramatic, low-key lighting |
 
 ## Key Points
 
-- `rememberEnvironment(engine, "envs/studio.hdr")` loads the HDR file from assets
+- `rememberEnvironment(engine, "environments/studio_2k.hdr")` loads the HDR file from assets
 - HDR environments provide **Image-Based Lighting** (IBL) for realistic reflections
 - They also set the skybox (background) — set `skybox = false` to keep a solid background
 - Combine IBL with `LightNode` for direct light sources (sun, lamps)
 - `LightNode`'s `apply` is a **named parameter**, not a trailing lambda: `apply = { ... }`
-- All HDR files should be in `src/main/assets/envs/` for Android
+- All HDR files should be in `src/main/assets/environments/` for Android

--- a/samples/recipes/multi-model.md
+++ b/samples/recipes/multi-model.md
@@ -18,7 +18,7 @@ fun MultiModelScene() {
         modifier = Modifier.fillMaxSize(),
         engine = engine,
         modelLoader = modelLoader,
-        environment = rememberEnvironment(engine, "envs/studio.hdr"),
+        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
         cameraManipulator = rememberCameraManipulator()
     ) {
         chair?.let {


### PR DESCRIPTION
## Summary

Fixes the post-v4.8.0 audit findings in `samples/` docs (issue #1542). Docs-only, no behavior change.

- **`samples/README.md`** — reconciled with `DemoRegistry.ALL_DEMOS`:
  - Corrected the android-demo demo count: `37 (24 3D + 13 AR)` → `42 (28 non-AR + 14 AR)`.
  - Fixed the tab list: the `RootTab` enum is `Explore, AR View, Samples, About` (no standalone "3D" tab).
  - Removed rows advertising demos that don't exist (`gltf-camera`, `ar-point-cloud`, `autopilot-demo`) — no matching `*Demo.kt` or registry entry.
- **Recipes** — fixed HDR asset paths in `environment-lighting.md`, `multi-model.md`, and `editable-model.md`: they referenced `envs/studio.hdr` but android-demo bundles `environments/studio_2k.hdr` etc. The "Available Environments" table now lists the real bundled files.
- **Flutter** — `flutter-demo/lib/pages/features_page.dart` snippet referenced `environments/studio.hdr`; the bundled asset is `environments/studio_small.hdr`.

## Test plan

- [x] Every count/path verified against the actual repo (`DemoRegistry.kt`, `demos/` dir, `git ls-files` for HDR assets).
- [x] `bash .claude/scripts/impact-check.sh` passes.
- [x] No remaining `envs/` or non-existent-demo references under `samples/`.

Closes #1542

🤖 Generated with [Claude Code](https://claude.com/claude-code)