### PR TITLE
ci: raise Unit tests + coverage and CI Gate timeouts

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -73,12 +73,16 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    # The internal poll loop self-terminates at a 25-min deadline (+30s
-    # warm-up sleep). The job timeout sits comfortably above that so the
-    # loop's own "::error:: timed out waiting for …" message is what
-    # surfaces — a hard runner kill would give no diagnostic. 35 min keeps
-    # a ~9-min cushion above the internal ~25.5-min worst case (#1360).
-    timeout-minutes: 35
+    # The internal poll loop self-terminates at a 50-min deadline (+30s
+    # warm-up sleep). It must comfortably exceed the slowest required job's
+    # own timeout — `Unit tests + coverage` is `timeout-minutes: 45` (#1554)
+    # — so a slow-but-succeeding unit-test job is still seen as completing,
+    # not as a gate timeout. The job timeout sits comfortably above the
+    # internal deadline so the loop's own "::error:: timed out waiting
+    # for …" message is what surfaces — a hard runner kill would give no
+    # diagnostic. 60 min keeps a ~9-min cushion above the internal
+    # ~50.5-min worst case (#1360, #1554).
+    timeout-minutes: 60
     steps:
       - name: Aggregate all PR check conclusions
         env:
@@ -122,7 +126,10 @@ jobs:
           # gate prematurely. So we additionally refuse to exit green
           # until at least one non-self check run has been observed AND
           # every expected core check (see REQUIRED_CHECKS) has registered.
-          deadline=$(( $(date +%s) + 25 * 60 ))
+          # 50-min internal deadline: must comfortably exceed the slowest
+          # required job's own timeout (`Unit tests + coverage` is 45 min,
+          # #1554) so a slow-but-succeeding job is seen as completing.
+          deadline=$(( $(date +%s) + 50 * 60 ))
           sleep 30
           seen_any_other=false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,11 @@ jobs:
     needs: changes
     if: inputs.force-all || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 min: the full sceneview + arsceneview + samples JaCoCo pass runs
+    # close to 30 min on a slow/contended runner and tipped over once on a
+    # release PR (#1554), producing a confusing double-red. The extra
+    # headroom absorbs runner-speed variance without re-architecting.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v6

--- a/changelog.d/1554-ci-timeout.md
+++ b/changelog.d/1554-ci-timeout.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **CI: raise `Unit tests + coverage` and `CI Gate` timeouts ([#1554](https://github.com/sceneview/sceneview/issues/1554)).** The full JaCoCo pass runs close to the old 30-min job timeout on a slow runner; it tipped over on a release PR and cascaded a confusing double-red. The `Unit tests + coverage` job timeout is now 45 min, and the `CI Gate` aggregator's internal poll deadline (50 min) and job timeout (60 min) comfortably exceed it so a slow-but-succeeding job is seen as completing.


### PR DESCRIPTION
## Summary
The `Unit tests + coverage` CI job's full JaCoCo pass (`sceneview` + `arsceneview` + `samples`) runs close to its 30-min `timeout-minutes` on a slow/contended runner. On the v4.9.0 release PR (#1552) it tipped over at ~29.5 min and cascaded the `CI Gate` aggregator to its own 25-min internal poll deadline — producing a confusing double-red on an otherwise-fine PR (a plain re-run passed).

This raises the timeouts so they comfortably exceed the slowest-runner JaCoCo pass. No re-architecture — just timeout adjustments plus comments.

## Changes
- **`ci.yml`** — `Unit tests + coverage` job `timeout-minutes`: 30 → 45.
- **`ci-gate.yml`** — internal poll deadline: 25 → 50 min, so a slow-but-succeeding unit-test job (45-min timeout) is still observed completing rather than read as timed-out; job `timeout-minutes`: 35 → 60, keeping the ~9-min cushion above the internal deadline so the loop's own diagnostic surfaces instead of a hard runner kill.
- **`changelog.d/1554-ci-timeout.md`** — changelog fragment.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] `actionlint` clean on both workflows
- [x] `CI Gate` poll logic untouched — only numeric timeout values changed

Closes #1554