### PR TITLE
feat(qa): Maestro device-QA harness for Android demo catalog

### DIFF
--- a/.claude/scripts/lib/maestro.sh
+++ b/.claude/scripts/lib/maestro.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# maestro.sh — shared helpers for Maestro (https://maestro.dev), the UI-test
+# tool that drives `samples/android-demo` like a real user for device-QA.
+#
+# Maestro is the Android/iOS leg of the autonomous device-QA harness (umbrella
+# #1560, slice #1562). It runs YAML flows under `.maestro/` that tap, swipe,
+# scroll and navigate the demo apps, then assert no crash / no FATAL.
+#
+# This helper is the Maestro analogue of `android-cli.sh`: it auto-installs a
+# **pinned** Maestro version to a user-local path on first use, never touches
+# the shell rc, and is CI-safe ($CI honoured — CI installs Maestro as a prior
+# workflow step rather than fetching binaries mid-job).
+#
+# Usage from another script:
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#     source "$SCRIPT_DIR/lib/maestro.sh"
+#     maestro_ensure                       # bootstraps install if missing
+#     maestro_run .maestro/android/catalog.yaml [extra maestro args...]
+#
+# Each helper falls back gracefully: if Maestro cannot be installed (offline,
+# unsupported host) the functions return non-zero so callers can warn+skip
+# rather than hard-fail.
+
+set -o pipefail
+
+# --- Pinned version --------------------------------------------------------
+# Maestro is pinned so a CI run and a local run exercise byte-identical tool
+# behaviour. Bump deliberately (and re-validate the flows) — never float.
+# 1.39.0 is the release current at the time slice #1562 landed.
+MAESTRO_VERSION="1.39.0"
+
+# Maestro installs under ~/.maestro by its official installer; the binary is
+# at ~/.maestro/bin/maestro. We keep that convention so a user who already has
+# Maestro on PATH is reused as-is.
+MAESTRO_HOME_DIR="${MAESTRO_HOME_DIR:-$HOME/.maestro}"
+
+# Reset state so successive `source`s in long-lived shells don't inherit a
+# stale binary path.
+MAESTRO_BIN=""
+
+# Resolve the `maestro` binary path. Returns 0 on success, sets MAESTRO_BIN.
+maestro_locate() {
+  MAESTRO_BIN=""
+  if command -v maestro >/dev/null 2>&1; then
+    MAESTRO_BIN="$(command -v maestro)"
+    return 0
+  fi
+  if [[ -x "$MAESTRO_HOME_DIR/bin/maestro" ]]; then
+    MAESTRO_BIN="$MAESTRO_HOME_DIR/bin/maestro"
+    return 0
+  fi
+  return 1
+}
+
+# Echo the installed Maestro version (best-effort, empty string if unknown).
+maestro_installed_version() {
+  maestro_locate || return 1
+  # `maestro --version` prints just the semver on a line.
+  "$MAESTRO_BIN" --version 2>/dev/null | head -n1 | tr -d ' \r'
+}
+
+# Ensure Maestro is installed and on the pinned version. Auto-installs to
+# ~/.maestro without touching the shell rc. Honours $CI: in CI we never
+# auto-download — the workflow installs Maestro as a prior step.
+#
+# Returns 0 when a usable `maestro` binary is available (MAESTRO_BIN set),
+# non-zero otherwise.
+maestro_ensure() {
+  if maestro_locate; then
+    local have; have="$(maestro_installed_version)"
+    if [[ "$have" != "$MAESTRO_VERSION" ]]; then
+      echo "[maestro] found Maestro $have, flows are pinned to $MAESTRO_VERSION." >&2
+      echo "[maestro] proceeding with $have — bump MAESTRO_VERSION in maestro.sh if intentional." >&2
+    fi
+    return 0
+  fi
+  if [[ -n "${CI:-}" ]]; then
+    echo "[maestro] not installed and CI=1 — install Maestro via your workflow before calling this helper." >&2
+    return 1
+  fi
+  # The official installer respects MAESTRO_VERSION when exported, so a pinned
+  # install is reproducible. It writes to ~/.maestro/bin and prints a PATH hint
+  # we deliberately ignore (we resolve the absolute path ourselves).
+  echo "[maestro] installing Maestro $MAESTRO_VERSION to $MAESTRO_HOME_DIR" >&2
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "[maestro] curl is required to install Maestro" >&2
+    return 1
+  fi
+  if ! command -v java >/dev/null 2>&1; then
+    echo "[maestro] WARNING: a JDK is required to run Maestro — install one before maestro_run" >&2
+  fi
+  if ! MAESTRO_VERSION="$MAESTRO_VERSION" curl -fsSL "https://get.maestro.dev" | bash >&2; then
+    echo "[maestro] install failed (offline or unsupported host?)" >&2
+    return 1
+  fi
+  if ! maestro_locate; then
+    echo "[maestro] installer ran but the binary was not found under $MAESTRO_HOME_DIR/bin" >&2
+    return 1
+  fi
+  echo "[maestro] installed: $(maestro_installed_version)" >&2
+}
+
+# maestro_run <flow.yaml> [extra args...]
+# Thin wrapper around `maestro test` that first ensures Maestro is installed.
+# Extra args are forwarded verbatim (e.g. `--format junit --output result.xml`).
+maestro_run() {
+  local flow="$1"; shift || true
+  if [[ -z "$flow" ]]; then
+    echo "[maestro] maestro_run: a flow path is required" >&2
+    return 2
+  fi
+  if [[ ! -e "$flow" ]]; then
+    echo "[maestro] maestro_run: flow not found: $flow" >&2
+    return 2
+  fi
+  maestro_ensure || return 1
+  "$MAESTRO_BIN" test "$flow" "$@"
+}

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -1,293 +1,112 @@
 #!/usr/bin/env bash
-# QA Android Demos — Screenshot & crash detection for every demo
-# Usage: bash .claude/scripts/qa-android-demos.sh [--install] [--report]
+# qa-android-demos.sh — Android demo device-QA, now a thin Maestro wrapper.
 #
-# Prerequisites:
-#   - Android emulator running (adb devices shows a device)
-#   - APK built: ./gradlew :samples:android-demo:assembleDebug
-#   - Google's `android` CLI on PATH (auto-installed from ~/.local/bin if missing).
-#     See https://developer.android.com/tools/agents/android-cli — it replaces
-#     `adb shell uiautomator dump` (XML) with JSON layouts and `adb exec-out screencap`
-#     with a corruption-free `screen capture`.
+# As of slice #1562 (umbrella #1560) the slow tap-and-wait / screenshot-by-
+# screenshot logic that used to live here has been replaced by Maestro YAML
+# flows under `.maestro/android/`. Maestro drives every one of the 42 demos
+# like a real user (deep-link launch, camera-orbit drag, viewport tap, ONE
+# screenshot per demo, navigate back) and asserts each demo's Activity stays
+# alive. See `.maestro/README.md`.
+#
+# This script just orchestrates the pieces around `maestro test`:
+#   1. (optional) build + install the demo APK
+#   2. run the Maestro catalog (or a single category subflow)
+#
+# Usage:
+#   bash .claude/scripts/qa-android-demos.sh [--install] [--flow <name>]
 #
 # Options:
-#   --install   Install APK before testing
-#   --report    Generate HTML report after testing
+#   --install        Build :samples:android-demo:assembleDebug and install it.
+#   --flow <name>    Run a single category flow instead of the full catalog,
+#                    e.g. `--flow lighting` → .maestro/android/lighting.yaml.
+#                    Defaults to `catalog` (all 42 demos).
+#   -h | --help      Show this help.
 
 set -euo pipefail
 
-# Pull in helpers for Google's Android CLI (with adb fallback).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=lib/maestro.sh
+source "$SCRIPT_DIR/lib/maestro.sh"
 # shellcheck source=lib/android-cli.sh
 source "$SCRIPT_DIR/lib/android-cli.sh"
-android_cli_ensure || true  # fallback to adb if install fails — script still works
 
 PACKAGE="io.github.sceneview.demo"
 ACTIVITY=".MainActivity"
-SCREENSHOT_DIR="tools/qa-screenshots/android"
-REPORT_FILE="tools/qa-screenshots/android/report.html"
-WAIT_DEMO=6        # seconds to wait after entering a demo
-WAIT_TRANSITION=2  # seconds to wait for transitions
+APK="samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk"
 
-# All non-AR demos in order (must match DemoRouter categories)
-DEMOS=(
-    "Model Viewer"
-    "Geometry Primitives"
-    "Animation"
-    "Multi Model"
-    "Lighting"
-    "Dynamic Sky"
-    "Fog"
-    "Environment Gallery"
-    "Text Labels"
-    "Lines & Paths"
-    "Image"
-    "Billboard"
-    "Video"
-    "Camera Controls"
-    "Gesture Editing"
-    "Collision"
-    "ViewNode"
-    "Physics"
-    "Post Processing"
-    "Custom Mesh"
-    "Shape"
-    "Reflection Probes"
-    "Secondary Camera"
-    "Debug Overlay"
-)
-
-# Color output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-# Parse args
 INSTALL=false
-REPORT=false
-for arg in "$@"; do
-    case $arg in
-        --install) INSTALL=true ;;
-        --report) REPORT=true ;;
-    esac
+FLOW="catalog"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install) INSTALL=true; shift ;;
+    --flow)    FLOW="${2:?--flow needs a name}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "[qa] unknown argument: $1" >&2; exit 2 ;;
+  esac
 done
 
-# Check emulator
-if ! adb get-state &>/dev/null; then
-    echo -e "${RED}ERROR: No Android device connected. Start an emulator first.${NC}"
-    exit 1
+FLOW_FILE=".maestro/android/${FLOW}.yaml"
+if [[ ! -f "$FLOW_FILE" ]]; then
+  echo "[qa] no such flow: $FLOW_FILE" >&2
+  echo "[qa] available: $(cd .maestro/android && ls *.yaml | sed 's/\.yaml//' | tr '\n' ' ')" >&2
+  exit 2
 fi
 
-# Install if requested. Uses `android run` for atomic install+launch when the
-# CLI is available, otherwise falls back to `adb install` + the launch block
-# below (`am start` is needed regardless to ensure a fresh process).
+# --- Emulator check --------------------------------------------------------
+if ! adb get-state >/dev/null 2>&1; then
+  echo "[qa] ERROR: no Android device. Boot one first:" >&2
+  echo "[qa]   bash .claude/scripts/setup-ar-emulator.sh" >&2
+  exit 1
+fi
+
+# --- Optional build + install ---------------------------------------------
 if $INSTALL; then
-    APK="samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk"
-    if [[ ! -f "$APK" ]]; then
-        echo "Building APK..."
-        ./gradlew :samples:android-demo:assembleDebug -q
-    fi
-    echo "Installing APK..."
-    if android_cli_locate; then
-        # `android run` installs AND launches. We still force-stop below so the
-        # subsequent demo-list flow starts from a known-cold state.
-        android_cli_install_and_launch "$APK" "${PACKAGE}/${ACTIVITY}" >/dev/null || {
-            echo -e "${YELLOW}[qa] android run failed, falling back to adb install${NC}"
-            adb install -r "$APK"
-        }
-    else
-        adb install -r "$APK"
-    fi
-fi
-
-# Create screenshot directory
-mkdir -p "$SCREENSHOT_DIR"
-
-# Force-stop and launch fresh
-echo "=== SceneView Android Demo QA ==="
-echo "Testing ${#DEMOS[@]} demos..."
-echo ""
-
-# `am force-stop` + `am start` have no `android` CLI equivalent in v0.7 (the
-# `run` subcommand does not accept `--es` intent extras nor a force-stop flag),
-# so they stay on adb. See CLAUDE.md "Android CLI (preferred for agent-driven QA)".
-adb shell "am force-stop $PACKAGE" 2>/dev/null
-sleep 1
-adb shell "am start -n ${PACKAGE}/${ACTIVITY}" 2>/dev/null
-sleep 3
-
-PASSED=0
-FAILED=0
-RESULTS=()
-
-for i in "${!DEMOS[@]}"; do
-    demo="${DEMOS[$i]}"
-    idx=$((i + 1))
-    filename=$(printf "%02d_%s" "$idx" "$(echo "$demo" | tr ' &' '_' | tr -d "'")")
-
-    echo -n "[$idx/${#DEMOS[@]}] $demo ... "
-
-    # Clear logcat
-    adb logcat -c 2>/dev/null
-
-    # Helper: dump UI as JSON via `android layout` (centers precomputed) and
-    # find the demo's tap coordinates. Falls back to uiautomator XML if the
-    # android CLI is unavailable.
-    find_demo() {
-        if android_cli_layout /tmp/qa_ui.json >/dev/null 2>&1; then
-            android_cli_resolve_tap /tmp/qa_ui.json "$demo" 2>/dev/null
-        else
-            adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1
-            adb pull /sdcard/ui.xml /tmp/qa_ui.xml >/dev/null 2>&1
-            python3 -c "
-import xml.etree.ElementTree as ET, re
-tree = ET.parse('/tmp/qa_ui.xml')
-target = '$demo'
-for node in tree.iter('node'):
-    text = node.get('text','')
-    if text == target:
-        bounds = node.get('bounds','')
-        m = re.findall(r'\d+', bounds)
-        if len(m) == 4:
-            cx = (int(m[0]) + int(m[2])) // 2
-            cy = (int(m[1]) + int(m[3])) // 2
-            print(f'{cx},{cy}')
-            break
-" 2>/dev/null
-        fi
+  if [[ ! -f "$APK" ]]; then
+    echo "[qa] building demo APK..."
+    ./gradlew :samples:android-demo:assembleDebug -q
+  fi
+  echo "[qa] installing $APK"
+  android_cli_ensure || true
+  if android_cli_locate; then
+    android_cli_install_and_launch "$APK" "${PACKAGE}/${ACTIVITY}" >/dev/null || {
+      echo "[qa] android run failed, falling back to adb install" >&2
+      adb install -r "$APK"
     }
-
-    COORDS=$(find_demo)
-
-    if [[ -z "$COORDS" ]]; then
-        # Demo not visible — scroll down and retry
-        adb shell "input swipe 540 1800 540 600 120" 2>/dev/null
-        sleep 1
-        COORDS=$(find_demo)
-    fi
-
-    if [[ -z "$COORDS" ]]; then
-        # Still not found — scroll more aggressively
-        for _ in 1 2 3; do
-            adb shell "input swipe 540 1800 540 400 80" 2>/dev/null
-            sleep 0.5
-        done
-        sleep 1
-        COORDS=$(find_demo)
-    fi
-
-    if [[ -z "$COORDS" ]]; then
-        echo -e "${YELLOW}NOT FOUND (scroll issue)${NC}"
-        RESULTS+=("SKIP|$demo|not found in UI")
-        continue
-    fi
-
-    # Tap on demo
-    IFS=',' read -r X Y <<< "$COORDS"
-    adb shell "input tap $X $Y" 2>/dev/null
-    sleep "$WAIT_DEMO"
-
-    # Check if app is still alive
-    PID=$(adb shell "pidof $PACKAGE" 2>/dev/null || echo "")
-
-    if [[ -z "$PID" ]]; then
-        echo -e "${RED}CRASH${NC}"
-        # Capture crash log
-        adb logcat -d '*:E' 2>/dev/null | grep -i "FATAL\|exception" | tail -5 > "$SCREENSHOT_DIR/${filename}_crash.log"
-        RESULTS+=("CRASH|$demo|app process died")
-        FAILED=$((FAILED + 1))
-        # Restart app
-        adb shell "am start -n ${PACKAGE}/${ACTIVITY}" 2>/dev/null
-        sleep 3
-        continue
-    fi
-
-    # Take screenshot via `android screen capture` (LF/CRLF-safe), adb fallback.
-    if ! android_cli_screenshot "$SCREENSHOT_DIR/${filename}.png" 2>/dev/null; then
-        echo -e "${RED}SCREENSHOT FAILED${NC}"
-        RESULTS+=("FAIL|$demo|screenshot capture failed")
-        FAILED=$((FAILED + 1))
-        adb shell "input keyevent KEYCODE_BACK" 2>/dev/null
-        sleep "$WAIT_TRANSITION"
-        continue
-    fi
-
-    # Check for errors in logcat (use || true so grep no-match doesn't kill set -e/pipefail)
-    ERRORS=$( { adb logcat -d '*:E' 2>/dev/null | grep -E "FATAL|IllegalState|NullPointer|ClassNotFound" || true; } | wc -l | tr -d ' \n')
-    ERRORS=${ERRORS:-0}
-
-    if [[ "$ERRORS" -gt 0 ]]; then
-        echo -e "${YELLOW}WARNING ($ERRORS errors in logcat)${NC}"
-        adb logcat -d '*:E' 2>/dev/null | grep "FATAL\|IllegalState\|NullPointer\|ClassNotFound" | tail -3 > "$SCREENSHOT_DIR/${filename}_errors.log"
-        RESULTS+=("WARN|$demo|$ERRORS errors in logcat")
-    else
-        echo -e "${GREEN}OK${NC}"
-        RESULTS+=("OK|$demo|screenshot saved")
-        PASSED=$((PASSED + 1))
-    fi
-
-    # Go back to list
-    adb shell "input keyevent KEYCODE_BACK" 2>/dev/null
-    sleep "$WAIT_TRANSITION"
-done
-
-# Summary
-echo ""
-echo "=== QA SUMMARY ==="
-echo -e "${GREEN}PASSED: $PASSED${NC}"
-echo -e "${RED}FAILED: $FAILED${NC}"
-echo "SKIPPED: $((${#DEMOS[@]} - PASSED - FAILED))"
-echo "Screenshots: $SCREENSHOT_DIR/"
-
-# Generate HTML report if requested
-if $REPORT; then
-    echo "Generating HTML report..."
-    cat > "$REPORT_FILE" << 'HTMLEOF'
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<title>SceneView Android Demo QA Report</title>
-<style>
-body { font-family: system-ui; max-width: 1200px; margin: 0 auto; padding: 20px; background: #0d1117; color: #e6edf3; }
-h1 { border-bottom: 1px solid #30363d; padding-bottom: 16px; }
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: 16px; }
-.card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; overflow: hidden; }
-.card img { width: 100%; height: auto; }
-.card-body { padding: 12px; }
-.card-title { font-weight: 600; margin-bottom: 4px; }
-.badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; font-weight: 600; }
-.badge-ok { background: #238636; color: white; }
-.badge-crash { background: #da3633; color: white; }
-.badge-warn { background: #d29922; color: white; }
-.badge-skip { background: #6e7681; color: white; }
-.summary { display: flex; gap: 16px; margin-bottom: 24px; }
-.stat { padding: 16px; border-radius: 8px; text-align: center; flex: 1; }
-.stat-ok { background: #0d2818; border: 1px solid #238636; }
-.stat-fail { background: #2d1216; border: 1px solid #da3633; }
-.stat-skip { background: #1c1e24; border: 1px solid #6e7681; }
-.stat .number { font-size: 32px; font-weight: 700; }
-</style>
-</head>
-<body>
-<h1>SceneView Android Demo QA Report</h1>
-<p>Generated: <span id="date"></span></p>
-<div class="summary">
-<div class="stat stat-ok"><div class="number" id="passed">0</div>Passed</div>
-<div class="stat stat-fail"><div class="number" id="failed">0</div>Failed</div>
-<div class="stat stat-skip"><div class="number" id="skipped">0</div>Skipped</div>
-</div>
-<div class="grid" id="grid"></div>
-<script>
-document.getElementById('date').textContent = new Date().toLocaleString();
-// Results will be injected by the script
-</script>
-</body>
-</html>
-HTMLEOF
-    echo "Report: $REPORT_FILE"
+  else
+    adb install -r "$APK"
+  fi
 fi
 
-echo ""
-echo "Done. Review screenshots in $SCREENSHOT_DIR/"
+# --- Crash gate: clear logcat so the post-run FATAL/ANR sweep is scoped -----
+adb logcat -c 2>/dev/null || true
+
+# --- Run the Maestro flow --------------------------------------------------
+echo "[qa] running Maestro flow: $FLOW_FILE"
+MAESTRO_RC=0
+maestro_run "$FLOW_FILE" || MAESTRO_RC=$?
+
+# --- FATAL / ANR logcat sweep ---------------------------------------------
+# Maestro's per-demo "Navigate back" assertion already fails on a hard crash,
+# but a backgrounded native crash or an ANR can leave the process technically
+# alive — so we also grep logcat. This complements (does not replace) the
+# orchestrator runner's sweep (umbrella slice #1566).
+CRASHES="$(adb logcat -d 2>/dev/null | grep -E "FATAL EXCEPTION|ANR in ${PACKAGE}" || true)"
+if [[ -n "$CRASHES" ]]; then
+  echo "[qa] CRASH/ANR detected in logcat:" >&2
+  echo "$CRASHES" | tail -20 >&2
+  MAESTRO_RC=1
+fi
+
+if [[ "$MAESTRO_RC" -eq 0 ]]; then
+  echo "[qa] PASS — $FLOW flow completed, no crash/ANR detected."
+else
+  echo "[qa] FAIL — see Maestro output above (rc=$MAESTRO_RC)." >&2
+fi
+exit "$MAESTRO_RC"

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,67 @@
+# Maestro device-QA flows
+
+[Maestro](https://maestro.dev) YAML flows that drive the SceneView demo apps
+**like a real user** — taps, swipes, camera-orbit drags, navigation — and
+assert no crash. This is the Android/iOS leg of the autonomous device-QA
+harness (umbrella [#1560](https://github.com/sceneview/sceneview/issues/1560)).
+
+## Layout
+
+```
+.maestro/
+  android/
+    catalog.yaml      master flow — all 42 demos
+    3d-basics.yaml    per-category subsets (run a fast slice)
+    lighting.yaml
+    content.yaml
+    interaction.yaml
+    advanced.yaml
+    ar.yaml
+    flows/
+      demo.yaml       reusable parameterised subflow (one demo)
+```
+
+## Run it
+
+```bash
+# Install the pinned Maestro version (idempotent, user-local, no shell-rc edit).
+source .claude/scripts/lib/maestro.sh && maestro_ensure
+
+# Boot the ARCore-friendly emulator and install the demo APK.
+bash .claude/scripts/setup-ar-emulator.sh
+./gradlew :samples:android-demo:assembleDebug
+adb install -r samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk
+
+# Full catalog (42 demos) …
+maestro test .maestro/android/catalog.yaml
+# … or a fast subset.
+maestro test .maestro/android/lighting.yaml
+```
+
+The legacy `.claude/scripts/qa-android-demos.sh` is now a thin wrapper that
+builds + installs the APK and invokes `catalog.yaml` through Maestro.
+
+## How a demo is exercised
+
+`flows/demo.yaml` is run once per demo with `DEMO_ID` / `DEMO_NAME` env vars:
+
+1. `launchApp` with the validated `sceneview://demo/<id>` deep link plus the
+   `qa_mode` argument (freezes auto-rotation for a deterministic screenshot).
+2. Orbit the camera (two opposite horizontal drags + one vertical drag).
+3. Tap the viewport centre (node pick / harmless empty-space tap).
+4. Capture **exactly one** screenshot (`demo-<id>`).
+5. Assert the "Navigate back" affordance is still visible — a process crash
+   makes this fail.
+6. Navigate back to the demo list.
+
+## Known limitations
+
+- **No pinch gesture.** Maestro cannot pinch, so 3D camera zoom is not
+  exercised. The demo deep-link registry exposes only `demo` / `qa_mode` /
+  `ar_playback_file` — there is no zoom parameter yet. Adding one is a tracked
+  follow-up so a future `flows/demo.yaml` can deep-link a zoomed framing.
+- **Logcat FATAL/ANR sweep** is not a Maestro primitive in 1.39. The
+  orchestrator runner (`device-qa.sh`, umbrella slice
+  [#1566](https://github.com/sceneview/sceneview/issues/1566)) clears logcat
+  before the run and greps it afterwards. Per-demo crash detection (the
+  "Navigate back" assertion) works standalone.

--- a/.maestro/android/3d-basics.yaml
+++ b/.maestro/android/3d-basics.yaml
@@ -1,0 +1,35 @@
+# Maestro flow — "3D Basics" demo category (5 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/3d-basics.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow (deep-link
+# launch, camera orbit, tap, one screenshot, crash assertion, navigate back).
+# Demo ids mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: model-viewer
+      DEMO_NAME: Model Viewer
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: geometry
+      DEMO_NAME: Geometry Primitives
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: animation
+      DEMO_NAME: Animation
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: multi-model
+      DEMO_NAME: Multi Model
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: scene-gallery
+      DEMO_NAME: Scene Gallery

--- a/.maestro/android/advanced.yaml
+++ b/.maestro/android/advanced.yaml
@@ -1,0 +1,59 @@
+# Maestro flow — "Advanced" demo category (10 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/advanced.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids
+# mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: materials
+      DEMO_NAME: Materials
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: physics
+      DEMO_NAME: Physics
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: double-pendulum
+      DEMO_NAME: Double Pendulum
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: post-processing
+      DEMO_NAME: Post Processing
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: custom-mesh
+      DEMO_NAME: Custom Mesh
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: texture-streaming
+      DEMO_NAME: Texture Streaming
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: shape
+      DEMO_NAME: Shape
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: reflection-probes
+      DEMO_NAME: Reflection Probes
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: secondary-camera
+      DEMO_NAME: Secondary Camera
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: debug-overlay
+      DEMO_NAME: Debug Overlay

--- a/.maestro/android/ar.yaml
+++ b/.maestro/android/ar.yaml
@@ -1,0 +1,86 @@
+# Maestro flow — "Augmented Reality" demo category (13 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/ar.yaml
+#
+# AR demos need the ARCore-friendly emulator from
+# `.claude/scripts/setup-ar-emulator.sh` (virtualscene back camera, host GPU,
+# Google Play Services for AR installed). They launch a live `ARSceneView`;
+# the deep-link flow still exercises tap + drag on the camera surface and
+# asserts the process stays alive — AR tracking quality itself is covered by
+# the ARCore MP4 replay harness (umbrella #1560, slice #1565), not here.
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids
+# mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-placement
+      DEMO_NAME: AR Placement
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-image
+      DEMO_NAME: AR Image
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-face
+      DEMO_NAME: AR Face
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-cloud-anchor
+      DEMO_NAME: AR Cloud Anchor
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-streetscape
+      DEMO_NAME: AR Streetscape
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-pose
+      DEMO_NAME: AR Pose
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-rerun
+      DEMO_NAME: AR Rerun Debug
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-record-playback
+      DEMO_NAME: AR Record & Playback
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-depth-occlusion
+      DEMO_NAME: AR Depth Occlusion
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-instant-placement
+      DEMO_NAME: AR Instant Placement
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-terrain
+      DEMO_NAME: AR Terrain Anchors
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-rooftop
+      DEMO_NAME: AR Rooftop Anchors
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-image-stabilization
+      DEMO_NAME: AR Image Stabilization
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-orbital
+      DEMO_NAME: AR Orbital

--- a/.maestro/android/catalog.yaml
+++ b/.maestro/android/catalog.yaml
@@ -1,0 +1,48 @@
+# Maestro MASTER flow — full SceneView Android demo catalog QA.
+#
+#   maestro test .maestro/android/catalog.yaml
+#
+# This is the Android leg of the autonomous device-QA harness (umbrella #1560,
+# slice #1562). It drives every one of the 42 demos in `samples/android-demo`
+# like a real user — deep-link launch, camera orbit drag, viewport tap, one
+# screenshot per demo, navigate back — and asserts each demo's Activity stays
+# alive (a crash drops the "Navigate back" affordance, failing the flow).
+#
+# It delegates to the six per-category flows so the demo list lives in exactly
+# one place per category and a fast subset (one category) can be run on its
+# own. Demo ids mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt:
+#   3D Basics ............ 5
+#   Lighting & Environment 5
+#   Content .............. 5
+#   Interaction .......... 4
+#   Advanced ............. 10
+#   Augmented Reality .... 13
+#                          --
+#   Total ................ 42
+#
+# Crash detection:
+#   - Per-demo: flows/demo.yaml asserts the "Navigate back" button is visible
+#     after interaction — a process crash makes that assertion fail.
+#   - FATAL / ANR logcat sweep: Maestro 1.39 cannot read logcat from a flow.
+#     The orchestrator runner (umbrella slice #1566, `device-qa.sh`) clears
+#     logcat before this flow and greps it for `FATAL EXCEPTION` / `ANR in`
+#     afterwards. Run this flow through that runner for the full crash gate;
+#     run it directly for a quick interactive smoke.
+#
+# Zoom limitation:
+#   Maestro has no pinch gesture, so 3D camera zoom is not exercised here.
+#   The demo deep-link registry (DeepLinkRouter / the `--es` intent extras)
+#   currently exposes only `demo`, `qa_mode` and `ar_playback_file` — there is
+#   no zoom/camera-distance parameter. Adding one is filed as a follow-up so a
+#   future revision of flows/demo.yaml can deep-link a zoomed framing.
+#
+# AR demos require the ARCore-friendly emulator from
+# `.claude/scripts/setup-ar-emulator.sh`.
+appId: io.github.sceneview.demo
+---
+- runFlow: 3d-basics.yaml
+- runFlow: lighting.yaml
+- runFlow: content.yaml
+- runFlow: interaction.yaml
+- runFlow: advanced.yaml
+- runFlow: ar.yaml

--- a/.maestro/android/content.yaml
+++ b/.maestro/android/content.yaml
@@ -1,0 +1,34 @@
+# Maestro flow — "Content" demo category (5 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/content.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids
+# mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: text
+      DEMO_NAME: Text Labels
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: lines-paths
+      DEMO_NAME: Lines & Paths
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: image
+      DEMO_NAME: Image
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: billboard
+      DEMO_NAME: Billboard
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: video
+      DEMO_NAME: Video

--- a/.maestro/android/flows/demo.yaml
+++ b/.maestro/android/flows/demo.yaml
@@ -1,0 +1,91 @@
+# Reusable Maestro subflow — exercises ONE SceneView demo like a real user.
+#
+# Called by the per-category flows and by catalog.yaml via `runFlow` with an
+# `env:` block. It never appears in a flow runner by itself.
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID    Stable demo id from ALL_DEMOS (e.g. "model-viewer", "ar-pose").
+#   DEMO_NAME  Human label, used only for screenshot file naming / readable logs.
+#
+# Strategy:
+#   - launchApp with the public `sceneview://demo/<id>` deep link so we jump
+#     straight to the demo screen — no tab navigation, no list scrolling. This
+#     is the same ingress the deep-link router validates (DeepLinkRouter.parse).
+#   - `qa_mode` extra freezes auto-rotation / orbit / animations so the single
+#     screenshot is deterministic frame-to-frame.
+#   - Exercise REAL interaction: drag to orbit the camera, swipe to pan, tap
+#     the centre of the viewport (hits demo controls / picks nodes). 3D zoom
+#     has no Maestro pinch gesture — see the catalog header note; zoom is a
+#     documented follow-up via a deep-link param.
+#   - Capture exactly ONE screenshot per demo (no screenshot-by-screenshot
+#     loop — that was the slow pattern in the old qa-android-demos.sh).
+#   - Assert the app process is still foregrounded afterwards. A crash would
+#     drop us out of the app; `assertVisible` on any app element then fails the
+#     flow. A FATAL/ANR sweep of logcat is done once, globally, by catalog.yaml.
+appId: io.github.sceneview.demo
+---
+# Cold-launch straight into the demo via the validated deep link.
+- launchApp:
+    appId: io.github.sceneview.demo
+    clearState: false
+    stopApp: true
+    arguments:
+      qa_mode: true
+    deepLink: "sceneview://demo/${DEMO_ID}"
+
+# Let the first frame render. The demo scaffold shows a scrim for up to 12 s
+# while the engine warms up; 6 s is plenty for the deep-linked demo to be
+# interactive on the ARCore emulator.
+- waitForAnimationToEnd:
+    timeout: 6000
+
+# --- Real user interaction -------------------------------------------------
+# Orbit the camera: drag across the viewport. Two opposite drags so we exercise
+# the manipulator in both directions and return roughly to the start framing.
+- swipe:
+    start: 30%, 55%
+    end: 70%, 55%
+    duration: 600
+- swipe:
+    start: 70%, 55%
+    end: 30%, 55%
+    duration: 600
+
+# Vertical drag — tilts the orbit camera / pans 2D-content demos.
+- swipe:
+    start: 50%, 65%
+    end: 50%, 40%
+    duration: 600
+
+# Tap the centre of the viewport: in interaction demos this picks a node, in
+# control-strip demos it is a harmless empty-space tap. Either way it must not
+# crash.
+- tapOn:
+    point: 50%, 55%
+
+# Give any tap-triggered work (node selection, gesture handlers, AR hit-test)
+# a moment to settle before the screenshot.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# --- One screenshot per demo ----------------------------------------------
+# Maestro writes screenshots to its output dir; the file name keys off DEMO_ID
+# so a category run produces one PNG per demo with no overwrites.
+- takeScreenshot: "demo-${DEMO_ID}"
+
+# --- Liveness assertion ----------------------------------------------------
+# If the demo had crashed, the process would be gone and we'd be on the
+# launcher / a system dialog — the back button's content description would not
+# be present. This is the per-demo crash gate.
+- assertVisible:
+    id: "io.github.sceneview.demo:id/decor_content_parent"
+    optional: true
+# Belt-and-braces: the demo scaffold always renders a "Navigate back" button.
+# Its presence proves the demo Activity is still foregrounded and composed.
+- assertVisible: "Navigate back"
+
+# --- Navigate back ---------------------------------------------------------
+# Return to the demo list so a subsequent flow step starts from a known state.
+- tapOn: "Navigate back"
+- waitForAnimationToEnd:
+    timeout: 2000

--- a/.maestro/android/interaction.yaml
+++ b/.maestro/android/interaction.yaml
@@ -1,0 +1,29 @@
+# Maestro flow — "Interaction" demo category (4 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/interaction.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids
+# mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: camera-controls
+      DEMO_NAME: Camera Controls
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: gesture-editing
+      DEMO_NAME: Gesture Editing
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: collision
+      DEMO_NAME: Collision
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: view-node
+      DEMO_NAME: ViewNode

--- a/.maestro/android/lighting.yaml
+++ b/.maestro/android/lighting.yaml
@@ -1,0 +1,34 @@
+# Maestro flow — "Lighting & Environment" demo category (5 demos).
+#
+# Run a fast subset of the device-QA harness:
+#   maestro test .maestro/android/lighting.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids
+# mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: lighting
+      DEMO_NAME: Lighting
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: movable-light
+      DEMO_NAME: Movable Light
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: dynamic-sky
+      DEMO_NAME: Dynamic Sky
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: fog
+      DEMO_NAME: Fog
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: environment
+      DEMO_NAME: Environment Gallery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- device-qa: added a maestro harness — `.maestro/android/` flows drive all 42 android demos like a real user (deep-link launch, camera-orbit drag, tap, one screenshot per demo, crash assertion), with per-category subflows and a `maestro.sh` auto-install helper; `qa-android-demos.sh` is now a thin maestro wrapper (#1562).
+
 ## v4.9.0 — Cross-platform demo catalogs, web auto-center parity & teardown safety (2026-05-16)
 
 ### Added


### PR DESCRIPTION
## Summary

Slice 1 of the autonomous device-QA harness umbrella (#1560): set up [Maestro](https://maestro.dev) and author YAML flows that drive `samples/android-demo` like a real user.

- **`.claude/scripts/lib/maestro.sh`** — Maestro install helper, analogous to `android-cli.sh`: auto-installs a *pinned* Maestro version (`1.39.0`) to a user-local path (`~/.maestro`) on first use, idempotent, CI-safe (`$CI` guard — CI installs Maestro as a prior step), exposes `maestro_ensure` / `maestro_run`.
- **`.maestro/android/`** — 8 Maestro YAML flows:
  - `flows/demo.yaml` — reusable parameterised subflow for **one** demo: deep-link launch via the validated public `sceneview://demo/<id>` scheme + the `qa_mode` argument, camera-orbit drag (two horizontal + one vertical swipe), viewport tap, **exactly one** screenshot per demo, a "Navigate back" liveness assertion (per-demo crash gate), navigate back.
  - Six per-category flows (`3d-basics`, `lighting`, `content`, `interaction`, `advanced`, `ar`) so a fast subset can run on its own.
  - `catalog.yaml` — master flow covering all **42 demos** (5 + 5 + 5 + 4 + 10 + 13).
- **`qa-android-demos.sh`** rewritten as a thin wrapper: builds/installs the demo APK, runs the Maestro catalog (or a `--flow <category>` subset), and does a logcat `FATAL`/`ANR` sweep.
- **`.maestro/README.md`** documents layout, usage and known limitations.

### Notes / limitations
- Maestro has no pinch gesture, so **3D zoom is not exercised**. The demo deep-link registry (`DeepLinkRouter` / the `--es` intent extras) currently exposes only `demo` / `qa_mode` / `ar_playback_file` — there is no zoom param. Adding one is a documented follow-up.
- The logcat `FATAL`/`ANR` sweep is not a Maestro 1.39 primitive — it lives in the wrapper script and (later) the orchestrator runner `device-qa.sh` (slice #1566). Per-demo crash detection (the "Navigate back" assertion) works standalone.

## Test plan

- [x] `./gradlew :samples:android-demo:assembleDebug` — BUILD SUCCESSFUL.
- [x] All 8 `.maestro/**/*.yaml` flows parse cleanly; all 42 demo ids cross-checked against `ALL_DEMOS`.
- [x] `maestro.sh` / `qa-android-demos.sh` pass `bash -n`.
- [ ] Live `maestro test .maestro/android/catalog.yaml` against the ARCore emulator — **deferred**: the build environment has no network route to `get.maestro.dev` (cannot install Maestro) and disk headroom was too tight to boot the emulator. Run locally / in CI per `.maestro/README.md`.

Part of #1560, closes #1562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)