### PR TITLE
test(android-demo): autonomous AR replay harness for device-QA

### DIFF
--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ar-replay-qa.sh — autonomous AR-demo replay QA, headless, no physical device.
+#
+# Slice 4 of the device-QA harness umbrella (#1560, this slice #1565).
+#
+# What it does:
+#   1. Builds + installs the android-demo *debug* APK (the debug sourceSet
+#      ships the bundled ARCore recording the harness replays).
+#   2. Runs the `ARReplayHarnessTest` instrumentation test, which deep-links
+#      every Augmented Reality demo, drives each through a recorded ARCore
+#      session, and asserts no crash. The one demo that consumes
+#      `playbackDataset` (`ar-record-playback`) additionally proves the
+#      recorded dataset advanced frames.
+#   3. Pulls the machine-readable verdict `ar-qa-summary.json` the test wrote
+#      to `/sdcard/Download/SceneView/` and echoes its path.
+#
+# This is the entrypoint the slice-5 orchestrator runner (`device-qa.sh`,
+# #1566) calls for the Android-AR leg. The JSON shape mirrors the device-QA
+# harness convention: `{ harness, passed, total, demos: [{ id, verdict,
+# replayedFrames }] }` — see ARReplayHarnessTest.writeSummary().
+#
+# Requirements:
+#   - An ARCore-friendly emulator (or device). `setup-ar-emulator.sh`
+#     provisions one with Google Play Services for AR.
+#   - A connected, booted device — this script does not boot one.
+#
+# Usage:
+#   bash .claude/scripts/ar-replay-qa.sh [--no-install] [--out <dir>]
+#
+# Options:
+#   --no-install   Skip the build+install step (APK already on device).
+#   --out <dir>    Directory to copy ar-qa-summary.json into. Default: a temp
+#                  dir; the resolved path is printed on the last line.
+#   -h | --help    Show this help.
+#
+# Exit status:
+#   0  every AR demo survived recorded-session replay
+#   1  one or more demos crashed, or the harness could not run
+#   2  no device / emulator connected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=lib/android-cli.sh
+source "$SCRIPT_DIR/lib/android-cli.sh"
+
+INSTALL=1
+OUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-install) INSTALL=0; shift ;;
+    --out) OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "[ar-replay-qa] unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Device check ───────────────────────────────────────────────────────────
+SERIAL="$(android_cli_pick_serial || true)"
+if [[ -z "$SERIAL" ]]; then
+  echo "[ar-replay-qa] no single device/emulator connected." >&2
+  echo "[ar-replay-qa] boot one first: bash .claude/scripts/setup-ar-emulator.sh" >&2
+  exit 2
+fi
+echo "[ar-replay-qa] target device: $SERIAL"
+
+# ── Build + install ────────────────────────────────────────────────────────
+# The replay harness needs the *debug* APK: the bundled ARCore recording
+# (bundled-pixel9-sample.mp4) ships only in the debug sourceSet so the release
+# APK stays lean (#934).
+if [[ "$INSTALL" -eq 1 ]]; then
+  echo "[ar-replay-qa] building + installing android-demo debug APK + test APK…"
+  ./gradlew --console=plain \
+    :samples:android-demo:installDebug \
+    :samples:android-demo:installDebugAndroidTest
+else
+  echo "[ar-replay-qa] --no-install: skipping build+install."
+fi
+
+# ── Clean logcat so a crash this run is not masked by an older one ──────────
+adb -s "$SERIAL" logcat -c || true
+
+# ── Run the replay harness ─────────────────────────────────────────────────
+echo "[ar-replay-qa] running ARReplayHarnessTest (headless AR replay over all AR demos)…"
+HARNESS_STATUS=0
+adb -s "$SERIAL" shell am instrument -w \
+  -e class io.github.sceneview.demo.ar.ARReplayHarnessTest \
+  io.github.sceneview.demo.test/androidx.test.runner.AndroidJUnitRunner \
+  || HARNESS_STATUS=$?
+
+# ── Pull the machine-readable verdict ──────────────────────────────────────
+DEVICE_SUMMARY="/sdcard/Download/SceneView/ar-qa-summary.json"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d)"
+fi
+mkdir -p "$OUT_DIR"
+LOCAL_SUMMARY="$OUT_DIR/ar-qa-summary.json"
+
+if adb -s "$SERIAL" pull "$DEVICE_SUMMARY" "$LOCAL_SUMMARY" >/dev/null 2>&1; then
+  echo "[ar-replay-qa] verdict summary:"
+  cat "$LOCAL_SUMMARY"
+  echo
+  echo "[ar-replay-qa] summary written to: $LOCAL_SUMMARY"
+else
+  echo "[ar-replay-qa] WARNING: no ar-qa-summary.json on device — the harness" >&2
+  echo "[ar-replay-qa] was likely assumeTrue-skipped (bundled recording absent," >&2
+  echo "[ar-replay-qa] or Google Play Services for AR missing). See test output." >&2
+fi
+
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+  echo "[ar-replay-qa] FAIL — one or more AR demos crashed during replay." >&2
+  exit 1
+fi
+echo "[ar-replay-qa] PASS — every AR demo survived recorded-session replay."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - device-qa: added a maestro harness — `.maestro/android/` flows drive all 42 android demos like a real user (deep-link launch, camera-orbit drag, tap, one screenshot per demo, crash assertion), with per-category subflows and a `maestro.sh` auto-install helper; `qa-android-demos.sh` is now a thin maestro wrapper (#1562).
+- device-qa: added an autonomous ar replay harness — `ARReplayHarnessTest` drives every augmented-reality demo through a recorded arcore session headless on the emulator (no physical device), asserts no crash, and emits a machine-readable `ar-qa-summary.json`; the `ar-replay-qa.sh` script is the orchestrator entrypoint that builds, runs and pulls the verdict (#1565).
 
 ## v4.9.0 — Cross-platform demo catalogs, web auto-center parity & teardown safety (2026-05-16)
 

--- a/samples/android-demo/AR_TESTING.md
+++ b/samples/android-demo/AR_TESTING.md
@@ -5,7 +5,7 @@
 
 ## TL;DR — what's tested
 
-Three layers of real-rendering tests in `samples/android-demo/src/androidTest/`:
+Four layers of real-rendering tests in `samples/android-demo/src/androidTest/`:
 
 1. **`DemoRenderingScreenshotTest`** (3D demos): launches each demo via deep-link,
    waits N seconds, screenshots via UiAutomator, compares to a golden in
@@ -20,6 +20,11 @@ Three layers of real-rendering tests in `samples/android-demo/src/androidTest/`:
    rendered AR frame at **fixed ARCore frame indices** (f=30/60/120/180), comparing
    each to a golden in `androidTest/assets/ar-screenshot-goldens/`. See
    [Frame-indexed AR screenshot regression](#frame-indexed-ar-screenshot-regression-1050)
+   below.
+4. **`ARReplayHarnessTest`** (autonomous AR replay harness, #1565): drives **every**
+   AR demo through the bundled recorded session and asserts no crash, emitting a
+   machine-readable `ar-qa-summary.json`. The breadth counterpart to the depth
+   golden tests. See [Autonomous AR replay harness](#autonomous-ar-replay-harness-1565)
    below.
 
 All run on `connectedDebugAndroidTest` (real device / hardware-accelerated emulator —
@@ -52,6 +57,56 @@ dev emulator" warning, is in
 CI runs this pipeline in the `ar-demo-playback-screenshots` job of
 `.github/workflows/render-tests.yml`, on a pinned emulator profile (api-30 /
 `google_apis` / `x86_64` / `swiftshader_indirect`) so goldens stay reproducible.
+
+## Autonomous AR replay harness (#1565)
+
+The frame-indexed test above gives **depth** — pixel-exact regression on the one
+demo (`ar-record-playback`) that genuinely consumes `playbackDataset`.
+`ARReplayHarnessTest` gives **breadth**: it drives *every* AR demo in
+`DemoCategory.AUGMENTED_REALITY` (13 demos) through the bundled recorded session
+and asserts the process survives.
+
+It is the headless, no-physical-device entrypoint the device-QA orchestrator
+runner (umbrella [#1560](https://github.com/sceneview/sceneview/issues/1560),
+slice [#1566](https://github.com/sceneview/sceneview/issues/1566)) calls for the
+Android-AR leg, via the wrapper script:
+
+```bash
+bash .claude/scripts/ar-replay-qa.sh          # build + install + run + pull verdict
+bash .claude/scripts/ar-replay-qa.sh --no-install   # APK already on device
+```
+
+The harness writes a machine-readable verdict to
+`/sdcard/Download/SceneView/ar-qa-summary.json`, which the script pulls:
+
+```json
+{
+  "harness": "ar-replay",
+  "recording": "bundled-pixel9-sample.mp4",
+  "passed": 13,
+  "total": 13,
+  "demos": [
+    { "id": "ar-record-playback", "verdict": "replayed", "replayedFrames": 47 },
+    { "id": "ar-placement",       "verdict": "alive",    "replayedFrames": 0 }
+  ]
+}
+```
+
+Per-demo verdict:
+
+- **`replayed`** — the demo consumed recorded ARCore frames (the frame counter
+  advanced). Today only `ar-record-playback` does, because it is the one demo
+  that reads `DemoSettings.arPendingPlaybackFile` and mounts
+  `ARSceneView(playbackDataset = file)`.
+- **`alive`** — the demo's process survived the recorded-session replay window
+  but did not advance the frame counter. The other 12 AR demos build a *live*
+  `ARSceneView`; surviving a recorded session still exercises ARCore session
+  creation, demo composition, the Filament engine and the AR overlay — the
+  layer that breaks silently between releases. As a demo opts into
+  `playbackDataset`, its verdict graduates from `alive` to `replayed`
+  automatically — no harness change needed.
+- **`crashed`** — the demo's process died during replay. **Any** `crashed`
+  verdict fails the harness.
 
 ## The AR record-once playback-many workflow
 

--- a/samples/android-demo/src/androidTest/assets/ar-recordings/README.md
+++ b/samples/android-demo/src/androidTest/assets/ar-recordings/README.md
@@ -4,6 +4,23 @@ This folder holds MP4 files captured by `ARRecorder.start(...)` then exported vi
 `ARRecorder.exportToDownloads(...)`. Each file is replayed by
 `ARDemoPlaybackSmokeTest` to drive the corresponding AR demo deterministically.
 
+## Current fixture status
+
+This directory is **README-only** today — no MP4 fixtures are committed yet, so
+`ARDemoPlaybackSmokeTest` is `assumeTrue`-skipped on a fresh checkout. Issue
+[#1442](https://github.com/sceneview/sceneview/issues/1442) tracks bundling a
+curated subset of the 8 real ARCore Record datasets captured in the 2026-05-16
+QA session (in-car drive, outdoor walks, ground markings, kitchen) here as
+deterministic CI fixtures. **Until #1442 lands, drop the in-car + outdoor MP4s
+into this directory** following the workflow below — the discovery code in
+`ARDemoPlaybackSmokeTest.discoverFixtures()` auto-enrols every `.mp4` it finds,
+so no test edit is needed.
+
+The autonomous AR replay harness (`ARReplayHarnessTest`, slice #1565) does
+**not** depend on fixtures in this directory — it replays the bundled recording
+that ships in the `debug` sourceSet (`src/debug/assets/ar-recordings/`), so the
+breadth-coverage harness works on a fresh checkout before #1442's fixtures land.
+
 ## How to add a new fixture
 
 See [`samples/android-demo/AR_TESTING.md`](../../../AR_TESTING.md) for the full

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
@@ -1,0 +1,310 @@
+package io.github.sceneview.demo.ar
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import io.github.sceneview.demo.ALL_DEMOS
+import io.github.sceneview.demo.DemoCategory
+import io.github.sceneview.demo.DemoSettings
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * **Autonomous AR replay harness** — slice 4 of the device-QA umbrella
+ * ([#1560](https://github.com/sceneview/sceneview/issues/1560), this slice
+ * [#1565](https://github.com/sceneview/sceneview/issues/1565)).
+ *
+ * This is the headless, emulator-runnable entrypoint the orchestrator runner
+ * ([#1566](https://github.com/sceneview/sceneview/issues/1566)) drives via
+ * `.claude/scripts/ar-replay-qa.sh`. It exercises **every AR demo** against a
+ * recorded ARCore session — no physical device, no live camera, no IMU — and
+ * emits a machine-readable pass/fail-per-demo result.
+ *
+ * ## What it does
+ *
+ * For each demo in [DemoCategory.AUGMENTED_REALITY] (13 demos, see
+ * [ALL_DEMOS]) it:
+ *
+ * 1. Deploys the bundled ARCore recording into the app's external files dir.
+ * 2. Deep-links the demo with `--es ar_playback_file <path>` so any demo that
+ *    honours [DemoSettings.arPendingPlaybackFile] auto-enters replay.
+ * 3. Leaves it running for a fixed window and asserts the process stayed
+ *    alive (catches ARCore session-init exceptions, missing manifest entries,
+ *    Filament JNI failures — the catastrophic class of regression).
+ * 4. For `ar-record-playback` — the one demo that genuinely consumes
+ *    [DemoSettings.arPendingPlaybackFile] today — it additionally asserts the
+ *    ARCore frame counter advanced, i.e. the dataset really replayed frames
+ *    rather than just not crashing.
+ *
+ * The per-demo verdict is collected into `ar-qa-summary.json` on the device
+ * (see [writeSummary]) so the slice-5 orchestrator can pull one file instead
+ * of scraping instrumentation stdout.
+ *
+ * ## Relationship to the sibling AR tests
+ *
+ * - [ARDemoPlaybackSmokeTest] — sweeps `androidTest/assets/ar-recordings/`
+ *   fixtures (currently README-only; populated by #1442) through the single
+ *   `ar-record-playback` demo with a per-fixture golden.
+ * - [ARPlaybackScreenshotTest] — frame-indexed (f=30/60/120/180) golden
+ *   regression for `ar-record-playback` against the bundled recording.
+ * - **This test** — breadth: every AR demo, crash-survival + (where the demo
+ *   supports it) real frame-advance, with a machine-readable summary.
+ *
+ * The three are complementary: depth (golden frames) on the replay demo,
+ * breadth (all AR demos) here.
+ *
+ * ## Why most demos get a crash-survival check, not a golden
+ *
+ * Only `ar-record-playback` reads [DemoSettings.arPendingPlaybackFile] and
+ * mounts `ARSceneView(playbackDataset = file)`. The other 12 AR demos build a
+ * **live** `ARSceneView`. Driving them through a recorded session still has
+ * real value — ARCore session creation, demo composition, the Filament
+ * engine, model loading and the AR overlay all execute on the emulator, which
+ * is exactly the layer that breaks silently between releases. As demos opt
+ * into `playbackDataset` (tracked as a follow-up to #1565) this harness picks
+ * them up automatically and the verdict graduates from `alive` to
+ * `replayed`.
+ *
+ * ## Requirements
+ *
+ * - The bundled recording ships in the `debug` sourceSet
+ *   (`src/debug/assets/ar-recordings/bundled-pixel9-sample.mp4`) — run against
+ *   a debug build, or `git sparse-checkout add` that path.
+ * - Google Play Services for AR installed (the ARCore runtime drives playback
+ *   even for recorded sessions). `.claude/scripts/setup-ar-emulator.sh`
+ *   provisions an emulator with it.
+ *
+ * The test is `assumeTrue`-skipped — never failed — when the bundled
+ * recording is absent, so a sparse checkout that excludes the MP4 stays
+ * green.
+ */
+@RunWith(AndroidJUnit4::class)
+class ARReplayHarnessTest {
+
+    private lateinit var context: Context
+    private lateinit var device: UiDevice
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        // Pre-grant runtime permissions: AGP reinstalls the demo APK before each
+        // test class, wiping any prior `pm grant`. Without CAMERA the AR demos
+        // block at the permission prompt instead of mounting the ARSceneView.
+        device.executeShellCommand("pm grant io.github.sceneview.demo android.permission.CAMERA")
+        device.executeShellCommand("pm grant io.github.sceneview.demo android.permission.RECORD_AUDIO")
+        device.wakeUp()
+        device.executeShellCommand("wm dismiss-keyguard")
+    }
+
+    @Test
+    fun everyArDemo_replaysRecordedSession_withoutCrash() {
+        val recording = locateBundledRecording()
+        assumeTrue(
+            "Bundled ARCore recording not found in the demo APK assets " +
+                "($BUNDLED_RECORDING). It ships in the `debug` sourceSet " +
+                "(samples/android-demo/src/debug/assets/ar-recordings/) — run the " +
+                "test against a debug build, or `git sparse-checkout add` that path.",
+            recording != null,
+        )
+        val deployed = deployFixtureToAppPrivateDir(recording!!)
+
+        val arDemos = ALL_DEMOS.filter { it.category == DemoCategory.AUGMENTED_REALITY }
+        assertTrue(
+            "Expected at least one Augmented Reality demo in ALL_DEMOS",
+            arDemos.isNotEmpty(),
+        )
+
+        val results = ArrayList<DemoResult>(arDemos.size)
+        try {
+            for (demo in arDemos) {
+                results += replayDemo(demo.id, deployed)
+                // Land on the demo list between demos so onNewIntent fires cleanly
+                // for the next deep-link.
+                device.pressHome()
+            }
+        } finally {
+            deployed.delete()
+        }
+
+        val summaryPath = writeSummary(results)
+
+        // The harness fails if ANY demo crashed during replay. Demos that the
+        // recording could not advance (live-only demos that ignore the playback
+        // extra) are reported as `alive`, not failed — surviving a recorded
+        // session is the contract for those.
+        val crashed = results.filter { it.verdict == VERDICT_CRASHED }
+        assertTrue(
+            "AR replay harness: ${crashed.size}/${results.size} demo(s) crashed " +
+                "during recorded-session replay — ${crashed.joinToString { it.demoId }}. " +
+                "Full machine-readable verdict: $summaryPath",
+            crashed.isEmpty(),
+        )
+    }
+
+    // ── Per-demo replay ─────────────────────────────────────────────────────
+
+    /**
+     * Replays [demoId] against the deployed [recording]. Returns the verdict:
+     *
+     * - [VERDICT_REPLAYED] — the demo consumed recorded ARCore frames (the
+     *   frame counter advanced past [MIN_REPLAYED_FRAMES]).
+     * - [VERDICT_ALIVE] — the demo's process stayed alive for the replay
+     *   window but did not advance the frame counter (a live-only AR demo
+     *   that does not yet honour `playbackDataset`).
+     * - [VERDICT_CRASHED] — the demo's process died during replay.
+     */
+    private fun replayDemo(demoId: String, recording: File): DemoResult {
+        // Reset the cross-thread frame counter so a stale value from the
+        // previous demo cannot be mistaken for this demo's progress.
+        DemoSettings.arPlaybackFrameCount = 0
+
+        launchDemo(demoId, recording.absolutePath)
+        // Give the activity time to boot, ARCore to init, and the recorded
+        // session to advance a few frames.
+        SystemClock.sleep(REPLAY_WINDOW_MILLIS)
+
+        val frames = DemoSettings.arPlaybackFrameCount
+        val alive = isDemoProcessAlive()
+
+        val verdict = when {
+            !alive -> VERDICT_CRASHED
+            frames >= MIN_REPLAYED_FRAMES -> VERDICT_REPLAYED
+            else -> VERDICT_ALIVE
+        }
+        return DemoResult(demoId, verdict, frames)
+    }
+
+    /**
+     * `true` when the demo process is still running. Uses `pidof` over the
+     * app's package name — a crashed Activity tears down the process, so an
+     * empty `pidof` is an unambiguous crash signal.
+     */
+    private fun isDemoProcessAlive(): Boolean {
+        val out = device.executeShellCommand("pidof io.github.sceneview.demo")
+        return out.trim().isNotEmpty()
+    }
+
+    // ── Machine-readable summary ────────────────────────────────────────────
+
+    /**
+     * Writes a machine-readable verdict file to
+     * `/sdcard/Download/SceneView/ar-qa-summary.json` — a path that survives
+     * AGP's post-test app uninstall so `.claude/scripts/ar-replay-qa.sh` can
+     * `adb pull` it.
+     *
+     * The shape mirrors the device-QA harness convention (umbrella #1560): a
+     * top-level `harness` / `passed` / `total` header plus a `demos` array of
+     * `{ id, verdict, replayedFrames }`. Slice #1564's `web-qa-summary.json`
+     * is expected to follow the same `{ harness, passed, total, <items> }`
+     * skeleton so the slice-5 orchestrator can merge platform reports without
+     * special-casing each.
+     */
+    private fun writeSummary(results: List<DemoResult>): File {
+        val demos = JSONArray()
+        for (r in results) {
+            demos.put(
+                JSONObject()
+                    .put("id", r.demoId)
+                    .put("verdict", r.verdict)
+                    .put("replayedFrames", r.replayedFrames),
+            )
+        }
+        val passed = results.count { it.verdict != VERDICT_CRASHED }
+        val root = JSONObject()
+            .put("harness", "ar-replay")
+            .put("recording", BUNDLED_RECORDING)
+            .put("passed", passed)
+            .put("total", results.size)
+            .put("demos", demos)
+
+        device.executeShellCommand("mkdir -p /sdcard/Download/SceneView")
+        val file = File("/sdcard/Download/SceneView/ar-qa-summary.json")
+        FileOutputStream(file).use { it.write(root.toString(2).toByteArray()) }
+        return file
+    }
+
+    private data class DemoResult(
+        val demoId: String,
+        val verdict: String,
+        val replayedFrames: Int,
+    )
+
+    // ── Fixture plumbing ────────────────────────────────────────────────────
+
+    /**
+     * Locates the bundled ARCore recording in the demo APK's assets. It ships
+     * in the `debug` sourceSet (`src/debug/assets/ar-recordings/`), so it is
+     * read through the *target* app's asset manager. Returns `null` if absent
+     * (release build, or a sparse checkout that excluded the MP4).
+     */
+    private fun locateBundledRecording(): String? = runCatching {
+        context.assets.list("ar-recordings")
+            ?.firstOrNull { it == BUNDLED_RECORDING }
+    }.getOrNull()
+
+    /**
+     * Copies the bundled recording from the demo APK's assets into the app's
+     * external-files `ar-recordings/` directory — the path the demo's
+     * Recordings list scans and that the `--es ar_playback_file` security
+     * guard in `MainActivity` allows.
+     */
+    private fun deployFixtureToAppPrivateDir(fixtureName: String): File {
+        val targetDir = context.getExternalFilesDir("ar-recordings")!!
+        targetDir.mkdirs()
+        val targetFile = File(targetDir, fixtureName)
+        context.assets.open("ar-recordings/$fixtureName").use { input ->
+            targetFile.outputStream().use { output -> input.copyTo(output) }
+        }
+        return targetFile
+    }
+
+    /**
+     * Deep-links a demo via `am start --es demo <slug>` with the recorded
+     * session attached via `--es ar_playback_file <path>` — the same path
+     * `ARDemoPlaybackSmokeTest` uses. Demos that honour
+     * [DemoSettings.arPendingPlaybackFile] auto-enter replay; the others
+     * launch live and the extra is harmlessly ignored.
+     */
+    private fun launchDemo(demoSlug: String, playbackFile: String) {
+        device.executeShellCommand(
+            "am start -n io.github.sceneview.demo/.MainActivity " +
+                "-f 0x14000000 " + // CLEAR_TOP | NEW_TASK so onNewIntent fires on re-launch
+                "--es demo $demoSlug " +
+                "--es ar_playback_file $playbackFile",
+        )
+    }
+
+    private companion object {
+        /** Bundled recording filename — matches `src/debug/assets/ar-recordings/`. */
+        const val BUNDLED_RECORDING = "bundled-pixel9-sample.mp4"
+
+        /**
+         * Time to leave each demo running before reading its verdict. Long
+         * enough for ARCore session init + a few replayed frames (~5 s on a
+         * Pixel 7a emulator), short enough that a 13-demo sweep stays well
+         * under the instrumentation timeout.
+         */
+        const val REPLAY_WINDOW_MILLIS = 7_000L
+
+        /**
+         * Minimum ARCore frames a demo must consume to be graded `replayed`
+         * rather than merely `alive`. A handful of frames proves the recorded
+         * dataset actually drove the session.
+         */
+        const val MIN_REPLAYED_FRAMES = 5
+
+        const val VERDICT_REPLAYED = "replayed"
+        const val VERDICT_ALIVE = "alive"
+        const val VERDICT_CRASHED = "crashed"
+    }
+}


### PR DESCRIPTION
## Summary

Slice 4 of the autonomous device-QA harness umbrella (#1560). Makes Android AR demo QA fully autonomous — no physical device, no live camera/IMU — by replaying a recorded ARCore session against **every** AR demo.

- **`ARReplayHarnessTest`** — enumerates every `Augmented Reality` demo from `ALL_DEMOS` (13 demos), deploys the bundled ARCore recording, deep-links each demo with `--es ar_playback_file`, and asserts the process survives the replay window. The one demo that consumes `playbackDataset` (`ar-record-playback`) is additionally graded `replayed` once its ARCore frame counter advances; the 12 live-only AR demos are graded `alive` (surviving a recorded session still exercises ARCore session creation + demo composition + Filament + the AR overlay). **Any crash fails the harness.**
- Emits a machine-readable verdict to `/sdcard/Download/SceneView/ar-qa-summary.json`, shaped `{ harness, passed, total, demos: [{ id, verdict, replayedFrames }] }` so the slice-5 orchestrator runner (#1566) can merge it with the web/Maestro reports.
- **`.claude/scripts/ar-replay-qa.sh`** — the autonomous entrypoint the orchestrator calls: builds the debug APK (which ships the bundled recording), installs, runs the harness headless, pulls the verdict JSON.
- `AR_TESTING.md` gains an "Autonomous AR replay harness" section; lowercase `## Unreleased` CHANGELOG entry added.

## Fixture status

`samples/android-demo/src/androidTest/assets/ar-recordings/` is still **README-only** — **#1442** must drop the in-car + outdoor ARCore recordings there. The replay harness does **not** depend on those: it replays the bundled recording in the `debug` sourceSet (`bundled-pixel9-sample.mp4`), so it works on a fresh checkout today. The fixture README and `AR_TESTING.md` document this clearly.

## Why the 12 live AR demos are not wired to `playbackDataset`

Only `ARRecordPlaybackDemo` reads `DemoSettings.arPendingPlaybackFile` and mounts `ARSceneView(playbackDataset = file)`. Wiring the other 12 demos would touch 12 files and risk regressing live AR — out of scope for a QA-harness slice. As demos opt into `playbackDataset` (tracked follow-up), the harness picks them up automatically and the verdict graduates from `alive` to `replayed` with no harness change.

## Test plan

- [x] Static review: all symbols (`ALL_DEMOS`, `DemoCategory`, `DemoSettings`, `UiDevice.executeShellCommand`, `org.json`) verified against the codebase; test runner package `io.github.sceneview.demo.test` confirmed.
- [ ] Deferred: `./gradlew :samples:android-demo:compileDebugAndroidTestKotlin` and an emulator run — the dev machine dropped below the 4 GB disk safety floor (`CLAUDE.md` hard rule) mid-session, so the AGP build was not run. Should be validated by CI / a follow-up run.

Part of #1560, closes #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)