### PR TITLE
fix(ios-demo): resolve Swift 6 concurrency warnings (#1574)

### DIFF
--- a/changelog.d/1574-ios-demo-concurrency.md
+++ b/changelog.d/1574-ios-demo-concurrency.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- iOS demo: resolved Swift 6 concurrency warnings — the `OrbitalARDemo` and `DoublePendulumDemo` per-frame timer closures now hop onto the main actor before touching main-actor-isolated scene state, fixing real data-race risks. `DemoDeepLinkRegistry.destination(for:)` is now `@MainActor`-isolated, and `SceneViewDemoApp` adopts the modern two-parameter `onChange(of:)` signature (#1574).

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -43,6 +43,12 @@ enum DemoDeepLinkRegistry {
     /// have an iOS destination wired up — this keeps the QR / deep-link
     /// path working as soon as a new id is published, even if the iOS
     /// catalogue lags behind.
+    ///
+    /// `@MainActor`-isolated because it constructs SwiftUI `View` values,
+    /// which are themselves main-actor-isolated; the only call site
+    /// (`ContentView`'s `.fullScreenCover` / `.sheet`) already runs on the
+    /// main actor.
+    @MainActor
     @ViewBuilder
     static func destination(for id: String) -> some View {
         switch id {

--- a/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
+++ b/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
@@ -99,7 +99,7 @@ struct ContentView: View {
                 .accessibilityLabel("About This App")
         }
         .tint(SceneViewTheme.primary)
-        .onChange(of: pendingDeepLinkDemo) { newId in
+        .onChange(of: pendingDeepLinkDemo) { _, newId in
             guard let id = newId else { return }
             // Switch to the Samples tab so the deep-link surface feels
             // contextual; then present the demo above it as a modal so we

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/DoublePendulumDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/DoublePendulumDemo.swift
@@ -294,23 +294,35 @@ private final class PendulumCoordinator {
     private var state = DoublePendulumState()
     private weak var link1: Entity?
     private weak var link2: Entity?
+    /// Wall-clock timestamp of the previous tick, relative to the timer's
+    /// start `Date`. Kept as a main-actor-isolated property (rather than a
+    /// captured `var`) so the `@Sendable` timer closure mutates it safely.
+    private var lastTick: TimeInterval = 0
 
     func start(state: DoublePendulumState, link1: Entity, link2: Entity) {
         stop()
         self.state = state
         self.link1 = link1
         self.link2 = link2
+        self.lastTick = 0
         // Place the links correctly on frame 0 so there's no initial pop.
         apply()
         let start = Date()
-        var last = TimeInterval(0)
+        // The Timer fires on the main run loop, but its closure is `@Sendable`,
+        // so the body must explicitly hop onto the main actor before touching
+        // `self.state` / `self.lastTick` and calling `apply()`.
+        // `MainActor.assumeIsolated` is correct here — the closure already runs
+        // on the main thread (the timer is added to `RunLoop.main`) — and it
+        // keeps the physics step synchronous, with no scheduling latency.
         let t = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            let now = Date().timeIntervalSince(start)
-            let dt = Float(now - last)
-            last = now
-            self.state = DoublePendulum.step(self.state, deltaSeconds: dt)
-            self.apply()
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let now = Date().timeIntervalSince(start)
+                let dt = Float(now - self.lastTick)
+                self.lastTick = now
+                self.state = DoublePendulum.step(self.state, deltaSeconds: dt)
+                self.apply()
+            }
         }
         RunLoop.main.add(t, forMode: .common)
         timer = t

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
@@ -208,28 +208,36 @@ struct OrbitalARDemo: View {
         // Invalidate any prior timer (e.g. session re-start) to avoid stacking ticks.
         orbitTimer?.invalidate()
         let start = Date()
+        // The Timer fires on the main run loop, but its closure is `@Sendable`,
+        // so the body must explicitly hop onto the main actor before touching
+        // main-actor state (`Self.planets`, `loadedNodes`, `position(for:time:)`).
+        // `MainActor.assumeIsolated` is correct here — the closure already runs
+        // on the main thread (the timer is added to `RunLoop.main`) — and it
+        // keeps the per-frame update synchronous, with no scheduling latency.
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
-            let now = Date().timeIntervalSince(start)
-            for (index, planet) in Self.planets.enumerated() {
-                guard let node = loadedNodes[index] else { continue }
-                node.entity.position = position(for: planet, time: Float(now))
-                // Models with a baked animation (dragon, phoenix) face the tangent
-                // of the orbit (= direction of motion) instead of spinning on Y —
-                // a flying creature pirouetting on itself breaks the illusion.
-                // The orbit angle modulo 2π is the same precision guard as #978.
-                let orbitAngle = (planet.initialAngle + planet.orbitSpeed * Float(now))
-                    .truncatingRemainder(dividingBy: 2 * .pi)
-                let yawAngle: Float
-                if planet.hasBakedAnimation {
-                    // For position (R·cos θ, h, R·sin θ) on a CCW orbit, the tangent
-                    // is (-sin θ, 0, cos θ). For a USDZ whose forward is -Z, that
-                    // maps to a Y-rotation of θ + π.
-                    yawAngle = orbitAngle + .pi
-                } else {
-                    yawAngle = (planet.spinSpeed * Float(now))
+            MainActor.assumeIsolated {
+                let now = Date().timeIntervalSince(start)
+                for (index, planet) in Self.planets.enumerated() {
+                    guard let node = loadedNodes[index] else { continue }
+                    node.entity.position = position(for: planet, time: Float(now))
+                    // Models with a baked animation (dragon, phoenix) face the tangent
+                    // of the orbit (= direction of motion) instead of spinning on Y —
+                    // a flying creature pirouetting on itself breaks the illusion.
+                    // The orbit angle modulo 2π is the same precision guard as #978.
+                    let orbitAngle = (planet.initialAngle + planet.orbitSpeed * Float(now))
                         .truncatingRemainder(dividingBy: 2 * .pi)
+                    let yawAngle: Float
+                    if planet.hasBakedAnimation {
+                        // For position (R·cos θ, h, R·sin θ) on a CCW orbit, the tangent
+                        // is (-sin θ, 0, cos θ). For a USDZ whose forward is -Z, that
+                        // maps to a Y-rotation of θ + π.
+                        yawAngle = orbitAngle + .pi
+                    } else {
+                        yawAngle = (planet.spinSpeed * Float(now))
+                            .truncatingRemainder(dividingBy: 2 * .pi)
+                    }
+                    node.entity.orientation = simd_quatf(angle: yawAngle, axis: .init(0, 1, 0))
                 }
-                node.entity.orientation = simd_quatf(angle: yawAngle, axis: .init(0, 1, 0))
             }
         }
         RunLoop.main.add(timer, forMode: .common)


### PR DESCRIPTION
## Summary

Fixes #1574 — building the iOS demo (`samples/ios-demo`) produced 14 warnings; the concerning ones were main-actor isolation violations that are real data-race risks (and hard errors under Swift 6 strict concurrency).

- **`OrbitalARDemo` / `DoublePendulumDemo`** — the per-frame `Timer` closures are `@Sendable`, so they touched main-actor-isolated scene state (`planets`, `loadedNodes`, `position(for:time:)`, `PendulumCoordinator.state`, `apply()`) off the main actor. The closure body now hops onto the main actor via `MainActor.assumeIsolated`. Both timers are added to `RunLoop.main`, so the closure already executes on the main thread — `assumeIsolated` keeps the update synchronous with no scheduling latency, behavior unchanged.
- **`DoublePendulumDemo`** — the captured `var last` (concurrently mutated from the timer closure) is promoted to a main-actor-isolated `lastTick` property on `PendulumCoordinator`.
- **`DemoDeepLinkRegistry.destination(for:)`** — now `@MainActor`. It constructs SwiftUI `View` values (main-actor-isolated); its only call site (`ContentView`'s `.fullScreenCover` / `.sheet`) already runs on the main actor.
- **`SceneViewDemoApp`** — adopts the modern two-parameter `onChange(of:)`, replacing the iOS 17-deprecated single-parameter form.

No `@unchecked Sendable`, no warning suppression — the fixes restore correct main-actor isolation.

## Test plan

- [x] `xcodebuild ... -scheme SceneViewDemo -destination 'platform=iOS Simulator,name=iPhone 16e' -configuration Debug build` — **BUILD SUCCEEDED, zero compiler warnings** (all four touched files force-recompiled).
- [x] Installed on the iPhone 16e simulator; `DoublePendulumDemo` opened via `sceneview://demo/double-pendulum` deep link — renders correctly and animates (consecutive frame captures differ). `OrbitalARDemo` is device-only (simulator shows its placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)