### PR TITLE
test(ios-demo): Maestro iOS device-QA flows (#1563)

### DIFF
--- a/.claude/scripts/ios-device-qa.sh
+++ b/.claude/scripts/ios-device-qa.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# ios-device-qa.sh — iOS demo device-QA, a thin Maestro wrapper.
+#
+# The iOS leg of the autonomous device-QA harness (umbrella #1560, slice
+# #1563). Maestro YAML flows under `.maestro/ios/` drive every iOS demo
+# reachable via the public `sceneview://demo/<id>` deep link in
+# `samples/ios-demo` like a real user (custom-scheme deep-link launch,
+# camera-orbit drag, viewport tap, ONE screenshot per demo) and assert each
+# demo's screen stays alive. See `.maestro/README.md`.
+#
+# This script is the iOS analogue of `qa-android-demos.sh`: it orchestrates the
+# pieces around `maestro test`:
+#   1. boot an iOS simulator (if none is booted)
+#   2. (optional) build + install the SceneViewDemo app on it
+#   3. run the Maestro catalog (or a single category subflow)
+#   4. sweep the simulator log for crash markers (Maestro 1.39 cannot read the
+#      device log from a flow — same gap the Android wrapper covers with adb).
+#
+# Usage:
+#   bash .claude/scripts/ios-device-qa.sh [--install] [--flow <name>] \
+#       [--simulator <name>]
+#
+# Options:
+#   --install            Build the SceneViewDemo app for the simulator and
+#                        install it before the flow run.
+#   --flow <name>        Run a single category flow instead of the full
+#                        catalog, e.g. `--flow lighting` ->
+#                        .maestro/ios/lighting.yaml. Defaults to `catalog`.
+#   --simulator <name>   Simulator device name to boot / target. Defaults to
+#                        "iPhone 16 Pro" (the name used by `.github/workflows/
+#                        ios.yml`).
+#   -h | --help          Show this help.
+#
+# Note — a full `xcodebuild` simulator build is heavy (Swift Package resolve +
+# RealityKit compile). On a disk-constrained host, run without `--install`
+# against an already-installed build, or let the orchestrator runner (umbrella
+# slice #1566) do the build once and reuse the simulator.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=lib/maestro.sh
+source "$SCRIPT_DIR/lib/maestro.sh"
+
+BUNDLE_ID="io.github.sceneview.demo"
+DEMO_DIR="samples/ios-demo"
+XCODE_PROJECT="SceneViewDemo.xcodeproj"
+XCODE_SCHEME="SceneViewDemo"
+
+INSTALL=false
+FLOW="catalog"
+SIMULATOR="iPhone 16 Pro"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)   INSTALL=true; shift ;;
+    --flow)      FLOW="${2:?--flow needs a name}"; shift 2 ;;
+    --simulator) SIMULATOR="${2:?--simulator needs a name}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "[ios-qa] unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+FLOW_FILE=".maestro/ios/${FLOW}.yaml"
+if [[ ! -f "$FLOW_FILE" ]]; then
+  echo "[ios-qa] no such flow: $FLOW_FILE" >&2
+  echo "[ios-qa] available: $(cd .maestro/ios && ls *.yaml | sed 's/\.yaml//' | tr '\n' ' ')" >&2
+  exit 2
+fi
+
+# --- Host check ------------------------------------------------------------
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "[ios-qa] ERROR: the iOS simulator only runs on macOS." >&2
+  exit 1
+fi
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "[ios-qa] ERROR: xcrun not found — install Xcode + command-line tools." >&2
+  exit 1
+fi
+
+# --- Boot a simulator ------------------------------------------------------
+# Reuse an already-booted simulator if there is one; otherwise boot the named
+# device. `simctl boot` is idempotent enough but we guard it anyway.
+BOOTED_UDID="$(xcrun simctl list devices booted -j \
+  | python3 -c 'import json,sys; ds=json.load(sys.stdin)["devices"]; \
+print(next((d["udid"] for v in ds.values() for d in v if d.get("state")=="Booted"), ""))' \
+  2>/dev/null || true)"
+
+if [[ -z "$BOOTED_UDID" ]]; then
+  echo "[ios-qa] no booted simulator — booting \"$SIMULATOR\"..."
+  TARGET_UDID="$(xcrun simctl list devices available -j \
+    | python3 -c "import json,sys; ds=json.load(sys.stdin)['devices']; \
+print(next((d['udid'] for v in ds.values() for d in v if d.get('name')=='$SIMULATOR'), ''))" \
+    2>/dev/null || true)"
+  if [[ -z "$TARGET_UDID" ]]; then
+    echo "[ios-qa] ERROR: no available simulator named \"$SIMULATOR\"." >&2
+    echo "[ios-qa] list devices with: xcrun simctl list devices available" >&2
+    exit 1
+  fi
+  xcrun simctl boot "$TARGET_UDID"
+  BOOTED_UDID="$TARGET_UDID"
+fi
+echo "[ios-qa] using simulator $BOOTED_UDID"
+
+# --- Optional build + install ---------------------------------------------
+if $INSTALL; then
+  echo "[ios-qa] building $XCODE_SCHEME for the simulator (this is heavy)..."
+  DERIVED_DATA="$(mktemp -d)"
+  set -o pipefail
+  xcodebuild build \
+    -project "$DEMO_DIR/$XCODE_PROJECT" \
+    -scheme "$XCODE_SCHEME" \
+    -destination "id=$BOOTED_UDID" \
+    -derivedDataPath "$DERIVED_DATA" \
+    | { command -v xcpretty >/dev/null 2>&1 && xcpretty || cat; }
+
+  APP_PATH="$(find "$DERIVED_DATA/Build/Products" -name 'SceneViewDemo.app' -maxdepth 3 -print -quit)"
+  if [[ -z "$APP_PATH" ]]; then
+    echo "[ios-qa] ERROR: build succeeded but SceneViewDemo.app was not found." >&2
+    rm -rf "$DERIVED_DATA"
+    exit 1
+  fi
+  echo "[ios-qa] installing $APP_PATH"
+  xcrun simctl install "$BOOTED_UDID" "$APP_PATH"
+  rm -rf "$DERIVED_DATA"
+fi
+
+# --- Crash gate: spawn a log tail so the post-run sweep is scoped ----------
+# Maestro's per-demo `assertVisible` already fails on a hard crash, but a
+# background NSException or a watchdog kill can be missed — so we also grep the
+# simulator log. This complements (does not replace) the orchestrator runner's
+# sweep (umbrella slice #1566).
+LOG_FILE="$(mktemp)"
+xcrun simctl spawn "$BOOTED_UDID" log stream \
+  --predicate "process == \"SceneViewDemo\"" --style compact \
+  > "$LOG_FILE" 2>/dev/null &
+LOG_PID=$!
+# Make sure the log tail dies with the script.
+trap 'kill "$LOG_PID" 2>/dev/null || true; rm -f "$LOG_FILE"' EXIT
+
+# --- Run the Maestro flow --------------------------------------------------
+echo "[ios-qa] running Maestro flow: $FLOW_FILE"
+MAESTRO_RC=0
+maestro_run "$FLOW_FILE" || MAESTRO_RC=$?
+
+# Give the log stream a moment to flush, then stop it.
+sleep 1
+kill "$LOG_PID" 2>/dev/null || true
+
+# --- Crash log sweep -------------------------------------------------------
+CRASHES="$(grep -E "Fatal error|NSException|EXC_BAD_ACCESS|did crash|Terminating app" "$LOG_FILE" 2>/dev/null || true)"
+if [[ -n "$CRASHES" ]]; then
+  echo "[ios-qa] CRASH detected in the simulator log:" >&2
+  echo "$CRASHES" | tail -20 >&2
+  MAESTRO_RC=1
+fi
+
+if [[ "$MAESTRO_RC" -eq 0 ]]; then
+  echo "[ios-qa] PASS — $FLOW flow completed, no crash detected."
+else
+  echo "[ios-qa] FAIL — see Maestro output above (rc=$MAESTRO_RC)." >&2
+fi
+exit "$MAESTRO_RC"

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -19,9 +19,23 @@ harness (umbrella [#1560](https://github.com/sceneview/sceneview/issues/1560)).
     ar.yaml
     flows/
       demo.yaml       reusable parameterised subflow (one demo)
+  ios/
+    catalog.yaml      master flow — all 24 deep-linkable demos
+    3d-basics.yaml    per-category subsets (run a fast slice)
+    lighting.yaml
+    content.yaml
+    interaction.yaml
+    advanced.yaml
+    ar.yaml           AR demos — launch-only smoke
+    placeholders.yaml deep-link placeholder smoke (un-ported ids)
+    flows/
+      demo.yaml          reusable subflow (one demo, with crash assertion)
+      demo-noassert.yaml subflow for demos with no overlaid SwiftUI chrome
+      ar-demo.yaml       launch-only AR smoke subflow
+      placeholder.yaml   deep-link-placeholder smoke subflow
 ```
 
-## Run it
+## Run it — Android
 
 ```bash
 # Install the pinned Maestro version (idempotent, user-local, no shell-rc edit).
@@ -41,9 +55,47 @@ maestro test .maestro/android/lighting.yaml
 The legacy `.claude/scripts/qa-android-demos.sh` is now a thin wrapper that
 builds + installs the APK and invokes `catalog.yaml` through Maestro.
 
+## Run it — iOS
+
+```bash
+# Build + install the demo on an iOS simulator and run the full catalog.
+bash .claude/scripts/ios-device-qa.sh --install
+
+# … or, against an already-installed build, a fast subset.
+bash .claude/scripts/ios-device-qa.sh --flow lighting
+```
+
+`ios-device-qa.sh` is the iOS analogue of `qa-android-demos.sh`: it boots a
+simulator, optionally builds + installs `samples/ios-demo` (`xcodebuild`,
+scheme `SceneViewDemo`), runs the Maestro flow, then sweeps the simulator log
+for crash markers. The `xcodebuild` step is heavy — on a disk-constrained host
+omit `--install` and reuse an installed build.
+
+### iOS coverage and known gaps
+
+- **Deep-link subset, not the full catalog.** iOS flows reach demos via the
+  public `sceneview://demo/<id>` custom scheme. The reachable set is
+  `DemoDeepLinkRegistry.allowedIds` (24 ids at the time slice
+  [#1563](https://github.com/sceneview/sceneview/issues/1563) landed), a subset
+  of Android's 42-demo catalog. The iOS Samples-tab presents demos in a
+  `.fullScreenCover` with **no Close affordance**, so a UI-navigation walk of
+  the catalog cannot advance past the first demo — deep-link launch +
+  `stopApp: true` cold-restart per demo is the only viable ingress. Widening
+  `allowedIds` (or adding a Close button to the full-screen cover) is a tracked
+  follow-up.
+- **AR demos are launch-only smoke.** RealityKit AR cannot run on the iOS
+  simulator — `ar.yaml` only asserts the AR screen mounts without crashing.
+- **No `qa_mode`.** Android freezes auto-rotation with a `qa_mode` deep-link
+  argument for a deterministic screenshot; iOS has no equivalent yet (tracked
+  follow-up). iOS screenshots are smoke artefacts, not pixel baselines.
+- **`text` / `model-viewer`** render no overlaid SwiftUI chrome on a key-less
+  simulator, so they use the assertion-free `flows/demo-noassert.yaml`; their
+  crash detection falls to the log sweep below.
+
 ## How a demo is exercised
 
-`flows/demo.yaml` is run once per demo with `DEMO_ID` / `DEMO_NAME` env vars:
+**Android** — `android/flows/demo.yaml` runs once per demo with `DEMO_ID` /
+`DEMO_NAME` env vars:
 
 1. `launchApp` with the validated `sceneview://demo/<id>` deep link plus the
    `qa_mode` argument (freezes auto-rotation for a deterministic screenshot).
@@ -54,14 +106,33 @@ builds + installs the APK and invokes `catalog.yaml` through Maestro.
    makes this fail.
 6. Navigate back to the demo list.
 
+**iOS** — `ios/flows/demo.yaml` runs once per demo with `DEMO_ID` /
+`DEMO_NAME` / `ASSERT_TEXT` env vars:
+
+1. `launchApp` cold-starts the app, then `openLink` fires the
+   `sceneview://demo/<id>` custom-scheme deep link.
+2. `extendedWaitUntil` waits for `ASSERT_TEXT` (a known on-screen string) so a
+   launch crash fails fast.
+3. Orbit the camera (two opposite horizontal drags + one vertical drag).
+4. Tap the viewport centre.
+5. Capture **exactly one** screenshot (`demo-<id>`).
+6. Assert `ASSERT_TEXT` is still visible — a process crash drops the app to
+   SpringBoard, failing this. There is no "navigate back": `stopApp: true` on
+   the next demo's `launchApp` is the per-demo isolation (the iOS Samples-tab
+   `.fullScreenCover` has no Close affordance — see the iOS gaps above).
+
 ## Known limitations
 
 - **No pinch gesture.** Maestro cannot pinch, so 3D camera zoom is not
-  exercised. The demo deep-link registry exposes only `demo` / `qa_mode` /
-  `ar_playback_file` — there is no zoom parameter yet. Adding one is a tracked
-  follow-up so a future `flows/demo.yaml` can deep-link a zoomed framing.
-- **Logcat FATAL/ANR sweep** is not a Maestro primitive in 1.39. The
+  exercised on either platform. The demo deep-link registry exposes only
+  `demo` / `qa_mode` / `ar_playback_file` — there is no zoom parameter yet.
+  Adding one is a tracked follow-up so a future `flows/demo.yaml` can deep-link
+  a zoomed framing.
+- **Device-log crash sweep** is not a Maestro primitive in 1.39. The
   orchestrator runner (`device-qa.sh`, umbrella slice
-  [#1566](https://github.com/sceneview/sceneview/issues/1566)) clears logcat
-  before the run and greps it afterwards. Per-demo crash detection (the
-  "Navigate back" assertion) works standalone.
+  [#1566](https://github.com/sceneview/sceneview/issues/1566)) clears / tails
+  the device log before the run and greps it afterwards — `adb logcat` on
+  Android (`FATAL EXCEPTION` / `ANR`), `simctl spawn … log` on iOS (`Fatal
+  error` / `NSException`). The wrapper scripts (`qa-android-demos.sh`,
+  `ios-device-qa.sh`) also do this sweep. Per-demo `assertVisible` crash
+  detection works standalone.

--- a/.maestro/ios/3d-basics.yaml
+++ b/.maestro/ios/3d-basics.yaml
@@ -1,0 +1,37 @@
+# Maestro flow — "3D Basics" iOS demo category.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/3d-basics.yaml
+#
+# Each demo is exercised by the matching reusable subflow (see flows/demo.yaml
+# header for the variant map): inline-overlay demos use flows/demo.yaml,
+# settings-sheet demos use flows/demo-settings.yaml, and `model-viewer`
+# (no Maestro-visible chrome on a key-less simulator) uses flows/demo-noassert.yaml.
+#
+# Demo ids are the subset of Android `DemoRegistry.kt` ALL_DEMOS ids that
+# `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` on iOS.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo-noassert.yaml
+    env:
+      DEMO_ID: model-viewer
+      DEMO_NAME: Model Viewer
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: geometry
+      DEMO_NAME: Geometry Primitives
+      ASSERT_TEXT: "5 built-in geometry types with PBR materials"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: animation
+      DEMO_NAME: Animation
+      ASSERT_TEXT: "Subject"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: multi-model
+      DEMO_NAME: Multi Model
+      ASSERT_TEXT: "Visibility"

--- a/.maestro/ios/advanced.yaml
+++ b/.maestro/ios/advanced.yaml
@@ -1,0 +1,37 @@
+# Maestro flow — "Advanced" iOS demo category.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/advanced.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. The iOS
+# Advanced demos reachable via `sceneview://demo/<id>` are physics,
+# double-pendulum and custom-mesh; `shape` is a registered deep-link id that
+# routes to `GeometryDemo` (DemoDeepLinkRegistry maps `shape -> GeometryDemo`).
+#
+# Demo ids mirror Android `DemoRegistry.kt` ALL_DEMOS.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: physics
+      DEMO_NAME: Physics
+      ASSERT_TEXT: "Crash-test mesh"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: double-pendulum
+      DEMO_NAME: Double Pendulum
+      ASSERT_TEXT: "Reset & drop"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: custom-mesh
+      DEMO_NAME: Custom Mesh
+      ASSERT_TEXT: "MeshNode.fromVertices -- raw vertex data"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: shape
+      DEMO_NAME: Shape (Geometry)
+      ASSERT_TEXT: "5 built-in geometry types with PBR materials"

--- a/.maestro/ios/ar.yaml
+++ b/.maestro/ios/ar.yaml
@@ -1,0 +1,44 @@
+# Maestro flow — "Augmented Reality" iOS demo category — LAUNCH-ONLY smoke.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/ar.yaml
+#
+# RealityKit AR (ARKit world tracking) cannot run on the iOS simulator — there
+# is no camera feed. So every AR id here is a LAUNCH-ONLY smoke (umbrella #1560
+# decision: iOS AR = launch-only): the flow asserts the AR demo screen mounts
+# without crashing and captures one screenshot. It does NOT scan a plane or
+# place a model. AR tracking behaviour is verified by the iOS QA session on a
+# physical device, not by this simulator harness.
+#
+# Two kinds of AR id reach this flow (see flows/ar-demo.yaml):
+#   - Ported AR demos — `ar-placement`, `ar-rerun` — route to the real iOS AR
+#     demo view, which renders a `simulatorPlaceholder` ("AR requires a
+#     physical device" / "ARKit is not available in the simulator.") on the
+#     simulator. That copy is the crash gate.
+#   - Registered-but-unported AR ids — `ar-image`, `ar-face` — route to the
+#     `DeepLinkPlaceholder`; flows/placeholder.yaml handles those, included
+#     here so the AR flow is the single place every AR deep-link id is smoked.
+#
+# Demo ids mirror Android `DemoRegistry.kt` ALL_DEMOS.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/ar-demo.yaml
+    env:
+      DEMO_ID: ar-placement
+      DEMO_NAME: AR Placement
+      ASSERT_TEXT: "AR requires a physical device"
+- runFlow:
+    file: flows/ar-demo.yaml
+    env:
+      DEMO_ID: ar-rerun
+      DEMO_NAME: AR Rerun Debug
+      ASSERT_TEXT: "ARKit is not available in the simulator."
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-image
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-face

--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -1,0 +1,71 @@
+# Maestro MASTER flow — full SceneView iOS demo catalog QA.
+#
+#   maestro test .maestro/ios/catalog.yaml
+#
+# This is the iOS leg of the autonomous device-QA harness (umbrella #1560,
+# slice #1563). It drives every iOS demo reachable via the public
+# `sceneview://demo/<id>` deep link in `samples/ios-demo` like a real user —
+# custom-scheme deep-link launch, camera orbit drag, viewport tap, one
+# screenshot per demo — and asserts each demo's screen stays alive (a crash
+# drops the app to SpringBoard, failing the per-demo `assertVisible`).
+#
+# It delegates to the per-category flows so the demo list lives in exactly one
+# place per category and a fast subset can be run on its own.
+#
+# Coverage vs the Android slice (#1562, 42 demos):
+#   iOS coverage is the subset of Android `DemoRegistry.kt` ALL_DEMOS ids that
+#   `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` —
+#   24 ids at the time slice #1563 landed:
+#     3D Basics ............ 4   (model-viewer, geometry, animation, multi-model)
+#     Lighting ............. 4   (lighting, movable-light, dynamic-sky, fog)
+#     Content .............. 4   (text, lines-paths, image, billboard)
+#     Interaction .......... 1   (camera-controls)
+#     Advanced ............. 4   (physics, double-pendulum, custom-mesh, shape)
+#     Augmented Reality .... 2   (ar-placement, ar-rerun — launch-only smoke)
+#     Deep-link placeholders 5   (environment, video, gesture-editing,
+#                                 ar-image, ar-face — router + placeholder smoke)
+#                                --
+#     Total ................ 24
+#
+# Why deep-link ingress, not Samples-tab navigation:
+#   The iOS Samples-tab presents demos in a `.fullScreenCover` with NO Close
+#   affordance — a real iOS-demo UX gap (filed as a slice #1563 follow-up).
+#   There is no in-app way to leave a full-screen demo, so a UI-navigation
+#   walk of the catalog could not advance past the first demo. Deep-link
+#   launch + `stopApp: true` cold-restart per demo (flows/demo.yaml) sidesteps
+#   this entirely and matches the Android subflow's per-demo isolation. The
+#   trade-off: only the `allowedIds` subset is reachable. Widening `allowedIds`
+#   to the full catalog (or adding a Close button) is a tracked follow-up.
+#
+# Crash detection (per-demo, see flows/demo.yaml for the variant map):
+#   - Inline-overlay demos — flows/demo.yaml asserts an always-on viewport
+#     caption / button-strip label.
+#   - Settings-sheet demos — flows/demo-settings.yaml asserts the always-present
+#     gear FAB (`demo-settings-fab` accessibility id), opens the sheet and
+#     asserts a control label inside it.
+#   - AR demos — flows/ar-demo.yaml asserts the simulator-placeholder copy.
+#   - `text` and `model-viewer` render no Maestro-visible SwiftUI chrome on a
+#     key-less simulator, so they use the assertion-free flows/demo-noassert
+#     .yaml; their crash detection falls to the log sweep below.
+#   A crash drops the app to SpringBoard so the `assertVisible` fails the flow.
+#   - FATAL / NSException log sweep: Maestro 1.39 cannot read the iOS device
+#     log from a flow. The orchestrator runner (umbrella slice #1566,
+#     `device-qa.sh`) tails the simulator log and greps it for crash markers.
+#     Run this flow through `ios-device-qa.sh` for the full crash gate; run it
+#     directly for a quick interactive smoke.
+#
+# Zoom limitation:
+#   Maestro has no pinch gesture, so 3D camera zoom is not exercised here — the
+#   same limitation as the Android slice. iOS additionally has no `qa_mode`
+#   deep-link argument to freeze auto-rotation; both are tracked follow-ups.
+#
+# AR demos are launch-only smoke — RealityKit AR cannot run on the simulator.
+appId: io.github.sceneview.demo
+---
+- runFlow: 3d-basics.yaml
+- runFlow: lighting.yaml
+- runFlow: content.yaml
+- runFlow: interaction.yaml
+- runFlow: advanced.yaml
+- runFlow: ar.yaml
+- runFlow: placeholders.yaml

--- a/.maestro/ios/content.yaml
+++ b/.maestro/ios/content.yaml
@@ -1,0 +1,36 @@
+# Maestro flow — "Content" iOS demo category.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/content.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. `text`
+# (TextDemo) is a bare 3D-text scene with no overlaid SwiftUI chrome, so it
+# uses the assertion-free flows/demo-noassert.yaml variant.
+#
+# Demo ids are the subset of Android `DemoRegistry.kt` ALL_DEMOS that
+# `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` on iOS.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo-noassert.yaml
+    env:
+      DEMO_ID: text
+      DEMO_NAME: 3D Text
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: lines-paths
+      DEMO_NAME: Lines & Paths
+      ASSERT_TEXT: "PathNode"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: image
+      DEMO_NAME: Image Planes
+      ASSERT_TEXT: "ImageNode.color -- solid-color planes in an arc"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: billboard
+      DEMO_NAME: Billboard
+      ASSERT_TEXT: "Orbit the camera -- labels always face you"

--- a/.maestro/ios/flows/ar-demo.yaml
+++ b/.maestro/ios/flows/ar-demo.yaml
@@ -1,0 +1,51 @@
+# Reusable Maestro subflow — LAUNCH-ONLY smoke for ONE iOS AR demo.
+#
+# Called by ar.yaml via `runFlow` with an `env:` block. It never appears in a
+# flow runner by itself.
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID      Stable demo id from DemoDeepLinkRegistry.allowedIds.
+#   DEMO_NAME    Human label, used only for screenshot file naming / logs.
+#   ASSERT_TEXT  A SwiftUI text/label string the AR screen is guaranteed to
+#                render once loaded (a status pill, a coaching string, or the
+#                deep-link placeholder copy). Used as the crash gate.
+#
+# Why launch-only:
+#   RealityKit AR (ARKit world tracking) cannot run on the iOS simulator —
+#   there is no camera feed and `ARWorldTrackingConfiguration.isSupported` is
+#   false. So this subflow does NOT tap a plane or place a model. It asserts
+#   the AR demo *screen* loads — view hierarchy mounts, `SceneViewSwift` AR
+#   surface is created, no crash on entry — and captures one screenshot. AR
+#   tracking behaviour itself is out of scope for the simulator harness (the
+#   issue #1560 decision: iOS AR = launch-only smoke).
+#
+# Two kinds of AR id reach this subflow:
+#   - Ported AR demos (`ar-placement`, `ar-rerun`) → DemoDeepLinkRegistry
+#     routes to the real iOS AR demo view. On the simulator the AR surface
+#     mounts but tracking never starts; the demo's own coaching / status copy
+#     is the ASSERT_TEXT.
+#   - AR ids registered for deep-link but not yet ported (`ar-image`,
+#     `ar-face`) → DemoDeepLinkRegistry routes to `DeepLinkPlaceholder`. The
+#     smoke still has value: it proves the router + placeholder path does not
+#     crash. ASSERT_TEXT is then the placeholder's "Demo:" copy.
+appId: io.github.sceneview.demo
+---
+- launchApp:
+    appId: io.github.sceneview.demo
+    stopApp: true
+    clearState: false
+
+- openLink: "sceneview://demo/${DEMO_ID}"
+
+# Allow the AR screen (or the deep-link placeholder) to mount. AR demos spin up
+# a RealityKit ARView which is heavier than a plain SceneView, so the timeout
+# is generous.
+- extendedWaitUntil:
+    visible: "${ASSERT_TEXT}"
+    timeout: 15000
+
+# One screenshot — proof the AR screen rendered without crashing on entry.
+- takeScreenshot: "ar-${DEMO_ID}"
+
+# Crash gate: a crash on AR entry drops us to SpringBoard and this fails.
+- assertVisible: "${ASSERT_TEXT}"

--- a/.maestro/ios/flows/demo-noassert.yaml
+++ b/.maestro/ios/flows/demo-noassert.yaml
@@ -1,0 +1,57 @@
+# Reusable Maestro subflow — exercises ONE iOS 3D demo that renders NO overlaid
+# SwiftUI chrome (a pure RealityView scene with no control strip or status pill).
+#
+# This is the assertion-free variant of `flows/demo.yaml`. A handful of iOS
+# demos — `text` (TextDemo, a bare 3D-text scene) and `model-viewer`
+# (ModelViewerDemo, whose only overlay is a "Surprise me" button hidden when no
+# Sketchfab key is configured, i.e. on CI / a clean simulator) — render nothing
+# that Maestro's view-hierarchy `assertVisible` can latch onto. There is no
+# stable on-screen SwiftUI string to use as the per-demo crash gate.
+#
+# So this variant does launch + real interaction + one screenshot, but skips
+# the `assertVisible` crash gate. Crash detection for these demos is delegated
+# to the orchestrator runner's FATAL/exception log sweep (umbrella #1560,
+# slice #1566) — exactly the Android slice's fallback for log-only crash modes.
+# `extendedWaitUntil` is still NOT possible (nothing to wait for); a fixed
+# `waitForAnimationToEnd` lets the first frame settle instead.
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID    Stable demo id from DemoDeepLinkRegistry.allowedIds.
+#   DEMO_NAME  Human label, used only for screenshot file naming / logs.
+#
+# Adding an iOS `qa_mode`-style overlay (even a tiny invisible accessibility
+# marker per demo) would let every demo use the asserting `flows/demo.yaml` —
+# tracked as a slice #1563 follow-up.
+appId: io.github.sceneview.demo
+---
+- launchApp:
+    appId: io.github.sceneview.demo
+    stopApp: true
+    clearState: false
+
+- openLink: "sceneview://demo/${DEMO_ID}"
+
+# No overlay text to wait on — let the RealityView first frame render.
+- waitForAnimationToEnd:
+    timeout: 8000
+
+# --- Real user interaction -------------------------------------------------
+- swipe:
+    start: 30%, 55%
+    end: 70%, 55%
+    duration: 600
+- swipe:
+    start: 70%, 55%
+    end: 30%, 55%
+    duration: 600
+- swipe:
+    start: 50%, 65%
+    end: 50%, 40%
+    duration: 600
+- tapOn:
+    point: 50%, 55%
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# --- One screenshot per demo ----------------------------------------------
+- takeScreenshot: "demo-${DEMO_ID}"

--- a/.maestro/ios/flows/demo-settings.yaml
+++ b/.maestro/ios/flows/demo-settings.yaml
@@ -1,0 +1,81 @@
+# Reusable Maestro subflow — exercises ONE iOS demo that carries its per-demo
+# controls in a `demoSettingsSheet` (the floating-gear settings sheet).
+#
+# This is the settings-sheet variant of `flows/demo.yaml`. Most iOS demos with
+# sliders / pickers / toggles put them inside `demoSettingsSheet { ... }`
+# (DemoSheet.swift) — a sheet that is CLOSED on launch. Only a floating gear
+# FAB and a "Settings" peek chip are visible at first; the control labels
+# (`Density`, `Subject`, …) are not. So this subflow:
+#   1. asserts the always-present FAB (`demo-settings-fab` accessibility id) —
+#      a launch crash makes that fail;
+#   2. taps the FAB to OPEN the settings sheet — real user interaction that
+#      also surfaces the control labels;
+#   3. asserts ASSERT_TEXT, a known control label inside the sheet — proof the
+#      sheet's content composed without crashing;
+#   4. dismisses the sheet, exercises the 3D viewport, screenshots, and
+#      re-asserts the FAB as the post-interaction crash gate.
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID      Stable demo id from DemoDeepLinkRegistry.allowedIds.
+#   DEMO_NAME    Human label, used only for screenshot file naming / logs.
+#   ASSERT_TEXT  A control label the demo's settings sheet is guaranteed to
+#                render (e.g. "Density" for fog, "Subject" for animation).
+appId: io.github.sceneview.demo
+---
+- launchApp:
+    appId: io.github.sceneview.demo
+    stopApp: true
+    clearState: false
+
+- openLink: "sceneview://demo/${DEMO_ID}"
+
+# The floating gear FAB is on screen as soon as the demo composes — a launch
+# crash drops us to SpringBoard and this fails fast.
+- extendedWaitUntil:
+    visible:
+      id: "demo-settings-fab"
+    timeout: 12000
+
+# --- Real user interaction: open the settings sheet ------------------------
+- tapOn:
+    id: "demo-settings-fab"
+
+# The sheet content scrolls in — assert a known control label is present.
+- extendedWaitUntil:
+    visible: "${ASSERT_TEXT}"
+    timeout: 4000
+
+# Close the sheet again (swipe the drag-indicator handle down) so the 3D
+# viewport is fully visible for the orbit interaction + screenshot.
+- swipe:
+    start: 50%, 35%
+    end: 50%, 95%
+    duration: 500
+- waitForAnimationToEnd:
+    timeout: 1500
+
+# --- Real user interaction: orbit the camera -------------------------------
+- swipe:
+    start: 30%, 50%
+    end: 70%, 50%
+    duration: 600
+- swipe:
+    start: 70%, 50%
+    end: 30%, 50%
+    duration: 600
+- swipe:
+    start: 50%, 60%
+    end: 50%, 40%
+    duration: 600
+- tapOn:
+    point: 50%, 45%
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# --- One screenshot per demo ----------------------------------------------
+- takeScreenshot: "demo-${DEMO_ID}"
+
+# --- Liveness assertion (per-demo crash gate) ------------------------------
+# The gear FAB is content-agnostic and always present while the demo is alive.
+- assertVisible:
+    id: "demo-settings-fab"

--- a/.maestro/ios/flows/demo.yaml
+++ b/.maestro/ios/flows/demo.yaml
@@ -1,0 +1,104 @@
+# Reusable Maestro subflow — exercises ONE iOS demo that renders its own
+# INLINE viewport overlay (an always-on caption, legend or button strip drawn
+# directly over the SceneView — not inside the closed `demoSettingsSheet`).
+#
+# Variant map — pick the subflow that matches the demo's UI:
+#   flows/demo.yaml          inline overlay text  (this file)
+#   flows/demo-settings.yaml controls live in the `demoSettingsSheet`
+#   flows/demo-noassert.yaml no Maestro-visible SwiftUI chrome at all
+#   flows/ar-demo.yaml       AR demo — launch-only smoke
+#   flows/placeholder.yaml   deep-link id with no iOS destination
+#
+# Called by the per-category flows via `runFlow` with an `env:` block. It never
+# appears in a flow runner by itself.
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID      Stable demo id from DemoDeepLinkRegistry.allowedIds
+#                (e.g. "geometry", "billboard"). Must match the Android
+#                ALL_DEMOS id byte-for-byte — the deep-link contract is shared.
+#   DEMO_NAME    Human label, used only for screenshot file naming / logs.
+#   ASSERT_TEXT  An inline-overlay SwiftUI text/label string the demo is
+#                guaranteed to render. Used as the per-demo crash gate — after
+#                a crash the app drops to SpringBoard and this `assertVisible`
+#                fails the flow.
+#
+# Strategy:
+#   - launchApp cold-starts the app, then `openLink` fires the public
+#     `sceneview://demo/<id>` custom-scheme deep link (DeepLinkRouter
+#     .schemeCustom). The app's `.onOpenURL` switches to the Samples tab and
+#     presents the demo as a `.fullScreenCover` — so we jump straight to the
+#     demo screen with no tab navigation or list scrolling. This is the same
+#     ingress `DeepLinkRouter.parse` validates.
+#   - `stopApp: true` cold-restarts the app per demo. The iOS Samples-tab
+#     `.fullScreenCover` has no Close affordance (a known iOS-demo UX gap — see
+#     `.maestro/README.md` and the slice #1563 follow-ups), so a cold relaunch
+#     is the deterministic way to leave one demo and start the next, and it
+#     doubles as the cleanest possible per-demo isolation.
+#   - Exercise REAL interaction: drag to orbit the camera, swipe to pan, tap
+#     the centre of the viewport. 3D zoom has no Maestro pinch gesture — see
+#     the catalog header note.
+#   - Capture exactly ONE screenshot per demo (no screenshot-by-screenshot
+#     loop).
+#   - Assert ASSERT_TEXT is still visible — the per-demo crash gate.
+#
+# Note — iOS has no `qa_mode` deep-link argument (the Android subflow passes
+# one to freeze auto-rotation for a deterministic screenshot). Adding an iOS
+# equivalent is a tracked follow-up; until then the screenshot is a smoke
+# artefact, not a pixel baseline.
+appId: io.github.sceneview.demo
+---
+# Cold-launch the app. `.onOpenURL` is only delivered to a running app, so the
+# deep link is fired as a discrete step once the process is up.
+- launchApp:
+    appId: io.github.sceneview.demo
+    stopApp: true
+    clearState: false
+
+- openLink: "sceneview://demo/${DEMO_ID}"
+
+# Wait for the demo to actually appear — `extendedWaitUntil` fails fast on a
+# launch-time crash instead of silently swiping an empty screen. The demo
+# mounts a full-screen SceneView (RealityView); RealityKit needs a moment to
+# warm up, so allow a generous timeout.
+- extendedWaitUntil:
+    visible: "${ASSERT_TEXT}"
+    timeout: 12000
+
+# --- Real user interaction -------------------------------------------------
+# Orbit the camera: drag across the viewport. Two opposite drags so we exercise
+# the manipulator in both directions and return roughly to the start framing.
+- swipe:
+    start: 30%, 55%
+    end: 70%, 55%
+    duration: 600
+- swipe:
+    start: 70%, 55%
+    end: 30%, 55%
+    duration: 600
+
+# Vertical drag — tilts the orbit camera / pans 2D-content demos.
+- swipe:
+    start: 50%, 65%
+    end: 50%, 40%
+    duration: 600
+
+# Tap the centre of the viewport: in interaction demos this picks a node, in
+# control-strip demos it is a harmless empty-space tap. Either way it must not
+# crash.
+- tapOn:
+    point: 50%, 55%
+
+# Give any tap-triggered work (node selection, gesture handlers) a moment to
+# settle before the screenshot.
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# --- One screenshot per demo ----------------------------------------------
+# Maestro writes screenshots to its output dir; the file name keys off DEMO_ID
+# so a category run produces one PNG per demo with no overwrites.
+- takeScreenshot: "demo-${DEMO_ID}"
+
+# --- Liveness assertion (per-demo crash gate) ------------------------------
+# If the demo had crashed during interaction, the process would be gone and we
+# would be on SpringBoard — ASSERT_TEXT would no longer be present.
+- assertVisible: "${ASSERT_TEXT}"

--- a/.maestro/ios/flows/placeholder.yaml
+++ b/.maestro/ios/flows/placeholder.yaml
@@ -1,0 +1,37 @@
+# Reusable Maestro subflow — smoke for a deep-link id that is REGISTERED in
+# `DemoDeepLinkRegistry.allowedIds` but has NO iOS destination wired up.
+#
+# Such ids (`environment`, `video`, `gesture-editing`, `ar-image`, `ar-face`
+# at the time slice #1563 landed) route through `DemoDeepLinkRegistry
+# .destination(for:)` to the `DeepLinkPlaceholder` view — a friendly "this
+# demo isn't available in the iOS app yet" screen. They exist as deep-link
+# ids because website / README QR codes may point at them and the cross-
+# platform `sceneview://demo/<id>` contract must not 404.
+#
+# This subflow proves the router + placeholder path itself does not crash:
+# launch, fire the deep link, assert the placeholder rendered (its "Demo:"
+# title is keyed on the id, so it doubles as a routing assertion).
+#
+# Required parameters (passed by the caller):
+#   DEMO_ID    Stable deep-link id (must be in `allowedIds` but un-wired).
+#
+# When one of these ids gains a real iOS destination, move it out of the
+# placeholder set into the matching per-category flow with a real ASSERT_TEXT.
+appId: io.github.sceneview.demo
+---
+- launchApp:
+    appId: io.github.sceneview.demo
+    stopApp: true
+    clearState: false
+
+- openLink: "sceneview://demo/${DEMO_ID}"
+
+# The placeholder renders `Text("Demo: <id>")` — keyed on the id, so this is
+# both a liveness check and a routing assertion.
+- extendedWaitUntil:
+    visible: "Demo: ${DEMO_ID}"
+    timeout: 8000
+
+- takeScreenshot: "placeholder-${DEMO_ID}"
+
+- assertVisible: "Demo: ${DEMO_ID}"

--- a/.maestro/ios/interaction.yaml
+++ b/.maestro/ios/interaction.yaml
@@ -1,0 +1,20 @@
+# Maestro flow — "Interaction" iOS demo category.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/interaction.yaml
+#
+# Only `camera-controls` is ported to iOS today; the Android Interaction
+# category's `gesture-editing` / `collision` / `view-node` demos are still
+# "Coming soon" on iOS (see SamplesTab.allScenes()). `gesture-editing` is a
+# registered deep-link id without a destination, so it routes to the
+# `DeepLinkPlaceholder` and is covered by placeholders.yaml.
+#
+# Demo ids mirror Android `DemoRegistry.kt` ALL_DEMOS.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: camera-controls
+      DEMO_NAME: Camera Controls
+      ASSERT_TEXT: "Recenter pivot on orbit"

--- a/.maestro/ios/lighting.yaml
+++ b/.maestro/ios/lighting.yaml
@@ -1,0 +1,39 @@
+# Maestro flow — "Lighting & Environment" iOS demo category.
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/lighting.yaml
+#
+# Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids are
+# the subset of Android `DemoRegistry.kt` ALL_DEMOS that
+# `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` on iOS.
+#
+# Note — `environment` is a registered deep-link id but has no iOS destination
+# wired in `DemoDeepLinkRegistry`, so it routes to the `DeepLinkPlaceholder`
+# (not a real demo). It is covered by content.yaml's placeholder smoke set
+# rather than here, to keep this flow purely the lighting demos that exist.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: lighting
+      DEMO_NAME: Light Types
+      ASSERT_TEXT: "Directional"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: movable-light
+      DEMO_NAME: Movable Light
+      ASSERT_TEXT: "Show light source"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: dynamic-sky
+      DEMO_NAME: Dynamic Sky
+      ASSERT_TEXT: "12:00"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: fog
+      DEMO_NAME: Fog
+      ASSERT_TEXT: "Density"

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -1,0 +1,30 @@
+# Maestro flow — deep-link placeholder smoke (non-AR).
+#
+# Run a fast subset of the iOS device-QA harness:
+#   maestro test .maestro/ios/placeholders.yaml
+#
+# Some Android demo ids are registered in `DemoDeepLinkRegistry.allowedIds`
+# (so the cross-platform `sceneview://demo/<id>` QR-code contract holds) but
+# have no iOS destination yet — they route to the `DeepLinkPlaceholder`. This
+# flow smoke-tests that router + placeholder path for the non-AR ids:
+#   environment / video / gesture-editing.
+# (The AR placeholder ids `ar-image` / `ar-face` are smoked from ar.yaml so
+# every AR id lives in one place.)
+#
+# Each id is exercised by flows/placeholder.yaml. When an id gains a real iOS
+# destination, move it into the matching per-category flow with a real
+# ASSERT_TEXT and drop it from here.
+appId: io.github.sceneview.demo
+---
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: environment
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: video
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: gesture-editing

--- a/changelog.d/1563-maestro-ios.md
+++ b/changelog.d/1563-maestro-ios.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- device-qa: added the maestro iOS leg — `.maestro/ios/` flows drive every iOS demo reachable via the `sceneview://demo/<id>` deep link in `samples/ios-demo` like a real user (custom-scheme launch, camera-orbit drag, tap, one screenshot per demo, crash assertion), with per-category subflows and launch-only smoke for AR demos (RealityKit AR cannot run on the simulator); `ios-device-qa.sh` is the maestro wrapper that boots a simulator, builds + installs the demo and sweeps the simulator log for crashes (#1563).


### PR DESCRIPTION
## Summary

iOS leg of the autonomous device-QA harness (umbrella #1560, slice #1563), mirroring the Android slice (#1562) under `.maestro/ios/`.

- **Maestro flows** under `.maestro/ios/` — `catalog.yaml` master flow + six per-category subflows (`3d-basics`, `lighting`, `content`, `interaction`, `advanced`, `ar`) + `placeholders.yaml`. They drive every iOS demo reachable via the public `sceneview://demo/<id>` deep link like a real user — custom-scheme launch, camera-orbit drag, viewport tap, one screenshot per demo — and assert each demo's screen stays alive.
- **Four reusable subflows** match each demo's actual UI: `flows/demo.yaml` (inline-overlay demos), `flows/demo-settings.yaml` (settings-sheet demos — asserts the always-present gear FAB, then opens the sheet), `flows/demo-noassert.yaml` (`text` / `model-viewer`, which render no Maestro-visible chrome on a key-less simulator), `flows/ar-demo.yaml` (AR launch-only smoke), `flows/placeholder.yaml` (deep-link ids with no iOS destination).
- **AR demos are launch-only smoke** — RealityKit AR cannot run on the iOS simulator; the flow asserts the AR screen mounts without crashing.
- **`ios-device-qa.sh`** — the iOS analogue of `qa-android-demos.sh`: boots a simulator, optionally builds + installs the demo (`xcodebuild`, scheme `SceneViewDemo`), runs the Maestro flow, and sweeps the simulator log for crash markers.
- `.maestro/README.md` gains an iOS section; a `changelog.d/` fragment is added.

## Coverage & follow-ups

iOS coverage is the `DemoDeepLinkRegistry.allowedIds` subset (24 ids), not the full Android 42-demo catalog. The iOS Samples-tab `.fullScreenCover` has **no Close affordance**, so a UI-navigation walk can't advance past the first demo — deep-link launch + `stopApp: true` cold-restart per demo is the only viable ingress. Documented follow-ups: widen `allowedIds` (or add a Close button to the full-screen cover), add an iOS `qa_mode` deep-link argument for deterministic screenshots.

## Test plan

- [x] All 13 YAML flows parse cleanly.
- [x] `bash -n` clean on `ios-device-qa.sh`.
- [x] Every `ASSERT_TEXT` / deep-link id verified against `samples/ios-demo` source (inline-overlay vs settings-sheet routing matches each demo's real UI; AR simulator-placeholder strings confirmed).
- [ ] **Deferred to the orchestrator validation pass** — live simulator build + `maestro test .maestro/ios/catalog.yaml` run (a full `xcodebuild` simulator build is too heavy for the disk-constrained authoring host).

Part of #1560, closes #1563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)