### PR TITLE
fix(react-native): bump iOS podspec SceneViewSwift pin off stale ~> 3.4 (#1512)

### DIFF
--- a/changelog.d/1512-rn-podspec-spm-pin.md
+++ b/changelog.d/1512-rn-podspec-spm-pin.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- React Native: bumped the iOS bridge podspec `SceneViewSwift` dependency from the year-old `~> 3.4` pin to `~> 4.9`, matching the published SPM tag the bridge code already targets. (#1512)

--- a/react-native/react-native-sceneview/react-native-sceneview.podspec
+++ b/react-native/react-native-sceneview/react-native-sceneview.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{swift,m}"
 
   s.dependency "React-Core"
-  s.dependency "SceneViewSwift", "~> 3.4"
+  s.dependency "SceneViewSwift", "~> 4.9"
 
   s.swift_version = "5.9"
 end


### PR DESCRIPTION
Closes #1512.

The RN iOS bridge podspec pinned `SceneViewSwift ~> 3.4` — a year-old line predating every 4.x iOS parity feature (LightSlot, RenderQuality, AnchorNode factories, NodeGesture, ARRecorder). Bumped to `~> 4.9`, matching the published SPM tag `v4.9.0`.

No 3.4-to-4.x API breakage: the bridge code (`ios/SceneViewModule.swift`) already uses 4.x-only APIs (`CameraControlMode`, `.cameraControls`, `.autoCenterContent`, `ARRecorder`) — only the dependency declaration was stale.

Scope limited to the iOS podspec SPM pin per the issue; the RN `android/build.gradle.kts` consumed Maven dep stays at its last-released coordinate (WARN-only, #1494).