### PR TITLE
fix(ios-demo): add Close affordance to Samples-tab full-screen demos (#1580)

### DIFF
--- a/changelog.d/ios-demo-ui-bug-batch.md
+++ b/changelog.d/ios-demo-ui-bug-batch.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- iOS demo: the Samples-tab full-screen demo cover now has an explicit Close button so a demo opened from the Samples list can always be dismissed back to the list (#1580).

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -81,6 +81,24 @@ struct SamplesTab: View {
             .fullScreenCover(item: $fullScreenScene) { scene in
                 NavigationStack {
                     sheetDestination(for: scene)
+                        // A `.fullScreenCover` has no drag-to-dismiss handle
+                        // (unlike the `.sheet` path), so it needs an explicit
+                        // Close affordance or the user gets stuck inside the
+                        // demo with no way back to the Samples list — see
+                        // #1580. Matches the Close button the deep-link
+                        // placeholder already uses (DemoDeepLinkRegistry).
+                        .toolbar {
+                            ToolbarItem(placement: .topBarLeading) {
+                                Button {
+                                    HapticManager.lightTap()
+                                    fullScreenScene = nil
+                                } label: {
+                                    Label("Close", systemImage: "xmark")
+                                }
+                                .accessibilityLabel("Close demo")
+                                .accessibilityIdentifier("demo-close")
+                            }
+                        }
                 }
             }
             #endif


### PR DESCRIPTION
## Summary

Batch investigation of 5 reported iOS-demo UI bugs (#1580, #1375, #1374, #1381, #1379). Only **#1580** still reproduces on `main` — the other four were already fixed by earlier work and are being closed separately with verification comments.

### Fixed here — #1580
The Samples-tab opens each demo in a SwiftUI `.fullScreenCover`, which has no drag-to-dismiss handle (unlike the `.sheet` path). The demos only set a `navigationTitle` with no toolbar item, so a user who opened a demo from the Samples list had no way back to the list. This forced the Maestro iOS QA harness to use deep-link + cold-restart ingress instead of a natural UI walk.

Added an explicit Close button (top-bar leading, `xmark`) to the `fullScreenCover`'s `NavigationStack`, consistent with the Close button `DemoDeepLinkRegistry` already uses. Covers both available demos and the `ComingSoonScreen`.

### Already fixed on `main` (closed via comments, not this PR)
- **#1375** — tab is already labelled `Samples` with `navigationTitle("Samples")`; no "Scenes" tab exists.
- **#1374** — `DemoSettingsSheetModifier` already lays the Settings pill in an `HStack` to the left of the FAB with an 8pt gap (no overlap).
- **#1381** — Scene Gallery subtitle, Image Planes caption ("solid-color planes"), AR-tab simulator wording, and Billboard in-scene title are all already accurate.
- **#1379** — `ExploreTab` has no dead "All samples" / "See all" buttons; no `V1.1: deep-link/navigate` TODO buttons remain.

## Test plan
- [x] `xcodebuild -scheme SceneViewDemo` for iOS Simulator — **BUILD SUCCEEDED**
- [x] `check-sceneview-skill.sh` — passed
- [x] `impact-check.sh` — passed (1 pre-existing unrelated WARN)
- [ ] Manual: open a demo from the Samples tab, tap Close, confirm return to the Samples list

Closes #1580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)