### PR TITLE
chore(ci): drain stale branch backlog + timeout-proof cleanup

### DIFF
--- a/.claude/scripts/cleanup-branches-worktrees.sh
+++ b/.claude/scripts/cleanup-branches-worktrees.sh
@@ -8,7 +8,10 @@
 # command to reclaim all three at once, safely.
 #
 # What it does (in order):
-#   1. `git fetch origin --prune` so every ref is current.
+#   1. `git fetch origin --prune`, then ONE bulk `gh pr list` per state
+#      (open / merged) so PR status is a pure in-memory lookup — no
+#      per-branch `gh pr view` (that's O(branches) API calls and times the
+#      CI job out before it can delete anything).
 #   2. Deletes MERGED local `claude/*` branches — "merged" means
 #      `git rev-list --count origin/main..<branch> == 0` (zero commits the
 #      branch carries that origin/main doesn't). Never the current branch.
@@ -102,12 +105,23 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     GH_AVAILABLE=true
 fi
 
-# pr_state <branch> — echoes the PR state (OPEN / MERGED / CLOSED) or "" if
-# none / gh unavailable. Degrades safely on any failure.
+# Bulk PR state — fetched ONCE, not per-branch. A repo with hundreds of
+# stale branches would otherwise fire hundreds of sequential `gh pr view`
+# calls and blow the CI timeout — exactly why the daily job never managed
+# to drain a 190-branch backlog. Two `gh pr list` calls cover everything.
+OPEN_PR_BRANCHES=""
+MERGED_PR_BRANCHES=""
+
+# pr_state <branch> — echoes OPEN / MERGED or "" (no PR, closed-unmerged,
+# or gh unavailable). Pure in-memory lookup against the bulk lists above.
+# A closed-unmerged PR returns "" — callers treat that identically: ahead>0
+# keeps it as unmerged work, ahead=0 makes it deletable.
 pr_state() {
     local branch="$1"
     [ "$GH_AVAILABLE" = "true" ] || { echo ""; return 0; }
-    gh pr view "$branch" --json state --jq .state 2>/dev/null || echo ""
+    if printf '%s\n' "$OPEN_PR_BRANCHES"   | grep -Fxq -- "$branch"; then echo "OPEN";   return 0; fi
+    if printf '%s\n' "$MERGED_PR_BRANCHES" | grep -Fxq -- "$branch"; then echo "MERGED"; return 0; fi
+    echo ""
 }
 
 echo -e "${CYAN}=== Branch + worktree cleanup ===${NC}"
@@ -127,6 +141,18 @@ echo -e "${CYAN}--- Fetching origin --prune ---${NC}"
 git -C "$REPO_ROOT" fetch origin --prune --quiet 2>/dev/null \
     || echo -e "${YELLOW}Warning: fetch failed — working from local refs.${NC}"
 echo ""
+
+# --- 1b. bulk PR state -----------------------------------------------------
+if [ "$GH_AVAILABLE" = "true" ]; then
+    echo -e "${CYAN}--- Fetching PR states (bulk) ---${NC}"
+    OPEN_PR_BRANCHES="$(gh pr list --state open --limit 1000 \
+        --json headRefName --jq '.[].headRefName' 2>/dev/null || echo "")"
+    MERGED_PR_BRANCHES="$(gh pr list --state merged --limit 2000 \
+        --json headRefName --jq '.[].headRefName' 2>/dev/null || echo "")"
+    echo "  open PRs:   $(printf '%s\n' "$OPEN_PR_BRANCHES"   | grep -c . || true)"
+    echo "  merged PRs: $(printf '%s\n' "$MERGED_PR_BRANCHES" | grep -c . || true)"
+    echo ""
+fi
 
 # ===========================================================================
 # 2. MERGED LOCAL claude/* branches

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -252,8 +252,13 @@ jobs:
           fi
 
   # ── 6. Stale claude/* branch cleanup ──────────────────────────────────────
-  # An orchestrator marathon leaves dozens of merged `claude/*` branches on
-  # `origin`. This job deletes the ones that are provably dead — fully merged
+  # PRIMARY mechanism is the repo's "Automatically delete head branches"
+  # setting (deleteBranchOnMerge) — every PR branch is dropped the instant
+  # its PR merges, so no backlog accumulates in normal operation.
+  # This job is the BACKSTOP for the cases that setting can't reach:
+  # branches whose PR merged before the setting was on, orphan branches
+  # fully merged into main with no PR (ahead=0), and merged-PR branches
+  # left over from API merges. It deletes the provably-dead ones — merged
   # into origin/main (ahead=0) OR carrying a MERGED PR (squash-merge case) —
   # in a SINGLE `git push --delete` call. Branches with an OPEN PR or genuine
   # unmerged commits are never touched. Worktrees are skipped (they only

--- a/changelog.d/branch-cleanup-automation.md
+++ b/changelog.d/branch-cleanup-automation.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Repo hygiene: stale `claude/*` branches no longer pile up on the remote. The `Automatically delete head branches` setting is now enabled, so every PR branch is dropped the instant its PR merges. The `cleanup-branches-worktrees.sh` backstop was reworked to fetch PR status with two bulk `gh pr list` calls instead of one `gh pr view` per branch — the per-branch form fired hundreds of sequential API calls and timed the daily `branch-cleanup` job out before it could delete anything, which had let the remote grow to ~190 branches.


### PR DESCRIPTION
## Summary
- The remote had grown to **~192 branches** (190 stale `claude/*`) — painful on clone. Root cause: the repo's `Automatically delete head branches` setting was off, and the daily `branch-cleanup` job's script fired one `gh pr view` per branch (~190 sequential API calls) and timed out before deleting anything.
- Enabled `deleteBranchOnMerge` on the repo → every future PR branch drops on merge (primary mechanism, no script needed).
- Reworked `cleanup-branches-worktrees.sh` to fetch PR status with two bulk `gh pr list` calls — the daily job is now fast and timeout-proof (backstop for orphans / pre-setting backlog).
- Drained the backlog: **192 → 16 remote branches** (remaining 16 = open PRs + genuine unmerged WIP, all correctly kept).

## Test plan
- [x] `bash -n` syntax check passes
- [x] dry-run categorises branches correctly (open PR / unmerged / deletable)
- [x] real run deleted 174 merged backlog branches + 95 merged local branches in single push operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)