### PR TITLE
fix(sceneview): honest PhysicsNode mass handling (#1599) + verify MeshNode teardown (#1598)

### DIFF
--- a/changelog.d/1598-1599-node-fixes.md
+++ b/changelog.d/1598-1599-node-fixes.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- `sceneview` node API honesty (#1598, #1599): verified `MeshNode` does not leak its `RenderableManager` component — `RenderableNode.destroy()` already releases the renderable built on `entity` (#1598 confirmed stale, no code change needed). Deprecated the `PhysicsNode` / `PhysicsBody` `mass` parameter — the Euler integration applies only gravity, which is mass-independent, so `mass` was a silent no-op; it is now `@Deprecated` with a clear message and the mass-free overload is the canonical one (#1599).

--- a/llms.txt
+++ b/llms.txt
@@ -653,7 +653,6 @@ Renders a triangulated 2D polygon in 3D space. Supports holes, Delaunay refineme
 ```kotlin
 @Composable fun PhysicsNode(
     node: Node,
-    mass: Float = 1f,
     restitution: Float = 0.6f,
     linearVelocity: Position = Position(0f, 0f, 0f),
     floorY: Float = 0f,
@@ -662,6 +661,8 @@ Renders a triangulated 2D polygon in 3D space. Supports holes, Delaunay refineme
 ```
 Attaches gravity + floor bounce to an existing node. Does NOT add the node to the scene — the node
 must already exist. Uses Euler integration at 9.8 m/s² with configurable restitution and floor.
+Note: a `mass` overload exists but is `@Deprecated` — gravity is mass-independent, so `mass` is
+a no-op until a force/impulse API lands.
 
 ```kotlin
 SceneView {

--- a/sceneview/src/androidTest/java/io/github/sceneview/node/PhysicsBodyTest.kt
+++ b/sceneview/src/androidTest/java/io/github/sceneview/node/PhysicsBodyTest.kt
@@ -49,7 +49,6 @@ class PhysicsBodyTest {
             }
             val body = PhysicsBody(
                 node = node,
-                mass = 1f,
                 restitution = 0f,
                 floorY = 0f,
                 radius = 0f,
@@ -170,6 +169,34 @@ class PhysicsBodyTest {
                 node.position.y >= radius - 0.01f)
 
             node.destroy()
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun mass_doesNotAffectFall() {
+        // #1599: gravity is an acceleration and therefore mass-independent. A heavy body and a
+        // light body released from the same height must fall identically. This pins the honest
+        // contract behind the now-deprecated `mass` parameter (it is a documented no-op).
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val lightNode = Node(engine).apply { position = Position(0f, 5f, 0f) }
+            val heavyNode = Node(engine).apply { position = Position(0f, 5f, 0f) }
+            val light = PhysicsBody(node = lightNode, mass = 0.1f, restitution = 0f, floorY = -100f)
+            val heavy = PhysicsBody(node = heavyNode, mass = 1000f, restitution = 0f, floorY = -100f)
+
+            var t = 0L
+            repeat(30) {
+                light.step(t + 16_000_000L, t)
+                heavy.step(t + 16_000_000L, t)
+                t += 16_000_000L
+            }
+
+            assertEquals(
+                "mass must not affect a gravity-only fall (mass is a no-op)",
+                lightNode.position.y, heavyNode.position.y, 0.0001f
+            )
+            lightNode.destroy()
+            heavyNode.destroy()
         }
     }
 

--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -1620,7 +1620,6 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
      * ```
      *
      * @param node           The [Node] whose position is driven by the simulation. Must be in scene.
-     * @param mass           Mass in kg (reserved for future impulse API).
      * @param restitution    Bounciness in [0, 1]. 0 = inelastic, 1 = perfectly elastic.
      * @param linearVelocity Initial velocity in m/s (world space).
      * @param floorY         World Y coordinate of the floor plane. Default 0.
@@ -1629,7 +1628,6 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
     @Composable
     fun PhysicsNode(
         node: NodeImpl,
-        mass: Float = 1f,
         restitution: Float = 0.6f,
         linearVelocity: Position = Position(0f, 0f, 0f),
         floorY: Float = 0f,
@@ -1638,7 +1636,6 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         val body = remember(node) {
             PhysicsBody(
                 node = node,
-                mass = mass,
                 restitution = restitution,
                 floorY = floorY,
                 radius = radius,
@@ -1654,6 +1651,34 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
             onDispose { node.onFrame = null }
         }
     }
+
+    /**
+     * Deprecated overload kept for source compatibility — the `mass` parameter is a no-op.
+     *
+     * The Euler integration applies only gravity, which is an acceleration and therefore
+     * mass-independent. Use the [PhysicsNode] overload without `mass`.
+     */
+    @Deprecated(
+        "The 'mass' parameter is currently a no-op (the Euler integration applies only " +
+            "gravity, which is mass-independent). Use the PhysicsNode overload without 'mass'.",
+        ReplaceWith("PhysicsNode(node, restitution, linearVelocity, floorY, radius)"),
+        DeprecationLevel.WARNING
+    )
+    @Composable
+    fun PhysicsNode(
+        node: NodeImpl,
+        @Suppress("UNUSED_PARAMETER") mass: Float,
+        restitution: Float = 0.6f,
+        linearVelocity: Position = Position(0f, 0f, 0f),
+        floorY: Float = 0f,
+        radius: Float = 0f
+    ) = PhysicsNode(
+        node = node,
+        restitution = restitution,
+        linearVelocity = linearVelocity,
+        floorY = floorY,
+        radius = radius
+    )
 
     // ── Internal lifecycle helper ─────────────────────────────────────────────────────────────────
 

--- a/sceneview/src/main/java/io/github/sceneview/node/PhysicsNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/PhysicsNode.kt
@@ -17,8 +17,6 @@ import io.github.sceneview.utils.intervalSeconds
  *   +Y is up, gravity pulls in the -Y direction.
  *
  * @param node         The node whose [Node.position] is driven by the simulation.
- * @param mass         Mass in kg. Currently unused in Euler integration but reserved for
- *                     future impulse/force API.
  * @param restitution  Coefficient of restitution in [0, 1]. 0 = fully inelastic,
  *                     1 = perfectly elastic. Applied on each floor bounce.
  * @param floorY       World-space Y coordinate of the floor plane. Default 0.0 (scene origin).
@@ -29,12 +27,46 @@ import io.github.sceneview.utils.intervalSeconds
  */
 class PhysicsBody(
     val node: Node,
-    val mass: Float = 1f,
     val restitution: Float = 0.6f,
     val floorY: Float = 0f,
     val radius: Float = 0f,
     initialVelocity: Position = Position(0f, 0f, 0f)
 ) {
+    /**
+     * Mass in kg.
+     *
+     * The current Euler integration only applies gravity, which is an acceleration and is
+     * therefore mass-independent (all bodies fall at the same rate). `mass` only becomes
+     * meaningful once a force/impulse API exists (`acceleration = force / mass`). Until
+     * then this property is a no-op and is kept solely so callers can read back the value
+     * they configured.
+     */
+    @Deprecated(
+        "Mass is currently a no-op: the Euler integration applies only gravity, which is " +
+            "mass-independent. It will gain an effect once a force/impulse API lands.",
+        level = DeprecationLevel.WARNING
+    )
+    var mass: Float = 1f
+        private set
+
+    @Deprecated(
+        "The 'mass' parameter is currently a no-op (the Euler integration applies only " +
+            "gravity, which is mass-independent). Use the constructor without 'mass'.",
+        ReplaceWith("PhysicsBody(node, restitution, floorY, radius, initialVelocity)"),
+        DeprecationLevel.WARNING
+    )
+    constructor(
+        node: Node,
+        mass: Float,
+        restitution: Float = 0.6f,
+        floorY: Float = 0f,
+        radius: Float = 0f,
+        initialVelocity: Position = Position(0f, 0f, 0f)
+    ) : this(node, restitution, floorY, radius, initialVelocity) {
+        @Suppress("DEPRECATION")
+        this.mass = mass
+    }
+
     companion object {
         const val GRAVITY = -9.8f   // m/s² downward (-Y)
 
@@ -111,7 +143,6 @@ class PhysicsBody(
  *     val sphereNode = remember(engine) { SphereNode(engine, radius = 0.15f) }
  *     PhysicsNode(
  *         node = sphereNode,
- *         mass = 1f,
  *         restitution = 0.7f,
  *         linearVelocity = Position(x = 0.5f, y = 2f, z = 0f)
  *     )
@@ -119,7 +150,6 @@ class PhysicsBody(
  * ```
  *
  * @param node           The [Node] to animate. Must already be added to the scene by the caller.
- * @param mass           Object mass in kg (reserved; not yet used in force calculations).
  * @param restitution    Bounciness in [0, 1].
  * @param linearVelocity Initial velocity in m/s.
  * @param floorY         World Y of the floor plane (default 0).
@@ -129,7 +159,6 @@ class PhysicsBody(
 @Composable
 fun PhysicsNode(
     node: Node,
-    mass: Float = 1f,
     restitution: Float = 0.6f,
     linearVelocity: Position = Position(0f, 0f, 0f),
     floorY: Float = 0f,
@@ -138,7 +167,6 @@ fun PhysicsNode(
     val body = remember(node) {
         PhysicsBody(
             node = node,
-            mass = mass,
             restitution = restitution,
             floorY = floorY,
             radius = radius,
@@ -157,3 +185,32 @@ fun PhysicsNode(
         }
     }
 }
+
+/**
+ * Deprecated overload kept for source compatibility — the `mass` parameter is a no-op.
+ *
+ * The Euler integration applies only gravity, which is an acceleration and therefore
+ * mass-independent. `mass` will gain an effect once a force/impulse API lands. Until then,
+ * use the [PhysicsNode] overload without `mass`.
+ */
+@Deprecated(
+    "The 'mass' parameter is currently a no-op (the Euler integration applies only gravity, " +
+        "which is mass-independent). Use the PhysicsNode overload without 'mass'.",
+    ReplaceWith("PhysicsNode(node, restitution, linearVelocity, floorY, radius)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+fun PhysicsNode(
+    node: Node,
+    @Suppress("UNUSED_PARAMETER") mass: Float,
+    restitution: Float = 0.6f,
+    linearVelocity: Position = Position(0f, 0f, 0f),
+    floorY: Float = 0f,
+    radius: Float = 0f
+) = PhysicsNode(
+    node = node,
+    restitution = restitution,
+    linearVelocity = linearVelocity,
+    floorY = floorY,
+    radius = radius
+)


### PR DESCRIPTION
## #1599 — PhysicsNode/PhysicsBody `mass` is a silent no-op — FIXED

The public `PhysicsNode` / `PhysicsBody` `mass` parameter did nothing. The
Euler integration applies **only gravity**, which is an *acceleration* (`GRAVITY`
is m/s²) and therefore mass-independent — all bodies fall at the same rate. `mass`
only becomes meaningful with a force/impulse API (`acceleration = force / mass`),
which does not exist.

**Smallest honest fix chosen: `@Deprecated`.** Removing `mass` would be a breaking
API change; implementing it would require inventing a whole force/impulse API
(out of scope). So:

- The `mass` parameter on the `PhysicsBody` constructor and **both** `PhysicsNode`
  composables (top-level + `SceneScope`) is now `@Deprecated` (WARNING level) with
  a clear message and a `ReplaceWith` quick-fix.
- The mass-free overload is now the canonical signature; the `mass` overload is a
  thin deprecated delegate, so existing source still compiles (warning only).
- `PhysicsBody` keeps a readable `mass` property (also `@Deprecated`) so callers
  do not lose a value they configured.
- KDoc no longer claims `mass` is "reserved" — it states plainly it is a no-op.

Instrumented test `PhysicsBodyTest.mass_doesNotAffectFall` pins the contract:
a 0.1 kg body and a 1000 kg body released from the same height fall identically.

## #1598 — MeshNode renderable leak — VERIFIED STALE, no change

`MeshNode` extends `RenderableNode(engine)` and builds its renderable on `entity`.
`RenderableNode.destroy()` already calls `engine.safeDestroyRenderable(entity)` —
on the main thread, before `Node.destroy()` frees the entity ID — which releases
the renderable component. So **MeshNode does not leak**. `GeometryNode`'s extra
`destroy()` override only tears down the `Geometry` it owns; `MeshNode` owns no
geometry (the caller supplies and owns the `vertexBuffer`/`indexBuffer`), so no
override is warranted. #1598 is closed separately with this verification.

## Threading
No new Filament JNI calls. #1598 needed no code change; #1599 is pure-Kotlin.

## Verification
- `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` — green
- `./gradlew :sceneview:testDebugUnitTest` — green
- `:sceneview:compileDebugAndroidTestKotlin` — green
- `llms.txt` `PhysicsNode` signature updated (dropped `mass`, noted the deprecated overload)

Closes #1599.