### PR TITLE
docs: align quickstart-ios platform minimums with Package.swift (#1621)

### DIFF
--- a/changelog.d/1621-quickstart-ios-minimums.md
+++ b/changelog.d/1621-quickstart-ios-minimums.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Align Apple platform minimums in docs with `SceneViewSwift/Package.swift` (iOS 18.0, macOS 15.0). (#1621)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -150,7 +150,7 @@ Yes — create the engine at a higher scope (e.g., ViewModel or CompositionLocal
 
 ### Does SceneView support iOS?
 
-Yes. SceneViewSwift (v4.0.0 alpha) provides a native SwiftUI library powered by RealityKit and ARKit. It supports iOS 17+, macOS 14+, and visionOS 1+. Install via Swift Package Manager. See the [Apple Quickstart](quickstart-ios.md).
+Yes. SceneViewSwift (v4.0.0 alpha) provides a native SwiftUI library powered by RealityKit and ARKit. It supports iOS 18+, macOS 15+, and visionOS 1+. Install via Swift Package Manager. See the [Apple Quickstart](quickstart-ios.md).
 
 ### What model formats work on iOS?
 

--- a/docs/docs/platforms.md
+++ b/docs/docs/platforms.md
@@ -44,7 +44,7 @@ SceneViewSwift provides a native SwiftUI library powered by RealityKit and ARKit
 
 - **3D**: `SceneView { }` with ModelNode, GeometryNode, LightNode, and more
 - **AR**: `ARSceneView()` with plane detection and tap-to-place (iOS only)
-- **Min versions**: iOS 17+, macOS 14+, visionOS 1+
+- **Min versions**: iOS 18+, macOS 15+, visionOS 1+
 - **Install**: `.package(url: "https://github.com/sceneview/sceneview.git", from: "4.9.0")`
 
 [:octicons-arrow-right-24: Apple Quickstart](quickstart-ios.md)

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -16,7 +16,7 @@ description: "Set up SceneViewSwift in your Xcode project in 10 minutes. Build a
 ## Prerequisites
 
 - **Xcode 15** or newer
-- An Apple device or simulator running **iOS 17+**, **macOS 14+**, or **visionOS 1+**
+- An Apple device or simulator running **iOS 18+**, **macOS 15+**, or **visionOS 1+**
 - Basic familiarity with Swift and SwiftUI
 
 ---
@@ -159,8 +159,8 @@ Point the camera at a flat surface, wait for plane detection, then tap to place 
 
 | Platform | Minimum version | Renderer |
 |---|---|---|
-| iOS | 17.0 | RealityKit + ARKit |
-| macOS | 14.0 | RealityKit |
+| iOS | 18.0 | RealityKit + ARKit |
+| macOS | 15.0 | RealityKit |
 | visionOS | 1.0 | RealityKit |
 
 !!! tip "AR is iOS-only"

--- a/docs/docs/samples-ios.md
+++ b/docs/docs/samples-ios.md
@@ -427,14 +427,14 @@ struct ARTapToPlaceSample: View {
 
 ### 3D samples
 
-3D samples run on iOS 17+, macOS 14+, and visionOS 1+. They work in both the Simulator and on physical devices.
+3D samples run on iOS 18+, macOS 15+, and visionOS 1+. They work in both the Simulator and on physical devices.
 
 ### AR samples
 
 AR samples require:
 
 - A physical iPhone or iPad with ARKit support (A9 chip or later)
-- iOS 17 or later
+- iOS 18 or later
 - Camera permission granted
 
 !!! tip


### PR DESCRIPTION
Closes #1621.