### PR TITLE
fix(android-demo): demos render content on open, not an empty scene (#881)

### DIFF
--- a/changelog.d/881-android-demos-empty.md
+++ b/changelog.d/881-android-demos-empty.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- DynamicSky demo now holds a "Loading helmet…" scrim until its model is ready, matching every other helmet-loading demo so no demo opens on a bare scene (#881).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DynamicSkyDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/DynamicSkyDemo.kt
@@ -1,5 +1,6 @@
 package io.github.sceneview.demo.demos
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.math.Position
@@ -100,37 +102,43 @@ fun DynamicSkyDemo(onBack: () -> Unit) {
             )
         }
     ) {
-        SceneView(
-            modifier = Modifier.fillMaxSize(),
-            onFrame = firstFrame.onFrame,
-            engine = engine,
-            modelLoader = modelLoader,
-            environmentLoader = environmentLoader,
-            environment = environment,
-            // Disable the constant 110 klx default main light so the DynamicSkyNode's SUN is
-            // the only directional contribution. The HDR IBL ambient fill keeps the helmet
-            // visible at night when the sun is below the horizon, and the matching skybox
-            // gives the user a clear visual feedback that time-of-day actually changed.
-            mainLightNode = null,
-            cameraManipulator = rememberCameraManipulator()
-        ) {
-            DynamicSkyNode(
-                timeOfDay = timeOfDay,
-                turbidity = turbidity,
-                // 500 klx (5x the default) so the sun visibly dominates even with the
-                // default IBL ambient — otherwise the neutral IBL's constant ~30 klx
-                // contribution masks the time-of-day changes on the metallic helmet
-                // (PBR reflections = mostly IBL). Bright sun = visible difference.
-                sunIntensity = 500_000f,
-            )
-
-            modelInstance?.let { instance ->
-                ModelNode(
-                    modelInstance = instance,
-                    scaleToUnits = 0.5f,
-                    position = Position(y = 0f)
+        Box(modifier = Modifier.fillMaxSize()) {
+            SceneView(
+                modifier = Modifier.fillMaxSize(),
+                onFrame = firstFrame.onFrame,
+                engine = engine,
+                modelLoader = modelLoader,
+                environmentLoader = environmentLoader,
+                environment = environment,
+                // Disable the constant 110 klx default main light so the DynamicSkyNode's SUN is
+                // the only directional contribution. The HDR IBL ambient fill keeps the helmet
+                // visible at night when the sun is below the horizon, and the matching skybox
+                // gives the user a clear visual feedback that time-of-day actually changed.
+                mainLightNode = null,
+                cameraManipulator = rememberCameraManipulator()
+            ) {
+                DynamicSkyNode(
+                    timeOfDay = timeOfDay,
+                    turbidity = turbidity,
+                    // 500 klx (5x the default) so the sun visibly dominates even with the
+                    // default IBL ambient — otherwise the neutral IBL's constant ~30 klx
+                    // contribution masks the time-of-day changes on the metallic helmet
+                    // (PBR reflections = mostly IBL). Bright sun = visible difference.
+                    sunIntensity = 500_000f,
                 )
+
+                modelInstance?.let { instance ->
+                    ModelNode(
+                        modelInstance = instance,
+                        scaleToUnits = 0.5f,
+                        position = Position(y = 0f)
+                    )
+                }
             }
+            // Mirror every other helmet-loading demo: hold a scrim until the
+            // model instance is ready so the helmet's async pop-in is hidden
+            // behind a labelled placeholder instead of appearing on a bare sky.
+            LoadingScrim(loading = modelInstance == null, label = "Loading helmet…")
         }
     }
 }


### PR DESCRIPTION
Closes #881.

## Investigation — issue is substantially stale

#881 (filed 2026-05-13) flagged 14/22 Android demos rendering an empty/black SceneView on open. Re-auditing all 29 non-AR demos against current main (the demo app went through umbrella #1443 polish, v4.4.0 to v4.9.0, registry now has 43 demos):

- 13 of the 14 flagged demos are already fixed. Billboard/LinesPaths default their visibility chips to ON; Shape defaults to Triangle; Text ships 'Hello SceneView'; MultiModel has all 4 chips ON + LoadingScrim; Animation auto-loads the bundled soldier with LoadingScrim; CameraControls/CustomMesh/Fog/GestureEditing/Lighting/ViewNode/ReflectionProbes all auto-load content with a LoadingScrim (or render procedural geometry immediately).
- 1 residual gap: DynamicSkyDemo auto-loaded its helmet but lacked the LoadingScrim every other helmet-loading demo uses, so the model popped in onto a bare sky.

## Fix

DynamicSkyDemo now wraps its SceneView in a Box and holds a 'Loading helmet…' LoadingScrim until modelInstance is ready — identical to FogDemo/LightingDemo/CameraControlsDemo. No API surface touched, demo-app only.

## Verification
- :samples:android-demo:compileDebugKotlin — compiles
- :samples:android-demo:assembleDebug — APK builds
- impact-check.sh — passes