### PR TITLE
fix(web): loadModel premature framing + replaced-asset leak (#1597)

### DIFF
--- a/changelog.d/1597-web-loadmodel.md
+++ b/changelog.d/1597-web-loadmodel.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `sceneview-web` `SceneView.loadModel` (#1597): the auto-center pass no longer frames the scene on a model whose `loadResources()` is still in flight (premature/wrong framing on an unreadable bounding box), and reloading the same model URL now destroys the prior `FilamentAsset` instead of orphaning it on the GPU — mirroring the `EnvironmentResourceTracker` leak-free-swap pattern from the IBL/skybox fix (#1496).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/AssetResourceTracker.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/AssetResourceTracker.kt
@@ -1,0 +1,54 @@
+package io.github.sceneview.web
+
+/**
+ * Tracks the most recently loaded glTF [FilamentAsset] per *logical model* and
+ * guarantees leak-free replacement and teardown.
+ *
+ * The web `SceneView` creates a Filament `FilamentAsset` in
+ * [SceneView.loadModel]. Before issue #1597 every load was simply appended to
+ * the `models` list and a prior asset for the *same logical model* (same URL)
+ * was never destroyed, so calling `loadModel` repeatedly on the same URL —
+ * e.g. a demo that hot-swaps the displayed model — orphaned every previous
+ * `FilamentAsset` on the GPU until `destroy()` finally ran.
+ *
+ * This mirrors the [EnvironmentResourceTracker] state machine that fixed the
+ * identical IBL/skybox replace-leak (issue #1496): "destroy the old handle
+ * before adopting a new one, destroy whatever is held on teardown". The only
+ * difference is that several distinct logical models can be live at once, so a
+ * resource is tracked per key (the model URL) rather than as a single slot.
+ *
+ * Isolating the bookkeeping from the Filament.js bindings keeps it directly
+ * unit-testable without a WebGL context — handles can be plain values and the
+ * `destroyer` simply records every release.
+ *
+ * @param T the handle type (`FilamentAsset`, or a test stand-in)
+ * @param destroyer invoked with a handle that must be released on the GPU
+ */
+internal class AssetResourceTracker<T>(
+    private val destroyer: (T) -> Unit,
+) {
+
+    private val byKey = mutableMapOf<String, T>()
+
+    /** The handle currently held for [key], or `null` if none. */
+    fun current(key: String): T? = byKey[key]
+
+    /**
+     * Adopt [handle] as the current resource for [key], destroying the
+     * previously held handle for the same key (if any) first. This is the
+     * leak-free replacement path for a 2nd `loadModel` of the same URL.
+     */
+    fun replaceWith(key: String, handle: T) {
+        byKey[key]?.let(destroyer)
+        byKey[key] = handle
+    }
+
+    /**
+     * Destroy every tracked handle and clear all slots. Idempotent — a second
+     * call is a no-op. Called from [SceneView.destroy].
+     */
+    fun release() {
+        byKey.values.forEach(destroyer)
+        byKey.clear()
+    }
+}

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -47,6 +47,10 @@ class SceneView private constructor(
     private var isRunning = false
     private var lastTimestamp = 0.0
 
+    /** Monotonic counter for synthesising unique tracker keys for un-keyed
+     *  (procedural geometry) assets — see [loadedAssets]. */
+    private var assetKeySeq = 0
+
     private val models = mutableListOf<LoadedModel>()
     private var assetLoader: AssetLoader? = null
     private val lightEntities = mutableListOf<Entity>()
@@ -68,6 +72,20 @@ class SceneView private constructor(
      */
     private val skybox = EnvironmentResourceTracker<Skybox> {
         engine.destroySkybox(it)
+    }
+
+    /**
+     * Single owner of every gltfio [FilamentAsset] live in the scene — both
+     * URL-loaded models ([loadModel], keyed by URL) and procedural geometry
+     * ([addGeometry], keyed by a synthetic id). Destroying a replaced asset
+     * before adopting its successor stops the #1597 GPU leak (a 2nd `loadModel`
+     * of the same URL previously orphaned the prior asset), and [release] tears
+     * down everything still held at [destroy] time. Mirrors the
+     * [indirectLight] / [skybox] leak-free-swap pattern of #1496.
+     */
+    private val loadedAssets = AssetResourceTracker<FilamentAsset> { asset ->
+        scene.removeEntities(asset.getEntities())
+        assetLoader?.destroyAsset(asset)
     }
 
     /**
@@ -100,6 +118,15 @@ class SceneView private constructor(
         val animator: Animator?,
         var animationTime: Double = 0.0
     ) {
+        /**
+         * `false` until `loadResources` has finished populating this asset's
+         * renderable buffers/textures. While `false` the model's
+         * `getBoundingBox()` reports a degenerate/wrong box, so the auto-center
+         * pass ([refreshContentCentering] via [contentBoxes]) must exclude it —
+         * otherwise it frames the scene on an unreadable diagonal (#1597).
+         */
+        var loaded: Boolean = false
+
         /**
          * The asset's root-entity transform *before* any auto-center offset
          * was applied — captured the first frame [refreshContentCentering]
@@ -307,6 +334,16 @@ class SceneView private constructor(
         }.then { buffer ->
             val asset = loader.createAsset(buffer)
             if (asset != null) {
+                // #1597: a 2nd loadModel of the same URL must release the prior
+                // asset for this logical model before adopting the replacement,
+                // otherwise the previous FilamentAsset leaks on the GPU. The
+                // tracker's destroyer also removes the old entities from the
+                // scene. Drop the stale LoadedModel from `models` here too so
+                // the render loop / auto-center pass never touch a freed asset.
+                loadedAssets.current(url)?.let { prior ->
+                    models.removeAll { it.asset == prior }
+                }
+
                 // Add all entities to the scene so they become visible
                 val entities = asset.getEntities()
                 scene.addEntities(entities)
@@ -320,6 +357,7 @@ class SceneView private constructor(
 
                 val loadedModel = LoadedModel(asset, animator)
                 models.add(loadedModel)
+                loadedAssets.replaceWith(url, asset)
 
                 // A new model changes the content bounds, so the auto-center pass
                 // must re-frame. The #1391-style diagonal-stability gate already
@@ -335,6 +373,12 @@ class SceneView private constructor(
                     onDone = {
                         // Release the source glTF data now that resources are loaded
                         asset.releaseSourceData()
+                        // #1597: only now is getBoundingBox() readable — mark the
+                        // model loaded so the auto-center pass starts including it.
+                        loadedModel.loaded = true
+                        // The model just became framable — re-arm the gate so the
+                        // auto-center pass re-frames on this freshly readable box.
+                        autoCenterGate.reset()
                         console.log("SceneView: Model loaded from $url (${entities.size} entities)")
                         onLoaded?.invoke(asset)
                     },
@@ -460,7 +504,12 @@ class SceneView private constructor(
                     null
                 }
 
-                models.add(LoadedModel(asset, animator))
+                val loadedModel = LoadedModel(asset, animator)
+                models.add(loadedModel)
+                // Track for leak-free teardown (#1597). Geometry has no logical
+                // URL identity, so synthesise a unique key — each primitive is
+                // a distinct asset, never a replacement.
+                loadedAssets.replaceWith("geometry#${assetKeySeq++}", asset)
 
                 // Re-arm the auto-center pass — a new primitive grows the union
                 // bounds. The diagonal-stability gate also re-frames on its own
@@ -471,7 +520,13 @@ class SceneView private constructor(
                 // Finalize the asset — loadResources uploads vertex/index buffers to GPU.
                 // Even for self-contained GLBs (no external resources), this step is required.
                 asset.loadResources(
-                    onDone = { asset.releaseSourceData() },
+                    onDone = {
+                        asset.releaseSourceData()
+                        // #1597: getBoundingBox() is only readable post-load —
+                        // mark loaded so the auto-center pass includes it.
+                        loadedModel.loaded = true
+                        autoCenterGate.reset()
+                    },
                     onFetched = null,
                     basePath = "",
                     asyncInterval = null
@@ -495,15 +550,21 @@ class SceneView private constructor(
     }
 
     /**
-     * Read every loaded asset's asset-space AABB as [ContentCentering.Aabb]s.
+     * Read every *fully loaded* asset's asset-space AABB as
+     * [ContentCentering.Aabb]s.
      *
-     * `getBoundingBox()` reports a degenerate/empty box until `loadResources()`
-     * has populated the renderables; an unreadable box (resources still in
-     * flight) is surfaced once and skipped so the pass retries next frame.
+     * `getBoundingBox()` reports a degenerate/wrong box until `loadResources()`
+     * has populated the renderables, so a model whose [LoadedModel.loaded] flag
+     * is still `false` is excluded entirely — this is the #1597 fix: the
+     * auto-center pass must never frame the scene on a not-yet-loaded model's
+     * unreadable diagonal. The defensive `try/catch` stays as a second guard.
      * Shared by [fitToModels] and [refreshContentCentering] so the union-AABB
      * read happens exactly once per call site instead of being duplicated.
      */
     private fun contentBoxes(): List<ContentCentering.Aabb> = models.mapNotNull { model ->
+        // #1597: skip models whose resources are still in flight — their box is
+        // not yet readable, so including them would frame on a wrong diagonal.
+        if (!model.loaded) return@mapNotNull null
         try {
             val aabb = model.asset.getBoundingBox()
             val mn: dynamic = aabb.min
@@ -662,11 +723,13 @@ class SceneView private constructor(
         stopRendering()
         cameraController?.dispose()
 
-        // Destroy loaded assets
-        assetLoader?.let { loader ->
-            models.forEach { loader.destroyAsset(it.asset) }
-            loader.delete()
-        }
+        // Destroy every loaded gltfio asset (#1597). The tracker is the single
+        // owner of all live FilamentAssets — URL models and geometry alike —
+        // so this releases each exactly once, including any not yet covered by
+        // the per-replace destroy. The `models` list is then purely render
+        // state and just needs clearing.
+        loadedAssets.release()
+        assetLoader?.delete()
         models.clear()
 
         // Destroy light entities

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/AssetResourceTrackerTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/AssetResourceTrackerTest.kt
@@ -1,0 +1,163 @@
+package io.github.sceneview.web
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for [AssetResourceTracker] — the per-logical-model GPU
+ * asset tracker behind `SceneView.loadModel`'s leak-free `FilamentAsset`
+ * lifecycle.
+ *
+ * Pins issue **#1597**: before the fix `loadModel` appended every loaded asset
+ * to the `models` list and never destroyed a prior asset when the *same
+ * logical model* (same URL) was reloaded — so a demo hot-swapping the
+ * displayed model orphaned every previous `FilamentAsset` on the GPU until
+ * `destroy()` finally ran.
+ *
+ * Mirrors [EnvironmentResourceTrackerTest] (#1496): the tracker isolates the
+ * "destroy the old handle before adopting a new one, destroy whatever is held
+ * on teardown" state machine so it is unit-testable without a WebGL context.
+ * Handles here are plain `String`s standing in for opaque `FilamentAsset`s and
+ * the `destroyer` records every release.
+ */
+class AssetResourceTrackerTest {
+
+    @Test
+    fun freshTrackerHoldsNothing() {
+        val tracker = AssetResourceTracker<String> {}
+        assertNull(tracker.current("models/a.glb"), "a fresh tracker holds no asset")
+    }
+
+    @Test
+    fun replaceWithAdoptsTheHandle() {
+        val tracker = AssetResourceTracker<String> {}
+        tracker.replaceWith("models/a.glb", "asset-a")
+        assertEquals(
+            "asset-a",
+            tracker.current("models/a.glb"),
+            "replaceWith must adopt the new asset for that key",
+        )
+    }
+
+    @Test
+    fun firstReplaceWithDestroysNothing() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+        tracker.replaceWith("models/a.glb", "asset-a")
+        assertTrue(destroyed.isEmpty(), "the first load of a URL has no prior asset to destroy")
+    }
+
+    /**
+     * #1597: a 2nd `loadModel` of the same URL must release the prior asset
+     * before adopting the replacement — otherwise the previous GPU asset leaks.
+     */
+    @Test
+    fun reloadingTheSameUrlReleasesThePriorAsset() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+
+        tracker.replaceWith("models/helmet.glb", "asset-v1")
+        tracker.replaceWith("models/helmet.glb", "asset-v2")
+
+        assertEquals(
+            listOf("asset-v1"),
+            destroyed,
+            "#1597: reloading the same URL must release the prior asset exactly once",
+        )
+        assertEquals(
+            "asset-v2",
+            tracker.current("models/helmet.glb"),
+            "the new asset becomes current for that URL",
+        )
+    }
+
+    /**
+     * #1597: distinct logical models (different URLs) coexist — loading a 2nd
+     * URL must not destroy the 1st URL's asset.
+     */
+    @Test
+    fun distinctUrlsCoexistWithoutDestroyingEachOther() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+
+        tracker.replaceWith("models/a.glb", "asset-a")
+        tracker.replaceWith("models/b.glb", "asset-b")
+
+        assertTrue(destroyed.isEmpty(), "two distinct models are both live — nothing destroyed")
+        assertEquals("asset-a", tracker.current("models/a.glb"))
+        assertEquals("asset-b", tracker.current("models/b.glb"))
+    }
+
+    /**
+     * #1597: `destroy()` must release every tracked asset — the original leak.
+     */
+    @Test
+    fun releaseDestroysEveryHeldAsset() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+
+        tracker.replaceWith("models/a.glb", "asset-a")
+        tracker.replaceWith("models/b.glb", "asset-b")
+        tracker.release()
+
+        assertEquals(
+            setOf("asset-a", "asset-b"),
+            destroyed.toSet(),
+            "#1597: destroy() must release every live GPU asset",
+        )
+        assertNull(tracker.current("models/a.glb"), "release() clears every slot")
+        assertNull(tracker.current("models/b.glb"))
+    }
+
+    @Test
+    fun releaseWithoutAssetsIsANoOp() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+        tracker.release()
+        assertTrue(destroyed.isEmpty(), "releasing an empty tracker destroys nothing")
+    }
+
+    @Test
+    fun releaseIsIdempotent() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+
+        tracker.replaceWith("models/a.glb", "asset-a")
+        tracker.release()
+        tracker.release()
+
+        assertEquals(
+            listOf("asset-a"),
+            destroyed,
+            "a 2nd destroy() must not double-free a handle",
+        )
+    }
+
+    /**
+     * End-to-end mirror of a `SceneView` session: load model A, hot-swap A
+     * twice, load a procedural geometry (synthetic key), then `destroy()`.
+     * Every asset ever adopted must be released exactly once.
+     */
+    @Test
+    fun fullSessionLeavesNoLeakedAssets() {
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<String> { destroyed += it }
+
+        tracker.replaceWith("models/a.glb", "a-v1")          // loadModel
+        tracker.replaceWith("models/a.glb", "a-v2")          // reload same URL
+        tracker.replaceWith("models/a.glb", "a-v3")          // reload again
+        tracker.replaceWith("geometry#0", "cube")            // addGeometry
+        tracker.release()                                    // destroy()
+
+        assertEquals(
+            setOf("a-v1", "a-v2", "a-v3", "cube"),
+            destroyed.toSet(),
+            "#1597: every FilamentAsset created during the session is destroyed once",
+        )
+        assertEquals(4, destroyed.size, "no asset is double-freed or leaked")
+        assertNull(tracker.current("models/a.glb"))
+        assertNull(tracker.current("geometry#0"))
+    }
+}


### PR DESCRIPTION
Closes #1597.

## Bug 1 — premature framing
`loadModel` added entities + a `LoadedModel` to the centering union immediately on `createAsset`, before the async `loadResources()` finished — so the per-frame auto-center pass could read `getBoundingBox()` on an unloaded asset and frame the scene on a degenerate/wrong diagonal.

Fix: `LoadedModel` now carries a `loaded` flag set in `loadResources`'s `onDone`. `contentBoxes()` excludes not-yet-loaded models, so the auto-center pass never frames on an unreadable box. The gate is re-armed in `onDone` so the model is framed once its box becomes readable.

## Bug 2 — replaced-asset GPU leak
`loadModel` appended every load to `models` and never destroyed a prior asset when the same URL was reloaded — a leak left uncovered by the `EnvironmentResourceTracker` fix (#1496).

Fix: new `AssetResourceTracker` (mirrors `EnvironmentResourceTracker`) tracks each `FilamentAsset` per logical model (URL key; synthetic key for procedural geometry). Reloading a URL destroys the prior asset + removes its entities; `destroy()` releases everything via the tracker as the single owner.

## Tests
- New `AssetResourceTrackerTest` — 9 tests, all green. Asserts a reloaded URL releases the prior asset exactly once, distinct URLs coexist, and a full session leaks nothing.
- `:sceneview-web:jsBrowserTest` green; `:sceneview-web:compileKotlinJs` clean.

## Cross-platform
Android `loadModel` is `suspend` + composable-lifecycle driven — it awaits `loadResources` and the `ModelNode` lifecycle handles destruction, so it has neither bug. No follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)