### PR TITLE
fix(web): guard loadModel stale loadResources callback — UAF after asset replacement (#1597)

### DIFF
--- a/changelog.d/1597-stale-callback-fix.md
+++ b/changelog.d/1597-stale-callback-fix.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Web: guard `SceneView.loadModel` against a use-after-free — a reloaded or destroyed model's pending `loadResources` callback no longer touches the freed `FilamentAsset` (#1597).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -137,6 +137,20 @@ class SceneView private constructor(
          * Filament.js represents a mat4 as a flat 16-element `number[]`.
          */
         var baseTransform: dynamic = null
+
+        /**
+         * `true` once this model's [asset] has been destroyed — either
+         * replaced by a 2nd `loadModel` of the same URL, or torn down by
+         * [destroy]. Set the instant the asset is freed so the still-pending
+         * `loadResources(onDone=...)` callback can detect it: a stale `onDone`
+         * for a superseded model must become a safe no-op and never touch the
+         * freed `FilamentAsset` (`releaseSourceData()`), never flip [loaded],
+         * and never re-arm the auto-center gate. Without this guard a quick
+         * `loadModel(url)` → `loadModel(url)` (or `destroy()`) before the
+         * first load's resources finish is a use-after-free on the WASM
+         * heap (#1597 Tier-2 review).
+         */
+        var superseded: Boolean = false
     }
 
     /** Orbit camera controller -- initialized when cameraControls is enabled. */
@@ -340,8 +354,15 @@ class SceneView private constructor(
                 // tracker's destroyer also removes the old entities from the
                 // scene. Drop the stale LoadedModel from `models` here too so
                 // the render loop / auto-center pass never touch a freed asset.
+                //
+                // #1597 (Tier-2): the prior model's `loadResources` may still
+                // be in flight — flag it `superseded` so its pending `onDone`
+                // becomes a no-op instead of touching the asset we destroy
+                // below via `replaceWith` (use-after-free on the WASM heap).
                 loadedAssets.current(url)?.let { prior ->
-                    models.removeAll { it.asset == prior }
+                    models.removeAll { stale ->
+                        (stale.asset == prior).also { if (it) stale.superseded = true }
+                    }
                 }
 
                 // Add all entities to the scene so they become visible
@@ -371,6 +392,20 @@ class SceneView private constructor(
                 // This is REQUIRED for models to render with correct materials.
                 asset.loadResources(
                     onDone = {
+                        // #1597 (Tier-2): if a 2nd loadModel of this URL — or
+                        // destroy() — replaced/freed `asset` before its
+                        // resources finished, this callback is stale. Bail out
+                        // before touching the freed FilamentAsset: no
+                        // releaseSourceData() on a dead handle, no `loaded`
+                        // flip, no gate reset, no onLoaded for a model that is
+                        // no longer in the scene.
+                        if (loadedModel.superseded) {
+                            console.log(
+                                "SceneView: dropped stale loadResources for $url " +
+                                    "(asset superseded before resources finished)",
+                            )
+                            return@loadResources
+                        }
                         // Release the source glTF data now that resources are loaded
                         asset.releaseSourceData()
                         // #1597: only now is getBoundingBox() readable — mark the
@@ -521,6 +556,12 @@ class SceneView private constructor(
                 // Even for self-contained GLBs (no external resources), this step is required.
                 asset.loadResources(
                     onDone = {
+                        // #1597 (Tier-2): destroy() can free this geometry
+                        // asset before its buffers finish uploading — guard
+                        // the stale callback so it never touches a dead
+                        // FilamentAsset. (Geometry has a unique key so it is
+                        // never replaced, but teardown still races it.)
+                        if (loadedModel.superseded) return@loadResources
                         asset.releaseSourceData()
                         // #1597: getBoundingBox() is only readable post-load —
                         // mark loaded so the auto-center pass includes it.
@@ -722,6 +763,12 @@ class SceneView private constructor(
     fun destroy() {
         stopRendering()
         cameraController?.dispose()
+
+        // #1597 (Tier-2): mark every model superseded BEFORE releasing its
+        // asset so any in-flight loadResources callback that fires after
+        // teardown is a no-op instead of a use-after-free on a freed
+        // FilamentAsset.
+        models.forEach { it.superseded = true }
 
         // Destroy every loaded gltfio asset (#1597). The tracker is the single
         // owner of all live FilamentAssets — URL models and geometry alike —

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/LoadModelStaleCallbackTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/LoadModelStaleCallbackTest.kt
@@ -1,0 +1,177 @@
+package io.github.sceneview.web
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the **#1597 Tier-2** use-after-free race in
+ * `SceneView.loadModel`.
+ *
+ * `loadModel` issues `asset.loadResources(onDone = { ... })` asynchronously.
+ * The `onDone` callback captures both the `FilamentAsset` and its `LoadedModel`
+ * and, when it fires, calls `asset.releaseSourceData()` and mutates
+ * `loadedModel.loaded` / `autoCenterGate`. If a 2nd `loadModel(url)` of the
+ * same URL — or `destroy()` — runs *before* that callback fires, the prior
+ * `FilamentAsset` is destroyed synchronously inside `AssetResourceTracker`. The
+ * still-pending stale `onDone` then touches a freed handle: a use-after-free on
+ * the WASM heap.
+ *
+ * The fix tags each `LoadedModel` with a `superseded` flag, set the instant its
+ * asset is freed (by the replace path or by `destroy()`), and the `onDone`
+ * callback bails out at entry when the flag is set.
+ *
+ * `SceneView`/`LoadedModel` need a live WebGL context, so this test models the
+ * exact production sequence with plain stand-ins — the same approach
+ * [AssetResourceTrackerTest] takes for the leak-free-swap state machine. A
+ * `FakeAsset` records whether it was destroyed and whether its source data was
+ * released; `runLoadResources` reproduces the guarded `onDone` body verbatim.
+ */
+class LoadModelStaleCallbackTest {
+
+    /** Stand-in for a Filament.js `FilamentAsset`. */
+    private class FakeAsset(val name: String) {
+        var destroyed = false
+        var sourceDataReleased = false
+
+        /** Reproduces `asset.releaseSourceData()` — illegal once destroyed. */
+        fun releaseSourceData() {
+            check(!destroyed) { "use-after-free: releaseSourceData() on destroyed asset '$name'" }
+            sourceDataReleased = true
+        }
+    }
+
+    /** Stand-in for `SceneView.LoadedModel` carrying the new `superseded` flag. */
+    private class FakeLoadedModel(val asset: FakeAsset) {
+        var loaded = false
+        var superseded = false
+    }
+
+    /** Records every `autoCenterGate.reset()` the (guarded) callback would issue. */
+    private class FakeGate {
+        var resetCount = 0
+        fun reset() {
+            resetCount++
+        }
+    }
+
+    /**
+     * Reproduces the guarded `onDone` body of `SceneView.loadModel`'s
+     * `asset.loadResources(...)` call: bail out for a superseded model,
+     * otherwise release source data, flip `loaded`, re-arm the gate, and
+     * invoke `onLoaded`.
+     */
+    private fun runLoadResources(
+        model: FakeLoadedModel,
+        gate: FakeGate,
+        onLoaded: (FakeAsset) -> Unit,
+    ) {
+        if (model.superseded) return
+        model.asset.releaseSourceData()
+        model.loaded = true
+        gate.reset()
+        onLoaded(model.asset)
+    }
+
+    /**
+     * #1597 Tier-2: a 2nd `loadModel(url)` of the same URL before the 1st
+     * load's resources finish must NOT let the stale `onDone` touch the freed
+     * asset.
+     */
+    @Test
+    fun reloadingSameUrlBeforeResourcesFinishDropsStaleCallback() {
+        val gate = FakeGate()
+        val destroyed = mutableListOf<String>()
+        val tracker = AssetResourceTracker<FakeAsset> { destroyed += it.name; it.destroyed = true }
+
+        // --- 1st loadModel(url): asset created, loadResources still in flight ---
+        val first = FakeAsset("helmet-v1")
+        val firstModel = FakeLoadedModel(first)
+        tracker.replaceWith("models/helmet.glb", first)
+
+        // --- 2nd loadModel(url) BEFORE the 1st onDone fires ---
+        // Production marks the prior model superseded, then replaceWith frees it.
+        tracker.current("models/helmet.glb")?.let { prior ->
+            if (prior === firstModel.asset) firstModel.superseded = true
+        }
+        val second = FakeAsset("helmet-v2")
+        val secondModel = FakeLoadedModel(second)
+        tracker.replaceWith("models/helmet.glb", second)
+
+        assertEquals(listOf("helmet-v1"), destroyed, "the prior asset is destroyed exactly once")
+        assertTrue(first.destroyed, "1st asset is freed")
+        assertTrue(firstModel.superseded, "1st model is flagged superseded before its asset is freed")
+
+        // --- the STALE 1st onDone finally fires ---
+        // Must be a no-op: no releaseSourceData on the freed handle, no state mutation.
+        runLoadResources(firstModel, gate) { error("stale onLoaded must not fire for a superseded model") }
+
+        assertFalse(first.sourceDataReleased, "no releaseSourceData() on the freed 1st asset")
+        assertFalse(firstModel.loaded, "stale callback must not flip `loaded` on the dropped model")
+        assertEquals(0, gate.resetCount, "stale callback must not re-arm the auto-center gate")
+
+        // --- the 2nd (live) onDone fires normally ---
+        var liveOnLoaded: FakeAsset? = null
+        runLoadResources(secondModel, gate) { liveOnLoaded = it }
+
+        assertTrue(second.sourceDataReleased, "the live 2nd asset releases its source data")
+        assertTrue(secondModel.loaded, "the live 2nd model is marked loaded")
+        assertEquals(1, gate.resetCount, "the live callback re-arms the gate once")
+        assertEquals(second, liveOnLoaded, "onLoaded fires for the live asset only")
+    }
+
+    /**
+     * #1597 Tier-2: `destroy()` while a load's resources are still in flight
+     * must inert the pending callback — no use-after-free on teardown.
+     */
+    @Test
+    fun destroyBeforeResourcesFinishDropsStaleCallback() {
+        val gate = FakeGate()
+        val tracker = AssetResourceTracker<FakeAsset> { it.destroyed = true }
+
+        val asset = FakeAsset("model")
+        val model = FakeLoadedModel(asset)
+        tracker.replaceWith("models/model.glb", asset)
+
+        // --- destroy(): mark every model superseded BEFORE releasing assets ---
+        val models = listOf(model)
+        models.forEach { it.superseded = true }
+        tracker.release()
+
+        assertTrue(asset.destroyed, "destroy() frees the asset")
+        assertTrue(model.superseded, "destroy() flags the model superseded before freeing")
+
+        // --- the stale onDone fires after teardown ---
+        runLoadResources(model, gate) { error("onLoaded must not fire after destroy()") }
+
+        assertFalse(asset.sourceDataReleased, "no releaseSourceData() on a destroyed asset after teardown")
+        assertFalse(model.loaded, "teardown's stale callback must not mutate model state")
+        assertEquals(0, gate.resetCount, "teardown's stale callback must not touch the auto-center gate")
+    }
+
+    /**
+     * A load that finishes normally — no replace, no destroy — must still run
+     * its `onDone` fully. Guards against the `superseded` check becoming an
+     * over-eager bail-out that breaks the happy path.
+     */
+    @Test
+    fun uninterruptedLoadRunsItsCallbackFully() {
+        val gate = FakeGate()
+        val tracker = AssetResourceTracker<FakeAsset> { it.destroyed = true }
+
+        val asset = FakeAsset("solo")
+        val model = FakeLoadedModel(asset)
+        tracker.replaceWith("models/solo.glb", asset)
+
+        var onLoadedFired = false
+        runLoadResources(model, gate) { onLoadedFired = true }
+
+        assertTrue(asset.sourceDataReleased, "an uninterrupted load releases its source data")
+        assertTrue(model.loaded, "an uninterrupted load marks the model loaded")
+        assertEquals(1, gate.resetCount, "an uninterrupted load re-arms the gate once")
+        assertTrue(onLoadedFired, "an uninterrupted load fires onLoaded")
+        assertFalse(model.superseded, "an uninterrupted model is never superseded")
+        assertFalse(asset.destroyed, "an uninterrupted asset stays live")
+    }
+}


### PR DESCRIPTION
## Summary

Fix-forward for a Tier-2 review finding on #1597 (merged via PR #1628).

The web `SceneView.loadModel` issues `asset.loadResources(onDone = { ... })` asynchronously. The `onDone` callback captures the `FilamentAsset` + its `LoadedModel` and, when it fires, calls `asset.releaseSourceData()` and mutates `loadedModel.loaded` / `autoCenterGate`. If a 2nd `loadModel(url)` of the **same URL** — or `destroy()` — runs *before* that callback fires, `AssetResourceTracker.replaceWith` (or `release`) destroys the prior `FilamentAsset` **synchronously**. The still-pending stale `onDone` then touched a freed handle: a **use-after-free** on the WASM heap.

## Fix — `superseded` guard flag

- `LoadedModel` gains a `superseded: Boolean` flag.
- `loadModel`: when a 2nd load of the same URL drops the prior `LoadedModel` from `models`, it now also sets `prior.superseded = true` — set **before** `replaceWith` frees the asset.
- `destroy()`: marks every model `superseded` **before** `loadedAssets.release()` frees the assets.
- Both the `loadModel` and `addGeometry` `loadResources(onDone=...)` callbacks bail out at entry when `superseded` is set: no `releaseSourceData()` on a dead handle, no `loaded` flip, no `autoCenterGate.reset()`, no `onLoaded`.

Filament.js engine calls stay on their established `.then`/`onDone` paths — only an early-return guard was added.

## Regression test

New `LoadModelStaleCallbackTest` (jsTest) models the exact production sequence with plain stand-ins (same WebGL-free approach as `AssetResourceTrackerTest`):
- `reloadingSameUrlBeforeResourcesFinishDropsStaleCallback` — reload before 1st `onDone` fires; asserts the stale callback never touches the freed asset and the live 2nd callback runs normally.
- `destroyBeforeResourcesFinishDropsStaleCallback` — `destroy()` mid-load; asserts no UAF on teardown.
- `uninterruptedLoadRunsItsCallbackFully` — happy path unaffected (guards against an over-eager bail-out).

`:sceneview-web:compileKotlinJs` and `:sceneview-web:jsBrowserTest` pass (3/3 new tests).

## Android safety — claim verified

The #1597 agent claimed Android has no analogous race. **Confirmed:** Android `ModelLoader.loadModel` is a `suspend fun` — `loadResourcesSuspended` is a sequential suspending step, not a fire-and-forget callback that outlives the function. Via the documented `rememberModelInstance` composable path, cancelling composition cancels the coroutine, so no orphaned callback survives to touch a freed asset. Android also exposes no "replace the asset at the same URL inside a stale callback" pattern. The race is web-only because the web `loadModel` is callback-driven and not lifecycle-cancellable.