### PR TITLE
fix(web): bound AutoCenterGate so animated scenes latch (#1633)

### DIFF
--- a/changelog.d/1633-web-autocentergate-bound.md
+++ b/changelog.d/1633-web-autocentergate-bound.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Web `AutoCenterGate` now latches after a bounded number of framing passes (`MAX_FRAMING_PASSES = 10`), so an animated / skeletal / physics scene whose union diagonal jitters every frame stops re-centring the camera forever — parity with Android's `FramingGate` ceiling (#1633, #1629).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/AutoCenterGate.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/AutoCenterGate.kt
@@ -34,6 +34,19 @@ import kotlin.math.max
  * stable versus the previous fitted diagonal, so deferred async models keep
  * the pass alive until the whole scene has settled.
  *
+ * ## Why an unconditional ceiling is also needed (#1633)
+ *
+ * The diagonal-stability latch alone is unbounded: a scene whose union diagonal
+ * jitters by *more* than [STABILITY_EPSILON] on every single frame — an
+ * animated / skeletal model, a physics demo, or two async models alternately
+ * growing the union — satisfies [shouldFrame] forever and **never** latches.
+ * The pass would then re-apply the camera / centroid every frame indefinitely,
+ * fighting user interaction and burning a content-bounds walk per frame. So
+ * [recordFraming] also latches unconditionally once it has framed
+ * [MAX_FRAMING_PASSES] times: a scene that has not settled by then is genuinely
+ * animated, and re-framing it every frame is wrong. This is the web port of the
+ * Android `FramingGate` ceiling (#1629) — kept in parity.
+ *
  * Isolating the state machine from any Filament.js binding keeps it directly
  * unit-testable without a WebGL context.
  */
@@ -48,6 +61,20 @@ internal class AutoCenterGate {
      */
     companion object {
         const val STABILITY_EPSILON: Double = 0.01
+
+        /**
+         * Hard ceiling on how many times the gate will (re-)frame before
+         * latching unconditionally. The diagonal-stability check handles a
+         * scene that genuinely settles; this ceiling caps the pathological case
+         * where the union diagonal jitters above [STABILITY_EPSILON] every
+         * frame (animated / skeletal models, physics demos, alternating async
+         * loads) and would otherwise re-frame forever. Generous enough to
+         * absorb a handful of staggered async model loads (the #1391 case the
+         * gate exists for), small enough that an animated scene stops fighting
+         * the user almost immediately. Mirrors Android `FramingGate`'s
+         * `MAX_FRAMING_PASSES` (#1629) — kept in parity.
+         */
+        const val MAX_FRAMING_PASSES: Int = 10
     }
 
     /** `true` once the union diagonal has stabilised and the pass has latched. */
@@ -60,6 +87,13 @@ internal class AutoCenterGate {
      * whether a streamed model just landed.
      */
     private var lastFramedDiagonal: Double = -1.0
+
+    /**
+     * How many times [recordFraming] has framed the content since the last
+     * [reset]. Once this reaches [MAX_FRAMING_PASSES] the gate latches
+     * unconditionally so a perpetually-jittering scene stops re-framing.
+     */
+    private var framingPasses: Int = 0
 
     /**
      * Whether the centring pass should run this frame.
@@ -90,24 +124,33 @@ internal class AutoCenterGate {
     }
 
     /**
-     * Record that the pass framed the content at union [diagonal].
+     * Record that the pass framed the content at union [diagonal]. Latches
+     * [didCenter] once either:
      *
-     * Latches [didCenter] once this diagonal is stable versus the previously
-     * recorded one — i.e. the scene has settled across consecutive ticks and
-     * no more async models are growing the union. Until then the pass keeps
-     * running so deferred async models re-frame the scene.
+     * - this diagonal is stable versus the previously recorded one — i.e. the
+     *   scene has settled across consecutive ticks and no more async models are
+     *   growing the union; or
+     * - the gate has now framed [MAX_FRAMING_PASSES] times — a hard ceiling that
+     *   stops a scene whose diagonal jitters above [STABILITY_EPSILON] every
+     *   frame (animated / skeletal models, physics demos) from re-framing
+     *   forever and fighting user interaction.
+     *
+     * Until one of those triggers the pass keeps running so deferred async
+     * models re-frame the scene.
      */
     fun recordFraming(diagonal: Double) {
         val stable = lastFramedDiagonal >= 0.0 &&
             abs(diagonal - lastFramedDiagonal) <=
             STABILITY_EPSILON * max(diagonal, lastFramedDiagonal)
         lastFramedDiagonal = diagonal
-        if (stable) didCenter = true
+        framingPasses++
+        if (stable || framingPasses >= MAX_FRAMING_PASSES) didCenter = true
     }
 
     /**
-     * Start a fresh content generation — clears the latch and the recorded
-     * diagonal so the next frame re-frames from scratch.
+     * Start a fresh content generation — clears the latch, the recorded
+     * diagonal and the framing-pass counter so the next frame re-frames from
+     * scratch.
      *
      * With the #1391 diagonal-stability logic the pass already re-frames
      * automatically whenever an async model grows the union, so an explicit
@@ -118,5 +161,6 @@ internal class AutoCenterGate {
     fun reset() {
         didCenter = false
         lastFramedDiagonal = -1.0
+        framingPasses = 0
     }
 }

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/AutoCenterGateTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/AutoCenterGateTest.kt
@@ -1,6 +1,7 @@
 package io.github.sceneview.web
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -13,6 +14,13 @@ import kotlin.test.assertTrue
  * first-stable-frame latch froze the framing on whichever model loaded first,
  * leaving later async models bunched in the corner — the multi-model bug #1391
  * fixed on iOS. [deferredAsyncModelReFramesAfterFirstModelCentered] pins that.
+ *
+ * The second headline case is **#1633**: a scene whose union diagonal jitters
+ * above the stability epsilon on every frame (animated model, physics demo)
+ * never satisfies the diagonal-stability latch, so the gate must latch via the
+ * [AutoCenterGate.MAX_FRAMING_PASSES] ceiling instead of re-framing forever.
+ * [perpetuallyJitteringSceneLatchesWithinTheCeiling] pins that — parity with
+ * Android's `FramingGateTest`.
  */
 class AutoCenterGateTest {
 
@@ -184,6 +192,83 @@ class AutoCenterGateTest {
         assertTrue(
             gate.shouldFrame(10.5),
             "a supra-epsilon diagonal change must re-frame",
+        )
+    }
+
+    /**
+     * #1633: a scene whose union diagonal jitters by *more* than
+     * [AutoCenterGate.STABILITY_EPSILON] on **every** frame — an animated /
+     * skeletal model, a physics demo, or two async models alternately growing
+     * the union — never satisfies the diagonal-stability latch. Without the
+     * [AutoCenterGate.MAX_FRAMING_PASSES] ceiling the gate would re-frame
+     * forever, fighting user interaction and burning a content-bounds walk per
+     * frame. The ceiling must force a deterministic latch. Parity with
+     * Android's `FramingGateTest.perpetuallyJitteringSceneLatchesWithinTheCeiling`.
+     */
+    @Test
+    fun perpetuallyJitteringSceneLatchesWithinTheCeiling() {
+        val gate = AutoCenterGate()
+        // A diagonal that swings ~5% (well above the 1% epsilon) every frame —
+        // never settles.
+        var diagonal = 2.0
+        var grow = true
+        var passes = 0
+        // Drive far more frames than the ceiling: the gate MUST latch before
+        // we run out.
+        repeat(AutoCenterGate.MAX_FRAMING_PASSES * 4) {
+            if (!gate.didCenter && gate.shouldRun(enabled = true, hasContent = true)) {
+                // Every frame `shouldFrame` is true because the jitter exceeds
+                // the epsilon.
+                assertTrue(
+                    gate.shouldFrame(diagonal),
+                    "a supra-epsilon jitter must always want to re-frame while unlatched",
+                )
+                gate.recordFraming(diagonal)
+                passes++
+                diagonal = if (grow) diagonal * 1.05 else diagonal / 1.05
+                grow = !grow
+            }
+        }
+        assertTrue(
+            gate.didCenter,
+            "a perpetually-jittering scene must latch via the MAX_FRAMING_PASSES ceiling",
+        )
+        assertEquals(
+            AutoCenterGate.MAX_FRAMING_PASSES,
+            passes,
+            "the gate must latch exactly at the framing-pass ceiling, not run unbounded",
+        )
+        assertFalse(
+            gate.shouldRun(enabled = true, hasContent = true),
+            "once the ceiling latches the gate, later frames must be a no-op",
+        )
+    }
+
+    /**
+     * The ceiling must not punish a scene that legitimately needs a few
+     * staggered re-frames (the #1391 async-model case): a handful of
+     * growing-then-settling frames — fewer than the ceiling — must still latch
+     * via the *stability* path, not the ceiling.
+     */
+    @Test
+    fun aFewStaggeredLoadsStillLatchViaStabilityNotTheCeiling() {
+        val gate = AutoCenterGate()
+        // 5 growing frames + a settled repeat — 6 passes total, under the
+        // 10-pass ceiling.
+        val diagonals = listOf(1.0, 1.5, 2.1, 2.8, 3.5, 3.5)
+        var passes = 0
+        for (d in diagonals) {
+            gate.shouldFrame(d)
+            gate.recordFraming(d)
+            passes++
+        }
+        assertTrue(
+            gate.didCenter,
+            "a scene that settles within the ceiling must latch via the stability path",
+        )
+        assertTrue(
+            passes < AutoCenterGate.MAX_FRAMING_PASSES,
+            "the staggered-async case must latch before hitting the ceiling",
         )
     }
 


### PR DESCRIPTION
Closes #1633. Ports the `MAX_FRAMING_PASSES = 10` ceiling from Android's `FramingGate` (#1629) to web's `AutoCenterGate`.

## The bug
`recordFraming` only latched `didCenter` when the union AABB diagonal was stable vs. the *immediately previous* framed diagonal. A scene whose diagonal jitters by more than `STABILITY_EPSILON` every frame (animated/skeletal model, physics, alternating async loads) satisfies `shouldFrame()` forever and never latches — re-framing the camera/centroid every frame indefinitely.

## The fix
- Added `MAX_FRAMING_PASSES = 10` to the companion object.
- Added a `framingPasses` counter incremented in `recordFraming`; latches unconditionally once the counter reaches the ceiling.
- `reset()` zeroes the counter.
- The diagonal-stability latch still wins for scenes that settle quickly — the #1391 staggered-async-load case is unaffected.

Structurally identical to the Android `FramingGate` so the two stay in parity (same constant value, same semantics).

## Tests
- `perpetuallyJitteringSceneLatchesWithinTheCeiling` — a >epsilon-jittering scene latches at the ceiling (mirrors Android's `FramingGateTest`).
- `aFewStaggeredLoadsStillLatchViaStabilityNotTheCeiling` — confirms the staggered-async case still latches via the stability path, not the ceiling.
- `./gradlew :sceneview-web:compileKotlinJs` + `:sceneview-web:jsBrowserTest` green.

cc PR #1629