### PR TITLE
fix(device-qa): Android CI emulator stability — more RAM + offline retry

### DIFF
--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -104,6 +104,21 @@ echo "[qa] running Maestro flow: $FLOW_FILE"
 MAESTRO_RC=0
 maestro_run "$FLOW_FILE" || MAESTRO_RC=$?
 
+# One-shot retry on an emulator-transport drop ("device offline" — the CI
+# emulator going unstable mid-flow, #1643). A transport drop is intermittent;
+# one retry rescues a flaky run without masking a genuine demo failure (a real
+# crash fails again the same way). Only retried for offline/transport errors.
+if [[ "$MAESTRO_RC" -ne 0 ]]; then
+  if adb get-state >/dev/null 2>&1; then
+    echo "[qa] device still online — Maestro failure is genuine, not retrying." >&2
+  else
+    echo "[qa] device offline after flow — emulator transport dropped; one retry..." >&2
+    adb wait-for-device 2>/dev/null || true
+    MAESTRO_RC=0
+    maestro_run "$FLOW_FILE" || MAESTRO_RC=$?
+  fi
+fi
+
 # --- FATAL / ANR logcat sweep ---------------------------------------------
 # Maestro's per-demo "Navigate back" assertion already fails on a hard crash,
 # but a backgrounded native crash or an ANR can leave the process technically

--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -167,7 +167,10 @@ jobs:
           api-level: 30
           target: google_apis
           arch: x86_64
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          # -memory 4096: the SceneView Filament 3D demo is GPU/RAM-heavy; the
+          # default emulator RAM let the device go offline mid-Maestro-flow on
+          # the software-GPU CI runner (#1643).
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -memory 4096
           disable-animations: true
           script: |
             export PATH="$HOME/.maestro/bin:$PATH"
@@ -223,7 +226,10 @@ jobs:
           api-level: 30
           target: google_apis
           arch: x86_64
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          # -memory 4096: the SceneView Filament 3D demo is GPU/RAM-heavy; the
+          # default emulator RAM let the device go offline mid-Maestro-flow on
+          # the software-GPU CI runner (#1643).
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -memory 4096
           disable-animations: true
           # NOTE: ReactiveCircus/android-emulator-runner runs each LINE of this
           # `script:` as a separate `sh -c` invocation — env vars do NOT persist

--- a/changelog.d/1643-android-emulator-stability.md
+++ b/changelog.d/1643-android-emulator-stability.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Device-QA Android leg — CI emulator stability ([#1643](https://github.com/sceneview/sceneview/issues/1643)).** The Maestro flow ran correctly (app launch + camera-orbit swipes) but the CI emulator went offline mid-flow under the SceneView Filament 3D demo's GPU/RAM load. The `android` and `ar` device-QA jobs now boot the emulator with `-memory 4096`, and `qa-android-demos.sh` retries the Maestro flow once when — and only when — the device drops offline (a genuine demo failure, where the device stays online, is not retried).


### PR DESCRIPTION
Closes #1643. Part of the device-QA harness (#1560).

Device QA run 25988150773: the Android Maestro flow ran correctly (app launch + 3 camera-orbit swipes all `COMPLETED`) then failed on a tap with `java.io.IOException: device offline` — the CI emulator went offline mid-flow under the SceneView Filament 3D demo's GPU/RAM load.

- `device-qa.yml`: the `android` and `ar` emulator jobs now boot with `-memory 4096` (the default RAM was too low for the heavy 3D app on a software-GPU runner).
- `qa-android-demos.sh`: retry the Maestro flow once **iff** the device dropped offline (intermittent transport loss). If the device is still online the failure is genuine and is **not** retried — real demo bugs are not masked.

Web + AR legs are already green; this targets the last leg.