### PR TITLE
chore(android-demo): remove stale TODO in AnimationDemo.kt (#1649)

### DIFF
--- a/changelog.d/1649-animationdemo-todo.md
+++ b/changelog.d/1649-animationdemo-todo.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Removed a stale verification TODO in the Android demo's `AnimationDemo` — `ModelNode.playAnimation`'s `loop` parameter is verified to be honoured correctly. (#1649)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/AnimationDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/AnimationDemo.kt
@@ -281,7 +281,6 @@ fun AnimationDemo(onBack: () -> Unit) {
         for (i in 0 until node.animationCount) node.stopAnimation(i)
         if (DemoSettings.qaMode) return@LaunchedEffect
         if (isPlaying && selectedAnim < node.animationCount) {
-            // TODO(audit-2026-05-04): SDK playAnimation may ignore loop= param — verify.
             node.playAnimation(selectedAnim, speed = speed, loop = loop)
         }
     }


### PR DESCRIPTION
Closes #1649.

Removes the stale `TODO(audit-2026-05-04)` comment in `AnimationDemo.kt`. Verified against `ModelNode.kt` that `playAnimation(animationIndex, speed, loop)` stores the flag in `PlayingAnimation(loop = loop)` and `applyAnimations` honours it (`!animation.loop && adjustedTimeSeconds >= animationDuration` removes non-looping tracks). Comment-only deletion, no behaviour change.