### PR TITLE
ci(device-qa): prebuild android APK + explicit release-gate WARN (#1652, #1651)

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -39,6 +39,15 @@
 #                    rarely has every runtime, and a partial pass is useful.
 #   --out <dir>      Directory for the aggregated report + per-platform
 #                    artifacts. Default: repo-root (`device-qa-report.json`).
+#   --advisory=<csv> Comma-separated platforms whose result is ADVISORY for the
+#                    release gate — a failure on an advisory leg surfaces as a
+#                    WARN (not a hard block) in release-checklist.sh section 14
+#                    (#1651). Default: `android,ar` — these legs run on the
+#                    chronically flaky SwiftShader emulator (#1643) and are
+#                    `continue-on-error: true` in device-qa.yml, so the release
+#                    gate must not be hard-blocked by them. The `web` leg is
+#                    intentionally NOT advisory: it is reliable and BLOCKING.
+#                    Pass `--advisory=` (empty) to make every leg blocking.
 #   -h | --help      Show this help.
 #
 # Exit status:
@@ -69,6 +78,11 @@ PLATFORM="all"
 FAST=false
 CI_MODE=false
 OUT_DIR="$REPO_ROOT"
+# Advisory legs (#1651): a failure here is a release-gate WARN, not a block.
+# `android,ar` ride the flaky SwiftShader emulator and are continue-on-error
+# in device-qa.yml; `web` is reliable and stays BLOCKING.
+ADVISORY="android,ar"
+ADVISORY_SET=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -78,13 +92,24 @@ while [[ $# -gt 0 ]]; do
     --ci)         CI_MODE=true; shift ;;
     --out=*)      OUT_DIR="${1#--out=}"; shift ;;
     --out)        OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
+    --advisory=*) ADVISORY="${1#--advisory=}"; ADVISORY_SET=true; shift ;;
+    --advisory)   ADVISORY="${2-}"; ADVISORY_SET=true; shift 2 ;;
     -h|--help)
-      sed -n '2,52p' "$SCRIPT_DIR/device-qa.sh" | sed 's/^# \{0,1\}//'
+      sed -n '2,62p' "$SCRIPT_DIR/device-qa.sh" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[device-qa] unknown argument: $1" >&2; exit 2 ;;
   esac
 done
+: "$ADVISORY_SET"  # silence unused-var warnings; reserved for future strictness
+
+# Is platform $1 in the advisory CSV?
+is_advisory() {
+  case ",$ADVISORY," in
+    *",$1,"*) return 0 ;;
+    *)        return 1 ;;
+  esac
+}
 
 case "$PLATFORM" in
   android|ios|web|ar|all) ;;
@@ -386,12 +411,18 @@ fi
 # The per-platform records are exported as DQ_* environment variables — far
 # more robust across shells than argv quoting for arbitrary reason strings.
 export DQ_N="${#RESULT_PLATFORMS[@]}"
+export DQ_ADVISORY="$ADVISORY"
 for i in "${!RESULT_PLATFORMS[@]}"; do
   export "DQ_PLATFORM_$i=${RESULT_PLATFORMS[$i]}"
   export "DQ_STATUS_$i=${RESULT_STATUSES[$i]}"
   export "DQ_REASON_$i=${RESULT_REASONS[$i]}"
   export "DQ_SUMMARY_$i=${RESULT_SUMMARIES[$i]}"
   export "DQ_DURATION_$i=${RESULT_DURATIONS[$i]}"
+  if is_advisory "${RESULT_PLATFORMS[$i]}"; then
+    export "DQ_ADVISORY_$i=true"
+  else
+    export "DQ_ADVISORY_$i=false"
+  fi
 done
 
 python3 - "$REPORT" "$RUN_STARTED" "$PLATFORM" "$FAST" "$CI_MODE" "$OVERALL" \
@@ -402,6 +433,9 @@ import json, sys, os
  passed, failed, skipped) = sys.argv[1:10]
 
 n = int(os.environ["DQ_N"])
+advisory_csv = os.environ.get("DQ_ADVISORY", "")
+advisory_set = {p for p in advisory_csv.split(",") if p}
+
 platforms = []
 for i in range(n):
     summary_path = os.environ.get(f"DQ_SUMMARY_{i}", "")
@@ -415,19 +449,47 @@ for i in range(n):
     platforms.append({
         "platform": os.environ[f"DQ_PLATFORM_{i}"],
         "status":   os.environ[f"DQ_STATUS_{i}"],
+        # advisory=true → a failure on this leg is a release-gate WARN, not a
+        # hard block (#1651). Mirrors `continue-on-error` in device-qa.yml.
+        "advisory": os.environ.get(f"DQ_ADVISORY_{i}", "false") == "true",
         "reason":   os.environ.get(f"DQ_REASON_{i}", ""),
         "durationSec": int(os.environ.get(f"DQ_DURATION_{i}", "0") or 0),
         "summary":  embedded,
     })
 
+# --- Release-gate verdict (#1651) ------------------------------------------
+# The aggregated `status` above answers "did every leg pass". The release gate
+# needs a finer signal: a failed ADVISORY leg (android/ar) is only a WARN,
+# while a failed BLOCKING leg (web) hard-blocks. Pre-compute that split so
+# release-checklist.sh section 14 reads an explicit field instead of
+# re-deriving the policy.
+blocking_failed = [p["platform"] for p in platforms
+                   if p["status"] == "failed" and not p["advisory"]]
+advisory_failed = [p["platform"] for p in platforms
+                   if p["status"] == "failed" and p["advisory"]]
+if blocking_failed:
+    gate = "blocked"
+elif advisory_failed:
+    gate = "warn"
+else:
+    gate = "clear"
+
 report = {
     "harness": "device-qa",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "startedAt": started,
     "platformSelection": platform,
     "fast": fast == "true",
     "ci": ci == "true",
     "status": overall,
+    "advisoryPlatforms": sorted(advisory_set),
+    # releaseGate: "clear" (tag freely) | "warn" (advisory leg red — human
+    # should see it before tagging) | "blocked" (a blocking leg is red).
+    "releaseGate": {
+        "verdict": gate,
+        "blockingFailed": blocking_failed,
+        "advisoryFailed": advisory_failed,
+    },
     "totals": {
         "passed": int(passed),
         "failed": int(failed),
@@ -449,14 +511,23 @@ echo "  selection : $PLATFORM   fast=$FAST   ci=$CI_MODE"
 echo "  report    : $REPORT"
 echo "───────────────────────────────────────────────────────"
 for i in "${!RESULT_PLATFORMS[@]}"; do
-  printf "  %-9s %-8s %4ss  %s\n" \
+  tag=""
+  if is_advisory "${RESULT_PLATFORMS[$i]}"; then
+    tag="[advisory]"
+    # A failed advisory leg is a release-gate WARN, not a block — flag it so
+    # it is never silent (#1651).
+    [[ "${RESULT_STATUSES[$i]}" == "failed" ]] && tag="[advisory — WARN, not a release blocker]"
+  fi
+  printf "  %-9s %-8s %4ss  %s %s\n" \
     "${RESULT_PLATFORMS[$i]}" \
     "${RESULT_STATUSES[$i]}" \
     "${RESULT_DURATIONS[$i]}" \
+    "$tag" \
     "${RESULT_REASONS[$i]}"
 done
 echo "───────────────────────────────────────────────────────"
 echo "  passed=$PASSED  failed=$FAILED  skipped=$SKIPPED  ->  $OVERALL"
+echo "  advisory legs: ${ADVISORY:-(none)}  (a red advisory leg is a release WARN, not a block — #1651)"
 echo "═══════════════════════════════════════════════════════"
 
 if [[ "$OVERALL" == "passed" ]]; then

--- a/.claude/scripts/release-checklist.sh
+++ b/.claude/scripts/release-checklist.sh
@@ -234,37 +234,80 @@ echo ""
 
 # ─── 14. Device-QA gate ─────────────────────────────────────────────────
 # The autonomous cross-platform device-QA harness (umbrella #1560, slice
-# #1566) must have produced a GREEN `device-qa-report.json` before a release
-# is tagged — a red device-QA pass means a demo crashes on a real device for
-# at least one platform.
+# #1566) must have produced a `device-qa-report.json` before a release is
+# tagged — a red device-QA pass means a demo crashes on a real device.
 #
-# This is a release BLOCKER. To satisfy it, run before tagging:
+# RELEASE-GATE POLICY FOR continue-on-error LEGS (#1651)
+# ------------------------------------------------------
+# Not every leg is equal. device-qa.yml runs the `android` and `ar` legs as
+# `continue-on-error: true` on a chronically flaky SwiftShader emulator
+# (#1643); the `web` leg is reliable. So the gate is graded:
+#   - web        — BLOCKING. A red web leg is a release FAIL (hard block).
+#   - android/ar — ADVISORY. A red android/ar leg is a WARN: a human must see
+#                  "android leg: WARN — did not pass" before tagging, but it
+#                  does NOT hard-block (#1643/#1645 must make it reliably
+#                  green first — then promote it to blocking).
+# device-qa.sh tags each leg `advisory: true|false` and pre-computes a
+# `releaseGate.verdict` (clear|warn|blocked); this check reads that field so
+# the policy is explicit, not an accident of which legs happened to be red.
+#
+# To satisfy this check, run before tagging:
 #   bash .claude/scripts/device-qa.sh --platform=all
-# That produces `device-qa-report.json` at the repo root; this check reads
-# its aggregated `status` field. `DEVICE_QA_REPORT=<path>` overrides the
-# location (e.g. a CI artifact downloaded into the workspace).
+# That produces `device-qa-report.json` at the repo root; `DEVICE_QA_REPORT=
+# <path>` overrides the location (e.g. a CI artifact downloaded into the
+# workspace). An older report without `releaseGate` (schemaVersion 1) falls
+# back to the legacy all-or-nothing `status` reading.
 echo -e "${CYAN}--- Device-QA Gate ---${NC}"
 
 DQ_REPORT="${DEVICE_QA_REPORT:-device-qa-report.json}"
 if [ -f "$DQ_REPORT" ]; then
-    DQ_STATUS=$(python3 -c "import json,sys; print(json.load(open('$DQ_REPORT')).get('status','?'))" 2>/dev/null || echo "?")
+    DQ_STATUS=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('status','?'))" 2>/dev/null || echo "?")
     DQ_FAILED=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('totals',{}).get('failed','?'))" 2>/dev/null || echo "?")
     DQ_SKIPPED=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('totals',{}).get('skipped','?'))" 2>/dev/null || echo "?")
-    case "$DQ_STATUS" in
-        passed)
-            if [ "$DQ_SKIPPED" = "0" ]; then
-                check "device-qa-report.json" "PASS" "all platforms green"
-            else
-                check "device-qa-report.json" "WARN" "green but $DQ_SKIPPED platform(s) skipped — re-run device-qa.sh --ci"
-            fi
-            ;;
-        failed)
-            check "device-qa-report.json" "FAIL" "$DQ_FAILED platform(s) failed — fix before tagging"
-            ;;
-        *)
-            check "device-qa-report.json" "FAIL" "unreadable status ($DQ_STATUS)"
-            ;;
-    esac
+    # releaseGate is present from schemaVersion 2 (#1651); empty on older reports.
+    DQ_GATE=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('releaseGate',{}).get('verdict',''))" 2>/dev/null || echo "")
+    DQ_BLOCKING=$(python3 -c "import json; print(','.join(json.load(open('$DQ_REPORT')).get('releaseGate',{}).get('blockingFailed',[])))" 2>/dev/null || echo "")
+    DQ_ADVISORY=$(python3 -c "import json; print(','.join(json.load(open('$DQ_REPORT')).get('releaseGate',{}).get('advisoryFailed',[])))" 2>/dev/null || echo "")
+
+    if [ -n "$DQ_GATE" ]; then
+        # schemaVersion >= 2 — graded gate.
+        case "$DQ_GATE" in
+            clear)
+                if [ "$DQ_SKIPPED" = "0" ]; then
+                    check "device-qa-report.json" "PASS" "all platforms green"
+                else
+                    check "device-qa-report.json" "WARN" "green but $DQ_SKIPPED platform(s) skipped — re-run device-qa.sh --ci"
+                fi
+                ;;
+            warn)
+                # Advisory leg(s) red — never silent, never a hard block (#1651).
+                check "device-qa-report.json" "WARN" "advisory leg(s) did not pass: $DQ_ADVISORY — review before tagging (non-blocking, flaky emulator #1643)"
+                ;;
+            blocked)
+                check "device-qa-report.json" "FAIL" "blocking leg(s) failed: $DQ_BLOCKING — fix before tagging"
+                ;;
+            *)
+                check "device-qa-report.json" "FAIL" "unreadable releaseGate verdict ($DQ_GATE)"
+                ;;
+        esac
+    else
+        # schemaVersion 1 — legacy all-or-nothing reading.
+        case "$DQ_STATUS" in
+            passed)
+                if [ "$DQ_SKIPPED" = "0" ]; then
+                    check "device-qa-report.json" "PASS" "all platforms green (legacy report — no releaseGate)"
+                else
+                    check "device-qa-report.json" "WARN" "green but $DQ_SKIPPED platform(s) skipped — re-run device-qa.sh --ci"
+                fi
+                ;;
+            failed)
+                check "device-qa-report.json" "FAIL" "$DQ_FAILED platform(s) failed — fix before tagging"
+                ;;
+            *)
+                check "device-qa-report.json" "FAIL" "unreadable status ($DQ_STATUS)"
+                ;;
+        esac
+    fi
 else
     check "device-qa-report.json" "FAIL" "missing — run: bash .claude/scripts/device-qa.sh --platform=all"
 fi

--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -31,6 +31,38 @@ name: Device QA
 # `device-qa-report.json` is uploaded as an artifact for the release
 # checkpoint (`release-checklist.sh` reads its `status`).
 #
+# PREBUILT ANDROID APK — BUILD/EMULATOR SPLIT (#1652)
+# ---------------------------------------------------
+# The `android` and `ar` emulator jobs do NOT build the demo APK themselves.
+# A cold `:samples:android-demo:assembleDebug` on a 2-core runner is slow
+# (~20-30 min) AND competes with the running emulator for CPU — a major cause
+# of the Android leg's slowness and instability (#1642 silent hang, #1643
+# emulator offline). Instead, a dedicated `build-android-apk` job (no emulator,
+# Gradle build-cache) compiles the APK once and uploads it as an artifact; the
+# emulator jobs `download-artifact` it into the path `qa-android-demos.sh`
+# expects (`samples/android-demo/build/outputs/apk/debug/`). That script
+# already skips its own build when the APK is present (`if [[ ! -f "$APK" ]]`),
+# so the emulator jobs become install + Maestro only — faster, and the build
+# no longer fights the emulator for cores.
+#
+# RELEASE-GATE POLICY FOR continue-on-error LEGS (#1651)
+# ------------------------------------------------------
+# The `android` and `ar` jobs are `continue-on-error: true` — a red leg does
+# NOT fail this workflow (the SwiftShader emulator is chronically flaky, #1643,
+# and this is not a required PR check). The `web` job is NOT continue-on-error:
+# it is cheap and reliable, so a red web leg DOES fail the workflow.
+#
+# This split has a release-gate consequence. `release-checklist.sh` section 14
+# reads the aggregated `device-qa-report.json`. The policy is:
+#   - web        — BLOCKING. A failed web leg hard-blocks the release.
+#   - android/ar — ADVISORY. A failed android/ar leg surfaces as a WARN in the
+#                  release checklist ("android leg: WARN — did not pass"), so a
+#                  human sees it before tagging, but it does NOT hard-block.
+# Advisory legs stay non-blocking until #1643/#1645 make the emulator reliably
+# green; at that point promote them to blocking. `device-qa.sh` tags each leg's
+# record with `advisory: true|false` so the gate's behaviour is intentional,
+# not accidental — see `device-qa.sh` and `release-checklist.sh` section 14.
+#
 # FOUR-LEG SPLIT — PER-PUSH vs NIGHTLY-ONLY (#1601)
 # -------------------------------------------------
 # `device-qa.sh` orchestrates FOUR platform legs: web / android / ios / ar.
@@ -113,29 +145,70 @@ jobs:
             device-qa-artifacts/
           if-no-files-found: ignore
 
+  # ── Build leg — compile the android-demo APK once, in a cached job ────────
+  # No emulator here: this is a pure Gradle build that produces the demo APK
+  # as a workflow artifact for the `android` and `ar` emulator jobs (#1652).
+  # Splitting the build out keeps the cold compile off the 2-core emulator
+  # runners, where it competed with the booted emulator for CPU. The
+  # setup-gradle composite action wires the Gradle build cache, so a warm run
+  # is fast. NOT continue-on-error: if the APK fails to compile there is
+  # nothing for the emulator jobs to install — the failure must be visible.
+  build-android-apk:
+    name: Device QA — build android-demo APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Build android-demo debug APK
+        run: ./gradlew :samples:android-demo:assembleDebug --console=plain
+
+      - name: Upload android-demo APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-demo-debug-apk
+          # qa-android-demos.sh expects the APK at this exact path and skips
+          # its own build when it is present — the emulator jobs restore the
+          # artifact into this directory before invoking device-qa.sh.
+          path: samples/android-demo/build/outputs/apk/debug/android-demo-debug.apk
+          if-no-files-found: error
+
   # ── Android leg — Maestro on the KVM-accelerated emulator ─────────────────
   # The orchestrator's own emulator boot (setup-ar-emulator.sh) targets a
   # local AVD; on GitHub-hosted runners the ReactiveCircus action provides the
   # emulator, so device-qa.sh detects the already-booted device and skips its
   # own boot. Non-blocking: SwiftShader emulator + Maestro timing is flaky and
   # this workflow is not a required PR check.
+  #
+  # This job does NOT build the APK — it downloads the artifact produced by
+  # `build-android-apk` into the path qa-android-demos.sh expects, so the
+  # emulator job is install + Maestro only (#1652). The release-gate treats a
+  # red leg here as ADVISORY (WARN, not a hard block) — see the header block.
   android:
     name: Device QA — android (Maestro)
     runs-on: ubuntu-latest
-    # 60 min: a cold `:samples:android-demo:assembleDebug` on a 2-core runner
-    # plus emulator boot plus the Maestro flow needs headroom. The per-step
-    # `timeout` guards inside qa-android-demos.sh / maestro.sh still abort a
-    # genuine hang fast (build 30 min, Maestro 15 min) — see #1560.
-    timeout-minutes: 60
+    needs: build-android-apk
+    # 35 min: with the APK prebuilt the heavy work is emulator boot + the
+    # Maestro flow. The per-step `timeout` inside maestro.sh still aborts a
+    # genuine hang fast (Maestro 15 min) — see #1560.
+    timeout-minutes: 35
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/setup-gradle
-
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+
+      - name: Download prebuilt android-demo APK
+        uses: actions/download-artifact@v7
+        with:
+          name: android-demo-debug-apk
+          # qa-android-demos.sh / device-qa.sh look for the APK here and skip
+          # the cold Gradle build when it exists (#1652).
+          path: samples/android-demo/build/outputs/apk/debug
 
       - name: Enable KVM
         run: |
@@ -207,12 +280,21 @@ jobs:
   ar:
     name: Device QA — ar (ARCore replay)
     runs-on: ubuntu-latest
+    needs: build-android-apk
     timeout-minutes: 45
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-gradle
+
+      - name: Download prebuilt android-demo APK
+        uses: actions/download-artifact@v7
+        with:
+          name: android-demo-debug-apk
+          # The AR replay leg reuses the same demo APK — restore it into the
+          # path qa-android-demos.sh expects so device-qa.sh skips the build.
+          path: samples/android-demo/build/outputs/apk/debug
 
       - name: Enable KVM
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,16 +76,38 @@ known limitations (no pinch gesture → 3D zoom is driven via deep-link param).
 ### Release-checkpoint mandate
 
 **A full device-QA pass runs at every release checkpoint, before tagging.**
-No release ships without a green `device-qa-report.json`. The gate is enforced
-in two places — keep both honest:
+No release ships with a red *blocking* leg in `device-qa-report.json`. The
+gate is enforced in two places — keep both honest:
 
-- `release-checklist.sh` **section 14** fails the checklist if
-  `device-qa-report.json` is missing or reports a failed platform.
+- `release-checklist.sh` **section 14** reads the report's graded
+  `releaseGate.verdict` and fails the checklist on a `blocked` verdict (or a
+  missing report).
 - The `/release` skill (**Step 6.5**) runs `device-qa.sh --platform=all`
   before the tag step.
 
-A red device-QA pass means a demo crashes for a real user — fix it before
-tagging, no exceptions.
+#### Release-gate policy for `continue-on-error` legs (#1651)
+
+The legs are **graded**, because they are not equally reliable:
+
+| Leg | CI behaviour | Release gate |
+|---|---|---|
+| `web` | NOT `continue-on-error` — a red leg fails the workflow | **BLOCKING** — a red web leg is a release `FAIL` |
+| `android`, `ar` | `continue-on-error: true` (flaky SwiftShader emulator, #1643) | **ADVISORY** — a red leg is a `WARN`, never a silent pass, never a hard block |
+
+`device-qa.sh` tags each leg `advisory: true|false` (default advisory set:
+`android,ar`, override with `--advisory=<csv>`) and pre-computes
+`releaseGate.verdict` in `device-qa-report.json`:
+
+- `clear` — every leg passed → checklist `PASS`.
+- `warn` — an advisory leg (android/ar) did not pass → checklist `WARN`
+  ("advisory leg(s) did not pass: … — review before tagging"). A human sees
+  it, but it does not block the release.
+- `blocked` — a blocking leg (web) failed → checklist `FAIL`, hard block.
+
+Advisory legs stay non-blocking until #1643/#1645 make the emulator reliably
+green; then promote them to blocking by shrinking the `--advisory=` set. A red
+*blocking* leg means a demo crashes for a real user — fix it before tagging,
+no exceptions.
 
 ## About
 

--- a/changelog.d/1652-deviceqa-ci.md
+++ b/changelog.d/1652-deviceqa-ci.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- Device-QA CI: prebuild the android-demo APK in a separate cached `build-android-apk` job and install the artifact in the emulator legs (no cold build on the 2-core emulator runner); the release gate now grades `continue-on-error` legs — a red advisory leg (android/ar) surfaces as a WARN instead of being silent or hard-blocking (#1652, #1651).


### PR DESCRIPTION
Closes #1652, closes #1651.

## #1652 — Prebuild the android-demo APK in a separate cached job

The `android` (and `ar`) device-QA emulator jobs previously ran a cold
`:samples:android-demo:assembleDebug` *inside* the emulator job — ~20-30 min
on a 2-core runner, competing with the booted emulator for CPU (a major cause
of #1642 silent hang / #1643 emulator offline).

- New `build-android-apk` job: pure Gradle build (no emulator), `setup-gradle`
  composite for build-cache, uploads `android-demo-debug.apk` as an artifact.
  Not `continue-on-error` — a non-compiling APK must be visible.
- `android` and `ar` jobs `needs: build-android-apk` and `download-artifact`
  the APK into `samples/android-demo/build/outputs/apk/debug/` — the exact
  path `qa-android-demos.sh` checks (`if [[ ! -f "$APK" ]]`), so the cold
  build is skipped automatically. No change needed to `qa-android-demos.sh`.
- `android` job drops `setup-gradle` (no longer builds) and its timeout
  tightens 60 -> 35 min. `ar` keeps `setup-gradle` — it still runs the
  `ARReplayHarnessTest` instrumented test via `./gradlew`.

## #1651 — Explicit release-gate behaviour for `continue-on-error` legs

The `android`/`ar` legs are `continue-on-error: true` (flaky SwiftShader
emulator, #1643); `web` is reliable and blocking. The release gate now grades
legs instead of an all-or-nothing read of `status`:

- `device-qa.sh` gains `--advisory=<csv>` (default `android,ar`). Each leg
  record is tagged `advisory: true|false`, and the report (schemaVersion 2)
  carries a pre-computed `releaseGate.verdict`: `clear` | `warn` | `blocked`.
- `release-checklist.sh` section 14 reads `releaseGate.verdict`:
  `clear`->PASS, `warn`->WARN (advisory leg red — "review before tagging",
  non-blocking, never silent), `blocked`->FAIL (a blocking/web leg is red).
  Legacy schemaVersion-1 reports fall back to the old `status` reading.
- Policy documented in a header comment in `device-qa.yml` and in CLAUDE.md's
  "Device QA -> Release-checkpoint mandate" section (graded-legs table).

## Verification
- `python3 yaml.safe_load` on `device-qa.yml` — OK.
- `bash -n` on `device-qa.sh` and `release-checklist.sh` — OK.
- `releaseGate` verdict logic unit-tested: android-failed->warn, web-failed->blocked.
- Section 14 read tested against warn (schemaVersion 2) and legacy (schemaVersion 1) reports.

Changelog fragment: `changelog.d/1652-deviceqa-ci.md` (category: Tests).

Generated with Claude Code