### PR TITLE
test(device-qa): make AR replay harness honest about replayedFrames=0 (#1645)

### DIFF
--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -11,6 +11,12 @@
 #      session, and asserts no crash. The one demo that consumes
 #      `playbackDataset` (`ar-record-playback`) additionally proves the
 #      recorded dataset advanced frames.
+#
+#      Honesty gate (#1645): ARCore dataset playback needs camera-stream
+#      support the x86 software-GPU CI emulator does not provide. When
+#      `ar-record-playback` advances 0 frames the harness reports it as
+#      `skipped` (with a reason) — NOT a misleading `pass` — and this script
+#      exits 3 so the device-QA orchestrator records the AR leg as `skipped`.
 #   3. Pulls the machine-readable verdict `ar-qa-summary.json` the test wrote
 #      to `/sdcard/Download/SceneView/` and echoes its path.
 #
@@ -34,9 +40,13 @@
 #   -h | --help    Show this help.
 #
 # Exit status:
-#   0  every AR demo survived recorded-session replay
+#   0  every AR demo survived recorded-session replay AND the recorded ARCore
+#      dataset genuinely replayed frames (verdict `replayed`)
 #   1  one or more demos crashed, or the harness could not run
 #   2  no device / emulator connected
+#   3  SKIPPED — no demo crashed, but `ar-record-playback` advanced 0 frames:
+#      ARCore dataset playback is unsupported on this emulator. An environment
+#      limitation reported honestly — the AR leg is NOT a pass (#1645).
 
 set -euo pipefail
 
@@ -59,7 +69,7 @@ while [[ $# -gt 0 ]]; do
     --no-install) INSTALL=0; shift ;;
     --out) OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
     -h|--help)
-      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,49p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[ar-replay-qa] unknown option: $1" >&2; exit 1 ;;
@@ -107,7 +117,9 @@ fi
 mkdir -p "$OUT_DIR"
 LOCAL_SUMMARY="$OUT_DIR/ar-qa-summary.json"
 
+SUMMARY_PULLED=0
 if adb -s "$SERIAL" pull "$DEVICE_SUMMARY" "$LOCAL_SUMMARY" >/dev/null 2>&1; then
+  SUMMARY_PULLED=1
   echo "[ar-replay-qa] verdict summary:"
   cat "$LOCAL_SUMMARY"
   echo
@@ -118,8 +130,49 @@ else
   echo "[ar-replay-qa] or Google Play Services for AR missing). See test output." >&2
 fi
 
+# ── Verdict ────────────────────────────────────────────────────────────────
+# A non-zero instrumentation status means a demo crashed (the harness asserts
+# no crash) -> hard FAIL. Note the harness also ends the test with assumeTrue
+# when the replay demo advanced 0 frames; an assumeTrue-skip is NOT an
+# instrumentation failure, so HARNESS_STATUS stays 0 in that case and we fall
+# through to the summary-based skip detection below.
 if [[ "$HARNESS_STATUS" -ne 0 ]]; then
   echo "[ar-replay-qa] FAIL — one or more AR demos crashed during replay." >&2
   exit 1
 fi
-echo "[ar-replay-qa] PASS — every AR demo survived recorded-session replay."
+
+# Honesty gate (#1645): inspect the machine-readable summary. If the replay
+# demo (`ar-record-playback`) advanced 0 frames it is graded `skipped` — the
+# CI emulator cannot do ARCore dataset playback. Surface that as exit 3 so the
+# AR leg is recorded `skipped`, never a misleading `pass`. The `passed` count
+# in the summary already excludes `skipped` demos (see writeSummary()).
+SKIPPED_COUNT=0
+if [[ "$SUMMARY_PULLED" -eq 1 ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    SKIPPED_COUNT="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    print(0); sys.exit(0)
+print(int(data.get("skipped", 0)))
+' "$LOCAL_SUMMARY" 2>/dev/null || echo 0)"
+  else
+    # Fallback for hosts without python3: the summary's top-level "skipped"
+    # key is the count we need. The first `"skipped":` line is the header
+    # field (per-demo objects carry `"verdict": "skipped"`, not `"skipped":`).
+    SKIPPED_COUNT="$(grep -m1 -oE '"skipped"[[:space:]]*:[[:space:]]*[0-9]+' "$LOCAL_SUMMARY" 2>/dev/null \
+      | grep -oE '[0-9]+$' || echo 0)"
+  fi
+fi
+if [[ "$SKIPPED_COUNT" =~ ^[0-9]+$ ]] && [[ "$SKIPPED_COUNT" -gt 0 ]]; then
+  echo "[ar-replay-qa] SKIPPED — no AR demo crashed, but $SKIPPED_COUNT demo(s)" >&2
+  echo "[ar-replay-qa] (incl. ar-record-playback) replayed 0 frames: ARCore dataset" >&2
+  echo "[ar-replay-qa] playback is not supported on this emulator. The recorded" >&2
+  echo "[ar-replay-qa] session was NOT exercised — this is not a pass (#1645)." >&2
+  exit 3
+fi
+
+echo "[ar-replay-qa] PASS — every AR demo survived recorded-session replay" \
+  "and the recorded ARCore dataset replayed frames."

--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -330,6 +330,10 @@ run_ar() {
   case $rc in
     0) record ar passed "ar-replay-qa.sh" "$kept" "$(( $(date +%s) - started ))" ;;
     2) record ar skipped "no device for ar-replay-qa.sh" "$kept" "$(( $(date +%s) - started ))" ;;
+    # rc=3 (#1645): no demo crashed, but `ar-record-playback` replayed 0 frames
+    # — ARCore dataset playback is unsupported on this emulator. The recorded
+    # session was not exercised, so the AR leg is `skipped`, never a pass.
+    3) record ar skipped "ARCore dataset playback unsupported on emulator (ar-record-playback replayed 0 frames)" "$kept" "$(( $(date +%s) - started ))" ;;
     *) record ar failed "ar-replay-qa.sh rc=$rc" "$kept" "$(( $(date +%s) - started ))" ;;
   esac
 }

--- a/changelog.d/1645-ar-replay-honesty.md
+++ b/changelog.d/1645-ar-replay-honesty.md
@@ -1,0 +1,9 @@
+<!-- category: Tests -->
+- AR replay device-QA harness (`ARReplayHarnessTest` + `ar-replay-qa.sh`) no
+  longer reports a misleading `pass` when the recorded ARCore session was never
+  actually replayed. ARCore dataset playback needs camera-stream support the
+  x86 software-GPU CI emulator does not provide, so `ar-record-playback`
+  advancing `replayedFrames: 0` is now graded `skipped` (with the reason
+  surfaced) rather than green `alive`. `ar-qa-summary.json` gains `skipped` /
+  `failed` counts and a per-demo `reason`; `ar-replay-qa.sh` exits `3` and the
+  device-QA AR leg records `skipped` — skips never count as passes (#1645).

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
@@ -49,6 +49,26 @@ import java.io.FileOutputStream
  * (see [writeSummary]) so the slice-5 orchestrator can pull one file instead
  * of scraping instrumentation stdout.
  *
+ * ## Honest reporting of `replayedFrames == 0` ([#1645](https://github.com/sceneview/sceneview/issues/1645))
+ *
+ * ARCore dataset playback (`Session.setPlaybackDataset`) needs camera-stream
+ * capabilities the x86 software-GPU CI emulator does not provide — on that
+ * host the recorded session never advances a frame. That is an *environment*
+ * limitation, not a product regression, so the replay demo must NOT be graded
+ * a green `alive` (which the device-QA orchestrator counts as a pass): a pass
+ * would falsely claim "the recorded ARCore session replayed".
+ *
+ * The harness therefore distinguishes:
+ *
+ * - `ar-record-playback` with `replayedFrames == 0` -> [VERDICT_SKIPPED] with
+ *   a `reason` ("ARCore dataset playback not supported on this emulator").
+ *   `ar-replay-qa.sh` reads the summary's `skipped` count, surfaces it as a
+ *   dedicated exit code, and the device-QA AR leg records `skipped`, never
+ *   `passed`.
+ * - any live-only demo with `replayedFrames == 0` -> [VERDICT_ALIVE]: those
+ *   demos build a live `ARSceneView` and never consume `playbackDataset`, so
+ *   surviving the launch IS their contract — that stays a pass.
+ *
  * ## Relationship to the sibling AR tests
  *
  * - [ARDemoPlaybackSmokeTest] — sweeps `androidTest/assets/ar-recordings/`
@@ -149,6 +169,25 @@ class ARReplayHarnessTest {
                 "Full machine-readable verdict: $summaryPath",
             crashed.isEmpty(),
         )
+
+        // Honesty gate (#1645): `ar-record-playback` is the one demo that MUST
+        // actually replay the recorded ARCore dataset. If it advanced 0 frames
+        // the harness is `skipped`, not `passed` — ARCore dataset playback is
+        // unsupported on this (CI software-GPU) emulator. `assumeTrue` makes
+        // JUnit/instrumentation report the test as skipped rather than green;
+        // `ar-replay-qa.sh` reads the summary's `skipped` count to surface the
+        // same verdict to the device-QA orchestrator.
+        val replayDemo = results.firstOrNull { it.demoId == REPLAY_DEMO_ID }
+        if (replayDemo != null) {
+            assumeTrue(
+                "AR replay harness SKIPPED: `$REPLAY_DEMO_ID` replayed " +
+                    "${replayDemo.replayedFrames} ARCore frame(s) (need " +
+                    "$MIN_REPLAYED_FRAMES) — $REASON_PLAYBACK_UNSUPPORTED. " +
+                    "This is an environment limitation, not a product bug; the " +
+                    "AR leg cannot be graded a pass. Full verdict: $summaryPath",
+                replayDemo.verdict != VERDICT_SKIPPED,
+            )
+        }
     }
 
     // ── Per-demo replay ─────────────────────────────────────────────────────
@@ -158,9 +197,14 @@ class ARReplayHarnessTest {
      *
      * - [VERDICT_REPLAYED] — the demo consumed recorded ARCore frames (the
      *   frame counter advanced past [MIN_REPLAYED_FRAMES]).
-     * - [VERDICT_ALIVE] — the demo's process stayed alive for the replay
-     *   window but did not advance the frame counter (a live-only AR demo
-     *   that does not yet honour `playbackDataset`).
+     * - [VERDICT_ALIVE] — a live-only AR demo (one that does NOT consume
+     *   `playbackDataset`) whose process stayed alive for the replay window.
+     *   Surviving a recorded-session launch IS the contract for these, so
+     *   this is a pass.
+     * - [VERDICT_SKIPPED] — the replay demo ([REPLAY_DEMO_ID]) survived but
+     *   advanced 0 frames: ARCore dataset playback is unsupported on this
+     *   emulator (#1645). An environment limitation, reported honestly with a
+     *   `reason` — never a misleading green.
      * - [VERDICT_CRASHED] — the demo's process died during replay.
      */
     private fun replayDemo(demoId: String, recording: File): DemoResult {
@@ -175,13 +219,19 @@ class ARReplayHarnessTest {
 
         val frames = DemoSettings.arPlaybackFrameCount
         val alive = isDemoProcessAlive()
+        // Only `ar-record-playback` mounts `ARSceneView(playbackDataset = …)`,
+        // so it is the only demo for which a 0-frame run is a problem rather
+        // than expected live-only behaviour.
+        val isReplayDemo = demoId == REPLAY_DEMO_ID
 
         val verdict = when {
             !alive -> VERDICT_CRASHED
             frames >= MIN_REPLAYED_FRAMES -> VERDICT_REPLAYED
+            isReplayDemo -> VERDICT_SKIPPED
             else -> VERDICT_ALIVE
         }
-        return DemoResult(demoId, verdict, frames)
+        val reason = if (verdict == VERDICT_SKIPPED) REASON_PLAYBACK_UNSUPPORTED else null
+        return DemoResult(demoId, verdict, frames, reason)
     }
 
     /**
@@ -203,27 +253,37 @@ class ARReplayHarnessTest {
      * `adb pull` it.
      *
      * The shape mirrors the device-QA harness convention (umbrella #1560): a
-     * top-level `harness` / `passed` / `total` header plus a `demos` array of
-     * `{ id, verdict, replayedFrames }`. Slice #1564's `web-qa-summary.json`
-     * is expected to follow the same `{ harness, passed, total, <items> }`
-     * skeleton so the slice-5 orchestrator can merge platform reports without
-     * special-casing each.
+     * top-level `harness` / `passed` / `skipped` / `failed` / `total` header
+     * plus a `demos` array of `{ id, verdict, replayedFrames, reason? }`.
+     * Slice #1564's `web-qa-summary.json` follows the same
+     * `{ harness, passed, total, <items> }` skeleton so the slice-5
+     * orchestrator can merge platform reports without special-casing each.
+     *
+     * `passed` counts only genuine passes — `replayed` and live-only `alive`.
+     * A `skipped` demo (#1645: replay demo that advanced 0 frames because the
+     * emulator cannot do ARCore dataset playback) is reported in its own
+     * `skipped` count and is NOT folded into `passed`, so a green AR leg
+     * genuinely means the recorded session replayed.
      */
     private fun writeSummary(results: List<DemoResult>): File {
         val demos = JSONArray()
         for (r in results) {
-            demos.put(
-                JSONObject()
-                    .put("id", r.demoId)
-                    .put("verdict", r.verdict)
-                    .put("replayedFrames", r.replayedFrames),
-            )
+            val obj = JSONObject()
+                .put("id", r.demoId)
+                .put("verdict", r.verdict)
+                .put("replayedFrames", r.replayedFrames)
+            if (r.reason != null) obj.put("reason", r.reason)
+            demos.put(obj)
         }
-        val passed = results.count { it.verdict != VERDICT_CRASHED }
+        val passed = results.count { it.verdict == VERDICT_REPLAYED || it.verdict == VERDICT_ALIVE }
+        val skipped = results.count { it.verdict == VERDICT_SKIPPED }
+        val failed = results.count { it.verdict == VERDICT_CRASHED }
         val root = JSONObject()
             .put("harness", "ar-replay")
             .put("recording", BUNDLED_RECORDING)
             .put("passed", passed)
+            .put("skipped", skipped)
+            .put("failed", failed)
             .put("total", results.size)
             .put("demos", demos)
 
@@ -237,6 +297,8 @@ class ARReplayHarnessTest {
         val demoId: String,
         val verdict: String,
         val replayedFrames: Int,
+        /** Human-readable reason — set only for [VERDICT_SKIPPED]. */
+        val reason: String? = null,
     )
 
     // ── Fixture plumbing ────────────────────────────────────────────────────
@@ -305,6 +367,24 @@ class ARReplayHarnessTest {
 
         const val VERDICT_REPLAYED = "replayed"
         const val VERDICT_ALIVE = "alive"
+        const val VERDICT_SKIPPED = "skipped"
         const val VERDICT_CRASHED = "crashed"
+
+        /**
+         * The one demo that mounts `ARSceneView(playbackDataset = …)` and so
+         * MUST advance the recorded ARCore frame counter. Matches the slug in
+         * `DemoRegistry.kt`. Live-only AR demos never consume the playback
+         * dataset and are graded `alive`, not `skipped`.
+         */
+        const val REPLAY_DEMO_ID = "ar-record-playback"
+
+        /**
+         * Reason surfaced for a [VERDICT_SKIPPED] replay demo: ARCore dataset
+         * playback (`Session.setPlaybackDataset`) needs camera-stream support
+         * the x86 software-GPU CI emulator does not provide.
+         */
+        const val REASON_PLAYBACK_UNSUPPORTED =
+            "ARCore dataset playback not supported on this emulator " +
+                "(software-GPU CI emulator has no replayable camera stream)"
     }
 }


### PR DESCRIPTION
Closes #1645.

## Root cause

The AR replay device-QA harness (`ARReplayHarnessTest` + `.claude/scripts/ar-replay-qa.sh`) reported **PASS 14/14** even though `ar-qa-summary.json` showed every demo — including `ar-record-playback`, the one demo built to genuinely replay the bundled ARCore recording — with `"verdict": "alive", "replayedFrames": 0`.

ARCore dataset playback (`Session.setPlaybackDataset`) needs camera-stream capabilities the x86 software-GPU CI emulator does not provide, so the recorded session never advances a frame. The harness had only three verdicts — `replayed` / `alive` / `crashed` — and its `passed` count folded `alive` into passes. For a live-only demo `alive` IS the contract, but for `ar-record-playback` a 0-frame `alive` is a misleading green: it claims "the recorded ARCore session replayed" when it did not.

## New pass / skipped / fail model

- **`ARReplayHarnessTest`** — adds a `skipped` verdict. `ar-record-playback` advancing 0 frames is now graded `skipped` with a `reason` ("ARCore dataset playback not supported on this emulator"), not `alive`. Other live-only demos with 0 frames stay `alive` (still a pass — surviving the launch is their contract). `ar-qa-summary.json` gains top-level `skipped` / `failed` counts and a per-demo `reason`; `passed` now counts only `replayed` + `alive`, never `skipped`. The test ends with `assumeTrue` when the replay demo is skipped, so instrumentation reports it as skipped rather than green.
- **`ar-replay-qa.sh`** — reads the summary's `skipped` count (python3, with a python-free `grep` fallback) and exits **3** when it is > 0. A crash still hard-fails (exit 1) first. New exit code documented in the header.
- **`device-qa.sh`** — AR leg maps `rc=3` to `record ar skipped` with the reason surfaced. Skips never count as passes in the overall conclusion.

An honest `skipped` is the right call here: the emulator genuinely cannot do dataset playback — an environment limitation, not a product bug.

## Validation

- `bash -n` clean on both scripts; `shellcheck` clean (only pre-existing SC1091 on the unrelated `source` line).
- `./gradlew :samples:android-demo:compileDebugAndroidTestKotlin` compiles.
- grep fallback verified to extract the header `skipped` count, not per-demo `verdict: skipped`.

Relates to #1576, #1592; child of #1560.