### PR TITLE
ci(device-qa): RAM-budgeted adaptive emulator pool (#1654)

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -58,11 +58,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
-# RAM-aware single-emulator selection helpers (#1647). The android and ar legs
-# share ONE emulator: whichever leg runs first boots it (RAM-gated, lock-guarded
-# inside setup-ar-emulator.sh) and the next leg reuses it.
+# RAM-budgeted adaptive emulator pool helpers (#1647 → #1654). The android and
+# ar legs lease an emulator from the pool: whichever leg runs first leases a
+# free running one (or boots a new pool member, RAM-gated, inside
+# setup-ar-emulator.sh) and the next leg leases its own — as many emulators as
+# live host RAM safely allows, floor 1.
 # shellcheck source=lib/emulator-select.sh
 source "$SCRIPT_DIR/lib/emulator-select.sh"
+
+# Release every emulator lease this orchestrator owns when it exits.
+trap 'emu_lease_release_all' EXIT
 
 # --- Flags -----------------------------------------------------------------
 PLATFORM="all"
@@ -155,10 +160,53 @@ record() {
   log "$1 -> $2 ${3:+($3)}"
 }
 
+# --- Pool emulator acquisition ---------------------------------------------
+# acquire_pool_emulator — lease an emulator from the RAM-budgeted adaptive pool
+# (#1654) for the android / ar legs. Strategy:
+#   1. Lease a free already-running emulator if one exists.
+#   2. Else delegate to setup-ar-emulator.sh, which leases or boots a new pool
+#      member (RAM-gated, multi-port) and publishes its serial; re-lease it
+#      here so the lease outlives that subprocess.
+# Echoes the leased serial on stdout; returns 1 if no emulator could be obtained.
+acquire_pool_emulator() {
+  emu_pool_reclaim_stale adb
+  local serial
+  # Step 1: lease a free running emulator outright.
+  if serial="$(emu_lease_free_serial adb)" && emu_lease_acquire "$serial"; then
+    echo "$serial"
+    return 0
+  fi
+  # Step 2: setup-ar-emulator.sh leases or boots a pool member, RAM-gated. It
+  # prints `EMU_SERIAL=<serial>` as its last stdout line — capture that to learn
+  # exactly which pool emulator it obtained (no race on a shared file). Its log
+  # lines are surfaced to our stderr so the run stays visible.
+  local setup_out setup_rc=0
+  setup_out="$(bash "$SCRIPT_DIR/setup-ar-emulator.sh" 2>&1)" || setup_rc=$?
+  printf '%s\n' "$setup_out" | grep -v '^EMU_SERIAL=' >&2 || true
+  if [[ "$setup_rc" -ne 0 ]]; then
+    return 1
+  fi
+  serial="$(printf '%s\n' "$setup_out" | sed -n 's/^EMU_SERIAL=//p' | tail -n1)"
+  # Fallbacks: the published-serial file, then the first running emulator.
+  if [[ -z "${serial:-}" ]] && [[ -f "$EMU_LEASE_DIR/last-booted.serial" ]]; then
+    serial="$(cat "$EMU_LEASE_DIR/last-booted.serial" 2>/dev/null || true)"
+  fi
+  if [[ -z "${serial:-}" ]] || ! emu_serial_alive "$serial" adb; then
+    serial="$(emu_running_serial adb || true)"
+  fi
+  [[ -n "${serial:-}" ]] || return 1
+  # Re-lease under this orchestrator's pid (setup-ar-emulator.sh dropped its own
+  # lease in its EXIT trap). Best-effort: even if a peer grabbed the lease, the
+  # emulator is up and we still target it via ANDROID_SERIAL.
+  emu_lease_acquire "$serial" || true
+  echo "$serial"
+  return 0
+}
+
 # --- Android leg -----------------------------------------------------------
 run_android() {
   local started; started=$(date +%s)
-  local reused_serial=""
+  local serial=""
   log "=== Android leg ==="
 
   if ! command -v adb >/dev/null 2>&1; then
@@ -166,21 +214,19 @@ run_android() {
     return 0
   fi
 
-  # Single shared emulator (#1647). If one is already up (this session, a peer
-  # session, or the previous leg), REUSE it — never boot a second. Otherwise
-  # setup-ar-emulator.sh boots one: it is RAM-gated and lock-guarded, so a
-  # RAM-starved host or a racing peer is handled cleanly inside that script.
-  if reused_serial="$(emu_running_serial adb)"; then
-    log "reusing already-running emulator: $reused_serial (no boot)"
-  else
-    log "no Android device — booting emulator via setup-ar-emulator.sh (RAM-aware, lock-guarded)"
-    if ! bash "$SCRIPT_DIR/setup-ar-emulator.sh" >/dev/null 2>&1; then
-      record android skipped "could not boot an Android emulator (RAM too tight or lock contention)" "" "$(( $(date +%s) - started ))"
-      return 0
-    fi
+  # Lease an emulator from the RAM-budgeted adaptive pool (#1654): a free
+  # running one, or a freshly-booted pool member if live RAM has room, or wait
+  # for a lease to free. All RAM-gating happens inside the pool helpers.
+  if ! serial="$(acquire_pool_emulator)"; then
+    record android skipped "could not lease/boot a pool emulator (RAM too tight or pool full)" "" "$(( $(date +%s) - started ))"
+    return 0
   fi
-  if ! adb get-state >/dev/null 2>&1; then
-    record android skipped "no Android device after emulator boot" "" "$(( $(date +%s) - started ))"
+  log "Android leg using pool emulator: $serial"
+  # Pin every downstream adb / android-CLI / Maestro call to the leased serial.
+  export ANDROID_SERIAL="$serial"
+
+  if ! adb -s "$serial" get-state >/dev/null 2>&1; then
+    record android skipped "leased emulator $serial not responding" "" "$(( $(date +%s) - started ))"
     return 0
   fi
 
@@ -192,7 +238,8 @@ run_android() {
   # leg silent in CI until the wrapper returned, so a slow APK build (or a
   # genuine hang) showed 40+ min of nothing before the job timed out and was
   # cancelled. `pipefail` (set above) makes `|| rc=$?` capture the wrapper's
-  # exit code, not tee's.
+  # exit code, not tee's. ANDROID_SERIAL (exported above) targets the leased
+  # emulator throughout the wrapper.
   bash "$SCRIPT_DIR/qa-android-demos.sh" --install --flow "$flow" 2>&1 \
     | tee "$ARTIFACTS/android-output.txt" || rc=$?
 
@@ -292,7 +339,7 @@ run_web() {
 # --- AR leg ----------------------------------------------------------------
 run_ar() {
   local started; started=$(date +%s)
-  local reused_serial=""
+  local serial=""
   log "=== AR leg ==="
 
   if ! command -v adb >/dev/null 2>&1; then
@@ -301,20 +348,23 @@ run_ar() {
   fi
 
   # The AR replay harness needs an ARCore-capable emulator. The android leg
-  # usually ran first and left one warm — REUSE it (#1647), never boot a second.
-  # If none is up, setup-ar-emulator.sh boots one (RAM-gated, lock-guarded) and
-  # sideloads Google Play Services for AR.
-  if reused_serial="$(emu_running_serial adb)"; then
-    log "reusing already-running emulator: $reused_serial (no boot)"
-  elif ! adb get-state >/dev/null 2>&1; then
-    log "no Android device — booting ARCore emulator via setup-ar-emulator.sh (RAM-aware, lock-guarded)"
-    if ! bash "$SCRIPT_DIR/setup-ar-emulator.sh" >/dev/null 2>&1; then
-      record ar skipped "could not boot an ARCore emulator (RAM too tight or lock contention)" "" "$(( $(date +%s) - started ))"
-      return 0
-    fi
+  # usually ran first in this same process and still holds a pool lease — reuse
+  # that emulator directly (no extra lease, no boot). Otherwise lease one from
+  # the RAM-budgeted pool (#1654): a free running emulator, or a fresh pool
+  # member if RAM has room. setup-ar-emulator.sh also sideloads ARCore.
+  if [[ -n "${ANDROID_SERIAL:-}" ]] && emu_serial_alive "$ANDROID_SERIAL" adb; then
+    serial="$ANDROID_SERIAL"
+    log "AR leg reusing the Android leg's pool emulator: $serial"
+  elif ! serial="$(acquire_pool_emulator)"; then
+    record ar skipped "could not lease/boot an ARCore pool emulator (RAM too tight or pool full)" "" "$(( $(date +%s) - started ))"
+    return 0
   fi
-  if ! adb get-state >/dev/null 2>&1; then
-    record ar skipped "no Android device after emulator boot" "" "$(( $(date +%s) - started ))"
+  log "AR leg using pool emulator: $serial"
+  # Pin every downstream adb / android-CLI call to the leased serial.
+  export ANDROID_SERIAL="$serial"
+
+  if ! adb -s "$serial" get-state >/dev/null 2>&1; then
+    record ar skipped "leased emulator $serial not responding" "" "$(( $(date +%s) - started ))"
     return 0
   fi
 

--- a/.claude/scripts/lib/emulator-select.sh
+++ b/.claude/scripts/lib/emulator-select.sh
@@ -1,51 +1,87 @@
 #!/usr/bin/env bash
-# emulator-select.sh — RAM-aware single-emulator selection for the device-QA harness.
+# emulator-select.sh — RAM-budgeted adaptive emulator pool for the device-QA harness.
 #
-# Why this exists (#1647):
+# Why this exists (#1647 → #1654):
 #   The autonomous device-QA harness boots an Android emulator for its android
-#   leg. When several Claude Code sessions / parallel agents run device-QA on the
-#   same RAM-constrained Mac, each tries to boot its own emulator → resource
-#   contention, boot failures, cross-session conflicts.
+#   and ar legs. When several Claude Code sessions / parallel agents run
+#   device-QA on the same Mac, each naïvely tries to boot its own emulator →
+#   RAM exhaustion, boot failures, cross-session conflicts.
 #
-#   ⛔ This is NOT a multi-emulator pool. The harness keeps ONE shared emulator
-#   and selects/reuses it intelligently:
-#     1. RAM monitoring  — refuse to boot a fresh emulator when host RAM is tight.
-#     2. Reuse           — if a suitable emulator is already up, reuse it.
-#     3. Right-size      — scale the `-memory` flag to current RAM headroom.
-#     4. Advisory lock   — two concurrent sessions cooperate on ONE emulator.
+#   #1647 first solved this with a STRICT single shared emulator + one global
+#   advisory lock. That removed the contention but also serialised every
+#   parallel session behind a rigid one-emulator barrier — wasteful on a host
+#   that has RAM to spare.
+#
+#   #1654 evolves it into a RAM-BUDGETED ADAPTIVE POOL — never a rigid barrier,
+#   never more emulators than live host RAM safely allows, floor of 1:
+#     1. RAM budget → cap  — max_emulators is derived from live free RAM, so a
+#                            tight host resolves to 1 naturally (just physics).
+#     2. Lease-based pool  — per-emulator lease files; a session leases a free
+#                            running emulator, boots a new one if the cap has
+#                            room, or waits (bounded) for a lease to free.
+#     3. Live RAM re-gate  — free RAM is re-read immediately before EVERY boot;
+#                            a boot below EMU_MIN_FREE_RAM_MB is refused even if
+#                            the cap said there was room. Memory safety is the
+#                            hard invariant — the pool never OOMs the host.
+#     4. Stale-lease reclaim — a lease whose owner pid is dead AND whose serial
+#                            is gone from `adb devices` is reclaimed.
+#     5. Multi-port boots  — each new emulator gets a distinct `-port` so they
+#                            coexist; the leased serial is plumbed downstream.
 #
 # Usage from another script:
 #     source "$(dirname "$0")/lib/emulator-select.sh"
-#     emu_running_serial                 # echoes serial of a booted emulator, or ""
 #     emu_host_free_ram_mb               # echoes available host RAM in MB
+#     emu_pool_cap                       # echoes the live RAM-budgeted cap [1..MAX]
 #     emu_ram_allows_boot                # 0 if RAM allows a fresh boot, else 1
 #     emu_recommended_memory_mb          # echoes a RAM-scaled `-memory` value
-#     emu_lock_acquire / emu_lock_release  # advisory single-emulator lock
-
+#     emu_running_serials [adb]          # newline list of booted emulator serials
+#     emu_count_running [adb]            # count of booted emulators
+#     emu_lease_acquire <serial>         # claim a lease for an already-up serial
+#     emu_lease_release <serial>         # drop a lease this process owns
+#     emu_lease_free_serial [adb]        # echo a running, unleased serial (or "")
+#     emu_pool_reclaim_stale [adb]       # GC dead leases
+#     emu_next_free_port [adb]           # echo a free emulator console port
+#     emu_pool_status [adb]              # human-readable pool snapshot to stderr
+#
 # This lib is sourced, not executed — do NOT `set -e` here (it would leak into
 # the caller). Helpers report via return codes / stdout.
 
 # --- Tunables ---------------------------------------------------------------
 # Minimum host RAM (MB) that must be FREE before we will boot a fresh emulator.
-# Below this, booting into a RAM-starved host is what causes the boot failures
-# (#1647) — so we refuse and tell the caller to reuse / free RAM instead.
-# Overridable via env for unusual hosts.
+# This is the HARD memory-safety gate: re-checked live immediately before every
+# boot, even when the pool cap says there is room. Below this we refuse to boot.
 EMU_MIN_FREE_RAM_MB="${EMU_MIN_FREE_RAM_MB:-3072}"
 
 # Emulator `-memory` floor / ceiling. The AVD config.ini pins hw.ramSize=4096,
 # but on a tight host we pass a smaller `-memory` at boot time to avoid OOM.
-# Floor: below this the emulator is too slow / unstable to QA with.
-# Ceiling: never give the guest more than this even on a roomy host.
 EMU_MEMORY_FLOOR_MB="${EMU_MEMORY_FLOOR_MB:-2048}"
 EMU_MEMORY_CEILING_MB="${EMU_MEMORY_CEILING_MB:-4096}"
-# Headroom (MB) the host keeps for itself — guest memory is capped so that
-# host_free - guest_memory stays above this.
+
+# Headroom (MB) the host always keeps for itself — subtracted from free RAM
+# both when sizing guest `-memory` and when computing the pool cap.
 EMU_HOST_HEADROOM_MB="${EMU_HOST_HEADROOM_MB:-2048}"
 
-# Advisory lock — a directory (mkdir is atomic) shared by all sessions on this
-# host. The first session to mkdir it owns the boot; others detect the running
-# emulator and reuse it.
-EMU_LOCK_DIR="${EMU_LOCK_DIR:-${TMPDIR:-/tmp}/sceneview-device-qa-emulator.lock}"
+# RAM budget charged to EACH emulator when computing the pool cap. The live
+# free-RAM minus headroom is divided by this to get how many emulators fit.
+# ~3 GB matches a right-sized guest plus its qemu/host overhead.
+EMU_RAM_BUDGET_PER_EMU_MB="${EMU_RAM_BUDGET_PER_EMU_MB:-3072}"
+
+# Hard ceiling on the pool size regardless of how much RAM the host has — keeps
+# a 128 GB workstation from spawning a dozen emulators and saturating CPU/GPU.
+EMU_POOL_MAX="${EMU_POOL_MAX:-3}"
+
+# Per-emulator lease directory. Each lease is a file `<serial>.lease` whose
+# contents is the owning pid. mkdir of the parent + a `noclobber`-style atomic
+# create give us a race-free pool registry shared by all sessions on the host.
+EMU_LEASE_DIR="${EMU_LEASE_DIR:-${TMPDIR:-/tmp}/sceneview-device-qa-emu}"
+
+# Bounded wait (seconds) for a lease to free when the pool is full.
+EMU_LEASE_WAIT_TIMEOUT="${EMU_LEASE_WAIT_TIMEOUT:-300}"
+
+# First emulator console port. Android emulator console ports are even and
+# start at 5554; the adb serial is `emulator-<port>`. New pool members step by
+# 2 (5554, 5556, 5558, …) so multiple emulators coexist.
+EMU_BASE_PORT="${EMU_BASE_PORT:-5554}"
 
 _emu_log() { echo "[emu-select] $*" >&2; }
 
@@ -89,8 +125,28 @@ emu_host_free_ram_mb() {
   esac
 }
 
-# emu_ram_allows_boot — return 0 if there is enough free RAM to safely boot a
-# fresh emulator, 1 otherwise. Logs a clear message either way.
+# emu_pool_cap — echo the live RAM-budgeted cap on the number of emulators.
+#   max_emulators = floor((free_RAM - EMU_HOST_HEADROOM_MB) / EMU_RAM_BUDGET_PER_EMU_MB)
+#   clamped to [1, EMU_POOL_MAX].
+# On a RAM-tight host this resolves to 1 naturally — no rigid barrier, just
+# physics. If RAM cannot be measured we conservatively return 1.
+emu_pool_cap() {
+  local free cap
+  free="$(emu_host_free_ram_mb)"
+  if [[ "$free" -le 0 ]]; then
+    echo 1
+    return 0
+  fi
+  cap=$(( (free - EMU_HOST_HEADROOM_MB) / EMU_RAM_BUDGET_PER_EMU_MB ))
+  [[ "$cap" -lt 1 ]] && cap=1
+  [[ "$cap" -gt "$EMU_POOL_MAX" ]] && cap="$EMU_POOL_MAX"
+  echo "$cap"
+}
+
+# emu_ram_allows_boot — HARD memory-safety gate. Return 0 if there is enough
+# free RAM RIGHT NOW to safely boot one more emulator, 1 otherwise. Callers MUST
+# invoke this immediately before every boot — the pool cap is an estimate, this
+# is the live truth and it is the invariant that keeps the host off the OOM cliff.
 emu_ram_allows_boot() {
   local free; free="$(emu_host_free_ram_mb)"
   if [[ "$free" -le 0 ]]; then
@@ -100,7 +156,7 @@ emu_ram_allows_boot() {
   fi
   if [[ "$free" -lt "$EMU_MIN_FREE_RAM_MB" ]]; then
     _emu_log "host free RAM ${free} MB is below the ${EMU_MIN_FREE_RAM_MB} MB boot threshold"
-    _emu_log "refusing to boot a fresh emulator — reuse a running one or free RAM first"
+    _emu_log "refusing to boot another emulator — lease a running one or free RAM first"
     return 1
   fi
   _emu_log "host free RAM ${free} MB — OK to boot (threshold ${EMU_MIN_FREE_RAM_MB} MB)"
@@ -124,15 +180,20 @@ emu_recommended_memory_mb() {
   echo "$mem"
 }
 
-# --- Reuse detection --------------------------------------------------------
-# emu_running_serial [adb_bin] — echo the serial of an already-booted emulator
-# (state "device"), or nothing. Empty stdout + return 1 means none is up.
-# We deliberately keep ONE emulator: the FIRST booted emulator-* device wins.
-emu_running_serial() {
+# --- Running-emulator detection ---------------------------------------------
+# emu_running_serials [adb_bin] — newline-separated list of every emulator-*
+# device currently in "device" state. Empty output means none is up.
+emu_running_serials() {
   local adb_bin="${1:-adb}"
+  "$adb_bin" devices 2>/dev/null \
+    | awk '/^emulator-[0-9]+/ && $2=="device" { print $1 }'
+}
+
+# emu_running_serial [adb_bin] — back-compat single-serial accessor: echoes the
+# FIRST booted emulator serial (or nothing, return 1).
+emu_running_serial() {
   local serial
-  serial="$("$adb_bin" devices 2>/dev/null \
-    | awk '/^emulator-[0-9]+/ && $2=="device" { print $1; exit }')"
+  serial="$(emu_running_serials "${1:-adb}" | head -n1)"
   if [[ -n "$serial" ]]; then
     echo "$serial"
     return 0
@@ -142,59 +203,168 @@ emu_running_serial() {
 
 # emu_count_running [adb_bin] — number of emulator-* devices in "device" state.
 emu_count_running() {
+  emu_running_serials "${1:-adb}" | grep -c . || true
+}
+
+# emu_serial_alive <serial> [adb_bin] — 0 if <serial> is a booted device.
+emu_serial_alive() {
+  local serial="$1" adb_bin="${2:-adb}"
+  emu_running_serials "$adb_bin" | grep -qxF "$serial"
+}
+
+# --- Lease-based pool -------------------------------------------------------
+# Each pool member is tracked by a lease file `${EMU_LEASE_DIR}/<serial>.lease`
+# containing the owning pid. Creating a lease atomically (via `set -o noclobber`
+# in a subshell) lets N racing sessions cooperate without a global lock — each
+# emulator can be leased by exactly one session at a time.
+
+# _emu_lease_dir_init — ensure the lease directory exists.
+_emu_lease_dir_init() {
+  mkdir -p "$EMU_LEASE_DIR" 2>/dev/null || true
+}
+
+# _emu_lease_path <serial> — echo the lease file path for a serial.
+_emu_lease_path() { echo "$EMU_LEASE_DIR/${1}.lease"; }
+
+# emu_lease_owner <serial> — echo the pid recorded in a serial's lease, or "".
+emu_lease_owner() {
+  local lf; lf="$(_emu_lease_path "$1")"
+  [[ -f "$lf" ]] && cat "$lf" 2>/dev/null || true
+}
+
+# emu_pool_reclaim_stale [adb_bin] — GC stale leases. A lease is stale when its
+# owner pid is dead AND its emulator serial is no longer a booted device. Such a
+# lease can never be released by its (gone) owner, so we reclaim it here.
+emu_pool_reclaim_stale() {
   local adb_bin="${1:-adb}"
-  "$adb_bin" devices 2>/dev/null \
-    | awk '/^emulator-[0-9]+/ && $2=="device" { n++ } END { print n+0 }'
-}
-
-# --- Advisory single-emulator lock -----------------------------------------
-# mkdir-based lock: mkdir is atomic on every POSIX filesystem, so exactly one
-# of N racing sessions creates the directory and "owns" the emulator boot.
-# A `pid` file inside records the owner so a stale lock (owner crashed, no
-# emulator alive) can be reclaimed instead of deadlocking.
-
-# _emu_lock_is_stale — 0 if the lock dir exists but is stale (no live owner
-# process AND no emulator running), 1 otherwise.
-_emu_lock_is_stale() {
-  [[ -d "$EMU_LOCK_DIR" ]] || return 1
-  local owner=""
-  [[ -f "$EMU_LOCK_DIR/pid" ]] && owner="$(cat "$EMU_LOCK_DIR/pid" 2>/dev/null)"
-  # Owner process still alive → not stale.
-  if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
-    return 1
-  fi
-  # Owner gone, but if an emulator is actually running the lock still reflects
-  # reality (someone reused it) — keep it. Only stale when nothing is alive.
-  if emu_running_serial >/dev/null 2>&1; then
-    return 1
-  fi
-  return 0
-}
-
-# emu_lock_acquire [timeout_sec] — acquire the advisory lock.
-#   return 0 → this caller now OWNS the lock (it should boot/select).
-#   return 0 is also returned to a caller that finds an emulator already up
-#            while waiting — see emu_select_or_boot, which checks reuse first.
-#   return 1 → timed out waiting for the lock.
-emu_lock_acquire() {
-  local timeout="${1:-300}"
-  local waited=0
-  while true; do
-    if mkdir "$EMU_LOCK_DIR" 2>/dev/null; then
-      echo "$$" > "$EMU_LOCK_DIR/pid"
-      _emu_log "acquired emulator lock ($EMU_LOCK_DIR)"
-      return 0
-    fi
-    # Lock held — reclaim it if stale.
-    if _emu_lock_is_stale; then
-      _emu_log "reclaiming stale emulator lock (owner gone, no emulator alive)"
-      rm -rf "$EMU_LOCK_DIR" 2>/dev/null || true
+  _emu_lease_dir_init
+  local lf serial owner
+  for lf in "$EMU_LEASE_DIR"/*.lease; do
+    [[ -e "$lf" ]] || continue
+    serial="$(basename "$lf" .lease)"
+    owner="$(cat "$lf" 2>/dev/null || true)"
+    # Owner process still alive → lease is live, keep it.
+    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
       continue
     fi
-    # A peer holds the lock and is booting/using the emulator — a caller that
-    # only wants to reuse should poll emu_running_serial; here we just wait.
+    # Owner gone but the emulator is still up → another session may be about to
+    # lease it; leave the (now ownerless) lease for emu_lease_acquire to take.
+    if emu_serial_alive "$serial" "$adb_bin"; then
+      continue
+    fi
+    # Owner dead AND emulator gone → genuinely stale, reclaim.
+    _emu_log "reclaiming stale lease for $serial (owner ${owner:-?} dead, emulator gone)"
+    rm -f "$lf" 2>/dev/null || true
+  done
+}
+
+# emu_lease_acquire <serial> — atomically claim the lease for an already-running
+# emulator <serial>. Returns 0 if THIS process now owns the lease, 1 if another
+# live owner holds it. An ownerless lease (owner pid dead) is taken over.
+emu_lease_acquire() {
+  local serial="$1"
+  [[ -n "$serial" ]] || { _emu_log "emu_lease_acquire: serial required"; return 1; }
+  _emu_lease_dir_init
+  local lf; lf="$(_emu_lease_path "$serial")"
+
+  # Atomic create — `noclobber` makes `>` fail if the file already exists, so
+  # exactly one of N racing sessions wins the lease.
+  if ( set -o noclobber; echo "$$" > "$lf" ) 2>/dev/null; then
+    _emu_log "leased emulator $serial (pid $$)"
+    return 0
+  fi
+
+  # Lease file exists — is its owner still alive?
+  local owner; owner="$(cat "$lf" 2>/dev/null || true)"
+  if [[ "$owner" == "$$" ]]; then
+    return 0   # already ours
+  fi
+  if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
+    return 1   # held by a live peer
+  fi
+  # Ownerless lease — take it over (best-effort; another reclaimer may race us).
+  echo "$$" > "$lf" 2>/dev/null || true
+  if [[ "$(cat "$lf" 2>/dev/null || true)" == "$$" ]]; then
+    _emu_log "took over ownerless lease for $serial (pid $$)"
+    return 0
+  fi
+  return 1
+}
+
+# emu_lease_release <serial> — release a lease IF this process owns it.
+emu_lease_release() {
+  local serial="$1"
+  [[ -n "$serial" ]] || return 0
+  local lf; lf="$(_emu_lease_path "$serial")"
+  [[ -f "$lf" ]] || return 0
+  if [[ "$(cat "$lf" 2>/dev/null || true)" == "$$" ]]; then
+    rm -f "$lf" 2>/dev/null || true
+    _emu_log "released lease for $serial"
+  fi
+}
+
+# emu_lease_release_all — release every lease this process owns. Safe in an
+# EXIT trap — a no-op for serials owned by other sessions.
+emu_lease_release_all() {
+  _emu_lease_dir_init
+  local lf
+  for lf in "$EMU_LEASE_DIR"/*.lease; do
+    [[ -e "$lf" ]] || continue
+    if [[ "$(cat "$lf" 2>/dev/null || true)" == "$$" ]]; then
+      local serial; serial="$(basename "$lf" .lease)"
+      rm -f "$lf" 2>/dev/null || true
+      _emu_log "released lease for $serial"
+    fi
+  done
+}
+
+# emu_lease_free_serial [adb_bin] — echo the serial of a RUNNING emulator that
+# currently has no live lease holder (so this caller could lease it). Empty
+# output means every running emulator is already leased (or none is running).
+emu_lease_free_serial() {
+  local adb_bin="${1:-adb}"
+  _emu_lease_dir_init
+  local serial owner
+  while IFS= read -r serial; do
+    [[ -n "$serial" ]] || continue
+    owner="$(emu_lease_owner "$serial")"
+    if [[ -z "$owner" ]] || ! kill -0 "$owner" 2>/dev/null; then
+      echo "$serial"
+      return 0
+    fi
+  done < <(emu_running_serials "$adb_bin")
+  return 1
+}
+
+# emu_next_free_port [adb_bin] — echo the lowest even console port not already
+# used by a running emulator. New pool members boot on this `-port` so they get
+# a distinct `emulator-<port>` serial and coexist with their peers.
+emu_next_free_port() {
+  local adb_bin="${1:-adb}"
+  local used port
+  used="$(emu_running_serials "$adb_bin" | sed 's/^emulator-//')"
+  port="$EMU_BASE_PORT"
+  while echo "$used" | grep -qx "$port"; do
+    port=$(( port + 2 ))
+  done
+  echo "$port"
+}
+
+# emu_lease_wait_for_free [adb_bin] [timeout_sec] — block (bounded) until a
+# running emulator's lease frees, then echo that serial. Used when the pool is
+# at its RAM cap and the caller cannot boot another. Returns 1 on timeout.
+emu_lease_wait_for_free() {
+  local adb_bin="${1:-adb}"
+  local timeout="${2:-$EMU_LEASE_WAIT_TIMEOUT}"
+  local waited=0 serial
+  while true; do
+    emu_pool_reclaim_stale "$adb_bin"
+    if serial="$(emu_lease_free_serial "$adb_bin")"; then
+      echo "$serial"
+      return 0
+    fi
     if [[ "$waited" -ge "$timeout" ]]; then
-      _emu_log "timed out after ${timeout}s waiting for the emulator lock"
+      _emu_log "timed out after ${timeout}s waiting for a pool lease to free"
       return 1
     fi
     sleep 3
@@ -202,13 +372,26 @@ emu_lock_acquire() {
   done
 }
 
-# emu_lock_release — release the lock IF this process owns it.
-emu_lock_release() {
-  [[ -d "$EMU_LOCK_DIR" ]] || return 0
-  local owner=""
-  [[ -f "$EMU_LOCK_DIR/pid" ]] && owner="$(cat "$EMU_LOCK_DIR/pid" 2>/dev/null)"
-  if [[ "$owner" == "$$" ]]; then
-    rm -rf "$EMU_LOCK_DIR" 2>/dev/null || true
-    _emu_log "released emulator lock"
-  fi
+# emu_pool_status [adb_bin] — print a human-readable pool snapshot to stderr:
+# running emulator count, the live RAM-budgeted cap, free RAM, and active leases.
+emu_pool_status() {
+  local adb_bin="${1:-adb}"
+  _emu_lease_dir_init
+  local free total cap running
+  free="$(emu_host_free_ram_mb)"
+  total="$(emu_host_total_ram_mb)"
+  cap="$(emu_pool_cap)"
+  running="$(emu_count_running "$adb_bin")"
+  _emu_log "pool: running=${running} cap=${cap} (RAM ${free}/${total} MB free, headroom ${EMU_HOST_HEADROOM_MB} MB, budget ${EMU_RAM_BUDGET_PER_EMU_MB} MB/emu, max ${EMU_POOL_MAX})"
+  local lf serial owner alive
+  local any=0
+  for lf in "$EMU_LEASE_DIR"/*.lease; do
+    [[ -e "$lf" ]] || continue
+    any=1
+    serial="$(basename "$lf" .lease)"
+    owner="$(cat "$lf" 2>/dev/null || true)"
+    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then alive="live"; else alive="ownerless"; fi
+    _emu_log "  lease ${serial} -> pid ${owner:-?} (${alive})"
+  done
+  [[ "$any" -eq 0 ]] && _emu_log "  no active leases"
 }

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -21,6 +21,11 @@
 #                    e.g. `--flow lighting` → .maestro/android/lighting.yaml.
 #                    Defaults to `catalog` (all 42 demos).
 #   -h | --help      Show this help.
+#
+# Pool-aware (#1654): with the RAM-budgeted adaptive emulator pool, several
+# emulators may be running. Set ANDROID_SERIAL to pin the QA run to a specific
+# leased emulator — device-qa.sh does this for its android leg. When unset, the
+# first running emulator is used and ANDROID_SERIAL is exported to pin it.
 
 set -euo pipefail
 
@@ -36,8 +41,8 @@ cd "$REPO_ROOT"
 source "$SCRIPT_DIR/lib/maestro.sh"
 # shellcheck source=lib/android-cli.sh
 source "$SCRIPT_DIR/lib/android-cli.sh"
-# RAM-aware single-emulator selection helpers (#1647) — used to detect and
-# report a reusable running emulator rather than implying a second boot.
+# RAM-budgeted adaptive emulator pool helpers (#1647 → #1654) — used to detect a
+# leasable running emulator and to target the leased serial via ANDROID_SERIAL.
 # shellcheck source=lib/emulator-select.sh
 source "$SCRIPT_DIR/lib/emulator-select.sh"
 
@@ -68,13 +73,27 @@ if [[ ! -f "$FLOW_FILE" ]]; then
 fi
 
 # --- Emulator check --------------------------------------------------------
-# Single shared emulator (#1647): if one is already running we reuse it; this
-# script never boots its own. Booting (RAM-gated, parallel-session-safe via an
-# advisory lock) is delegated to setup-ar-emulator.sh.
-if reuse_serial="$(emu_running_serial adb)"; then
-  echo "[qa] reusing already-running emulator: $reuse_serial"
+# Adaptive emulator pool (#1647 → #1654). This script never boots its own
+# emulator — leasing/booting a pool member (RAM-gated, multi-port) is delegated
+# to setup-ar-emulator.sh / the device-qa.sh orchestrator.
+#   - If ANDROID_SERIAL is set (device-qa.sh leased a pool emulator for us),
+#     target THAT serial — every adb / android-CLI / Maestro call below honours
+#     ANDROID_SERIAL, so the QA run stays pinned to the leased emulator even
+#     when several emulators are up in the pool.
+#   - Otherwise pick a single running emulator (standalone invocation).
+if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+  if ! emu_serial_alive "$ANDROID_SERIAL" adb; then
+    echo "[qa] ERROR: ANDROID_SERIAL=$ANDROID_SERIAL is not a running emulator." >&2
+    exit 1
+  fi
+  echo "[qa] targeting leased pool emulator: $ANDROID_SERIAL"
+elif reuse_serial="$(emu_running_serial adb)"; then
+  echo "[qa] using running emulator: $reuse_serial"
+  # Pin downstream adb / android-CLI / Maestro to this serial so a peer pool
+  # emulator booting mid-run can never steal the QA target.
+  export ANDROID_SERIAL="$reuse_serial"
 elif ! adb get-state >/dev/null 2>&1; then
-  echo "[qa] ERROR: no Android device. Boot one first (RAM-aware, lock-guarded):" >&2
+  echo "[qa] ERROR: no Android device. Boot one first (RAM-budgeted pool):" >&2
   echo "[qa]   bash .claude/scripts/setup-ar-emulator.sh" >&2
   exit 1
 fi

--- a/.claude/scripts/setup-ar-emulator.sh
+++ b/.claude/scripts/setup-ar-emulator.sh
@@ -11,34 +11,40 @@
 #   2. Patches its config.ini for ARCore: 4 GB RAM, virtualscene back camera,
 #      emulated front camera (front cam is needed for Augmented Faces demos),
 #      host GPU mode.
-#   3. Boots the emulator headless — RAM-aware and parallel-session-safe (#1647):
-#      reuses an already-running emulator, checks free host RAM before a fresh
-#      boot, scales the `-memory` flag to RAM headroom, and cooperates with
-#      concurrent sessions via an advisory lock so only ONE emulator ever runs.
+#   3. Boots the emulator headless — RAM-budgeted adaptive pool (#1647 → #1654):
+#      leases a free already-running emulator, or — if the live RAM-budgeted
+#      pool cap has room and free RAM clears the hard safety gate — boots a new
+#      one on a distinct `-port`, or waits (bounded) for a lease to free. Guest
+#      `-memory` is scaled to RAM headroom. The pool never exceeds what live
+#      host RAM safely allows; the floor is always 1.
 #   4. Waits for `sys.boot_completed`.
 #   5. Verifies Google Play Services for AR (com.google.ar.core) is installed;
 #      if not, opens the Play Store to the listing (one-time manual click).
 #
 # Flags:
 #   --check   Read-only inspection: prints current AVD config + ARCore state +
-#             host RAM / running-emulator status. No mutation.
+#             pool state (running emulator count, RAM-budgeted cap, free RAM,
+#             active leases). No mutation.
 #   --clean   Wipe the AVD's userdata and recreate config from scratch.
 #   --no-boot Skip the emulator boot (useful in CI where boot is deferred).
 #   -h|--help Show this help.
 #
-# Idempotent: re-running with no flag will skip work that's already done. Re-uses an
-# already-booted emulator on the standard adb port. Stops nothing — caller closes the
+# Idempotent: re-running with no flag will skip work that's already done. Leases a
+# free already-running emulator when one exists. Stops nothing — caller closes the
 # emulator (or it stays warm for follow-up scripts).
 #
-# Single-emulator guarantee (#1647): this script never boots a second emulator
-# when one is already up, and two concurrent sessions cooperate via the advisory
-# lock in lib/emulator-select.sh — the first boots, the rest reuse.
+# Adaptive pool (#1647 → #1654): this script does NOT enforce a single emulator.
+# It leases a free running emulator if one exists; otherwise, only when the live
+# RAM-budgeted pool cap has room AND free RAM clears the hard safety gate, it
+# boots a new emulator on a distinct `-port`; otherwise it waits for a lease to
+# free. The pool never exceeds what host RAM safely allows; the floor is 1.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# RAM-aware single-emulator selection helpers (#1647): RAM monitoring, running-
-# emulator reuse detection, RAM-scaled `-memory`, advisory parallel-session lock.
+# RAM-budgeted adaptive emulator pool (#1647 → #1654): RAM monitoring, pool-cap
+# computation, per-emulator lease registry, RAM-scaled `-memory`, multi-port
+# boot, stale-lease reclaim.
 # shellcheck source=lib/emulator-select.sh
 source "$SCRIPT_DIR/lib/emulator-select.sh"
 
@@ -168,22 +174,25 @@ show_config() {
   grep -E "^(PlayStore|hw\.camera|hw\.gpu|hw\.ramSize|vm\.heapSize|hw\.gps|image\.sysdir)" "$AVD_CONFIG" | sed 's/^/  /'
 }
 
-# Report host RAM + running-emulator state (#1647). Used by --check and before
-# every boot decision.
+# Report pool state (#1654). Used by --check and before every boot decision:
+# running emulator count, the live RAM-budgeted cap, free RAM, active leases.
 show_ram_and_emulator_status() {
-  local total free running
-  total="$(emu_host_total_ram_mb)"
-  free="$(emu_host_free_ram_mb)"
-  log "host RAM: ${free} MB free / ${total} MB total (boot threshold ${EMU_MIN_FREE_RAM_MB} MB)"
-  if running="$(emu_running_serial "$ADB_BIN")"; then
-    log "running emulator detected: $running — would REUSE it (no second boot)"
+  emu_pool_reclaim_stale "$ADB_BIN"
+  emu_pool_status "$ADB_BIN"
+  local running cap
+  running="$(emu_count_running "$ADB_BIN")"
+  cap="$(emu_pool_cap)"
+  local free_serial
+  if free_serial="$(emu_lease_free_serial "$ADB_BIN")"; then
+    log "an unleased running emulator is available ($free_serial) — would LEASE it (no boot)"
+  elif [[ "$running" -ge "$cap" ]]; then
+    log "pool is at its RAM-budgeted cap (running ${running} >= cap ${cap}) — would WAIT for a lease to free"
+  elif emu_ram_allows_boot >/dev/null 2>&1; then
+    log "pool has room (running ${running} < cap ${cap}) and free RAM clears the boot gate"
+    log "would boot a new emulator on -port $(emu_next_free_port "$ADB_BIN") with -memory $(emu_recommended_memory_mb) MB"
   else
-    log "no emulator currently running"
-    if emu_ram_allows_boot >/dev/null 2>&1; then
-      log "RAM OK for a fresh boot — would launch with -memory $(emu_recommended_memory_mb) MB"
-    else
-      log "RAM too tight — a fresh boot would be REFUSED"
-    fi
+    log "pool has a free slot (running ${running} < cap ${cap}) but live free RAM is below the ${EMU_MIN_FREE_RAM_MB} MB gate"
+    log "memory safety wins — would WAIT for a running emulator's lease to free instead of booting"
   fi
 }
 
@@ -195,63 +204,37 @@ else
   show_config
 fi
 
-# --- step 5: boot the emulator ------------------------------------------------
-# RAM-aware, single-emulator, parallel-session-safe (#1647). The decision flow:
-#   1. Already an emulator running?  -> REUSE it, no boot, no lock needed.
-#   2. Otherwise acquire the advisory lock so two sessions cooperate.
-#   3. Re-check inside the lock (a peer may have booted while we waited) -> REUSE.
-#   4. Gate on free host RAM; refuse a fresh boot on a RAM-starved host.
-#   5. Boot with a `-memory` value scaled to current RAM headroom.
+# --- step 5: lease or boot a pool emulator ------------------------------------
+# RAM-budgeted adaptive pool (#1647 → #1654). The decision flow:
+#   1. An unleased running emulator?  -> LEASE it, no boot.
+#   2. Pool cap has room AND free RAM clears the hard gate?  -> boot a new
+#      emulator on a distinct `-port` and lease it.
+#   3. Otherwise the pool is at its RAM-budgeted cap  -> WAIT (bounded) for a
+#      lease to free, then lease that emulator.
+# The leased serial is exported as EMU_SERIAL for the rest of the script and
+# any downstream QA caller.
 
-emulator_is_running() {
-  emu_running_serial "$ADB_BIN" >/dev/null 2>&1
-}
+# EMU_SERIAL holds the serial this run is responsible for. Lease bookkeeping is
+# keyed by pid inside emulator-select.sh, so there is no separate state to track.
+EMU_SERIAL=""
 
-# Release the advisory lock on exit no matter how the script ends. emu_lock_release
-# is a no-op unless THIS process owns the lock, so it is safe even when we reused.
-trap 'emu_lock_release' EXIT
+# Release every lease this process owns on exit, no matter how the script ends.
+# emu_lease_release_all is a no-op for serials owned by other sessions.
+trap 'emu_lease_release_all' EXIT
 
-boot_emulator() {
-  # Step 1: reuse a running emulator outright — never boot a second one.
-  if emulator_is_running; then
-    log "emulator already running ($(emu_running_serial "$ADB_BIN")) — re-using, no boot"
-    return 0
-  fi
-
-  # Step 2: cooperate with concurrent sessions. The first to acquire the lock
-  # boots; peers wait, then find the running emulator in step 3 and reuse it.
-  if ! emu_lock_acquire "${EMU_LOCK_TIMEOUT:-300}"; then
-    # Lock wait timed out — last-chance reuse check before giving up.
-    if emulator_is_running; then
-      log "lock timed out but an emulator is up — re-using $(emu_running_serial "$ADB_BIN")"
-      return 0
-    fi
-    log "could not acquire the emulator lock and no emulator is running — aborting boot"
-    return 1
-  fi
-
-  # Step 3: re-check under the lock — a peer may have booted while we waited.
-  if emulator_is_running; then
-    log "another session booted the emulator ($(emu_running_serial "$ADB_BIN")) — re-using"
-    return 0
-  fi
-
-  # Step 4: RAM gate. Booting into a RAM-starved host is what causes the boot
-  # failures this fix targets (#1647), so refuse rather than crash mid-boot.
-  if ! emu_ram_allows_boot; then
-    log "ABORT: insufficient free host RAM to boot a fresh emulator safely"
-    log "       reuse a running emulator, close other apps, or lower EMU_MIN_FREE_RAM_MB"
-    return 1
-  fi
-
-  # Step 5: boot with a RAM-scaled `-memory`. The AVD config pins hw.ramSize,
-  # but `-memory` at launch wins and lets us right-size to the live host.
+# boot_new_emulator <port> — boot a fresh emulator on a distinct console port so
+# it coexists with pool peers. Echoes nothing; the serial is `emulator-<port>`.
+boot_new_emulator() {
+  local port="$1"
   local mem; mem="$(emu_recommended_memory_mb)"
-  log "starting emulator $AVD_NAME (headless, no snapshot, -memory ${mem} MB)"
-  # Use nohup + & so the emulator survives this script. Redirect to a log so we
-  # can debug a failed boot without spinning up an interactive console.
-  local emu_log="/tmp/sceneview-emulator-$AVD_NAME.log"
+  log "booting a new pool emulator $AVD_NAME on -port ${port} (headless, no snapshot, -memory ${mem} MB)"
+  # `-read-only` lets multiple emulators share the one AVD's disk images without
+  # clobbering each other's userdata; `-port` gives each a distinct serial.
+  # nohup + & so the emulator survives this script; per-port log for debugging.
+  local emu_log="/tmp/sceneview-emulator-${AVD_NAME}-${port}.log"
   nohup "$EMULATOR_BIN" -avd "$AVD_NAME" \
+    -port "$port" \
+    -read-only \
     -gpu host \
     -memory "$mem" \
     -no-snapshot-load \
@@ -259,21 +242,76 @@ boot_emulator() {
     -no-boot-anim \
     -netdelay none -netspeed full \
     >"$emu_log" 2>&1 &
-  log "emulator pid=$! log=$emu_log"
+  log "emulator pid=$! serial=emulator-${port} log=$emu_log"
+}
+
+select_or_boot_emulator() {
+  # Reclaim any leases left behind by crashed sessions before we decide.
+  emu_pool_reclaim_stale "$ADB_BIN"
+
+  # Step 1: lease a free already-running emulator if one exists.
+  local free_serial
+  if free_serial="$(emu_lease_free_serial "$ADB_BIN")"; then
+    if emu_lease_acquire "$free_serial"; then
+      log "leased already-running emulator $free_serial — no boot"
+      EMU_SERIAL="$free_serial"
+      return 0
+    fi
+    # Lost the lease race — fall through and re-evaluate.
+  fi
+
+  # Step 2: pool cap has room? Boot a new emulator on a distinct port.
+  local running cap
+  running="$(emu_count_running "$ADB_BIN")"
+  cap="$(emu_pool_cap)"
+  if [[ "$running" -lt "$cap" ]]; then
+    # HARD memory-safety re-gate: re-read free RAM immediately before booting.
+    # The cap is an estimate; this live check is the invariant that keeps the
+    # host off the OOM cliff. Refuse the boot if RAM is below the threshold.
+    if emu_ram_allows_boot; then
+      local port; port="$(emu_next_free_port "$ADB_BIN")"
+      local serial="emulator-${port}"
+      boot_new_emulator "$port"
+      # Lease the slot immediately so a racing peer counts us against the cap.
+      emu_lease_acquire "$serial" || true
+      EMU_SERIAL="$serial"
+      return 0
+    fi
+    log "pool cap has room (running ${running} < cap ${cap}) but live free RAM is below ${EMU_MIN_FREE_RAM_MB} MB"
+    log "memory safety wins — will WAIT for a running emulator's lease to free instead of booting"
+  else
+    log "pool is at its RAM-budgeted cap (running ${running}, cap ${cap}) — waiting for a lease to free"
+  fi
+
+  # Step 3: pool full (by cap or by the live RAM gate). Wait for a lease to free.
+  local waited_serial
+  if waited_serial="$(emu_lease_wait_for_free "$ADB_BIN" "${EMU_LEASE_WAIT_TIMEOUT:-300}")"; then
+    if emu_lease_acquire "$waited_serial"; then
+      log "leased emulator $waited_serial after waiting for the pool"
+      EMU_SERIAL="$waited_serial"
+      return 0
+    fi
+  fi
+  log "could not lease or boot a pool emulator — pool is full and no lease freed in time"
+  return 1
 }
 
 wait_for_boot() {
-  log "waiting for boot complete (up to 180s)"
-  local serial
-  # Poll for first emulator-* device showing up
-  for _ in $(seq 1 60); do
-    serial="$("$ADB_BIN" devices | awk '/^emulator-[0-9]+/ && $2=="device" {print $1; exit}')"
-    [[ -n "$serial" ]] && break
-    sleep 2
-  done
-  if [[ -z "$serial" ]]; then
-    log "no emulator-* device appeared after 120s — boot failed"
-    return 1
+  # When we leased an already-running emulator, EMU_SERIAL is already booted.
+  local serial="$EMU_SERIAL"
+  if [[ -n "$serial" ]] && emu_serial_alive "$serial" "$ADB_BIN"; then
+    log "leased emulator $serial already online"
+  else
+    log "waiting for $serial to come online (up to 180s)"
+    local i=0
+    while ! emu_serial_alive "$serial" "$ADB_BIN"; do
+      i=$((i+1))
+      if [[ $i -gt 90 ]]; then
+        log "$serial did not appear after 180s — boot failed"
+        return 1
+      fi
+      sleep 2
+    done
   fi
   log "device $serial online, waiting for sys.boot_completed"
   "$ADB_BIN" -s "$serial" wait-for-device
@@ -288,17 +326,24 @@ wait_for_boot() {
   done
   log "boot complete on $serial"
   export EMU_SERIAL="$serial"
+  # Publish the leased serial to a file as a fallback for a parent QA
+  # orchestrator. The primary channel is the `EMU_SERIAL=<serial>` stdout line
+  # emitted in step 8. This script's own lease is dropped by the EXIT trap; the
+  # parent re-acquires it for the QA run.
+  _emu_lease_dir_init
+  echo "$serial" > "$EMU_LEASE_DIR/last-booted.serial" 2>/dev/null || true
 }
 
 if ! $CHECK_ONLY && ! $NO_BOOT; then
-  # boot_emulator returns non-zero when it reused nothing AND refused a fresh
-  # boot (RAM too tight, or the lock could not be acquired). In that case there
-  # is no emulator to wait for — fail fast with a clear exit so the device-QA
-  # orchestrator records a `skipped`/`failed` leg instead of hanging.
-  if boot_emulator; then
+  # select_or_boot_emulator returns non-zero only when the pool is full AND no
+  # lease freed within the bounded wait (or RAM stayed too tight to boot). In
+  # that case there is no emulator to wait for — fail fast with a clear exit so
+  # the device-QA orchestrator records a `skipped`/`failed` leg instead of
+  # hanging. The leased serial is exported as EMU_SERIAL for downstream callers.
+  if select_or_boot_emulator; then
     wait_for_boot
   else
-    log "emulator boot was refused — see the reason above"
+    log "could not obtain a pool emulator — see the reason above"
     exit 1
   fi
 fi
@@ -341,6 +386,8 @@ else:
   }
 }
 
+# Target the leased serial (EMU_SERIAL) — never a hardcoded one. With an
+# adaptive pool several emulators may be up; we must verify ARCore on ours.
 serial="${EMU_SERIAL:-$("$ADB_BIN" devices | awk '/^emulator-[0-9]+/ && $2=="device" {print $1; exit}')}"
 if [[ -n "$serial" ]]; then
   if "$ADB_BIN" -s "$serial" shell pm list packages 2>/dev/null | grep -q "com.google.ar.core"; then
@@ -364,11 +411,18 @@ if $STOP_AFTER && ! $CHECK_ONLY && [[ -n "$serial" ]]; then
 fi
 
 # --- step 8: summary ----------------------------------------------------------
+# Emit the leased serial on stdout (machine-readable, last line) so a parent
+# orchestrator capturing this script's stdout gets the exact pool emulator it
+# obtained, without racing on the shared last-booted.serial file.
+if ! $CHECK_ONLY && [[ -n "${serial:-}" ]]; then
+  echo "EMU_SERIAL=${serial}"
+fi
 log "done."
 if $STOP_AFTER; then
   log "emulator stopped. Re-run without --stop to leave it warm for QA."
 else
-  log "emulator left running for QA. next steps:"
+  log "emulator left running for QA on serial ${serial:-emulator-5554}. next steps:"
+  log "  export ANDROID_SERIAL=${serial:-emulator-5554}   # pin QA to the leased emulator"
   log "  source .claude/scripts/lib/android-cli.sh && android_cli_ensure"
   log "  android run --apks <apk> --activity io.github.sceneview.demo/.MainActivity"
   log "  stop it with: $ADB_BIN -s ${serial:-emulator-5554} emu kill"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,18 +195,33 @@ and AR UI/state QA. AR features that need real world tracking (Cloud Anchor,
 Streetscape/VPS, face mesh against a live face) still need a physical-device
 AR Record — request one rather than driving someone's personal phone over USB.
 
-**One shared emulator — RAM-aware, parallel-session-safe (#1647).** The harness
-keeps a **single** shared emulator; it never spins up a multi-emulator pool. Before
-any fresh boot, `setup-ar-emulator.sh` (via `lib/emulator-select.sh`):
-- **reuses a running emulator** — if an `emulator-*` device is already up (this
-  session, a parallel agent, or a previous device-QA leg), it is reused, no boot;
-- **gates on host RAM** — refuses to boot when free RAM is under the threshold
-  (`EMU_MIN_FREE_RAM_MB`, default 3072 MB) instead of crashing mid-boot;
+**RAM-budgeted adaptive emulator pool (#1647 → #1654).** The harness runs an
+**adaptive pool** of emulators — as many as live host RAM safely allows, with a
+floor of 1 and never a rigid barrier. #1647's strict-single design is superseded:
+parallel sessions / agents no longer serialise behind one emulator when the host
+has RAM to spare. `setup-ar-emulator.sh` (via `lib/emulator-select.sh`):
+- **computes a RAM-budgeted cap** —
+  `max_emulators = floor((free_RAM − EMU_HOST_HEADROOM_MB) / EMU_RAM_BUDGET_PER_EMU_MB)`,
+  clamped to `[1, EMU_POOL_MAX]` (defaults: headroom 2048 MB, budget 3072 MB/emu,
+  `EMU_POOL_MAX=3`). On a RAM-tight host this resolves to 1 naturally — physics,
+  not policy;
+- **leases from a per-emulator pool** — each running emulator has a lease file
+  (`${TMPDIR:-/tmp}/sceneview-device-qa-emu/<serial>.lease`, owner pid inside). A
+  caller leases a free running emulator; else, if the running count is below the
+  live cap, boots a new one on a distinct `-port` (5554, 5556, …) so emulators
+  coexist; else waits (bounded) for a lease to free;
+- **re-gates RAM before every boot** — free RAM is re-read immediately before
+  each boot and the boot is refused below `EMU_MIN_FREE_RAM_MB` (default 3072 MB)
+  even when the cap said there was room. Memory safety is the hard invariant —
+  the pool never pushes the host into RAM exhaustion;
 - **right-sizes `-memory`** — scales the guest memory flag to RAM headroom,
   clamped to `[EMU_MEMORY_FLOOR_MB, EMU_MEMORY_CEILING_MB]` (2048–4096 MB);
-- **takes an advisory lock** (`${TMPDIR:-/tmp}/sceneview-device-qa-emulator.lock`)
-  so two concurrent sessions cooperate: the first boots, the rest reuse — never
-  two emulators at once. Stale locks (owner gone, no emulator alive) self-reclaim.
+- **reclaims stale leases** — a lease whose owner pid is dead AND whose serial is
+  gone from `adb devices` is reclaimed automatically.
+Every threshold is env-overridable. `setup-ar-emulator.sh --check` reports pool
+state (running count, computed cap, free RAM, active leases). The QA scripts
+(`device-qa.sh`, `qa-android-demos.sh`, `ar-replay-qa.sh`) pin `ANDROID_SERIAL`
+to the leased emulator so the right device is targeted when the pool has several.
 
 `--check` now also reports host free RAM and whether a running emulator would be
 reused. This is why parallel Claude Code sessions running device-QA on the same
@@ -629,8 +644,8 @@ Hooks trigger automatically on specific Claude Code actions:
 | `cross-platform-check.sh` | Compare Android vs iOS vs Web API surface, report gaps |
 | `release-checklist.sh` | Pre-release validation (versions, changelog, tests, etc.) |
 | `lib/android-cli.sh` | Shared helpers for Google's `android` CLI (screenshot, layout, install+launch) with `adb` fallback |
-| `setup-ar-emulator.sh` | Bootstrap a reusable ARCore-ready `Pixel_7a` emulator (virtualscene camera, 4 GB RAM, host GPU, ARCore APK). Idempotent — `--check` (read-only), `--clean` (wipe+recreate). RAM-aware single-emulator selection (#1647): reuses a running emulator, gates fresh boots on free host RAM, scales `-memory` to headroom, advisory-locks against parallel sessions. **Use this for routine QA — never QA on a personal device.** |
-| `lib/emulator-select.sh` | Sourced helper for `setup-ar-emulator.sh` / `device-qa.sh` — RAM monitoring (`vm_stat`/`/proc/meminfo`), running-emulator reuse detection, RAM-scaled `-memory`, and a mkdir-based advisory lock so concurrent sessions share ONE emulator (#1647). |
+| `setup-ar-emulator.sh` | Bootstrap a reusable ARCore-ready `Pixel_7a` emulator (virtualscene camera, 4 GB RAM, host GPU, ARCore APK). Idempotent — `--check` (read-only, reports pool state), `--clean` (wipe+recreate). RAM-budgeted adaptive emulator pool (#1647 → #1654): leases a free running emulator, or boots a new one on a distinct `-port` when the live RAM-budgeted cap has room and free RAM clears the hard safety gate, or waits for a lease to free. **Use this for routine QA — never QA on a personal device.** |
+| `lib/emulator-select.sh` | Sourced helper for `setup-ar-emulator.sh` / `device-qa.sh` / `qa-android-demos.sh` — RAM monitoring (`vm_stat`/`/proc/meminfo`), RAM-budgeted pool-cap computation, a per-emulator lease registry, RAM-scaled `-memory`, multi-port boot, and stale-lease reclaim. The adaptive pool runs as many emulators as live host RAM safely allows (floor 1, `EMU_POOL_MAX` ceiling), superseding #1647's strict-single design (#1654). |
 | `qa-android-demos.sh` | QA loop over every demo — uses `android layout`/`screen capture` for the UI dump and screenshots |
 | `capture-play-store-screenshots.sh` | Play Store screenshot capture — `android screen capture` (no LF/CRLF corruption) |
 | `visual-check.sh` | Before/after baseline capture — Android via `android` CLI, iOS via `xcrun simctl` |

--- a/changelog.d/1654-emulator-pool.md
+++ b/changelog.d/1654-emulator-pool.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- device-QA harness (#1654): the emulator-selection layer is now a RAM-budgeted adaptive pool — it leases a free running emulator or boots a new one on a distinct `-port` whenever live host RAM safely allows (cap `floor((free_RAM − headroom) / per-emu budget)`, clamped `[1, EMU_POOL_MAX]`), re-gates free RAM as a hard memory-safety check before every boot, reclaims stale per-emulator leases, and pins `ANDROID_SERIAL` to the leased device — superseding the strict-single emulator of #1647 while keeping the floor at 1 on RAM-tight hosts.


### PR DESCRIPTION
Closes #1654. Evolves the strict-single emulator (#1647/#1653) into a RAM-budgeted lease-based pool — as many emulators as live RAM safely allows, floor 1, never exceeding host memory.