### PR TITLE
fix(arsceneview): ARRecorder recordingRotation degrees vs ordinal (#1648)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt
@@ -8,6 +8,7 @@ import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.util.Size
+import android.view.Surface
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -172,7 +173,11 @@ public class ARRecorder {
      * @param recordingRotation  Optional [android.view.Display] rotation (`Surface.ROTATION_0` …
      *                           `Surface.ROTATION_270`) so the MP4 plays back upright when
      *                           captured in landscape. Pass the current display rotation from
-     *                           the calling context. Default `null` keeps ARCore's default of 0.
+     *                           the calling context (`display.rotation`). The value is converted
+     *                           to degrees via [surfaceRotationToDegrees] before being handed to
+     *                           [RecordingConfig.setRecordingRotation], which expects degrees
+     *                           (`0`/`90`/`180`/`270`) — not the `Surface.ROTATION_*` ordinal
+     *                           (`0`/`1`/`2`/`3`). Default `null` keeps ARCore's default of 0.
      * @param recordingResolution Optional target CPU-image resolution for the recording. ARCore
      *                           writes the **CPU image stream** into the MP4, whose default is
      *                           the lowest-resolution config the device exposes (often 640×480 on
@@ -257,7 +262,11 @@ public class ARRecorder {
             val config = RecordingConfig(session)
                 .setMp4DatasetFilePath(file.absolutePath)
                 .setAutoStopOnPause(true)
-            recordingRotation?.let { config.setRecordingRotation(it) }
+            // ARCore's RecordingConfig.setRecordingRotation(int) expects the display rotation in
+            // DEGREES (0/90/180/270). Callers pass a Surface.ROTATION_* constant (ordinals
+            // 0/1/2/3) — forwarding it verbatim records a 90° capture as 1° and leaves the
+            // dataset sideways (#1648). Convert to degrees before the ARCore call.
+            recordingRotation?.let { config.setRecordingRotation(surfaceRotationToDegrees(it)) }
             session.startRecording(config)
             _recordingFile = file
             _errorMessage = null
@@ -363,6 +372,25 @@ public class ARRecorder {
 
     public companion object {
         private const val TAG = "ARRecorder"
+
+        /**
+         * Convert an `android.view.Display` rotation — a [Surface.ROTATION_0] … [Surface.ROTATION_270]
+         * constant whose underlying ordinals are `0`/`1`/`2`/`3` — to the **degrees** value
+         * (`0`/`90`/`180`/`270`) expected by ARCore's [RecordingConfig.setRecordingRotation].
+         *
+         * Passing the `Surface.ROTATION_*` ordinal straight through records a 90° physical
+         * rotation as `1°`, so the dataset plays back sideways (#1648). Any unrecognised value
+         * falls back to `0` — the same default ARCore uses when no rotation is set.
+         *
+         * Pure function — no ARCore session interaction — so the mapping is unit-testable.
+         */
+        @JvmStatic
+        public fun surfaceRotationToDegrees(surfaceRotation: Int): Int = when (surfaceRotation) {
+            Surface.ROTATION_90 -> 90
+            Surface.ROTATION_180 -> 180
+            Surface.ROTATION_270 -> 270
+            else -> 0
+        }
 
         /**
          * Pick the [CameraConfig] from [configs] whose CPU [image size][CameraConfig.getImageSize]

--- a/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecorderTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecorderTest.kt
@@ -1,6 +1,7 @@
 package io.github.sceneview.ar.recording
 
 import android.util.Size
+import android.view.Surface
 import com.google.ar.core.CameraConfig
 import com.google.ar.core.CameraConfigFilter
 import com.google.ar.core.PlaybackStatus
@@ -437,18 +438,36 @@ class ARRecorderTest {
     }
 
     @Test
-    fun `start with recordingRotation calls setRecordingRotation with that exact value`() {
+    fun `start converts Surface ROTATION ordinal to degrees for setRecordingRotation`() {
+        // Regression for #1648: callers pass a Surface.ROTATION_* constant (ordinal 0/1/2/3);
+        // ARCore's RecordingConfig.setRecordingRotation wants degrees (0/90/180/270). The
+        // recorder must convert — forwarding ROTATION_90 (ordinal 1) verbatim recorded the
+        // dataset as 1°, i.e. sideways.
         val recorder = ARRecorder()
         val session = FakeSession()
         recorder.attach(session)
 
-        recorder.start(outFile, recordingRotation = 90)
+        recorder.start(outFile, recordingRotation = Surface.ROTATION_90)
 
         val captured = ShadowRecordingConfig.lastInstance
         assertNotNull(captured)
         assertEquals(outFile.absolutePath, captured!!.mp4Path)
         assertEquals(true, captured.autoStopOnPause)
-        assertEquals(90, captured.rotation)
+        assertEquals(
+            "ROTATION_90 (ordinal 1) must reach ARCore as 90 degrees",
+            90,
+            captured.rotation,
+        )
+    }
+
+    @Test
+    fun `surfaceRotationToDegrees maps every Surface ROTATION constant to degrees`() {
+        assertEquals(0, ARRecorder.surfaceRotationToDegrees(Surface.ROTATION_0))
+        assertEquals(90, ARRecorder.surfaceRotationToDegrees(Surface.ROTATION_90))
+        assertEquals(180, ARRecorder.surfaceRotationToDegrees(Surface.ROTATION_180))
+        assertEquals(270, ARRecorder.surfaceRotationToDegrees(Surface.ROTATION_270))
+        // Unrecognised input falls back to ARCore's own default of 0.
+        assertEquals(0, ARRecorder.surfaceRotationToDegrees(42))
     }
 
     @Test
@@ -456,7 +475,7 @@ class ARRecorderTest {
         val recorder = ARRecorder()
         val session = FakeSession()
         recorder.attach(session)
-        recorder.start(outFile, recordingRotation = 270)
+        recorder.start(outFile, recordingRotation = Surface.ROTATION_270)
         assertEquals(true, ShadowRecordingConfig.lastInstance!!.autoStopOnPause)
     }
 

--- a/changelog.d/1648-arrecorder-rotation.md
+++ b/changelog.d/1648-arrecorder-rotation.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `ARRecorder` now converts the `Surface.ROTATION_*` constant passed as `recordingRotation` into degrees (`0`/`90`/`180`/`270`) before handing it to ARCore's `RecordingConfig.setRecordingRotation`, which expects degrees — not the ordinal (`0`/`1`/`2`/`3`). Previously a 90° capture was recorded as `1°`, leaving AR datasets stored sideways. New public `ARRecorder.surfaceRotationToDegrees(Int)` exposes the mapping. (#1648)


### PR DESCRIPTION
Closes #1648.

## Root cause

`ARRecorder.startInternal()` forwarded the `recordingRotation` parameter verbatim to ARCore's `RecordingConfig.setRecordingRotation(int)`:

```kotlin
recordingRotation?.let { config.setRecordingRotation(it) }
```

Callers pass a `Surface.ROTATION_*` constant (`display.rotation`), whose underlying ordinals are `0`/`1`/`2`/`3`. But ARCore's `setRecordingRotation` expects the rotation in **degrees** — `0`/`90`/`180`/`270`. So a 90° portrait capture (`Surface.ROTATION_90`, ordinal `1`) was recorded as `1°` ≈ 0°, leaving every AR dataset stored sideways with no rotation metadata. The `ARRecorder` KDoc had always promised the `Surface.ROTATION_*` contract — the code simply didn't honour it.

## Fix

- New `@JvmStatic ARRecorder.surfaceRotationToDegrees(Int)` maps `Surface.ROTATION_0..270` → `0/90/180/270` (unknown input → `0`, ARCore's own default). Mirrors the existing `pickCameraConfig` companion-object pattern; pure function, unit-testable.
- `startInternal()` now calls `config.setRecordingRotation(surfaceRotationToDegrees(it))`.
- KDoc updated to state the conversion explicitly.

## Verification

- `./gradlew :arsceneview:compileReleaseKotlin` — BUILD SUCCESSFUL.
- `./gradlew :arsceneview:testDebugUnitTest --tests ARRecorderTest` — all pass.
- Updated the existing rotation test to pass `Surface.ROTATION_90` and assert it reaches ARCore as `90`; added a dedicated test covering every `Surface.ROTATION_*` constant plus the unknown-input fallback.

Android-only — ARCore recording has no iOS/Web equivalent, so no cross-platform parity gap.