### PR TITLE
ci(device-qa): non-cancellable concurrency group for release-gate dispatch runs (#1665)

### DIFF
--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -112,8 +112,14 @@ on:
   # the device-QA legs too — see #1324.
   workflow_call:
 
+# A Device QA run is ~50 min (emulator + Maestro). A `workflow_dispatch` run is
+# a deliberate release gate — keying its concurrency group on `github.run_id`
+# makes it unique so a later push to the same ref can never cancel it (#1665).
+# `push` (and the nightly `workflow_call`) runs share the `push` group, so a
+# stale push run is still auto-cancelled — desirable, no point burning a 50-min
+# emulator run on a superseded SHA.
 concurrency:
-  group: device-qa-${{ github.ref }}
+  group: device-qa-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'push' }}
   cancel-in-progress: true
 
 permissions:

--- a/changelog.d/1665-deviceqa-concurrency.md
+++ b/changelog.d/1665-deviceqa-concurrency.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- Device QA workflow (#1665): `workflow_dispatch` (release-gate) runs now get a unique, non-cancellable concurrency group keyed on `github.run_id`, so a subsequent push to `main` can no longer cancel an in-progress release-gate Device QA run. Push-triggered runs still share a `push` group and auto-cancel stale runs.


### PR DESCRIPTION
Closes #1665.

## Problem
`device-qa.yml` keyed its concurrency group only on `github.ref`, so every push to `main` cancelled any in-progress Device QA run on `main` — including a manually `workflow_dispatch`-ed release-gate run (~50 min). During an active merge batch the release-gate run almost never survived.

## Fix
```yaml
group: device-qa-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'push' }}
```
- `workflow_dispatch` → group includes `run_id` → unique → never superseded.
- `push` / nightly `workflow_call` → shared `push` group → stale runs still auto-cancel.

YAML-only change + inline comment. Changelog fragment added (`Tests`).