### PR TITLE
feat(sceneview): on-disk http cache + cinematic turntable camera

### DIFF
--- a/changelog.d/cinematic-camera.md
+++ b/changelog.d/cinematic-camera.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- New cinematic turntable camera: `applyCinematicOrbit(cameraNode, timeSeconds)` drives a slow, eased "hero shot" orbit around the content — long lens, gentle downward tilt and a soft vertical bob. Three feel presets are provided (`CinematicCameraProfile.HeroProduct`, `SlowCinematic`, `NeutralWeb`); `CinematicCameraProfile.Default` is the contemplative `SlowCinematic` profile. Pairs with `SceneView(autoCenterContent = true, cameraManipulator = null)` for a one-call cinematic showcase.

--- a/changelog.d/file-cache.md
+++ b/changelog.d/file-cache.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- Remote files loaded over http(s) — glTF/GLB models, KTX environments, textures — are now cached on disk by the new `FileCache`. The first load downloads and persists the bytes; every later load reuses the cached file, so there are no repeated downloads and assets stay available offline. Caching is wired transparently into `FileLoader.loadFileBuffer`, with `Context.fileCacheDir` / `Context.clearFileCache()` to inspect or reclaim it, and `FileCache.enabled` to opt out.

--- a/sceneview/src/main/java/io/github/sceneview/CinematicCamera.kt
+++ b/sceneview/src/main/java/io/github/sceneview/CinematicCamera.kt
@@ -1,0 +1,194 @@
+package io.github.sceneview
+
+import com.google.android.filament.Camera
+import io.github.sceneview.math.Position
+import io.github.sceneview.node.CameraNode
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.tan
+
+/**
+ * Camera-feel preset for the cinematic turntable — a slow, eased orbit around auto-framed content
+ * that mimics the "hero shot" of product photography and animation cinema.
+ *
+ * The maths driving a profile live in [cinematicAzimuth], [cinematicElevation],
+ * [cinematicCameraEye] and [cinematicDistance] — all pure functions, so a profile can be unit
+ * tested and previewed without a renderer. Three ready-made profiles are provided as companion
+ * constants; build a custom one by copying and tweaking.
+ *
+ * @property secondsPerRevolution Time for one full 360° orbit at cruising speed.
+ * @property elevationDegrees     Base camera elevation above the horizon. Positive looks slightly
+ *                                *down* at the subject — the "presented" product look.
+ * @property elevationBobDegrees  Amplitude of a gentle sinusoidal rise/fall added to the
+ *                                elevation; `0` keeps the orbit perfectly flat.
+ * @property bobSecondsPerCycle   Period of the elevation bob.
+ * @property fovDegrees           Vertical field of view. Narrower (a longer lens) flattens
+ *                                perspective distortion — the flattering cinematic look.
+ * @property easeInSeconds        Ramp-up time: azimuth speed accelerates linearly from rest to
+ *                                cruising speed over this window, then stays constant. `0`
+ *                                starts at full speed.
+ * @property frameMargin          Multiplier on the fitted camera distance — `1.0` frames the
+ *                                content edge-to-edge, `>1` leaves breathing room around it.
+ */
+data class CinematicCameraProfile(
+    val secondsPerRevolution: Float,
+    val elevationDegrees: Float,
+    val elevationBobDegrees: Float,
+    val bobSecondsPerCycle: Float,
+    val fovDegrees: Float,
+    val easeInSeconds: Float,
+    val frameMargin: Float
+) {
+    companion object {
+        /** Reveal-grade orbit: brisk, slight downward tilt, long-lens look. */
+        val HeroProduct = CinematicCameraProfile(
+            secondsPerRevolution = 10f,
+            elevationDegrees = 18f,
+            elevationBobDegrees = 0f,
+            bobSecondsPerCycle = 8f,
+            fovDegrees = 30f,
+            easeInSeconds = 1.2f,
+            frameMargin = 1.25f
+        )
+
+        /** Contemplative orbit: slow, very long lens, a soft vertical bob for life. */
+        val SlowCinematic = CinematicCameraProfile(
+            secondsPerRevolution = 18f,
+            elevationDegrees = 17f,
+            elevationBobDegrees = 5f,
+            bobSecondsPerCycle = 12f,
+            fovDegrees = 28f,
+            easeInSeconds = 1.5f,
+            frameMargin = 1.33f
+        )
+
+        /** Sober web-viewer spin: very slow, near eye-level, standard lens. */
+        val NeutralWeb = CinematicCameraProfile(
+            secondsPerRevolution = 24f,
+            elevationDegrees = 10f,
+            elevationBobDegrees = 0f,
+            bobSecondsPerCycle = 8f,
+            fovDegrees = 45f,
+            easeInSeconds = 0f,
+            frameMargin = 1.4f
+        )
+
+        /**
+         * The recommended default — [SlowCinematic]. A slow, contemplative orbit with a long
+         * lens and a soft vertical bob reads as the most "cinematic" of the presets, so it is
+         * what [applyCinematicOrbit] uses unless a profile is passed explicitly.
+         */
+        val Default = SlowCinematic
+    }
+}
+
+/**
+ * Azimuth angle, in radians, the orbit has reached after [timeSeconds].
+ *
+ * Speed ramps linearly from rest to the cruising rate (`2π / secondsPerRevolution`) over
+ * [CinematicCameraProfile.easeInSeconds], then stays constant — so the orbit starts gently
+ * instead of snapping into motion. The result grows without bound; callers needing a wrapped
+ * angle can take it modulo `2π`.
+ */
+fun cinematicAzimuth(timeSeconds: Float, profile: CinematicCameraProfile): Float {
+    val t = timeSeconds.coerceAtLeast(0f)
+    val cruiseSpeed = (2.0 * PI / profile.secondsPerRevolution).toFloat() // rad/s
+    val ease = profile.easeInSeconds
+    return if (ease > 0f && t < ease) {
+        // Area under a 0→cruiseSpeed ramp: ½·cruiseSpeed·t²/ease.
+        cruiseSpeed * t * t / (2f * ease)
+    } else if (ease > 0f) {
+        // Constant cruise, offset by the half-revolution "lost" during the ramp.
+        cruiseSpeed * (t - ease / 2f)
+    } else {
+        cruiseSpeed * t
+    }
+}
+
+/**
+ * Camera elevation above the horizon, in radians, at [timeSeconds] — the base
+ * [CinematicCameraProfile.elevationDegrees] plus the optional sinusoidal bob.
+ */
+fun cinematicElevation(timeSeconds: Float, profile: CinematicCameraProfile): Float {
+    val bob = if (profile.elevationBobDegrees != 0f && profile.bobSecondsPerCycle > 0f) {
+        profile.elevationBobDegrees *
+            sin(2.0 * PI * timeSeconds / profile.bobSecondsPerCycle).toFloat()
+    } else {
+        0f
+    }
+    // Clamp short of the poles: at ±90° the orbit basis degenerates (cos → 0) and the camera
+    // would tip over the subject. The built-in profiles stay well inside this; the clamp only
+    // guards a custom profile whose elevation + bob would otherwise cross a pole.
+    val degrees = (profile.elevationDegrees + bob).coerceIn(-89f, 89f)
+    return degrees * (PI / 180.0).toFloat()
+}
+
+/**
+ * World-space camera eye position at [timeSeconds] for an orbit of radius [distance] around the
+ * origin — the point auto-centred content sits at (see `SceneView(autoCenterContent = …)`).
+ *
+ * Pair with [cinematicDistance] to derive [distance] from the content size, and aim the camera at
+ * `Position(0f, 0f, 0f)` each frame.
+ */
+fun cinematicCameraEye(
+    timeSeconds: Float,
+    profile: CinematicCameraProfile,
+    distance: Float
+): Position {
+    val azimuth = cinematicAzimuth(timeSeconds, profile)
+    val elevation = cinematicElevation(timeSeconds, profile)
+    val horizontal = distance * cos(elevation)
+    return Position(
+        x = horizontal * sin(azimuth),
+        y = distance * sin(elevation),
+        z = horizontal * cos(azimuth)
+    )
+}
+
+/**
+ * Orbit radius that frames a subject of the given [contentRadius] (bounding-sphere radius, in
+ * metres) within the profile's vertical field of view, with [CinematicCameraProfile.frameMargin]
+ * breathing room.
+ *
+ * `distance = contentRadius / tan(fov / 2) · frameMargin` — the standard "fit a sphere to the
+ * frustum" relation. A model whose largest extent is `n` metres has a bounding-sphere radius of
+ * roughly `n / 2`, which is a sound estimate for [contentRadius].
+ */
+fun cinematicDistance(contentRadius: Float, profile: CinematicCameraProfile): Float {
+    val halfFovRad = (profile.fovDegrees / 2.0 * PI / 180.0)
+    return (contentRadius / tan(halfFovRad)).toFloat() * profile.frameMargin
+}
+
+/**
+ * Drives [cameraNode] for one frame of the cinematic turntable: positions the camera on the
+ * eased orbit at [timeSeconds], aims it at the origin, and applies the profile's field of view.
+ *
+ * Call this every frame from `SceneView(onFrame = …)` with `cameraManipulator = null` so the
+ * turntable owns the camera, and `autoCenterContent = true` so the content centroid sits on the
+ * origin the orbit looks at. Pass the subject's bounding-sphere radius as [contentRadius] (the
+ * default `0.5f` suits a model about 1 m across). [contentRadius] is a bounding-sphere radius, so
+ * the framing is independent of the orbit elevation; [CinematicCameraProfile.frameMargin] absorbs
+ * the slack for non-spherical subjects.
+ *
+ * **Threading:** writes Filament camera state — call it on the main thread (the `SceneView`
+ * frame loop already satisfies this).
+ *
+ * @param cameraNode    the active [CameraNode] (pass it explicitly to `SceneView`).
+ * @param timeSeconds   elapsed time since the orbit started.
+ * @param profile       the camera feel — defaults to [CinematicCameraProfile.Default].
+ * @param contentRadius bounding-sphere radius of the subject, in metres.
+ */
+fun applyCinematicOrbit(
+    cameraNode: CameraNode,
+    timeSeconds: Float,
+    profile: CinematicCameraProfile = CinematicCameraProfile.Default,
+    contentRadius: Float = 0.5f
+) {
+    val distance = cinematicDistance(contentRadius, profile)
+    cameraNode.position = cinematicCameraEye(timeSeconds, profile, distance)
+    cameraNode.lookAt(Position(0f, 0f, 0f), smooth = false)
+    // Explicit VERTICAL axis: cinematicDistance frames against the vertical FOV, so the
+    // projection must use the same axis regardless of viewport aspect.
+    cameraNode.setProjection(profile.fovDegrees.toDouble(), direction = Camera.Fov.VERTICAL)
+}

--- a/sceneview/src/main/java/io/github/sceneview/utils/File.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/File.kt
@@ -38,8 +38,8 @@ object FileLoader {
         val uri = Uri.parse(fileLocation)
         return withContext(Dispatchers.IO) {
             when (uri.scheme) {
-                "http", "https" -> {
-                    ByteBuffer.wrap(fuelManager.get(fileLocation).awaitByteArray())
+                "http", "https" -> FileCache.getOrPut(context.fileCacheDir, fileLocation) {
+                    fuelManager.get(fileLocation).awaitByteArray()
                 }
 
                 else -> {
@@ -111,6 +111,21 @@ fun InputStream.readBuffer(): ByteBuffer = toByteArray().let {
 fun Context.getResourceUri(resId: Int): String {
     return "${ContentResolver.SCHEME_ANDROID_RESOURCE}://$packageName/$resId"
 }
+
+/**
+ * Directory backing the [FileCache] for remote files downloaded over http(s).
+ *
+ * Lives under the app cache directory, so the OS may reclaim it under storage pressure.
+ */
+val Context.fileCacheDir: File
+    get() = File(cacheDir, FileCache.DIRECTORY_NAME)
+
+/**
+ * Deletes every remote file cached by [FileCache] for this app.
+ *
+ * @return the number of cached files removed.
+ */
+fun Context.clearFileCache(): Int = FileCache.clear(fileCacheDir)
 
 fun InputStream.toByteArray() = use { readBytes() }
 

--- a/sceneview/src/main/java/io/github/sceneview/utils/FileCache.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/FileCache.kt
@@ -1,0 +1,115 @@
+package io.github.sceneview.utils
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * On-disk cache for remote files (glTF/GLB models, KTX environments, textures…) fetched over
+ * http(s).
+ *
+ * The first time a URL is loaded its bytes are persisted under a cache directory and reused on
+ * every subsequent load — no repeated downloads, instant offline reuse. Entries are keyed by the
+ * full URL; since 3D asset files are immutable there is no invalidation to worry about. Call
+ * [clear] to reclaim disk space.
+ *
+ * It is wired into [FileLoader.loadFileBuffer], so every http(s) model, environment and texture
+ * load goes through it automatically. Set [enabled] to `false` to bypass it entirely.
+ *
+ * This object is intentionally [Context][android.content.Context]-free so its logic is unit
+ * testable on a plain JVM — the `cacheDir` is supplied by the caller. App code resolves it via
+ * [Context.fileCacheDir].
+ */
+object FileCache {
+
+    /** When `false`, http(s) loads always hit the network and nothing is persisted. */
+    @Volatile
+    var enabled: Boolean = true
+
+    /** Sub-directory name used under the host app cache directory. */
+    const val DIRECTORY_NAME: String = "sceneview-http-cache"
+
+    /** Per-URL locks de-duplicating concurrent downloads of the same file. */
+    private val locks = ConcurrentHashMap<String, Mutex>()
+
+    /** SHA-256 hex of [url] — a filesystem-safe, collision-free cache key. */
+    fun keyOf(url: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(url.toByteArray())
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+    /** The cache file backing [url] inside [cacheDir], whether or not it currently exists. */
+    fun fileOf(cacheDir: File, url: String): File = File(cacheDir, keyOf(url))
+
+    /**
+     * Returns the cached bytes for [url], or downloads, persists and returns them on a miss.
+     *
+     * Concurrent requests for the same [url] are de-duplicated: only the first triggers
+     * [download], the rest await its result and read it back from disk. The on-disk write is
+     * atomic (temp file + rename), so an interrupted download never leaves a corrupt entry.
+     *
+     * @param cacheDir directory the entry is stored in; created on demand.
+     * @param url      the http(s) URL identifying the entry.
+     * @param download fetches the raw bytes when the cache has no entry for [url].
+     * @return the file bytes, or `null` when [download] yields `null`.
+     */
+    suspend fun getOrPut(
+        cacheDir: File,
+        url: String,
+        download: suspend () -> ByteArray?
+    ): ByteBuffer? {
+        if (!enabled) return download()?.let { ByteBuffer.wrap(it) }
+        val file = fileOf(cacheDir, url)
+        readEntry(file)?.let { return it }
+        val mutex = locks.getOrPut(url) { Mutex() }
+        try {
+            return mutex.withLock {
+                // Another coroutine may have populated the entry while we waited for the lock.
+                readEntry(file) ?: download()?.let { bytes ->
+                    writeEntry(file, bytes)
+                    ByteBuffer.wrap(bytes)
+                }
+            }
+        } finally {
+            // Drop the per-URL lock once nobody holds it, so `locks` cannot grow without bound
+            // as distinct URLs are streamed. A lost race here only costs a redundant download —
+            // never a corrupt entry, since writeEntry publishes atomically.
+            if (!mutex.isLocked) locks.remove(url, mutex)
+        }
+    }
+
+    /**
+     * Deletes every cached entry in [cacheDir]. Returns the number of files removed.
+     *
+     * Not synchronized against in-flight [getOrPut] downloads — a download that publishes
+     * concurrently may survive the clear. That is harmless for a cache.
+     */
+    fun clear(cacheDir: File): Int =
+        cacheDir.listFiles()?.count { it.isFile && it.delete() } ?: 0
+
+    /** Total size of the cache under [cacheDir], in bytes. */
+    fun size(cacheDir: File): Long =
+        cacheDir.listFiles()?.filter { it.isFile }?.sumOf { it.length() } ?: 0L
+
+    /** Number of per-URL download locks currently retained — test hook for the no-leak invariant. */
+    internal fun pendingLockCount(): Int = locks.size
+
+    private fun readEntry(file: File): ByteBuffer? =
+        if (file.isFile) runCatching { ByteBuffer.wrap(file.readBytes()) }.getOrNull() else null
+
+    private fun writeEntry(file: File, bytes: ByteArray) {
+        file.parentFile?.mkdirs()
+        val tmp = File(file.parentFile, "${file.name}.tmp")
+        runCatching {
+            tmp.writeBytes(bytes)
+            // Atomic publish: a reader sees either no entry or the complete file, never a partial.
+            if (!tmp.renameTo(file)) {
+                file.writeBytes(bytes)
+                tmp.delete()
+            }
+        }.onFailure { tmp.delete() }
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/CinematicCameraTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/CinematicCameraTest.kt
@@ -1,0 +1,152 @@
+package io.github.sceneview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.sqrt
+
+/**
+ * Pure-JVM pins for the cinematic turntable maths ([CinematicCamera.kt]) — the eased orbit that
+ * drives `SceneView`'s "hero shot" camera. No renderer is involved; this locks the azimuth ramp,
+ * the elevation bob, the orbit geometry and the framing-distance relation.
+ */
+class CinematicCameraTest {
+
+    private val twoPi = (2.0 * PI).toFloat()
+
+    // ── cinematicAzimuth ─────────────────────────────────────────────────────────
+
+    @Test
+    fun azimuthStartsAtZero() {
+        assertEquals(0f, cinematicAzimuth(0f, CinematicCameraProfile.HeroProduct), 1e-6f)
+    }
+
+    @Test
+    fun azimuthReachesOneRevolutionPerPeriodAtConstantSpeed() {
+        // NeutralWeb has no ease-in: after secondsPerRevolution it has travelled exactly 2π.
+        val p = CinematicCameraProfile.NeutralWeb
+        assertEquals(twoPi, cinematicAzimuth(p.secondsPerRevolution, p), 1e-4f)
+        assertEquals(twoPi / 2f, cinematicAzimuth(p.secondsPerRevolution / 2f, p), 1e-4f)
+    }
+
+    @Test
+    fun azimuthIsMonotonicallyIncreasing() {
+        val p = CinematicCameraProfile.HeroProduct
+        var prev = -1f
+        var t = 0f
+        while (t <= 12f) {
+            val a = cinematicAzimuth(t, p)
+            assertTrue("azimuth must not decrease at t=$t", a >= prev)
+            prev = a
+            t += 0.1f
+        }
+    }
+
+    @Test
+    fun azimuthEaseInIsContinuousAtTheRampBoundary() {
+        // Across t = easeInSeconds the ramp and cruise formulas must meet with no speed jump:
+        // over a 2·δ window straddling the boundary the camera should travel exactly the
+        // cruise-speed distance (the ramp has reached cruise speed precisely at the boundary).
+        val p = CinematicCameraProfile.HeroProduct
+        val e = p.easeInSeconds
+        val delta = 1e-3f
+        val cruiseSpeed = twoPi / p.secondsPerRevolution
+        val travelled = cinematicAzimuth(e + delta, p) - cinematicAzimuth(e - delta, p)
+        assertEquals(cruiseSpeed * 2f * delta, travelled, 1e-5f)
+    }
+
+    @Test
+    fun azimuthEaseInTravelsLessThanConstantSpeedWouldDuringRamp() {
+        // During the ramp the camera is slower than cruise — it has covered strictly less ground
+        // than a no-ease orbit of the same period would have.
+        val p = CinematicCameraProfile.HeroProduct
+        val cruiseSpeed = twoPi / p.secondsPerRevolution
+        val tMid = p.easeInSeconds / 2f
+        assertTrue(cinematicAzimuth(tMid, p) < cruiseSpeed * tMid)
+    }
+
+    // ── cinematicElevation ───────────────────────────────────────────────────────
+
+    @Test
+    fun elevationWithoutBobIsConstant() {
+        val p = CinematicCameraProfile.HeroProduct // elevationBobDegrees = 0
+        val expected = (p.elevationDegrees * PI / 180.0).toFloat()
+        assertEquals(expected, cinematicElevation(0f, p), 1e-6f)
+        assertEquals(expected, cinematicElevation(5f, p), 1e-6f)
+    }
+
+    @Test
+    fun elevationBobStartsAtBaseAndPeaksAtAQuarterCycle() {
+        val p = CinematicCameraProfile.SlowCinematic // has a bob
+        val base = (p.elevationDegrees * PI / 180.0).toFloat()
+        assertEquals(base, cinematicElevation(0f, p), 1e-6f)
+        // sin peaks at a quarter period → base + full amplitude.
+        val peak = ((p.elevationDegrees + p.elevationBobDegrees) * PI / 180.0).toFloat()
+        assertEquals(peak, cinematicElevation(p.bobSecondsPerCycle / 4f, p), 1e-5f)
+    }
+
+    @Test
+    fun elevationIsClampedShortOfThePoles() {
+        // A custom profile whose base + bob would cross +90° must stay short of the pole, or the
+        // orbit basis degenerates and the camera tips over the subject.
+        val steep = CinematicCameraProfile.SlowCinematic.copy(
+            elevationDegrees = 85f,
+            elevationBobDegrees = 20f
+        )
+        val limitRad = 89f * (PI / 180.0).toFloat()
+        for (t in listOf(0f, 2f, 3f, 6f, 9f, 12f, 15f)) {
+            val e = cinematicElevation(t, steep)
+            assertTrue("elevation at t=$t must stay within the pole limit", e <= limitRad + 1e-4f)
+        }
+    }
+
+    // ── cinematicCameraEye ───────────────────────────────────────────────────────
+
+    @Test
+    fun eyeIsAlwaysAtTheOrbitRadiusFromTheOrigin() {
+        val p = CinematicCameraProfile.SlowCinematic
+        for (t in listOf(0f, 1f, 4.5f, 9f, 13.7f)) {
+            val eye = cinematicCameraEye(t, p, distance = 3f)
+            val r = sqrt(eye.x * eye.x + eye.y * eye.y + eye.z * eye.z)
+            assertEquals("radius at t=$t", 3f, r, 1e-4f)
+        }
+    }
+
+    @Test
+    fun eyeStartsInFrontOfAndAboveTheSubject() {
+        // At t = 0 azimuth is 0 → camera sits on +z, lifted by the elevation, centred on x.
+        val eye = cinematicCameraEye(0f, CinematicCameraProfile.HeroProduct, distance = 4f)
+        assertEquals(0f, eye.x, 1e-5f)
+        assertTrue("camera in front (+z)", eye.z > 0f)
+        assertTrue("camera above the horizon", eye.y > 0f)
+    }
+
+    // ── cinematicDistance ────────────────────────────────────────────────────────
+
+    @Test
+    fun distanceForA90DegreeLensEqualsRadiusTimesMargin() {
+        // tan(45°) = 1, so distance reduces to contentRadius · frameMargin.
+        val p = CinematicCameraProfile.NeutralWeb.copy(fovDegrees = 90f, frameMargin = 1f)
+        assertEquals(2f, cinematicDistance(contentRadius = 2f, profile = p), 1e-4f)
+    }
+
+    @Test
+    fun distanceScalesLinearlyWithContentRadius() {
+        val p = CinematicCameraProfile.HeroProduct
+        assertEquals(
+            2f * cinematicDistance(1f, p),
+            cinematicDistance(2f, p),
+            1e-4f
+        )
+    }
+
+    @Test
+    fun narrowerLensPushesTheCameraFurtherBack() {
+        // Hero (30° FOV) is a longer lens than NeutralWeb (45°) → larger framing distance for the
+        // same subject, ignoring frame margin.
+        val hero = CinematicCameraProfile.HeroProduct.copy(frameMargin = 1f)
+        val web = CinematicCameraProfile.NeutralWeb.copy(frameMargin = 1f)
+        assertTrue(cinematicDistance(1f, hero) > cinematicDistance(1f, web))
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/utils/FileCacheTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/utils/FileCacheTest.kt
@@ -1,0 +1,184 @@
+package io.github.sceneview.utils
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for [FileCache] — the on-disk cache for remote http(s) files.
+ *
+ * [FileCache] is deliberately `Context`-free and operates on a plain [File] directory, so these
+ * run on a pure JVM with no Android or Filament dependency.
+ */
+class FileCacheTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var cacheDir: File
+
+    private val url = "https://example.com/models/helmet.glb"
+    private val bytes = byteArrayOf(1, 2, 3, 4, 5)
+
+    @Before
+    fun setUp() {
+        cacheDir = tempFolder.newFolder("cache")
+        FileCache.enabled = true
+    }
+
+    @After
+    fun tearDown() {
+        FileCache.enabled = true
+    }
+
+    private fun bufferBytes(buffer: java.nio.ByteBuffer?): ByteArray {
+        requireNotNull(buffer)
+        return ByteArray(buffer.remaining()).also { buffer.get(it) }
+    }
+
+    // ── getOrPut: miss / hit ─────────────────────────────────────────────────────
+
+    @Test
+    fun `getOrPut on a miss downloads and returns the bytes`() = runBlocking {
+        val result = FileCache.getOrPut(cacheDir, url) { bytes }
+        assertArrayEquals(bytes, bufferBytes(result))
+    }
+
+    @Test
+    fun `getOrPut on a miss persists the file to disk`() = runBlocking {
+        FileCache.getOrPut(cacheDir, url) { bytes }
+        assertTrue(FileCache.fileOf(cacheDir, url).isFile)
+    }
+
+    @Test
+    fun `getOrPut on a hit does not invoke download again`() = runBlocking {
+        val downloads = AtomicInteger(0)
+        FileCache.getOrPut(cacheDir, url) { downloads.incrementAndGet(); bytes }
+        val second = FileCache.getOrPut(cacheDir, url) { downloads.incrementAndGet(); bytes }
+
+        assertEquals(1, downloads.get())
+        assertArrayEquals(bytes, bufferBytes(second))
+    }
+
+    @Test
+    fun `getOrPut returns null when download yields null`() = runBlocking {
+        val result = FileCache.getOrPut(cacheDir, url) { null }
+        assertNull(result)
+        assertFalse(FileCache.fileOf(cacheDir, url).exists())
+    }
+
+    @Test
+    fun `getOrPut keeps distinct entries for distinct urls`() = runBlocking {
+        val other = "https://example.com/models/fox.glb"
+        FileCache.getOrPut(cacheDir, url) { bytes }
+        FileCache.getOrPut(cacheDir, other) { byteArrayOf(9, 9) }
+
+        assertArrayEquals(bytes, FileCache.fileOf(cacheDir, url).readBytes())
+        assertArrayEquals(byteArrayOf(9, 9), FileCache.fileOf(cacheDir, other).readBytes())
+    }
+
+    // ── disabled ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getOrPut bypasses cache when disabled`() = runBlocking {
+        FileCache.enabled = false
+        val downloads = AtomicInteger(0)
+
+        FileCache.getOrPut(cacheDir, url) { downloads.incrementAndGet(); bytes }
+        FileCache.getOrPut(cacheDir, url) { downloads.incrementAndGet(); bytes }
+
+        assertEquals(2, downloads.get())
+        assertFalse(FileCache.fileOf(cacheDir, url).exists())
+    }
+
+    // ── concurrency ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getOrPut leaves no lingering per-url locks`() = runBlocking {
+        // Regression pin: the per-URL lock map must not grow without bound as distinct URLs
+        // are streamed — each getOrPut drops its lock once nobody holds it.
+        for (i in 1..25) {
+            FileCache.getOrPut(cacheDir, "https://example.com/m$i.glb") { byteArrayOf(i.toByte()) }
+        }
+        assertEquals(0, FileCache.pendingLockCount())
+    }
+
+    @Test
+    fun `concurrent getOrPut for the same url downloads only once`() = runBlocking {
+        val downloads = AtomicInteger(0)
+        val results = (1..8).map {
+            async {
+                FileCache.getOrPut(cacheDir, url) {
+                    downloads.incrementAndGet()
+                    delay(20)
+                    bytes
+                }
+            }
+        }.awaitAll()
+
+        assertEquals(1, downloads.get())
+        results.forEach { assertArrayEquals(bytes, bufferBytes(it)) }
+    }
+
+    // ── clear / size ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clear removes every entry and returns the count`() = runBlocking {
+        FileCache.getOrPut(cacheDir, url) { bytes }
+        FileCache.getOrPut(cacheDir, "https://example.com/b.glb") { byteArrayOf(7) }
+
+        assertEquals(2, FileCache.clear(cacheDir))
+        assertEquals(0L, FileCache.size(cacheDir))
+    }
+
+    @Test
+    fun `clear on an empty directory returns zero`() {
+        assertEquals(0, FileCache.clear(cacheDir))
+    }
+
+    @Test
+    fun `size reports the total bytes on disk`() = runBlocking {
+        FileCache.getOrPut(cacheDir, url) { bytes }
+        FileCache.getOrPut(cacheDir, "https://example.com/b.glb") { byteArrayOf(7, 7, 7) }
+
+        assertEquals((bytes.size + 3).toLong(), FileCache.size(cacheDir))
+    }
+
+    // ── keyOf / fileOf ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `keyOf is deterministic`() {
+        assertEquals(FileCache.keyOf(url), FileCache.keyOf(url))
+    }
+
+    @Test
+    fun `keyOf differs per url`() {
+        assertNotEquals(FileCache.keyOf(url), FileCache.keyOf("https://example.com/other.glb"))
+    }
+
+    @Test
+    fun `keyOf is a 64-char lowercase hex string`() {
+        val key = FileCache.keyOf(url)
+        assertEquals(64, key.length)
+        assertTrue(key.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun `fileOf resolves inside the cache directory`() {
+        assertEquals(cacheDir, FileCache.fileOf(cacheDir, url).parentFile)
+    }
+}


### PR DESCRIPTION
## Summary

Two new `sceneview` library features.

### `FileCache` — on-disk cache for remote files
URL-keyed disk cache for any http(s) resource (glTF/GLB models, KTX environments, textures). First load downloads and persists the bytes; later loads reuse the cached file — no repeated downloads, instant offline reuse. Writes are atomic (temp + rename); concurrent downloads of the same URL are de-duplicated via a per-URL mutex that is dropped once unheld, so the lock map never grows unbounded. Wired transparently into `FileLoader.loadFileBuffer`, so every http(s) model / environment / texture load benefits. `Context.fileCacheDir` / `clearFileCache()` to inspect or reclaim it; `FileCache.enabled` to opt out.

### `CinematicCamera` — cinematic turntable camera
A slow, eased "hero shot" orbit around centred content — long lens, gentle downward tilt, soft vertical bob. `applyCinematicOrbit(cameraNode, timeSeconds)` drives it in one call. Three feel presets (`HeroProduct`, `SlowCinematic`, `NeutralWeb`); `CinematicCameraProfile.Default` is `SlowCinematic`. Orbit maths are pure functions (eased azimuth ramp, elevation bob clamped short of the poles, framing distance); projection uses an explicit vertical FOV axis so framing holds on any viewport aspect. Pairs with `SceneView(autoCenterContent = true, cameraManipulator = null)`.

## Notes

- A third feature (a content-scaling `autoFitContent`) was prototyped and **dropped** before this PR — `main` already shipped an `autoFitContent` camera-framing parameter via #1439, which solves the same need and is the approach kept.
- An independent Opus review ran before this PR; its one blocker (unbounded `FileCache` lock map) and findings (explicit FOV axis, elevation clamp) are folded in.

## Test plan

- [x] `:sceneview:compileReleaseKotlin` + `:arsceneview:compileReleaseKotlin`
- [x] `:sceneview:testDebugUnitTest` — `FileCacheTest` 15/15, `CinematicCameraTest` 13/13
- [x] `:arsceneview:testDebugUnitTest` — all pass
- [x] `impact-check.sh` — pass
- [ ] Visual QA of the cinematic camera in a demo — pending (no demo wires it yet; emulator 3D-render QA tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)