### PR TITLE
test(web): pass --enable-unsafe-swiftshader to the Playwright runner

### DIFF
--- a/changelog.d/1674-web-qa-swiftshader.md
+++ b/changelog.d/1674-web-qa-swiftshader.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **Web QA: pass `--enable-unsafe-swiftshader` to the Playwright Chromium runner ([#1674](https://github.com/sceneview/sceneview/issues/1674)).** Chrome removed the automatic SwiftShader fallback for WebGL. On a GPU-less CI runner ANGLE has no hardware path and nothing to fall back to, so WebGL context creation would fail outright — the Filament.js viewer would never get a context and the web-demo test suite could go green-on-nothing. The flag re-enables the software rasteriser so headless CI keeps a real WebGL context.

--- a/samples/web-demo/playwright.config.ts
+++ b/samples/web-demo/playwright.config.ts
@@ -73,6 +73,13 @@ export default defineConfig({
             '--use-gl=angle',
             '--enable-features=Vulkan',
             '--ignore-gpu-blocklist',
+            // Chrome removed the automatic SwiftShader fallback for WebGL. On a
+            // GPU-less CI runner ANGLE has no hardware path and nothing to fall
+            // back to, so WebGL context creation fails outright — the demo
+            // never gets a context and the suite would go green-on-nothing.
+            // This flag re-enables the software rasteriser so the Filament.js
+            // viewer still gets a context on headless CI.
+            '--enable-unsafe-swiftshader',
           ],
         },
       },


### PR DESCRIPTION
## Summary

Adds `--enable-unsafe-swiftshader` to the Playwright Chromium launch args in `samples/web-demo/playwright.config.ts`.

Chrome removed the **automatic SwiftShader fallback for WebGL** (deprecation warned since Chrome 130). On a GPU-less CI runner the existing `--use-gl=angle` path has no hardware GPU and nothing to fall back to, so **WebGL context creation fails outright** — the Filament.js viewer never gets a context and the web-demo Playwright suite could go **green-on-nothing**. The flag re-enables the software rasteriser so headless CI keeps a real WebGL context.

Closes the highest-priority item of #1674.

## Why this is the only change here

The web QA suite is already solid — `helpers.ts:sampleCanvas()` detects a blank canvas via luminance-variance on a compositor screenshot (correctly avoiding `gl.readPixels`, which returns zeros against Filament.js's `preserveDrawingBuffer: false`). The other #1674 ideas (`page.screencast`, IWER) are larger follow-ups tracked in that issue.

## Test plan

- [ ] CI web-demo Playwright leg stays green
- Local run not done — the web-demo Kotlin/JS build is disk-blocked on this host; the change is a single well-documented launch flag and CI is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)