### PR TITLE
fix(release): deterministic non-blocking device-QA release gate (#1683)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -109,19 +109,39 @@ ALL checks must pass. If any mismatch, fix before proceeding.
 bash .claude/scripts/quality-gate.sh --quick
 ```
 
-## Step 6.5: Run the device-QA harness (BLOCKER)
+## Step 6.5: Device QA gate (deterministic, non-blocking — #1683)
 
-The autonomous cross-platform device-QA harness (umbrella #1560) must pass on
-every platform before a release is tagged. A red pass means a demo crashes on
-a real device / emulator / browser.
+The cross-platform device-QA harness (umbrella #1560) **informs** the release;
+it can **never** block it indefinitely. Two ways to satisfy the gate:
 
-```bash
-bash .claude/scripts/device-qa.sh --platform=all
-```
+**A. Let the release gate dispatch its own run (recommended).** Skip this step
+— `release-checklist.sh` (Step 7) calls `release-device-qa-gate.sh`, which:
 
-This produces `device-qa-report.json` at the repo root. `release-checklist.sh`
-(Step 7's gate) reads its `status` field and **FAILS the release** if it is not
-`passed`. Do not tag without a green report.
+- triggers its OWN Device QA run via `gh workflow run "Device QA"` — a
+  `workflow_dispatch` run is isolated from push-concurrency cancellation
+  (#1665/#1667), so it can never be killed by a later push (the root cause of
+  the 58-commit freeze in #1683);
+- polls **that specific run id** with a **bounded loop + hard timeout**
+  (`RELEASE_QA_TIMEOUT_MIN`, default 60 min);
+- grades the result by leg.
+
+**B. Run it locally first.** `bash .claude/scripts/device-qa.sh --platform=all`
+produces `device-qa-report.json` at the repo root; if that file is present the
+gate reads it directly (fast path, no dispatch).
+
+### Gate policy
+
+| Leg | Role | A failure means |
+|---|---|---|
+| **web** (Playwright) | **REQUIRED** | release-gate **FAIL** (hard block) |
+| **ar** (ARCore replay) | **REQUIRED** | release-gate **FAIL** (hard block) |
+| **android** (Maestro emulator) | **ADVISORY** | **WARN** only — never blocks (flaky SwiftShader #1643/#1676) |
+| _timeout / dispatch failure / missing artifact_ | — | `device-qa: TIMEOUT (advisory)` — **proceeds with warning** |
+
+A genuine FAIL on `web` or `ar` is the **only** outcome that blocks tagging.
+Everything else (advisory red, timeout, stuck harness) yields
+`RELEASE-GATE: PASS-WITH-WARNINGS` and the release proceeds. A flaky or
+cancelled harness can never hold shipping hostage.
 
 ## Step 7: Commit and tag
 

--- a/.claude/scripts/release-checklist.sh
+++ b/.claude/scripts/release-checklist.sh
@@ -234,33 +234,64 @@ echo ""
 
 # ─── 14. Device-QA gate ─────────────────────────────────────────────────
 # The autonomous cross-platform device-QA harness (umbrella #1560, slice
-# #1566) must have produced a `device-qa-report.json` before a release is
-# tagged — a red device-QA pass means a demo crashes on a real device.
+# #1566) informs the release — but it must NEVER be able to block it
+# indefinitely.
 #
-# RELEASE-GATE POLICY FOR continue-on-error LEGS (#1651)
-# ------------------------------------------------------
-# Not every leg is equal. device-qa.yml runs the `android` and `ar` legs as
-# `continue-on-error: true` on a chronically flaky SwiftShader emulator
-# (#1643); the `web` leg is reliable. So the gate is graded:
-#   - web        — BLOCKING. A red web leg is a release FAIL (hard block).
-#   - android/ar — ADVISORY. A red android/ar leg is a WARN: a human must see
-#                  "android leg: WARN — did not pass" before tagging, but it
-#                  does NOT hard-block (#1643/#1645 must make it reliably
-#                  green first — then promote it to blocking).
-# device-qa.sh tags each leg `advisory: true|false` and pre-computes a
-# `releaseGate.verdict` (clear|warn|blocked); this check reads that field so
-# the policy is explicit, not an accident of which legs happened to be red.
+# RELEASE-GATE POLICY (#1683 — deterministic, non-blocking)
+# ---------------------------------------------------------
+# History: the gate used to HARD-block on a pre-existing green
+# `device-qa-report.json`. In practice that froze the release for 58+
+# commits — a push-triggered Device QA run on `main` is killed by
+# `cancel-in-progress` concurrency before the long android Maestro leg
+# finishes, so no verdict was ever produced, and the orchestrator waited
+# forever. The android leg is `continue-on-error` / advisory and should
+# never have been able to block anything.
 #
-# To satisfy this check, run before tagging:
-#   bash .claude/scripts/device-qa.sh --platform=all
-# That produces `device-qa-report.json` at the repo root; `DEVICE_QA_REPORT=
-# <path>` overrides the location (e.g. a CI artifact downloaded into the
-# workspace). An older report without `releaseGate` (schemaVersion 1) falls
-# back to the legacy all-or-nothing `status` reading.
+# The gate is therefore DETERMINISTIC and NON-BLOCKING:
+#   - It triggers its OWN Device QA run via `gh workflow run "Device QA"`.
+#     A `workflow_dispatch` run is isolated from push-concurrency
+#     cancellation (#1665/#1667) — it cannot be killed by a later push.
+#   - It polls THAT specific run id with a BOUNDED loop and a HARD TIMEOUT
+#     (RELEASE_QA_TIMEOUT_MIN, default 60 min). No unbounded poll.
+#   - REQUIRED legs = web (Playwright) + ar (ARCore replay): a genuine FAIL
+#     on either => release-gate FAIL (the ONLY blocking outcome).
+#   - ADVISORY leg  = android (Maestro emulator): a failure/cancel/skip is a
+#     WARN line only, never a block — matches device-qa.yml's
+#     `continue-on-error: true` on the android job (#1670/#1676).
+#   - TIMEOUT FALLBACK: if the run does not complete within the timeout the
+#     gate emits `device-qa: TIMEOUT (advisory) — proceeding` and returns
+#     SUCCESS. A flaky / stuck / cancelled harness can NEVER freeze a
+#     release. The release always proceeds; Device QA INFORMS it.
+#
+# The full logic lives in `.claude/scripts/release-device-qa-gate.sh`.
+# Env overrides: RELEASE_QA_TIMEOUT_MIN, RELEASE_QA_POLL_SEC,
+# RELEASE_QA_REQUIRED, RELEASE_QA_ADVISORY, RELEASE_QA_REF.
+#
+# Two modes:
+#   - If a `device-qa-report.json` is already present (e.g. a CI artifact
+#     downloaded into the workspace, or a fresh local `device-qa.sh` run),
+#     this section reads it directly — the fast path, no dispatch.
+#     `DEVICE_QA_REPORT=<path>` overrides the location. A schemaVersion-1
+#     report without `releaseGate` falls back to the legacy `status`.
+#   - Otherwise it delegates to `release-device-qa-gate.sh`, which
+#     dispatches + waits + grades, and can never block on a stuck harness.
 echo -e "${CYAN}--- Device-QA Gate ---${NC}"
 
 DQ_REPORT="${DEVICE_QA_REPORT:-device-qa-report.json}"
-if [ -f "$DQ_REPORT" ]; then
+GATE_SCRIPT="$REPO_ROOT/.claude/scripts/release-device-qa-gate.sh"
+if [ ! -f "$DQ_REPORT" ] && [ -x "$GATE_SCRIPT" ]; then
+    # No local report — run the deterministic, non-blocking gate. It
+    # dispatches its own uncancellable Device QA run, waits with a hard
+    # timeout, and grades web+ar as required / android as advisory. It
+    # exits 1 ONLY on a genuine required-leg FAIL; timeout / advisory red /
+    # dispatch failure all proceed-with-warning.
+    echo -e "  No local device-qa-report.json — invoking release-device-qa-gate.sh"
+    if bash "$GATE_SCRIPT"; then
+        check "device-qa gate" "PASS" "deterministic gate passed (required legs green or proceed-with-warning)"
+    else
+        check "device-qa gate" "FAIL" "a required device-QA leg (web/ar) failed — fix before tagging"
+    fi
+elif [ -f "$DQ_REPORT" ]; then
     DQ_STATUS=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('status','?'))" 2>/dev/null || echo "?")
     DQ_FAILED=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('totals',{}).get('failed','?'))" 2>/dev/null || echo "?")
     DQ_SKIPPED=$(python3 -c "import json; print(json.load(open('$DQ_REPORT')).get('totals',{}).get('skipped','?'))" 2>/dev/null || echo "?")
@@ -309,7 +340,10 @@ if [ -f "$DQ_REPORT" ]; then
         esac
     fi
 else
-    check "device-qa-report.json" "FAIL" "missing — run: bash .claude/scripts/device-qa.sh --platform=all"
+    # No local report AND release-device-qa-gate.sh is not available — the
+    # deterministic gate path is unreachable. Surface a WARN, not a hard
+    # block: a missing harness must never freeze the release (#1683).
+    check "device-qa gate" "WARN" "no report and release-device-qa-gate.sh missing — run: bash .claude/scripts/device-qa.sh --platform=all"
 fi
 echo ""
 

--- a/.claude/scripts/release-device-qa-gate.sh
+++ b/.claude/scripts/release-device-qa-gate.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# release-device-qa-gate.sh — deterministic, non-blocking Device QA release gate.
+#
+# Issue #1683. The release checkpoint used to HARD-gate on a green Device QA
+# run and got stuck INDEFINITELY (58+ commits piled up unreleased): a
+# push-triggered Device QA run on `main` is killed by `cancel-in-progress`
+# concurrency before the long android Maestro leg finishes, so no verdict was
+# ever produced — and the orchestrator waited forever for an all-green run
+# that could not materialise. The android leg is `continue-on-error` /
+# advisory and should never have been able to hard-block a release.
+#
+# WHAT THIS SCRIPT DOES (deterministic, terminating, never freezes)
+# -----------------------------------------------------------------
+# 1. TRIGGERS ITS OWN Device QA run via `gh workflow run "Device QA"
+#    --ref main`. A `workflow_dispatch` run keys its concurrency group on
+#    `github.run_id` (device-qa.yml), so it is UNIQUE and CANNOT be cancelled
+#    by a later push to the same ref (#1665/#1667). This is the fix for the
+#    root cause: a push-triggered run was a moving target; a dispatched run
+#    is ours and runs to completion.
+# 2. CAPTURES that specific run id and POLLS ONLY THAT run id — with a
+#    BOUNDED loop (fixed iteration cap) and a HARD TIMEOUT
+#    (RELEASE_QA_TIMEOUT_MIN, default 60 min, env-overridable). The loop
+#    provably terminates: iterations = ceil(timeout*60 / POLL_INTERVAL_SEC),
+#    and total wall time is capped at the timeout. No unbounded `while true`.
+# 3. READS the structured verdict. device-qa.yml runs each leg as a separate
+#    job, each uploading its own single-platform `device-qa-report.json`
+#    artifact (device-qa-report-web / -android / -ar). This gate downloads
+#    every per-leg artifact and reads each report's `platforms[0].status`
+#    (schemaVersion-2, #1657).
+# 4. APPLIES THE RELEASE-GATE POLICY:
+#       REQUIRED  legs = web (Playwright) + ar (ARCore replay)
+#                        -> a genuine FAIL on either => release-gate FAIL.
+#       ADVISORY  leg   = android (Maestro emulator)
+#                        -> a failure/cancel/skip => WARN line only,
+#                           NEVER a gate fail. This matches device-qa.yml's
+#                           `continue-on-error: true` on the android job and
+#                           the flaky-SwiftShader reality (#1643/#1670/#1676).
+# 5. TIMEOUT FALLBACK — NEVER FREEZES. If the dispatched run has not completed
+#    within RELEASE_QA_TIMEOUT_MIN, the gate prints
+#    `device-qa: TIMEOUT (advisory) — proceeding` and returns SUCCESS (0).
+#    A flaky / stuck / cancelled harness must NEVER hold a release hostage —
+#    the release always proceeds; Device QA INFORMS it, it does not deadlock
+#    it.
+#
+# EXIT STATUS
+#   0  RELEASE-GATE: PASS               — all required legs passed.
+#   0  RELEASE-GATE: PASS-WITH-WARNINGS — required legs passed; an advisory
+#                                         leg did not pass, OR the run timed
+#                                         out / could not be dispatched.
+#   1  RELEASE-GATE: FAIL               — a REQUIRED leg (web or ar) genuinely
+#                                         failed. This is the ONLY blocking
+#                                         outcome.
+#
+# Usage:
+#   bash .claude/scripts/release-device-qa-gate.sh
+#
+# Env overrides:
+#   RELEASE_QA_TIMEOUT_MIN   hard timeout in minutes        (default 60)
+#   RELEASE_QA_POLL_SEC      poll interval in seconds        (default 30)
+#   RELEASE_QA_REQUIRED      CSV of required legs            (default web,ar)
+#   RELEASE_QA_ADVISORY      CSV of advisory legs            (default android)
+#   RELEASE_QA_REF           git ref to dispatch against     (default main)
+#
+# This script is called by `release-checklist.sh` section 14. It is also
+# runnable stand-alone for a manual pre-tag check.
+
+set -euo pipefail
+
+# ─── Config ──────────────────────────────────────────────────────────────
+TIMEOUT_MIN="${RELEASE_QA_TIMEOUT_MIN:-60}"
+POLL_SEC="${RELEASE_QA_POLL_SEC:-30}"
+REQUIRED_LEGS="${RELEASE_QA_REQUIRED:-web,ar}"
+ADVISORY_LEGS="${RELEASE_QA_ADVISORY:-android}"
+REF="${RELEASE_QA_REF:-main}"
+WORKFLOW_NAME="Device QA"
+
+# Colors (disabled when not a tty).
+if [ -t 1 ]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+log()  { printf '%b\n' "$*"; }
+warn() { printf '%b\n' "${YELLOW}$*${NC}"; }
+err()  { printf '%b\n' "${RED}$*${NC}" >&2; }
+
+log "${CYAN}=== Device QA Release Gate (#1683) ===${NC}"
+log "  Policy: REQUIRED = ${REQUIRED_LEGS} | ADVISORY = ${ADVISORY_LEGS}"
+log "  Hard timeout: ${TIMEOUT_MIN} min | poll every ${POLL_SEC}s"
+log ""
+
+# ─── Outcome helpers ─────────────────────────────────────────────────────
+# This script can NEVER block a release except on a genuine required-leg
+# FAIL. Every other path (no gh, dispatch failed, timeout, advisory red)
+# emits a WARN and returns SUCCESS.
+emit_proceed() {
+    # $1 = human reason for proceeding without a clean verdict.
+    warn "  device-qa: $1"
+    log ""
+    log "${YELLOW}RELEASE-GATE: PASS-WITH-WARNINGS${NC}  (Device QA did not produce a blocking verdict — release proceeds)"
+    exit 0
+}
+
+# ─── 0. Preconditions ────────────────────────────────────────────────────
+if ! command -v gh >/dev/null 2>&1; then
+    emit_proceed "gh CLI unavailable — cannot dispatch Device QA (advisory) — proceeding"
+fi
+if ! gh auth status >/dev/null 2>&1; then
+    emit_proceed "gh not authenticated — cannot dispatch Device QA (advisory) — proceeding"
+fi
+
+# Bounded iteration cap. The loop runs AT MOST $MAX_ITERS times; with a
+# $POLL_SEC sleep per iteration the total wall time is bounded by
+# TIMEOUT_MIN*60 seconds. Provable termination — no unbounded poll.
+DEADLINE=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+MAX_ITERS=$(( (TIMEOUT_MIN * 60 + POLL_SEC - 1) / POLL_SEC ))
+[ "$MAX_ITERS" -lt 1 ] && MAX_ITERS=1
+
+# ─── 1. Dispatch our OWN Device QA run ───────────────────────────────────
+# A workflow_dispatch run is isolated from push-concurrency cancellation
+# (device-qa.yml keys workflow_dispatch concurrency on github.run_id) — it
+# cannot be killed by a later push to `main` (#1665/#1667). This is the
+# core fix for the indefinite block.
+log "${CYAN}--- Dispatching Device QA workflow_dispatch run (ref: ${REF}) ---${NC}"
+
+# Record the newest pre-existing run id so we can identify OURS afterwards.
+BEFORE_ID="$(gh run list --workflow "$WORKFLOW_NAME" --event workflow_dispatch \
+    --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0)"
+
+if ! gh workflow run "$WORKFLOW_NAME" --ref "$REF" >/dev/null 2>&1; then
+    emit_proceed "failed to dispatch Device QA workflow (advisory) — proceeding"
+fi
+
+# The dispatched run takes a moment to register. Poll the run list (bounded)
+# for a workflow_dispatch run newer than BEFORE_ID.
+RUN_ID=""
+for _ in $(seq 1 12); do
+    sleep 5
+    CANDIDATE="$(gh run list --workflow "$WORKFLOW_NAME" --event workflow_dispatch \
+        --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0)"
+    if [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "0" ] && [ "$CANDIDATE" != "$BEFORE_ID" ]; then
+        RUN_ID="$CANDIDATE"
+        break
+    fi
+done
+
+if [ -z "$RUN_ID" ]; then
+    emit_proceed "dispatched run never appeared in the run list (advisory) — proceeding"
+fi
+log "  Dispatched run id: ${GREEN}${RUN_ID}${NC}"
+log "  Watching: $(gh run view "$RUN_ID" --json url --jq '.url' 2>/dev/null || echo "run $RUN_ID")"
+log ""
+
+# ─── 2. Bounded poll of THAT specific run id ─────────────────────────────
+log "${CYAN}--- Polling run ${RUN_ID} (bounded: <= ${MAX_ITERS} iterations) ---${NC}"
+RUN_STATUS=""
+for (( iter = 1; iter <= MAX_ITERS; iter++ )); do
+    # Hard deadline guard — independent of the iteration cap.
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+        break
+    fi
+    RUN_STATUS="$(gh run view "$RUN_ID" --json status --jq '.status' 2>/dev/null || echo "unknown")"
+    if [ "$RUN_STATUS" = "completed" ]; then
+        log "  run ${RUN_ID}: completed after ${iter} poll(s)"
+        break
+    fi
+    log "  [poll ${iter}/${MAX_ITERS}] run ${RUN_ID}: ${RUN_STATUS:-unknown} — waiting ${POLL_SEC}s"
+    sleep "$POLL_SEC"
+done
+
+# ─── 3. Timeout fallback — NEVER freeze ──────────────────────────────────
+if [ "$RUN_STATUS" != "completed" ]; then
+    emit_proceed "TIMEOUT (advisory) — run ${RUN_ID} did not complete within ${TIMEOUT_MIN} min — proceeding"
+fi
+
+# ─── 4. Collect per-leg reports ──────────────────────────────────────────
+# device-qa.yml runs each leg as a separate job; each uploads its own
+# single-platform device-qa-report.json artifact (device-qa-report-web /
+# -android / -ar). Download them all into a temp dir and read each report's
+# platforms[0].status.
+log ""
+log "${CYAN}--- Reading per-leg verdicts from run ${RUN_ID} artifacts ---${NC}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if ! gh run download "$RUN_ID" --dir "$TMP_DIR" >/dev/null 2>&1; then
+    emit_proceed "could not download Device QA artifacts for run ${RUN_ID} (advisory) — proceeding"
+fi
+
+# leg_status <leg> — echoes passed|failed|skipped|missing for one leg by
+# reading device-qa-report-<leg>/device-qa-report.json. A leg's per-job
+# report is single-platform, so platforms[0] is authoritative.
+leg_status() {
+    local leg="$1"
+    local report="$TMP_DIR/device-qa-report-$leg/device-qa-report.json"
+    [ -f "$report" ] || { echo "missing"; return; }
+    python3 - "$report" "$leg" <<'PY' 2>/dev/null || echo "missing"
+import json, sys
+report, leg = sys.argv[1], sys.argv[2]
+try:
+    data = json.load(open(report))
+except Exception:
+    print("missing"); sys.exit()
+plats = data.get("platforms", [])
+# Prefer the matching platform entry; fall back to the first.
+match = next((p for p in plats if p.get("platform") == leg), None)
+if match is None and plats:
+    match = plats[0]
+print((match or {}).get("status", "missing"))
+PY
+}
+
+# ─── 5. Apply the required vs advisory policy ────────────────────────────
+log ""
+log "${CYAN}--- Release-gate verdict ---${NC}"
+REQUIRED_FAIL=0
+ADVISORY_WARN=0
+
+for leg in ${REQUIRED_LEGS//,/ }; do
+    st="$(leg_status "$leg")"
+    case "$st" in
+        passed)
+            printf "  ${GREEN}[PASS]${NC}  %-10s (required) — passed\n" "$leg" ;;
+        failed)
+            printf "  ${RED}[FAIL]${NC}  %-10s (required) — FAILED — blocks the release\n" "$leg"
+            REQUIRED_FAIL=$((REQUIRED_FAIL + 1)) ;;
+        skipped|missing|*)
+            # A required leg with no verdict is treated as advisory (do NOT
+            # block on a missing artifact — the harness itself flaked, #1683).
+            printf "  ${YELLOW}[WARN]${NC}  %-10s (required) — no clear verdict (%s) — advisory, not blocking\n" "$leg" "$st"
+            ADVISORY_WARN=$((ADVISORY_WARN + 1)) ;;
+    esac
+done
+
+for leg in ${ADVISORY_LEGS//,/ }; do
+    st="$(leg_status "$leg")"
+    case "$st" in
+        passed)
+            printf "  ${GREEN}[PASS]${NC}  %-10s (advisory) — passed\n" "$leg" ;;
+        *)
+            printf "  ${YELLOW}[WARN]${NC}  %-10s (advisory) — %s — does NOT block (flaky emulator #1643/#1676)\n" "$leg" "$st"
+            ADVISORY_WARN=$((ADVISORY_WARN + 1)) ;;
+    esac
+done
+
+# ─── 6. Final verdict ────────────────────────────────────────────────────
+log ""
+if [ "$REQUIRED_FAIL" -gt 0 ]; then
+    err "RELEASE-GATE: FAIL  ($REQUIRED_FAIL required leg(s) failed — fix before tagging)"
+    exit 1
+elif [ "$ADVISORY_WARN" -gt 0 ]; then
+    log "${YELLOW}RELEASE-GATE: PASS-WITH-WARNINGS${NC}  (all required legs passed; $ADVISORY_WARN advisory warning(s))"
+    exit 0
+else
+    log "${GREEN}RELEASE-GATE: PASS${NC}  (all required legs passed, no warnings)"
+    exit 0
+fi

--- a/changelog.d/1683-robust-release-gate.md
+++ b/changelog.d/1683-robust-release-gate.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Release device-QA gate is now deterministic and non-blocking — it dispatches its own uncancellable Device QA run, waits with a hard timeout, treats web+ar as required and android as advisory, and proceeds-with-warning on timeout, so a flaky harness can never block a release indefinitely (#1683).


### PR DESCRIPTION
Closes #1683. The release gate now triggers its own uncancellable Device QA run, waits with a hard timeout, treats web+ar as required and android as advisory, and proceeds-with-warning on timeout — it can never infinite-block a release again.