### PR TITLE
fix(samples): cleanup — stale labels, MULTIPLATFORM.md, loading-scrim (#1361)

### DIFF
--- a/changelog.d/1361-samples-cleanup.md
+++ b/changelog.d/1361-samples-cleanup.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Samples cleanup: dropped the stale "Coming in v1.1" version label from the iOS demo's coming-soon placeholders (now a plain "Coming soon" badge), and documented that AR demos intentionally skip the 3D first-frame loading scrim (#1361).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -120,6 +120,13 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
  *   timeout dismisses the scrim even if `onFrame` never fires. Demos that load
  *   models can still layer their own [LoadingScrim] spinner on top.
  *
+ *   All 3D (non-AR) demos wire `firstFrameRendered`. The AR demos
+ *   (`ARSceneView`-based: `AR*Demo` + `OrbitalARDemo`) **intentionally skip it**
+ *   — their viewport is the live camera feed, which appears instantly with no
+ *   cold-start black frame, and they already gate behind their own ARCore
+ *   permission / availability screens. Passing `firstFrameRendered = null`
+ *   from an AR demo is correct, not an oversight (#1361).
+ *
  * Stage 3 polish (#1154):
  * - `peekHeader` → a short status string (e.g. `"3 anchors placed"`) rendered on
  *   the closed peek chip in place of the generic "Settings" label. Mirrors the
@@ -262,9 +269,9 @@ private fun BoxScope.AssetSourceChip(state: AssetSourceState) {
 
 /**
  * Surface-tinted scrim that covers the 3D viewport until the SceneView presents
- * its first Filament frame (#1022). Without it, 13 of the demos render a black
+ * its first Filament frame (#1022). Without it, a 3D demo renders a black
  * viewport for 5–12 s on a cold start while shaders compile — which reads as a
- * crash to a first-time user.
+ * crash to a first-time user. All 3D demos wire it; AR demos skip it (#1361).
  *
  * The scrim is an opaque [MaterialTheme.colorScheme.surface] fill (light + dark
  * both covered by the theme token) carrying a small centred progress indicator.

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
@@ -6,16 +6,16 @@ import SwiftUI
 /// "Coming soon" badge and route to ``ComingSoonScreen`` instead of crashing or hiding.
 enum DemoStatus: Equatable {
     case available
-    case comingSoon(version: String)
+    case comingSoon
 
     var isAvailable: Bool {
         if case .available = self { return true }
         return false
     }
 
-    var comingSoonVersion: String? {
-        if case let .comingSoon(version) = self { return version }
-        return nil
+    var isComingSoon: Bool {
+        if case .comingSoon = self { return true }
+        return false
     }
 }
 
@@ -53,14 +53,13 @@ struct DemoItem: Identifiable {
         comingSoonTitle title: String,
         icon: String,
         subtitle: String,
-        category: DemoCategory,
-        version: String = "1.1"
+        category: DemoCategory
     ) {
         self.title = title
         self.icon = icon
         self.subtitle = subtitle
         self.category = category
-        self.status = .comingSoon(version: version)
+        self.status = .comingSoon
         self.destination = AnyView(EmptyView())
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
@@ -2,13 +2,12 @@ import SwiftUI
 
 /// Placeholder shown when the user taps a demo that is not yet ported to iOS.
 ///
-/// Mirrors an Android-only feature with a friendly "Coming soon" message, a version target,
-/// and links to track progress or try the equivalent on the Android demo app.
+/// Mirrors an Android-only feature with a friendly "Coming soon" message and
+/// links to track progress or try the equivalent on the Android demo app.
 struct ComingSoonScreen: View {
     let title: String
     let subtitle: String
     let icon: String
-    let version: String
 
     @Environment(\.dismiss) private var dismiss
 
@@ -42,7 +41,7 @@ struct ComingSoonScreen: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 24)
 
-                    Text("Coming in v\(version)")
+                    Text("Coming soon")
                         .font(.caption.weight(.semibold))
                         .padding(.horizontal, 12)
                         .padding(.vertical, 5)
@@ -91,8 +90,7 @@ struct ComingSoonScreen: View {
         ComingSoonScreen(
             title: "Gesture Editing",
             subtitle: "Move, scale, and rotate models with one-finger drag, pinch, and rotate gestures.",
-            icon: "hand.pinch.fill",
-            version: "1.1"
+            icon: "hand.pinch.fill"
         )
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -158,7 +158,6 @@ struct SamplesTab: View {
                         SceneRow(scene: scene)
                     }
                     .buttonStyle(.plain)
-                    .disabled(!scene.status.isAvailable && scene.status.comingSoonVersion != nil ? false : !scene.status.isAvailable)
                     .accessibilityLabel(accessibilityLabel(for: scene))
                 }
             }
@@ -187,12 +186,11 @@ struct SamplesTab: View {
                 #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
                 #endif
-        case let .comingSoon(version):
+        case .comingSoon:
             ComingSoonScreen(
                 title: scene.title,
                 subtitle: scene.subtitle,
-                icon: scene.icon,
-                version: version
+                icon: scene.icon
             )
         }
     }
@@ -201,8 +199,8 @@ struct SamplesTab: View {
         switch scene.status {
         case .available:
             return "\(scene.title): \(scene.subtitle)"
-        case let .comingSoon(version):
-            return "\(scene.title): \(scene.subtitle). Coming soon in version \(version)."
+        case .comingSoon:
+            return "\(scene.title): \(scene.subtitle). Coming soon."
         }
     }
 
@@ -330,8 +328,7 @@ struct SamplesTab: View {
                 comingSoonTitle: "Secondary Camera (PiP)",
                 icon: "pip.fill",
                 subtitle: "Picture-in-picture camera view",
-                category: .advanced,
-                version: "4.4"
+                category: .advanced
             ),
         ]
 
@@ -453,8 +450,8 @@ private struct SceneRow: View {
                         .foregroundStyle(scene.status.isAvailable ? Color.primary : Color.secondary)
                         .lineLimit(1)
 
-                    if let version = scene.status.comingSoonVersion {
-                        Text("v\(version)")
+                    if scene.status.isComingSoon {
+                        Text("Soon")
                             .font(.caption2.weight(.semibold))
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)


### PR DESCRIPTION
Addresses #1361. iOS coming-soon version label dropped (was stale `v1.1`); MULTIPLATFORM.md + dead router already fixed on main; loading-scrim rollout complete for all 3D demos with AR-skip now documented in DemoScaffold KDoc. No build run (host disk tight); impact-check passes.