### PR TITLE
ci(device-qa): emulator legs fail cleanly instead of cancelling the whole run (#1643)

### DIFF
--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -253,10 +253,19 @@ jobs:
           disable-animations: true
           script: |
             export PATH="$HOME/.maestro/bin:$PATH"
-            adb wait-for-device
+            # Every wait below is `timeout`-bounded so a flaky CI emulator
+            # produces a clean step FAILURE — which continue-on-error absorbs —
+            # instead of letting the job run to `timeout-minutes`. A job killed
+            # by `timeout-minutes` ends `cancelled`, and continue-on-error does
+            # NOT neutralise a cancellation: the whole Device QA run conclusion
+            # then goes red even though web/ar/build passed (#1643). Bare
+            # `adb wait-for-device` in particular blocks forever if the emulator
+            # never comes online. Internal bounds (150s + 1500s + ~120s boot
+            # poll ≈ 29 min) always fire before `timeout-minutes: 35`.
+            timeout 150 adb wait-for-device || { echo "::warning::android leg — emulator never came online"; exit 1; }
             attempts=0; while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do sleep 2; attempts=$((attempts + 1)); done
             # --fast: one representative category, keeps the emulator job lean.
-            bash .claude/scripts/device-qa.sh --platform=android --fast --ci
+            timeout 1500 bash .claude/scripts/device-qa.sh --platform=android --fast --ci
 
       - name: Upload android device-QA report
         if: always()
@@ -325,10 +334,10 @@ jobs:
           # ("end of file unexpected"). Every step below must therefore be a
           # single self-contained logical line (matching the `android` job).
           script: |
-            adb wait-for-device
+            timeout 150 adb wait-for-device || { echo "::warning::ar leg — emulator never came online"; exit 1; }
             attempts=0; while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r\n')" != "1" ] && [ "$attempts" -lt 60 ]; do sleep 2; attempts=$((attempts + 1)); done
             bash .claude/scripts/sideload-arcore.sh || echo "[ar-leg] ARCore sideload failed — harness will assumeTrue-skip"
-            bash .claude/scripts/device-qa.sh --platform=ar --ci
+            timeout 1800 bash .claude/scripts/device-qa.sh --platform=ar --ci
 
       - name: Upload ar device-QA report
         if: always()

--- a/changelog.d/1643-android-leg-clean-fail.md
+++ b/changelog.d/1643-android-leg-clean-fail.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Device QA runs no longer show `cancelled` when only the advisory android/ar emulator leg is flaky ([#1643](https://github.com/sceneview/sceneview/issues/1643)).** The emulator-leg `script:` blocks bounded `adb wait-for-device` and `device-qa.sh` with internal `timeout`s. A flaky CI emulator now produces a clean step **failure** (absorbed by `continue-on-error`) instead of letting the job run to `timeout-minutes` — a timed-out job ends `cancelled`, and a cancelled job drags the whole run conclusion red even when web/build/the other legs passed.


### PR DESCRIPTION
## Problem

9 of the last 10 Device QA runs show overall conclusion `cancelled` — the Actions tab looks like a wall of failures. But the substance is fine: `web` ✅, `build-android-apk` ✅, `ar` ✅ — only the advisory `android` (Maestro) leg ends red.

## Root cause

The `android` and `ar` emulator jobs are `continue-on-error: true` (advisory). But `adb wait-for-device` inside the emulator `script:` has **no timeout** — if the CI emulator never comes online it blocks forever, the job runs until `timeout-minutes` (35/45) and GitHub kills it → job conclusion = **`cancelled`**. `continue-on-error: true` neutralises a job **`failure`** but **not a `cancelled`** — so a cancelled advisory job drags the whole run's conclusion red, even though every other leg passed.

## Fix

Bound every wait in the emulator `script:` blocks with `timeout` (`timeout 150 adb wait-for-device`, `timeout 1500/1800` around `device-qa.sh`). Internal bounds (~29 min android, ~37 min ar) always fire before `timeout-minutes`. A flaky emulator now produces a clean step **failure** that `continue-on-error` absorbs → the overall run stays green when web/build pass.

Does not fix the underlying emulator flakiness — #1643 stays open for that — it stops the flakiness masquerading as a total QA failure.