### PR TITLE
docs: ROADMAP refresh + mcp/package.json version-track contradiction (#1701, #1705)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,9 +323,7 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 | | `sceneview/gradle.properties` | `VERSION_NAME=X.Y.Z` |
 | | `arsceneview/gradle.properties` | `VERSION_NAME=X.Y.Z` |
 | | `sceneview-core/gradle.properties` | `VERSION_NAME=X.Y.Z` |
-| **npm** | `mcp/package.json` | `"version": "X.Y.Z"` |
-| | `mcp/src/index.ts` | version in server info |
-| | `sceneview-web/package.json` | `"version": "X.Y.Z"` |
+| **npm** | `sceneview-web/package.json` | `"version": "X.Y.Z"` |
 | | `react-native/react-native-sceneview/package.json` | `"version": "X.Y.Z"` |
 | **Flutter** | `flutter/sceneview_flutter/pubspec.yaml` | `version: X.Y.Z` |
 | | `flutter/.../android/build.gradle` | `version 'X.Y.Z'` |
@@ -356,6 +354,16 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 > plugins' OWN package versions (`version 'X.Y.Z'`, `pubspec.yaml`, podspec,
 > `package.json`) bump to the release version. `sync-versions.sh` reports these
 > consumed-dep coordinates WARN-only and never auto-bumps them (issue #1494).
+
+> ⚠️ **`mcp/package.json` and `mcp/src/index.ts` follow an INDEPENDENT version
+> track — do NOT sync them to `VERSION_NAME`.**
+> `sceneview-mcp` (npm) has its own release cadence (e.g. `4.0.12` while the
+> SDK is at `4.10.0`) and is published independently of the Maven Central
+> artifacts. `sync-versions.sh` deliberately **excludes** `mcp/package.json`
+> from the version check — forcing them to match once caused a regression
+> where the sync agent downgraded `mcp/package.json` behind the published npm
+> `@next` tag. When releasing `sceneview-mcp`, bump these two files to the
+> next *MCP* version, never to the SDK `VERSION_NAME` (issue #1705).
 
 **Automation:**
 - `bash .claude/scripts/sync-versions.sh` — checks all 30+ locations
@@ -703,10 +711,13 @@ Source of truth: `gradle.properties` → `VERSION_NAME=X.Y.Z`
 | `sceneview/gradle.properties` | `VERSION_NAME=` |
 | `arsceneview/gradle.properties` | `VERSION_NAME=` |
 | `sceneview-core/gradle.properties` | `VERSION_NAME=` |
-| `mcp/package.json` | `"version":` |
 | `llms.txt` | Artifact version references |
 | `README.md` | Install snippets |
 | `CLAUDE.md` | "Latest release" in session state |
+
+> ⚠️ `mcp/package.json` / `mcp/src/index.ts` are **not** in this map —
+> `sceneview-mcp` has its own independent npm version track. `sync-versions.sh`
+> excludes it on purpose. See the Version Location Map note above (issue #1705).
 
 ### Published artifact registry
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,12 @@
 # Roadmap
 
 > Ship fast, ship often. Every feature = a release.
+>
+> **Maintenance note:** the "Current" version below must be refreshed at every
+> release. The source of truth is `gradle.properties` → `VERSION_NAME` — read
+> that, not this file, if they ever disagree.
 
-## Current: v4.0.9 stable (May 2026)
+## Current: v4.10.0 stable (May 2026)
 
 **AI-first SDK** — 9 platforms, MCP server on npm, Claude Code plugin marketplace, Rerun.io debug integration.
 
@@ -15,39 +19,51 @@
 | Android TV | Alpha |
 | Flutter bridge | Alpha |
 | React Native bridge | Alpha |
-| MCP on npm | **4.0.11 @latest** |
+| MCP on npm | **Live** ([`sceneview-mcp`](https://www.npmjs.com/package/sceneview-mcp) — independent version track) |
 | Claude Code plugin marketplace | **Live** ([`sceneview/claude-marketplace`](https://github.com/sceneview/claude-marketplace)) |
 | Telemetry Worker | **Live** |
 | Rerun.io debug integration | **Shipped** (Android + iOS + Python) |
 | Play Store demo app | Deployed |
-| App Store demo app | TestFlight |
-| GitHub Release | **v4.0.9 stable** |
+| App Store demo app | **Live** (`id6761329763`) |
+| GitHub Release | **v4.10.0 stable** |
 
-### Completed in v4.0
+### Completed since v4.0
+
 - [x] Unify naming: `SceneView {}` / `ARSceneView {}` (v3.6)
 - [x] Separate modules intentionally: `sceneview` (3D-only) + `arsceneview` (opt-in AR)
-- [x] Render tests CI (SwiftShader, 4 test classes)
-- [x] NodeAnimator bug fix (#388)
+- [x] Render tests CI (SwiftShader)
 - [x] Anonymous telemetry (Cloudflare Worker + D1)
 - [x] Claude playground on website
-- [x] Claude Code plugin marketplace (Apache-2.0, single `sceneview` plugin v4.0.11)
+- [x] Claude Code plugin marketplace (Apache-2.0, single `sceneview` plugin)
+- [x] iOS V1 parity sprint — LightSlot, RenderQuality, NodeGesture, AR anchors (v4.1–v4.3)
+- [x] iOS App Store release — demo app live (`id6761329763`)
+- [x] visionOS spatial features — immersive-space skybox, `SceneViewSwift` visionOS target builds (v4.5, v4.10)
+- [x] ARCore Recording / Playback — `ARRecorder` + `ARSceneView(playbackDataset = …)` (v4.3)
+- [x] Auto-fit camera framing from glTF bounds — Android + iOS (v4.10, #1439 / #1391)
+- [x] Sketchfab model streaming
+- [x] Cross-platform demo unification — one showcase app per platform
+- [x] Fragment-based changelog system (`changelog.d/`)
+- [x] Autonomous cross-platform device-QA harness (Maestro Android/iOS + Playwright web + AR replay)
 
 ---
 
-## Next: v4.1
+## Next
 
 ### Platform maturity
+
 - [ ] Filament JNI for Desktop (hardware 3D, replace placeholder)
 - [ ] Android XR module (Jetpack XR SceneCore)
-- [ ] visionOS spatial features (immersive spaces, hand tracking)
 - [ ] sceneview-core WASM target (when kotlin-math supports wasmJs)
+- [ ] Promote iOS / Web / Flutter / React Native from Alpha toward Stable
 
 ### Quality
+
 - [ ] Visual regression testing across platforms
 - [ ] Performance benchmarks (FPS, memory, load time)
-- [ ] iOS App Store release (Apple Developer secrets needed)
+- [ ] Raise unit-test coverage on `sceneview` / `arsceneview`
 
 ### Growth
+
 - [ ] First external paying customer
 - [ ] Rerun.io official partnership / listing
 - [ ] Community announcements (Reddit, HN, LinkedIn)
@@ -56,12 +72,15 @@
 
 ## Future
 
-### v4.2+
+### v5.0+
+
 - Compose Multiplatform renderer (shared Compose UI across Android + Desktop + Web)
 - Filament 2.x migration (when available)
 - Scene graph serialization (save/load scenes as files)
+- `ViewNode<Content>` generic API
 
 ### Exploration
+
 - Android Auto / AAOS (when custom 3D views are supported)
 - Wear OS (Canvas-based 3D for watch faces)
 - Cloud rendering API (server-side Filament)

--- a/changelog.d/1701-1705-docs.md
+++ b/changelog.d/1701-1705-docs.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Refreshed the stale `ROADMAP.md` (was pinned at v4.0.9) to v4.10.0 and resolved the `CLAUDE.md` ↔ `sync-versions.sh` contradiction over `mcp/package.json` — the Version Location Map now documents `sceneview-mcp` as an independent npm version track that must NOT be synced to the SDK `VERSION_NAME` (#1701, #1705).


### PR DESCRIPTION
Closes #1701, #1705.