### PR TITLE
fix(web): glTF animation playback + teardown leaks (#1697, #1698, #1700)

### DIFF
--- a/changelog.d/1697-web-bugs.md
+++ b/changelog.d/1697-web-bugs.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Web: glTF animations now play instead of freezing at t=0, `OrbitCameraController.dispose()` detaches its DOM listeners, and `SceneView.destroy()` releases leaked `LightManager` components (#1697, #1698, #1700).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/OrbitCameraController.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/OrbitCameraController.kt
@@ -2,8 +2,9 @@ package io.github.sceneview.web
 
 import io.github.sceneview.web.bindings.Camera
 import io.github.sceneview.web.bindings.float3
-import kotlinx.browser.window
 import org.w3c.dom.HTMLCanvasElement
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventListener
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
 import kotlin.math.PI
@@ -66,6 +67,11 @@ class OrbitCameraController(
     private var isRightDragging = false
     private var lastX = 0.0
     private var lastY = 0.0
+    private var lastPinchDistance = -1.0
+
+    /** Tracks every (type, handler) pair so [dispose] can detach all of them. */
+    private val listeners = mutableListOf<Pair<String, EventListener>>()
+    private var disposed = false
 
     init {
         setupEventListeners()
@@ -113,14 +119,37 @@ class OrbitCameraController(
         )
     }
 
-    /** Remove all event listeners. Call when destroying the SceneView. */
+    /**
+     * Remove every DOM event listener this controller registered on the canvas.
+     *
+     * Must be called when destroying the SceneView — the listener lambdas
+     * capture `this` (and therefore the Filament [Camera]), so leaving them
+     * attached pins the destroyed controller + camera to a canvas that
+     * typically outlives the SceneView, and stale `wheel`/`mousemove` events
+     * keep mutating a dead controller (#1698).
+     */
     fun dispose() {
-        // Event listeners are attached to the canvas and will be GC'd with it
+        if (disposed) return
+        disposed = true
+        listeners.forEach { (type, handler) ->
+            // Options must match the add call; `wheel`/`touch*` were registered
+            // with {passive: false}. removeEventListener ignores a mismatch
+            // silently, so always pass the same options object shape.
+            canvas.removeEventListener(type, handler, js("{passive: false}"))
+        }
+        listeners.clear()
+    }
+
+    /** Register [handler] on the canvas and record it for later removal. */
+    private fun listen(type: String, handler: (Event) -> Unit) {
+        val listener = EventListener { handler(it) }
+        listeners.add(type to listener)
+        canvas.addEventListener(type, listener, js("{passive: false}"))
     }
 
     private fun setupEventListeners() {
         // Mouse down
-        canvas.addEventListener("mousedown", { event ->
+        listen("mousedown") { event ->
             val e = event as MouseEvent
             when (e.button.toInt()) {
                 0 -> { isDragging = true }    // Left button = orbit
@@ -129,10 +158,10 @@ class OrbitCameraController(
             lastX = e.clientX.toDouble()
             lastY = e.clientY.toDouble()
             e.preventDefault()
-        })
+        }
 
         // Mouse move
-        canvas.addEventListener("mousemove", { event ->
+        listen("mousemove") { event ->
             val e = event as MouseEvent
             val dx = e.clientX.toDouble() - lastX
             val dy = e.clientY.toDouble() - lastY
@@ -153,35 +182,35 @@ class OrbitCameraController(
                 targetX += dx * panSensitivity * distance
                 targetY -= dy * panSensitivity * distance
             }
-        })
+        }
 
         // Mouse up
-        canvas.addEventListener("mouseup", {
+        listen("mouseup") {
             isDragging = false
             isRightDragging = false
-        })
+        }
 
-        canvas.addEventListener("mouseleave", {
+        listen("mouseleave") {
             isDragging = false
             isRightDragging = false
-        })
+        }
 
         // Scroll wheel = zoom
-        canvas.addEventListener("wheel", { event ->
+        listen("wheel") { event ->
             val e = event as WheelEvent
             val delta = if (e.deltaY > 0) 1.0 else -1.0
             distance *= 1.0 + delta * zoomSensitivity
             distance = max(minDistance, min(maxDistance, distance))
             e.preventDefault()
-        }, js("{passive: false}"))
+        }
 
         // Prevent context menu on right-click
-        canvas.addEventListener("contextmenu", { event ->
+        listen("contextmenu") { event ->
             event.preventDefault()
-        })
+        }
 
         // Touch support
-        canvas.addEventListener("touchstart", { event ->
+        listen("touchstart") { event ->
             val e = event.asDynamic()
             if (e.touches.length == 1) {
                 isDragging = true
@@ -189,9 +218,9 @@ class OrbitCameraController(
                 lastY = (e.touches[0].clientY as Number).toDouble()
             }
             event.preventDefault()
-        }, js("{passive: false}"))
+        }
 
-        canvas.addEventListener("touchmove", { event ->
+        listen("touchmove") { event ->
             val e = event.asDynamic()
             if (isDragging && e.touches.length == 1) {
                 val dx = (e.touches[0].clientX as Number).toDouble() - lastX
@@ -220,13 +249,11 @@ class OrbitCameraController(
                 lastPinchDistance = pinchDistance
             }
             event.preventDefault()
-        }, js("{passive: false}"))
+        }
 
-        canvas.addEventListener("touchend", {
+        listen("touchend") {
             isDragging = false
             lastPinchDistance = -1.0
-        })
+        }
     }
-
-    private var lastPinchDistance = -1.0
 }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -779,8 +779,15 @@ class SceneView private constructor(
         assetLoader?.delete()
         models.clear()
 
-        // Destroy light entities
-        lightEntities.forEach { engine.destroyEntity(it) }
+        // Destroy light entities. The LightManager component is a separately
+        // managed native allocation — destroying the entity alone leaks it
+        // (#1700), mirroring the Android LightNode.destroy() teardown. Destroy
+        // the component first, then the entity.
+        val lightManager = engine.getLightManager()
+        lightEntities.forEach { entity ->
+            if (lightManager.hasComponent(entity)) lightManager.destroy(entity)
+            engine.destroyEntity(entity)
+        }
         lightEntities.clear()
 
         // Destroy the environment GPU resources — IBL + skybox (issue #1496).
@@ -846,14 +853,11 @@ class SceneView private constructor(
                         // Loop the animation
                         model.animationTime = model.animationTime % duration
                     }
-                    // In Filament.js, applyAnimation only takes the index.
-                    // The animation time is set by calling the animator at the right moment.
-                    // Actually, the gltfio$Animator.applyAnimation(index) applies the animation
-                    // at the CURRENT time set internally -- we need to advance it.
-                    // The proper way is: animator.applyAnimation(index) after setting time
-                    // via the asset's animation system.
-                    // For Filament.js, we use the asset instance animator which tracks time internally.
-                    animator.applyAnimation(0)
+                    // Apply animation 0 at the accumulated (looped) time so
+                    // skeletal/keyframe animations actually advance. The time
+                    // argument is mandatory — without it the animator re-applies
+                    // every frame at t=0 and the model renders frozen (#1697).
+                    animator.applyAnimation(0, model.animationTime)
                     animator.updateBoneMatrices()
                 }
             }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/bindings/Filament.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/bindings/Filament.kt
@@ -233,6 +233,12 @@ external class LightManager {
 
     fun hasComponent(entity: Entity): Boolean
     fun getInstance(entity: Entity): dynamic // LightManager$Instance
+    /**
+     * Destroy the light component attached to [entity]. The component is a
+     * separately-managed native allocation — `Engine.destroyEntity` alone
+     * leaks it (#1700). Call this before destroying the entity.
+     */
+    fun destroy(entity: Entity)
     fun setPosition(instance: dynamic, value: dynamic) // float3
     fun getPosition(instance: dynamic): dynamic
     fun setDirection(instance: dynamic, value: dynamic) // float3
@@ -333,11 +339,14 @@ external class FilamentInstance {
 }
 
 // --- Animator (gltfio) ---
-// NOTE: applyAnimation takes only index. Time is advanced externally.
+// applyAnimation(index, time) — the second `time` argument is required for the
+// animation to advance. The Filament.js `.d.ts` historically omitted it, but
+// the underlying C++ `Animator::applyAnimation(size_t, float)` and the runtime
+// both accept it (Filament's own filament-viewer.js calls it with two args).
 
 @JsName("gltfio\$Animator")
 external class Animator {
-    fun applyAnimation(index: Int)
+    fun applyAnimation(index: Int, time: Double)
     fun applyCrossFade(previousAnimIndex: Int, previousAnimTime: Double, alpha: Double)
     fun updateBoneMatrices()
     fun resetBoneMatrices()

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/OrbitCameraControllerTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/OrbitCameraControllerTest.kt
@@ -216,6 +216,55 @@ class OrbitCameraControllerTest {
         assertEquals(3, cam.lookAtCalls, "every update() must push a fresh lookAt to the camera")
     }
 
+    /**
+     * Dispatch a synthetic cancelable `wheel` event with the given `deltaY`
+     * onto [canvas]. Built via `js` so `deltaY` is populated under ChromeHeadless.
+     */
+    private fun dispatchWheel(canvas: HTMLCanvasElement, deltaY: Double) {
+        val event = js("new WheelEvent('wheel', { deltaY: deltaY, cancelable: true })")
+        canvas.dispatchEvent(event.unsafeCast<org.w3c.dom.events.Event>())
+    }
+
+    @Test
+    fun wheelEventChangesDistanceBeforeDispose() {
+        // Sanity: while listeners are live a wheel event must zoom (change distance).
+        val canvas = newCanvas()
+        val controller = OrbitCameraController(canvas, FakeCamera().toCamera())
+        val before = controller.distance
+        dispatchWheel(canvas, 100.0)
+        assertTrue(
+            controller.distance != before,
+            "a live wheel listener must change distance — was $before, still ${controller.distance}",
+        )
+    }
+
+    @Test
+    fun disposeDetachesWheelListenerSoEventsNoLongerMutateController() {
+        // #1698: after dispose() the canvas must no longer drive the controller.
+        val canvas = newCanvas()
+        val controller = OrbitCameraController(canvas, FakeCamera().toCamera())
+        controller.dispose()
+        val frozen = controller.distance
+        dispatchWheel(canvas, 100.0)
+        dispatchWheel(canvas, -100.0)
+        assertEquals(
+            frozen,
+            controller.distance,
+            "after dispose() a wheel event must not mutate the dead controller's distance",
+        )
+    }
+
+    @Test
+    fun disposeIsIdempotent() {
+        // Calling dispose() twice must not throw (e.g. double-destroy of a SceneView).
+        val canvas = newCanvas()
+        val controller = OrbitCameraController(canvas, FakeCamera().toCamera())
+        controller.dispose()
+        controller.dispose()
+        dispatchWheel(canvas, 100.0)
+        assertTrue(true, "dispose() must be safe to call twice")
+    }
+
     @Test
     fun fullOrbitReturnsToSameEyePosition() {
         // theta + 2π is geometrically identical -> eye position must match.


### PR DESCRIPTION
Closes #1697, #1698, #1700.

## Summary
Three related sceneview-web library bugs fixed in one PR.

- #1697 — glTF animations were frozen at t=0. applyAnimation(index) re-applied the animation at the animator's internal default time every frame. Changed the gltfio$Animator binding to applyAnimation(index, time) and the render loop now passes the accumulated, looped model.animationTime.
- #1698 — OrbitCameraController.dispose() was a no-op. Every DOM listener is now tracked as a named EventListener and detached in dispose(), which is also idempotent.
- #1700 — SceneView.destroy() leaked LightManager components. Added LightManager.destroy(entity) to the binding and destroy() now releases the component (guarded with hasComponent) before destroying each light entity, mirroring Android's LightNode.

## Tests
:sceneview-web:jsBrowserTest green. Added 3 focused OrbitCameraController dispose tests.

## Cross-platform parity
#1697 restores parity with Android. #1700's issue confirms Android's LightNode already destroys the component. No Android/iOS follow-up needed.