### PR TITLE
feat(arsceneview): depth hit-test API — Frame.hitTestDepth (#1712)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/DepthHitResult.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/DepthHitResult.kt
@@ -1,0 +1,210 @@
+package io.github.sceneview.ar.arcore
+
+import com.google.ar.core.Coordinates2d
+import com.google.ar.core.Frame
+import com.google.ar.core.TrackingState
+import dev.romainguy.kotlin.math.cross
+import dev.romainguy.kotlin.math.distance
+import dev.romainguy.kotlin.math.dot
+import dev.romainguy.kotlin.math.length
+import dev.romainguy.kotlin.math.normalize
+import io.github.sceneview.math.Direction
+import io.github.sceneview.math.Position
+import java.nio.ByteOrder
+
+/**
+ * Result of a depth-based hit test — a real-world point and the orientation of the surface it
+ * sits on, sampled from the ARCore depth image rather than from a detected [com.google.ar.core.Plane].
+ *
+ * Unlike [Frame.hitTest], a depth hit test resolves a point on *any* real-world geometry the
+ * depth camera can see — a sofa, a slope, a cluttered desk — without waiting for ARCore to grow
+ * a plane there, and it carries a real surface [normal].
+ *
+ * @see Frame.hitTestDepth
+ */
+data class DepthHitResult(
+    /** World-space point on the real-world surface under the queried screen pixel. */
+    val position: Position,
+    /**
+     * Unit surface normal at [position], estimated from neighbouring depth samples and oriented
+     * to face the camera.
+     */
+    val normal: Direction,
+    /** Distance from the camera to [position], in meters. */
+    val distance: Float
+)
+
+/**
+ * Number of depth-image pixels away from the centre sample used to estimate the surface normal.
+ */
+private const val NORMAL_SAMPLE_RADIUS = 2
+
+/**
+ * Raycasts the ARCore depth image at a screen pixel and returns the real-world point hit, together
+ * with the surface normal at that point.
+ *
+ * This is the SceneView equivalent of Google's [arcore-depth-lab](https://github.com/googlesamples/arcore-depth-lab)
+ * "Oriented Reticle": it works on arbitrary geometry, not just detected planes, and gives the
+ * surface orientation so a placed object can be aligned to whatever it lands on.
+ *
+ * Requires the [com.google.ar.core.Session] to be configured with a depth mode — either
+ * [com.google.ar.core.Config.DepthMode.AUTOMATIC] or
+ * [com.google.ar.core.Config.DepthMode.RAW_DEPTH_ONLY]. Returns `null` when depth is unavailable
+ * (not supported, not yet computed, camera not tracking, or no valid depth at that pixel).
+ *
+ * The depth image is acquired and released within this call. It is inexpensive enough for
+ * tap-driven placement; do not call it for every pixel of every frame.
+ *
+ * Threading: must be called on the GL/main thread, like the rest of the AR frame pipeline.
+ *
+ * @param xPx screen X in pixels.
+ * @param yPx screen Y in pixels.
+ */
+fun Frame.hitTestDepth(xPx: Float, yPx: Float): DepthHitResult? {
+    val camera = camera
+    if (camera.trackingState != TrackingState.TRACKING) return null
+
+    val depthImage = runCatching { acquireDepthImage16Bits() }.getOrNull()
+        ?: runCatching { acquireRawDepthImage16Bits() }.getOrNull()
+        ?: return null
+
+    try {
+        val depthWidth = depthImage.width
+        val depthHeight = depthImage.height
+        val plane = depthImage.planes[0]
+        val rowStrideShorts = plane.rowStride / 2
+        // ARCore packs DEPTH16 little-endian on every supported device; nativeOrder matches it.
+        val buffer = plane.buffer.order(ByteOrder.nativeOrder()).asShortBuffer()
+
+        // Map the screen pixel to normalized depth-image coordinates.
+        val normalized = FloatArray(2)
+        transformCoordinates2d(
+            Coordinates2d.VIEW,
+            floatArrayOf(xPx, yPx),
+            Coordinates2d.IMAGE_NORMALIZED,
+            normalized
+        )
+        val depthX = (normalized[0] * depthWidth).toInt()
+        val depthY = (normalized[1] * depthHeight).toInt()
+
+        val centerDepth = buffer.depthMetersAt(depthX, depthY, rowStrideShorts, depthWidth, depthHeight)
+        if (centerDepth <= 0f) return null
+
+        // ARCore reports intrinsics for the full-resolution CPU image; scale them to the
+        // (much smaller) depth image resolution.
+        val intrinsics = camera.imageIntrinsics
+        val scaleX = depthWidth / intrinsics.imageDimensions[0].toFloat()
+        val scaleY = depthHeight / intrinsics.imageDimensions[1].toFloat()
+        val fx = intrinsics.focalLength[0] * scaleX
+        val fy = intrinsics.focalLength[1] * scaleY
+        val cx = intrinsics.principalPoint[0] * scaleX
+        val cy = intrinsics.principalPoint[1] * scaleY
+
+        val pose = camera.pose
+
+        fun worldAt(px: Int, py: Int, depthMeters: Float): Position {
+            val cameraSpace = unprojectDepthPixel(px, py, depthMeters, fx, fy, cx, cy)
+            val world = pose.transformPoint(cameraSpace.toFloatArray())
+            return Position(world[0], world[1], world[2])
+        }
+
+        val center = worldAt(depthX, depthY, centerDepth)
+
+        // Sample the four neighbours for the surface normal; fall back to the centre when a
+        // neighbour has no valid depth (object edge, hole) so a degenerate sample never skews it.
+        fun neighbour(dx: Int, dy: Int): Position {
+            val nx = depthX + dx
+            val ny = depthY + dy
+            val d = buffer.depthMetersAt(nx, ny, rowStrideShorts, depthWidth, depthHeight)
+            return if (d > 0f) worldAt(nx, ny, d) else center
+        }
+
+        val normal = estimateNormal(
+            center = center,
+            right = neighbour(NORMAL_SAMPLE_RADIUS, 0),
+            left = neighbour(-NORMAL_SAMPLE_RADIUS, 0),
+            up = neighbour(0, -NORMAL_SAMPLE_RADIUS),
+            down = neighbour(0, NORMAL_SAMPLE_RADIUS),
+            cameraPosition = pose.position
+        )
+
+        return DepthHitResult(
+            position = center,
+            normal = normal,
+            distance = distance(pose.position, center)
+        )
+    } finally {
+        depthImage.close()
+    }
+}
+
+/**
+ * Reads the depth sample at depth-image pixel ([x], [y]) and returns it in meters, or `0f` when
+ * the pixel is out of bounds or has no depth.
+ */
+private fun java.nio.ShortBuffer.depthMetersAt(
+    x: Int,
+    y: Int,
+    rowStrideShorts: Int,
+    width: Int,
+    height: Int
+): Float {
+    if (x !in 0 until width || y !in 0 until height) return 0f
+    val millimeters = get(y * rowStrideShorts + x).toInt() and 0xFFFF
+    return millimeters / 1000f
+}
+
+/**
+ * Unprojects a depth-image pixel into a 3D point in ARCore camera space.
+ *
+ * ARCore camera space is +X right, +Y up, -Z forward, while the depth image has its origin at the
+ * top-left with Y growing downward — hence the negated Y, and the depth (a positive forward
+ * distance) mapping to a negative Z.
+ *
+ * `internal` so the projection math can be unit-tested without an ARCore [Frame].
+ */
+internal fun unprojectDepthPixel(
+    pixelX: Int,
+    pixelY: Int,
+    depthMeters: Float,
+    fx: Float,
+    fy: Float,
+    cx: Float,
+    cy: Float
+): Position = Position(
+    x = (pixelX - cx) * depthMeters / fx,
+    y = -(pixelY - cy) * depthMeters / fy,
+    z = -depthMeters
+)
+
+/**
+ * Estimates a unit surface normal from a [center] point and its four neighbours, oriented to face
+ * the camera at [cameraPosition].
+ *
+ * When the neighbourhood is degenerate (all samples collapsed onto the centre), it falls back to a
+ * normal pointing straight at the camera so a placed object still faces the user.
+ *
+ * `internal` so the vector math can be unit-tested without an ARCore [Frame].
+ */
+internal fun estimateNormal(
+    center: Position,
+    right: Position,
+    left: Position,
+    up: Position,
+    down: Position,
+    cameraPosition: Position
+): Direction {
+    val tangentX = right - left
+    val tangentY = up - down
+    var normal = cross(tangentX, tangentY)
+    if (length(normal) <= 0f) {
+        // Degenerate neighbourhood — fall back to facing straight at the camera.
+        normal = cameraPosition - center
+    }
+    normal = normalize(normal)
+    // Flip so the normal points back toward the camera.
+    if (dot(normal, cameraPosition - center) < 0f) {
+        normal = -normal
+    }
+    return normal
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/arcore/DepthHitResultTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/arcore/DepthHitResultTest.kt
@@ -1,0 +1,99 @@
+package io.github.sceneview.ar.arcore
+
+import io.github.sceneview.math.Position
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the pure projection + normal-estimation math behind [Frame.hitTestDepth] (#1712).
+ *
+ * The ARCore [com.google.ar.core.Frame] / depth [android.media.Image] plumbing cannot run in a
+ * JVM unit test, so [unprojectDepthPixel] and [estimateNormal] are `internal` and verified here in
+ * isolation — a sign error in either would otherwise only surface on a physical device.
+ */
+class DepthHitResultTest {
+
+    // Synthetic pinhole intrinsics — focal length 100 px, principal point at (50, 40).
+    private val fx = 100f
+    private val fy = 100f
+    private val cx = 50f
+    private val cy = 40f
+
+    @Test
+    fun `principal-point pixel unprojects onto the optical axis`() {
+        val p = unprojectDepthPixel(cx.toInt(), cy.toInt(), depthMeters = 2f, fx, fy, cx, cy)
+
+        assertEquals(0f, p.x, EPSILON)
+        assertEquals(0f, p.y, EPSILON)
+        // Depth is a positive forward distance; ARCore camera space looks down -Z.
+        assertEquals(-2f, p.z, EPSILON)
+    }
+
+    @Test
+    fun `a pixel one focal length right of centre unprojects to +X = depth`() {
+        val p = unprojectDepthPixel((cx + fx).toInt(), cy.toInt(), depthMeters = 2f, fx, fy, cx, cy)
+
+        assertEquals(2f, p.x, EPSILON)
+        assertEquals(0f, p.y, EPSILON)
+    }
+
+    @Test
+    fun `a pixel above centre unprojects to +Y (image Y is flipped)`() {
+        // Smaller pixelY is higher on screen, which is +Y up in ARCore camera space.
+        val p = unprojectDepthPixel(cx.toInt(), (cy - fy).toInt(), depthMeters = 2f, fx, fy, cx, cy)
+
+        assertEquals(2f, p.y, EPSILON)
+    }
+
+    @Test
+    fun `normal of a horizontal floor points up toward a camera above it`() {
+        // A floor lying in the XZ plane.
+        val normal = estimateNormal(
+            center = Position(0f, 0f, 0f),
+            right = Position(1f, 0f, 0f),
+            left = Position(-1f, 0f, 0f),
+            up = Position(0f, 0f, -1f),
+            down = Position(0f, 0f, 1f),
+            cameraPosition = Position(0f, 5f, 0f)
+        )
+
+        assertEquals(0f, normal.x, EPSILON)
+        assertEquals(1f, normal.y, EPSILON)
+        assertEquals(0f, normal.z, EPSILON)
+    }
+
+    @Test
+    fun `normal is flipped to face a camera below the surface`() {
+        val normal = estimateNormal(
+            center = Position(0f, 0f, 0f),
+            right = Position(1f, 0f, 0f),
+            left = Position(-1f, 0f, 0f),
+            up = Position(0f, 0f, -1f),
+            down = Position(0f, 0f, 1f),
+            cameraPosition = Position(0f, -5f, 0f)
+        )
+
+        assertEquals(-1f, normal.y, EPSILON)
+    }
+
+    @Test
+    fun `degenerate neighbourhood falls back to facing the camera`() {
+        val center = Position(0f, 0f, 0f)
+        val normal = estimateNormal(
+            center = center,
+            right = center,
+            left = center,
+            up = center,
+            down = center,
+            cameraPosition = Position(0f, 0f, 3f)
+        )
+
+        assertEquals(0f, normal.x, EPSILON)
+        assertEquals(0f, normal.y, EPSILON)
+        assertEquals(1f, normal.z, EPSILON)
+    }
+
+    companion object {
+        private const val EPSILON = 1e-4f
+    }
+}

--- a/changelog.d/1712-depth-hit-test.md
+++ b/changelog.d/1712-depth-hit-test.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- `Frame.hitTestDepth(xPx, yPx)` raycasts the ARCore depth image and returns a `DepthHitResult` (world position, camera-facing surface normal, distance) — placement onto *any* real-world surface, not just detected planes, inspired by [arcore-depth-lab](https://github.com/googlesamples/arcore-depth-lab)'s "Oriented Reticle" (#1712).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -815,6 +815,43 @@ ARSceneView(modifier = Modifier.fillMaxSize()) {
 }
 ```
 
+### Depth hit test — place on any real surface
+
+`HitResultNode` / `Frame.hitTest` resolve only against **detected planes / feature points**.
+`Frame.hitTestDepth` instead raycasts the **ARCore depth image**, so it lands on *any* real-world
+geometry (a sofa, a slope, a cluttered desk) without waiting for a plane to grow there — and it
+returns the **surface normal**, so a placed object can be aligned to whatever it lands on.
+
+Requires the session depth mode set to `Config.DepthMode.AUTOMATIC` or `RAW_DEPTH_ONLY`.
+Returns `null` when depth is unavailable (not supported, not yet computed, camera not tracking,
+or no valid depth at that pixel). Cheap enough for tap-driven placement — do not call it per-pixel.
+
+```kotlin
+data class DepthHitResult(
+    val position: Position,   // world-space point on the real surface
+    val normal: Direction,    // unit surface normal, facing the camera
+    val distance: Float       // camera-to-point distance, meters
+)
+
+fun Frame.hitTestDepth(xPx: Float, yPx: Float): DepthHitResult?
+```
+
+```kotlin
+ARSceneView(
+    modifier = Modifier.fillMaxSize(),
+    sessionConfiguration = { session, config ->
+        config.depthMode = Config.DepthMode.AUTOMATIC
+    },
+    onGestureListener = rememberOnGestureListener(
+        onSingleTapConfirmed = { e, _ ->
+            arSceneView.frame?.hitTestDepth(e.x, e.y)?.let { hit ->
+                // hit.position / hit.normal — place & orient a node on the real surface
+            }
+        }
+    )
+)
+```
+
 ### AugmentedImageNode — image tracking
 ```kotlin
 @Composable fun AugmentedImageNode(

--- a/llms.txt
+++ b/llms.txt
@@ -815,6 +815,43 @@ ARSceneView(modifier = Modifier.fillMaxSize()) {
 }
 ```
 
+### Depth hit test — place on any real surface
+
+`HitResultNode` / `Frame.hitTest` resolve only against **detected planes / feature points**.
+`Frame.hitTestDepth` instead raycasts the **ARCore depth image**, so it lands on *any* real-world
+geometry (a sofa, a slope, a cluttered desk) without waiting for a plane to grow there — and it
+returns the **surface normal**, so a placed object can be aligned to whatever it lands on.
+
+Requires the session depth mode set to `Config.DepthMode.AUTOMATIC` or `RAW_DEPTH_ONLY`.
+Returns `null` when depth is unavailable (not supported, not yet computed, camera not tracking,
+or no valid depth at that pixel). Cheap enough for tap-driven placement — do not call it per-pixel.
+
+```kotlin
+data class DepthHitResult(
+    val position: Position,   // world-space point on the real surface
+    val normal: Direction,    // unit surface normal, facing the camera
+    val distance: Float       // camera-to-point distance, meters
+)
+
+fun Frame.hitTestDepth(xPx: Float, yPx: Float): DepthHitResult?
+```
+
+```kotlin
+ARSceneView(
+    modifier = Modifier.fillMaxSize(),
+    sessionConfiguration = { session, config ->
+        config.depthMode = Config.DepthMode.AUTOMATIC
+    },
+    onGestureListener = rememberOnGestureListener(
+        onSingleTapConfirmed = { e, _ ->
+            arSceneView.frame?.hitTestDepth(e.x, e.y)?.let { hit ->
+                // hit.position / hit.normal — place & orient a node on the real surface
+            }
+        }
+    )
+)
+```
+
 ### AugmentedImageNode — image tracking
 ```kotlin
 @Composable fun AugmentedImageNode(


### PR DESCRIPTION
## Summary

Implements #1712 (part of the ARCore Depth API parity umbrella #1711, inspired by Google's [arcore-depth-lab](https://github.com/googlesamples/arcore-depth-lab)).

- **`Frame.hitTestDepth(xPx, yPx): DepthHitResult?`** — raycasts the ARCore depth image instead of resolving against detected planes, so placement works on *any* real-world geometry (sofa, slope, cluttered desk) and returns a real surface **normal**. The SceneView equivalent of Depth Lab's "Oriented Reticle".
- `DepthHitResult(position, normal, distance)` — world point, camera-facing unit normal, camera-to-point distance.
- Acquires/releases the depth image within the call; works with `DepthMode.AUTOMATIC` and `RAW_DEPTH_ONLY`; returns `null` when depth is unavailable.
- Projection + normal-estimation math extracted into `internal` `unprojectDepthPixel` / `estimateNormal` helpers so a sign error surfaces off-device.
- `llms.txt` (+ `docs/docs/llms.txt` mirror) documents the new API; changelog fragment added.

## Test plan

- [x] `:arsceneview:compileReleaseKotlin` — compiles
- [x] `:arsceneview:testDebugUnitTest` — full suite green, incl. 6 new `DepthHitResultTest` cases (principal-point projection, +X / +Y axis signs, floor normal orientation, camera-facing flip, degenerate-neighbourhood fallback)
- [x] `pre-push-check.sh` — green (iOS goldens skipped: no simulator booted)
- [ ] On-device validation — stable position + normal on non-planar geometry (needs a depth-capable device/emulator)
- [ ] iOS parity via `ARFrame.sceneDepth` — tracked in #1712, deferred to the iOS parity sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)