### PR TITLE
fix(android-tv-demo): D-pad dead on launch — focus never requested (#1704)

### DIFF
--- a/changelog.d/1704-tv-dpad.md
+++ b/changelog.d/1704-tv-dpad.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+Android TV demo: D-pad controls now work on launch — the root `Box` is `focusable()` and requests focus on first composition so key events reach the `onKeyEvent` handler.

--- a/samples/android-tv-demo/src/main/java/io/github/sceneview/sample/tv/TvModelViewerActivity.kt
+++ b/samples/android-tv-demo/src/main/java/io/github/sceneview/sample/tv/TvModelViewerActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import io.github.sceneview.sample.common.update.UpdateBanner
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -124,10 +126,17 @@ private fun TvModelViewerScreen(updateManager: InAppUpdateManager? = null) {
 
     val focusRequester = remember { FocusRequester() }
 
+    // Android TV is entirely D-pad driven with no touch. The root Box owns the
+    // whole control scheme via onKeyEvent, but onKeyEvent only fires when its
+    // node holds focus — so the Box must be focusable() AND must actually grab
+    // focus on first composition, or every D-pad key is inert from launch.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .focusRequester(focusRequester)
+            .focusable()
             .onKeyEvent { event ->
                 if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onKeyEvent false
                 when (event.nativeKeyEvent.keyCode) {


### PR DESCRIPTION
Closes #1704.

The Android TV demo's root `Box` owned the entire D-pad control scheme via `onKeyEvent`, but it was never `focusable()` and nothing requested focus on first composition. With no focus owner, `onKeyEvent` never fired — D-pad rotate/zoom/cycle and Play/Pause toggle were all inert from launch.

Fix: add `.focusable()` to the `Box` and a `LaunchedEffect(Unit) { focusRequester.requestFocus() }` so focus is grabbed on first composition.

Verified: `./gradlew :samples:android-tv-demo:compileDebugKotlin` succeeds.