### PR TITLE
fix(ios): FogNode height-based fog no longer a silent no-op (#1380)

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/FogNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/FogNode.swift
@@ -9,15 +9,17 @@ import AppKit
 
 /// Atmospheric fog effect simulated with a large translucent sphere.
 ///
-/// Mirrors SceneView Android's `FogNode` — provides linear, exponential, and
-/// height-based fog modes. Because RealityKit does not expose a native per-view
-/// fog API, `FogNode` places a translucent sphere around the camera origin to
-/// approximate the effect.
+/// Mirrors SceneView Android's `FogNode` — provides linear and exponential fog
+/// modes. Because RealityKit does not expose a native per-view fog API,
+/// `FogNode` places a translucent sphere around the camera origin to approximate
+/// the effect.
 ///
-/// - Note: The ``heightBased(density:height:color:)`` factory and ``heightFalloff``
-///   property are kept for Android API parity, but the height gradient itself is
-///   **not rendered on iOS** — a uniform translucent sphere cannot vary opacity by
-///   world height. On iOS, height-based fog looks identical to exponential fog.
+/// - Note: Android's `FogNode` also exposes a `heightFalloff` parameter backed
+///   by Filament's native `View.fogOptions.heightFalloff` (a per-pixel shader
+///   feature). RealityKit has no equivalent: a uniform-color `UnlitMaterial`
+///   cannot vary opacity by world height. The legacy ``heightBased(density:height:color:)``
+///   factory and ``heightFalloff`` property are **deprecated** on iOS — use
+///   ``exponential(density:color:)`` for the closest equivalent. See [#1380](https://github.com/sceneview/sceneview/issues/1380).
 ///
 /// ```swift
 /// SceneView { content in
@@ -65,20 +67,19 @@ public struct FogNode: Sendable {
 
     /// Height falloff in world-space meters, mirroring Android's `FogNode.heightFalloff`.
     ///
-    /// - Important: **The height gradient is not rendered on iOS.** On Android, fog
-    ///   uses Filament's native `View.setFog` which exposes a true per-pixel
-    ///   `heightFalloff`. RealityKit has no native fog API, so `FogNode` approximates
-    ///   fog with a single uniform translucent sphere (see ``makeFog(density:start:end:heightFalloff:color:)``).
-    ///   A uniform-color `UnlitMaterial` cannot vary opacity by world height — that
-    ///   would require a custom `ShaderGraphMaterial`. The value is stored and kept
-    ///   for Android API parity, but height-based fog renders identically to
-    ///   exponential fog on iOS. See ``heightBased(density:height:color:)``.
+    /// - Warning: **Not supported on RealityKit.** Android uses Filament's native
+    ///   `View.fogOptions.heightFalloff` (a per-pixel shader feature). RealityKit has
+    ///   no equivalent, so `FogNode` approximates fog with a single translucent
+    ///   sphere whose `UnlitMaterial` cannot vary opacity by world height. The setter
+    ///   stores the value (kept for source compatibility) but does **not** affect the
+    ///   rendered output. Use ``exponential(density:color:)`` for the closest
+    ///   visual equivalent. See [#1380](https://github.com/sceneview/sceneview/issues/1380).
+    @available(*, deprecated, message: "Height-based fog is not supported on RealityKit; use exponential(density:color:) instead. See #1380.")
     public var heightFalloff: Float {
         get { _heightFalloff }
         set {
-            // Stored for Android API parity only — see the property doc-comment.
-            // RealityKit's UnlitMaterial cannot render a height gradient, so no
-            // rebuildMaterial()/updateScale() call is intentional here (not a bug).
+            // No-op for rendering — see the @available(deprecated) message and #1380.
+            // Stored only so the getter round-trips for callers that still set it.
             _heightFalloff = newValue
         }
     }
@@ -152,18 +153,19 @@ public struct FogNode: Sendable {
 
     /// Creates height-based fog, mirroring Android's `FogNode.heightBased`.
     ///
-    /// - Important: **The height gradient is not rendered on iOS.** RealityKit has no
-    ///   native fog API, so `FogNode` approximates fog with a uniform translucent
-    ///   sphere that cannot vary opacity by world height. On iOS this factory behaves
-    ///   identically to ``exponential(density:color:)`` — the `height` argument is
-    ///   stored on ``heightFalloff`` for Android API parity only. Use Android for
-    ///   true height-based fog (Filament's native `View.setFog`). See ``heightFalloff``.
+    /// - Warning: **Not supported on RealityKit.** Android backs height-based fog with
+    ///   Filament's native `View.fogOptions.heightFalloff` (a per-pixel shader feature).
+    ///   RealityKit has no equivalent, so on iOS this factory falls back to a uniform
+    ///   translucent sphere — visually identical to ``exponential(density:color:)``.
+    ///   The `height` argument is stored on ``heightFalloff`` but never rendered.
+    ///   Use ``exponential(density:color:)`` directly on iOS. See [#1380](https://github.com/sceneview/sceneview/issues/1380).
     ///
     /// - Parameters:
     ///   - density: Fog density in [0.0, 1.0]. Default 0.05.
     ///   - height: Height falloff in meters (stored, not rendered on iOS). Default 1.0.
     ///   - color: Fog color. Default `.white`.
     /// - Returns: A configured `FogNode`.
+    @available(*, deprecated, message: "Height-based fog is not supported on RealityKit; use exponential(density:color:) instead. See #1380.")
     public static func heightBased(
         density: Float = 0.05,
         height: Float = 1.0,

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/FogNodeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/FogNodeTests.swift
@@ -24,6 +24,7 @@ final class FogNodeTests: XCTestCase {
         XCTAssertNotNil(fog.entity.model)
     }
 
+    @available(*, deprecated)
     func testHeightBasedFogCreatesEntity() {
         let fog = FogNode.heightBased(density: 0.1, height: 2.0)
         XCTAssertNotNil(fog.entity)
@@ -46,6 +47,7 @@ final class FogNodeTests: XCTestCase {
         XCTAssertEqual(fog.endDistance, 40.0, accuracy: 0.001)
     }
 
+    @available(*, deprecated)
     func testHeightBasedDefaultValues() {
         let fog = FogNode.heightBased()
         XCTAssertEqual(fog.density, 0.05, accuracy: 0.001)
@@ -149,18 +151,20 @@ final class FogNodeTests: XCTestCase {
         XCTAssertEqual(fog.position.z, 1.0, accuracy: 0.001)
     }
 
-    // MARK: - Height-based specific
+    // MARK: - Height-based specific (deprecated, see #1380)
 
-    // `heightFalloff` is stored for Android API parity but the height gradient is
-    // not rendered on iOS (RealityKit has no native fog API; a uniform translucent
-    // sphere cannot vary opacity by world height). See FogNode.heightFalloff docs
-    // and issue #1380. These tests pin the documented store-only behavior.
+    // `heightFalloff` and `heightBased(...)` are deprecated on iOS — RealityKit has
+    // no per-pixel fog gradient equivalent to Filament's `View.fogOptions.heightFalloff`.
+    // The setter remains as a no-op pass-through purely so the getter round-trips
+    // (source compatibility). These tests pin that store-only contract.
 
+    @available(*, deprecated)
     func testHeightBasedFogSetsHeightFalloff() {
         let fog = FogNode.heightBased(density: 0.1, height: 5.0)
         XCTAssertEqual(fog.heightFalloff, 5.0, accuracy: 0.001)
     }
 
+    @available(*, deprecated)
     func testHeightFalloffPropertySet() {
         var fog = FogNode.heightBased(density: 0.1, height: 1.0)
         fog.heightFalloff = 3.0
@@ -170,7 +174,8 @@ final class FogNodeTests: XCTestCase {
     /// Height-based fog renders identically to exponential fog on iOS: the height
     /// gradient is a documented RealityKit parity gap (#1380). Verifies that
     /// changing `heightFalloff` does not alter the rendered material/mesh, so the
-    /// API is honestly a store-only no-op rather than silently pretending.
+    /// API is honestly a deprecated store-only no-op rather than silently pretending.
+    @available(*, deprecated)
     func testHeightFalloffDoesNotAffectRenderedMaterial() {
         let exponential = FogNode.exponential(density: 0.1)
         let heightBased = FogNode.heightBased(density: 0.1, height: 5.0)
@@ -282,12 +287,14 @@ final class FogNodeTests: XCTestCase {
 
     // MARK: - Height falloff mutable property
 
+    @available(*, deprecated)
     func testHeightFalloffNegativeValue() {
         var fog = FogNode.heightBased()
         fog.heightFalloff = -5.0
         XCTAssertEqual(fog.heightFalloff, -5.0, accuracy: 0.001)
     }
 
+    @available(*, deprecated)
     func testHeightFalloffZero() {
         var fog = FogNode.heightBased()
         fog.heightFalloff = 0.0

--- a/changelog.d/1380-ios-fognode-heightfog.md
+++ b/changelog.d/1380-ios-fognode-heightfog.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **iOS**: `FogNode.heightBased(...)` and `FogNode.heightFalloff` are now formally deprecated with a compile-warning instead of silently no-op'ing at runtime — RealityKit has no per-pixel height fog equivalent to Filament's `View.fogOptions.heightFalloff`. Use `FogNode.exponential(density:color:)` instead. The iOS Fog demo no longer advertises a "Height" mode. ([#1380](https://github.com/sceneview/sceneview/issues/1380))

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -447,6 +447,7 @@ silent stub.
 | `CameraNode.depthOfField(...)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process required (out of scope) |
 | `CameraNode.exposure(_:)` | No `exposureCompensation` on `PerspectiveCameraComponent` (verified Xcode 26.x compile failure in #1019) | `ARSceneView(cameraExposure:)` for AR; `SceneView.renderQuality(_:)` to tune IBL for 3D |
 | `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | Use `castsShadow(_:)` + `shadowMaximumDistance(_:)` |
+| `FogNode.heightBased(...)` / `FogNode.heightFalloff` | `UnlitMaterial` cannot vary opacity by world height; no per-view fog API in RealityKit (#1380) | `FogNode.exponential(density:color:)` |
 
 ### Android-only — no port planned (or pending)
 
@@ -464,7 +465,7 @@ Use as you would on Android; expect minor visual differences.
 
 | Symbol | Android renderer | iOS approximation |
 |---|---|---|
-| `FogNode.linear / .exponential / .heightBased` | Filament fog modes | Translucent-sphere shader (visual approximation; same factory API) |
+| `FogNode.linear / .exponential` | Filament fog modes | Translucent-sphere shader (visual approximation; same factory API). `FogNode.heightBased` is deprecated on iOS — see #1380. |
 | `ReflectionProbeNode.box(...) / .sphere(...)` | Volumetric Filament probe | Unbounded `ImageBasedLightReceiverComponent` (volume scope is best-effort) |
 | `CustomMaterial.subsurface(...)` | Filament SSS | PBR `metallic` + `roughness` tuning |
 

--- a/llms.txt
+++ b/llms.txt
@@ -2606,13 +2606,14 @@ Full canonical reference in `docs/docs/cheatsheet-ios.md`. Three buckets:
 
 ### Deprecated on iOS (v4.0.10+ — compile-warning, no-op runtime)
 
-These three APIs ship as `@available(*, deprecated, message: …)` factories and silently no-op when called. Migrate to the alternative listed.
+These APIs ship as `@available(*, deprecated, message: …)` factories and silently no-op when called. Migrate to the alternative listed.
 
 | Deprecated | Why iOS can't | Replacement |
 |---|---|---|
 | `CameraNode.depthOfField(...)` | `PerspectiveCameraComponent` has no DOF | Custom Metal post-process (out of scope) |
 | `CameraNode.exposure(_:)` | `PerspectiveCameraComponent` has no `exposureCompensation` (verified Xcode 26.x build, #1019) | `ARSceneView(cameraExposure:)` (AR) or `.renderQuality(_:)` IBL tune (3D) |
 | `LightNode.shadowColor(_:)` | `DirectionalLightComponent.Shadow` has no `color` property | `.castsShadow(_:)` + `.shadowMaximumDistance(_:)` |
+| `FogNode.heightBased(...)` / `FogNode.heightFalloff` | `UnlitMaterial` cannot vary opacity by world height; no per-view fog API in RealityKit (#1380) | `FogNode.exponential(density:color:)` |
 
 ### Android-only — no port planned or pending
 
@@ -2631,7 +2632,7 @@ Same public API name on both platforms; the iOS render path differs but the fact
 
 | Symbol | Android renderer | iOS approximation |
 |---|---|---|
-| `FogNode.linear / .exponential / .heightBased` | Filament fog modes | Translucent-sphere shader |
+| `FogNode.linear / .exponential` | Filament fog modes | Translucent-sphere shader (`.heightBased` is deprecated on iOS — see #1380) |
 | `ReflectionProbeNode.box(...) / .sphere(...)` | Volumetric Filament probe | Unbounded `ImageBasedLightReceiverComponent` (volume scope is best-effort) |
 | `CustomMaterial.subsurface(...)` | Filament SSS | PBR `metallic` + `roughness` tuning |
 
@@ -2654,7 +2655,7 @@ DynamicSkyNode(timeOfDay: 14, turbidity: 3, sunIntensity: 1200)
 ```swift
 FogNode.linear(start: 1.0, end: 20.0).color(.cool)
 FogNode.exponential(density: 0.15)
-FogNode.heightBased(density: 0.1, height: 1.0)
+// FogNode.heightBased(...) is deprecated on iOS (RealityKit parity gap, #1380) — use .exponential instead
 ```
 
 **ReflectionProbeNode** — local environment reflections:

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/FogDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/FogDemo.swift
@@ -2,13 +2,17 @@ import SwiftUI
 import RealityKit
 import SceneViewSwift
 
-/// Fog effect demo -- linear, exponential, and height-based modes.
+/// Fog effect demo -- linear and exponential modes.
+///
+/// Height-based fog is not supported on RealityKit (Filament-only feature on Android);
+/// see #1380. The mode is omitted from this demo so the UI does not advertise a
+/// silent no-op.
 struct FogDemo: View {
     @State private var fogMode: Int = 0
     @State private var density: Float = 0.3
 
-    private let modeNames = ["Linear", "Exponential", "Height"]
-    private let modeIcons = ["line.diagonal", "waveform", "mountain.2.fill"]
+    private let modeNames = ["Linear", "Exponential"]
+    private let modeIcons = ["line.diagonal", "waveform"]
 
     var body: some View {
         sceneContent
@@ -49,10 +53,8 @@ struct FogDemo: View {
                 case 0:
                     fog = FogNode.linear(start: 0.5, end: 5.0, color: .cool)
                         .density(density)
-                case 1:
-                    fog = FogNode.exponential(density: density, color: .warm)
                 default:
-                    fog = FogNode.heightBased(density: density, height: 1.0, color: .white)
+                    fog = FogNode.exponential(density: density, color: .warm)
                 }
                 fog.entity.position = .init(x: 0, y: 0, z: -2)
                 root.addChild(fog.entity)
@@ -69,7 +71,7 @@ struct FogDemo: View {
         VStack(spacing: 12) {
             // Mode selector
             HStack(spacing: 8) {
-                ForEach(0..<3, id: \.self) { i in
+                ForEach(0..<modeNames.count, id: \.self) { i in
                     Button {
                         fogMode = i
                         #if os(iOS)

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -240,7 +240,7 @@ struct SamplesTab: View {
             DemoItem(title: "Dynamic Sky", icon: "sun.horizon.fill", subtitle: "Time-of-day sun simulation", category: .lighting) {
                 DynamicSkyDemo()
             },
-            DemoItem(title: "Fog", icon: "cloud.fog.fill", subtitle: "Linear, exponential, and height fog", category: .lighting) {
+            DemoItem(title: "Fog", icon: "cloud.fog.fill", subtitle: "Linear and exponential fog", category: .lighting) {
                 FogDemo()
             },
 


### PR DESCRIPTION
Closes #1380.

## Path taken: honestly deprecated

Android backs `FogNode.heightFalloff` with Filament's native `View.fogOptions.heightFalloff` — a per-pixel shader feature with no RealityKit equivalent. The previous iOS implementation stored the value and silently ignored it at render time, which is a #928-class dishonesty regression.

Rather than build a `ShaderGraphMaterial` workaround (large effort for a feature that ~no iOS user is asking for), this PR brings the API in line with the existing deprecated-on-iOS pattern (`CameraNode.exposure`, `LightNode.shadowColor`):

- `FogNode.heightFalloff` (property) — now `@available(*, deprecated, message: "Height-based fog is not supported on RealityKit; use exponential(density:color:) instead. See #1380.")`. The setter still stores the value so the getter round-trips (source compatibility), but no longer pretends to affect rendering.
- `FogNode.heightBased(density:height:color:)` (factory) — same `@available(*, deprecated, ...)` annotation. Existing call sites still compile (with warning) and fall back to translucent-sphere rendering identical to `.exponential`.
- iOS `FogDemo` drops the misleading "Height" mode tab (subtitle previously advertised "Linear, exponential & height fog"; now "Linear and exponential fog").
- Tests annotated with `@available(*, deprecated)` to suppress warnings while pinning the documented store-only behavior — 38/38 `FogNodeTests` still pass on iPhone 17 simulator.
- `llms.txt` and `docs/docs/cheatsheet-ios.md`: `FogNode.heightBased` moved from the "Approximated" bucket to "Deprecated on iOS".

## Cross-platform parity note

Android's `FogNode.heightFalloff` works correctly (mapped 1:1 to `View.fogOptions.heightFalloff` in `sceneview/src/main/java/io/github/sceneview/node/FogNode.kt`). No Android-side bug found, no follow-up filed.

## Verification

- `xcodebuild -scheme SceneViewSwift -destination 'generic/platform=iOS Simulator' build` ✅
- `xcodebuild -scheme SceneViewSwift -destination 'generic/platform=macOS' build` ✅
- `xcodebuild test ... -only-testing:SceneViewSwiftTests/FogNodeTests` — 38/38 pass ✅
- `bash .claude/scripts/impact-check.sh` — PASS with 1 unrelated WARN (`Swift-only nodes`) ✅
- `bash .claude/scripts/check-sceneview-skill.sh` — PASS ✅