### PR TITLE
feat(android-demo): persist hosted Cloud Anchors across launches (#1734)

### DIFF
--- a/changelog.d/1734-cloud-anchor-persistence.md
+++ b/changelog.d/1734-cloud-anchor-persistence.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- Cloud Anchor persistence in `ARCloudAnchorDemo` — a new `CloudAnchorStore` / `rememberCloudAnchorRegistry` helper persists `{name → cloudAnchorId, expiry}` in `SharedPreferences` so a hosted anchor can be re-resolved across app launches with the ARCore 365-day TTL maximum. Adds a one-time privacy disclosure dialog and a "Host & save" / saved-anchor list to the demo UI (#1734).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -1047,6 +1047,28 @@ val resolveFuture: ResolveCloudAnchorFuture = CloudAnchorNode.resolve(
     engine, session, cloudAnchorId
 ) { state, node -> /* ... */ }
 DisposableEffect(cloudAnchorId) { onDispose { resolveFuture.cancel() } }
+
+// CloudAnchorNode.host(session, ttlDays = 1..365, onCompleted)
+// ttlDays caps at 365 (ARCore 1.33+). Anchors with ttlDays > 1 are billed
+// as "persistent" cloud anchors in the Google Cloud Console and keep
+// resolving for the requested window before the backend GCs them.
+//
+// Persistent cloud-anchor pattern — store {name -> cloudAnchorId, expiry}
+// across launches, re-resolve on next start, prune expired entries. The
+// android-demo ships a SharedPreferences-backed helper that demos can
+// reuse as a copy-paste pattern:
+//
+//   import io.github.sceneview.demo.common.rememberCloudAnchorRegistry
+//   val registry = rememberCloudAnchorRegistry()
+//   LaunchedEffect(Unit) { registry.pruneExpired() }
+//   registry.save(name = "Living room", cloudAnchorId = id, ttlDays = 365)
+//   registry.entries // List<CloudAnchorEntry(name, cloudAnchorId, expiryEpochMillis)>
+//
+// **Privacy disclosure (REQUIRED):** hosting a Cloud Anchor uploads visual
+// feature points from the user's surroundings to Google's ARCore Cloud
+// Anchor service. Per ARCore's terms of service, apps MUST show a one-time
+// consent dialog before the first host call. See
+// `samples/android-demo/.../ARCloudAnchorDemo.kt` for the reference flow.
 ```
 
 ### TrackableNode — generic trackable

--- a/llms.txt
+++ b/llms.txt
@@ -1060,6 +1060,28 @@ val resolveFuture: ResolveCloudAnchorFuture = CloudAnchorNode.resolve(
     engine, session, cloudAnchorId
 ) { state, node -> /* ... */ }
 DisposableEffect(cloudAnchorId) { onDispose { resolveFuture.cancel() } }
+
+// CloudAnchorNode.host(session, ttlDays = 1..365, onCompleted)
+// ttlDays caps at 365 (ARCore 1.33+). Anchors with ttlDays > 1 are billed
+// as "persistent" cloud anchors in the Google Cloud Console and keep
+// resolving for the requested window before the backend GCs them.
+//
+// Persistent cloud-anchor pattern — store {name -> cloudAnchorId, expiry}
+// across launches, re-resolve on next start, prune expired entries. The
+// android-demo ships a SharedPreferences-backed helper that demos can
+// reuse as a copy-paste pattern:
+//
+//   import io.github.sceneview.demo.common.rememberCloudAnchorRegistry
+//   val registry = rememberCloudAnchorRegistry()
+//   LaunchedEffect(Unit) { registry.pruneExpired() }
+//   registry.save(name = "Living room", cloudAnchorId = id, ttlDays = 365)
+//   registry.entries // List<CloudAnchorEntry(name, cloudAnchorId, expiryEpochMillis)>
+//
+// **Privacy disclosure (REQUIRED):** hosting a Cloud Anchor uploads visual
+// feature points from the user's surroundings to Google's ARCore Cloud
+// Anchor service. Per ARCore's terms of service, apps MUST show a one-time
+// consent dialog before the first host call. See
+// `samples/android-demo/.../ARCloudAnchorDemo.kt` for the reference flow.
 ```
 
 **Persistence — `ttlDays`.** `CloudAnchorNode.host(session, ttlDays = 1)` accepts any value in `CloudAnchorNode.TTL_DAYS_RANGE` (= `1..365`, inclusive). Values outside this range throw `IllegalArgumentException`. Pick a short ttl for ephemeral collaborative sessions, a longer one (e.g. 7..30) for "leave behind" multi-day experiences.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/CloudAnchorStore.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/CloudAnchorStore.kt
@@ -1,0 +1,167 @@
+package io.github.sceneview.demo.common
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * SharedPreferences-backed registry of hosted ARCore Cloud Anchors.
+ *
+ * Models the persistent-cloud-anchor pattern from Google's
+ * [`persistent_cloud_anchor_java`](https://github.com/google-ar/arcore-android-sdk/tree/main/samples/persistent_cloud_anchor_java)
+ * sample: each entry maps a user-chosen `name` to its `cloudAnchorId` plus the
+ * `expiryEpochMillis` at which the Cloud Anchor backend will stop resolving it
+ * (`System.currentTimeMillis() + ttlDays * 86_400_000L`).
+ *
+ * ### TTL contract (ARCore 1.33+)
+ * `Session.hostCloudAnchorAsync(anchor, ttlDays)` accepts `ttlDays` between
+ * `1` and `365`. Anchors hosted with `ttlDays > 1` are billed as
+ * "persistent" cloud anchors in the Google Cloud Console and will keep
+ * resolving for the requested window before the backend GCs them. After
+ * expiry, `Session.resolveCloudAnchorAsync` returns
+ * `Anchor.CloudAnchorState.ERROR_RESOLVING_CLOUD_ANCHOR_ID_NOT_FOUND`.
+ *
+ * ### Privacy disclosure
+ * Hosting a Cloud Anchor uploads visual feature points around the user to
+ * Google's ARCore Cloud Anchor service. Per ARCore's terms, apps using this
+ * API MUST surface a privacy notice to the user before the first host call.
+ * This sample's [io.github.sceneview.demo.demos.ARCloudAnchorDemo] shows a
+ * one-time disclosure dialog backed by [hasAcceptedPrivacy] /
+ * [setAcceptedPrivacy] below.
+ *
+ * ### Implementation
+ * We persist a single JSON-encoded array under one SharedPreferences key.
+ * Json keeps the schema explicit (name / id / expiry) and is trivially
+ * forward-compatible if we want to add `hostedAt` or `lastResolvedAt` later.
+ * This stays consistent with [io.github.sceneview.demo.ui.explore.RecentSearchesStore]
+ * which also chose SharedPreferences over DataStore for the demo app to
+ * keep the APK lean.
+ *
+ * Storage is keyed per-app on the device only — anchor IDs themselves are
+ * scoped to the Cloud project that hosted them, so the registry is a pure
+ * convenience bookmark, not a security boundary.
+ */
+data class CloudAnchorEntry(
+    val name: String,
+    val cloudAnchorId: String,
+    val expiryEpochMillis: Long,
+) {
+    /** `true` once the Cloud Anchor backend's TTL has elapsed for this entry. */
+    fun isExpired(nowEpochMillis: Long = System.currentTimeMillis()): Boolean =
+        nowEpochMillis >= expiryEpochMillis
+}
+
+private const val PREFS_NAME = "io.github.sceneview.demo.cloudanchor"
+private const val KEY_ENTRIES = "entries"
+private const val KEY_PRIVACY_ACCEPTED = "privacyAccepted"
+
+/** Maximum TTL (in days) accepted by `Session.hostCloudAnchorAsync` since ARCore 1.33. */
+const val CLOUD_ANCHOR_MAX_TTL_DAYS: Int = 365
+
+/** Default TTL the demo uses when the user picks "Host & save". */
+const val CLOUD_ANCHOR_DEFAULT_TTL_DAYS: Int = 365
+
+class CloudAnchorStore internal constructor(context: Context) {
+    private val prefs = context.applicationContext
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): List<CloudAnchorEntry> {
+        val raw = prefs.getString(KEY_ENTRIES, null) ?: return emptyList()
+        return runCatching {
+            val arr = JSONArray(raw)
+            (0 until arr.length()).mapNotNull { i ->
+                val o = arr.optJSONObject(i) ?: return@mapNotNull null
+                val name = o.optString("name").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val id = o.optString("cloudAnchorId").takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+                val expiry = o.optLong("expiryEpochMillis", 0L)
+                CloudAnchorEntry(name, id, expiry)
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    fun save(entries: List<CloudAnchorEntry>) {
+        val arr = JSONArray()
+        entries.forEach { e ->
+            arr.put(
+                JSONObject()
+                    .put("name", e.name)
+                    .put("cloudAnchorId", e.cloudAnchorId)
+                    .put("expiryEpochMillis", e.expiryEpochMillis)
+            )
+        }
+        prefs.edit().putString(KEY_ENTRIES, arr.toString()).apply()
+    }
+
+    /** Whether the user has acknowledged the Cloud Anchor privacy disclosure. */
+    fun hasAcceptedPrivacy(): Boolean = prefs.getBoolean(KEY_PRIVACY_ACCEPTED, false)
+
+    fun setAcceptedPrivacy(accepted: Boolean) {
+        prefs.edit().putBoolean(KEY_PRIVACY_ACCEPTED, accepted).apply()
+    }
+}
+
+/** Compose-friendly handle around [CloudAnchorStore]. */
+class CloudAnchorRegistry internal constructor(
+    initial: List<CloudAnchorEntry>,
+    private val store: CloudAnchorStore,
+) {
+    private val _entries = mutableStateListOf<CloudAnchorEntry>().also { it.addAll(initial) }
+    val entries: List<CloudAnchorEntry> get() = _entries
+
+    /**
+     * Persist [name] → [cloudAnchorId] with an `expiryEpochMillis` of `now + ttlDays`.
+     * If [name] already exists, the entry is replaced (latest wins).
+     */
+    fun save(
+        name: String,
+        cloudAnchorId: String,
+        ttlDays: Int,
+        nowEpochMillis: Long = System.currentTimeMillis(),
+    ) {
+        val trimmedName = name.trim().ifEmpty { cloudAnchorId.take(8) }
+        val clampedTtl = ttlDays.coerceIn(1, CLOUD_ANCHOR_MAX_TTL_DAYS)
+        val expiry = nowEpochMillis + clampedTtl * 86_400_000L
+        _entries.removeAll { it.name.equals(trimmedName, ignoreCase = true) }
+        _entries.add(0, CloudAnchorEntry(trimmedName, cloudAnchorId, expiry))
+        store.save(_entries.toList())
+    }
+
+    fun remove(name: String) {
+        _entries.removeAll { it.name == name }
+        store.save(_entries.toList())
+    }
+
+    /** Drop any entries whose TTL has elapsed — they will not resolve any more. */
+    fun pruneExpired(nowEpochMillis: Long = System.currentTimeMillis()) {
+        val before = _entries.size
+        _entries.removeAll { it.isExpired(nowEpochMillis) }
+        if (_entries.size != before) store.save(_entries.toList())
+    }
+}
+
+@Composable
+fun rememberCloudAnchorRegistry(): CloudAnchorRegistry {
+    val context = LocalContext.current
+    val store = remember(context) { CloudAnchorStore(context) }
+    return remember(store) { CloudAnchorRegistry(store.load(), store) }
+}
+
+/** Compose-friendly read of the one-time privacy-acceptance flag. */
+@Composable
+fun rememberCloudAnchorPrivacyAccepted(): Pair<Boolean, (Boolean) -> Unit> {
+    val context = LocalContext.current
+    val store = remember(context) { CloudAnchorStore(context) }
+    val initial = remember(store) { store.hasAcceptedPrivacy() }
+    val state = remember { mutableStateOf(initial) }
+    val setter: (Boolean) -> Unit = { value ->
+        state.value = value
+        store.setAcceptedPrivacy(value)
+    }
+    return state.value to setter
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
@@ -9,16 +9,21 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +44,10 @@ import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.CloudAnchorNode as CloudAnchorNodeImpl
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.CLOUD_ANCHOR_DEFAULT_TTL_DAYS
+import io.github.sceneview.demo.common.CLOUD_ANCHOR_MAX_TTL_DAYS
+import io.github.sceneview.demo.common.rememberCloudAnchorPrivacyAccepted
+import io.github.sceneview.demo.common.rememberCloudAnchorRegistry
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.math.Position
@@ -85,6 +94,7 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
     var localAnchor by remember { mutableStateOf<Anchor?>(null) }
     var cloudAnchorId by remember { mutableStateOf<String?>(null) }
     var resolveId by remember { mutableStateOf("") }
+    var anchorName by remember { mutableStateOf("") }
     var isTracking by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var hostedId by remember { mutableStateOf<String?>(null) }
@@ -105,7 +115,91 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
     // the Host button just updated the status text and nothing hit the Cloud Anchor API.
     var cloudNode by remember { mutableStateOf<CloudAnchorNodeImpl?>(null) }
 
+    // Persistent registry of previously hosted Cloud Anchors so users can
+    // re-resolve a saved anchor across app launches. Mirrors the persistent-
+    // cloud-anchor flow shipped in arcore-android-sdk's
+    // `persistent_cloud_anchor_java` sample. See `CloudAnchorStore.kt`.
+    val registry = rememberCloudAnchorRegistry()
+    val (privacyAccepted, setPrivacyAccepted) = rememberCloudAnchorPrivacyAccepted()
+    // Prune entries whose TTL elapsed — they would return
+    // ERROR_RESOLVING_CLOUD_ANCHOR_ID_NOT_FOUND otherwise, which is confusing.
+    LaunchedEffect(Unit) { registry.pruneExpired() }
+    // Privacy-disclosure gate: hosting uploads visual feature points to
+    // Google's ARCore Cloud Anchor service, so we surface a one-time consent
+    // dialog before the first Host call (per ARCore's terms of service).
+    var pendingHost by remember { mutableStateOf(false) }
+    var pendingSave by remember { mutableStateOf(false) }
+    val showPrivacyDialog = !privacyAccepted && (pendingHost || pendingSave)
+
     val modelInstance = rememberModelInstance(modelLoader, "models/khronos_damaged_helmet.glb")
+
+    // Actually run the host call once the user has acknowledged the privacy
+    // disclosure. Persistent anchors are hosted with the maximum 365-day TTL so
+    // the registry can re-resolve them weeks later. ARCore caps `ttlDays` at
+    // [CLOUD_ANCHOR_MAX_TTL_DAYS] (since 1.33).
+    val hostAndOptionallySave: (Boolean) -> Unit = { save ->
+        val node = cloudNode
+        val session = arSession
+        val name = anchorName.trim()
+        when {
+            localAnchor == null -> Toast.makeText(
+                context, "Place an anchor first", Toast.LENGTH_SHORT
+            ).show()
+            node == null || session == null -> Toast.makeText(
+                context, "AR session not ready", Toast.LENGTH_SHORT
+            ).show()
+            save && name.isEmpty() -> Toast.makeText(
+                context, "Enter a name to save this anchor", Toast.LENGTH_SHORT
+            ).show()
+            else -> {
+                statusMessage = if (save) {
+                    "Hosting & saving \u201c$name\u201d\u2026"
+                } else {
+                    "Hosting anchor\u2026"
+                }
+                val ttlDays = if (save) CLOUD_ANCHOR_DEFAULT_TTL_DAYS else 1
+                node.host(session, ttlDays = ttlDays) { id, state ->
+                    if (save && state == Anchor.CloudAnchorState.SUCCESS && id != null) {
+                        registry.save(name, id, ttlDays)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showPrivacyDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                pendingHost = false
+                pendingSave = false
+            },
+            title = { Text("Share AR view with Google?") },
+            text = {
+                Text(
+                    "Hosting a Cloud Anchor uploads visual feature points from " +
+                        "your surroundings to Google's ARCore Cloud Anchor service " +
+                        "so the same point in space can be recognised on other " +
+                        "devices. Make sure no sensitive content is in view before " +
+                        "you continue."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    setPrivacyAccepted(true)
+                    val save = pendingSave
+                    pendingHost = false
+                    pendingSave = false
+                    hostAndOptionallySave(save)
+                }) { Text("Allow & host") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    pendingHost = false
+                    pendingSave = false
+                }) { Text("Cancel") }
+            }
+        )
+    }
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_cloud_anchor_title),
@@ -119,20 +213,8 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
             ) {
                 Button(
                     onClick = {
-                        val node = cloudNode
-                        val session = arSession
-                        when {
-                            localAnchor == null -> Toast.makeText(
-                                context, "Place an anchor first", Toast.LENGTH_SHORT
-                            ).show()
-                            node == null || session == null -> Toast.makeText(
-                                context, "AR session not ready", Toast.LENGTH_SHORT
-                            ).show()
-                            else -> {
-                                statusMessage = "Hosting anchor\u2026"
-                                node.host(session)
-                            }
-                        }
+                        if (privacyAccepted) hostAndOptionallySave(false)
+                        else pendingHost = true
                     },
                     // Without an ARCore Cloud API key the SDK returns
                     // ERROR_NOT_AUTHORIZED silently \u2014 disable the action so the
@@ -142,6 +224,19 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
                     enabled = hasArcoreApiKey && localAnchor != null && hostedId == null
                 ) {
                     Text("Host")
+                }
+
+                Button(
+                    onClick = {
+                        if (privacyAccepted) hostAndOptionallySave(true)
+                        else pendingSave = true
+                    },
+                    // Save = host with a 365-day TTL + persist locally so we can
+                    // re-resolve on next launch. Same API-key gate as Host.
+                    enabled = hasArcoreApiKey && localAnchor != null && hostedId == null
+                        && anchorName.isNotBlank()
+                ) {
+                    Text("Host & save")
                 }
 
                 Button(
@@ -180,6 +275,14 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
             }
 
             OutlinedTextField(
+                value = anchorName,
+                onValueChange = { anchorName = it },
+                label = { Text("Anchor name (for saving)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            OutlinedTextField(
                 value = resolveId,
                 onValueChange = { resolveId = it },
                 label = { Text("Cloud Anchor ID") },
@@ -193,6 +296,36 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary
                 )
+            }
+
+            // Saved-anchor registry \u2014 re-resolve on next launch.
+            if (registry.entries.isNotEmpty()) {
+                Text(
+                    text = "Saved anchors (max TTL ${CLOUD_ANCHOR_MAX_TTL_DAYS} days):",
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+                Column {
+                    registry.entries.forEach { entry ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = entry.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.weight(1f)
+                            )
+                            OutlinedButton(onClick = {
+                                resolveId = entry.cloudAnchorId
+                            }) { Text("Use") }
+                            TextButton(onClick = { registry.remove(entry.name) }) {
+                                Text("Forget")
+                            }
+                        }
+                    }
+                }
             }
         }
     ) {

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/common/CloudAnchorStoreTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/common/CloudAnchorStoreTest.kt
@@ -1,0 +1,135 @@
+package io.github.sceneview.demo.common
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for the persistent Cloud Anchor registry — issue #1734.
+ *
+ * Robolectric provides a real `SharedPreferences` so the JSON round-trip,
+ * upsert-by-name, and TTL clamp can be exercised on the JVM.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CloudAnchorStoreTest {
+
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    private lateinit var store: CloudAnchorStore
+
+    @Before
+    fun setUp() {
+        // Wipe between tests so each one starts clean.
+        context.getSharedPreferences("io.github.sceneview.demo.cloudanchor", 0)
+            .edit().clear().commit()
+        store = CloudAnchorStore(context)
+    }
+
+    @Test
+    fun `empty store loads as empty list`() {
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `round-trips entries through SharedPreferences`() {
+        val now = 1_000_000L
+        val entry = CloudAnchorEntry(
+            name = "Kitchen wall",
+            cloudAnchorId = "ua-xxx-yyy",
+            expiryEpochMillis = now + 365L * 86_400_000L,
+        )
+        store.save(listOf(entry))
+
+        val reloaded = CloudAnchorStore(context).load()
+        assertEquals(1, reloaded.size)
+        assertEquals(entry, reloaded.first())
+    }
+
+    @Test
+    fun `registry replaces entries with same name (latest wins)`() {
+        val registry = CloudAnchorRegistry(initial = emptyList(), store = store)
+        registry.save(name = "spot", cloudAnchorId = "ua-1", ttlDays = 1, nowEpochMillis = 0L)
+        registry.save(name = "spot", cloudAnchorId = "ua-2", ttlDays = 1, nowEpochMillis = 0L)
+
+        assertEquals(1, registry.entries.size)
+        assertEquals("ua-2", registry.entries.first().cloudAnchorId)
+    }
+
+    @Test
+    fun `registry clamps ttl to max 365 days`() {
+        val registry = CloudAnchorRegistry(initial = emptyList(), store = store)
+        registry.save(
+            name = "huge",
+            cloudAnchorId = "ua-big",
+            ttlDays = 9_999,
+            nowEpochMillis = 0L,
+        )
+        val expected = 365L * 86_400_000L
+        assertEquals(expected, registry.entries.first().expiryEpochMillis)
+    }
+
+    @Test
+    fun `registry clamps ttl to min 1 day`() {
+        val registry = CloudAnchorRegistry(initial = emptyList(), store = store)
+        registry.save(
+            name = "zero",
+            cloudAnchorId = "ua-zero",
+            ttlDays = 0,
+            nowEpochMillis = 0L,
+        )
+        // Clamped to 1 day, not 0.
+        val expected = 86_400_000L
+        assertEquals(expected, registry.entries.first().expiryEpochMillis)
+    }
+
+    @Test
+    fun `pruneExpired drops entries whose TTL elapsed`() {
+        val registry = CloudAnchorRegistry(initial = emptyList(), store = store)
+        registry.save("fresh", "ua-fresh", ttlDays = 30, nowEpochMillis = 0L)
+        registry.save("stale", "ua-stale", ttlDays = 1, nowEpochMillis = 0L)
+
+        // Simulate "now = 2 days later"
+        registry.pruneExpired(nowEpochMillis = 2L * 86_400_000L)
+
+        assertEquals(1, registry.entries.size)
+        assertEquals("fresh", registry.entries.first().name)
+    }
+
+    @Test
+    fun `pruneExpired persists the trimmed list`() {
+        val registry = CloudAnchorRegistry(initial = emptyList(), store = store)
+        registry.save("stale", "ua-stale", ttlDays = 1, nowEpochMillis = 0L)
+        registry.pruneExpired(nowEpochMillis = 365L * 86_400_000L)
+
+        val reloaded = CloudAnchorStore(context).load()
+        assertTrue(reloaded.isEmpty())
+    }
+
+    @Test
+    fun `privacy acceptance round-trips`() {
+        assertFalse(store.hasAcceptedPrivacy())
+        store.setAcceptedPrivacy(true)
+        assertTrue(CloudAnchorStore(context).hasAcceptedPrivacy())
+    }
+
+    @Test
+    fun `isExpired returns true at or after expiry`() {
+        val entry = CloudAnchorEntry("x", "ua", expiryEpochMillis = 1_000L)
+        assertFalse(entry.isExpired(nowEpochMillis = 0L))
+        assertTrue(entry.isExpired(nowEpochMillis = 1_000L))
+        assertTrue(entry.isExpired(nowEpochMillis = 9_999L))
+    }
+
+    @Test
+    fun `corrupt JSON loads as empty without throwing`() {
+        context.getSharedPreferences("io.github.sceneview.demo.cloudanchor", 0)
+            .edit().putString("entries", "{not valid json").commit()
+        assertNotNull(store.load())
+        assertTrue(store.load().isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `ARCloudAnchorDemo` with a SharedPreferences-backed registry so users can save a hosted Cloud Anchor under a name and re-resolve it on a future launch — the persistent-cloud-anchor pattern from arcore-android-sdk's `persistent_cloud_anchor_java` sample.
- New `CloudAnchorStore` + `rememberCloudAnchorRegistry` in `samples/android-demo/.../common/`: persists `{name → cloudAnchorId, expiryEpochMillis}`, clamps `ttlDays` to ARCore's `1..365` range, and prunes expired entries on start.
- One-time privacy disclosure dialog before the first host call (required by ARCore's terms — hosting uploads visual feature points to Google's Cloud Anchor service).
- 10 Robolectric unit tests cover the JSON round-trip, upsert-by-name, TTL clamp, pruneExpired, privacy flag, and corrupt-JSON recovery.
- `llms.txt` + `docs/docs/llms.txt` document the 365-day TTL cap, the persistence pattern, and the privacy disclosure requirement.

Closes #1734

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — clean
- [x] `./gradlew :samples:android-demo:testDebugUnitTest --tests "io.github.sceneview.demo.common.CloudAnchorStoreTest"` — 10/10 passing
- [ ] **⚠️ NEEDS VISUAL QA before merge** — Cloud Anchor host/resolve requires the ARCore Cloud API key and a real device; emulator can only smoke-test that the controls render. Suggested manual flow: place anchor → "Host & save" with a name → kill app → relaunch → tap "Use" on the saved entry → "Resolve". Verify the privacy dialog appears once and never again.

## Tier 1 self-review

| Angle | Result |
|---|---|
| Compile | Clean. Adds 6 new Compose imports + 3 helpers from the new `common/` package. |
| Unit tests | 10 new Robolectric tests, all passing. |
| Threading | All registry mutations happen from Compose state (main thread). JSON IO is `apply()` (async). |
| Privacy | One-time `AlertDialog` gated on `rememberCloudAnchorPrivacyAccepted()`. Acceptance persists across launches. |
| API surface | New helper lives in `samples/android-demo/.../common/` — sample-side only, not part of the public library. |

## Notes
- The `cloudNode.host(session, ttlDays = 365) { id, state -> registry.save(name, id, 365) }` extra callback is layered on top of the existing `onHosted` callback fired by the composable — both fire (status update + persistence).
- `CloudAnchorNode.host` already takes `ttlDays` since 1.33 — no library-side change was needed for #1734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)