### PR TITLE
feat(arsceneview): Cloud Anchor ttlDays + local registry helper (#1734)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/CloudAnchorRegistry.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/CloudAnchorRegistry.kt
@@ -1,0 +1,223 @@
+package io.github.sceneview.ar
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.github.sceneview.ar.node.CloudAnchorNode
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A single Cloud Anchor entry tracked by a [CloudAnchorRegistry].
+ *
+ * Each entry pairs a user-meaningful [name] with the ARCore [cloudAnchorId] returned from
+ * [CloudAnchorNode.host], plus the wall-clock host time and the requested [ttlDays] so callers
+ * can detect when a hosted anchor has expired on Google's ARCore API and should no longer be
+ * resolved.
+ *
+ * @param name           Caller-defined display name (e.g. "Living room marker"). Keys the entry.
+ * @param cloudAnchorId  The ARCore-issued Cloud Anchor ID. Pass to
+ *                       [CloudAnchorNode.Companion.resolve] to re-attach across launches.
+ * @param hostedAtEpochMs Wall-clock time (`System.currentTimeMillis()`) when the anchor was hosted.
+ * @param ttlDays        The ttl value passed to [CloudAnchorNode.host]; in `1..365`.
+ */
+data class CloudAnchorEntry(
+    val name: String,
+    val cloudAnchorId: String,
+    val hostedAtEpochMs: Long,
+    val ttlDays: Int
+) {
+    init {
+        require(ttlDays in CloudAnchorNode.TTL_DAYS_RANGE) {
+            "ttlDays must be in ${CloudAnchorNode.TTL_DAYS_RANGE}, was $ttlDays."
+        }
+    }
+
+    /**
+     * Returns `true` if the anchor's ttl window has elapsed relative to [now] (defaults to the
+     * current wall-clock time). Expired entries are no longer resolvable on Google's ARCore API
+     * and should typically be removed from the registry.
+     */
+    fun isExpired(now: Long = System.currentTimeMillis()): Boolean =
+        now >= hostedAtEpochMs + ttlDays * MILLIS_PER_DAY
+
+    /**
+     * The wall-clock epoch ms at which this anchor's ttl window ends.
+     * `resolve()` on an ID past this point will fail with `CloudAnchorState.ERROR_RESOLVING_*`.
+     */
+    val expiresAtEpochMs: Long
+        get() = hostedAtEpochMs + ttlDays * MILLIS_PER_DAY
+
+    internal fun toJson(): JSONObject = JSONObject()
+        .put(KEY_NAME, name)
+        .put(KEY_CLOUD_ANCHOR_ID, cloudAnchorId)
+        .put(KEY_HOSTED_AT, hostedAtEpochMs)
+        .put(KEY_TTL_DAYS, ttlDays)
+
+    companion object {
+        internal const val MILLIS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+        private const val KEY_NAME = "name"
+        private const val KEY_CLOUD_ANCHOR_ID = "cloudAnchorId"
+        private const val KEY_HOSTED_AT = "hostedAtEpochMs"
+        private const val KEY_TTL_DAYS = "ttlDays"
+
+        internal fun fromJson(o: JSONObject): CloudAnchorEntry = CloudAnchorEntry(
+            name = o.getString(KEY_NAME),
+            cloudAnchorId = o.getString(KEY_CLOUD_ANCHOR_ID),
+            hostedAtEpochMs = o.getLong(KEY_HOSTED_AT),
+            ttlDays = o.getInt(KEY_TTL_DAYS)
+        )
+    }
+}
+
+/**
+ * Lightweight local store for ARCore Cloud Anchor IDs that an app has hosted (or wants to
+ * remember after resolving). The library does not persist anchors itself — Cloud Anchors are
+ * server-side state managed by Google's ARCore API — but apps that host long-ttl anchors
+ * typically need a small client-side index keyed by a user-meaningful name so the IDs can be
+ * passed back to [CloudAnchorNode.Companion.resolve] on the next launch.
+ *
+ * Implementations must be safe to call from the main thread (no blocking I/O on hot paths).
+ * The default [SharedPreferencesCloudAnchorRegistry] is backed by an apply-based
+ * [SharedPreferences] write, which is non-blocking.
+ *
+ * ### Privacy
+ *
+ * The IDs stored here are opaque tokens, not personal data, but the anchors they reference were
+ * hosted by uploading visual features from the user's surroundings to Google. Apps must surface
+ * a clear in-app disclosure (see [CloudAnchorNode.host]'s KDoc).
+ *
+ * ### Typical usage
+ *
+ * ```kotlin
+ * val registry = SharedPreferencesCloudAnchorRegistry(context)
+ *
+ * // On host success:
+ * cloudAnchorNode.host(session, ttlDays = 7) { id, state ->
+ *     if (id != null && !state.isError) {
+ *         registry.add(CloudAnchorEntry(
+ *             name = "Living room marker",
+ *             cloudAnchorId = id,
+ *             hostedAtEpochMs = System.currentTimeMillis(),
+ *             ttlDays = 7
+ *         ))
+ *     }
+ * }
+ *
+ * // On next launch:
+ * registry.list().filterNot { it.isExpired() }.forEach { entry ->
+ *     CloudAnchorNode.resolve(engine, session, entry.cloudAnchorId) { state, node -> /* ... */ }
+ * }
+ * ```
+ */
+interface CloudAnchorRegistry {
+
+    /**
+     * Inserts or replaces the entry keyed by [CloudAnchorEntry.name].
+     */
+    fun add(entry: CloudAnchorEntry)
+
+    /**
+     * Removes the entry with the given [name], if any. Returns `true` if an entry was removed.
+     */
+    fun remove(name: String): Boolean
+
+    /**
+     * Returns the entry with the given [name], or `null` if no such entry is stored.
+     */
+    fun get(name: String): CloudAnchorEntry?
+
+    /**
+     * Returns a snapshot list of all stored entries (insertion order not guaranteed).
+     */
+    fun list(): List<CloudAnchorEntry>
+
+    /**
+     * Removes every entry from the registry.
+     */
+    fun clear()
+
+    /**
+     * Removes every entry whose [CloudAnchorEntry.isExpired] returns `true` at [now].
+     * Returns the number of entries removed.
+     */
+    fun purgeExpired(now: Long = System.currentTimeMillis()): Int {
+        var removed = 0
+        list().forEach { entry ->
+            if (entry.isExpired(now) && remove(entry.name)) removed++
+        }
+        return removed
+    }
+}
+
+/**
+ * Default [CloudAnchorRegistry] implementation backed by a per-app [SharedPreferences] file.
+ * Entries are serialised as a single JSON array under the [PREFS_KEY] key. All writes use
+ * `apply()` so callers can invoke `add`/`remove`/`clear` from the main thread without blocking.
+ *
+ * @param prefs The [SharedPreferences] file to read/write. Defaults to a dedicated
+ *              `"sceneview_cloud_anchors"` preferences file in `MODE_PRIVATE`.
+ */
+class SharedPreferencesCloudAnchorRegistry(
+    private val prefs: SharedPreferences
+) : CloudAnchorRegistry {
+
+    /**
+     * Convenience constructor that opens (or creates) the default
+     * `"sceneview_cloud_anchors"` [SharedPreferences] file in `MODE_PRIVATE`.
+     */
+    constructor(context: Context, prefsName: String = DEFAULT_PREFS_NAME) : this(
+        context.applicationContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    )
+
+    override fun add(entry: CloudAnchorEntry) {
+        val updated = readAll().toMutableMap()
+        updated[entry.name] = entry
+        writeAll(updated.values)
+    }
+
+    override fun remove(name: String): Boolean {
+        val current = readAll()
+        if (name !in current) return false
+        val updated = current.toMutableMap().apply { remove(name) }
+        writeAll(updated.values)
+        return true
+    }
+
+    override fun get(name: String): CloudAnchorEntry? = readAll()[name]
+
+    override fun list(): List<CloudAnchorEntry> = readAll().values.toList()
+
+    override fun clear() {
+        prefs.edit().remove(PREFS_KEY).apply()
+    }
+
+    private fun readAll(): Map<String, CloudAnchorEntry> {
+        val raw = prefs.getString(PREFS_KEY, null) ?: return emptyMap()
+        return try {
+            val arr = JSONArray(raw)
+            val out = LinkedHashMap<String, CloudAnchorEntry>(arr.length())
+            for (i in 0 until arr.length()) {
+                val entry = CloudAnchorEntry.fromJson(arr.getJSONObject(i))
+                out[entry.name] = entry
+            }
+            out
+        } catch (_: Exception) {
+            // Corrupt payload — surface nothing rather than crashing the app.
+            emptyMap()
+        }
+    }
+
+    private fun writeAll(entries: Collection<CloudAnchorEntry>) {
+        val arr = JSONArray()
+        entries.forEach { arr.put(it.toJson()) }
+        prefs.edit().putString(PREFS_KEY, arr.toString()).apply()
+    }
+
+    companion object {
+        /** Default [SharedPreferences] file name used by the no-`prefs` constructor. */
+        const val DEFAULT_PREFS_NAME: String = "sceneview_cloud_anchors"
+
+        /** SharedPreferences key under which the JSON-encoded entry array is stored. */
+        const val PREFS_KEY: String = "entries"
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/CloudAnchorNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/CloudAnchorNode.kt
@@ -54,18 +54,38 @@ open class CloudAnchorNode constructor(
     var hostTask: HostCloudAnchorFuture? = null
 
     /**
-     * Hosts a Cloud Anchor based on the [Anchor]
+     * Hosts a Cloud Anchor based on the [Anchor].
      *
-     * @param ttlDays The lifetime of the anchor in days.
+     * **Persistence — `ttlDays`.** ARCore lets the host specify how many days the cloud anchor
+     * lives on Google's ARCore API before being auto-deleted. The valid range is **1..365** days
+     * (inclusive). For short-lived collaborative sessions, `ttlDays = 1` (the default and ARCore's
+     * legacy `hostCloudAnchor` behaviour) is enough. For "leave behind" multi-day or multi-session
+     * experiences (e.g. a treasure hunt that persists for a week), pass a larger value. Pair this
+     * with a [io.github.sceneview.ar.CloudAnchorRegistry] to remember which IDs your app has
+     * hosted/resolved across launches.
+     *
+     * **Privacy disclosure (required).** ARCore Cloud Anchors upload feature points from the
+     * user's surroundings to Google. Apps using Cloud Anchors must surface a clear in-app
+     * disclosure to the user explaining this data collection and link to Google's ARCore data
+     * policy: https://developers.google.com/ar/data-privacy. See the ARCloudAnchorDemo sample
+     * for a reference disclosure UI.
+     *
+     * @param ttlDays    The lifetime of the anchor in days. Must be in `1..365` (inclusive);
+     *                   any value outside this range will throw [IllegalArgumentException].
+     *                   Defaults to `1` for parity with the legacy ARCore default.
      * @param onCompleted Called when the task completes successfully or with an error.
      *
-     * @see [Session.hostCloudAnchorWithTtl] for more details.
+     * @throws IllegalArgumentException if [ttlDays] is not in `1..365`.
+     * @see [Session.hostCloudAnchorAsync] for more details.
      */
     fun host(
         session: Session,
         ttlDays: Int = 1,
         onCompleted: ((cloudAnchorId: String?, state: CloudAnchorState) -> Unit)? = null
     ) {
+        require(ttlDays in TTL_DAYS_RANGE) {
+            "ttlDays must be in $TTL_DAYS_RANGE (ARCore Cloud Anchor persistence limit), was $ttlDays."
+        }
         cancelHost()
         hostTask = session.hostCloudAnchorAsync(anchor, ttlDays) { cloudAnchorId, state ->
             onHosted(cloudAnchorId, state)
@@ -93,6 +113,12 @@ open class CloudAnchorNode constructor(
     }
 
     companion object {
+        /**
+         * Valid range (inclusive) for [host]'s `ttlDays` parameter, mirroring the
+         * ARCore Cloud Anchor persistence limit of 1..365 days.
+         */
+        val TTL_DAYS_RANGE: IntRange = 1..365
+
         /**
          * Resolves a Cloud Anchor
          *

--- a/arsceneview/src/test/java/io/github/sceneview/ar/CloudAnchorRegistryTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/CloudAnchorRegistryTest.kt
@@ -1,0 +1,205 @@
+package io.github.sceneview.ar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * JVM unit tests for [CloudAnchorEntry] and [SharedPreferencesCloudAnchorRegistry]
+ * — the local Cloud Anchor index helper added for
+ * [#1734](https://github.com/sceneview/sceneview/issues/1734).
+ *
+ * These tests exercise:
+ * - `ttlDays` validation at construction time (1..365 inclusive).
+ * - `isExpired()` / `expiresAtEpochMs` math against a fixed wall-clock.
+ * - The `SharedPreferences`-backed default impl: add / remove / get / list / clear,
+ *   replacement semantics on duplicate keys, corrupt-payload tolerance, and `purgeExpired`.
+ *
+ * Robolectric provides a real in-memory [android.content.SharedPreferences] backed by
+ * `ShadowSharedPreferences` so we can hit the JSON serialisation path end-to-end without
+ * a device.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class CloudAnchorRegistryTest {
+
+    private val context: android.content.Context get() = RuntimeEnvironment.getApplication()
+
+    private fun freshRegistry(): SharedPreferencesCloudAnchorRegistry {
+        // Use a per-test prefs file to avoid cross-test bleed.
+        val name = "sceneview_cloud_anchors_test_${System.nanoTime()}"
+        return SharedPreferencesCloudAnchorRegistry(context, name)
+    }
+
+    private fun entry(
+        name: String = "marker",
+        cloudAnchorId: String = "ca-$name",
+        hostedAtEpochMs: Long = 1_700_000_000_000L,
+        ttlDays: Int = 1
+    ) = CloudAnchorEntry(
+        name = name,
+        cloudAnchorId = cloudAnchorId,
+        hostedAtEpochMs = hostedAtEpochMs,
+        ttlDays = ttlDays
+    )
+
+    // ── CloudAnchorEntry ─────────────────────────────────────────────────────
+
+    @Test
+    fun `entry rejects ttlDays below 1`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            entry(ttlDays = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            entry(ttlDays = -5)
+        }
+    }
+
+    @Test
+    fun `entry rejects ttlDays above 365`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            entry(ttlDays = 366)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            entry(ttlDays = 10_000)
+        }
+    }
+
+    @Test
+    fun `entry accepts both inclusive boundaries of TTL_DAYS_RANGE`() {
+        // No exception:
+        entry(ttlDays = 1)
+        entry(ttlDays = 365)
+    }
+
+    @Test
+    fun `isExpired returns false strictly before the ttl window ends`() {
+        val hostedAt = 1_700_000_000_000L
+        val e = entry(hostedAtEpochMs = hostedAt, ttlDays = 7)
+        assertFalse("Just after host", e.isExpired(hostedAt + 1L))
+        // One ms before expiry:
+        assertFalse(e.isExpired(e.expiresAtEpochMs - 1L))
+    }
+
+    @Test
+    fun `isExpired returns true at and after the ttl window end`() {
+        val hostedAt = 1_700_000_000_000L
+        val e = entry(hostedAtEpochMs = hostedAt, ttlDays = 7)
+        assertTrue("At the exact expiry instant", e.isExpired(e.expiresAtEpochMs))
+        assertTrue("Long after expiry", e.isExpired(e.expiresAtEpochMs + 999_999L))
+    }
+
+    @Test
+    fun `expiresAtEpochMs is hostedAt plus ttlDays in millis`() {
+        val hostedAt = 1_700_000_000_000L
+        val e = entry(hostedAtEpochMs = hostedAt, ttlDays = 3)
+        assertEquals(hostedAt + 3L * 24 * 60 * 60 * 1000, e.expiresAtEpochMs)
+    }
+
+    // ── SharedPreferencesCloudAnchorRegistry ─────────────────────────────────
+
+    @Test
+    fun `add then get returns the same entry`() {
+        val r = freshRegistry()
+        val e = entry()
+        r.add(e)
+        assertEquals(e, r.get(e.name))
+    }
+
+    @Test
+    fun `add replaces the existing entry with the same name`() {
+        val r = freshRegistry()
+        r.add(entry(name = "k", cloudAnchorId = "id-1", ttlDays = 1))
+        r.add(entry(name = "k", cloudAnchorId = "id-2", ttlDays = 30))
+        val stored = r.get("k")
+        assertNotNull(stored)
+        assertEquals("id-2", stored!!.cloudAnchorId)
+        assertEquals(30, stored.ttlDays)
+        assertEquals(1, r.list().size)
+    }
+
+    @Test
+    fun `list returns all stored entries`() {
+        val r = freshRegistry()
+        r.add(entry(name = "a", cloudAnchorId = "ca-a"))
+        r.add(entry(name = "b", cloudAnchorId = "ca-b"))
+        r.add(entry(name = "c", cloudAnchorId = "ca-c"))
+        val ids = r.list().map { it.cloudAnchorId }.toSet()
+        assertEquals(setOf("ca-a", "ca-b", "ca-c"), ids)
+    }
+
+    @Test
+    fun `get returns null for an unknown name`() {
+        val r = freshRegistry()
+        r.add(entry(name = "a"))
+        assertNull(r.get("missing"))
+    }
+
+    @Test
+    fun `remove returns true when an entry was removed and false otherwise`() {
+        val r = freshRegistry()
+        r.add(entry(name = "a"))
+        assertTrue(r.remove("a"))
+        assertNull(r.get("a"))
+        assertFalse("Second remove must be a no-op", r.remove("a"))
+        assertFalse("Unknown name must be a no-op", r.remove("never-stored"))
+    }
+
+    @Test
+    fun `clear removes every entry`() {
+        val r = freshRegistry()
+        r.add(entry(name = "a"))
+        r.add(entry(name = "b"))
+        r.clear()
+        assertTrue(r.list().isEmpty())
+    }
+
+    @Test
+    fun `entries survive a fresh registry instance on the same prefs file`() {
+        val prefsName = "sceneview_cloud_anchors_persist_${System.nanoTime()}"
+        val first = SharedPreferencesCloudAnchorRegistry(context, prefsName)
+        first.add(entry(name = "persisted", cloudAnchorId = "ca-persisted", ttlDays = 14))
+        val second = SharedPreferencesCloudAnchorRegistry(context, prefsName)
+        val read = second.get("persisted")
+        assertNotNull(read)
+        assertEquals("ca-persisted", read!!.cloudAnchorId)
+        assertEquals(14, read.ttlDays)
+    }
+
+    @Test
+    fun `corrupt payload yields an empty registry rather than crashing`() {
+        val prefsName = "sceneview_cloud_anchors_corrupt_${System.nanoTime()}"
+        // Write garbage under the registry's PREFS_KEY directly:
+        context.getSharedPreferences(prefsName, android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putString(SharedPreferencesCloudAnchorRegistry.PREFS_KEY, "not-json")
+            .apply()
+        val r = SharedPreferencesCloudAnchorRegistry(context, prefsName)
+        assertTrue(r.list().isEmpty())
+        assertNull(r.get("anything"))
+        // Subsequent writes still work:
+        r.add(entry(name = "fresh"))
+        assertEquals("fresh", r.get("fresh")?.name)
+    }
+
+    @Test
+    fun `purgeExpired removes only expired entries and returns the removed count`() {
+        val r = freshRegistry()
+        val now = 1_700_000_000_000L
+        val twoDays = 2L * CloudAnchorEntry.MILLIS_PER_DAY
+        r.add(entry(name = "fresh", hostedAtEpochMs = now, ttlDays = 7))
+        r.add(entry(name = "expired-1", hostedAtEpochMs = now - twoDays, ttlDays = 1))
+        r.add(entry(name = "expired-2", hostedAtEpochMs = now - twoDays * 10, ttlDays = 1))
+        val removed = r.purgeExpired(now = now)
+        assertEquals(2, removed)
+        assertEquals(setOf("fresh"), r.list().map { it.name }.toSet())
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/CloudAnchorNodeTtlRangeTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/CloudAnchorNodeTtlRangeTest.kt
@@ -1,0 +1,25 @@
+package io.github.sceneview.ar.node
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * JVM unit tests for [CloudAnchorNode.TTL_DAYS_RANGE].
+ *
+ * The full `host()` path requires a live ARCore `Session` + Filament `Engine` (JNI), but the
+ * `ttlDays` validation lives in a [kotlin.require] block executed BEFORE the ARCore call, so the
+ * range constant itself is the public contract. Pin it here so any future widening/narrowing of
+ * the allowed range is intentional (and the corresponding [io.github.sceneview.ar.CloudAnchorEntry]
+ * validation stays in lockstep).
+ *
+ * See [#1734](https://github.com/sceneview/sceneview/issues/1734).
+ */
+class CloudAnchorNodeTtlRangeTest {
+
+    @Test
+    fun `TTL_DAYS_RANGE pins the ARCore 1 to 365 day persistence limit`() {
+        // ARCore's hostCloudAnchorAsync rejects ttlDays outside this range — pin so a future
+        // refactor doesn't silently widen the contract.
+        assertEquals(1..365, CloudAnchorNode.TTL_DAYS_RANGE)
+    }
+}

--- a/changelog.d/1734-cloud-anchor-ttldays.md
+++ b/changelog.d/1734-cloud-anchor-ttldays.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- `arsceneview`: surfaced `CloudAnchorNode.TTL_DAYS_RANGE = 1..365` and added the `CloudAnchorRegistry` interface plus a `SharedPreferencesCloudAnchorRegistry` default for persisting hosted Cloud Anchor IDs (name → cloudAnchorId, hostedAt, ttlDays) across app launches, with `isExpired()` / `purgeExpired()` helpers. `CloudAnchorNode.host()` now validates `ttlDays ∈ 1..365` and documents the required ARCore data-privacy disclosure (#1734).

--- a/llms.txt
+++ b/llms.txt
@@ -889,7 +889,66 @@ ARSceneView(
     apply: CloudAnchorNode.() -> Unit = {},
     content: (@Composable NodeScope.() -> Unit)? = null
 )
+
+// Imperative host call with explicit ttl (1..365 days, ARCore persistence limit):
+cloudAnchorNode.host(session, ttlDays = 7) { cloudAnchorId, state ->
+    if (cloudAnchorId != null && !state.isError) {
+        // Persist the ID locally so we can re-resolve across launches:
+        registry.add(CloudAnchorEntry(
+            name = "Living room marker",
+            cloudAnchorId = cloudAnchorId,
+            hostedAtEpochMs = System.currentTimeMillis(),
+            ttlDays = 7
+        ))
+    }
+}
 ```
+
+**Persistence — `ttlDays`.** `CloudAnchorNode.host(session, ttlDays = 1)` accepts any value in `CloudAnchorNode.TTL_DAYS_RANGE` (= `1..365`, inclusive). Values outside this range throw `IllegalArgumentException`. Pick a short ttl for ephemeral collaborative sessions, a longer one (e.g. 7..30) for "leave behind" multi-day experiences.
+
+**Privacy disclosure (required).** ARCore Cloud Anchors upload feature points from the user's surroundings to Google. Surface a clear in-app disclosure and link to the ARCore data policy (https://developers.google.com/ar/data-privacy) before hosting.
+
+### CloudAnchorRegistry — local persistence helper for hosted Cloud Anchor IDs
+
+The library does NOT manage Cloud Anchor lifetime — that lives server-side on Google's ARCore API. But apps that host long-ttl anchors typically want a small client-side index keyed by a user-meaningful name so the IDs can be passed back to `CloudAnchorNode.resolve(...)` on the next launch. `CloudAnchorRegistry` is exactly that helper.
+
+```kotlin
+data class CloudAnchorEntry(
+    val name: String,
+    val cloudAnchorId: String,
+    val hostedAtEpochMs: Long,
+    val ttlDays: Int                       // validated against 1..365 at construction
+) {
+    fun isExpired(now: Long = System.currentTimeMillis()): Boolean
+    val expiresAtEpochMs: Long
+}
+
+interface CloudAnchorRegistry {
+    fun add(entry: CloudAnchorEntry)        // insert or replace by name
+    fun remove(name: String): Boolean
+    fun get(name: String): CloudAnchorEntry?
+    fun list(): List<CloudAnchorEntry>
+    fun clear()
+    fun purgeExpired(now: Long = System.currentTimeMillis()): Int
+}
+
+// Default implementation — SharedPreferences-backed, non-blocking writes (apply()):
+class SharedPreferencesCloudAnchorRegistry(
+    prefs: SharedPreferences
+) : CloudAnchorRegistry {
+    constructor(context: Context, prefsName: String = "sceneview_cloud_anchors")
+}
+```
+
+**Re-resolve across launches:**
+```kotlin
+val registry = SharedPreferencesCloudAnchorRegistry(context)
+registry.list().filterNot { it.isExpired() }.forEach { entry ->
+    CloudAnchorNode.resolve(engine, session, entry.cloudAnchorId) { state, node -> /* attach */ }
+}
+```
+
+Threading: safe to call from the main thread — `SharedPreferences.edit().apply()` is non-blocking.
 
 ### TrackableNode — generic trackable
 ```kotlin


### PR DESCRIPTION
Closes #1734.

## Summary

Two coordinated additions on the ARCore Cloud Anchor surface (part of #1729 — May 2026 ARCore-samples inspection):

1. **`ttlDays` validation surfaced on `CloudAnchorNode.host()`.** The existing `host(session, ttlDays = 1, ...)` API now `require()`s `ttlDays in 1..365` (the ARCore Cloud Anchor persistence limit), fast-failing before the JNI call rather than returning a generic `ERROR_HOSTING_*` state. The new `CloudAnchorNode.TTL_DAYS_RANGE = 1..365` is exported as the single source of truth so callers and `CloudAnchorEntry` stay in lockstep.

2. **`CloudAnchorRegistry` — small local helper for `(name -> cloudAnchorId, hostedAt, ttlDays)` entries.** The library does not manage Cloud Anchor lifetime (that's server-side on Google's ARCore API), but apps that host long-ttl anchors need a tiny client-side index keyed by a user-meaningful name so the IDs can be passed back to `CloudAnchorNode.resolve(...)` on the next launch. Shape:

```kotlin
data class CloudAnchorEntry(
    val name: String,
    val cloudAnchorId: String,
    val hostedAtEpochMs: Long,
    val ttlDays: Int                       // validated against 1..365 at construction
) {
    fun isExpired(now: Long = System.currentTimeMillis()): Boolean
    val expiresAtEpochMs: Long
}

interface CloudAnchorRegistry {
    fun add(entry: CloudAnchorEntry)        // insert or replace by name
    fun remove(name: String): Boolean
    fun get(name: String): CloudAnchorEntry?
    fun list(): List<CloudAnchorEntry>
    fun clear()
    fun purgeExpired(now: Long = System.currentTimeMillis()): Int
}

class SharedPreferencesCloudAnchorRegistry(prefs: SharedPreferences) : CloudAnchorRegistry {
    constructor(context: Context, prefsName: String = "sceneview_cloud_anchors")
}
```

The default `SharedPreferencesCloudAnchorRegistry` serialises entries as a JSON array and writes via `apply()` so the API is safe to call from the main thread. Corrupt payloads surface as an empty registry rather than crashing the host app.

## Threading

- `host()` keeps ARCore on the main thread (unchanged).
- Registry writes use `SharedPreferences.edit().apply()` (non-blocking on hot paths).

## Privacy disclosure

`CloudAnchorNode.host()` KDoc now documents the required in-app ARCore data-policy disclosure (https://developers.google.com/ar/data-privacy), and the same paragraph appears in `llms.txt` so AI-generated samples surface it.

## Cross-platform parity

iOS (`SceneViewSwift`) does NOT ship a Cloud Anchor surface — RealityKit + ARKit have no ARCore Cloud Anchor equivalent, only `ARWorldMap` / `WorldAnchor`-style local persistence. No `ttlDays` / registry work is needed on iOS for this PR. If iOS ever grows a Cloud Anchor adapter, the same registry shape can be ported (`Codable` + `UserDefaults`) — tracked under the existing iOS Cloud Anchor parity work in #894.

## Acceptance for #1734

- [x] Persistence helper (`CloudAnchorRegistry` + `SharedPreferencesCloudAnchorRegistry` default impl)
- [x] Privacy disclosure documented (KDoc on `CloudAnchorNode.host()` + `llms.txt`)
- [ ] `ARCloudAnchorDemo` save + re-resolve — deferred (sample-layer change; the demo lives under `samples/android-demo` which is outside this PR's library scope — opening a follow-up against `samples/` once the helper is published)

## Tests

- `CloudAnchorRegistryTest` (15 tests, Robolectric-backed):
  - `ttlDays` boundary validation (0, -5, 366, 10000 reject; 1 and 365 accept)
  - `isExpired()` / `expiresAtEpochMs` math (strict before, true at-and-after)
  - `add` / `get` / `list` / `remove` / `clear`
  - `add` replaces by name
  - Cross-instance persistence on the same prefs file
  - Corrupt-payload tolerance
  - `purgeExpired` removes only expired entries
- `CloudAnchorNodeTtlRangeTest` (1 test): pins `TTL_DAYS_RANGE = 1..365` so any future widening/narrowing of the public contract is intentional.

Total: **16 new pure-JVM tests**, all passing locally.

## Verify

- `./gradlew :arsceneview:compileReleaseKotlin` — green
- `./gradlew :sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest` — green