### PR TITLE
fix(arsceneview): cache identity tangent buffer in AugmentedFaceNode (#1758)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -122,6 +122,13 @@ open class AugmentedFaceNode(
     // allocated once and reused for the life of the node.
     private var tangentsBuffer: ByteBuffer? = null
 
+    // For unlit materials we upload an identity-quaternion buffer ONCE (mesh creation)
+    // and never touch it again. We track its filled vertex count so a recreate-after-
+    // destroy or vertex-count change re-initialises lazily without the per-frame
+    // (0,0,0,1) write loop the issue (#1758) flagged.
+    private var identityTangentsBuffer: ByteBuffer? = null
+    private var identityTangentsVertexCount: Int = 0
+
     /**
      * The region nodes at the tip of the nose, the detected face's left side of the forehead,
      * the detected face's right side of the forehead.
@@ -281,32 +288,30 @@ open class AugmentedFaceNode(
     }
 
     /**
-     * Builds (or reuses) [tangentsBuffer] and fills it with quaternions computed from
-     * the supplied positions, normals, UVs and indices via Filament's
-     * [SurfaceOrientation]. The returned buffer holds `vertexCount * 16` bytes
-     * (4 floats per vertex) and is rewound to position 0, ready for upload.
-     */
-    /**
      * Identity-quaternion buffer for unlit face mesh — fills the TANGENTS slot once at
      * construction so Filament's stride contract is honoured, then is never re-uploaded.
      * Layout: 4 floats per vertex `(0, 0, 0, 1)` (identity quaternion). The shader
      * never samples it, so the value doesn't matter — but the slot must be the right
      * size and never empty (Filament asserts at build time).
+     *
+     * Cached on the node (separate slot from [tangentsBuffer] so a future toggle of
+     * `computeTangents` doesn't clobber the lit tangents). The (0, 0, 0, 1) write
+     * loop runs at most once per `vertexCount` change — typically exactly once for
+     * the lifetime of the node since ARCore returns a fixed-topology face mesh
+     * (#1758). The previous implementation re-ran the per-vertex write loop on every
+     * call, which was a latent regression risk if this method ever moved back into
+     * the per-frame path.
      */
     private fun identityTangentsBuffer(vertexCount: Int): ByteBuffer {
-        val neededBytes = vertexCount * 4 * 4
-        val buf = tangentsBuffer?.takeIf { it.capacity() >= neededBytes }
-            ?: ByteBuffer.allocateDirect(neededBytes).order(ByteOrder.nativeOrder())
-                .also { tangentsBuffer = it }
-
-        buf.clear()
-        buf.limit(neededBytes)
-        // Write (0, 0, 0, 1) per vertex — identity quaternion. Cheap one-shot pass.
-        val floats = buf.asFloatBuffer()
-        repeat(vertexCount) {
-            floats.put(0f); floats.put(0f); floats.put(0f); floats.put(1f)
+        val (buf, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = identityTangentsBuffer,
+            cachedVertexCount = identityTangentsVertexCount,
+            vertexCount = vertexCount
+        )
+        if (!wasCacheHit) {
+            identityTangentsBuffer = buf
+            identityTangentsVertexCount = vertexCount
         }
-        buf.rewind()
         return buf
     }
 
@@ -363,6 +368,56 @@ open class AugmentedFaceNode(
         }
         runCatching { centerNode.destroy() }
         regionNodes.values.forEach { runCatching { it.destroy() } }
+        // Drop the cached tangent / identity-tangent buffers — direct ByteBuffers are
+        // GC'd eventually, but releasing the reference frees the off-heap memory
+        // immediately when the JVM's Cleaner runs.
+        tangentsBuffer = null
+        identityTangentsBuffer = null
+        identityTangentsVertexCount = 0
         super.destroy()
     }
+}
+
+/**
+ * Pure logic for [AugmentedFaceNode]'s identity-tangent buffer cache (#1758).
+ *
+ * Returns a [ByteBuffer] of `vertexCount * 16` bytes (4 floats per vertex)
+ * filled with `(0, 0, 0, 1)` identity quaternions when first allocated. On a cache
+ * hit (same [vertexCount] and capacity >= needed bytes), the cached buffer is
+ * returned unchanged — **no per-vertex rewrite**, which is the perf bug the issue
+ * flagged.
+ *
+ * Returns the buffer and a boolean indicating whether it was a cache hit. Callers
+ * persist `buf` + `vertexCount` to their own state on a miss.
+ *
+ * Extracted as an internal top-level function so JVM unit tests can exercise the
+ * caching contract without instantiating a Filament Engine or ARCore Session.
+ */
+internal fun obtainIdentityTangentsBuffer(
+    cached: ByteBuffer?,
+    cachedVertexCount: Int,
+    vertexCount: Int
+): Pair<ByteBuffer, Boolean> {
+    val neededBytes = vertexCount * 4 * 4
+    if (cached != null &&
+        cached.capacity() >= neededBytes &&
+        cachedVertexCount == vertexCount
+    ) {
+        cached.rewind()
+        cached.limit(neededBytes)
+        return cached to true
+    }
+
+    val buf = cached?.takeIf { it.capacity() >= neededBytes }
+        ?: ByteBuffer.allocateDirect(neededBytes).order(ByteOrder.nativeOrder())
+
+    buf.clear()
+    buf.limit(neededBytes)
+    // Write (0, 0, 0, 1) per vertex — identity quaternion. Cheap one-shot pass.
+    val floats = buf.asFloatBuffer()
+    repeat(vertexCount) {
+        floats.put(0f); floats.put(0f); floats.put(0f); floats.put(1f)
+    }
+    buf.rewind()
+    return buf to false
 }

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/AugmentedFaceTangentsCacheTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/AugmentedFaceTangentsCacheTest.kt
@@ -1,0 +1,162 @@
+package io.github.sceneview.ar.node
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Pins the identity-tangent buffer cache contract for [AugmentedFaceNode] (#1758).
+ *
+ * The Filament Engine + ARCore [com.google.ar.core.AugmentedFace] plumbing cannot run in a JVM
+ * unit test, so the cache lookup is `internal` ([obtainIdentityTangentsBuffer]) and verified here
+ * in isolation. Without this pin, a regression that re-runs the per-vertex `(0,0,0,1)` write
+ * loop every frame (or reallocates the direct buffer) would only surface on-device under the
+ * unlit ARFaceDemo material and never on CI.
+ */
+class AugmentedFaceTangentsCacheTest {
+
+    /** ARCore face mesh has 468 vertices in practice — picks a representative size. */
+    private val faceVertexCount = 468
+
+    @Test
+    fun `first call allocates a fresh buffer and writes identity quaternions`() {
+        val (buf, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = faceVertexCount
+        )
+
+        assertEquals("first call must be a miss", false, wasCacheHit)
+        assertEquals(
+            "buffer must hold vertexCount * 4 floats * 4 bytes",
+            faceVertexCount * 4 * 4,
+            buf.limit()
+        )
+
+        // Verify the identity-quaternion layout (0, 0, 0, 1) per vertex.
+        val floats = buf.asFloatBuffer()
+        for (v in 0 until faceVertexCount) {
+            assertEquals(0f, floats.get(v * 4 + 0), 0f)
+            assertEquals(0f, floats.get(v * 4 + 1), 0f)
+            assertEquals(0f, floats.get(v * 4 + 2), 0f)
+            assertEquals(1f, floats.get(v * 4 + 3), 0f)
+        }
+    }
+
+    @Test
+    fun `second call at same vertex count is a cache hit returning the same buffer`() {
+        val (first, _) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = faceVertexCount
+        )
+
+        val (second, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = first,
+            cachedVertexCount = faceVertexCount,
+            vertexCount = faceVertexCount
+        )
+
+        assertEquals("second call must be a cache hit", true, wasCacheHit)
+        assertSame("must return the cached buffer instance, not a fresh one", first, second)
+    }
+
+    @Test
+    fun `cache hit does NOT re-run the per-vertex write loop`() {
+        // Allocate, then sabotage the buffer to detect a re-write.
+        val (first, _) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = 4
+        )
+        first.asFloatBuffer().apply {
+            // Overwrite vertex 0's quaternion with garbage.
+            put(0, 9f); put(1, 9f); put(2, 9f); put(3, 9f)
+        }
+
+        val (second, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = first,
+            cachedVertexCount = 4,
+            vertexCount = 4
+        )
+
+        assertEquals(true, wasCacheHit)
+        val floats = second.asFloatBuffer()
+        // Garbage is still there — proves no rewrite happened, which is the whole point:
+        // re-running the loop every frame is the perf bug the issue flagged.
+        assertEquals(9f, floats.get(0), 0f)
+        assertEquals(9f, floats.get(1), 0f)
+        assertEquals(9f, floats.get(2), 0f)
+        assertEquals(9f, floats.get(3), 0f)
+    }
+
+    @Test
+    fun `larger vertex count miss reallocates and rewrites the buffer`() {
+        val (small, _) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = 8
+        )
+
+        val (large, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = small,
+            cachedVertexCount = 8,
+            vertexCount = 16
+        )
+
+        assertEquals("growing vertex count must miss the cache", false, wasCacheHit)
+        assertNotSame("must allocate a new larger direct buffer", small, large)
+        assertEquals(16 * 4 * 4, large.limit())
+
+        val floats = large.asFloatBuffer()
+        // Layout still correct after reallocation.
+        for (v in 0 until 16) {
+            assertEquals(0f, floats.get(v * 4 + 0), 0f)
+            assertEquals(0f, floats.get(v * 4 + 1), 0f)
+            assertEquals(0f, floats.get(v * 4 + 2), 0f)
+            assertEquals(1f, floats.get(v * 4 + 3), 0f)
+        }
+    }
+
+    @Test
+    fun `smaller vertex count after larger one reuses the existing buffer capacity`() {
+        // Edge case: ARCore changes mesh topology mid-session. The capacity check should
+        // allow reuse without a heap-grow allocation.
+        val (large, _) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = 16
+        )
+
+        val (smaller, wasCacheHit) = obtainIdentityTangentsBuffer(
+            cached = large,
+            cachedVertexCount = 16,
+            vertexCount = 8
+        )
+
+        // It's a miss because vertex count differs, but the underlying ByteBuffer
+        // is reused (no fresh allocateDirect call). Sample-check: same identity hash.
+        assertEquals(false, wasCacheHit)
+        assertSame("must reuse the larger backing buffer, not reallocate", large, smaller)
+        assertEquals(8 * 4 * 4, smaller.limit())
+    }
+
+    @Test
+    fun `direct ByteBuffer uses native order so Filament reads correct floats`() {
+        val (buf, _) = obtainIdentityTangentsBuffer(
+            cached = null,
+            cachedVertexCount = 0,
+            vertexCount = 1
+        )
+        assertTrue("must be a direct (off-heap) buffer for Filament JNI", buf.isDirect)
+        assertEquals(
+            "must use native byte order (Filament expects host endianness)",
+            ByteOrder.nativeOrder(),
+            buf.order()
+        )
+    }
+}

--- a/changelog.d/1758-augmented-face-tangent-cache.md
+++ b/changelog.d/1758-augmented-face-tangent-cache.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Cache the identity tangent buffer on `AugmentedFaceNode` ([#1758](https://github.com/sceneview/sceneview/issues/1758)).** The `(0, 0, 0, 1)` identity-quaternion buffer used to honour Filament's FLOAT4 TANGENTS stride contract under unlit face materials is now built once at mesh creation and reused unchanged — no per-vertex rewrite on subsequent calls, even when the cached size matches. JVM unit test pins the cache hit/miss contract.


### PR DESCRIPTION
## Summary

Closes #1758.

`AugmentedFaceNode` allocates an identity-quaternion `(0, 0, 0, 1)` buffer to honour Filament's FLOAT4 TANGENTS stride contract when the face material is unlit (the v4.0.9 default for ARFaceDemo). The previous implementation re-ran the per-vertex `(0,0,0,1)` write loop on every call — fine today because the call site is gated behind `if (meshNode == null)`, but a latent regression risk if that gate ever moves back to the per-frame path.

- Move the identity buffer into its **own cached slot** (separate from `tangentsBuffer` for the lit Mikkelsen quaternions) keyed by vertex count
- Subsequent calls at the same vertex count return the cached buffer unchanged — **no per-vertex rewrite**
- Extracted the cache logic to an `internal` top-level function `obtainIdentityTangentsBuffer` so JVM unit tests can pin the contract without instantiating Filament Engine + ARCore Session
- Drop cached refs in `destroy()` so the off-heap direct memory is released promptly

## Tier-1 self-review

- **Security**: no new attack surface; pure perf change. Direct buffer still uses native byte order for Filament JNI.
- **Threading**: cache state read/written only on the GL render thread (the existing `update()` callsite). No new shared state.
- **API consistency**: no public API change — both new state fields and the helper are `private` / `internal`.
- **Performance**: eliminates a `repeat(vertexCount) { ... }` write loop and avoids a `ByteBuffer.allocateDirect` reallocation on every node-recreate sequence. For unlit ARFaceDemo at 30 fps, the loop was previously running for ~468 vertices = 1872 float writes per call (called once at mesh creation in the current code, but the new cache also defends against future regressions putting it back in the hot path).
- **Docs**: KDoc updated to explain the new cache contract and the regression-risk rationale.

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin` — green
- [x] `./gradlew :arsceneview:testDebugUnitTest --tests "io.github.sceneview.ar.node.AugmentedFaceTangentsCacheTest"` — **6 / 6 tests pass**
- [ ] CI green
- [ ] Visual smoke: ARFaceDemo unaffected (no behavioural change for either lit or unlit materials)

Auto-merge armed on CI green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>