### PR TITLE
fix(build): pin webpack <5.107.0 — restore sceneview-web npm publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,11 @@ plugins {
 plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin) {
     extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension).tap {
         resolution("serialize-javascript", ">=7.0.3")
-        resolution("webpack", ">=5.104.1")
+        // 5.107.0 moved `lib/ModuleNotFoundError` → `lib/errors/ModuleNotFoundError`,
+        // which kotlin-web-helpers still requires by the old path → every
+        // jsBrowserProductionWebpack task crashes. Cap at <5.107.0 until
+        // kotlin-web-helpers ships a fix.
+        resolution("webpack", ">=5.104.1 <5.107.0")
         resolution("webpack-dev-server", ">=5.2.1")
         resolution("path-to-regexp", ">=0.2.2")
         resolution("brace-expansion", ">=1.1.13")


### PR DESCRIPTION
## Why

`v4.11.0` release stalled: `release.yml`'s `Publish sceneview-web to npm` job failed at the build step, and PR #1755's `Build web targets` check fails the same way. Same root cause for both — and it also blocks the unfailing demo CI on any branch that exercises web.

## Root cause

`webpack@5.107.0` (released this week) moved `lib/ModuleNotFoundError.js` → `lib/errors/ModuleNotFoundError.js`. `kotlin-web-helpers/dist/tc-log-error-webpack.js` (bundled with the Kotlin/JS Gradle plugin) still requires the **old** path:

```js
const ModuleNotFoundError = require("webpack/lib/ModuleNotFoundError");
```

So every `jsBrowserProductionWebpack` invocation now crashes with `[webpack-cli] Error: Cannot find module 'webpack/lib/ModuleNotFoundError'`.

The repo's `YarnPlugin` resolution was unbounded above 5.104.1, so yarn happily installed 5.107.0.

## Fix

Tighten the root `build.gradle` Yarn resolution:

```diff
-resolution("webpack", ">=5.104.1")
+resolution("webpack", ">=5.104.1 <5.107.0")
```

Verified locally:
- `webpack@5.106.2` resolves, `webpack/lib/ModuleNotFoundError.js` exists.
- `./gradlew :sceneview-web:jsBrowserProductionWebpack` → BUILD SUCCESSFUL.
- `./gradlew :samples:web-demo:jsBrowserProductionWebpack` → BUILD SUCCESSFUL.

## Follow-up

Lift the upper bound when `kotlin-web-helpers` ships a fix that requires the new path. This is a Kotlin Gradle plugin dependency — track it in the next Kotlin bump.

## Release impact

Once merged, the v4.11.0 npm publish jobs can be re-triggered (manual `workflow_dispatch` of `release.yml` after PR #1755 lands). The `4.11.0` tag, GitHub Release, Maven Central, MCP npm, Dokka, Play Store, App Store have all already published correctly — only `sceneview-web` and `@sceneview-sdk/react-native` on npm are still at 4.10.0.