### PR TITLE
feat(arsceneview): surface ARCore Flash Mode (#1732)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
@@ -154,6 +154,11 @@ import java.util.concurrent.atomic.AtomicReference
  *                                 recordings capture at full camera resolution instead of ARCore's
  *                                 low-res 640×480 CPU-stream default (#1065). Pass `null` to keep
  *                                 ARCore's stock default config.
+ * @param flashMode                ARCore v1.45+ Flash Mode — drives the device torch during the AR
+ *                                 session for low-light tracking ([Config.FlashMode.OFF] /
+ *                                 [Config.FlashMode.TORCH]). Default `OFF`. Support-gated —
+ *                                 unsupported devices / front-camera configs silently downgrade
+ *                                 to `OFF` (#1732).
  * @param sessionConfiguration     Callback to configure the ARCore [Session] and [Config].
  *                                 SceneView pre-sets `config.lightEstimationMode = ENVIRONMENTAL_HDR`
  *                                 (replacing ARCore's `AMBIENT_INTENSITY` default) BEFORE invoking
@@ -263,6 +268,23 @@ fun ARSceneView(
      * Pass `null` to keep ARCore's stock default config, or supply a custom selector.
      */
     sessionCameraConfig: ((Session) -> CameraConfig)? = ::highestResolutionCameraConfig,
+    /**
+     * Drives the device torch during the AR session — ARCore v1.45+ Flash Mode API (#1732).
+     *
+     * - [Config.FlashMode.OFF] (default): no torch.
+     * - [Config.FlashMode.TORCH]: ARCore keeps the back-camera LED on while the session is
+     *   running. Helps tracking in low-light scenes; battery cost is significant — toggle off
+     *   once the user re-enters daylight.
+     *
+     * **Support-gated.** Flash Mode requires (a) ARCore 1.45+ runtime on-device, and (b) a
+     * back-camera config — front-camera sessions never expose a torch. If the device or the
+     * current camera config does not support the requested mode, SceneView silently downgrades
+     * the session to `OFF` (matching the auto-fallback used for unsupported `depthMode`). Apps
+     * that want to surface the support state to the user can call
+     * [com.google.ar.core.Session.isSupported] with a config carrying the desired
+     * [Config.FlashMode] directly.
+     */
+    flashMode: Config.FlashMode = Config.FlashMode.OFF,
     /**
      * Configures the session and verifies that the enabled features in the specified session
      * config are supported with the currently set camera config.
@@ -431,6 +453,7 @@ fun ARSceneView(
     val onTrackingFailureChangedRef = remember { AtomicReference(onTrackingFailureChanged) }
     val sessionConfigurationRef = remember { AtomicReference(sessionConfiguration) }
     val sessionCameraConfigRef = remember { AtomicReference(sessionCameraConfig) }
+    val flashModeRef = remember { AtomicReference(flashMode) }
 
     SideEffect {
         onSessionCreatedRef.set(onSessionCreated)
@@ -442,6 +465,7 @@ fun ARSceneView(
         onTrackingFailureChangedRef.set(onTrackingFailureChanged)
         sessionConfigurationRef.set(sessionConfiguration)
         sessionCameraConfigRef.set(sessionCameraConfig)
+        flashModeRef.set(flashMode)
     }
 
     val prevTrackingFailureRef = remember { AtomicReference<TrackingFailureReason?>(null) }
@@ -530,6 +554,10 @@ fun ARSceneView(
                     // still force DISABLED inside `ARSession.configure()` regardless. Set BEFORE
                     // invoking the user callback so callers can opt back into another mode.
                     config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
+                    // Apply the caller-requested Flash Mode (#1732). Support is verified inside
+                    // ArSession.configure (silently downgraded to OFF if unsupported). Set BEFORE
+                    // the user callback so callers can opt back into a different mode.
+                    config.flashMode = flashModeRef.get() ?: Config.FlashMode.OFF
                     sessionConfigurationRef.get()?.invoke(session, config)
                 }
                 cameraStream?.let { scene.addEntity(it.entity) }
@@ -565,6 +593,19 @@ fun ARSceneView(
         onDispose {
             lifecycle.removeObserver(observer)
             arCore.destroy()
+        }
+    }
+
+    // ── Flash mode reactivity (#1732) ─────────────────────────────────────────────────────────────
+    //
+    // Allow apps to toggle the torch by recomposing with a new `flashMode` value. The session is
+    // reconfigured only when the actual value changes, so flipping unrelated state does not pay
+    // for an ARCore `configure()` call. Support gating + front-camera downgrade is centralised
+    // inside `ArSession.configure()`.
+    LaunchedEffect(flashMode) {
+        val session = arCore.session ?: return@LaunchedEffect
+        if (session.config.flashMode != flashMode) {
+            session.configure { config -> config.flashMode = flashMode }
         }
     }
 
@@ -1189,7 +1230,7 @@ private fun ARScenePreview(modifier: Modifier) {
  * @deprecated Use [ARSceneView] instead. This function is a direct alias provided for backward
  * compatibility with code written against earlier SceneView versions.
  */
-@Deprecated("Use ARSceneView instead", ReplaceWith("ARSceneView(modifier, surfaceType, engine, modelLoader, materialLoader, environmentLoader, sessionFeatures, playbackDataset, sessionCameraConfig, sessionConfiguration, planeRenderer, cameraStream, view, isOpaque, renderer, scene, environment, mainLightNode, fillLightNode, cameraNode, cameraExposure, collisionSystem, viewNodeWindowManager, onSessionCreated, onSessionResumed, onSessionPaused, onSessionFailed, onPlaybackFailed, onSessionUpdated, onTrackingFailureChanged, onGestureListener, onTouchEvent, permissionHandler, lifecycle, content)"))
+@Deprecated("Use ARSceneView instead", ReplaceWith("ARSceneView(modifier, surfaceType, engine, modelLoader, materialLoader, environmentLoader, sessionFeatures, playbackDataset, sessionCameraConfig, flashMode, sessionConfiguration, planeRenderer, cameraStream, view, isOpaque, renderer, scene, environment, mainLightNode, fillLightNode, cameraNode, cameraExposure, collisionSystem, viewNodeWindowManager, onSessionCreated, onSessionResumed, onSessionPaused, onSessionFailed, onPlaybackFailed, onSessionUpdated, onTrackingFailureChanged, onGestureListener, onTouchEvent, permissionHandler, lifecycle, content)"))
 @Composable
 fun ARScene(
     modifier: Modifier = Modifier,
@@ -1201,6 +1242,7 @@ fun ARScene(
     sessionFeatures: Set<Session.Feature> = setOf(),
     playbackDataset: File? = null,
     sessionCameraConfig: ((Session) -> CameraConfig)? = ::highestResolutionCameraConfig,
+    flashMode: Config.FlashMode = Config.FlashMode.OFF,
     sessionConfiguration: ((session: Session, Config) -> Unit)? = null,
     planeRenderer: Boolean = true,
     cameraStream: ARCameraStream? = rememberARCameraStream(materialLoader),
@@ -1239,6 +1281,7 @@ fun ARScene(
     sessionFeatures = sessionFeatures,
     playbackDataset = playbackDataset,
     sessionCameraConfig = sessionCameraConfig,
+    flashMode = flashMode,
     sessionConfiguration = sessionConfiguration,
     planeRenderer = planeRenderer,
     cameraStream = cameraStream,

--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/ArSession.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/ArSession.kt
@@ -73,6 +73,24 @@ class ARSession(
             config.depthMode = Config.DepthMode.DISABLED
         }
 
+        // Flash mode is only available on a subset of devices (and only with a BACK camera config
+        // — front-camera sessions never expose a torch). ARCore throws if a session is configured
+        // with an unsupported FlashMode, so we silently fall back to OFF here, matching the
+        // depthMode auto-fallback above (#1732).
+        //
+        // ARCore doesn't ship an `isFlashModeSupported(FlashMode)` getter (cf. depthMode etc.),
+        // so we test the whole config via `Session.isSupported(config)`. Logic is centralised in
+        // [resolveFlashMode] so it can be exercised without a live Session.
+        config.flashMode = resolveFlashMode(config.flashMode) { mode ->
+            // Temporarily mutate the config to probe support, then restore — `isSupported` is a
+            // read-only check against the native session, so probing is side-effect free.
+            val previous = config.flashMode
+            config.flashMode = mode
+            val supported = isSupported(config)
+            config.flashMode = previous
+            supported
+        }
+
         // Light estimation is not usable with front camera
         if (cameraConfig.facingDirection == CameraConfig.FacingDirection.FRONT
             && config.lightEstimationMode != Config.LightEstimationMode.DISABLED
@@ -135,6 +153,25 @@ class ARSession(
         }
     }
 }
+
+/**
+ * Pure-Kotlin support-gate for [Config.FlashMode] used by [ARSession.configure] (#1732).
+ *
+ * Returns the requested mode if the session supports it; otherwise [Config.FlashMode.OFF].
+ *
+ * Extracted so the gate can be unit-tested without an ARCore [Session] instance — the JNI-bound
+ * `Session.isFlashModeSupported()` is impossible to mock under pure-JVM tests.
+ *
+ * @param requested The mode the caller asked for (typically from `Config.flashMode`).
+ * @param isSupported Adapter returning `true` if the session supports `requested` (typically
+ *   `session::isFlashModeSupported`).
+ */
+internal fun resolveFlashMode(
+    requested: Config.FlashMode,
+    isSupported: (Config.FlashMode) -> Boolean
+): Config.FlashMode =
+    if (requested == Config.FlashMode.OFF || isSupported(requested)) requested
+    else Config.FlashMode.OFF
 
 /**
  * Define the session config used by ARCore

--- a/arsceneview/src/test/java/io/github/sceneview/ar/ARCompletenessDefaultsTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/ARCompletenessDefaultsTest.kt
@@ -64,8 +64,9 @@ class ARCompletenessDefaultsTest {
         // matches the open `{` after `config ->`.
         val openIdx = Regex("""session\.configure\s*\{\s*config\s*->""").find(src)?.range?.last
             ?: throw AssertionError("Could not find `session.configure { config -> ` in ARScene.kt")
-        // We only need to scan past the user callback line, so a window of ~600 chars is plenty.
-        val window = src.substring(openIdx, (openIdx + 1200).coerceAtMost(src.length))
+        // We only need to scan past the user callback line. Window must accommodate the long-form
+        // KDoc-style comments + later additions (e.g. #1732 flashMode wiring).
+        val window = src.substring(openIdx, (openIdx + 2000).coerceAtMost(src.length))
         val modeIdx = window.indexOf(
             "config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR"
         )

--- a/arsceneview/src/test/java/io/github/sceneview/ar/arcore/ResolveFlashModeTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/arcore/ResolveFlashModeTest.kt
@@ -1,0 +1,61 @@
+package io.github.sceneview.ar.arcore
+
+import com.google.ar.core.Config
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM regression test for the Flash Mode support gate landed in #1732.
+ *
+ * ARCore's `Session.isFlashModeSupported()` is a JNI call that cannot be mocked under pure-JVM
+ * tests, so the decision logic was extracted into [resolveFlashMode] — this test pins the
+ * support-gate contract:
+ *
+ *  - `OFF` is always honoured.
+ *  - `TORCH` is honoured when the adapter reports it as supported.
+ *  - `TORCH` silently downgrades to `OFF` when the adapter reports it as unsupported (front
+ *    camera, ARCore < 1.45 runtime, or device without a back-camera LED).
+ */
+class ResolveFlashModeTest {
+
+    @Test
+    fun `OFF is returned unchanged on supported devices`() {
+        val result = resolveFlashMode(Config.FlashMode.OFF, isSupported = { true })
+        assertEquals(Config.FlashMode.OFF, result)
+    }
+
+    @Test
+    fun `OFF is returned unchanged on unsupported devices`() {
+        // The support-check is skipped for OFF — apps must be able to leave the torch off
+        // regardless of device capability.
+        val result = resolveFlashMode(Config.FlashMode.OFF, isSupported = { false })
+        assertEquals(Config.FlashMode.OFF, result)
+    }
+
+    @Test
+    fun `TORCH is returned when supported`() {
+        val result = resolveFlashMode(Config.FlashMode.TORCH, isSupported = { true })
+        assertEquals(Config.FlashMode.TORCH, result)
+    }
+
+    @Test
+    fun `TORCH downgrades to OFF when unsupported`() {
+        val result = resolveFlashMode(Config.FlashMode.TORCH, isSupported = { false })
+        assertEquals(Config.FlashMode.OFF, result)
+    }
+
+    @Test
+    fun `support adapter is only invoked for non-OFF modes`() {
+        var invocations = 0
+        resolveFlashMode(Config.FlashMode.OFF, isSupported = {
+            invocations++
+            true
+        })
+        assertEquals(
+            "isFlashModeSupported must not be invoked for OFF — calling it on devices without " +
+                "Flash Mode runtime support could surface an unexpected throw.",
+            0,
+            invocations
+        )
+    }
+}

--- a/changelog.d/1732-flash-mode.md
+++ b/changelog.d/1732-flash-mode.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- `arsceneview`: surfaced ARCore v1.45+ Flash Mode as a new `flashMode: Config.FlashMode` parameter on `ARSceneView` (default `OFF`). Toggling between `OFF` / `TORCH` recomposes the session config reactively, and unsupported devices / front-camera sessions silently downgrade to `OFF` via `Session.isFlashModeSupported()` — matching the existing `depthMode` auto-fallback behaviour (#1732).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -120,6 +120,7 @@ fun ARSceneView(
     sessionFeatures: Set<Session.Feature> = setOf(),
     playbackDataset: File? = null,                 // Replay an MP4 recorded via ARRecorder. See "AR Recording & Playback".
     sessionCameraConfig: ((Session) -> CameraConfig)? = ::highestResolutionCameraConfig,  // Picks the highest-res 30fps BACK config so ARRecorder records at full resolution (#1065). Pass null for ARCore's stock default.
+    flashMode: Config.FlashMode = Config.FlashMode.OFF,  // ARCore v1.45+ Flash Mode — OFF/TORCH. Reactive; unsupported devices/front-camera silently downgrade to OFF (#1732).
     sessionConfiguration: ((session: Session, Config) -> Unit)? = null,
     planeRenderer: Boolean = true,
     cameraStream: ARCameraStream? = rememberARCameraStream(materialLoader),

--- a/llms.txt
+++ b/llms.txt
@@ -120,6 +120,7 @@ fun ARSceneView(
     sessionFeatures: Set<Session.Feature> = setOf(),
     playbackDataset: File? = null,                 // Replay an MP4 recorded via ARRecorder. See "AR Recording & Playback".
     sessionCameraConfig: ((Session) -> CameraConfig)? = ::highestResolutionCameraConfig,  // Picks the highest-res 30fps BACK config so ARRecorder records at full resolution (#1065). Pass null for ARCore's stock default.
+    flashMode: Config.FlashMode = Config.FlashMode.OFF,  // ARCore v1.45+ Flash Mode — OFF/TORCH. Reactive; unsupported devices/front-camera silently downgrade to OFF (#1732).
     sessionConfiguration: ((session: Session, Config) -> Unit)? = null,
     planeRenderer: Boolean = true,
     cameraStream: ARCameraStream? = rememberARCameraStream(materialLoader),


### PR DESCRIPTION
Closes #1732.

## Summary

Surfaces ARCore v1.45+ Flash Mode on `ARSceneView`:

```kotlin
ARSceneView(
    flashMode = Config.FlashMode.TORCH,  // OFF (default) | TORCH
    sessionConfiguration = { _, config -> /* ... */ },
) { /* DSL */ }
```

The torch is driven by ARCore directly, helps low-light tracking, costs battery — apps typically expose it as a user-controlled toggle.

## Why this matters

Mentioned in umbrella #1729 as a self-contained quick win, this is the smallest of the four ARCore-config-extension issues in the current batch. Apps no longer have to drop into the raw `Session` to drive the torch.

## Design notes

- **Reactive**: recomposing with a new `flashMode` reconfigures the session via a `LaunchedEffect(flashMode)`. Toggling unrelated state does not pay for an ARCore `configure()` call.
- **Support-gated**: ARCore doesn't ship `Session.isFlashModeSupported(FlashMode)` (cf. `isDepthModeSupported`, `isGeospatialModeSupported`). We probe via `Session.isSupported(config)` with the requested mode applied. Unsupported devices and front-camera configs silently downgrade to `OFF`, matching the `depthMode` auto-fallback policy in `ARSession.configure`.
- **Testable**: the pure decision logic is extracted into `resolveFlashMode(requested, isSupported)` so the support-gate contract is exercised under JVM unit tests without a live ARCore Session (which is JNI-only and can't be mocked).
- **Deprecated alias parity**: `fun ARScene(...)` forwards the new `flashMode` param so existing call-sites compile unchanged.

## Tier-1 self-review (5 angles)

1. **Threading**: `LaunchedEffect(flashMode)` runs in the composition's coroutine scope; `session.configure` is safe to call there. The `session.config.flashMode != flashMode` early-return avoids redundant configure() spam on every recomposition.
2. **Lifecycle**: nothing held to outlive composition — no extra refs, no disposable resources. The session itself owns the FlashMode state; on session destroy ARCore tears it down.
3. **API consistency**: the new param sits adjacent to `sessionCameraConfig` and ships the same KDoc shape (rationale, support gate, fallback). The deprecated alias's `ReplaceWith` was updated to keep the alias-forwarding test green.
4. **Cross-platform parity**: torch is an Android/ARCore feature. iOS/RealityKit has no parallel surfaced via `ARView`/`ARSession`. Documented in the KDoc as ARCore-specific.
5. **Minimality**: 7 files touched — only the necessary `ARSceneView` signature + plumbing + `ArSession.configure` gate + unit tests + llms.txt mirror + changelog fragment.

## Test plan

- [x] `:sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` — green
- [x] `:arsceneview:testDebugUnitTest` — 232 tests pass (including the 5 new `ResolveFlashModeTest` cases)
- [x] `:sceneview:testDebugUnitTest` — green
- [ ] On-device QA (low-light scene with `TORCH` enabled) — recommended once a paired demo opt-in lands; out of scope for this minimum-surface PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)