### PR TITLE
fix(arsceneview,sceneview): DepthCollider KDoc + PhysicsNode ReplaceWith preserve floorProvider (#1807)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/physics/DepthCollider.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/physics/DepthCollider.kt
@@ -36,7 +36,7 @@ import io.github.sceneview.node.FloorProvider
  *     PhysicsNode(
  *         node = sphereNode,
  *         restitution = 0.7f,
- *         depthCollider = collider,
+ *         floorProvider = collider,
  *         radius = 0.08f,
  *     )
  * }

--- a/changelog.d/1807-depthcollider-kdoc-fix.md
+++ b/changelog.d/1807-depthcollider-kdoc-fix.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- arsceneview: `DepthCollider` class-level KDoc example now passes the collider through `floorProvider = collider` instead of the non-existent `depthCollider = collider` parameter (#1807). Code pasted from the KDoc previously did not compile. The `ARSceneScope.rememberDepthCollider` KDoc and the `PhysicsNode` KDoc already used the correct form, so the bug was isolated to `DepthCollider.kt`.
+- sceneview: deprecated mass-overload `PhysicsNode`'s `@Deprecated(ReplaceWith(...))` now preserves the newly-added `floorProvider` parameter (#1807). The IDE quick-fix on the deprecation previously silently stripped AR floor wiring. The deprecated overload itself also gained a `floorProvider` parameter so the replacement is a 1:1 source-compatible swap.

--- a/sceneview/src/main/java/io/github/sceneview/node/PhysicsNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/PhysicsNode.kt
@@ -266,11 +266,14 @@ fun PhysicsNode(
  * The Euler integration applies only gravity, which is an acceleration and therefore
  * mass-independent. `mass` will gain an effect once a force/impulse API lands. Until then,
  * use the [PhysicsNode] overload without `mass`.
+ *
+ * Note: [ReplaceWith] **preserves [floorProvider]** so the IDE quick-fix on the deprecation
+ * never silently strips the AR-floor wiring (#1807).
  */
 @Deprecated(
     "The 'mass' parameter is currently a no-op (the Euler integration applies only gravity, " +
         "which is mass-independent). Use the PhysicsNode overload without 'mass'.",
-    ReplaceWith("PhysicsNode(node, restitution, linearVelocity, floorY, radius)"),
+    ReplaceWith("PhysicsNode(node, restitution, linearVelocity, floorY, radius, floorProvider)"),
     DeprecationLevel.WARNING
 )
 @Composable
@@ -280,11 +283,13 @@ fun PhysicsNode(
     restitution: Float = 0.6f,
     linearVelocity: Position = Position(0f, 0f, 0f),
     floorY: Float = 0f,
-    radius: Float = 0f
+    radius: Float = 0f,
+    floorProvider: FloorProvider? = null,
 ) = PhysicsNode(
     node = node,
     restitution = restitution,
     linearVelocity = linearVelocity,
     floorY = floorY,
-    radius = radius
+    radius = radius,
+    floorProvider = floorProvider,
 )


### PR DESCRIPTION
## Summary

Closes #1807. Confirmed independently by the May 2026 Tier-2 API-consistency + DOCS audits on commit `33d4290d4` (PR #1783).

Two isolated documentation/API-hygiene bugs:

1. `arsceneview/.../physics/DepthCollider.kt:36` class-level KDoc example wrote `PhysicsNode(... depthCollider = collider, ...)` but the actual public parameter is `floorProvider`. **Code pasted from the KDoc would not compile.** `ARSceneScope.rememberDepthCollider` KDoc and `PhysicsNode` KDoc both already used the correct form, so the bug was isolated to `DepthCollider.kt`.

2. `sceneview/.../node/PhysicsNode.kt` deprecated mass-overload's `@Deprecated(ReplaceWith(...))` **dropped** the newly added `floorProvider` parameter. The IDE quick-fix on the deprecation silently stripped AR-floor wiring.

## Change

- Fix the KDoc snippet to use `floorProvider = collider`.
- Extend the `ReplaceWith` template to `PhysicsNode(node, restitution, linearVelocity, floorY, radius, floorProvider)` AND add `floorProvider: FloorProvider? = null` to the deprecated overload itself, so the IDE quick-fix produces a 1:1 source-compatible swap.

## Test plan

- [x] `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` — green
- [x] `./gradlew :sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest` — green
- [x] Grep-pin: `PhysicsNode(... depthCollider =` returns zero occurrences across `arsceneview`, `sceneview`, `samples`, `docs`. The remaining `depthCollider =` hits are all `val depthCollider = rememberDepthCollider(...)` local-variable assignments — intentional.

## Tier-1 self-review

- **Security** — n/a (docs + deprecation template).
- **Threading** — n/a (no runtime behaviour change).
- **API** — additive only. The deprecated overload gains an optional `floorProvider` parameter with a default of `null`, so all existing call sites (`PhysicsNode(node = x, mass = 2f, ...)`) continue to compile unchanged. The new parameter mirrors the non-deprecated overload's signature.
- **Performance** — n/a.
- **Docs** — KDoc snippet now compiles when copy-pasted. `ReplaceWith` template now mirrors the non-deprecated overload's full parameter list, so IDE quick-fix preserves AR floor wiring.

Closes #1807