### PR TITLE
feat(arsceneview): tier-2 polish — DepthHitResultNode + migration + IBL dispose (#1814)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
@@ -490,8 +490,17 @@ fun ARSceneView(
     // is freed too — closing the lifecycle leak that the umbrella audit flagged
     // for long AR sessions with intermittent estimation.
     val builtIndirectLightRef = remember { AtomicReference<IndirectLight?>(null) }
-    DisposableEffect(engine, builtIndirectLightRef) {
+    DisposableEffect(engine, builtIndirectLightRef, scene) {
         onDispose {
+            // Defensive ordering (#1814): clear the scene's [IndirectLight] reference BEFORE
+            // freeing it. The window between [Engine.destroyIndirectLight] and Compose teardown
+            // could otherwise have an in-flight `onARFrame` (still queued on the GL thread) walk
+            // [scene.indirectLight] and dereference a freed native handle. Setting `null` first
+            // unblocks the destroy: Filament's renderer simply skips IBL sampling when the slot
+            // is null. If a third party overwrote `scene.indirectLight` with their own resource
+            // after we last set it, this null-out replaces *their* reference too — and that is
+            // fine: we're tearing the scene down, the slot owner is leaving anyway.
+            scene.indirectLight = null
             builtIndirectLightRef.getAndSet(null)?.let {
                 engine.safeDestroyIndirectLight(it)
             }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
@@ -37,6 +37,7 @@ import io.github.sceneview.ar.node.AnchorNode as AnchorNodeImpl
 import io.github.sceneview.ar.node.AugmentedFaceNode as AugmentedFaceNodeImpl
 import io.github.sceneview.ar.node.AugmentedImageNode as AugmentedImageNodeImpl
 import io.github.sceneview.ar.node.CloudAnchorNode as CloudAnchorNodeImpl
+import io.github.sceneview.ar.node.DepthHitResultNode as DepthHitResultNodeImpl
 import io.github.sceneview.ar.node.DepthMeshNode as DepthMeshNodeImpl
 import io.github.sceneview.ar.node.DepthMeshSnapshot
 import io.github.sceneview.ar.physics.DepthCollider
@@ -309,6 +310,55 @@ class ARSceneScope internal constructor(
     ) {
         val node = remember(engine) {
             HitResultNodeImpl(engine = engine, hitTest = hitTest).apply(apply)
+        }
+        NodeLifecycle(node, content)
+    }
+
+    // ── DepthHitResultNode ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * A node that follows real-time **depth-based** AR hit-test results at the given view
+     * coordinates — Compose-idiomatic mirror of [HitResultNode] for placement against arbitrary
+     * real-world geometry rather than against detected planes / points (#1814).
+     *
+     * On each [Frame] update, the node performs a depth hit test at ([xPx], [yPx]) in view space
+     * via [io.github.sceneview.ar.arcore.hitTestDepth] and moves to the world-space surface point
+     * under that pixel. Unlike [HitResultNode], a depth hit test resolves a point on *any* visible
+     * geometry the depth camera can see (sofa, slope, cluttered desk) without waiting for ARCore
+     * to grow a plane there, and the underlying [io.github.sceneview.ar.arcore.DepthHitResult]
+     * carries a real surface normal — read it via [DepthHitResultNodeImpl.depthHitResult] if you
+     * want to align the placed object with the surface orientation.
+     *
+     * Requires the session depth mode set to [com.google.ar.core.Config.DepthMode.AUTOMATIC] or
+     * [com.google.ar.core.Config.DepthMode.RAW_DEPTH_ONLY]. When depth is unavailable, the node
+     * keeps its last known pose (same fallback contract as [HitResultNode]).
+     *
+     * ```kotlin
+     * ARSceneView(
+     *     sessionConfiguration = { _, config ->
+     *         config.depthMode = Config.DepthMode.AUTOMATIC
+     *     }
+     * ) {
+     *     DepthHitResultNode(xPx = viewWidth / 2f, yPx = viewHeight / 2f) {
+     *         CubeNode(size = Float3(0.05f))
+     *     }
+     * }
+     * ```
+     *
+     * @param xPx       View X coordinate in pixels for the depth hit test.
+     * @param yPx       View Y coordinate in pixels for the depth hit test.
+     * @param apply     Additional imperative configuration on the underlying [DepthHitResultNodeImpl].
+     * @param content   Optional child nodes declared in a [NodeScope].
+     */
+    @Composable
+    fun DepthHitResultNode(
+        xPx: Float,
+        yPx: Float,
+        apply: DepthHitResultNodeImpl.() -> Unit = {},
+        content: (@Composable NodeScope.() -> Unit)? = null,
+    ) {
+        val node = remember(engine, xPx, yPx) {
+            DepthHitResultNodeImpl(engine = engine, xPx = xPx, yPx = yPx).apply(apply)
         }
         NodeLifecycle(node, content)
     }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/DepthHitResult.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/DepthHitResult.kt
@@ -59,6 +59,14 @@ private const val NORMAL_SAMPLE_RADIUS = 2
  *
  * @param xPx screen X in pixels.
  * @param yPx screen Y in pixels.
+ *
+ * @return a single [DepthHitResult] — the real-world point under the queried pixel — or `null`
+ *         when depth is unavailable. **This is intentionally not a list, unlike
+ *         [Frame.hitTest]**: the depth at one screen pixel is by definition a unique point in
+ *         space (the depth image stores one Z per pixel), whereas a standard
+ *         [Frame.hitTest] casts a ray that can pierce multiple parallel planes / surfaces at
+ *         increasing distances. A list return would always have at most one element here, so
+ *         the API is flattened to `DepthHitResult?` for ergonomics.
  */
 fun Frame.hitTestDepth(xPx: Float, yPx: Float): DepthHitResult? {
     val camera = camera

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/DepthHitResultNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/DepthHitResultNode.kt
@@ -1,0 +1,73 @@
+package io.github.sceneview.ar.node
+
+import com.google.android.filament.Engine
+import com.google.ar.core.Frame
+import com.google.ar.core.Pose
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.arcore.DepthHitResult
+import io.github.sceneview.ar.arcore.hitTestDepth
+
+/**
+ * AR real-time **depth-based** hit-test positioned node — Compose-idiomatic mirror of
+ * [HitResultNode] for placement against the ARCore depth image rather than against detected
+ * planes / points / instant-placement (#1814).
+ *
+ * Each AR frame the node re-runs [Frame.hitTestDepth] at the configured screen pixel and moves
+ * to the world-space surface point under that pixel. Unlike [HitResultNode], a depth hit test
+ * resolves a point on *any* real-world geometry the depth camera can see (sofa, slope,
+ * cluttered desk) without waiting for ARCore to grow a plane there, and carries a real surface
+ * normal — see [DepthHitResult].
+ *
+ * Requires the [Session] to be configured with a depth mode — [com.google.ar.core.Config.DepthMode.AUTOMATIC]
+ * or [com.google.ar.core.Config.DepthMode.RAW_DEPTH_ONLY]. When depth is unavailable (not
+ * supported, not yet computed, camera not tracking, no valid depth at the pixel) the node
+ * keeps its last known pose — same fallback contract as [HitResultNode].
+ *
+ * Threading: updated on the AR frame thread (the rendering thread) — same protocol as
+ * [PoseNode.update].
+ *
+ * @param engine    The Filament [Engine].
+ * @param xPx       Screen X coordinate in pixels for the depth hit test.
+ * @param yPx       Screen Y coordinate in pixels for the depth hit test.
+ */
+open class DepthHitResultNode(
+    engine: Engine,
+    val xPx: Float,
+    val yPx: Float,
+) : PoseNode(engine) {
+
+    /**
+     * Whether the node re-runs the depth hit test each frame. Default `true`. Set to `false` to
+     * freeze the node at its current pose — useful to "lock" the placement after a tap.
+     */
+    var update: Boolean = true
+
+    /**
+     * The latest [DepthHitResult], or `null` until the first successful frame.
+     *
+     * Exposed read-only so callers can read the surface [DepthHitResult.normal] (e.g. to align a
+     * placed object with the surface orientation) or the [DepthHitResult.distance] from the
+     * camera.
+     */
+    var depthHitResult: DepthHitResult? = null
+        protected set
+
+    init {
+        // Smooth the per-frame jitter inherent to depth sampling — same default as [HitResultNode].
+        isSmoothTransformEnabled = true
+    }
+
+    override fun update(session: Session, frame: Frame) {
+        if (update && frame.camera.trackingState == TrackingState.TRACKING) {
+            frame.hitTestDepth(xPx, yPx)?.let { result ->
+                depthHitResult = result
+                // Build a `Pose` whose translation is the depth hit point, orientation is identity
+                // (the depth hit carries a normal but not a full surface frame). Callers that need
+                // the surface normal can read it via [depthHitResult].
+                pose = Pose.makeTranslation(result.position.x, result.position.y, result.position.z)
+            }
+        }
+        super.update(session, frame)
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/DepthHitResultNodeContractTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/DepthHitResultNodeContractTest.kt
@@ -1,0 +1,53 @@
+package io.github.sceneview.ar.node
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the public API contract of [DepthHitResultNode] introduced by #1814:
+ *  - Class is open + public (callers should be able to subclass for custom behaviour).
+ *  - Inherits from [PoseNode] so it integrates with the existing
+ *    `ARScene.kt`'s per-frame `childNodes` iteration that runs both `PoseNode` and
+ *    `DepthMeshNode` updates.
+ *  - Carries the `xPx` / `yPx` constructor properties (read-only) and exposes
+ *    `depthHitResult` for surface-normal reads.
+ *
+ * The full per-frame `update(session, frame)` path requires an ARCore `Frame`, which is
+ * JNI-backed and not instantiable in a JVM unit test, but the **shape** of the public
+ * API can be pinned via reflection — and that catches the regression where a future
+ * refactor accidentally hides the node behind an `internal` or drops a property.
+ */
+class DepthHitResultNodeContractTest {
+
+    @Test
+    fun `DepthHitResultNode is a subclass of PoseNode (for per-frame update wiring)`() {
+        assertTrue(
+            "DepthHitResultNode must extend PoseNode so ARScene.kt's " +
+                "childNodes.filterIsInstance<PoseNode>().forEach { update() } loop picks it up.",
+            PoseNode::class.java.isAssignableFrom(DepthHitResultNode::class.java),
+        )
+    }
+
+    @Test
+    fun `class is open so callers can subclass for custom placement logic`() {
+        val mod = DepthHitResultNode::class.java.modifiers
+        // Kotlin `open class` → JVM `non-final`. A final class would surface as Modifier.isFinal.
+        assertTrue(
+            "DepthHitResultNode must be open so callers can subclass it to customise the " +
+                "per-frame depth-hit response — matches the [HitResultNode] pattern.",
+            !java.lang.reflect.Modifier.isFinal(mod),
+        )
+    }
+
+    @Test
+    fun `xPx and yPx are exposed as public read-only properties`() {
+        val xPxField = DepthHitResultNode::class.java.declaredFields.firstOrNull { it.name == "xPx" }
+        val yPxField = DepthHitResultNode::class.java.declaredFields.firstOrNull { it.name == "yPx" }
+        assertNotNull("xPx field must exist (Kotlin val backing field).", xPxField)
+        assertNotNull("yPx field must exist (Kotlin val backing field).", yPxField)
+        assertEquals(Float::class.java, xPxField!!.type)
+        assertEquals(Float::class.java, yPxField!!.type)
+    }
+}

--- a/changelog.d/1814-tier2-polish.md
+++ b/changelog.d/1814-tier2-polish.md
@@ -1,0 +1,7 @@
+<!-- category: Added -->
+- arsceneview: new `ARSceneScope.DepthHitResultNode(xPx, yPx, content)` composable — Compose-idiomatic mirror of `HitResultNode` for placement against the ARCore depth image. Each frame re-runs `Frame.hitTestDepth` and moves to the resulting world-space surface point; `depthHitResult` exposes the live `DepthHitResult` for surface-normal-aligned content (#1814).
+- docs: new migration block in `docs/docs/migration.md` for the `CloudAnchorNode.host()` return-type change (`Unit` → `HostCloudAnchorFuture`, #1768). Covers the source-compatibility break + the `DisposableEffect.onDispose { future.cancel() }` recommendation with billing rationale (#1814).
+- llms.txt: `DepthHitResultNode` section and `Frame.hitTestDepth` `@return` KDoc clarification documenting the single-vs-list asymmetry vs `Frame.hitTest` (depth at one pixel is unique) (#1814).
+
+<!-- category: Fixed -->
+- arsceneview: defensive `onDispose` ordering on `ARScene`'s per-frame `IndirectLight` rebuild — clear `scene.indirectLight = null` BEFORE `engine.safeDestroyIndirectLight(...)` so a late `onARFrame` queued on the GL thread cannot dereference a freed native handle (#1814).

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -7,6 +7,60 @@ description: "Migration guides for SceneView: 3.6.x to 4.0.0 Rerun integration, 
 
 ---
 
+## SceneView 4.10.x to 4.11.0 (Android) — `CloudAnchorNode.host()` returns `HostCloudAnchorFuture`
+
+### `CloudAnchorNode.host()` now returns the underlying ARCore `HostCloudAnchorFuture` ([#1768](https://github.com/sceneview/sceneview/pull/1768))
+
+Pre-v4.11.0, `CloudAnchorNode.host(session, ttlDays, onCompleted)` returned `Unit`
+and stored the in-flight future privately — apps had no way to cancel a pending
+host request when the UI scope was leaving. The network round-trip ran to
+completion regardless, accruing a Google Cloud billing event whether or not the
+caller was still listening.
+
+v4.11.0 surfaces the underlying ARCore [`HostCloudAnchorFuture`](https://developers.google.com/ar/reference/java/com/google/ar/core/HostCloudAnchorFuture)
+as the return value so callers can cancel via `future.cancel()` — typically from
+`DisposableEffect.onDispose { future?.cancel() }`. The same change applies to
+`CloudAnchorNode.resolve(...)`, `TerrainAnchorNode.resolve(...)`, and
+`RooftopAnchorNode.resolve(...)`.
+
+**Billing rationale.** Each pending host/resolve future is **one Google Cloud
+ARCore API request**. Without explicit cancellation, the request runs to
+completion (a few seconds, sometimes longer for cross-continent resolves) and
+the billing event lands on your Google Cloud project even after the user has
+navigated away from the screen that started it. For apps that surface a "Place
+anchor" CTA inside a navigable hierarchy (Compose / Fragment / Activity stack)
+this is a measurable cost on cancelled user flows — see
+[Google's ARCore Cloud Anchors pricing](https://developers.google.com/ar/develop/cloud-anchors-faq#pricing).
+Cancellation does **not** invoke the `onCompleted` callback (matches ARCore
+semantics), so observers stay clean.
+
+**Action — source compatibility.** Most call sites are unaffected — the new
+return type is purely additive. The only break is for callers that wrote
+`val unused: Unit = node.host(...)` or any test that asserts the return type is
+`Unit`. Adjust the local binding and (recommended) cancel the future on dispose:
+
+```kotlin
+// pre-v4.11.0
+DisposableEffect(anchorNode) {
+    anchorNode.host(session, ttlDays = 7) { id, state -> /* ... */ }
+    onDispose { /* nothing to cancel — the future was internal */ }
+}
+
+// v4.11.0 — capture the future, cancel on dispose to free the billing event
+DisposableEffect(anchorNode) {
+    val future = anchorNode.host(session, ttlDays = 7) { id, state -> /* ... */ }
+    onDispose { future.cancel() }
+}
+```
+
+The same pattern applies to `CloudAnchorNode.resolve(engine, session, id) { ... }`,
+`TerrainAnchorNode.resolve(...)`, and `RooftopAnchorNode.resolve(...)`. The
+node's own `destroy()` lifecycle still calls `cancelHost()` internally, so an
+app that doesn't cancel explicitly still cleans up on scene disposal — but it
+pays the round-trip until destroy fires.
+
+---
+
 ## SceneView 4.3.x to 4.4.0 (iOS) — true camera motion + skybox renders + mirror retired
 
 ### `Environment.showSkybox = true` now actually paints the HDR as background ([PR #1215](https://github.com/sceneview/sceneview/pull/1215))

--- a/llms.txt
+++ b/llms.txt
@@ -866,6 +866,7 @@ data class DepthHitResult(
     val distance: Float       // camera-to-point distance, meters
 )
 
+// Single result (not a list) — depth at one pixel is unique, unlike Frame.hitTest's ray cast.
 fun Frame.hitTestDepth(xPx: Float, yPx: Float): DepthHitResult?
 ```
 
@@ -883,6 +884,32 @@ ARSceneView(
         }
     )
 )
+```
+
+### DepthHitResultNode — Compose-idiomatic depth-hit placement
+
+For continuous, declarative placement against any real-world surface, use `DepthHitResultNode` —
+the depth-image mirror of `HitResultNode`. Each frame it re-runs `Frame.hitTestDepth` at the
+configured pixel and moves to the resulting world-space point. When depth is unavailable, the
+node keeps its last known pose (same fallback contract as `HitResultNode`).
+
+```kotlin
+@Composable fun ARSceneScope.DepthHitResultNode(
+    xPx: Float,
+    yPx: Float,
+    apply: DepthHitResultNode.() -> Unit = {},
+    content: (@Composable NodeScope.() -> Unit)? = null,
+)
+```
+
+```kotlin
+ARSceneView(
+    sessionConfiguration = { _, config -> config.depthMode = Config.DepthMode.AUTOMATIC }
+) {
+    DepthHitResultNode(xPx = viewWidth / 2f, yPx = viewHeight / 2f) {
+        CubeNode(size = Float3(0.05f))
+    }
+}
 ```
 
 ### Depth visualization — false-color depth overlay


### PR DESCRIPTION
Closes #1814. Tier-2 audit finale follow-up — four polish items in one PR.

## Items

1. **Migration block** in `docs/docs/migration.md` for `CloudAnchorNode.host()`'s `Unit` -> `HostCloudAnchorFuture` return-type change (#1768). Source-compatibility break + `DisposableEffect.onDispose { future.cancel() }` recommendation with billing rationale.
2. **`ARSceneScope.DepthHitResultNode(xPx, yPx, content)`** composable — Compose-idiomatic mirror of `HitResultNode` for placement against the ARCore depth image. New class `DepthHitResultNode` extends `PoseNode` so it slots into the existing per-frame childNodes iteration.
3. **`Frame.hitTestDepth` `@return` KDoc** documents the single-vs-list asymmetry vs `Frame.hitTest` (depth at one pixel is unique).
4. **`ARScene` IBL fix `onDispose` ordering** — `scene.indirectLight = null` BEFORE `engine.safeDestroyIndirectLight(it)` so a late `onARFrame` queued on the GL thread cannot dereference a freed native handle.

## Files touched

- `arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt` — IBL onDispose ordering
- `arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt` — `DepthHitResultNode` composable wiring
- `arsceneview/src/main/java/io/github/sceneview/ar/arcore/DepthHitResult.kt` — KDoc `@return`
- `arsceneview/src/main/java/io/github/sceneview/ar/node/DepthHitResultNode.kt` — new
- `arsceneview/src/test/java/io/github/sceneview/ar/node/DepthHitResultNodeContractTest.kt` — new (3 tests)
- `docs/docs/migration.md` — new v4.10.x -> v4.11.0 block
- `llms.txt` — new `DepthHitResultNode` section + updated `hitTestDepth` `@return`
- `changelog.d/1814-tier2-polish.md` — new

## Tier 1 self-review

1. **Threading**: `DepthHitResultNode.update` runs on the AR frame thread via PoseNode protocol; `scene.indirectLight = null` runs on the dispose path (already on main).
2. **API parity**: new `DepthHitResultNode` mirrors `HitResultNode` shape exactly (composable + node class + xPx/yPx + content NodeScope).
3. **Style**: matches surrounding KDoc voice and import-alias pattern.
4. **Performance**: no per-frame allocations introduced. Depth-image acquisition path was already exercised by the imperative `Frame.hitTestDepth` callers.
5. **Test coverage**: 3 JVM contract tests pin the new node's public surface (open class, PoseNode subclass, xPx/yPx fields).

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin` green
- [x] `./gradlew :arsceneview:testDebugUnitTest` green
- [ ] CI green