### PR TITLE
fix(web): SceneViewJS.SCENEVIEW_VERSION 4.9.0 → 4.11.1 + harden sync-versions check

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -624,14 +624,17 @@ for cdnfile in README.md docs/docs/index.md website-static/index.html website-st
 done
 
 # SceneViewJS.kt — `SCENEVIEW_VERSION` constant stamped into the Kotlin/JS
-# bundle. The .kt file lives in a library module other agents own, so this
-# check is REPORT-ONLY (critical=false) and never auto-fixed here — bumping
-# the constant is tracked separately (#1357).
+# bundle. This is a public `@JsExport`-reachable code constant; web consumers
+# querying the library version get whatever this literal says, so silent drift
+# is a real defect (it lagged 2 majors before #1357). Hard MISMATCH check —
+# never demote back to WARN-only. The literal is pinned by a jsTest in
+# `sceneview-web/src/jsTest/.../SceneViewVersionTest.kt` as a second line of
+# defense.
 SCENEVIEWJS_KT=$(find "$REPO_ROOT/sceneview-web" -name 'SceneViewJS.kt' 2>/dev/null | head -1 || true)
 if [ -n "$SCENEVIEWJS_KT" ] && [ -f "$SCENEVIEWJS_KT" ]; then
     V=$(grep -E 'SCENEVIEW_VERSION' "$SCENEVIEWJS_KT" | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?"' | tr -d '"' | head -1 || echo "NOT FOUND")
     if [ "$V" != "NOT FOUND" ]; then
-        add_check "sceneview-web SceneViewJS.kt SCENEVIEW_VERSION" "$V" "false"
+        add_check "sceneview-web SceneViewJS.kt SCENEVIEW_VERSION" "$V"
     fi
 fi
 

--- a/changelog.d/sceneview-version-constant.md
+++ b/changelog.d/sceneview-version-constant.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **`sceneview-web` `SCENEVIEW_VERSION` constant lagged 2 releases (`4.9.0` while shipping `4.11.1`).** Bumped to `4.11.1` and promoted the `sync-versions.sh` check for this code-resident constant from WARN-only to a hard MISMATCH so it can never silently drift again. The regression-pin jsTest (#1357) was bumped in lockstep.

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
@@ -189,4 +189,4 @@ class SceneViewJS {
  * Gradle `buildConfig` plugin, so this literal is the single source of truth for the JS surface.
  * Bump it together with every other version location (see CLAUDE.md "Version Location Map").
  */
-const val SCENEVIEW_VERSION = "4.9.0"
+const val SCENEVIEW_VERSION = "4.11.1"

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/SceneViewVersionTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/SceneViewVersionTest.kt
@@ -16,7 +16,7 @@ class SceneViewVersionTest {
     @Test
     fun versionIsCurrent() {
         // Bump in lockstep with `gradle.properties` -> `VERSION_NAME`.
-        assertEquals("4.9.0", SCENEVIEW_VERSION)
+        assertEquals("4.11.1", SCENEVIEW_VERSION)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Found via `/sync-check` post-v4.11.0. The `@JsExport`-reachable
`SCENEVIEW_VERSION` constant in `sceneview-web/.../SceneViewJS.kt`
had lagged **2 releases silently** (`4.9.0` while the library
shipped `4.11.1`) because `sync-versions.sh` treated it as
WARN-only (`critical=false`) — never blocking a release.

A code-resident version constant that lies to consumers is a real
defect (cf. #1357 — same constant once lagged 2 majors stale at `3.6.0`).

## Changes

- **Bumped** `SCENEVIEW_VERSION` from `4.9.0` → `4.11.1` (matches
  root `gradle.properties` `VERSION_NAME`).
- **Bumped** the regression-pin jsTest
  (`SceneViewVersionTest.versionIsCurrent`) to `4.11.1` in lockstep —
  this was 2 releases behind too and would have failed the next jsTest
  run.
- **Promoted** the `sync-versions.sh` check for this constant from
  WARN-only to a hard MISMATCH so the exact same silent drift can
  never recur. Removed the `"false"` argument from `add_check` and
  rewrote the inline comment to explain why this one is critical
  (public `@JsExport` surface, vs `Module.md` docs prose which stays
  WARN-only).

## Verify

- `bash -n .claude/scripts/sync-versions.sh` — syntax OK.
- `bash .claude/scripts/sync-versions.sh` — reports
  `sceneview-web SceneViewJS.kt SCENEVIEW_VERSION` as **OK** at
  `4.11.1`, **0 errors** overall.
- No build needed — string literal + shell script edit.

## Other WARN-only checks reviewed

Audited the remaining 7 `add_check ... "false"` calls. None are
public code constants exporting from a library module like
`SCENEVIEW_VERSION` does — they're CHANGELOG entries, sample-app
`versionName`s, `Module.md` docs prose, iOS pbxproj
`MARKETING_VERSION`, and Flutter plugin SDK deps (which must
legitimately lag to the last-released Maven Central artifact per
`CLAUDE.md`). No consolidated follow-up filed.