### PR TITLE
fix(arsceneview): DepthMeshNode no leak when upload throws mid-frame (#1840)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/DepthMeshNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/DepthMeshNode.kt
@@ -274,105 +274,150 @@ open class DepthMeshNode(
      * (#1805).
      */
     private fun uploadGeometry(geometry: DepthMeshGeometry) {
-        val staleBuffers = rebuildBuffersIfNeeded(geometry.vertexCount, geometry.indices.size)
+        // Build any newly-needed buffers WITHOUT swapping the owned* fields yet (#1840). If the
+        // upload below throws (engine teardown mid-frame, OOM, etc.) we still need a clean handle
+        // on every buffer this method allocated so we can free them — and we still need the OLD
+        // owned* fields intact so [destroy] can release them when the node is torn down.
+        val rebuild = rebuildBuffersIfNeeded(geometry.vertexCount, geometry.indices.size)
+        val targetVertexBuffer = rebuild.newVertexBuffer ?: ownedVertexBuffer
+        val targetIndexBuffer = rebuild.newIndexBuffer ?: ownedIndexBuffer
+        val newVertexAllocCount = rebuild.newVertexCount ?: allocatedVertexCount
+        val newIndexAllocCount = rebuild.newIndexCount ?: allocatedIndexCount
 
-        // VertexBuffer expects a direct ByteBuffer. Per-rebuild fresh-allocate path was ~11 KB
-        // per upload at 5 Hz = ~100 KB/s direct-buffer churn (#1810). Cached buffers below are
-        // grown in powers of two and reused across rebuilds — steady-state is zero-alloc.
-        val positions = geometry.positions
-        val vertexBytesNeeded = positions.size * Float.SIZE_BYTES
-        val vertexBytes = acquireDirectBuffer(vertexUploadBuffer, vertexBytesNeeded).also {
-            vertexUploadBuffer = it
+        val indicesCount = geometry.indices.size
+        try {
+            // VertexBuffer expects a direct ByteBuffer. Per-rebuild fresh-allocate path was ~11 KB
+            // per upload at 5 Hz = ~100 KB/s direct-buffer churn (#1810). Cached buffers below are
+            // grown in powers of two and reused across rebuilds — steady-state is zero-alloc.
+            val positions = geometry.positions
+            val vertexBytesNeeded = positions.size * Float.SIZE_BYTES
+            val vertexBytes = acquireDirectBuffer(vertexUploadBuffer, vertexBytesNeeded).also {
+                vertexUploadBuffer = it
+            }
+            vertexBytes.clear()
+            vertexBytes.asFloatBuffer().put(positions)
+            // ByteBuffer position stays at 0 (we mutated the FloatBuffer view only); setBufferAt
+            // reads from the underlying ByteBuffer's position.
+            targetVertexBuffer.setBufferAt(engine, 0, vertexBytes, 0, vertexBytesNeeded)
+
+            val indices = geometry.indices
+            val indexBytesNeeded = indices.size * Int.SIZE_BYTES
+            val indexBytes = acquireDirectBuffer(indexUploadBuffer, indexBytesNeeded).also {
+                indexUploadBuffer = it
+            }
+            indexBytes.clear()
+            indexBytes.asIntBuffer().put(indices)
+            targetIndexBuffer.setBuffer(engine, indexBytes, 0, indexBytesNeeded)
+
+            // Tell Filament how many indices to actually render. We don't expose the offset/count
+            // overload publicly, but we can replace the renderable's geometry in-place.
+            // Rebinding the renderable to the NEW buffers BEFORE freeing the old ones closes the
+            // use-after-free window (#1805): for one frame between safeDestroy and setGeometryAt the
+            // renderable would otherwise reference freed Filament native handles.
+            renderableManager.setGeometryAt(
+                renderableInstance,
+                0,
+                PrimitiveType.TRIANGLES,
+                targetVertexBuffer,
+                targetIndexBuffer,
+                0,
+                indicesCount,
+            )
+
+            // Recompute and apply the AABB so frustum culling works once the mesh has real content.
+            renderableManager.setAxisAlignedBoundingBox(renderableInstance, computeAabb(positions))
+        } catch (t: Throwable) {
+            // setBufferAt / setBuffer / setGeometryAt / setAxisAlignedBoundingBox threw (engine
+            // teardown mid-frame is the realistic case). The renderable is still bound to the
+            // PREVIOUS owned* buffers — keep those reachable via the unchanged owned* fields, and
+            // destroy the freshly-allocated buffers that nothing else owns now (#1840).
+            rebuild.newVertexBuffer?.let { engine.safeDestroyVertexBuffer(it) }
+            rebuild.newIndexBuffer?.let { engine.safeDestroyIndexBuffer(it) }
+            throw t
         }
-        vertexBytes.clear()
-        vertexBytes.asFloatBuffer().put(positions)
-        // ByteBuffer position stays at 0 (we mutated the FloatBuffer view only); setBufferAt
-        // reads from the underlying ByteBuffer's position.
-        ownedVertexBuffer.setBufferAt(engine, 0, vertexBytes, 0, vertexBytesNeeded)
 
-        val indices = geometry.indices
-        val indexBytesNeeded = indices.size * Int.SIZE_BYTES
-        val indexBytes = acquireDirectBuffer(indexUploadBuffer, indexBytesNeeded).also {
-            indexUploadBuffer = it
+        // Upload + rebind succeeded — commit the swap (#1840) and free the now-stale OLD buffers.
+        // Field updates are render-thread-only, mirror what the previous in-place swap did.
+        if (rebuild.newVertexBuffer != null) {
+            val stale = ownedVertexBuffer
+            ownedVertexBuffer = rebuild.newVertexBuffer
+            allocatedVertexCount = newVertexAllocCount
+            engine.safeDestroyVertexBuffer(stale)
         }
-        indexBytes.clear()
-        indexBytes.asIntBuffer().put(indices)
-        ownedIndexBuffer.setBuffer(engine, indexBytes, 0, indexBytesNeeded)
-
-        // Tell Filament how many indices to actually render. We don't expose the offset/count
-        // overload publicly, but we can replace the renderable's geometry in-place.
-        // Rebinding the renderable to the NEW buffers BEFORE freeing the old ones closes the
-        // use-after-free window (#1805): for one frame between safeDestroy and setGeometryAt the
-        // renderable would otherwise reference freed Filament native handles.
-        renderableManager.setGeometryAt(
-            renderableInstance,
-            0,
-            PrimitiveType.TRIANGLES,
-            ownedVertexBuffer,
-            ownedIndexBuffer,
-            0,
-            indices.size,
-        )
-
-        // Now that the renderable points at the new buffers, it is safe to release the old ones.
-        staleBuffers.staleVertexBuffer?.let { engine.safeDestroyVertexBuffer(it) }
-        staleBuffers.staleIndexBuffer?.let { engine.safeDestroyIndexBuffer(it) }
-
-        // Recompute and apply the AABB so frustum culling works once the mesh has real content.
-        renderableManager.setAxisAlignedBoundingBox(renderableInstance, computeAabb(positions))
+        if (rebuild.newIndexBuffer != null) {
+            val stale = ownedIndexBuffer
+            ownedIndexBuffer = rebuild.newIndexBuffer
+            allocatedIndexCount = newIndexAllocCount
+            engine.safeDestroyIndexBuffer(stale)
+        }
     }
 
     /**
-     * Reallocate [ownedVertexBuffer] / [ownedIndexBuffer] when the requested capacity exceeds the
-     * current one. Grows in powers of two to amortise allocation churn across rebuilds — the
-     * depth image dimensions are constant, so this typically reallocates **once**.
+     * Allocate replacement [VertexBuffer] / [IndexBuffer] handles when the requested capacity
+     * exceeds the currently-allocated one. Grows in powers of two to amortise allocation churn
+     * across rebuilds — the depth image dimensions are constant, so this typically reallocates
+     * **once**.
      *
-     * Returns the **old** [VertexBuffer] / [IndexBuffer] handles that the caller must destroy
-     * **after** rebinding the renderable to the new buffers. Destroying in-place here would
-     * leave the renderable pointing at freed Filament native handles between this call and the
-     * subsequent [RenderableManager.setGeometryAt] — a use-after-free (#1805).
+     * **Does NOT mutate** [ownedVertexBuffer] / [ownedIndexBuffer] / [allocatedVertexCount] /
+     * [allocatedIndexCount] (#1840). The caller is responsible for the **commit** step after
+     * [RenderableManager.setGeometryAt] returns successfully:
+     *
+     *   - swap the field to the new buffer
+     *   - update the allocated-count tracker
+     *   - destroy the old buffer
+     *
+     * If `setGeometryAt` (or any upload step) throws BEFORE the commit, the new buffer is the
+     * only reference and the caller must `safeDestroy` it. Mutating the owned* fields up-front,
+     * as the previous code did, would have left the OLD buffer unreachable AND undestroyed on
+     * any mid-upload exception (#1840).
+     *
+     * Rebuild → rebind → destroy-old still respects the #1805 ordering invariant — the new
+     * `setGeometryAt` happens BEFORE the old buffers are destroyed.
      */
     private fun rebuildBuffersIfNeeded(
         requestedVertexCount: Int,
         requestedIndexCount: Int,
-    ): StaleBuffers {
+    ): BufferRebuild {
         val plan = planBufferRebuild(
             allocatedVertexCount = allocatedVertexCount,
             allocatedIndexCount = allocatedIndexCount,
             requestedVertexCount = requestedVertexCount,
             requestedIndexCount = requestedIndexCount,
         )
-        var staleVertexBuffer: VertexBuffer? = null
-        var staleIndexBuffer: IndexBuffer? = null
-        if (plan.newVertexCount != null) {
-            // Capture the OLD buffer first; build the new buffer; swap the field. The old buffer
-            // is returned so the caller can destroy it AFTER rebinding the renderable.
-            staleVertexBuffer = ownedVertexBuffer
-            ownedVertexBuffer = VertexBuffer.Builder()
+        val newVertexBuffer = plan.newVertexCount?.let { count ->
+            VertexBuffer.Builder()
                 .bufferCount(1)
-                .vertexCount(plan.newVertexCount)
+                .vertexCount(count)
                 .attribute(VertexAttribute.POSITION, 0, AttributeType.FLOAT3)
                 .build(engine)
-            allocatedVertexCount = plan.newVertexCount
         }
-        if (plan.newIndexCount != null) {
-            staleIndexBuffer = ownedIndexBuffer
-            ownedIndexBuffer = IndexBuffer.Builder()
+        val newIndexBuffer = plan.newIndexCount?.let { count ->
+            IndexBuffer.Builder()
                 .bufferType(IndexBuffer.Builder.IndexType.UINT)
-                .indexCount(plan.newIndexCount)
+                .indexCount(count)
                 .build(engine)
-            allocatedIndexCount = plan.newIndexCount
         }
-        return StaleBuffers(staleVertexBuffer, staleIndexBuffer)
+        return BufferRebuild(
+            newVertexBuffer = newVertexBuffer,
+            newIndexBuffer = newIndexBuffer,
+            newVertexCount = plan.newVertexCount,
+            newIndexCount = plan.newIndexCount,
+        )
     }
 
     /**
-     * Buffers superseded by [rebuildBuffersIfNeeded] — destroyed by [uploadGeometry] **after** the
-     * renderable has been rebound to the new buffers (#1805 ordering invariant).
+     * Freshly-allocated replacement buffers produced by [rebuildBuffersIfNeeded].
+     *
+     * The fields are **not yet owned** by the node — `uploadGeometry` commits them after a
+     * successful `setGeometryAt`, swapping the [ownedVertexBuffer] / [ownedIndexBuffer] fields
+     * and destroying the displaced old buffers. On any upload failure, the caller must destroy
+     * these new buffers to avoid leaking them (#1840).
      */
-    private data class StaleBuffers(
-        val staleVertexBuffer: VertexBuffer?,
-        val staleIndexBuffer: IndexBuffer?,
+    private data class BufferRebuild(
+        val newVertexBuffer: VertexBuffer?,
+        val newIndexBuffer: IndexBuffer?,
+        val newVertexCount: Int?,
+        val newIndexCount: Int?,
     )
 
     override fun destroy() {

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/DepthMeshNodeUploadThrowLeakTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/DepthMeshNodeUploadThrowLeakTest.kt
@@ -1,0 +1,188 @@
+package io.github.sceneview.ar.node
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the throw-during-upload leak fix in [DepthMeshNode.uploadGeometry] (#1840).
+ *
+ * Before the fix, [DepthMeshNode.rebuildBuffersIfNeeded] swapped `ownedVertexBuffer` /
+ * `ownedIndexBuffer` to the NEW buffer **before** running the Filament upload calls
+ * ([com.google.android.filament.VertexBuffer.setBufferAt] / [com.google.android.filament.IndexBuffer.setBuffer]
+ * / [com.google.android.filament.RenderableManager.setGeometryAt]).
+ *
+ * If any of those upload calls threw — `IllegalStateException` on engine teardown mid-frame is
+ * the realistic case — the OLD buffers became unreachable AND undestroyed. `destroy()` only
+ * walks the current `owned*` fields, so the orphaned old handles leaked into the next session.
+ *
+ * The fix:
+ *  - `rebuildBuffersIfNeeded` no longer mutates `owned*` — it returns the freshly-built buffers
+ *    plus the new capacity for the caller to commit later.
+ *  - `uploadGeometry` runs the entire Filament upload sequence against `target*` locals first;
+ *    on success it swaps fields + destroys the old buffers; on any throw it destroys the freshly
+ *    allocated buffers (the only references to them) and rethrows.
+ *
+ * The Filament Engine can't run on the JVM, so this test models the upload-with-throw flow via a
+ * recorder that mirrors the post-fix [DepthMeshNode.uploadGeometry] exactly. The recorder makes
+ * the property under test ("on throw: stale old buffer is preserved, new buffer is destroyed
+ * exactly once") observable as a list of events the new code path emits.
+ */
+class DepthMeshNodeUploadThrowLeakTest {
+
+    /**
+     * Mirrors the post-fix [DepthMeshNode.uploadGeometry] data flow. `throwOnUpload` simulates
+     * `setGeometryAt` throwing.
+     */
+    private class ThrowingUploader {
+        val events = mutableListOf<String>()
+        val destroyedHandles = mutableListOf<String>()
+        private var nextHandle = 1
+        var currentVertexBufferHandle: String = "vb#0"
+            private set
+        var currentIndexBufferHandle: String = "ib#0"
+            private set
+        var allocatedVertexCount: Int = DepthMeshNode.INITIAL_VERTEX_CAPACITY
+            private set
+        var allocatedIndexCount: Int = DepthMeshNode.INITIAL_INDEX_CAPACITY
+            private set
+
+        /** Returns true if the upload succeeded; false if it caught + rethrew at the boundary. */
+        fun upload(
+            requestedVertexCount: Int,
+            requestedIndexCount: Int,
+            throwOnUpload: Boolean,
+        ): Boolean {
+            val plan = planBufferRebuild(
+                allocatedVertexCount = allocatedVertexCount,
+                allocatedIndexCount = allocatedIndexCount,
+                requestedVertexCount = requestedVertexCount,
+                requestedIndexCount = requestedIndexCount,
+            )
+            // Phase A: build the new buffers WITHOUT mutating any owned* state.
+            var newVertexHandle: String? = null
+            var newIndexHandle: String? = null
+            if (plan.newVertexCount != null) {
+                newVertexHandle = "vb#${nextHandle++}"
+                events += "build:$newVertexHandle"
+            }
+            if (plan.newIndexCount != null) {
+                newIndexHandle = "ib#${nextHandle++}"
+                events += "build:$newIndexHandle"
+            }
+            val targetVertex = newVertexHandle ?: currentVertexBufferHandle
+            val targetIndex = newIndexHandle ?: currentIndexBufferHandle
+            try {
+                events += "setGeometryAt:$targetVertex:$targetIndex"
+                if (throwOnUpload) throw IllegalStateException("engine teardown mid-frame")
+            } catch (t: Throwable) {
+                // Failure-rollback path: destroy the newly-allocated buffers (the only refs to
+                // them) and leave the owned* fields unchanged so [destroy] can still free them.
+                newVertexHandle?.let { events += "rollback-destroy:$it"; destroyedHandles += it }
+                newIndexHandle?.let { events += "rollback-destroy:$it"; destroyedHandles += it }
+                return false
+            }
+            // Phase B: commit — swap fields, destroy displaced old buffers.
+            if (newVertexHandle != null) {
+                val stale = currentVertexBufferHandle
+                currentVertexBufferHandle = newVertexHandle
+                allocatedVertexCount = plan.newVertexCount!!
+                events += "destroy:$stale"
+                destroyedHandles += stale
+            }
+            if (newIndexHandle != null) {
+                val stale = currentIndexBufferHandle
+                currentIndexBufferHandle = newIndexHandle
+                allocatedIndexCount = plan.newIndexCount!!
+                events += "destroy:$stale"
+                destroyedHandles += stale
+            }
+            return true
+        }
+
+        /** Mirrors [DepthMeshNode.destroy] — releases the owned* refs. */
+        fun destroy() {
+            events += "destroy:$currentVertexBufferHandle"
+            destroyedHandles += currentVertexBufferHandle
+            events += "destroy:$currentIndexBufferHandle"
+            destroyedHandles += currentIndexBufferHandle
+        }
+    }
+
+    @Test
+    fun `setGeometryAt throw destroys new buffers and keeps old buffers reachable for destroy`() {
+        val uploader = ThrowingUploader()
+        val originalVertex = uploader.currentVertexBufferHandle
+        val originalIndex = uploader.currentIndexBufferHandle
+
+        // Force a growth so new buffers get built; then make the upload throw.
+        val ok = uploader.upload(
+            requestedVertexCount = DepthMeshNode.INITIAL_VERTEX_CAPACITY + 1,
+            requestedIndexCount = DepthMeshNode.INITIAL_INDEX_CAPACITY + 1,
+            throwOnUpload = true,
+        )
+        assertFalse("upload must report failure when setGeometryAt throws", ok)
+
+        // The owned* fields must still point at the OLD buffers — otherwise the next destroy()
+        // would leak the originals (#1840).
+        assertEquals(originalVertex, uploader.currentVertexBufferHandle)
+        assertEquals(originalIndex, uploader.currentIndexBufferHandle)
+
+        // The freshly-built buffers must have been destroyed exactly once during rollback —
+        // they're the only references and would otherwise leak forever (#1840).
+        val rollbackDestroys = uploader.events.filter { it.startsWith("rollback-destroy:") }
+        assertEquals("must destroy both new vertex + new index buffers", 2, rollbackDestroys.size)
+
+        // Now simulate node teardown — destroy() must release the STILL-OLD owned buffers.
+        uploader.destroy()
+        assertTrue("old vertex buffer must be destroyed by destroy()", originalVertex in uploader.destroyedHandles)
+        assertTrue("old index buffer must be destroyed by destroy()", originalIndex in uploader.destroyedHandles)
+
+        // No buffer destroyed more than once (no double-free).
+        val grouped = uploader.destroyedHandles.groupingBy { it }.eachCount()
+        for ((handle, count) in grouped) {
+            assertEquals("buffer $handle destroyed more than once", 1, count)
+        }
+    }
+
+    @Test
+    fun `successful upload still commits the swap and destroys old buffers exactly once`() {
+        // Sanity check — the success path must be unchanged by the throw-rollback fix.
+        val uploader = ThrowingUploader()
+        val originalVertex = uploader.currentVertexBufferHandle
+        val originalIndex = uploader.currentIndexBufferHandle
+
+        val ok = uploader.upload(
+            requestedVertexCount = DepthMeshNode.INITIAL_VERTEX_CAPACITY + 1,
+            requestedIndexCount = DepthMeshNode.INITIAL_INDEX_CAPACITY + 1,
+            throwOnUpload = false,
+        )
+        assertTrue("upload must succeed when nothing throws", ok)
+        // Old buffers must have been destroyed by the commit path.
+        assertTrue(originalVertex in uploader.destroyedHandles)
+        assertTrue(originalIndex in uploader.destroyedHandles)
+        // owned* must now point at the new buffers.
+        assertTrue(uploader.currentVertexBufferHandle != originalVertex)
+        assertTrue(uploader.currentIndexBufferHandle != originalIndex)
+    }
+
+    @Test
+    fun `throw during upload does not leak even when only the vertex buffer was reallocated`() {
+        // Capacity bump for vertices only — index buffer still fits. The fix must still destroy
+        // the (single) newly allocated vertex buffer + leave the OLD vertex buffer reachable.
+        val uploader = ThrowingUploader()
+        val originalVertex = uploader.currentVertexBufferHandle
+
+        val ok = uploader.upload(
+            requestedVertexCount = DepthMeshNode.INITIAL_VERTEX_CAPACITY + 1,
+            requestedIndexCount = DepthMeshNode.INITIAL_INDEX_CAPACITY - 100,
+            throwOnUpload = true,
+        )
+        assertFalse(ok)
+        assertEquals(originalVertex, uploader.currentVertexBufferHandle)
+        val rollbackDestroys = uploader.events.filter { it.startsWith("rollback-destroy:") }
+        assertEquals("only the new vertex buffer needed destruction", 1, rollbackDestroys.size)
+        assertTrue(rollbackDestroys.single().startsWith("rollback-destroy:vb#"))
+    }
+}

--- a/changelog.d/1840-depthmesh-uaf-throw-leak.md
+++ b/changelog.d/1840-depthmesh-uaf-throw-leak.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `DepthMeshNode` no longer leaks the old `VertexBuffer` / `IndexBuffer` when an upload step throws mid-frame (engine teardown is the realistic trigger). `rebuildBuffersIfNeeded` returns the freshly-built buffers without mutating the `owned*` fields; `uploadGeometry` commits the swap + destroys the old buffers ONLY after `setGeometryAt` returns. On any exception the new buffers are `safeDestroy`-rolled-back and the owned* fields remain reachable for `destroy()`. Closes a latent leak introduced by the #1805 UAF fix (#1840).


### PR DESCRIPTION
## Summary

The #1805 UAF fix reordered `rebuildBuffersIfNeeded` to rebind-before-destroy, but mutated `ownedVertexBuffer` / `ownedIndexBuffer` to the NEW handles upfront. If any of the Filament upload calls then threw (`setBufferAt`, `setBuffer`, `setGeometryAt`, `setAxisAlignedBoundingBox` — engine teardown mid-frame is the realistic trigger), the OLD buffers became unreachable AND undestroyed. `destroy()` only walks the current `owned*` fields, so the orphaned old handles leaked into the next session.

## Fix

- `rebuildBuffersIfNeeded` now returns the freshly-built buffers without mutating any `owned*` state.
- `uploadGeometry` runs the entire Filament upload sequence against `target*` locals inside a `try`:
  - **Success**: commit the swap (update `owned*` + capacity tracker) and `safeDestroy` the OLD buffers. The #1805 rebind-before-destroy ordering is preserved.
  - **Throw**: `safeDestroy` the NEW buffers (the only references to them) and rethrow. `owned*` is still pointing at the OLD buffers, so the renderable's Filament refs are still valid AND `destroy()` will release them when the node tears down.

## Tier-1 self-review

| Angle | Verdict |
|---|---|
| Correctness | `owned*` always references a Filament-valid + still-destroyable buffer in both paths. |
| Threading | Same render thread as before. No new concurrency. |
| Compose API | Untouched. |
| Memory | No leak (rollback destroys the new buffer). No double-free (each branch destroys exactly one set). |
| Backwards compat | Public API unchanged. Exception now propagates AFTER the rollback so callers see the original failure cause + a clean state. |

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin` passes.
- [x] `./gradlew :arsceneview:testDebugUnitTest` passes (new `DepthMeshNodeUploadThrowLeakTest` + the existing `DepthMeshNodeBufferRebuildTest`).
- [x] `DepthMeshNodeUploadThrowLeakTest` asserts via a recorder mirroring the post-fix data flow that on throw `owned*` still points at the old handles, the newly allocated buffers are destroyed exactly once, and a subsequent `destroy()` releases the old handles (no double-free either).

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)