### PR TITLE
fix(android-demo): ARDepthColliderDemo spawn at camera forward + hide DepthMesh by default (#1874 #1875)

### DIFF
--- a/changelog.d/1874-1875-ar-depth-collider-ux.md
+++ b/changelog.d/1874-1875-ar-depth-collider-ux.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `samples/android-demo`: `ARDepthColliderDemo` now spawns balls in front of the **current** camera pose instead of the AR-session origin, so the balls are always visible regardless of how the user has moved before tapping Drop (#1874), and hides the underlying `DepthMeshNode` renderable by default — the cream dotted grid that the default material drew on every real surface was distracting and ambiguous. A new "Show depth mesh (dev)" Settings switch re-enables the visualization for collider debugging (#1875).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthColliderDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthColliderDemo.kt
@@ -2,23 +2,29 @@ package io.github.sceneview.demo.demos
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Config
+import com.google.ar.core.Pose
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.physics.DepthCollider
 import io.github.sceneview.demo.DemoScaffold
@@ -58,6 +64,22 @@ import io.github.sceneview.sample.rememberMaterialInstance
 fun ARDepthColliderDemo(onBack: () -> Unit) {
     var ballCount by remember { mutableIntStateOf(0) }
     var generation by remember { mutableIntStateOf(0) }
+    // Dev toggle (#1875): the depth mesh is hidden by default so the demo's focus stays on the
+    // bouncing balls — the dotted grid of depth samples on every real surface was distracting and
+    // visually ambiguous (a user couldn't tell if it was a debug overlay, the collider's spheres,
+    // or part of the AR scene). Toggling this on re-renders the underlying DepthMeshNode for
+    // debugging the collider geometry.
+    var showDepthMesh by remember { mutableStateOf(false) }
+    // Captured per-frame in onSessionUpdated (#1874). The previous demo spawned every ball at
+    // the AR-session origin (the device pose when the demo opened); if the user re-aimed the
+    // device before tapping Drop the balls fell outside the camera view and looked "invisible".
+    // We now spawn at the **current** camera pose's forward direction so the balls always
+    // appear in front of the user, no matter how much they have moved.
+    val latestCameraPoseRef = remember { mutableStateOf<Pose?>(null) }
+    // Memoise the spawn pose at the moment ballCount last changed so re-running the for-loop
+    // for an unrelated recomposition (slider, theme, settings toggle) keeps the same world
+    // anchor — only the "Drop" / "Drop 5" buttons re-anchor the spawn.
+    val spawnAnchorRef = remember { mutableStateOf<Pose?>(null) }
 
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
@@ -74,10 +96,17 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Button(onClick = { ballCount++ }) { Text("Drop") }
-                Button(onClick = { ballCount += 5 }) { Text("Drop 5") }
+                Button(onClick = {
+                    spawnAnchorRef.value = latestCameraPoseRef.value
+                    ballCount++
+                }) { Text("Drop") }
+                Button(onClick = {
+                    spawnAnchorRef.value = latestCameraPoseRef.value
+                    ballCount += 5
+                }) { Text("Drop 5") }
                 Button(onClick = {
                     ballCount = 0
+                    spawnAnchorRef.value = null
                     generation++
                 }) { Text("Reset") }
             }
@@ -86,6 +115,21 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
                     "via DepthCollider (#1713).",
                 style = MaterialTheme.typography.labelSmall,
             )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Show depth mesh (dev)",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Switch(
+                    checked = showDepthMesh,
+                    onCheckedChange = { showDepthMesh = it },
+                )
+            }
         },
     ) {
         // key(generation) forces full recomposition on reset so previous bodies are torn down.
@@ -120,22 +164,48 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
                 // per-ball `apply.onFrame` fan-out which ran `publishCollisionRegion` N× per
                 // frame at 5 balls × 60 fps = 300 redundant FloatArrays/sec (#1842). The
                 // ARSceneView's `onSessionUpdated` is the canonical "once per frame" hook with
-                // access to the live session + frame; we ignore them here because all we need
-                // is the cadence.
-                onSessionUpdated = { _, _ ->
+                // access to the live session + frame; we use them to (a) keep the latest
+                // camera pose so a future Drop tap spawns balls in front of the user (#1874),
+                // and (b) feed the per-frame collider region cull.
+                onSessionUpdated = { _, frame ->
+                    latestCameraPoseRef.value = frame.camera.pose
                     val collider = depthColliderRef.value ?: return@ARSceneView
                     publishCollisionRegion(nodeRefs, collider)
                 },
             ) {
-                // The depth collider. Default 5 Hz rebuild rate — the cost of touching the
-                // depth image + transforming vertices per rebuild stays under the 16 ms budget
-                // on a Pixel 7a (160×90 image, stride 4 → ~900 quads after edge-cull). Tune
-                // refreshIntervalMs lower for a "live" surface, higher for cheaper.
-                val depthCollider: DepthCollider = rememberDepthCollider(refreshIntervalMs = 200L)
-                // Surface the collider to the Scene-level onSessionUpdated callback above.
+                // The depth collider. We construct it manually rather than via
+                // `rememberDepthCollider(...)` so we can flip the underlying mesh's `isVisible`
+                // reactively from the Settings toggle (#1875). `rememberDepthCollider` applies
+                // its layer-mask trick once in `apply` and the meshNode is keyed only on the
+                // engine, so changing `renderMesh` at runtime would not take effect there.
+                //
+                // Default 5 Hz rebuild rate — the cost of touching the depth image + transforming
+                // vertices per rebuild stays under the 16 ms budget on a Pixel 7a (160×90 image,
+                // stride 4 → ~900 quads after edge-cull). Tune refreshIntervalMs lower for a
+                // "live" surface, higher for cheaper.
+                val depthMeshNode = rememberDepthMesh(refreshIntervalMs = 200L)
+                // Hide the mesh's renderable by default (#1875). The body of the demo only
+                // needs the mesh's COLLIDER role — the cream dotted grid that the default
+                // material renders is distracting. Reactive on the dev toggle.
+                // TODO(#1875): switch to a fully transparent occlusion material instance once
+                // MaterialLoader.createOcclusionInstance() lands (#1776 / #1832) so the depth
+                // mesh can still depth-write (occluding virtual balls behind real geometry)
+                // without contributing visible pixels.
+                SideEffect {
+                    depthMeshNode.isVisible = showDepthMesh
+                }
+                DepthMeshNode(node = depthMeshNode)
+
+                val depthCollider: DepthCollider = remember(depthMeshNode) {
+                    DepthCollider(depthMeshNode)
+                }
+                // Lifecycle: free the collider's internal snapshot/listener wiring on dispose.
                 DisposableEffect(depthCollider) {
                     depthColliderRef.value = depthCollider
-                    onDispose { depthColliderRef.value = null }
+                    onDispose {
+                        depthColliderRef.value = null
+                        depthCollider.destroy()
+                    }
                 }
 
                 val ballMaterial = rememberMaterialInstance(
@@ -143,18 +213,45 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
                     SceneViewColors.Ramp4[0],
                 )
 
+                // Anchor the spawn at the camera's pose **at the moment Drop was tapped**
+                // (#1874). `spawnAnchorRef` is updated by the button handlers; if the device
+                // doesn't have a valid camera pose yet (first frames, lost tracking), we fall
+                // back to the session origin to keep the demo functional rather than dropping
+                // nothing — visible at the origin is better than silently failing.
+                val spawnAnchor = spawnAnchorRef.value
+
                 for (i in 0 until ballCount) {
-                    // Spawn at the scene origin + a small column above so multiple drops don't
-                    // pile up at a single XY.
+                    // Local-space spawn: a small XY scatter so multiple balls don't pile up at
+                    // one XY, and a Y column so the first ball lands before the next is dropped.
+                    // -Z is forward in SceneView/Filament local space — these offsets are then
+                    // composed through `spawnAnchor` (the camera pose) to get the world-space
+                    // start position, so "forward" tracks the camera regardless of where the
+                    // user has moved before tapping Drop.
                     val xOffset = (i % 5 - 2) * 0.05f
-                    val zOffset = -0.3f - ((i / 5) * 0.05f)
+                    val zOffset = -0.5f - ((i / 5) * 0.05f)
                     val startY = 0.5f + (i / 5) * 0.05f
+
+                    val startPosition = remember(i, spawnAnchor) {
+                        if (spawnAnchor != null) {
+                            // Pose.transformPoint composes the camera rotation + translation,
+                            // so a -Z offset in local pose space becomes "in front of the
+                            // camera in world space". Same pattern as ARPoseDemo.
+                            val world = spawnAnchor.transformPoint(
+                                floatArrayOf(xOffset, startY, zOffset),
+                            )
+                            Position(world[0], world[1], world[2])
+                        } else {
+                            // First-frame / pre-tracking fallback: spawn at scene origin so
+                            // something visible appears, matching the previous demo behaviour.
+                            Position(x = xOffset, y = startY, z = zOffset)
+                        }
+                    }
 
                     var nodeRef by remember(i) { mutableStateOf<SphereNode?>(null) }
                     SphereNode(
                         radius = 0.05f,
                         materialInstance = ballMaterial,
-                        position = Position(x = xOffset, y = startY, z = zOffset),
+                        position = startPosition,
                         apply = {
                             nodeRef = this
                             // Write into our per-slot ref array. The slot is keyed by `i` so


### PR DESCRIPTION
Closes #1874, #1875.

Two sister Pixel 9 device-QA findings in the same demo, bundled into one PR.

## Summary

### Fix #1874 — balls spawn in front of the **current** camera

Before: `Position(x=xOffset, y=startY, z=zOffset)` is **scene-graph local space** — at AR
session start the camera matches the world origin, but as soon as the user re-aimed the
device, the balls dropped at the original origin (now outside the viewport). "Balls
dropped: 5" ticked up, nothing visible. Reproduced on Pixel 9.

After: capture `frame.camera.pose` every frame in `onSessionUpdated`, snapshot it at the
moment Drop / Drop 5 is tapped (`spawnAnchorRef`), and compose the per-ball local-space
scatter through that pose via `Pose.transformPoint(floatArrayOf(x, y, z))`. Matches the
existing ARPoseDemo pattern. Falls back to the scene origin if no camera pose has landed
yet (first frame / lost tracking) so the demo doesn't silently fail.

Reset clears the spawn anchor; bumped the local-space Z offset from `-0.3` to `-0.5` so
the column is comfortably in front of the camera, not clipping the near plane on tap.

### Fix #1875 — hide the DepthMesh by default + dev toggle

Before: cream dotted grid on every real surface (floor, walls, plant, radiator, TV)
distracted from the actual physics demo and was visually ambiguous — a user couldn't tell
if the dots were a debug overlay, the collider's spheres, or part of the scene.

After: build the collider manually (`rememberDepthMesh` + `DepthCollider(...)` directly
instead of `rememberDepthCollider`, whose one-shot layer-mask in `apply` block would not
flip at runtime) and set `depthMeshNode.isVisible = false` via a reactive `SideEffect`.
Default off, with a new "Show depth mesh (dev)" `Switch` in the Settings panel re-enabling
the visualization for collider debugging.

Left a `TODO(#1875)` pointing at #1776 / #1832 — once `MaterialLoader.createOcclusionInstance()`
lands, we can swap the hide for a transparent depth-writing instance so virtual balls
correctly get occluded by real geometry instead of just being invisible at the mesh.

Checked at session open: `grep -rn createOcclusionInstance arsceneview/src/main` → no
hits, so #1776 / #1832 has not landed yet. The simple hide is the right shape until then.

## Self-review

1. **Correctness** — balls now spawn in front of the user regardless of session origin
   (verified by walking through the pose math: ARPoseDemo uses the same
   `cameraPose.transformPoint(floatArrayOf(0, 0, -1))` pattern for the basePose); the
   DepthMesh is hidden by default via the documented `Node.isVisible` → `setLayerVisible(false)`
   path; dev toggle preserves the visualization.
2. **Threading** — Compose state updates remain on the main thread; `frame.camera.pose`
   is read on the AR frame thread inside `onSessionUpdated` (same as the existing
   `publishCollisionRegion` call) and the resulting `Pose` is stored in a `mutableStateOf`
   — the read on tap is on the UI thread but `Pose` is immutable so the snapshot is safe.
   `depthMeshNode.isVisible` is set in a `SideEffect` which runs on the composition thread,
   same as the recommended Compose pattern for pushing declarative props to imperative
   handles.
3. **API consistency** — Settings Row + Switch matches the existing demo Settings pattern
   (see ARImageStabilizationDemo:217-231).
4. **Minimality** — only `ARDepthColliderDemo.kt` (+ a few imports) and one changelog
   fragment. Library code unchanged. No fragment regeneration needed (the file is a demo
   composable, not a fragment).
5. **Cross-platform parity** — Android-only demo; the underlying API choices
   (`Node.isVisible`, `Pose.transformPoint`) match how the iOS demo would express the
   same intent (`Entity.isEnabled`, `Transform.matrix` * local point).

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :samples:android-demo:assembleDebug` — BUILD SUCCESSFUL
- [x] `bash samples/android-demo/scripts/collate-demos.sh --check` — in sync (no fragment change)
- [x] `bash .claude/scripts/sync-versions.sh` — 54 checks, 0 errors
- [ ] Pixel 9 device QA: walk into a room, re-aim camera at floor, tap Drop 5 → balls
      land on the carpet in front of the user (was: invisible at session origin)
- [ ] Pixel 9 device QA: default depth mesh hidden (no cream dotted grid); toggle on →
      grid reappears
- [ ] Pixel 9 device QA: Reset clears balls AND clears the spawn anchor so the next Drop
      re-anchors to the camera's current pose

🤖 Generated with [Claude Code](https://claude.com/claude-code)