### PR TITLE
docs(arsceneview): tighten ARDepthOfField KDoc with upstream verification + device-QA caveats (#1716 follow-up)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/postprocessing/ARDepthOfField.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/postprocessing/ARDepthOfField.kt
@@ -17,8 +17,13 @@ import io.github.sceneview.components.CameraComponent
  * `camera_stream_depth.mat`). Filament's DoF samples that same z-buffer, so the bokeh blur kicks
  * in for both the virtual scene and the camera background without any extra render passes.
  *
- * Inspired by Google's
- * [arcore-depth-lab](https://github.com/googlesamples/arcore-depth-lab) "Depth-of-Field" sample.
+ * **Why this works** (verified against upstream Filament — search `colorPassOutput.depth` in
+ * [`filament/src/details/Renderer.cpp`](https://github.com/google/filament/blob/main/filament/src/details/Renderer.cpp)):
+ * the DoF pass receives the *geometric-pass depth attachment* — exactly the buffer
+ * `camera_stream_depth.mat` writes `gl_FragDepth` into. The separate "Structure Pass" linear-depth
+ * target is reserved for SSAO and contact shadows, not DoF. `dofCoc.mat`'s `getCOC()` consumes the
+ * raw NDC reverse-Z value and rescales it via `cocParams` derived from the active projection
+ * matrix, so the AR camera's projection is the single source of truth for both focus and CoC.
  *
  * **Hard requirements** (callers must satisfy both, otherwise the effect degrades silently):
  *
@@ -28,6 +33,22 @@ import io.github.sceneview.components.CameraComponent
  *     depth image and the z-buffer holds only virtual content, so the background never blurs.
  *  2. [io.github.sceneview.ar.camera.ARCameraStream.isDepthOcclusionEnabled] is `true` — that's
  *     the toggle that swaps in the depth-aware camera material that writes `gl_FragDepth`.
+ *
+ * **Device-QA caveats** (the static reasoning checks out, but these need verification on real
+ * hardware before claiming the effect is correct end-to-end):
+ *
+ *  - **Reverse-Z + early-Z.** Filament uses reverse-Z (`1.0` = near, `0.0` = far).
+ *    `camera_stream_depth.mat` sets `clip.z = 0.9999f` in the vertex shader and overwrites
+ *    `gl_FragDepth` per fragment. Depth-occlusion already ships against this convention, so the
+ *    rasterizer path is known good — but DoF sampling at non-occluded background pixels is a new
+ *    code path and should be eyeballed on a Pixel-class device.
+ *  - **MSAA resolve.** When MSAA is on, Filament inserts a "Resolved Depth Buffer" min-reduce
+ *    before the DoF pass; `gl_FragDepth` values survive but may be filtered. Test with MSAA off
+ *    first to isolate any resolve-time artefact.
+ *  - **CoC calibration.** Filament's `cocParams` is derived from the active camera projection.
+ *    If the AR camera node's near/far diverge from the projection used to compute `ndc_depth`
+ *    from `depth_mm` in `camera_stream_depth.mat`, [focusDepth] will not land at exactly the
+ *    requested meters in screen space.
  *
  * **Off by default.** Apps opt in by passing this struct to [applyARDepthOfField] (or wiring it
  * via the [arDepthOfField] composable). When [enabled] is `false`, [applyARDepthOfField] clears

--- a/changelog.d/1716-kdoc-tightening.md
+++ b/changelog.d/1716-kdoc-tightening.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- `arsceneview`: Tighten `ARDepthOfField` KDoc with the upstream Filament verification (`colorPassOutput.depth` is the buffer `gl_FragDepth` writes to, so DoF post-pass + camera-stream depth occlusion compose without surprises) and surface three device-QA caveats that need eyeballing on real hardware: reverse-Z + early-Z culling around the `clip.z = 0.9999f` vertex hack, MSAA resolve filtering on the depth attachment, and `cocParams` calibration against the AR camera node's projection. Pure docs change; no API/behaviour delta (follow-up to #1716).


### PR DESCRIPTION
## Summary

Follow-up to #1906 / #1716. Post-merge review challenge from Thomas: *"are you actually using the right Filament + ARCore APIs, or is the SceneView implementation maybe wrong?"* — this PR closes the loop with the upstream verification I should have run before the original merge.

## What changed

Pure KDoc / docs change. **No API or runtime behaviour delta.**

- Drops the stale `arcore-depth-lab "Depth-of-Field" sample` pointer in `ARDepthOfField.kt` — the referenced shader is **not actually checked into the upstream repo HEAD** (`DepthEffects/Shaders/` in `googlesamples/arcore-depth-lab` contains only `BackgroundToDepth*` variants, no bokeh shader). The README references it but the asset isn't there.

- Adds a "Why this works" block citing the load-bearing Filament source-of-truth verified post-merge:

  ```cpp
  // filament/src/details/Renderer.cpp
  auto depth = ppm.resolve(fg, "Resolved Depth Buffer", colorPassOutput.depth, ...);
  input = ppm.dof(fg, input, depth, cameraInfo, ..., dofOptions);
  ```

  The DoF pass samples `colorPassOutput.depth` — i.e., the geometric-pass depth attachment, the same one `camera_stream_depth.mat` writes `gl_FragDepth` into. The separate "Structure Pass" linear-depth target (used by SSAO + contact shadows) is **not** touched by DoF. `dofCoc.mat`'s `getCOC()` consumes raw NDC reverse-Z and rescales via `cocParams` derived from the active projection — exactly the convention `camera_stream_depth.mat` already writes against.

- Surfaces **three device-QA caveats** the original PR did not verify:
  1. **Reverse-Z + early-Z culling** around the `clip.z = 0.9999f` vertex hack — depth-occlusion already ships against this convention so the rasterizer path is known good, but the DoF post-pass sampling pattern at non-occluded background pixels is new.
  2. **MSAA resolve filtering** — Filament inserts a min-reduce on the depth attachment before DoF when MSAA is on; `gl_FragDepth` values survive but can be filtered.
  3. **`cocParams` calibration** — if the AR camera node's near/far diverge from the projection used to compute `ndc_depth` from `depth_mm` in the depth shader, `focusDepth` won't land at exactly the requested meters in screen space.

## Why now

The original PR shipped the technically-correct implementation based on first-principles reasoning. Thomas's challenge prompted me to actually pull the Filament source and verify. The verification confirmed the foundation, but raised three real-hardware questions the KDoc was silent on. This follow-up surfaces them so future readers (and the Maestro release-checkpoint QA harness) know what to eyeball.

## Verification

- [x] `:arsceneview:compileReleaseKotlin` ✅ (8s, fully cache-hit after the first config).
- [x] No code touched — KDoc + changelog fragment only.
- [x] Manual cross-check against [`filament/src/details/Renderer.cpp`](https://github.com/google/filament/blob/main/filament/src/details/Renderer.cpp), [`PostProcessManager.cpp:556`](https://github.com/google/filament/blob/main/filament/src/PostProcessManager.cpp), [`dofCoc.mat`](https://github.com/google/filament/blob/main/filament/src/materials/dof/dofCoc.mat), [`dofUtils.fs`](https://github.com/google/filament/blob/main/filament/src/materials/dof/dofUtils.fs), and [`gh api repos/googlesamples/arcore-depth-lab/git/trees`](https://github.com/googlesamples/arcore-depth-lab) — all citations in the new KDoc map to real upstream code.

## Test plan

- [ ] Reviewer (Thomas): sanity-check the three device-QA caveats wording — do they describe the right risks, or is one of them a strawman?
- [ ] Future release-checkpoint Maestro QA: run the `ar-depth-of-field` demo on a Pixel_7a virtualscene record, eyeball that tap-near actually blurs the far background and vice-versa. If any of the three caveats fires, that's a defect — file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)