### PR TITLE
fix(scripts): quality-gate.sh LARGE_FILES check no longer aborts under pipefail (#1914)

### DIFF
--- a/.claude/scripts/quality-gate.sh
+++ b/.claude/scripts/quality-gate.sh
@@ -50,8 +50,16 @@ CONFLICT_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null | wc -l | tr -
 [ "$CONFLICT_FILES" -eq 0 ] && check "No merge conflicts" "PASS" "" || check "No merge conflicts" "FAIL" "$CONFLICT_FILES files"
 
 # Check for large files being committed
+# Note: the inner per-file checks must NOT propagate a non-zero exit when the
+# file is under the threshold — pipefail + set -e would otherwise abort the
+# whole quality-gate run on the common case (see issue #1914).
 LARGE_FILES=$(git diff --cached --name-only 2>/dev/null | while read f; do
-    [ -f "$f" ] && SIZE=$(wc -c < "$f" 2>/dev/null | tr -d ' ') && [ "$SIZE" -gt 10485760 ] && echo "$f"
+    if [ -f "$f" ]; then
+        SIZE=$(wc -c < "$f" 2>/dev/null | tr -d ' ')
+        if [ "${SIZE:-0}" -gt 10485760 ]; then
+            echo "$f"
+        fi
+    fi
 done | wc -l | tr -d ' ')
 [ "$LARGE_FILES" -eq 0 ] && check "No large files (>10MB) staged" "PASS" "" || check "No large files staged" "WARN" "$LARGE_FILES files"
 

--- a/changelog.d/1914-quality-gate-large-files-fix.md
+++ b/changelog.d/1914-quality-gate-large-files-fix.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `.claude/scripts/quality-gate.sh`: The `LARGE_FILES` check no longer aborts the whole quality gate under `set -euo pipefail` when staged files are under the 10 MB threshold (the common case). Restructured the per-file `&&` chain into nested `if` blocks so the size comparison returning false stays local to the loop iteration instead of propagating through `pipefail` and bailing the script via `set -e`. Local pre-push runs now reach the final `Quality Gate Summary` block as intended (#1914).


### PR DESCRIPTION
Closes #1914.

## Root cause

`.claude/scripts/quality-gate.sh:53-56` had the LARGE_FILES check structured as a single `&&` chain:

```bash
[ -f "$f" ] && SIZE=$(wc -c < "$f" 2>/dev/null | tr -d ' ') && [ "$SIZE" -gt 10485760 ] && echo "$f"
```

For staged files under the 10 MB threshold (the common case), the final `[ "$SIZE" -gt 10485760 ]` returns exit 1. The `while read` subshell propagates that to the outer pipeline, `pipefail` makes the whole `$(... | wc -l ...)` non-zero, and `set -e` bails the script before the version-sync section runs. Local pre-push runs ended after only 5 lines with no FAIL/WARN/BLOCKED marker.

## Fix

Restructured the inner per-file logic into nested `if` blocks so the "file is under threshold" verdict stays local to the loop iteration instead of becoming the loop's exit status. Empty `SIZE` defended via `${SIZE:-0}` for robustness.

```bash
LARGE_FILES=$(git diff --cached --name-only 2>/dev/null | while read f; do
    if [ -f "$f" ]; then
        SIZE=$(wc -c < "$f" 2>/dev/null | tr -d ' ')
        if [ "${SIZE:-0}" -gt 10485760 ]; then
            echo "$f"
        fi
    fi
done | wc -l | tr -d ' ')
```

CI behaviour is unchanged — the runner has no staged files, so the loop body never executes.

## Self-review

1. **Correctness** — verified via three scenarios:
   - Before fix, stage `CLAUDE.md`, run `quality-gate.sh --quick` → exits 1 after 5 lines.
   - After fix, same scenario → reaches `Quality Gate Summary` block.
   - After fix, stage a synthetic 11 MB file → `[WARN] No large files staged: 1 files` correctly fires.
2. **Threading** — N/A (bash).
3. **API consistency** — uses the same `if` / `[ … ]` style as the rest of `quality-gate.sh`.
4. **Minimality** — single function block in `quality-gate.sh` + changelog fragment. No other refactor.
5. **Cross-platform parity** — bash 3.2 (macOS) compatible + GNU coreutils (Linux CI). `shellcheck` introduces zero new warnings (existing SC2015 / SC2162 are pre-existing across the whole file).

## Acceptance criteria

- [x] `quality-gate.sh` reaches the final `Quality Gate Summary` block when files are staged.
- [x] CI `Quality gate (full)` job stays green (no behavioural change there).