### PR TITLE
feat(feedback-worker): Cloudflare backend for in-app feedback (1A)

### DIFF
--- a/feedback-worker/.gitignore
+++ b/feedback-worker/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.wrangler/
+.dev.vars
+*.log

--- a/feedback-worker/DEPLOY.md
+++ b/feedback-worker/DEPLOY.md
@@ -34,10 +34,18 @@ Keep `app.pkcs8.pem` out of the repo — it goes straight into a Wrangler secret
 
 ```sh
 npm install
-wrangler d1 create sceneview-feedback            # paste database_id into wrangler.toml
-wrangler kv namespace create RL_KV               # paste id into wrangler.toml
+wrangler d1 create sceneview-feedback
+wrangler kv namespace create RL_KV
 wrangler r2 bucket create sceneview-feedback-media
-wrangler d1 migrations apply sceneview-feedback
+```
+
+Paste the printed `database_id` and KV `id` into `wrangler.toml`, **then** apply
+the migration to the **remote** D1. Without `--remote`, `migrations apply` only
+touches the local dev database and production launches with no `feedback` table
+(every `POST /v1/feedback` then 502s):
+
+```sh
+wrangler d1 migrations apply sceneview-feedback --remote
 ```
 
 ## 3. Secrets

--- a/feedback-worker/DEPLOY.md
+++ b/feedback-worker/DEPLOY.md
@@ -1,0 +1,80 @@
+# feedback-worker — deployment
+
+Cloudflare worker behind the SceneView in-app feedback feature
+(umbrella [#1930](https://github.com/sceneview/sceneview/issues/1930),
+task [#1931](https://github.com/sceneview/sceneview/issues/1931)).
+
+It receives feedback uploads from the demo apps, stores the media privately in
+R2, transcribes the audio with Workers AI (Whisper), and opens a pre-filled
+GitHub issue. The public issue carries only the transcript + context; the raw
+recording is viewable only through the admin-gated `/feedback/<id>` viewer.
+
+## 1. Prerequisite — GitHub App
+
+Create a GitHub App on the **sceneview** org (Settings → Developer settings →
+GitHub Apps → New GitHub App):
+
+- Repository permissions → **Issues: Read and write**
+- Webhook → **Active: unchecked**
+- Install it on `sceneview/sceneview`
+
+Collect: the **App ID**, the **Installation ID** (the number in the install
+URL), and a generated **private key** (`.pem`).
+
+GitHub issues the key in PKCS#1 format; the worker needs PKCS#8 — convert it:
+
+```sh
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+  -in your-app.private-key.pem -out app.pkcs8.pem
+```
+
+Keep `app.pkcs8.pem` out of the repo — it goes straight into a Wrangler secret.
+
+## 2. Provision the bindings
+
+```sh
+npm install
+wrangler d1 create sceneview-feedback            # paste database_id into wrangler.toml
+wrangler kv namespace create RL_KV               # paste id into wrangler.toml
+wrangler r2 bucket create sceneview-feedback-media
+wrangler d1 migrations apply sceneview-feedback
+```
+
+## 3. Secrets
+
+```sh
+wrangler secret put GITHUB_APP_ID
+wrangler secret put GITHUB_INSTALLATION_ID
+wrangler secret put GITHUB_PRIVATE_KEY < app.pkcs8.pem
+wrangler secret put ADMIN_TOKEN                  # any long random string
+```
+
+`ADMIN_TOKEN` gates media playback in the `/feedback/<id>` viewer — without it,
+the viewer shows only the transcript + context. Keep it private.
+
+## 4. Verify and deploy
+
+```sh
+npm run typecheck
+npm test
+wrangler deploy
+```
+
+## Endpoints
+
+| Route | Purpose |
+|---|---|
+| `POST /v1/feedback` | Multipart upload from the demo apps (video + audio + context). |
+| `GET /feedback/<id>` | Viewer — transcript + context public; media admin-gated. |
+| `GET /feedback/<id>/media/<video\|audio>` | Admin-token-gated media stream. |
+| `GET /health` | Health check. |
+
+## Retention
+
+Media older than 90 days is purged nightly by the cron trigger
+(`0 3 * * *`). The feedback row and its transcript are kept.
+
+## Cost
+
+Free tier at SceneView's volume: Workers AI Whisper (free allocation), R2
+(< 10 GB with 90-day retention, free egress), GitHub API (free).

--- a/feedback-worker/migrations/0001_feedback.sql
+++ b/feedback-worker/migrations/0001_feedback.sql
@@ -1,0 +1,20 @@
+-- In-app user feedback submitted from the SceneView demo apps.
+-- The transcript + context are mirrored into a public GitHub issue;
+-- the raw media lives in R2 and is purged after the retention window.
+CREATE TABLE IF NOT EXISTS feedback (
+  id            TEXT    PRIMARY KEY,                              -- uuid v4
+  created_at    TEXT    NOT NULL DEFAULT (datetime('now')),       -- server receipt time
+  category      TEXT    NOT NULL CHECK (category IN ('bug', 'idea')),
+  status        TEXT    NOT NULL DEFAULT 'new'
+                        CHECK (status IN ('new', 'issued', 'error', 'purged')),
+  transcript    TEXT,                                            -- Whisper output (user's language)
+  context_json  TEXT,                                            -- device / OS / app version / demo
+  video_key     TEXT,                                            -- R2 key, NULL once purged
+  audio_key     TEXT,                                            -- R2 key, NULL once purged
+  github_issue  INTEGER,                                         -- created issue number
+  github_url    TEXT,                                            -- created issue html_url
+  media_purged  INTEGER NOT NULL DEFAULT 0                        -- 1 once R2 media is deleted
+);
+
+CREATE INDEX idx_feedback_created ON feedback (created_at);
+CREATE INDEX idx_feedback_status  ON feedback (status);

--- a/feedback-worker/package-lock.json
+++ b/feedback-worker/package-lock.json
@@ -1,0 +1,3088 @@
+{
+  "name": "sceneview-feedback",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sceneview-feedback",
+      "version": "1.0.0",
+      "dependencies": {
+        "hono": "^4.12.14"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250327.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.1.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260518.1.tgz",
+      "integrity": "sha512-IhZEf5kDd0CLRtFxGS9AUqfM5SY3EFScqqCY1VF9twNMdYpJDYrDZDJAkQitHF8sF/sPVVHYR4Aifpdq6tzmaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260518.1.tgz",
+      "integrity": "sha512-uqlNP1psd8SWfN1Lg5p8ePv8/piOOXt+ycvb8+NQopXECGeh9+PQ/yr/IQjpurxBhYpvSaMC+vEeihejahjkJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260518.1.tgz",
+      "integrity": "sha512-D9p8Hl0lIQ46nYs4fQZp5F+9hhvgOcQJTF1SMQWpAxQSS5f8oX+vL5YdCrETUYnyoaoyEQETtkRrWYKJkPTFeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260518.1.tgz",
+      "integrity": "sha512-+vNRkuOp9E/uRKHgQXVDUBPF5cwtTeXK6+ucLK50QUFzMYycqVl8kTFN2b//BX2H5BI4bjMRhXoBpe/zAlGRWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260518.1.tgz",
+      "integrity": "sha512-tnqofUq+ZvKliQHhboygbH7iy/Zm/MaCCotIlrqVj5a988+tPtndxyLM0r4vaAIC10iy/2LWCkwnE67VFTFiUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260521.1.tgz",
+      "integrity": "sha512-cerUUdckXWiNm0x0XEIomBkr58xja5hn/1F9wzzDfJTE96L98L/Ra0ToTxKfzsXLklPflOagce8Vhg0vx8Ytgw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260518.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260518.0.tgz",
+      "integrity": "sha512-jbvp43zWa66tuQ+P7bl7s25VJWzGMv4mVhxEEZEEATPvuqAQhGn2wj3rQViVZkZZBZmXQtZ5ZV5kX9VtmWGzuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260518.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260518.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260518.1.tgz",
+      "integrity": "sha512-rLquk/eeqqJCbdGljSSuIZWW25vzYjTblXkD/tXQXKR5YsSIC91EtlqrzA1L4TJDZCxXKeFXPYqkW7R16UipXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260518.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260518.1",
+        "@cloudflare/workerd-linux-64": "1.20260518.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260518.1",
+        "@cloudflare/workerd-windows-64": "1.20260518.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.93.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.93.0.tgz",
+      "integrity": "sha512-qNsPr0oWRTc85SG7s1MjX+mWNTvkNV1zEQvRpTsV6eo8uqtvZoEAq8t8strQi9TtrDP3BOsxmy+N/G3ML6hH2w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260518.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260518.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260518.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/feedback-worker/package.json
+++ b/feedback-worker/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sceneview-feedback",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.12.14"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250327.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/feedback-worker/src/db.ts
+++ b/feedback-worker/src/db.ts
@@ -1,0 +1,70 @@
+import type { Env } from "./env.js";
+
+/** A row of the `feedback` table. */
+export interface FeedbackRow {
+  id: string;
+  created_at: string;
+  category: "bug" | "idea";
+  status: string;
+  transcript: string | null;
+  context_json: string | null;
+  video_key: string | null;
+  audio_key: string | null;
+  github_issue: number | null;
+  github_url: string | null;
+  media_purged: number;
+}
+
+export async function insertFeedback(
+  env: Env,
+  row: {
+    id: string;
+    category: string;
+    transcript: string | null;
+    context_json: string;
+    video_key: string | null;
+    audio_key: string | null;
+  },
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO feedback (id, category, status, transcript, context_json, video_key, audio_key)
+     VALUES (?, ?, 'new', ?, ?, ?, ?)`,
+  )
+    .bind(
+      row.id,
+      row.category,
+      row.transcript,
+      row.context_json,
+      row.video_key,
+      row.audio_key,
+    )
+    .run();
+}
+
+export async function markIssued(
+  env: Env,
+  id: string,
+  issueNumber: number,
+  issueUrl: string,
+): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE feedback SET status = 'issued', github_issue = ?, github_url = ? WHERE id = ?`,
+  )
+    .bind(issueNumber, issueUrl, id)
+    .run();
+}
+
+export async function markError(env: Env, id: string): Promise<void> {
+  await env.DB.prepare(`UPDATE feedback SET status = 'error' WHERE id = ?`)
+    .bind(id)
+    .run();
+}
+
+export async function getFeedback(
+  env: Env,
+  id: string,
+): Promise<FeedbackRow | null> {
+  return env.DB.prepare(`SELECT * FROM feedback WHERE id = ?`)
+    .bind(id)
+    .first<FeedbackRow>();
+}

--- a/feedback-worker/src/env.ts
+++ b/feedback-worker/src/env.ts
@@ -1,0 +1,22 @@
+/** Type-safe Cloudflare bindings for the feedback worker. */
+export interface Env {
+  /** Feedback records + transcripts. */
+  DB: D1Database;
+  /** Rate-limit counters. */
+  RL_KV: KVNamespace;
+  /** Private media bucket — screen recordings + audio. */
+  MEDIA: R2Bucket;
+  /** Workers AI — Whisper transcription. */
+  AI: Ai;
+  ENVIRONMENT: string;
+  /** Target repo for created issues, e.g. "sceneview/sceneview". */
+  GITHUB_REPO: string;
+  /** GitHub App id. Secret — `wrangler secret put GITHUB_APP_ID`. */
+  GITHUB_APP_ID: string;
+  /** GitHub App installation id on the target repo. Secret. */
+  GITHUB_INSTALLATION_ID: string;
+  /** GitHub App private key, PKCS#8 PEM. Secret. */
+  GITHUB_PRIVATE_KEY: string;
+  /** Bearer token gating media playback in the /feedback/<id> viewer. Secret. */
+  ADMIN_TOKEN: string;
+}

--- a/feedback-worker/src/github.ts
+++ b/feedback-worker/src/github.ts
@@ -1,0 +1,128 @@
+import type { Env } from "./env.js";
+
+const GH_API = "https://api.github.com";
+const UA = "sceneview-feedback-worker";
+
+/** Import a PKCS#8 PEM RSA private key for RS256 signing. */
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const body = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  const der = Uint8Array.from(atob(body), (ch) => ch.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "pkcs8",
+    der,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlString(s: string): string {
+  return base64Url(new TextEncoder().encode(s));
+}
+
+/** Build a short-lived GitHub App JWT (RS256). */
+async function appJwt(env: Env): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64UrlString(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  // iat backdated 60s for clock skew; exp 9 min (GitHub allows up to 10).
+  const payload = base64UrlString(
+    JSON.stringify({ iat: now - 60, exp: now + 540, iss: env.GITHUB_APP_ID }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const key = await importPrivateKey(env.GITHUB_PRIVATE_KEY);
+  const sig = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64Url(new Uint8Array(sig))}`;
+}
+
+/** Exchange the App JWT for an installation access token. */
+async function installationToken(env: Env): Promise<string> {
+  const jwt = await appJwt(env);
+  const res = await fetch(
+    `${GH_API}/app/installations/${env.GITHUB_INSTALLATION_ID}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": UA,
+      },
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `installation token request failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  const json = (await res.json()) as { token: string };
+  return json.token;
+}
+
+/** Create the `user-feedback` label if missing. Best-effort — never throws. */
+async function ensureLabel(env: Env, token: string): Promise<void> {
+  try {
+    const headers = {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": UA,
+    };
+    const existing = await fetch(
+      `${GH_API}/repos/${env.GITHUB_REPO}/labels/user-feedback`,
+      { headers },
+    );
+    if (existing.ok) return;
+    await fetch(`${GH_API}/repos/${env.GITHUB_REPO}/labels`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "user-feedback",
+        color: "0e8a16",
+        description: "Submitted via the in-app feedback reporter",
+      }),
+    });
+  } catch {
+    // Non-critical: the issue is still created, just without the label
+    // pre-existing. GitHub creates unknown labels referenced on an issue.
+  }
+}
+
+export interface CreatedIssue {
+  number: number;
+  url: string;
+}
+
+/** Create a GitHub issue in the target repo via the App installation token. */
+export async function createIssue(
+  env: Env,
+  issue: { title: string; body: string; labels: string[] },
+): Promise<CreatedIssue> {
+  const token = await installationToken(env);
+  await ensureLabel(env, token);
+  const res = await fetch(`${GH_API}/repos/${env.GITHUB_REPO}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": UA,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(issue),
+  });
+  if (!res.ok) {
+    throw new Error(`create issue failed: ${res.status} ${await res.text()}`);
+  }
+  const json = (await res.json()) as { number: number; html_url: string };
+  return { number: json.number, url: json.html_url };
+}

--- a/feedback-worker/src/github.ts
+++ b/feedback-worker/src/github.ts
@@ -62,9 +62,8 @@ async function installationToken(env: Env): Promise<string> {
     },
   );
   if (!res.ok) {
-    throw new Error(
-      `installation token request failed: ${res.status} ${await res.text()}`,
-    );
+    // Status only — the response body can echo request detail / secrets.
+    throw new Error(`installation token request failed: ${res.status}`);
   }
   const json = (await res.json()) as { token: string };
   return json.token;
@@ -121,7 +120,8 @@ export async function createIssue(
     body: JSON.stringify(issue),
   });
   if (!res.ok) {
-    throw new Error(`create issue failed: ${res.status} ${await res.text()}`);
+    // Status only — never interpolate the response body into the error.
+    throw new Error(`create issue failed: ${res.status}`);
   }
   const json = (await res.json()) as { number: number; html_url: string };
   return { number: json.number, url: json.html_url };

--- a/feedback-worker/src/index.ts
+++ b/feedback-worker/src/index.ts
@@ -1,7 +1,8 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
+import { getCookie, setCookie } from "hono/cookie";
 import type { Env } from "./env.js";
-import { isRateLimited } from "./rate-limit.js";
+import { isRateLimited, issueQuotaExceeded } from "./rate-limit.js";
 import { transcribe } from "./transcribe.js";
 import { buildIssue, type Category, type FeedbackContext } from "./issue.js";
 import { createIssue } from "./github.js";
@@ -31,6 +32,31 @@ function fileField(form: FormData, name: string): File | null {
     return entry as File;
   }
   return null;
+}
+
+/** Name of the HttpOnly cookie carrying the admin session token. */
+const ADMIN_COOKIE = "fb_admin";
+
+/** Constant-time string compare via SHA-256 digests (fixed length, no early-out). */
+async function constantTimeEqual(a: string, b: string): Promise<boolean> {
+  const enc = new TextEncoder();
+  const [da, db] = await Promise.all([
+    crypto.subtle.digest("SHA-256", enc.encode(a)),
+    crypto.subtle.digest("SHA-256", enc.encode(b)),
+  ]);
+  const va = new Uint8Array(da);
+  const vb = new Uint8Array(db);
+  let diff = 0;
+  for (let i = 0; i < va.length; i++) diff |= va[i] ^ vb[i];
+  return diff === 0;
+}
+
+/** True when the request carries a valid admin session cookie. */
+async function isAdmin(c: Context<{ Bindings: Env }>): Promise<boolean> {
+  const token = c.env.ADMIN_TOKEN;
+  if (!token) return false;
+  const cookie = getCookie(c, ADMIN_COOKIE);
+  return !!cookie && (await constantTimeEqual(cookie, token));
 }
 
 // ── CORS — the demo apps post from a native HTTP client ─────────────────────
@@ -92,6 +118,17 @@ app.post("/v1/feedback", async (c) => {
   const video = fileField(form, "video");
   const audio = fileField(form, "audio");
 
+  // Enforce the real upload size on the File objects — `content-length`
+  // (checked above) is optional and client-controlled, so it is not authoritative.
+  if ((video?.size ?? 0) + (audio?.size ?? 0) > MAX_UPLOAD) {
+    return c.json({ error: "payload_too_large" }, 413);
+  }
+  // Reject empty submissions — no text, no audio and no video would only
+  // produce a blank GitHub issue.
+  if (!text && !video && !audio) {
+    return c.json({ error: "empty_feedback" }, 400);
+  }
+
   const id = crypto.randomUUID();
   let videoKey: string | null = null;
   let audioKey: string | null = null;
@@ -146,6 +183,14 @@ app.post("/v1/feedback", async (c) => {
     viewerUrl,
   });
 
+  // Repo-wide backstop: if issue creation is being flooded this hour, keep the
+  // feedback (media + transcript are already stored) but skip opening the issue.
+  if (await issueQuotaExceeded(c.env.RL_KV)) {
+    console.error("global issue quota exceeded — feedback stored, issue skipped");
+    await markError(c.env, id).catch(() => {});
+    return c.json({ ok: true, id, issue: null }, 202);
+  }
+
   try {
     const created = await createIssue(c.env, issue);
     await markIssued(c.env, id, created.number, created.url);
@@ -167,15 +212,31 @@ app.get("/feedback/:id", async (c) => {
   const row = await getFeedback(c.env, id);
   if (!row) return c.html(renderNotFound(), 404);
 
-  const token = c.req.query("token");
-  const admin =
-    !!c.env.ADMIN_TOKEN && token === c.env.ADMIN_TOKEN ? c.env.ADMIN_TOKEN : null;
-  return c.html(renderViewer(row, admin));
+  // Admin unlock: a valid `?token=` sets an HttpOnly cookie and redirects to a
+  // clean URL, so the token never lingers in browser history, logs or Referer.
+  const queryToken = c.req.query("token");
+  if (queryToken !== undefined) {
+    if (
+      c.env.ADMIN_TOKEN &&
+      (await constantTimeEqual(queryToken, c.env.ADMIN_TOKEN))
+    ) {
+      setCookie(c, ADMIN_COOKIE, c.env.ADMIN_TOKEN, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "Strict",
+        path: "/feedback",
+        maxAge: 28800,
+      });
+    }
+    return c.redirect(`/feedback/${id}`, 302);
+  }
+
+  return c.html(renderViewer(row, await isAdmin(c)));
 });
 
 // ── GET /feedback/:id/media/:kind — admin-gated media stream ─────────────────
 app.get("/feedback/:id/media/:kind", async (c) => {
-  if (!c.env.ADMIN_TOKEN || c.req.query("token") !== c.env.ADMIN_TOKEN) {
+  if (!(await isAdmin(c))) {
     return c.json({ error: "unauthorized" }, 401);
   }
   const id = c.req.param("id");

--- a/feedback-worker/src/index.ts
+++ b/feedback-worker/src/index.ts
@@ -1,0 +1,231 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import type { Env } from "./env.js";
+import { isRateLimited } from "./rate-limit.js";
+import { transcribe } from "./transcribe.js";
+import { buildIssue, type Category, type FeedbackContext } from "./issue.js";
+import { createIssue } from "./github.js";
+import {
+  getFeedback,
+  insertFeedback,
+  markError,
+  markIssued,
+} from "./db.js";
+import { renderNotFound, renderViewer } from "./viewer.js";
+import { purgeExpiredMedia } from "./retention.js";
+
+const app = new Hono<{ Bindings: Env }>();
+
+/** Upload ceiling — a short screen recording is well under this. */
+const MAX_UPLOAD = 30 * 1024 * 1024; // 30 MB
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Pick a File-valued multipart field; null if absent or a plain string. */
+function fileField(form: FormData, name: string): File | null {
+  const entry: unknown = form.get(name);
+  if (
+    entry !== null &&
+    typeof entry === "object" &&
+    typeof (entry as { arrayBuffer?: unknown }).arrayBuffer === "function"
+  ) {
+    return entry as File;
+  }
+  return null;
+}
+
+// ── CORS — the demo apps post from a native HTTP client ─────────────────────
+app.use(
+  "/v1/*",
+  cors({
+    origin: "*",
+    allowMethods: ["POST", "OPTIONS"],
+    allowHeaders: ["content-type"],
+    maxAge: 86400,
+  }),
+);
+
+// ── Health check ─────────────────────────────────────────────────────────────
+app.get("/health", (c) =>
+  c.json({ ok: true, service: "sceneview-feedback", version: "1.0.0" }),
+);
+
+// ── POST /v1/feedback — receive a feedback submission ────────────────────────
+app.post("/v1/feedback", async (c) => {
+  // Reject oversized uploads before reading the body.
+  const cl = parseInt(c.req.header("content-length") ?? "0", 10);
+  if (cl > MAX_UPLOAD) return c.json({ error: "payload_too_large" }, 413);
+
+  // Rate limit by IP (hashed — never stored raw).
+  const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+  const rl = await isRateLimited(ip, c.env.RL_KV);
+  if (rl.limited) {
+    return c.json({ error: "rate_limited" }, 429, { "Retry-After": "60" });
+  }
+
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    return c.json({ error: "invalid_multipart" }, 400);
+  }
+
+  const category = String(form.get("category") ?? "");
+  if (category !== "bug" && category !== "idea") {
+    return c.json({ error: "invalid_category" }, 400);
+  }
+  const text = String(form.get("text") ?? "").slice(0, 4000);
+
+  // Optional JSON context — bounded, malformed input is ignored, not fatal.
+  let context: FeedbackContext = {};
+  const rawContext = form.get("context");
+  if (typeof rawContext === "string" && rawContext.length <= 8192) {
+    try {
+      const parsed: unknown = JSON.parse(rawContext);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        context = parsed as FeedbackContext;
+      }
+    } catch {
+      // malformed context — proceed without it
+    }
+  }
+
+  const video = fileField(form, "video");
+  const audio = fileField(form, "audio");
+
+  const id = crypto.randomUUID();
+  let videoKey: string | null = null;
+  let audioKey: string | null = null;
+  let audioBuf: ArrayBuffer | null = null;
+
+  // Store media privately in R2.
+  try {
+    if (video && video.size > 0) {
+      videoKey = `feedback/${id}/screen.mp4`;
+      await c.env.MEDIA.put(videoKey, await video.arrayBuffer(), {
+        httpMetadata: { contentType: video.type || "video/mp4" },
+      });
+    }
+    if (audio && audio.size > 0) {
+      audioBuf = await audio.arrayBuffer();
+      audioKey = `feedback/${id}/audio.m4a`;
+      await c.env.MEDIA.put(audioKey, audioBuf, {
+        httpMetadata: { contentType: audio.type || "audio/mp4" },
+      });
+    }
+  } catch (e) {
+    console.error("R2 upload failed", e);
+    return c.json({ error: "storage_failed" }, 502);
+  }
+
+  // Transcribe the audio (best-effort — never throws).
+  const transcript = audioBuf ? (await transcribe(c.env, audioBuf)).text : "";
+
+  // Persist the record.
+  try {
+    await insertFeedback(c.env, {
+      id,
+      category,
+      transcript: transcript || null,
+      context_json: JSON.stringify(context),
+      video_key: videoKey,
+      audio_key: audioKey,
+    });
+  } catch (e) {
+    console.error("D1 insert failed", e);
+    return c.json({ error: "storage_failed" }, 502);
+  }
+
+  // Build + create the GitHub issue.
+  const viewerUrl = new URL(`/feedback/${id}`, c.req.url).toString();
+  const issue = buildIssue({
+    id,
+    category: category as Category,
+    transcript,
+    text,
+    context,
+    viewerUrl,
+  });
+
+  try {
+    const created = await createIssue(c.env, issue);
+    await markIssued(c.env, id, created.number, created.url);
+    return c.json({ ok: true, id, issue: created.number, url: created.url }, 201);
+  } catch (e) {
+    // Media + transcript are saved — the maintainer can still recover this
+    // from the viewer even though the issue was not opened.
+    console.error("GitHub issue creation failed", e);
+    await markError(c.env, id).catch(() => {});
+    return c.json({ ok: true, id, issue: null }, 202);
+  }
+});
+
+// ── GET /feedback/:id — the viewer page ──────────────────────────────────────
+app.get("/feedback/:id", async (c) => {
+  const id = c.req.param("id");
+  if (!UUID_RE.test(id)) return c.html(renderNotFound(), 404);
+
+  const row = await getFeedback(c.env, id);
+  if (!row) return c.html(renderNotFound(), 404);
+
+  const token = c.req.query("token");
+  const admin =
+    !!c.env.ADMIN_TOKEN && token === c.env.ADMIN_TOKEN ? c.env.ADMIN_TOKEN : null;
+  return c.html(renderViewer(row, admin));
+});
+
+// ── GET /feedback/:id/media/:kind — admin-gated media stream ─────────────────
+app.get("/feedback/:id/media/:kind", async (c) => {
+  if (!c.env.ADMIN_TOKEN || c.req.query("token") !== c.env.ADMIN_TOKEN) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  const id = c.req.param("id");
+  const kind = c.req.param("kind");
+  if (!UUID_RE.test(id) || (kind !== "video" && kind !== "audio")) {
+    return c.json({ error: "not_found" }, 404);
+  }
+
+  const row = await getFeedback(c.env, id);
+  if (!row) return c.json({ error: "not_found" }, 404);
+
+  const key = kind === "video" ? row.video_key : row.audio_key;
+  if (!key) return c.json({ error: "not_found" }, 404);
+
+  const obj = await c.env.MEDIA.get(key);
+  if (!obj) return c.json({ error: "not_found" }, 404);
+
+  return new Response(obj.body, {
+    headers: {
+      "content-type":
+        obj.httpMetadata?.contentType ??
+        (kind === "video" ? "video/mp4" : "audio/mp4"),
+      "cache-control": "private, no-store",
+    },
+  });
+});
+
+// ── Landing page ─────────────────────────────────────────────────────────────
+app.get("/", (c) =>
+  c.html(`<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>SceneView Feedback</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+background:#0d1117;color:#e6edf3;min-height:100vh;display:flex;align-items:center;
+justify-content:center;padding:2rem;text-align:center}div{max-width:420px}
+h1{font-size:1.3rem;margin-bottom:.75rem}p{color:#8b949e;font-size:.9rem;line-height:1.6}</style>
+</head><body><div><h1>SceneView Feedback</h1>
+<p>Receives in-app feedback from the SceneView demo apps and opens pre-filled
+GitHub issues. Screen recordings and audio are kept private.</p></div></body></html>`),
+);
+
+// ── Catch-all ────────────────────────────────────────────────────────────────
+app.all("*", (c) => c.json({ error: "not_found" }, 404));
+
+export { app };
+
+export default {
+  fetch: app.fetch,
+  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(purgeExpiredMedia(env));
+  },
+};

--- a/feedback-worker/src/issue.ts
+++ b/feedback-worker/src/issue.ts
@@ -60,7 +60,11 @@ export function buildIssue(input: {
     text.trim() ||
     transcript.trim().split(/[.\n]/)[0]?.trim() ||
     "User feedback";
-  const title = `[${tag}] ${summary}`.replace(/\s+/g, " ").slice(0, 110);
+  // neutralize() so an @mention / #ref in the summary cannot ping a user or
+  // cross-link an unrelated issue from the title.
+  const title = `[${tag}] ${neutralize(summary)}`
+    .replace(/\s+/g, " ")
+    .slice(0, 110);
 
   const lines: string[] = [
     `> Submitted via the in-app feedback reporter (${category}).`,

--- a/feedback-worker/src/issue.ts
+++ b/feedback-worker/src/issue.ts
@@ -1,0 +1,126 @@
+export type Category = "bug" | "idea";
+
+export type FeedbackContext = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+/**
+ * Neutralize @mentions and #refs in user text so a transcript can never ping a
+ * GitHub user or cross-link an unrelated issue. Inserts a zero-width space
+ * (U+200B) — visually identical, but breaks GitHub's autolink pattern.
+ */
+function neutralize(text: string): string {
+  return text.replace(/([@#])(?=[\w-])/g, "$1\u200b");
+}
+
+/** Escape a value for a single Markdown table cell. */
+function cell(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\|/g, "\\|")
+    .trim()
+    .slice(0, 300);
+}
+
+/** Friendly labels + stable display order for known context keys. */
+const CONTEXT_LABELS: Record<string, string> = {
+  appVersion: "App version",
+  appVersionCode: "App build",
+  androidVersion: "Android",
+  sdkInt: "API level",
+  device: "Device",
+  demoId: "Demo",
+  demoTitle: "Demo title",
+  locale: "Locale",
+  freeRamMb: "Free RAM (MB)",
+};
+
+const MAX_BODY = 60_000;
+
+export interface BuiltIssue {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+/** Build the GitHub issue title/body/labels from a feedback submission. */
+export function buildIssue(input: {
+  id: string;
+  category: Category;
+  transcript: string;
+  text: string;
+  context: FeedbackContext;
+  viewerUrl: string;
+}): BuiltIssue {
+  const { id, category, transcript, text, context, viewerUrl } = input;
+
+  const tag = category === "bug" ? "Bug" : "Idea";
+  const summary =
+    text.trim() ||
+    transcript.trim().split(/[.\n]/)[0]?.trim() ||
+    "User feedback";
+  const title = `[${tag}] ${summary}`.replace(/\s+/g, " ").slice(0, 110);
+
+  const lines: string[] = [
+    `> Submitted via the in-app feedback reporter (${category}).`,
+    "",
+  ];
+
+  if (transcript.trim()) {
+    lines.push("### What the user said", "");
+    for (const l of neutralize(transcript.trim()).split("\n")) {
+      lines.push(`> ${l}`);
+    }
+    lines.push("");
+  }
+
+  if (text.trim()) {
+    lines.push("### Description", "", neutralize(text.trim()), "");
+  }
+
+  if (!transcript.trim() && !text.trim()) {
+    lines.push(
+      "_No transcript available — see the recording in the viewer below._",
+      "",
+    );
+  }
+
+  // Context table — known keys first (stable order), then any extras.
+  const rows: string[] = [];
+  const seen = new Set<string>();
+  for (const key of Object.keys(CONTEXT_LABELS)) {
+    const v = context[key];
+    if (v !== undefined && v !== null && String(v) !== "") {
+      rows.push(`| ${CONTEXT_LABELS[key]} | ${cell(v)} |`);
+      seen.add(key);
+    }
+  }
+  for (const [key, v] of Object.entries(context)) {
+    if (seen.has(key)) continue;
+    if (v !== undefined && v !== null && String(v) !== "") {
+      rows.push(`| ${cell(key)} | ${cell(v)} |`);
+    }
+  }
+  if (rows.length) {
+    lines.push(
+      "### Context",
+      "",
+      "| Field | Value |",
+      "| --- | --- |",
+      ...rows,
+      "",
+    );
+  }
+
+  lines.push(
+    `🎬 **[Screen recording + audio — maintainers only](${viewerUrl})**`,
+    "",
+    `<sub>Feedback ID: \`${id}\`</sub>`,
+  );
+
+  const body = lines.join("\n").slice(0, MAX_BODY);
+  const labels = ["user-feedback", category === "bug" ? "bug" : "enhancement"];
+
+  return { title, body, labels };
+}

--- a/feedback-worker/src/rate-limit.ts
+++ b/feedback-worker/src/rate-limit.ts
@@ -37,20 +37,33 @@ export async function isRateLimited(
 ): Promise<{ limited: boolean; remaining: number; limit: number }> {
   const key = `rl:${hashIp(ip)}:${minuteBucket()}`;
 
-  const current = await kv.get(key);
-  const count = current ? parseInt(current, 10) : 0;
+  try {
+    const current = await kv.get(key);
+    const count = current ? parseInt(current, 10) : 0;
 
-  if (count >= MAX_REQUESTS_PER_MINUTE) {
-    return { limited: true, remaining: 0, limit: MAX_REQUESTS_PER_MINUTE };
+    if (count >= MAX_REQUESTS_PER_MINUTE) {
+      return { limited: true, remaining: 0, limit: MAX_REQUESTS_PER_MINUTE };
+    }
+
+    await kv.put(key, String(count + 1), { expirationTtl: BUCKET_TTL_SECONDS });
+
+    return {
+      limited: false,
+      remaining: MAX_REQUESTS_PER_MINUTE - (count + 1),
+      limit: MAX_REQUESTS_PER_MINUTE,
+    };
+  } catch (e) {
+    // KV unavailable — exhausted daily write quota or a transient error. Fail
+    // open: a rate-limiter infrastructure failure must never crash (500) the
+    // whole feedback endpoint. The quota resets daily; abuse risk for the short
+    // window is acceptable next to dropping every genuine submission.
+    console.error("rate-limit KV error — failing open", e);
+    return {
+      limited: false,
+      remaining: MAX_REQUESTS_PER_MINUTE,
+      limit: MAX_REQUESTS_PER_MINUTE,
+    };
   }
-
-  await kv.put(key, String(count + 1), { expirationTtl: BUCKET_TTL_SECONDS });
-
-  return {
-    limited: false,
-    remaining: MAX_REQUESTS_PER_MINUTE - (count + 1),
-    limit: MAX_REQUESTS_PER_MINUTE,
-  };
 }
 
 /** Repo-wide cap on GitHub issue creation per hour. */
@@ -68,9 +81,16 @@ function hourBucket(): string {
  */
 export async function issueQuotaExceeded(kv: KVNamespace): Promise<boolean> {
   const key = `issuequota:${hourBucket()}`;
-  const current = await kv.get(key);
-  const count = current ? parseInt(current, 10) : 0;
-  if (count >= MAX_ISSUES_PER_HOUR) return true;
-  await kv.put(key, String(count + 1), { expirationTtl: 7200 });
-  return false;
+  try {
+    const current = await kv.get(key);
+    const count = current ? parseInt(current, 10) : 0;
+    if (count >= MAX_ISSUES_PER_HOUR) return true;
+    await kv.put(key, String(count + 1), { expirationTtl: 7200 });
+    return false;
+  } catch (e) {
+    // KV unavailable — fail open so a counter failure never blocks a genuine
+    // feedback submission. The per-IP limiter is the primary abuse guard.
+    console.error("issue-quota KV error — failing open", e);
+    return false;
+  }
 }

--- a/feedback-worker/src/rate-limit.ts
+++ b/feedback-worker/src/rate-limit.ts
@@ -52,3 +52,25 @@ export async function isRateLimited(
     limit: MAX_REQUESTS_PER_MINUTE,
   };
 }
+
+/** Repo-wide cap on GitHub issue creation per hour. */
+const MAX_ISSUES_PER_HOUR = 30;
+
+function hourBucket(): string {
+  return Math.floor(Date.now() / 3_600_000).toString(36);
+}
+
+/**
+ * Repo-wide backstop against an issue-creation flood that gets past the per-IP
+ * limiter (e.g. a botnet rotating IPs). Same approximate KV semantics as
+ * `isRateLimited` — an exact count is not needed, only a usable ceiling.
+ * Returns true (and does NOT consume a slot) once the hourly cap is reached.
+ */
+export async function issueQuotaExceeded(kv: KVNamespace): Promise<boolean> {
+  const key = `issuequota:${hourBucket()}`;
+  const current = await kv.get(key);
+  const count = current ? parseInt(current, 10) : 0;
+  if (count >= MAX_ISSUES_PER_HOUR) return true;
+  await kv.put(key, String(count + 1), { expirationTtl: 7200 });
+  return false;
+}

--- a/feedback-worker/src/rate-limit.ts
+++ b/feedback-worker/src/rate-limit.ts
@@ -1,0 +1,54 @@
+/**
+ * Simple sliding-window rate limiter using KV — mirrors telemetry-worker.
+ *
+ * Feedback submissions are heavy (media upload) and infrequent, so the cap is
+ * deliberately low: a real user submits a handful per hour at most, while the
+ * cap still blunts a scripted flood of issue-creating requests.
+ *
+ * NOTE — TOCTOU / non-atomic: the KV get and put are two separate operations.
+ * A burst of concurrent requests can each read the same count. This is
+ * acceptable here — KV is eventually consistent and an approximate cap is
+ * enough to stop abuse. Use Durable Objects for strict atomicity.
+ */
+
+const MAX_REQUESTS_PER_MINUTE = 5;
+const BUCKET_TTL_SECONDS = 120;
+
+/** Non-cryptographic salt — only makes KV keys non-reversible at a glance. */
+const HASH_SALT = "sv-fb-2026:";
+
+function hashIp(ip: string): string {
+  const salted = HASH_SALT + ip;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < salted.length; i++) {
+    hash ^= salted.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function minuteBucket(): string {
+  return Math.floor(Date.now() / 60_000).toString(36);
+}
+
+export async function isRateLimited(
+  ip: string,
+  kv: KVNamespace,
+): Promise<{ limited: boolean; remaining: number; limit: number }> {
+  const key = `rl:${hashIp(ip)}:${minuteBucket()}`;
+
+  const current = await kv.get(key);
+  const count = current ? parseInt(current, 10) : 0;
+
+  if (count >= MAX_REQUESTS_PER_MINUTE) {
+    return { limited: true, remaining: 0, limit: MAX_REQUESTS_PER_MINUTE };
+  }
+
+  await kv.put(key, String(count + 1), { expirationTtl: BUCKET_TTL_SECONDS });
+
+  return {
+    limited: false,
+    remaining: MAX_REQUESTS_PER_MINUTE - (count + 1),
+    limit: MAX_REQUESTS_PER_MINUTE,
+  };
+}

--- a/feedback-worker/src/retention.ts
+++ b/feedback-worker/src/retention.ts
@@ -1,21 +1,17 @@
 import type { Env } from "./env.js";
 
-/** Media older than this is purged from R2; the D1 transcript is kept. */
-const RETENTION_DAYS = 90;
-
 /**
- * Delete R2 media past the retention window. The feedback row and its
- * transcript are kept forever — only the heavy audio/video expires.
+ * Delete R2 media older than 90 days. The feedback row, its transcript and its
+ * `status` are left untouched — only the heavy audio/video expires, so the
+ * record stays honest about whether the GitHub issue was ever created.
  * Returns the number of records purged.
  */
 export async function purgeExpiredMedia(env: Env): Promise<number> {
   const rows = await env.DB.prepare(
     `SELECT id, video_key, audio_key FROM feedback
      WHERE media_purged = 0
-       AND created_at < datetime('now', '-' || ? || ' days')`,
-  )
-    .bind(RETENTION_DAYS)
-    .all<{ id: string; video_key: string | null; audio_key: string | null }>();
+       AND created_at < datetime('now', '-90 days')`,
+  ).all<{ id: string; video_key: string | null; audio_key: string | null }>();
 
   let purged = 0;
   for (const row of rows.results) {
@@ -24,8 +20,7 @@ export async function purgeExpiredMedia(env: Env): Promise<number> {
       if (row.audio_key) await env.MEDIA.delete(row.audio_key);
       await env.DB.prepare(
         `UPDATE feedback
-         SET media_purged = 1, video_key = NULL, audio_key = NULL,
-             status = CASE WHEN status = 'error' THEN status ELSE 'purged' END
+         SET media_purged = 1, video_key = NULL, audio_key = NULL
          WHERE id = ?`,
       )
         .bind(row.id)

--- a/feedback-worker/src/retention.ts
+++ b/feedback-worker/src/retention.ts
@@ -1,0 +1,39 @@
+import type { Env } from "./env.js";
+
+/** Media older than this is purged from R2; the D1 transcript is kept. */
+const RETENTION_DAYS = 90;
+
+/**
+ * Delete R2 media past the retention window. The feedback row and its
+ * transcript are kept forever — only the heavy audio/video expires.
+ * Returns the number of records purged.
+ */
+export async function purgeExpiredMedia(env: Env): Promise<number> {
+  const rows = await env.DB.prepare(
+    `SELECT id, video_key, audio_key FROM feedback
+     WHERE media_purged = 0
+       AND created_at < datetime('now', '-' || ? || ' days')`,
+  )
+    .bind(RETENTION_DAYS)
+    .all<{ id: string; video_key: string | null; audio_key: string | null }>();
+
+  let purged = 0;
+  for (const row of rows.results) {
+    try {
+      if (row.video_key) await env.MEDIA.delete(row.video_key);
+      if (row.audio_key) await env.MEDIA.delete(row.audio_key);
+      await env.DB.prepare(
+        `UPDATE feedback
+         SET media_purged = 1, video_key = NULL, audio_key = NULL,
+             status = CASE WHEN status = 'error' THEN status ELSE 'purged' END
+         WHERE id = ?`,
+      )
+        .bind(row.id)
+        .run();
+      purged++;
+    } catch (e) {
+      console.error(`media purge failed for ${row.id}`, e);
+    }
+  }
+  return purged;
+}

--- a/feedback-worker/src/transcribe.ts
+++ b/feedback-worker/src/transcribe.ts
@@ -1,0 +1,47 @@
+import type { Env } from "./env.js";
+
+/** Base64-encode an ArrayBuffer (chunked to stay within argument limits). */
+function toBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let bin = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin);
+}
+
+export interface Transcription {
+  text: string;
+  /** Detected language code, when the model reports one. */
+  language?: string;
+}
+
+/**
+ * Transcribe an audio clip with Workers AI (Whisper large-v3-turbo).
+ * Language is auto-detected — the user speaks in their own language.
+ *
+ * Never throws: on failure it returns an empty transcript so the feedback
+ * still produces an issue, with the private recording as the fallback signal.
+ */
+export async function transcribe(
+  env: Env,
+  audio: ArrayBuffer,
+): Promise<Transcription> {
+  try {
+    const run = env.AI.run as unknown as (
+      model: string,
+      inputs: unknown,
+    ) => Promise<{ text?: string; transcription_info?: { language?: string } }>;
+    const result = await run("@cf/openai/whisper-large-v3-turbo", {
+      audio: toBase64(audio),
+    });
+    return {
+      text: (result.text ?? "").trim(),
+      language: result.transcription_info?.language,
+    };
+  } catch (e) {
+    console.error("transcription failed", e);
+    return { text: "" };
+  }
+}

--- a/feedback-worker/src/viewer.ts
+++ b/feedback-worker/src/viewer.ts
@@ -5,7 +5,8 @@ function esc(s: unknown): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function shell(title: string, inner: string): string {
@@ -51,13 +52,10 @@ export function renderNotFound(): string {
 
 /**
  * Render the feedback viewer page.
- * @param adminToken non-null when the request carried a valid admin token —
+ * @param admin true when the request carried a valid admin session cookie —
  *   only then are the screen recording + audio players embedded.
  */
-export function renderViewer(
-  row: FeedbackRow,
-  adminToken: string | null,
-): string {
+export function renderViewer(row: FeedbackRow, admin: boolean): string {
   let context: Record<string, unknown> = {};
   try {
     context = row.context_json ? JSON.parse(row.context_json) : {};
@@ -91,13 +89,14 @@ export function renderViewer(
     mediaCard = `<div class="card"><h2>Recording</h2><p class="muted">Media expired and was purged after the 90-day retention window.</p></div>`;
   } else if (!hasMedia) {
     mediaCard = `<div class="card"><h2>Recording</h2><p class="muted">No screen recording or audio was attached to this feedback.</p></div>`;
-  } else if (adminToken) {
-    const t = encodeURIComponent(adminToken);
+  } else if (admin) {
+    // Media is fetched with the admin session cookie (Path=/feedback) — no
+    // token in the URL.
     const video = row.video_key
-      ? `<video controls preload="metadata" src="/feedback/${row.id}/media/video?token=${t}"></video>`
+      ? `<video controls preload="metadata" src="/feedback/${row.id}/media/video"></video>`
       : "";
     const audio = row.audio_key
-      ? `<audio controls preload="metadata" src="/feedback/${row.id}/media/audio?token=${t}"></audio>`
+      ? `<audio controls preload="metadata" src="/feedback/${row.id}/media/audio"></audio>`
       : "";
     mediaCard = `<div class="card"><h2>Recording</h2>${video}${audio}</div>`;
   } else {

--- a/feedback-worker/src/viewer.ts
+++ b/feedback-worker/src/viewer.ts
@@ -1,0 +1,120 @@
+import type { FeedbackRow } from "./db.js";
+
+function esc(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function shell(title: string, inner: string): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="robots" content="noindex"/>
+<title>${esc(title)}</title>
+<style>
+  *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+       background:#0d1117;color:#e6edf3;min-height:100vh;padding:2rem 1rem}
+  .wrap{max-width:680px;margin:0 auto}
+  h1{font-size:1.3rem;font-weight:600}
+  h2{font-size:.95rem;margin-bottom:.6rem}
+  .muted{color:#8b949e;font-size:.85rem;line-height:1.6}
+  .badge{display:inline-block;font-size:.7rem;font-weight:600;text-transform:uppercase;
+         letter-spacing:.04em;padding:.2rem .55rem;border-radius:20px;margin:.5rem 0 .25rem}
+  .badge.bug{background:#3d1418;color:#ff7b72}
+  .badge.idea{background:#1a2f1a;color:#3fb950}
+  .card,.gate{background:#161b22;border:1px solid #30363d;border-radius:12px;
+       padding:1.25rem 1.5rem;margin-top:1rem}
+  blockquote{border-left:3px solid #30363d;padding-left:.9rem;color:#c9d1d9;
+       white-space:pre-wrap;line-height:1.65}
+  table{width:100%;border-collapse:collapse;font-size:.85rem}
+  td{padding:.35rem .5rem;border-bottom:1px solid #21262d;vertical-align:top}
+  td:first-child{color:#8b949e;white-space:nowrap;width:38%}
+  video,audio{width:100%;margin-top:.6rem;border-radius:8px}
+  a{color:#4493f8}
+  input{background:#0d1117;border:1px solid #30363d;color:#e6edf3;border-radius:6px;
+       padding:.45rem .6rem;font-size:.85rem;width:210px}
+  button{background:#238636;color:#fff;border:0;border-radius:6px;padding:.5rem 1rem;
+       font-size:.85rem;font-weight:600;cursor:pointer;margin-left:.4rem}
+</style></head><body><div class="wrap">${inner}</div></body></html>`;
+}
+
+export function renderNotFound(): string {
+  return shell(
+    "Feedback not found",
+    `<h1>Feedback not found</h1><p class="muted" style="margin-top:.5rem">This feedback id does not exist, or its record was removed.</p>`,
+  );
+}
+
+/**
+ * Render the feedback viewer page.
+ * @param adminToken non-null when the request carried a valid admin token —
+ *   only then are the screen recording + audio players embedded.
+ */
+export function renderViewer(
+  row: FeedbackRow,
+  adminToken: string | null,
+): string {
+  let context: Record<string, unknown> = {};
+  try {
+    context = row.context_json ? JSON.parse(row.context_json) : {};
+  } catch {
+    context = {};
+  }
+
+  const ctxRows = Object.entries(context)
+    .filter(([, v]) => v !== undefined && v !== null && String(v) !== "")
+    .map(([k, v]) => `<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`)
+    .join("");
+  const ctxCard = ctxRows
+    ? `<div class="card"><h2>Context</h2><table>${ctxRows}</table></div>`
+    : "";
+
+  const transcriptCard = row.transcript?.trim()
+    ? `<div class="card"><h2>What the user said</h2><blockquote>${esc(
+        row.transcript.trim(),
+      )}</blockquote></div>`
+    : `<div class="card"><h2>What the user said</h2><p class="muted">No transcript — see the recording.</p></div>`;
+
+  const issueLink = row.github_url
+    ? `<p class="muted" style="margin-top:1rem">GitHub issue: <a href="${esc(
+        row.github_url,
+      )}">#${esc(row.github_issue)}</a></p>`
+    : "";
+
+  const hasMedia = !!(row.video_key || row.audio_key);
+  let mediaCard: string;
+  if (row.media_purged) {
+    mediaCard = `<div class="card"><h2>Recording</h2><p class="muted">Media expired and was purged after the 90-day retention window.</p></div>`;
+  } else if (!hasMedia) {
+    mediaCard = `<div class="card"><h2>Recording</h2><p class="muted">No screen recording or audio was attached to this feedback.</p></div>`;
+  } else if (adminToken) {
+    const t = encodeURIComponent(adminToken);
+    const video = row.video_key
+      ? `<video controls preload="metadata" src="/feedback/${row.id}/media/video?token=${t}"></video>`
+      : "";
+    const audio = row.audio_key
+      ? `<audio controls preload="metadata" src="/feedback/${row.id}/media/audio?token=${t}"></audio>`
+      : "";
+    mediaCard = `<div class="card"><h2>Recording</h2>${video}${audio}</div>`;
+  } else {
+    mediaCard = `<div class="gate"><h2>Recording — maintainers only</h2>
+      <p class="muted" style="margin:.4rem 0 .8rem">The screen recording and audio are private. Enter the admin token to play them.</p>
+      <form method="get"><input type="password" name="token" placeholder="admin token" autocomplete="off"/><button type="submit">Unlock</button></form></div>`;
+  }
+
+  const inner = `<h1>Feedback</h1>
+    <span class="badge ${row.category}">${esc(row.category)}</span>
+    <p class="muted">Received ${esc(row.created_at)} UTC · status: ${esc(
+      row.status,
+    )}</p>
+    ${transcriptCard}
+    ${ctxCard}
+    ${mediaCard}
+    ${issueLink}`;
+
+  return shell(`Feedback ${row.id}`, inner);
+}

--- a/feedback-worker/test/feedback.test.ts
+++ b/feedback-worker/test/feedback.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { app } from "../src/index.js";
+import type { Env } from "../src/env.js";
+import { purgeExpiredMedia } from "../src/retention.js";
+import { createMockKV } from "./helpers/mock-kv.js";
+import { createMockD1, type MockD1 } from "./helpers/mock-d1.js";
+import { createMockR2, type MockR2 } from "./helpers/mock-r2.js";
+
+// A real RSA key is needed so the GitHub App JWT can actually be signed.
+let PRIVATE_KEY_PEM = "";
+
+beforeAll(async () => {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const b64 = Buffer.from(pkcs8).toString("base64");
+  PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----\n${b64
+    .match(/.{1,64}/g)!
+    .join("\n")}\n-----END PRIVATE KEY-----\n`;
+});
+
+interface TestEnv {
+  DB: MockD1;
+  RL_KV: ReturnType<typeof createMockKV>;
+  MEDIA: MockR2;
+  AI: { run: (model: string, inputs: unknown) => Promise<unknown> };
+  ENVIRONMENT: string;
+  GITHUB_REPO: string;
+  GITHUB_APP_ID: string;
+  GITHUB_INSTALLATION_ID: string;
+  GITHUB_PRIVATE_KEY: string;
+  ADMIN_TOKEN: string;
+}
+
+function makeEnv(): TestEnv {
+  return {
+    DB: createMockD1(),
+    RL_KV: createMockKV(),
+    MEDIA: createMockR2(),
+    AI: {
+      run: async () => ({
+        text: "the spinner never stops",
+        transcription_info: { language: "en" },
+      }),
+    },
+    ENVIRONMENT: "test",
+    GITHUB_REPO: "sceneview/sceneview",
+    GITHUB_APP_ID: "12345",
+    GITHUB_INSTALLATION_ID: "67890",
+    GITHUB_PRIVATE_KEY: PRIVATE_KEY_PEM,
+    ADMIN_TOKEN: "admin-secret",
+  };
+}
+
+const asEnv = (e: TestEnv) => e as unknown as Env;
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function stubGitHub(opts: { issueFails?: boolean } = {}) {
+  globalThis.fetch = (async (input: unknown, init?: { method?: string }) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (url.endsWith("/access_tokens") && method === "POST") {
+      return new Response(JSON.stringify({ token: "ghs_test" }), {
+        status: 201,
+      });
+    }
+    if (url.includes("/labels/user-feedback")) {
+      return new Response("", { status: 404 });
+    }
+    if (url.endsWith("/labels") && method === "POST") {
+      return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+    }
+    if (url.endsWith("/issues") && method === "POST") {
+      return opts.issueFails
+        ? new Response("server error", { status: 500 })
+        : new Response(
+            JSON.stringify({
+              number: 1234,
+              html_url:
+                "https://github.com/sceneview/sceneview/issues/1234",
+            }),
+            { status: 201 },
+          );
+    }
+    return new Response("unexpected", { status: 599 });
+  }) as typeof fetch;
+}
+
+function feedbackForm(category = "bug"): FormData {
+  const fd = new FormData();
+  fd.set("category", category);
+  fd.set(
+    "context",
+    JSON.stringify({
+      appVersion: "4.11.1",
+      device: "Pixel 7a",
+      demoId: "lighting",
+    }),
+  );
+  fd.set(
+    "audio",
+    new File([new Uint8Array([1, 2, 3, 4])], "audio.m4a", {
+      type: "audio/mp4",
+    }),
+  );
+  return fd;
+}
+
+function feedbackRow(id: string): Record<string, unknown> {
+  return {
+    id,
+    created_at: "2026-05-21 10:00:00",
+    category: "bug",
+    status: "issued",
+    transcript: "the spinner never stops",
+    context_json: JSON.stringify({ device: "Pixel 7a", demoId: "lighting" }),
+    video_key: null,
+    audio_key: `feedback/${id}/audio.m4a`,
+    github_issue: 1234,
+    github_url: "https://github.com/sceneview/sceneview/issues/1234",
+    media_purged: 0,
+  };
+}
+
+describe("feedback worker", () => {
+  it("GET /health is ok", async () => {
+    const res = await app.request("/health", {}, asEnv(makeEnv()));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      service: "sceneview-feedback",
+    });
+  });
+
+  it("rejects an invalid category", async () => {
+    const fd = new FormData();
+    fd.set("category", "nonsense");
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: fd },
+      asEnv(makeEnv()),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a GitHub issue on the happy path", async () => {
+    stubGitHub();
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: feedbackForm("bug") },
+      asEnv(env),
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { ok: boolean; issue: number };
+    expect(json.ok).toBe(true);
+    expect(json.issue).toBe(1234);
+
+    const sqls = env.DB._statements.map((s) => s.sql).join(" | ");
+    expect(sqls).toContain("INSERT INTO feedback");
+    expect(sqls).toContain("status = 'issued'");
+    expect(
+      [...env.MEDIA._store.keys()].some((k) => k.endsWith("/audio.m4a")),
+    ).toBe(true);
+  });
+
+  it("returns 202 and records an error when issue creation fails", async () => {
+    stubGitHub({ issueFails: true });
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: feedbackForm("bug") },
+      asEnv(env),
+    );
+    expect(res.status).toBe(202);
+    const json = (await res.json()) as { ok: boolean; issue: number | null };
+    expect(json.ok).toBe(true);
+    expect(json.issue).toBeNull();
+    expect(env.DB._statements.map((s) => s.sql).join(" | ")).toContain(
+      "status = 'error'",
+    );
+  });
+
+  it("rate-limits after 5 submissions from the same IP", async () => {
+    stubGitHub();
+    const env = makeEnv();
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await app.request(
+        "/v1/feedback",
+        { method: "POST", body: feedbackForm("idea") },
+        asEnv(env),
+      );
+      statuses.push(res.status);
+    }
+    expect(statuses.filter((s) => s === 429).length).toBe(1);
+    expect(statuses[5]).toBe(429);
+  });
+
+  it("viewer returns 404 for an unknown id", async () => {
+    const res = await app.request(
+      `/feedback/${crypto.randomUUID()}`,
+      {},
+      asEnv(makeEnv()),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("viewer hides media behind the admin gate without a token", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    env.DB._rows = [feedbackRow(id)];
+    const res = await app.request(`/feedback/${id}`, {}, asEnv(env));
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("the spinner never stops");
+    expect(html).not.toContain("<audio");
+    expect(html).toContain('name="token"');
+  });
+
+  it("viewer embeds the player with a valid admin token", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    env.DB._rows = [feedbackRow(id)];
+    const res = await app.request(
+      `/feedback/${id}?token=admin-secret`,
+      {},
+      asEnv(env),
+    );
+    expect(await res.text()).toContain("<audio");
+  });
+
+  it("media endpoint rejects requests without the admin token", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    env.DB._rows = [feedbackRow(id)];
+    const res = await app.request(
+      `/feedback/${id}/media/audio`,
+      {},
+      asEnv(env),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("media endpoint streams the file with a valid admin token", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    const row = feedbackRow(id);
+    env.DB._rows = [row];
+    await env.MEDIA.put(
+      row.audio_key as string,
+      new Uint8Array([9, 9, 9]).buffer,
+      { httpMetadata: { contentType: "audio/mp4" } },
+    );
+    const res = await app.request(
+      `/feedback/${id}/media/audio?token=admin-secret`,
+      {},
+      asEnv(env),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("audio");
+  });
+
+  it("retention purges expired media and keeps the record", async () => {
+    const env = makeEnv();
+    env.DB._rows = [
+      {
+        id: "old-1",
+        video_key: "feedback/old-1/screen.mp4",
+        audio_key: "feedback/old-1/audio.m4a",
+      },
+    ];
+    await env.MEDIA.put(
+      "feedback/old-1/screen.mp4",
+      new Uint8Array([1]).buffer,
+    );
+    await env.MEDIA.put(
+      "feedback/old-1/audio.m4a",
+      new Uint8Array([2]).buffer,
+    );
+    const purged = await purgeExpiredMedia(asEnv(env));
+    expect(purged).toBe(1);
+    expect(env.MEDIA._store.size).toBe(0);
+    expect(env.DB._statements.map((s) => s.sql).join(" | ")).toContain(
+      "media_purged = 1",
+    );
+  });
+});

--- a/feedback-worker/test/feedback.test.ts
+++ b/feedback-worker/test/feedback.test.ts
@@ -209,6 +209,24 @@ describe("feedback worker", () => {
     expect(statuses[5]).toBe(429);
   });
 
+  it("fails open (still succeeds) when the rate-limit KV is exhausted", async () => {
+    stubGitHub();
+    const env = makeEnv();
+    // Reproduce Cloudflare KV's daily write-quota exhaustion: every put()
+    // throws. The rate limiter and the issue-quota backstop must both fail
+    // open so a KV-infrastructure failure never 500s the whole endpoint.
+    env.RL_KV.put = async () => {
+      throw new Error("KV put() limit exceeded for the day.");
+    };
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: feedbackForm("bug") },
+      asEnv(env),
+    );
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+  });
+
   it("viewer returns 404 for an unknown id", async () => {
     const res = await app.request(
       `/feedback/${crypto.randomUUID()}`,

--- a/feedback-worker/test/feedback.test.ts
+++ b/feedback-worker/test/feedback.test.ts
@@ -230,7 +230,7 @@ describe("feedback worker", () => {
     expect(html).toContain('name="token"');
   });
 
-  it("viewer embeds the player with a valid admin token", async () => {
+  it("a valid ?token= sets an admin cookie and redirects to a clean URL", async () => {
     const env = makeEnv();
     const id = crypto.randomUUID();
     env.DB._rows = [feedbackRow(id)];
@@ -239,10 +239,26 @@ describe("feedback worker", () => {
       {},
       asEnv(env),
     );
-    expect(await res.text()).toContain("<audio");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`/feedback/${id}`);
+    expect(res.headers.get("set-cookie") ?? "").toContain("fb_admin=");
   });
 
-  it("media endpoint rejects requests without the admin token", async () => {
+  it("viewer embeds the player when the request carries the admin cookie", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    env.DB._rows = [feedbackRow(id)];
+    const res = await app.request(
+      `/feedback/${id}`,
+      { headers: { Cookie: "fb_admin=admin-secret" } },
+      asEnv(env),
+    );
+    const html = await res.text();
+    expect(html).toContain("<audio");
+    expect(html).not.toContain("?token=");
+  });
+
+  it("media endpoint rejects requests without the admin cookie", async () => {
     const env = makeEnv();
     const id = crypto.randomUUID();
     env.DB._rows = [feedbackRow(id)];
@@ -254,7 +270,7 @@ describe("feedback worker", () => {
     expect(res.status).toBe(401);
   });
 
-  it("media endpoint streams the file with a valid admin token", async () => {
+  it("media endpoint streams the file with a valid admin cookie", async () => {
     const env = makeEnv();
     const id = crypto.randomUUID();
     const row = feedbackRow(id);
@@ -265,12 +281,63 @@ describe("feedback worker", () => {
       { httpMetadata: { contentType: "audio/mp4" } },
     );
     const res = await app.request(
-      `/feedback/${id}/media/audio?token=admin-secret`,
-      {},
+      `/feedback/${id}/media/audio`,
+      { headers: { Cookie: "fb_admin=admin-secret" } },
       asEnv(env),
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("audio");
+  });
+
+  it("rejects an empty submission (no text, no audio, no video)", async () => {
+    const fd = new FormData();
+    fd.set("category", "idea");
+    fd.set("context", "{}");
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: fd },
+      asEnv(makeEnv()),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an over-sized upload by actual file size", async () => {
+    const fd = new FormData();
+    fd.set("category", "bug");
+    fd.set("context", "{}");
+    // 31 MB — over the 30 MB ceiling; the guard reads File.size, not the header.
+    fd.set(
+      "video",
+      new File([new Uint8Array(31 * 1024 * 1024)], "screen.mp4", {
+        type: "video/mp4",
+      }),
+    );
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: fd },
+      asEnv(makeEnv()),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("skips issue creation when the global hourly quota is exhausted", async () => {
+    stubGitHub();
+    const env = makeEnv();
+    // Pre-fill the current hour's global issue-quota bucket to the cap.
+    const bucket = Math.floor(Date.now() / 3_600_000).toString(36);
+    env.RL_KV._store.set(`issuequota:${bucket}`, "30");
+    const res = await app.request(
+      "/v1/feedback",
+      { method: "POST", body: feedbackForm("bug") },
+      asEnv(env),
+    );
+    expect(res.status).toBe(202);
+    const json = (await res.json()) as { ok: boolean; issue: number | null };
+    expect(json.ok).toBe(true);
+    expect(json.issue).toBeNull();
+    expect(env.DB._statements.map((s) => s.sql).join(" | ")).toContain(
+      "status = 'error'",
+    );
   });
 
   it("retention purges expired media and keeps the record", async () => {

--- a/feedback-worker/test/helpers/mock-d1.ts
+++ b/feedback-worker/test/helpers/mock-d1.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal in-memory D1 mock for testing.
+ * Tracks all bound statements so tests can inspect inserts/updates, and
+ * serves `_rows` back from first()/all() so reads can be exercised.
+ */
+
+export interface MockStatement {
+  sql: string;
+  params: unknown[];
+}
+
+export interface MockD1 {
+  _statements: MockStatement[];
+  _rows: Record<string, unknown>[];
+  _shouldFail: boolean;
+  prepare: (sql: string) => MockPreparedStatement;
+  batch: (stmts: MockPreparedStatement[]) => Promise<unknown[]>;
+}
+
+interface MockPreparedStatement {
+  _sql: string;
+  _params: unknown[];
+  bind: (...params: unknown[]) => MockPreparedStatement;
+  run: () => Promise<{ success: boolean }>;
+  first: () => Promise<Record<string, unknown> | null>;
+  all: () => Promise<{ results: Record<string, unknown>[] }>;
+}
+
+export function createMockD1(): MockD1 {
+  const db: MockD1 = {
+    _statements: [],
+    _rows: [],
+    _shouldFail: false,
+
+    prepare(sql: string): MockPreparedStatement {
+      const stmt: MockPreparedStatement = {
+        _sql: sql,
+        _params: [],
+
+        bind(...params: unknown[]) {
+          stmt._params = params;
+          return stmt;
+        },
+
+        async run() {
+          if (db._shouldFail) throw new Error("D1 mock failure");
+          db._statements.push({ sql: stmt._sql, params: stmt._params });
+          return { success: true };
+        },
+
+        async first() {
+          if (db._shouldFail) throw new Error("D1 mock failure");
+          db._statements.push({ sql: stmt._sql, params: stmt._params });
+          return db._rows[0] ?? null;
+        },
+
+        async all() {
+          if (db._shouldFail) throw new Error("D1 mock failure");
+          db._statements.push({ sql: stmt._sql, params: stmt._params });
+          return { results: db._rows };
+        },
+      };
+      return stmt;
+    },
+
+    async batch(stmts: MockPreparedStatement[]) {
+      if (db._shouldFail) throw new Error("D1 mock batch failure");
+      for (const s of stmts) {
+        db._statements.push({ sql: s._sql, params: s._params });
+      }
+      return stmts.map(() => ({ success: true }));
+    },
+  };
+
+  return db;
+}

--- a/feedback-worker/test/helpers/mock-kv.ts
+++ b/feedback-worker/test/helpers/mock-kv.ts
@@ -1,0 +1,32 @@
+/** Minimal in-memory KV mock for testing rate limiting. */
+
+export interface MockKV {
+  _store: Map<string, string>;
+  get: (key: string) => Promise<string | null>;
+  put: (
+    key: string,
+    value: string,
+    opts?: { expirationTtl?: number },
+  ) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+}
+
+export function createMockKV(): MockKV {
+  const store = new Map<string, string>();
+
+  return {
+    _store: store,
+
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+
+    async delete(key: string) {
+      store.delete(key);
+    },
+  };
+}

--- a/feedback-worker/test/helpers/mock-r2.ts
+++ b/feedback-worker/test/helpers/mock-r2.ts
@@ -1,0 +1,51 @@
+/** Minimal in-memory R2 mock for testing media storage. */
+
+export interface MockR2 {
+  _store: Map<string, { data: ArrayBuffer; contentType?: string }>;
+  put: (
+    key: string,
+    value: ArrayBuffer,
+    opts?: { httpMetadata?: { contentType?: string } },
+  ) => Promise<void>;
+  get: (key: string) => Promise<{
+    body: ReadableStream;
+    httpMetadata?: { contentType?: string };
+  } | null>;
+  delete: (key: string) => Promise<void>;
+}
+
+export function createMockR2(): MockR2 {
+  const store = new Map<string, { data: ArrayBuffer; contentType?: string }>();
+
+  return {
+    _store: store,
+
+    async put(key, value, opts) {
+      store.set(key, {
+        data: value,
+        contentType: opts?.httpMetadata?.contentType,
+      });
+    },
+
+    async get(key) {
+      const entry = store.get(key);
+      if (!entry) return null;
+      const data = entry.data;
+      return {
+        httpMetadata: entry.contentType
+          ? { contentType: entry.contentType }
+          : undefined,
+        body: new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new Uint8Array(data));
+            ctrl.close();
+          },
+        }),
+      };
+    },
+
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}

--- a/feedback-worker/test/issue.test.ts
+++ b/feedback-worker/test/issue.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildIssue } from "../src/issue.js";
+
+describe("buildIssue", () => {
+  it("neutralizes @mentions and #refs in the transcript", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "ping @octocat and #1234 both broke",
+      text: "",
+      context: {},
+      viewerUrl: "https://w/feedback/abc",
+    });
+    expect(r.body).not.toContain("@octocat");
+    expect(r.body).not.toContain("#1234");
+    expect(r.body).toContain("@​octocat");
+    expect(r.body).toContain("#​1234");
+  });
+
+  it("escapes pipe characters in context values", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "t",
+      text: "",
+      context: { device: "Pixel | 7a" },
+      viewerUrl: "u",
+    });
+    expect(r.body).toContain("Pixel \\| 7a");
+  });
+
+  it("builds a [Bug] title with bug + user-feedback labels", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "crash on tap",
+      text: "",
+      context: {},
+      viewerUrl: "u",
+    });
+    expect(r.title).toBe("[Bug] crash on tap");
+    expect(r.labels).toEqual(["user-feedback", "bug"]);
+  });
+
+  it("uses the enhancement label for ideas and prefers typed text", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "idea",
+      transcript: "a long spoken thought that rambles",
+      text: "Add a dark mode",
+      context: {},
+      viewerUrl: "u",
+    });
+    expect(r.title).toBe("[Idea] Add a dark mode");
+    expect(r.labels).toContain("enhancement");
+  });
+
+  it("notes a missing transcript when there is no audio and no text", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "",
+      text: "",
+      context: {},
+      viewerUrl: "u",
+    });
+    expect(r.body).toContain("No transcript available");
+  });
+
+  it("renders the context table and the viewer link", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "t",
+      text: "",
+      context: { appVersion: "4.11.1", demoId: "lighting" },
+      viewerUrl: "https://w/feedback/abc",
+    });
+    expect(r.body).toContain("| App version | 4.11.1 |");
+    expect(r.body).toContain("| Demo | lighting |");
+    expect(r.body).toContain("https://w/feedback/abc");
+  });
+});

--- a/feedback-worker/tsconfig.json
+++ b/feedback-worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/feedback-worker/vitest.config.ts
+++ b/feedback-worker/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Node pool — Hono's app.request() is pure JS, no Workers runtime needed.
+    // Cloudflare bindings (D1, KV, R2, AI) are mocked; see test/helpers/.
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/feedback-worker/wrangler.toml
+++ b/feedback-worker/wrangler.toml
@@ -50,6 +50,10 @@ bucket_name = "sceneview-feedback-media"
 [ai]
 binding = "AI"
 
+# ── Observability (Workers Logs — surfaces console.error in the dashboard) ───
+[observability]
+enabled = true
+
 # ── Environment variables ────────────────────────────────────────────────────
 [vars]
 ENVIRONMENT = "production"

--- a/feedback-worker/wrangler.toml
+++ b/feedback-worker/wrangler.toml
@@ -1,0 +1,66 @@
+# ─── SceneView Feedback Worker ────────────────────────────────────────────────
+#
+# Receives in-app feedback (screen recording + voice) from the SceneView demo
+# apps, transcribes the audio with Workers AI (Whisper), stores the media
+# privately in R2, and opens a pre-filled GitHub issue.
+#
+# The public GitHub issue carries only the transcript + context. The raw
+# audio/video stay private in R2, viewable only through the admin-gated viewer.
+#
+# Deploy: wrangler deploy
+# Dev:    wrangler dev
+#
+# Before first deploy, provision the bindings (see DEPLOY.md):
+#   wrangler d1 create sceneview-feedback
+#   wrangler kv namespace create RL_KV
+#   wrangler r2 bucket create sceneview-feedback-media
+# Then fill in the IDs below, and set the secrets:
+#   wrangler secret put GITHUB_APP_ID
+#   wrangler secret put GITHUB_INSTALLATION_ID
+#   wrangler secret put GITHUB_PRIVATE_KEY      # PKCS#8 PEM — see DEPLOY.md
+#   wrangler secret put ADMIN_TOKEN
+
+name = "sceneview-feedback"
+main = "src/index.ts"
+compatibility_date = "2025-04-01"
+
+# ── Local development ─────────────────────────────────────────────────────────
+[dev]
+port = 8788
+local_protocol = "http"
+
+# ── D1 database (feedback records + transcripts) ─────────────────────────────
+[[d1_databases]]
+binding = "DB"
+database_name = "sceneview-feedback"
+database_id = "TODO-run-wrangler-d1-create"
+migrations_dir = "migrations"
+
+# ── KV namespace (rate-limit counters) ───────────────────────────────────────
+[[kv_namespaces]]
+binding = "RL_KV"
+id = "TODO-run-wrangler-kv-namespace-create"
+
+# ── R2 bucket (private media — screen recordings + audio) ────────────────────
+[[r2_buckets]]
+binding = "MEDIA"
+bucket_name = "sceneview-feedback-media"
+
+# ── Workers AI (Whisper transcription) ───────────────────────────────────────
+[ai]
+binding = "AI"
+
+# ── Environment variables ────────────────────────────────────────────────────
+[vars]
+ENVIRONMENT = "production"
+GITHUB_REPO = "sceneview/sceneview"
+
+# Secrets (NOT in this file — set via `wrangler secret put`):
+#   GITHUB_APP_ID           GitHub App id
+#   GITHUB_INSTALLATION_ID  installation id on sceneview/sceneview
+#   GITHUB_PRIVATE_KEY      GitHub App private key, PKCS#8 PEM
+#   ADMIN_TOKEN             gates media playback in the /feedback/<id> viewer
+
+# ── Cron trigger (daily media retention purge) ───────────────────────────────
+[triggers]
+crons = ["0 3 * * *"]

--- a/feedback-worker/wrangler.toml
+++ b/feedback-worker/wrangler.toml
@@ -33,13 +33,13 @@ local_protocol = "http"
 [[d1_databases]]
 binding = "DB"
 database_name = "sceneview-feedback"
-database_id = "TODO-run-wrangler-d1-create"
+database_id = "4b903de8-efb1-4a78-b35e-ba55e43410d8"
 migrations_dir = "migrations"
 
 # ── KV namespace (rate-limit counters) ───────────────────────────────────────
 [[kv_namespaces]]
 binding = "RL_KV"
-id = "TODO-run-wrangler-kv-namespace-create"
+id = "5598b0f12d2d4c21ba1cae2f1392f359"
 
 # ── R2 bucket (private media — screen recordings + audio) ────────────────────
 [[r2_buckets]]


### PR DESCRIPTION
## Summary

Phase 1, task 1A of the in-app feedback feature (umbrella #1930). Adds a new
standalone Cloudflare worker `feedback-worker/` — sibling of `telemetry-worker/`.

- **`POST /v1/feedback`** — receives the multipart upload (screen recording +
  audio + JSON context) from the demo apps, rate-limited by IP. Stores media
  privately in R2, transcribes the audio with Workers AI (Whisper, language
  auto-detected), creates a pre-filled GitHub issue via a GitHub App, and
  returns the issue number to the app.
- **`GET /feedback/<id>`** — viewer page. Transcript + context are public; the
  screen recording and audio are gated behind an admin token.
- **`GET /feedback/<id>/media/<video|audio>`** — admin-token-gated media stream.
- **Cron** — nightly purge of R2 media past a 90-day retention window; the
  transcript is kept.

Privacy by design: the public GitHub issue never carries the raw voice/video —
only the transcript + context. `@mentions` / `#refs` in the transcript are
neutralized so a feedback cannot ping a user or cross-link an issue.

Deployment (GitHub App, D1/KV/R2 provisioning, secrets) is documented in
`feedback-worker/DEPLOY.md`. Cost is ~0 at SceneView's volume.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 17/17 vitest tests pass (happy path, GitHub-failure fallback,
  rate limit, viewer auth gating, media 401/200, retention purge)
- [ ] Deploy to Cloudflare once the GitHub App credentials are available
- [ ] End-to-end smoke test from the Android app (arrives with task 1D)

Part of #1930. Closes #1931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)