### PR TITLE
feat(android-demo): in-app feedback button + flow (1B)

### DIFF
--- a/.github/PRIVACY_POLICY.md
+++ b/.github/PRIVACY_POLICY.md
@@ -1,10 +1,14 @@
 # Privacy Policy — SceneView Demo
 
-**Last updated:** March 27, 2026
+**Last updated:** May 21, 2026
 
 ## Summary
 
-**SceneView Demo does not collect, store, or transmit any personal data.**
+**SceneView Demo collects no personal data and its 3D content works fully
+offline.** The one exception is the **optional in-app feedback feature**: if you
+choose to report a bug or share an idea, it records your screen and microphone
+and sends them to the SceneView team. Nothing is recorded or sent unless you
+explicitly start a feedback report and agree.
 
 ## Details
 
@@ -12,7 +16,7 @@
 
 - **No personal data collected** — The app does not collect names, email addresses, IP addresses, or any other personally identifiable information.
 - **No analytics or tracking** — No analytics SDKs, telemetry, fingerprinting, or behavioral tracking of any kind.
-- **No network requests** — The app operates entirely offline. All 3D models, textures, and environments are bundled locally.
+- **Offline by default** — All 3D models, textures, and environments are bundled locally and need no network. The only feature that uses the network is the opt-in feedback reporter described below.
 - **No accounts** — The app does not require or support user accounts.
 
 ### Camera Usage (AR Features)
@@ -21,6 +25,29 @@
 - Camera data is processed **locally on-device** in real time for plane detection and object placement.
 - **No camera images or video are stored, recorded, or transmitted** to any server.
 - Camera access is only requested when the user navigates to the AR tab.
+
+### In-App Feedback (Optional)
+
+The app includes an optional feedback reporter so you can report a bug or
+suggest an idea. It is **opt-in and consent-gated** — nothing is recorded or
+sent unless you start a feedback report and explicitly agree on the consent
+screen.
+
+When you submit feedback:
+
+- The app records **your screen**, and — if you allow it — **your microphone**,
+  so you can demonstrate and describe the issue.
+- The screen recording, a transcript of your narration, and basic device
+  context (app version, Android version, device model, locale, free memory)
+  are sent over HTTPS to the SceneView feedback service.
+- A pre-filled issue is opened in the public SceneView issue tracker on GitHub.
+  **That public issue contains only the written transcript and the device
+  context — never your screen recording or audio.**
+- The screen recording and audio are kept **private** and are **automatically
+  deleted after 90 days**; only the SceneView maintainers can view them.
+
+You can cancel at any point before sending. If you never use the feedback
+feature, none of the above applies.
 
 ### Third-Party SDKs
 
@@ -32,7 +59,10 @@
 
 ### Data Sharing
 
-- No data is shared with third parties.
+- The only data that ever leaves the device is feedback **you** choose to
+  submit. It is sent to the SceneView feedback service (a Cloudflare Worker
+  operated by the SceneView open-source project) and surfaces as an issue on
+  GitHub, as described in *In-App Feedback* above.
 - No data is sold or used for advertising.
 
 ### Children's Privacy

--- a/changelog.d/1930-in-app-feedback.md
+++ b/changelog.d/1930-in-app-feedback.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **In-app feedback** — the Android demo app now has a "Feedback" button on every tab: users record their screen + voice to report a bug or share an idea, the recording is transcribed server-side and filed as a pre-filled GitHub issue, and a "My feedback" screen tracks each submitted ticket's live Open/Closed status with a tap-through to the real issue. ([#1930](https://github.com/sceneview/sceneview/issues/1930))

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -37,6 +37,14 @@
         android:name="android.hardware.camera"
         android:required="false" />
 
+    <!-- In-app feedback (#1933) — screen + microphone recording via
+         MediaProjection, captured by a foreground service while the user
+         demonstrates a bug. All opt-in and consent-gated. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -77,6 +85,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- In-app feedback screen + mic recorder (#1933). -->
+        <service
+            android:name=".feedback.FeedbackRecordingService"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
 
         <activity
             android:name=".MainActivity"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -50,6 +50,7 @@ import io.github.sceneview.demo.feedback.FeedbackRecordingService
 import io.github.sceneview.demo.feedback.RecordingState
 import io.github.sceneview.demo.feedback.RecordingStopPill
 import io.github.sceneview.demo.feedback.rememberFeedbackRecordingLauncher
+import io.github.sceneview.demo.feedback.sweepStaleFeedbackMedia
 
 class MainActivity : ComponentActivity() {
 
@@ -72,6 +73,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Clean up any feedback recording stranded in the cache by a prior run.
+        sweepStaleFeedbackMedia(this)
         updateManager = InAppUpdateManager(this)
         // Two ingress channels: (1) `--es demo <id>` from `adb shell am` for QA / instrumented
         // tests, (2) URL deep-links via the public sceneview://demo/<id> scheme parsed by
@@ -302,9 +305,9 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
             RecordingStopPill(
                 onStop = { FeedbackRecordingService.stop(context) },
                 modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .windowInsetsPadding(WindowInsets.navigationBars)
-                    .padding(bottom = 24.dp),
+                    .align(Alignment.TopCenter)
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .padding(top = 24.dp),
             )
         }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -42,8 +42,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.compose.ui.platform.LocalContext
 import io.github.sceneview.demo.feedback.FeedbackButton
 import io.github.sceneview.demo.feedback.FeedbackFlow
+import io.github.sceneview.demo.feedback.FeedbackRecorder
+import io.github.sceneview.demo.feedback.FeedbackRecordingService
+import io.github.sceneview.demo.feedback.RecordingState
+import io.github.sceneview.demo.feedback.RecordingStopPill
+import io.github.sceneview.demo.feedback.rememberFeedbackRecordingLauncher
 
 class MainActivity : ComponentActivity() {
 
@@ -263,10 +269,24 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
         // screens place their own controls in every corner (movement pads, AR
         // action buttons), so a floating FAB there would collide; an in-demo
         // feedback entry point is a separate follow-up (#1932).
+        val context = LocalContext.current
         val currentEntry by navController.currentBackStackEntryAsState()
         val onListScreen = currentEntry?.destination?.route == "list"
         var feedbackOpen by rememberSaveable { mutableStateOf(false) }
-        if (onListScreen) {
+        val recordingState by FeedbackRecorder.state.collectAsState()
+        val isRecording = recordingState is RecordingState.Recording
+        val startRecording = rememberFeedbackRecordingLauncher()
+
+        // A finished or failed recording re-opens the flow at its review step.
+        LaunchedEffect(recordingState) {
+            if (recordingState is RecordingState.Done ||
+                recordingState is RecordingState.Failed
+            ) {
+                feedbackOpen = true
+            }
+        }
+
+        if (onListScreen && !isRecording) {
             FeedbackButton(
                 onClick = { feedbackOpen = true },
                 modifier = Modifier
@@ -275,8 +295,27 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                     .padding(start = 16.dp, bottom = FEEDBACK_FAB_BOTTOM_INSET),
             )
         }
-        if (feedbackOpen) {
-            FeedbackFlow(onDismiss = { feedbackOpen = false })
+
+        // While recording, the dialog is hidden so the user can demonstrate the
+        // bug; a floating Stop pill stays on top of every screen.
+        if (isRecording) {
+            RecordingStopPill(
+                onStop = { FeedbackRecordingService.stop(context) },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .padding(bottom = 24.dp),
+            )
+        }
+
+        if (feedbackOpen && !isRecording) {
+            FeedbackFlow(
+                onDismiss = {
+                    feedbackOpen = false
+                    FeedbackRecorder.reset()
+                },
+                onStartRecording = startRecording,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -178,6 +178,12 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+/**
+ * Bottom inset for the feedback FAB on the tab screens — clears the 80 dp M3
+ * `NavigationBar` plus a 16 dp gap.
+ */
+private val FEEDBACK_FAB_BOTTOM_INSET = 96.dp
+
 @Composable
 fun SceneViewDemoApp(activity: MainActivity? = null) {
     val navController = rememberNavController()
@@ -253,24 +259,22 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
             )
         }
 
-        // Global feedback entry point — overlays every screen (#1932). Bottom-start
-        // so it never collides with a demo's bottom-end settings FAB.
+        // Feedback entry point — shown only on the four tab screens. Demo
+        // screens place their own controls in every corner (movement pads, AR
+        // action buttons), so a floating FAB there would collide; an in-demo
+        // feedback entry point is a separate follow-up (#1932).
         val currentEntry by navController.currentBackStackEntryAsState()
         val onListScreen = currentEntry?.destination?.route == "list"
         var feedbackOpen by rememberSaveable { mutableStateOf(false) }
-        FeedbackButton(
-            expanded = onListScreen,
-            onClick = { feedbackOpen = true },
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .padding(
-                    start = 16.dp,
-                    // On the four tab screens, clear the 80 dp M3 NavigationBar so
-                    // the button floats above it; a demo screen has no bottom bar.
-                    bottom = if (onListScreen) 96.dp else 16.dp,
-                ),
-        )
+        if (onListScreen) {
+            FeedbackButton(
+                onClick = { feedbackOpen = true },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .padding(start = 16.dp, bottom = FEEDBACK_FAB_BOTTOM_INSET),
+            )
+        }
         if (feedbackOpen) {
             FeedbackFlow(onDismiss = { feedbackOpen = false })
         }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -35,6 +35,15 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.currentBackStackEntryAsState
+import io.github.sceneview.demo.feedback.FeedbackButton
+import io.github.sceneview.demo.feedback.FeedbackFlow
 
 class MainActivity : ComponentActivity() {
 
@@ -242,6 +251,28 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                     .align(Alignment.TopCenter)
                     .windowInsetsPadding(WindowInsets.statusBars),
             )
+        }
+
+        // Global feedback entry point — overlays every screen (#1932). Bottom-start
+        // so it never collides with a demo's bottom-end settings FAB.
+        val currentEntry by navController.currentBackStackEntryAsState()
+        val onListScreen = currentEntry?.destination?.route == "list"
+        var feedbackOpen by rememberSaveable { mutableStateOf(false) }
+        FeedbackButton(
+            expanded = onListScreen,
+            onClick = { feedbackOpen = true },
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .padding(
+                    start = 16.dp,
+                    // On the four tab screens, clear the 80 dp M3 NavigationBar so
+                    // the button floats above it; a demo screen has no bottom bar.
+                    bottom = if (onListScreen) 96.dp else 16.dp,
+                ),
+        )
+        if (feedbackOpen) {
+            FeedbackFlow(onDismiss = { feedbackOpen = false })
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/AudioDemux.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/AudioDemux.kt
@@ -1,0 +1,62 @@
+package io.github.sceneview.demo.feedback
+
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import java.io.File
+import java.nio.ByteBuffer
+
+/**
+ * Copy the audio track out of [source] (an mp4 screen recording) into a
+ * standalone [dest] file — a plain track copy, no re-encode. The feedback
+ * worker sends this audio-only file to Whisper for transcription.
+ *
+ * Returns [dest] on success, or null if [source] has no audio track or the
+ * copy fails (in which case the screen recording is still usable on its own).
+ */
+fun demuxAudioTrack(source: File, dest: File): File? {
+    val extractor = MediaExtractor()
+    var muxer: MediaMuxer? = null
+    return try {
+        extractor.setDataSource(source.absolutePath)
+
+        var audioTrack = -1
+        var audioFormat: MediaFormat? = null
+        for (i in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(i)
+            if (format.getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true) {
+                audioTrack = i
+                audioFormat = format
+                break
+            }
+        }
+        if (audioTrack < 0 || audioFormat == null) return null
+
+        extractor.selectTrack(audioTrack)
+        muxer = MediaMuxer(dest.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        val outTrack = muxer.addTrack(audioFormat)
+        muxer.start()
+
+        val buffer = ByteBuffer.allocate(256 * 1024)
+        val info = MediaCodec.BufferInfo()
+        while (true) {
+            val size = extractor.readSampleData(buffer, 0)
+            if (size < 0) break
+            info.offset = 0
+            info.size = size
+            info.presentationTimeUs = extractor.sampleTime
+            info.flags = extractor.sampleFlags
+            muxer.writeSampleData(outTrack, buffer, info)
+            extractor.advance()
+        }
+        muxer.stop()
+        dest
+    } catch (e: Exception) {
+        dest.delete()
+        null
+    } finally {
+        runCatching { extractor.release() }
+        runCatching { muxer?.release() }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackButton.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackButton.kt
@@ -1,0 +1,37 @@
+package io.github.sceneview.demo.feedback
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Feedback
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import io.github.sceneview.demo.R
+
+/**
+ * Always-visible entry point to the feedback flow. Extended (icon + label) on
+ * the tab screens where there is room, collapsed to an icon inside the
+ * full-screen demos so it never competes with the 3D scene.
+ */
+@Composable
+fun FeedbackButton(
+    expanded: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val cd = stringResource(R.string.feedback_cd_button)
+    ExtendedFloatingActionButton(
+        onClick = onClick,
+        expanded = expanded,
+        icon = { Icon(Icons.Outlined.Feedback, contentDescription = null) },
+        text = { Text(stringResource(R.string.feedback_button)) },
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = modifier.semantics { contentDescription = cd },
+    )
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackButton.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackButton.kt
@@ -9,29 +9,24 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import io.github.sceneview.demo.R
 
 /**
- * Always-visible entry point to the feedback flow. Extended (icon + label) on
- * the tab screens where there is room, collapsed to an icon inside the
- * full-screen demos so it never competes with the 3D scene.
+ * Entry point to the feedback flow — an extended FAB (icon + "Feedback" label)
+ * shown on the demo app's tab screens. The visible label is its own accessible
+ * name, so no extra content description is needed.
  */
 @Composable
 fun FeedbackButton(
-    expanded: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val cd = stringResource(R.string.feedback_cd_button)
     ExtendedFloatingActionButton(
         onClick = onClick,
-        expanded = expanded,
         icon = { Icon(Icons.Outlined.Feedback, contentDescription = null) },
         text = { Text(stringResource(R.string.feedback_button)) },
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        modifier = modifier.semantics { contentDescription = cd },
+        modifier = modifier,
     )
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackCategory.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackCategory.kt
@@ -1,0 +1,4 @@
+package io.github.sceneview.demo.feedback
+
+/** What a feedback submission is about — drives the GitHub label downstream. */
+enum class FeedbackCategory { BUG, IDEA }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
@@ -1,0 +1,30 @@
+package io.github.sceneview.demo.feedback
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import io.github.sceneview.demo.BuildConfig
+import java.util.Locale
+
+/**
+ * Snapshot of device / app context attached to a feedback submission. This is
+ * what the maintainer sees in the GitHub issue's context table — it tells them
+ * exactly which app build, OS and device the feedback came from.
+ */
+fun captureFeedbackContext(context: Context): Map<String, String> {
+    val freeRamMb = (context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager)
+        ?.let { am ->
+            val info = ActivityManager.MemoryInfo()
+            am.getMemoryInfo(info)
+            info.availMem / (1024L * 1024L)
+        }
+    return buildMap {
+        put("appVersion", BuildConfig.VERSION_NAME)
+        put("appVersionCode", BuildConfig.VERSION_CODE.toString())
+        put("androidVersion", Build.VERSION.RELEASE ?: Build.VERSION.SDK_INT.toString())
+        put("sdkInt", Build.VERSION.SDK_INT.toString())
+        put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
+        put("locale", Locale.getDefault().toLanguageTag())
+        if (freeRamMb != null) put("freeRamMb", freeRamMb.toString())
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -1,5 +1,10 @@
 package io.github.sceneview.demo.feedback
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.text.format.DateUtils
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +49,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -56,13 +62,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import io.github.sceneview.demo.R
 import kotlinx.coroutines.launch
 
-private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENDING }
+private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENDING, TICKETS }
 
 /** State of the feedback upload, driving the SENDING step. */
 private sealed interface UploadUiState {
@@ -98,6 +105,10 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
     var note by rememberSaveable { mutableStateOf("") }
     var uploadState by remember { mutableStateOf<UploadUiState>(UploadUiState.Sending) }
 
+    // The previously submitted tickets — read once per dialog open. Used to
+    // surface the "My feedback" entry and to populate the tracking screen.
+    val tickets = remember { SubmittedFeedbackStore.all(context) }
+
     fun send() {
         val recording = (FeedbackRecorder.state.value as? RecordingState.Done)?.recording
         val chosen = FeedbackRecorder.category ?: category ?: FeedbackCategory.BUG
@@ -116,7 +127,26 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
             } else {
                 UploadUiState.Failed
             }
-            if (result.ok) FeedbackRecorder.reset()
+            if (result.ok) {
+                // Index the new ticket locally so "My feedback" can track it.
+                // Skipped when the worker stored the feedback but opened no
+                // issue (e.g. its hourly issue quota was hit) — there is then
+                // nothing to link to.
+                if (result.issueNumber != null && result.issueUrl != null) {
+                    SubmittedFeedbackStore.add(
+                        context,
+                        SubmittedFeedback(
+                            feedbackId = result.feedbackId ?: "",
+                            issueNumber = result.issueNumber,
+                            issueUrl = result.issueUrl,
+                            category = chosen,
+                            title = text,
+                            createdAt = System.currentTimeMillis(),
+                        ),
+                    )
+                }
+                FeedbackRecorder.reset()
+            }
         }
     }
 
@@ -173,6 +203,8 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
                             category = it
                             step = FeedbackStep.CONSENT
                         },
+                        hasTickets = tickets.isNotEmpty(),
+                        onViewTickets = { step = FeedbackStep.TICKETS },
                     )
                     FeedbackStep.CONSENT -> ConsentStep(
                         category = category ?: FeedbackCategory.BUG,
@@ -186,6 +218,12 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
                             FeedbackRecorder.category = category
                             step = FeedbackStep.REVIEW
                         },
+                    )
+                    FeedbackStep.TICKETS -> TicketsStep(
+                        tickets = tickets,
+                        onClose = onDismiss,
+                        onBack = { step = FeedbackStep.CATEGORY },
+                        onOpenTicket = { openIssue(context, it.issueUrl) },
                     )
                     FeedbackStep.REVIEW, FeedbackStep.SENDING -> Unit // handled above
                 }
@@ -217,8 +255,22 @@ private fun OnboardingStep(onClose: () -> Unit, onContinue: () -> Unit) {
 }
 
 @Composable
-private fun CategoryStep(onClose: () -> Unit, onPick: (FeedbackCategory) -> Unit) {
-    FeedbackStepScaffold(onClose = onClose) {
+private fun CategoryStep(
+    onClose: () -> Unit,
+    onPick: (FeedbackCategory) -> Unit,
+    hasTickets: Boolean,
+    onViewTickets: () -> Unit,
+) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            if (hasTickets) {
+                TextButton(onClick = onViewTickets, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.feedback_tickets_entry))
+                }
+            }
+        },
+    ) {
         Spacer(Modifier.height(8.dp))
         StepTitle(stringResource(R.string.feedback_category_title))
         Spacer(Modifier.height(24.dp))
@@ -420,6 +472,162 @@ private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
         StepTitle(stringResource(R.string.feedback_record_failed_title))
         Spacer(Modifier.height(12.dp))
         StepBody(stringResource(R.string.feedback_record_failed_body))
+    }
+}
+
+@Composable
+private fun TicketsStep(
+    tickets: List<SubmittedFeedback>,
+    onClose: () -> Unit,
+    onBack: () -> Unit,
+    onOpenTicket: (SubmittedFeedback) -> Unit,
+) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            TextButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.feedback_tickets_back))
+            }
+        },
+    ) {
+        Spacer(Modifier.height(8.dp))
+        StepTitle(stringResource(R.string.feedback_tickets_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_tickets_body))
+        Spacer(Modifier.height(20.dp))
+        if (tickets.isEmpty()) {
+            StepBody(stringResource(R.string.feedback_tickets_empty))
+        } else {
+            tickets.forEachIndexed { index, ticket ->
+                if (index > 0) Spacer(Modifier.height(12.dp))
+                TicketRow(ticket = ticket, onClick = { onOpenTicket(ticket) })
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+    }
+}
+
+@Composable
+private fun TicketRow(ticket: SubmittedFeedback, onClick: () -> Unit) {
+    // The GitHub issue is the source of truth — the live state is read from it,
+    // never stored. null = still loading.
+    val state by produceState<TicketState?>(initialValue = null, ticket.issueNumber) {
+        value = FeedbackTicketStatus.fetch(ticket.issueNumber)
+    }
+    val isBug = ticket.category == FeedbackCategory.BUG
+    val tint = if (isBug) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 1.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(tint.copy(alpha = 0.18f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    if (isBug) Icons.Outlined.BugReport else Icons.Outlined.Lightbulb,
+                    contentDescription = null,
+                    tint = tint,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    ticketDisplayTitle(ticket),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    stringResource(
+                        R.string.feedback_tickets_row_meta,
+                        ticket.issueNumber,
+                        relativeTime(ticket.createdAt),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TicketStatusBadge(state)
+        }
+    }
+}
+
+@Composable
+private fun TicketStatusBadge(state: TicketState?) {
+    when (state) {
+        null -> CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeWidth = 2.dp,
+        )
+        TicketState.OPEN -> StatusPill(
+            text = stringResource(R.string.feedback_tickets_open),
+            container = MaterialTheme.colorScheme.tertiaryContainer,
+            content = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+        TicketState.CLOSED -> StatusPill(
+            text = stringResource(R.string.feedback_tickets_closed),
+            container = MaterialTheme.colorScheme.surfaceContainerHighest,
+            content = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // Status unavailable (offline / rate-limited) — show nothing rather
+        // than a misleading badge; the row still opens the real issue.
+        TicketState.UNKNOWN -> Unit
+    }
+}
+
+@Composable
+private fun StatusPill(text: String, container: Color, content: Color) {
+    Surface(shape = CircleShape, color = container) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            color = content,
+        )
+    }
+}
+
+@Composable
+private fun ticketDisplayTitle(ticket: SubmittedFeedback): String =
+    ticket.title.ifBlank {
+        stringResource(
+            if (ticket.category == FeedbackCategory.BUG) {
+                R.string.feedback_tickets_untitled_bug
+            } else {
+                R.string.feedback_tickets_untitled_idea
+            },
+        )
+    }
+
+private fun relativeTime(createdAt: Long): String =
+    DateUtils.getRelativeTimeSpanString(
+        createdAt,
+        System.currentTimeMillis(),
+        DateUtils.MINUTE_IN_MILLIS,
+    ).toString()
+
+/** Open the real GitHub issue — the GitHub app handles it if installed, else a
+ *  browser. A device with neither shows a toast rather than crashing. */
+private fun openIssue(context: Context, url: String) {
+    runCatching {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    }.onFailure {
+        Toast.makeText(context, R.string.feedback_tickets_no_app, Toast.LENGTH_LONG).show()
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material.icons.outlined.Lock
@@ -34,10 +35,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -55,26 +58,34 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import io.github.sceneview.demo.R
 
-private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, STUB }
+private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENT }
 
 /**
- * The in-app feedback flow, shown as a full-screen dialog: a one-time
- * onboarding screen, the Bug/Idea picker, and the screen + microphone consent
- * screen.
+ * The in-app feedback flow, shown as a full-screen dialog: one-time onboarding,
+ * the Bug/Idea picker, the screen + microphone consent screen, then — after the
+ * user has recorded — a review screen.
  *
- * The actual screen + audio recording is wired in a later step (1C, #1933) —
- * for now the consent screen leads to a placeholder.
+ * The recording itself happens with the dialog dismissed (so the user can
+ * demonstrate the bug); [FeedbackRecorder] bridges the recording state back in,
+ * and this flow shows the review step once a recording is available.
+ *
+ * Sending the feedback is wired in task 1D (#1934) — for now "Send" leads to a
+ * placeholder confirmation.
+ *
+ * @param onStartRecording requests the screen + mic permissions and starts the
+ *   recording service; see [rememberFeedbackRecordingLauncher].
  */
 @Composable
-fun FeedbackFlow(onDismiss: () -> Unit) {
+fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
     val context = LocalContext.current
+    val recState by FeedbackRecorder.state.collectAsState()
+
     var step by rememberSaveable {
         mutableStateOf(
             if (FeedbackPrefs.hasSeenOnboarding(context)) FeedbackStep.CATEGORY
             else FeedbackStep.ONBOARDING,
         )
     }
-    // Retained for the recording / upload steps (1C / 1D).
     var category by rememberSaveable { mutableStateOf<FeedbackCategory?>(null) }
 
     Dialog(
@@ -88,28 +99,62 @@ fun FeedbackFlow(onDismiss: () -> Unit) {
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.surface,
         ) {
-            when (step) {
-                FeedbackStep.ONBOARDING -> OnboardingStep(
+            val doneRecording = (recState as? RecordingState.Done)?.recording
+            when {
+                recState is RecordingState.Failed -> FailedStep(
                     onClose = onDismiss,
-                    onContinue = {
-                        FeedbackPrefs.markOnboardingSeen(context)
-                        step = FeedbackStep.CATEGORY
+                    onRetry = {
+                        FeedbackRecorder.reset()
+                        onStartRecording()
                     },
                 )
-                FeedbackStep.CATEGORY -> CategoryStep(
+
+                doneRecording != null || step == FeedbackStep.REVIEW -> ReviewStep(
+                    recording = doneRecording,
                     onClose = onDismiss,
-                    onPick = {
-                        category = it
-                        step = FeedbackStep.CONSENT
+                    onRerecord = {
+                        FeedbackRecorder.reset()
+                        onStartRecording()
+                    },
+                    onSend = {
+                        // Upload is wired in task 1D — for now discard the
+                        // local recording and show a placeholder confirmation.
+                        FeedbackRecorder.reset()
+                        step = FeedbackStep.SENT
                     },
                 )
-                FeedbackStep.CONSENT -> ConsentStep(
-                    category = category ?: FeedbackCategory.BUG,
-                    onClose = onDismiss,
-                    onBack = { step = FeedbackStep.CATEGORY },
-                    onAgree = { step = FeedbackStep.STUB },
-                )
-                FeedbackStep.STUB -> StubStep(onClose = onDismiss)
+
+                else -> when (step) {
+                    FeedbackStep.ONBOARDING -> OnboardingStep(
+                        onClose = onDismiss,
+                        onContinue = {
+                            FeedbackPrefs.markOnboardingSeen(context)
+                            step = FeedbackStep.CATEGORY
+                        },
+                    )
+                    FeedbackStep.CATEGORY -> CategoryStep(
+                        onClose = onDismiss,
+                        onPick = {
+                            category = it
+                            step = FeedbackStep.CONSENT
+                        },
+                    )
+                    FeedbackStep.CONSENT -> ConsentStep(
+                        category = category ?: FeedbackCategory.BUG,
+                        onClose = onDismiss,
+                        onBack = { step = FeedbackStep.CATEGORY },
+                        onAgree = {
+                            FeedbackRecorder.category = category
+                            onStartRecording()
+                        },
+                        onSkip = {
+                            FeedbackRecorder.category = category
+                            step = FeedbackStep.REVIEW
+                        },
+                    )
+                    FeedbackStep.SENT -> SentStep(onClose = onDismiss)
+                    FeedbackStep.REVIEW -> Unit // handled above
+                }
             }
         }
     }
@@ -167,6 +212,7 @@ private fun ConsentStep(
     onClose: () -> Unit,
     onBack: () -> Unit,
     onAgree: () -> Unit,
+    onSkip: () -> Unit,
 ) {
     FeedbackStepScaffold(
         onClose = onClose,
@@ -175,6 +221,11 @@ private fun ConsentStep(
                 text = stringResource(R.string.feedback_consent_agree),
                 onClick = onAgree,
             )
+            if (category == FeedbackCategory.IDEA) {
+                TextButton(onClick = onSkip, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.feedback_consent_skip))
+                }
+            }
             TextButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.feedback_consent_back))
             }
@@ -203,7 +254,71 @@ private fun ConsentStep(
 }
 
 @Composable
-private fun StubStep(onClose: () -> Unit) {
+private fun ReviewStep(
+    recording: FeedbackRecording?,
+    onClose: () -> Unit,
+    onRerecord: () -> Unit,
+    onSend: (note: String) -> Unit,
+) {
+    var note by rememberSaveable { mutableStateOf("") }
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            PrimaryButton(
+                text = stringResource(R.string.feedback_review_send),
+                onClick = { onSend(note.trim()) },
+            )
+            TextButton(onClick = onRerecord, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.feedback_review_rerecord))
+            }
+        },
+    ) {
+        Spacer(Modifier.height(16.dp))
+        FeedbackHeroIcon(Icons.Outlined.CheckCircle, Modifier.align(Alignment.CenterHorizontally))
+        Spacer(Modifier.height(24.dp))
+        StepTitle(stringResource(R.string.feedback_review_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_review_body))
+        Spacer(Modifier.height(16.dp))
+        if (recording != null) {
+            RecordingSummary(recording)
+        } else {
+            StepBody(stringResource(R.string.feedback_review_no_recording))
+        }
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = note,
+            onValueChange = { note = it },
+            label = { Text(stringResource(R.string.feedback_review_note_label)) },
+            placeholder = { Text(stringResource(R.string.feedback_review_note_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 3,
+        )
+    }
+}
+
+@Composable
+private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            PrimaryButton(
+                text = stringResource(R.string.feedback_record_retry),
+                onClick = onRetry,
+            )
+        },
+    ) {
+        Spacer(Modifier.height(16.dp))
+        FeedbackHeroIcon(Icons.Outlined.ErrorOutline, Modifier.align(Alignment.CenterHorizontally))
+        Spacer(Modifier.height(24.dp))
+        StepTitle(stringResource(R.string.feedback_record_failed_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_record_failed_body))
+    }
+}
+
+@Composable
+private fun SentStep(onClose: () -> Unit) {
     FeedbackStepScaffold(
         onClose = onClose,
         actions = {
@@ -406,4 +521,47 @@ private fun PrivacyNote() {
             )
         }
     }
+}
+
+@Composable
+private fun RecordingSummary(recording: FeedbackRecording) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Outlined.Videocam,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.feedback_review_recorded),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    formatDuration(recording.durationMs),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun formatDuration(ms: Long): String {
+    val totalSeconds = (ms / 1000).coerceAtLeast(0)
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%d:%02d".format(minutes, seconds)
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -326,7 +327,7 @@ private fun CategoryCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(role = Role.Button, onClick = onClick),
         shape = RoundedCornerShape(16.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 1.dp,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -1,0 +1,408 @@
+package io.github.sceneview.demo.feedback
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Feedback
+import androidx.compose.material.icons.outlined.Lightbulb
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.Smartphone
+import androidx.compose.material.icons.outlined.Videocam
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import io.github.sceneview.demo.R
+
+private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, STUB }
+
+/**
+ * The in-app feedback flow, shown as a full-screen dialog: a one-time
+ * onboarding screen, the Bug/Idea picker, and the screen + microphone consent
+ * screen.
+ *
+ * The actual screen + audio recording is wired in a later step (1C, #1933) —
+ * for now the consent screen leads to a placeholder.
+ */
+@Composable
+fun FeedbackFlow(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    var step by rememberSaveable {
+        mutableStateOf(
+            if (FeedbackPrefs.hasSeenOnboarding(context)) FeedbackStep.CATEGORY
+            else FeedbackStep.ONBOARDING,
+        )
+    }
+    // Retained for the recording / upload steps (1C / 1D).
+    var category by rememberSaveable { mutableStateOf<FeedbackCategory?>(null) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnClickOutside = false,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            when (step) {
+                FeedbackStep.ONBOARDING -> OnboardingStep(
+                    onClose = onDismiss,
+                    onContinue = {
+                        FeedbackPrefs.markOnboardingSeen(context)
+                        step = FeedbackStep.CATEGORY
+                    },
+                )
+                FeedbackStep.CATEGORY -> CategoryStep(
+                    onClose = onDismiss,
+                    onPick = {
+                        category = it
+                        step = FeedbackStep.CONSENT
+                    },
+                )
+                FeedbackStep.CONSENT -> ConsentStep(
+                    category = category ?: FeedbackCategory.BUG,
+                    onClose = onDismiss,
+                    onBack = { step = FeedbackStep.CATEGORY },
+                    onAgree = { step = FeedbackStep.STUB },
+                )
+                FeedbackStep.STUB -> StubStep(onClose = onDismiss)
+            }
+        }
+    }
+}
+
+// ── Steps ────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun OnboardingStep(onClose: () -> Unit, onContinue: () -> Unit) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            PrimaryButton(
+                text = stringResource(R.string.feedback_onboarding_continue),
+                onClick = onContinue,
+            )
+        },
+    ) {
+        Spacer(Modifier.height(16.dp))
+        FeedbackHeroIcon(Icons.Outlined.Feedback, Modifier.align(Alignment.CenterHorizontally))
+        Spacer(Modifier.height(24.dp))
+        StepTitle(stringResource(R.string.feedback_onboarding_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_onboarding_body))
+    }
+}
+
+@Composable
+private fun CategoryStep(onClose: () -> Unit, onPick: (FeedbackCategory) -> Unit) {
+    FeedbackStepScaffold(onClose = onClose) {
+        Spacer(Modifier.height(8.dp))
+        StepTitle(stringResource(R.string.feedback_category_title))
+        Spacer(Modifier.height(24.dp))
+        CategoryCard(
+            icon = Icons.Outlined.BugReport,
+            tint = MaterialTheme.colorScheme.error,
+            title = stringResource(R.string.feedback_bug_title),
+            subtitle = stringResource(R.string.feedback_bug_subtitle),
+            onClick = { onPick(FeedbackCategory.BUG) },
+        )
+        Spacer(Modifier.height(12.dp))
+        CategoryCard(
+            icon = Icons.Outlined.Lightbulb,
+            tint = MaterialTheme.colorScheme.tertiary,
+            title = stringResource(R.string.feedback_idea_title),
+            subtitle = stringResource(R.string.feedback_idea_subtitle),
+            onClick = { onPick(FeedbackCategory.IDEA) },
+        )
+    }
+}
+
+@Composable
+private fun ConsentStep(
+    category: FeedbackCategory,
+    onClose: () -> Unit,
+    onBack: () -> Unit,
+    onAgree: () -> Unit,
+) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            PrimaryButton(
+                text = stringResource(R.string.feedback_consent_agree),
+                onClick = onAgree,
+            )
+            TextButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.feedback_consent_back))
+            }
+        },
+    ) {
+        Spacer(Modifier.height(16.dp))
+        FeedbackHeroIcon(Icons.Outlined.Videocam, Modifier.align(Alignment.CenterHorizontally))
+        Spacer(Modifier.height(24.dp))
+        StepTitle(stringResource(R.string.feedback_consent_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_consent_body))
+        Spacer(Modifier.height(16.dp))
+        ConsentBullet(Icons.Outlined.Smartphone, stringResource(R.string.feedback_consent_screen))
+        Spacer(Modifier.height(10.dp))
+        ConsentBullet(Icons.Outlined.Mic, stringResource(R.string.feedback_consent_voice))
+        if (category == FeedbackCategory.IDEA) {
+            Spacer(Modifier.height(10.dp))
+            ConsentBullet(
+                Icons.Outlined.Lightbulb,
+                stringResource(R.string.feedback_consent_idea_optional),
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+        PrivacyNote()
+    }
+}
+
+@Composable
+private fun StubStep(onClose: () -> Unit) {
+    FeedbackStepScaffold(
+        onClose = onClose,
+        actions = {
+            PrimaryButton(
+                text = stringResource(R.string.feedback_stub_done),
+                onClick = onClose,
+            )
+        },
+    ) {
+        Spacer(Modifier.height(16.dp))
+        FeedbackHeroIcon(Icons.Outlined.CheckCircle, Modifier.align(Alignment.CenterHorizontally))
+        Spacer(Modifier.height(24.dp))
+        StepTitle(stringResource(R.string.feedback_stub_title))
+        Spacer(Modifier.height(12.dp))
+        StepBody(stringResource(R.string.feedback_stub_body))
+    }
+}
+
+// ── Shared pieces ────────────────────────────────────────────────────────────
+
+/** Close row, scrolling content area, and a pinned action area at the bottom. */
+@Composable
+private fun FeedbackStepScaffold(
+    onClose: () -> Unit,
+    actions: @Composable ColumnScope.() -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            IconButton(onClick = onClose) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.feedback_cd_close),
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            content = content,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            content = actions,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.PrimaryButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        shape = RoundedCornerShape(percent = 50),
+    ) {
+        Text(text, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+@Composable
+private fun StepTitle(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+@Composable
+private fun StepBody(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun FeedbackHeroIcon(icon: ImageVector, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.size(34.dp),
+        )
+    }
+}
+
+@Composable
+private fun CategoryCard(
+    icon: ImageVector,
+    tint: Color,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 1.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(tint.copy(alpha = 0.18f), RoundedCornerShape(12.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(26.dp))
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConsentBullet(icon: ImageVector, text: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(22.dp),
+        )
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun PrivacyNote() {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Outlined.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                stringResource(R.string.feedback_consent_privacy),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -16,11 +16,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -61,6 +64,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -489,6 +494,7 @@ private fun TicketsStep(
                 Text(stringResource(R.string.feedback_tickets_back))
             }
         },
+        scrollableContent = false,
     ) {
         Spacer(Modifier.height(8.dp))
         StepTitle(stringResource(R.string.feedback_tickets_title))
@@ -498,12 +504,20 @@ private fun TicketsStep(
         if (tickets.isEmpty()) {
             StepBody(stringResource(R.string.feedback_tickets_empty))
         } else {
-            tickets.forEachIndexed { index, ticket ->
-                if (index > 0) Spacer(Modifier.height(12.dp))
-                TicketRow(ticket = ticket, onClick = { onOpenTicket(ticket) })
+            // A LazyColumn so each row's GitHub status fetch fires only when the
+            // row scrolls into view — not all at once on open.
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(bottom = 8.dp),
+            ) {
+                items(tickets, key = { it.issueNumber }) { ticket ->
+                    TicketRow(ticket = ticket, onClick = { onOpenTicket(ticket) })
+                }
             }
         }
-        Spacer(Modifier.height(8.dp))
     }
 }
 
@@ -515,11 +529,17 @@ private fun TicketRow(ticket: SubmittedFeedback, onClick: () -> Unit) {
         value = FeedbackTicketStatus.fetch(ticket.issueNumber)
     }
     val isBug = ticket.category == FeedbackCategory.BUG
-    val tint = if (isBug) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary
+    // A category accent, not an alert — these are the user's own filed tickets,
+    // so `error` (reserved for alarms) would wrongly read as "something wrong".
+    val tint = if (isBug) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.tertiary
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(role = Role.Button, onClick = onClick),
+            .clickable(
+                role = Role.Button,
+                onClickLabel = stringResource(R.string.feedback_tickets_open_a11y),
+                onClick = onClick,
+            ),
         shape = RoundedCornerShape(16.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 1.dp,
@@ -569,10 +589,15 @@ private fun TicketRow(ticket: SubmittedFeedback, onClick: () -> Unit) {
 @Composable
 private fun TicketStatusBadge(state: TicketState?) {
     when (state) {
-        null -> CircularProgressIndicator(
-            modifier = Modifier.size(16.dp),
-            strokeWidth = 2.dp,
-        )
+        null -> {
+            val loadingDesc = stringResource(R.string.feedback_tickets_status_loading)
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(16.dp)
+                    .semantics { contentDescription = loadingDesc },
+                strokeWidth = 2.dp,
+            )
+        }
         TicketState.OPEN -> StatusPill(
             text = stringResource(R.string.feedback_tickets_open),
             container = MaterialTheme.colorScheme.tertiaryContainer,
@@ -633,11 +658,18 @@ private fun openIssue(context: Context, url: String) {
 
 // ── Shared pieces ────────────────────────────────────────────────────────────
 
-/** Close row, scrolling content area, and a pinned action area at the bottom. */
+/**
+ * Close row, content area, and a pinned action area at the bottom.
+ *
+ * @param scrollableContent when true (default) the content area is wrapped in a
+ *   `verticalScroll`; pass false for a step that owns its own scrolling (e.g. a
+ *   `LazyColumn`), since nesting two same-axis scroll containers is illegal.
+ */
 @Composable
 private fun FeedbackStepScaffold(
     onClose: (() -> Unit)?,
     actions: @Composable ColumnScope.() -> Unit = {},
+    scrollableContent: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
@@ -665,7 +697,13 @@ private fun FeedbackStepScaffold(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .verticalScroll(rememberScrollState())
+                .then(
+                    if (scrollableContent) {
+                        Modifier.verticalScroll(rememberScrollState())
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(horizontal = 24.dp),
             content = content,
         )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -302,6 +302,7 @@ private fun ReviewStep(
             PrimaryButton(
                 text = stringResource(R.string.feedback_review_send),
                 onClick = onSend,
+                enabled = recording != null || note.isNotBlank(),
             )
             TextButton(onClick = onRerecord, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.feedback_review_rerecord))
@@ -339,7 +340,7 @@ private fun SendingStep(
     onRetry: () -> Unit,
 ) {
     when (state) {
-        UploadUiState.Sending -> FeedbackStepScaffold(onClose = onClose) {
+        UploadUiState.Sending -> FeedbackStepScaffold(onClose = null) {
             Spacer(Modifier.height(64.dp))
             CircularProgressIndicator(
                 modifier = Modifier
@@ -410,7 +411,11 @@ private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
         },
     ) {
         Spacer(Modifier.height(16.dp))
-        FeedbackHeroIcon(Icons.Outlined.ErrorOutline, Modifier.align(Alignment.CenterHorizontally))
+        FeedbackHeroIcon(
+            Icons.Outlined.ErrorOutline,
+            Modifier.align(Alignment.CenterHorizontally),
+            error = true,
+        )
         Spacer(Modifier.height(24.dp))
         StepTitle(stringResource(R.string.feedback_record_failed_title))
         Spacer(Modifier.height(12.dp))
@@ -423,7 +428,7 @@ private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
 /** Close row, scrolling content area, and a pinned action area at the bottom. */
 @Composable
 private fun FeedbackStepScaffold(
-    onClose: () -> Unit,
+    onClose: (() -> Unit)?,
     actions: @Composable ColumnScope.() -> Unit = {},
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -435,14 +440,17 @@ private fun FeedbackStepScaffold(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .height(56.dp)
                 .padding(4.dp),
             horizontalArrangement = Arrangement.End,
         ) {
-            IconButton(onClick = onClose) {
-                Icon(
-                    Icons.Default.Close,
-                    contentDescription = stringResource(R.string.feedback_cd_close),
-                )
+            if (onClose != null) {
+                IconButton(onClick = onClose) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = stringResource(R.string.feedback_cd_close),
+                    )
+                }
             }
         }
         Column(
@@ -464,9 +472,14 @@ private fun FeedbackStepScaffold(
 }
 
 @Composable
-private fun ColumnScope.PrimaryButton(text: String, onClick: () -> Unit) {
+private fun ColumnScope.PrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
     Button(
         onClick = onClick,
+        enabled = enabled,
         modifier = Modifier
             .fillMaxWidth()
             .height(52.dp),
@@ -496,17 +509,27 @@ private fun StepBody(text: String) {
 }
 
 @Composable
-private fun FeedbackHeroIcon(icon: ImageVector, modifier: Modifier = Modifier) {
+private fun FeedbackHeroIcon(
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    error: Boolean = false,
+) {
+    val container =
+        if (error) MaterialTheme.colorScheme.errorContainer
+        else MaterialTheme.colorScheme.secondaryContainer
+    val content =
+        if (error) MaterialTheme.colorScheme.onErrorContainer
+        else MaterialTheme.colorScheme.onSecondaryContainer
     Box(
         modifier = modifier
             .size(72.dp)
-            .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape),
+            .background(container, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             icon,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            tint = content,
             modifier = Modifier.size(34.dp),
         )
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Smartphone
 import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,6 +44,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,20 +60,24 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import io.github.sceneview.demo.R
+import kotlinx.coroutines.launch
 
-private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENT }
+private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENDING }
+
+/** State of the feedback upload, driving the SENDING step. */
+private sealed interface UploadUiState {
+    data object Sending : UploadUiState
+    data class Sent(val issueNumber: Int?) : UploadUiState
+    data object Failed : UploadUiState
+}
 
 /**
  * The in-app feedback flow, shown as a full-screen dialog: one-time onboarding,
- * the Bug/Idea picker, the screen + microphone consent screen, then — after the
- * user has recorded — a review screen.
+ * the Bug/Idea picker, the screen + microphone consent screen, a review screen,
+ * and the upload to the SceneView feedback worker.
  *
  * The recording itself happens with the dialog dismissed (so the user can
- * demonstrate the bug); [FeedbackRecorder] bridges the recording state back in,
- * and this flow shows the review step once a recording is available.
- *
- * Sending the feedback is wired in task 1D (#1934) — for now "Send" leads to a
- * placeholder confirmation.
+ * demonstrate the bug); [FeedbackRecorder] bridges the recording state back in.
  *
  * @param onStartRecording requests the screen + mic permissions and starts the
  *   recording service; see [rememberFeedbackRecordingLauncher].
@@ -78,6 +85,7 @@ private enum class FeedbackStep { ONBOARDING, CATEGORY, CONSENT, REVIEW, SENT }
 @Composable
 fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val recState by FeedbackRecorder.state.collectAsState()
 
     var step by rememberSaveable {
@@ -87,6 +95,30 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
         )
     }
     var category by rememberSaveable { mutableStateOf<FeedbackCategory?>(null) }
+    var note by rememberSaveable { mutableStateOf("") }
+    var uploadState by remember { mutableStateOf<UploadUiState>(UploadUiState.Sending) }
+
+    fun send() {
+        val recording = (FeedbackRecorder.state.value as? RecordingState.Done)?.recording
+        val chosen = FeedbackRecorder.category ?: category ?: FeedbackCategory.BUG
+        val text = note.trim()
+        uploadState = UploadUiState.Sending
+        step = FeedbackStep.SENDING
+        scope.launch {
+            val result = FeedbackUploader.upload(
+                category = chosen,
+                note = text,
+                context = captureFeedbackContext(context),
+                recording = recording,
+            )
+            uploadState = if (result.ok) {
+                UploadUiState.Sent(result.issueNumber)
+            } else {
+                UploadUiState.Failed
+            }
+            if (result.ok) FeedbackRecorder.reset()
+        }
+    }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -101,6 +133,12 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
         ) {
             val doneRecording = (recState as? RecordingState.Done)?.recording
             when {
+                step == FeedbackStep.SENDING -> SendingStep(
+                    state = uploadState,
+                    onClose = onDismiss,
+                    onRetry = { send() },
+                )
+
                 recState is RecordingState.Failed -> FailedStep(
                     onClose = onDismiss,
                     onRetry = {
@@ -111,17 +149,14 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
 
                 doneRecording != null || step == FeedbackStep.REVIEW -> ReviewStep(
                     recording = doneRecording,
+                    note = note,
+                    onNoteChange = { note = it },
                     onClose = onDismiss,
                     onRerecord = {
                         FeedbackRecorder.reset()
                         onStartRecording()
                     },
-                    onSend = {
-                        // Upload is wired in task 1D — for now discard the
-                        // local recording and show a placeholder confirmation.
-                        FeedbackRecorder.reset()
-                        step = FeedbackStep.SENT
-                    },
+                    onSend = { send() },
                 )
 
                 else -> when (step) {
@@ -152,8 +187,7 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
                             step = FeedbackStep.REVIEW
                         },
                     )
-                    FeedbackStep.SENT -> SentStep(onClose = onDismiss)
-                    FeedbackStep.REVIEW -> Unit // handled above
+                    FeedbackStep.REVIEW, FeedbackStep.SENDING -> Unit // handled above
                 }
             }
         }
@@ -256,17 +290,18 @@ private fun ConsentStep(
 @Composable
 private fun ReviewStep(
     recording: FeedbackRecording?,
+    note: String,
+    onNoteChange: (String) -> Unit,
     onClose: () -> Unit,
     onRerecord: () -> Unit,
-    onSend: (note: String) -> Unit,
+    onSend: () -> Unit,
 ) {
-    var note by rememberSaveable { mutableStateOf("") }
     FeedbackStepScaffold(
         onClose = onClose,
         actions = {
             PrimaryButton(
                 text = stringResource(R.string.feedback_review_send),
-                onClick = { onSend(note.trim()) },
+                onClick = onSend,
             )
             TextButton(onClick = onRerecord, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.feedback_review_rerecord))
@@ -288,12 +323,78 @@ private fun ReviewStep(
         Spacer(Modifier.height(16.dp))
         OutlinedTextField(
             value = note,
-            onValueChange = { note = it },
+            onValueChange = onNoteChange,
             label = { Text(stringResource(R.string.feedback_review_note_label)) },
             placeholder = { Text(stringResource(R.string.feedback_review_note_placeholder)) },
             modifier = Modifier.fillMaxWidth(),
             minLines = 3,
         )
+    }
+}
+
+@Composable
+private fun SendingStep(
+    state: UploadUiState,
+    onClose: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    when (state) {
+        UploadUiState.Sending -> FeedbackStepScaffold(onClose = onClose) {
+            Spacer(Modifier.height(64.dp))
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(48.dp),
+            )
+            Spacer(Modifier.height(24.dp))
+            StepBody(stringResource(R.string.feedback_sending))
+        }
+
+        is UploadUiState.Sent -> FeedbackStepScaffold(
+            onClose = onClose,
+            actions = {
+                PrimaryButton(
+                    text = stringResource(R.string.feedback_sent_done),
+                    onClick = onClose,
+                )
+            },
+        ) {
+            Spacer(Modifier.height(16.dp))
+            FeedbackHeroIcon(
+                Icons.Outlined.CheckCircle,
+                Modifier.align(Alignment.CenterHorizontally),
+            )
+            Spacer(Modifier.height(24.dp))
+            StepTitle(stringResource(R.string.feedback_sent_title))
+            Spacer(Modifier.height(12.dp))
+            StepBody(
+                if (state.issueNumber != null) {
+                    stringResource(R.string.feedback_sent_issue, state.issueNumber)
+                } else {
+                    stringResource(R.string.feedback_sent_generic)
+                },
+            )
+        }
+
+        UploadUiState.Failed -> FeedbackStepScaffold(
+            onClose = onClose,
+            actions = {
+                PrimaryButton(
+                    text = stringResource(R.string.feedback_send_retry),
+                    onClick = onRetry,
+                )
+            },
+        ) {
+            Spacer(Modifier.height(16.dp))
+            FeedbackHeroIcon(
+                Icons.Outlined.ErrorOutline,
+                Modifier.align(Alignment.CenterHorizontally),
+            )
+            Spacer(Modifier.height(24.dp))
+            StepTitle(stringResource(R.string.feedback_send_failed_title))
+            Spacer(Modifier.height(12.dp))
+            StepBody(stringResource(R.string.feedback_send_failed_body))
+        }
     }
 }
 
@@ -314,26 +415,6 @@ private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
         StepTitle(stringResource(R.string.feedback_record_failed_title))
         Spacer(Modifier.height(12.dp))
         StepBody(stringResource(R.string.feedback_record_failed_body))
-    }
-}
-
-@Composable
-private fun SentStep(onClose: () -> Unit) {
-    FeedbackStepScaffold(
-        onClose = onClose,
-        actions = {
-            PrimaryButton(
-                text = stringResource(R.string.feedback_stub_done),
-                onClick = onClose,
-            )
-        },
-    ) {
-        Spacer(Modifier.height(16.dp))
-        FeedbackHeroIcon(Icons.Outlined.CheckCircle, Modifier.align(Alignment.CenterHorizontally))
-        Spacer(Modifier.height(24.dp))
-        StepTitle(stringResource(R.string.feedback_stub_title))
-        Spacer(Modifier.height(12.dp))
-        StepBody(stringResource(R.string.feedback_stub_body))
     }
 }
 
@@ -561,7 +642,5 @@ private fun RecordingSummary(recording: FeedbackRecording) {
 
 private fun formatDuration(ms: Long): String {
     val totalSeconds = (ms / 1000).coerceAtLeast(0)
-    val minutes = totalSeconds / 60
-    val seconds = totalSeconds % 60
-    return "%d:%02d".format(minutes, seconds)
+    return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackPrefs.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackPrefs.kt
@@ -1,0 +1,22 @@
+package io.github.sceneview.demo.feedback
+
+import android.content.Context
+
+/**
+ * One-time "feedback onboarding seen" flag, backed by [android.content.SharedPreferences].
+ * A single boolean does not warrant a DataStore dependency.
+ */
+object FeedbackPrefs {
+    private const val PREFS = "sceneview_feedback"
+    private const val KEY_ONBOARDED = "onboarding_seen"
+
+    fun hasSeenOnboarding(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_ONBOARDED, false)
+
+    fun markOnboardingSeen(context: Context) {
+        prefs(context).edit().putBoolean(KEY_ONBOARDED, true).apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackPrefs.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackPrefs.kt
@@ -17,6 +17,7 @@ object FeedbackPrefs {
         prefs(context).edit().putBoolean(KEY_ONBOARDED, true).apply()
     }
 
+    // applicationContext — prefs access must never pin an Activity context.
     private fun prefs(context: Context) =
-        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
@@ -1,0 +1,62 @@
+package io.github.sceneview.demo.feedback
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
+
+/** A finished screen + microphone recording. */
+data class FeedbackRecording(
+    val video: File,
+    /** Audio track demuxed out of [video] for transcription; null if demux failed. */
+    val audio: File?,
+    val durationMs: Long,
+)
+
+/** Lifecycle of an in-app feedback recording. */
+sealed interface RecordingState {
+    data object Idle : RecordingState
+    data object Recording : RecordingState
+    data class Done(val recording: FeedbackRecording) : RecordingState
+    data class Failed(val reason: String) : RecordingState
+}
+
+/**
+ * Process-wide bridge between [FeedbackRecordingService] — which owns the
+ * MediaProjection capture — and the Compose feedback flow.
+ *
+ * The feedback dialog is dismissed while recording so the user can navigate
+ * the app and demonstrate the bug, so the recording state cannot live in
+ * composition. The service publishes here; `MainActivity` observes it and
+ * re-opens the flow at the review step once a recording is [RecordingState.Done].
+ */
+object FeedbackRecorder {
+    private val _state = MutableStateFlow<RecordingState>(RecordingState.Idle)
+    val state: StateFlow<RecordingState> = _state.asStateFlow()
+
+    /** Category of the in-progress feedback — set by the UI before recording
+     *  starts, so it survives the dialog being dismissed during capture. */
+    var category: FeedbackCategory? = null
+
+    fun setRecording() {
+        _state.value = RecordingState.Recording
+    }
+
+    fun setDone(recording: FeedbackRecording) {
+        _state.value = RecordingState.Done(recording)
+    }
+
+    fun setFailed(reason: String) {
+        _state.value = RecordingState.Failed(reason)
+    }
+
+    /** Clear the state and delete any media left by a finished recording. */
+    fun reset() {
+        (_state.value as? RecordingState.Done)?.recording?.let { rec ->
+            rec.video.delete()
+            rec.audio?.delete()
+        }
+        category = null
+        _state.value = RecordingState.Idle
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
@@ -1,5 +1,6 @@
 package io.github.sceneview.demo.feedback
 
+import android.content.Context
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,5 +59,18 @@ object FeedbackRecorder {
         }
         category = null
         _state.value = RecordingState.Idle
+    }
+}
+
+/**
+ * Delete any feedback recordings left in the cache by a previous run — call on
+ * app start so a crash, an OOM-kill or a failed upload never strands a screen +
+ * microphone capture on disk.
+ */
+fun sweepStaleFeedbackMedia(context: Context) {
+    runCatching {
+        context.cacheDir
+            .listFiles { file -> file.name.startsWith("feedback-") }
+            ?.forEach { it.delete() }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingLauncher.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingLauncher.kt
@@ -1,0 +1,60 @@
+package io.github.sceneview.demo.feedback
+
+import android.Manifest
+import android.app.Activity
+import android.media.projection.MediaProjectionManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Provides a `startRecording` lambda that requests the microphone (and, on
+ * Android 13+, the notification) permission, then the screen-capture
+ * permission, and finally hands the granted MediaProjection token to
+ * [FeedbackRecordingService]. Any denial publishes a [RecordingState.Failed].
+ */
+@Composable
+fun rememberFeedbackRecordingLauncher(): () -> Unit {
+    val context = LocalContext.current
+
+    val projectionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val data = result.data
+        if (result.resultCode == Activity.RESULT_OK && data != null) {
+            FeedbackRecordingService.start(context, result.resultCode, data)
+        } else {
+            FeedbackRecorder.setFailed("screen-capture permission was not granted")
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { grants ->
+        if (grants[Manifest.permission.RECORD_AUDIO] == true) {
+            val mpm = context.getSystemService(MediaProjectionManager::class.java)
+            if (mpm != null) {
+                projectionLauncher.launch(mpm.createScreenCaptureIntent())
+            } else {
+                FeedbackRecorder.setFailed("screen capture is unavailable on this device")
+            }
+        } else {
+            FeedbackRecorder.setFailed("microphone permission was not granted")
+        }
+    }
+
+    return remember(permissionLauncher) {
+        {
+            val perms = buildList {
+                add(Manifest.permission.RECORD_AUDIO)
+                if (Build.VERSION.SDK_INT >= 33) {
+                    add(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+            permissionLauncher.launch(perms.toTypedArray())
+        }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
@@ -1,0 +1,246 @@
+package io.github.sceneview.demo.feedback
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.MediaRecorder
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import io.github.sceneview.demo.MainActivity
+import io.github.sceneview.demo.R
+import java.io.File
+
+/**
+ * Foreground service that captures the screen + microphone with MediaProjection
+ * while the user demonstrates a bug. Started once the user has granted the
+ * screen-capture permission; stopped from its notification action. The result
+ * is published through [FeedbackRecorder].
+ */
+class FeedbackRecordingService : Service() {
+
+    private var projection: MediaProjection? = null
+    private var virtualDisplay: VirtualDisplay? = null
+    private var recorder: MediaRecorder? = null
+    private var videoFile: File? = null
+    private var startedAt = 0L
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            stopRecording()
+            return START_NOT_STICKY
+        }
+
+        val resultCode = intent?.getIntExtra(EXTRA_RESULT_CODE, 0) ?: 0
+        val data: Intent? = intent?.let {
+            if (Build.VERSION.SDK_INT >= 33) {
+                it.getParcelableExtra(EXTRA_DATA, Intent::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                it.getParcelableExtra(EXTRA_DATA)
+            }
+        }
+        if (resultCode == 0 || data == null) {
+            FeedbackRecorder.setFailed("missing screen-capture permission")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        // The service must be foreground (with the mediaProjection type) BEFORE
+        // the MediaProjection is acquired — required on Android 14+.
+        goForeground()
+        startRecording(resultCode, data)
+        return START_NOT_STICKY
+    }
+
+    private fun goForeground() {
+        val nm = getSystemService(NotificationManager::class.java)
+        nm.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.feedback_recording_channel),
+                NotificationManager.IMPORTANCE_LOW,
+            ),
+        )
+
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val stopIntent = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, FeedbackRecordingService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(getString(R.string.feedback_recording_title))
+            .setContentText(getString(R.string.feedback_recording_text))
+            .setOngoing(true)
+            .setContentIntent(contentIntent)
+            .addAction(
+                android.R.drawable.ic_media_pause,
+                getString(R.string.feedback_recording_stop),
+                stopIntent,
+            )
+            .build()
+
+        if (Build.VERSION.SDK_INT >= 29) {
+            startForeground(
+                NOTIF_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION,
+            )
+        } else {
+            startForeground(NOTIF_ID, notification)
+        }
+    }
+
+    private fun startRecording(resultCode: Int, data: Intent) {
+        try {
+            val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+            val mp = mpm.getMediaProjection(resultCode, data)
+                ?: error("could not acquire the screen-capture session")
+            projection = mp
+            mp.registerCallback(projectionCallback, null)
+
+            val dm = resources.displayMetrics
+            // Downscale so the longer edge is <= 1280 px — keeps the clip small
+            // (the worker caps uploads at 30 MB) and within H.264 encoder
+            // limits. Dimensions are rounded to even numbers.
+            val scale = minOf(1f, 1280f / maxOf(dm.widthPixels, dm.heightPixels))
+            val width = (dm.widthPixels * scale).toInt() / 2 * 2
+            val height = (dm.heightPixels * scale).toInt() / 2 * 2
+
+            val out = File(cacheDir, "feedback-${System.currentTimeMillis()}.mp4")
+            videoFile = out
+
+            val rec = if (Build.VERSION.SDK_INT >= 31) {
+                MediaRecorder(this)
+            } else {
+                @Suppress("DEPRECATION")
+                MediaRecorder()
+            }
+            rec.setVideoSource(MediaRecorder.VideoSource.SURFACE)
+            rec.setAudioSource(MediaRecorder.AudioSource.MIC)
+            rec.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            rec.setOutputFile(out.absolutePath)
+            rec.setVideoEncoder(MediaRecorder.VideoEncoder.H264)
+            rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            rec.setVideoSize(width, height)
+            rec.setVideoFrameRate(30)
+            rec.setVideoEncodingBitRate(3_500_000)
+            rec.prepare()
+
+            virtualDisplay = mp.createVirtualDisplay(
+                "feedback-capture",
+                width,
+                height,
+                dm.densityDpi,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                rec.surface,
+                null,
+                null,
+            )
+            rec.start()
+            recorder = rec
+            startedAt = System.currentTimeMillis()
+            FeedbackRecorder.setRecording()
+        } catch (e: Exception) {
+            FeedbackRecorder.setFailed(e.message ?: "could not start recording")
+            cleanup()
+            stopForegroundAndSelf()
+        }
+    }
+
+    private fun stopRecording() {
+        val out = videoFile
+        val duration = if (startedAt > 0) System.currentTimeMillis() - startedAt else 0L
+        val stopped = try {
+            recorder?.stop()
+            true
+        } catch (e: Exception) {
+            // MediaRecorder.stop() throws if too few frames were captured.
+            false
+        }
+        cleanup()
+        if (stopped && out != null && out.exists() && out.length() > 0L) {
+            val audio = File(cacheDir, "feedback-audio-${System.currentTimeMillis()}.m4a")
+            FeedbackRecorder.setDone(
+                FeedbackRecording(out, demuxAudioTrack(out, audio), duration),
+            )
+        } else {
+            out?.delete()
+            FeedbackRecorder.setFailed("recording too short")
+        }
+        stopForegroundAndSelf()
+    }
+
+    private val projectionCallback = object : MediaProjection.Callback() {
+        override fun onStop() {
+            // Projection revoked externally (system / another app) — the
+            // recording is finalized by stopRecording() / onDestroy().
+        }
+    }
+
+    private fun cleanup() {
+        runCatching { recorder?.release() }
+        recorder = null
+        runCatching { virtualDisplay?.release() }
+        virtualDisplay = null
+        runCatching { projection?.unregisterCallback(projectionCallback) }
+        runCatching { projection?.stop() }
+        projection = null
+    }
+
+    private fun stopForegroundAndSelf() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cleanup()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "feedback_recording"
+        private const val NOTIF_ID = 4711
+        private const val ACTION_STOP = "io.github.sceneview.demo.feedback.STOP"
+        private const val EXTRA_RESULT_CODE = "result_code"
+        private const val EXTRA_DATA = "data"
+
+        /** Start recording with a granted MediaProjection token. */
+        fun start(context: Context, resultCode: Int, data: Intent) {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, FeedbackRecordingService::class.java)
+                    .putExtra(EXTRA_RESULT_CODE, resultCode)
+                    .putExtra(EXTRA_DATA, data),
+            )
+        }
+
+        /** Stop an in-progress recording. */
+        fun stop(context: Context) {
+            context.startService(
+                Intent(context, FeedbackRecordingService::class.java)
+                    .setAction(ACTION_STOP),
+            )
+        }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
@@ -7,13 +7,14 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
-import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.media.MediaRecorder
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import io.github.sceneview.demo.MainActivity
@@ -23,8 +24,9 @@ import java.io.File
 /**
  * Foreground service that captures the screen + microphone with MediaProjection
  * while the user demonstrates a bug. Started once the user has granted the
- * screen-capture permission; stopped from its notification action. The result
- * is published through [FeedbackRecorder].
+ * screen-capture permission; stopped from its notification action, the in-app
+ * Stop pill, or when the system revokes the projection. The result is published
+ * through [FeedbackRecorder].
  */
 class FeedbackRecordingService : Service() {
 
@@ -33,6 +35,10 @@ class FeedbackRecordingService : Service() {
     private var recorder: MediaRecorder? = null
     private var videoFile: File? = null
     private var startedAt = 0L
+
+    /** Guards [stopRecording] against the notification / pill / projection-callback
+     *  all triggering a stop. */
+    private var stopping = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -59,12 +65,17 @@ class FeedbackRecordingService : Service() {
 
         // The service must be foreground (with the mediaProjection type) BEFORE
         // the MediaProjection is acquired — required on Android 14+.
-        goForeground()
+        if (!goForeground()) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
         startRecording(resultCode, data)
         return START_NOT_STICKY
     }
 
-    private fun goForeground() {
+    /** Promote to a foreground service. Returns false (and publishes a failure)
+     *  if the system refuses the foreground start. */
+    private fun goForeground(): Boolean {
         val nm = getSystemService(NotificationManager::class.java)
         nm.createNotificationChannel(
             NotificationChannel(
@@ -100,14 +111,20 @@ class FeedbackRecordingService : Service() {
             )
             .build()
 
-        if (Build.VERSION.SDK_INT >= 29) {
-            startForeground(
-                NOTIF_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION,
-            )
-        } else {
-            startForeground(NOTIF_ID, notification)
+        return try {
+            if (Build.VERSION.SDK_INT >= 29) {
+                startForeground(
+                    NOTIF_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION,
+                )
+            } else {
+                startForeground(NOTIF_ID, notification)
+            }
+            true
+        } catch (e: Exception) {
+            FeedbackRecorder.setFailed("could not start the recording service")
+            false
         }
     }
 
@@ -117,7 +134,7 @@ class FeedbackRecordingService : Service() {
             val mp = mpm.getMediaProjection(resultCode, data)
                 ?: error("could not acquire the screen-capture session")
             projection = mp
-            mp.registerCallback(projectionCallback, null)
+            mp.registerCallback(projectionCallback, Handler(Looper.getMainLooper()))
 
             val dm = resources.displayMetrics
             // Downscale so the longer edge is <= 1280 px — keeps the clip small
@@ -152,7 +169,7 @@ class FeedbackRecordingService : Service() {
                 width,
                 height,
                 dm.densityDpi,
-                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                0, // a projection-backed display mirrors implicitly — no flags
                 rec.surface,
                 null,
                 null,
@@ -169,6 +186,9 @@ class FeedbackRecordingService : Service() {
     }
 
     private fun stopRecording() {
+        if (stopping) return
+        stopping = true
+
         val out = videoFile
         val duration = if (startedAt > 0) System.currentTimeMillis() - startedAt else 0L
         val stopped = try {
@@ -180,21 +200,26 @@ class FeedbackRecordingService : Service() {
         }
         cleanup()
         if (stopped && out != null && out.exists() && out.length() > 0L) {
-            val audio = File(cacheDir, "feedback-audio-${System.currentTimeMillis()}.m4a")
-            FeedbackRecorder.setDone(
-                FeedbackRecording(out, demuxAudioTrack(out, audio), duration),
-            )
+            // Demux the audio track off the main thread, then publish the result.
+            val cache = cacheDir
+            Thread {
+                val audio = File(cache, "feedback-audio-${System.currentTimeMillis()}.m4a")
+                FeedbackRecorder.setDone(
+                    FeedbackRecording(out, demuxAudioTrack(out, audio), duration),
+                )
+            }.start()
         } else {
             out?.delete()
-            FeedbackRecorder.setFailed("recording too short")
+            FeedbackRecorder.setFailed("recording incomplete")
         }
         stopForegroundAndSelf()
     }
 
     private val projectionCallback = object : MediaProjection.Callback() {
         override fun onStop() {
-            // Projection revoked externally (system / another app) — the
-            // recording is finalized by stopRecording() / onDestroy().
+            // Projection revoked externally (system / another app) — finalize
+            // the recording rather than leaving the service stuck.
+            stopRecording()
         }
     }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
@@ -1,0 +1,76 @@
+package io.github.sceneview.demo.feedback
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/** Live Open/Closed state of a tracked feedback ticket. */
+enum class TicketState { OPEN, CLOSED, UNKNOWN }
+
+/**
+ * Reads the live Open/Closed state of a feedback ticket straight from GitHub's
+ * public REST API — the issue is the source of truth, never re-implemented.
+ *
+ * Results are cached in memory for [CACHE_TTL_MS] so reopening the "My feedback"
+ * screen does not burn the unauthenticated 60 req/h GitHub limit. [UNKNOWN]
+ * results (offline, rate-limited) are deliberately not cached so a transient
+ * failure self-heals on the next view.
+ */
+object FeedbackTicketStatus {
+    private const val REPO = "sceneview/sceneview"
+    private val CACHE_TTL_MS = TimeUnit.MINUTES.toMillis(5)
+
+    private data class Cached(val state: TicketState, val at: Long)
+    private val cache = mutableMapOf<Int, Cached>()
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+
+    /** Fetch (or return cached) the state of issue [issueNumber]; never throws. */
+    suspend fun fetch(issueNumber: Int): TicketState = withContext(Dispatchers.IO) {
+        synchronized(cache) {
+            cache[issueNumber]?.let {
+                if (System.currentTimeMillis() - it.at < CACHE_TTL_MS) {
+                    return@withContext it.state
+                }
+            }
+        }
+
+        val request = Request.Builder()
+            .url("https://api.github.com/repos/$REPO/issues/$issueNumber")
+            .header("Accept", "application/vnd.github+json")
+            // GitHub rejects API requests that carry no User-Agent.
+            .header("User-Agent", "SceneView-Demo")
+            .build()
+
+        val state = try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    TicketState.UNKNOWN
+                } else {
+                    when (JSONObject(response.body.string()).optString("state")) {
+                        "open" -> TicketState.OPEN
+                        "closed" -> TicketState.CLOSED
+                        else -> TicketState.UNKNOWN
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            TicketState.UNKNOWN
+        }
+
+        if (state != TicketState.UNKNOWN) {
+            synchronized(cache) {
+                cache[issueNumber] = Cached(state, System.currentTimeMillis())
+            }
+        }
+        state
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
@@ -15,9 +15,9 @@ enum class TicketState { OPEN, CLOSED, UNKNOWN }
  * public REST API — the issue is the source of truth, never re-implemented.
  *
  * Results are cached in memory for [CACHE_TTL_MS] so reopening the "My feedback"
- * screen does not burn the unauthenticated 60 req/h GitHub limit. [UNKNOWN]
- * results (offline, rate-limited) are deliberately not cached so a transient
- * failure self-heals on the next view.
+ * screen does not burn the unauthenticated 60 req/h GitHub limit. [TicketState.UNKNOWN]
+ * results (offline, rate-limited) are deliberately not cached, so the next call
+ * — a later screen open, or a row scrolled back into view — retries.
  */
 object FeedbackTicketStatus {
     private const val REPO = "sceneview/sceneview"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
@@ -1,0 +1,80 @@
+package io.github.sceneview.demo.feedback
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/** Uploads feedback submissions to the SceneView feedback worker. */
+object FeedbackUploader {
+
+    private const val ENDPOINT =
+        "https://sceneview-feedback.mcp-tools-lab.workers.dev/v1/feedback"
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .callTimeout(90, TimeUnit.SECONDS)
+            .build()
+    }
+
+    /** Outcome of an upload. [ok] is true when the worker accepted the feedback. */
+    data class Result(val ok: Boolean, val issueNumber: Int?)
+
+    /**
+     * POST a feedback submission as multipart form data. Runs on
+     * [Dispatchers.IO] and never throws — a network failure returns `ok = false`.
+     */
+    suspend fun upload(
+        category: FeedbackCategory,
+        note: String,
+        context: Map<String, String>,
+        recording: FeedbackRecording?,
+    ): Result = withContext(Dispatchers.IO) {
+        val body = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "category",
+                if (category == FeedbackCategory.BUG) "bug" else "idea",
+            )
+            .addFormDataPart("context", JSONObject(context).toString())
+            .apply {
+                if (note.isNotBlank()) addFormDataPart("text", note)
+                recording?.video?.let {
+                    addFormDataPart(
+                        "video",
+                        "screen.mp4",
+                        it.asRequestBody("video/mp4".toMediaTypeOrNull()),
+                    )
+                }
+                recording?.audio?.let {
+                    addFormDataPart(
+                        "audio",
+                        "audio.m4a",
+                        it.asRequestBody("audio/mp4".toMediaTypeOrNull()),
+                    )
+                }
+            }
+            .build()
+
+        val request = Request.Builder().url(ENDPOINT).post(body).build()
+        try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext Result(false, null)
+                val json = runCatching {
+                    JSONObject(response.body.string())
+                }.getOrNull()
+                Result(
+                    ok = json?.optBoolean("ok") == true,
+                    issueNumber = json?.optInt("issue", 0)?.takeIf { it > 0 },
+                )
+            }
+        } catch (e: Exception) {
+            Result(false, null)
+        }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
@@ -18,7 +18,10 @@ object FeedbackUploader {
 
     private val client by lazy {
         OkHttpClient.Builder()
-            .callTimeout(90, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .callTimeout(120, TimeUnit.SECONDS)
             .build()
     }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
@@ -25,8 +25,17 @@ object FeedbackUploader {
             .build()
     }
 
-    /** Outcome of an upload. [ok] is true when the worker accepted the feedback. */
-    data class Result(val ok: Boolean, val issueNumber: Int?)
+    /**
+     * Outcome of an upload. [ok] is true when the worker accepted the feedback.
+     * [issueNumber] / [issueUrl] are null when the worker stored the feedback
+     * but did not open a GitHub issue (e.g. the hourly issue quota was hit).
+     */
+    data class Result(
+        val ok: Boolean,
+        val issueNumber: Int?,
+        val issueUrl: String?,
+        val feedbackId: String?,
+    )
 
     /**
      * POST a feedback submission as multipart form data. Runs on
@@ -67,17 +76,21 @@ object FeedbackUploader {
         val request = Request.Builder().url(ENDPOINT).post(body).build()
         try {
             client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return@withContext Result(false, null)
+                if (!response.isSuccessful) {
+                    return@withContext Result(false, null, null, null)
+                }
                 val json = runCatching {
                     JSONObject(response.body.string())
                 }.getOrNull()
                 Result(
                     ok = json?.optBoolean("ok") == true,
                     issueNumber = json?.optInt("issue", 0)?.takeIf { it > 0 },
+                    issueUrl = json?.optString("url")?.takeIf { it.isNotBlank() },
+                    feedbackId = json?.optString("id")?.takeIf { it.isNotBlank() },
                 )
             }
         } catch (e: Exception) {
-            Result(false, null)
+            Result(false, null, null, null)
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/RecordingStopPill.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/RecordingStopPill.kt
@@ -1,0 +1,30 @@
+package io.github.sceneview.demo.feedback
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.sceneview.demo.R
+
+/**
+ * Floating "Stop recording" control shown while a feedback screen recording is
+ * in progress. The feedback dialog is dismissed during capture so the user can
+ * demonstrate the bug; this pill stays on top as the in-app stop affordance
+ * (the foreground-service notification carries the same action as a backup).
+ */
+@Composable
+fun RecordingStopPill(onStop: () -> Unit, modifier: Modifier = Modifier) {
+    ExtendedFloatingActionButton(
+        onClick = onStop,
+        icon = { Icon(Icons.Filled.Stop, contentDescription = null) },
+        text = { Text(stringResource(R.string.feedback_recording_stop_action)) },
+        containerColor = MaterialTheme.colorScheme.error,
+        contentColor = MaterialTheme.colorScheme.onError,
+        modifier = modifier,
+    )
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/SubmittedFeedback.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/SubmittedFeedback.kt
@@ -1,0 +1,81 @@
+package io.github.sceneview.demo.feedback
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A feedback submission the user made, indexed locally so the "My feedback"
+ * screen can list it and deep-link back into the real GitHub issue.
+ *
+ * The GitHub issue is the source of truth — this record only keeps enough to
+ * show a row and open the issue; the live Open/Closed status is read straight
+ * from GitHub by [FeedbackTicketStatus].
+ */
+data class SubmittedFeedback(
+    val feedbackId: String,
+    val issueNumber: Int,
+    val issueUrl: String,
+    val category: FeedbackCategory,
+    /** The note the user typed — may be blank when only a recording was sent. */
+    val title: String,
+    val createdAt: Long,
+)
+
+/**
+ * Local index of submitted feedback, backed by [android.content.SharedPreferences]
+ * (a small JSON array). Newest first. Capped at [MAX_ENTRIES] so a heavy tester
+ * never grows the prefs unbounded.
+ */
+object SubmittedFeedbackStore {
+    private const val PREFS = "sceneview_feedback"
+    private const val KEY_TICKETS = "submitted_tickets"
+    private const val MAX_ENTRIES = 50
+
+    /** Every submitted ticket, newest first. */
+    fun all(context: Context): List<SubmittedFeedback> {
+        val raw = prefs(context).getString(KEY_TICKETS, null) ?: return emptyList()
+        return runCatching {
+            val arr = JSONArray(raw)
+            (0 until arr.length()).mapNotNull { i -> fromJson(arr.optJSONObject(i)) }
+        }.getOrDefault(emptyList()).sortedByDescending { it.createdAt }
+    }
+
+    /** Record a freshly submitted ticket; a re-send of the same issue replaces it. */
+    fun add(context: Context, entry: SubmittedFeedback) {
+        val kept = all(context).filter { it.issueNumber != entry.issueNumber }
+        val updated = (listOf(entry) + kept).take(MAX_ENTRIES)
+        val arr = JSONArray()
+        updated.forEach { arr.put(toJson(it)) }
+        prefs(context).edit().putString(KEY_TICKETS, arr.toString()).apply()
+    }
+
+    private fun toJson(e: SubmittedFeedback): JSONObject = JSONObject().apply {
+        put("feedbackId", e.feedbackId)
+        put("issueNumber", e.issueNumber)
+        put("issueUrl", e.issueUrl)
+        put("category", e.category.name)
+        put("title", e.title)
+        put("createdAt", e.createdAt)
+    }
+
+    private fun fromJson(o: JSONObject?): SubmittedFeedback? {
+        if (o == null) return null
+        val issueNumber = o.optInt("issueNumber", 0)
+        val issueUrl = o.optString("issueUrl")
+        if (issueNumber <= 0 || issueUrl.isBlank()) return null
+        return SubmittedFeedback(
+            feedbackId = o.optString("feedbackId"),
+            issueNumber = issueNumber,
+            issueUrl = issueUrl,
+            category = runCatching { FeedbackCategory.valueOf(o.optString("category")) }
+                .getOrDefault(FeedbackCategory.BUG),
+            title = o.optString("title"),
+            createdAt = o.optLong("createdAt", 0L),
+        )
+    }
+
+    // applicationContext — prefs access must never pin an Activity context.
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -311,7 +311,7 @@
     <string name="feedback_review_rerecord">Record again</string>
     <string name="feedback_review_send">Send feedback</string>
     <string name="feedback_record_failed_title">Recording didn\'t work</string>
-    <string name="feedback_record_failed_body">The screen recording was interrupted or not granted. You can try again.</string>
+    <string name="feedback_record_failed_body">The recording didn\'t finish. You can try again.</string>
     <string name="feedback_record_retry">Try again</string>
     <string name="feedback_sending">Sending your feedback…</string>
     <string name="feedback_sent_title">Thank you!</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -296,9 +296,6 @@
     <string name="feedback_consent_privacy">The recording stays private — only the SceneView team can view it, and it is deleted after 90 days. The public report contains only a written summary.</string>
     <string name="feedback_consent_agree">Allow &amp; continue</string>
     <string name="feedback_consent_back">Back</string>
-    <string name="feedback_stub_title">Almost there</string>
-    <string name="feedback_stub_body">Screen recording is being wired up and lands in the next update. Thanks for helping improve SceneView!</string>
-    <string name="feedback_stub_done">Done</string>
     <string name="feedback_recording_channel">Feedback recording</string>
     <string name="feedback_recording_title">Recording your feedback</string>
     <string name="feedback_recording_text">Show what happens, then tap Stop</string>
@@ -316,4 +313,12 @@
     <string name="feedback_record_failed_title">Recording didn\'t work</string>
     <string name="feedback_record_failed_body">The screen recording was interrupted or not granted. You can try again.</string>
     <string name="feedback_record_retry">Try again</string>
+    <string name="feedback_sending">Sending your feedback…</string>
+    <string name="feedback_sent_title">Thank you!</string>
+    <string name="feedback_sent_issue">Your report was filed as issue #%1$d. The team will take a look.</string>
+    <string name="feedback_sent_generic">Your feedback was received by the SceneView team.</string>
+    <string name="feedback_sent_done">Done</string>
+    <string name="feedback_send_failed_title">Couldn\'t send</string>
+    <string name="feedback_send_failed_body">Your feedback couldn\'t be sent. Check your connection and try again.</string>
+    <string name="feedback_send_retry">Try again</string>
 </resources>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -333,4 +333,6 @@
     <string name="feedback_tickets_untitled_idea">Idea</string>
     <string name="feedback_tickets_row_meta">#%1$d · %2$s</string>
     <string name="feedback_tickets_no_app">No app available to open the issue</string>
+    <string name="feedback_tickets_open_a11y">Open issue on GitHub</string>
+    <string name="feedback_tickets_status_loading">Loading status</string>
 </resources>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -279,10 +279,9 @@
 
     <!-- In-app feedback (issue #1932) -->
     <string name="feedback_button">Feedback</string>
-    <string name="feedback_cd_button">Send feedback</string>
     <string name="feedback_cd_close">Close</string>
     <string name="feedback_onboarding_title">Help improve SceneView</string>
-    <string name="feedback_onboarding_body">See a bug or have an idea? Tap Feedback anytime. Record your screen and describe what\'s happening in your own words — we\'ll turn it into a report for the team. It only takes a few seconds.</string>
+    <string name="feedback_onboarding_body">See a bug or have an idea? Tap Feedback anytime. Record your screen and describe what\'s happening in your own words — we\'ll turn it into a report for the team.</string>
     <string name="feedback_onboarding_continue">Get started</string>
     <string name="feedback_category_title">What would you like to share?</string>
     <string name="feedback_bug_title">Report a bug</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -321,4 +321,16 @@
     <string name="feedback_send_failed_title">Couldn\'t send</string>
     <string name="feedback_send_failed_body">Your feedback couldn\'t be sent. Check your connection and try again.</string>
     <string name="feedback_send_retry">Try again</string>
+    <!-- In-app feedback — ticket tracking (issue #1940) -->
+    <string name="feedback_tickets_entry">My feedback</string>
+    <string name="feedback_tickets_title">My feedback</string>
+    <string name="feedback_tickets_body">Tap a report to see its status and the team\'s replies on GitHub.</string>
+    <string name="feedback_tickets_back">Back</string>
+    <string name="feedback_tickets_empty">You haven\'t submitted any feedback yet.</string>
+    <string name="feedback_tickets_open">Open</string>
+    <string name="feedback_tickets_closed">Closed</string>
+    <string name="feedback_tickets_untitled_bug">Bug report</string>
+    <string name="feedback_tickets_untitled_idea">Idea</string>
+    <string name="feedback_tickets_row_meta">#%1$d · %2$s</string>
+    <string name="feedback_tickets_no_app">No app available to open the issue</string>
 </resources>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -276,4 +276,28 @@
     <string name="tracking_failure_excessive_motion">Moving too fast — slow down</string>
     <string name="tracking_failure_insufficient_features">Not enough detail — point at a more textured surface</string>
     <string name="tracking_failure_camera_unavailable">Camera unavailable — close other camera apps</string>
+
+    <!-- In-app feedback (issue #1932) -->
+    <string name="feedback_button">Feedback</string>
+    <string name="feedback_cd_button">Send feedback</string>
+    <string name="feedback_cd_close">Close</string>
+    <string name="feedback_onboarding_title">Help improve SceneView</string>
+    <string name="feedback_onboarding_body">See a bug or have an idea? Tap Feedback anytime. Record your screen and describe what\'s happening in your own words — we\'ll turn it into a report for the team. It only takes a few seconds.</string>
+    <string name="feedback_onboarding_continue">Get started</string>
+    <string name="feedback_category_title">What would you like to share?</string>
+    <string name="feedback_bug_title">Report a bug</string>
+    <string name="feedback_bug_subtitle">Something isn\'t working right</string>
+    <string name="feedback_idea_title">Share an idea</string>
+    <string name="feedback_idea_subtitle">A suggestion or feature request</string>
+    <string name="feedback_consent_title">Screen &amp; microphone</string>
+    <string name="feedback_consent_body">To capture your feedback, the next step records:</string>
+    <string name="feedback_consent_screen">Your screen, while you show what happens</string>
+    <string name="feedback_consent_voice">Your voice, describing the issue in your own words</string>
+    <string name="feedback_consent_idea_optional">Sharing an idea? Recording is optional — a few spoken words are enough</string>
+    <string name="feedback_consent_privacy">The recording stays private — only the SceneView team can view it, and it is deleted after 90 days. The public report contains only a written summary.</string>
+    <string name="feedback_consent_agree">Allow &amp; continue</string>
+    <string name="feedback_consent_back">Back</string>
+    <string name="feedback_stub_title">Almost there</string>
+    <string name="feedback_stub_body">Screen recording is being wired up and lands in the next update. Thanks for helping improve SceneView!</string>
+    <string name="feedback_stub_done">Done</string>
 </resources>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -299,4 +299,21 @@
     <string name="feedback_stub_title">Almost there</string>
     <string name="feedback_stub_body">Screen recording is being wired up and lands in the next update. Thanks for helping improve SceneView!</string>
     <string name="feedback_stub_done">Done</string>
+    <string name="feedback_recording_channel">Feedback recording</string>
+    <string name="feedback_recording_title">Recording your feedback</string>
+    <string name="feedback_recording_text">Show what happens, then tap Stop</string>
+    <string name="feedback_recording_stop">Stop</string>
+    <string name="feedback_recording_stop_action">Stop recording</string>
+    <string name="feedback_consent_skip">Skip recording</string>
+    <string name="feedback_review_title">Review your feedback</string>
+    <string name="feedback_review_body">Send it to the SceneView team, or record again.</string>
+    <string name="feedback_review_recorded">Screen recording captured</string>
+    <string name="feedback_review_no_recording">No recording — your note will be sent on its own.</string>
+    <string name="feedback_review_note_label">Add a note (optional)</string>
+    <string name="feedback_review_note_placeholder">Anything else the team should know?</string>
+    <string name="feedback_review_rerecord">Record again</string>
+    <string name="feedback_review_send">Send feedback</string>
+    <string name="feedback_record_failed_title">Recording didn\'t work</string>
+    <string name="feedback_record_failed_body">The screen recording was interrupted or not granted. You can try again.</string>
+    <string name="feedback_record_retry">Try again</string>
 </resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackPrefsTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackPrefsTest.kt
@@ -1,0 +1,24 @@
+package io.github.sceneview.demo.feedback
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Round-trip test for the one-time feedback-onboarding flag. */
+@RunWith(RobolectricTestRunner::class)
+class FeedbackPrefsTest {
+
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun `onboarding flag defaults to false then persists once marked`() {
+        assertFalse(FeedbackPrefs.hasSeenOnboarding(context))
+
+        FeedbackPrefs.markOnboardingSeen(context)
+
+        assertTrue(FeedbackPrefs.hasSeenOnboarding(context))
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/SubmittedFeedbackStoreTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/SubmittedFeedbackStoreTest.kt
@@ -61,4 +61,27 @@ class SubmittedFeedbackStoreTest {
         assertEquals(1, all.size)
         assertEquals(5_000L, all.single().createdAt)
     }
+
+    @Test
+    fun `corrupt stored data is ignored rather than crashing`() {
+        // White-box: write garbage straight into the backing prefs.
+        context.getSharedPreferences("sceneview_feedback", android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putString("submitted_tickets", "{not valid json")
+            .apply()
+
+        assertTrue(SubmittedFeedbackStore.all(context).isEmpty())
+    }
+
+    @Test
+    fun `store keeps only the 50 most recent entries`() {
+        repeat(60) { i ->
+            SubmittedFeedbackStore.add(context, entry(i + 1, createdAt = (i + 1).toLong()))
+        }
+
+        val all = SubmittedFeedbackStore.all(context)
+        assertEquals(50, all.size)
+        assertEquals(60, all.first().issueNumber) // newest kept
+        assertEquals(11, all.last().issueNumber) // entries 1..10 dropped
+    }
 }

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/SubmittedFeedbackStoreTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/SubmittedFeedbackStoreTest.kt
@@ -1,0 +1,64 @@
+package io.github.sceneview.demo.feedback
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Round-trip, ordering and de-dup tests for the local submitted-feedback index. */
+@RunWith(RobolectricTestRunner::class)
+class SubmittedFeedbackStoreTest {
+
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private fun entry(
+        issueNumber: Int,
+        createdAt: Long,
+        category: FeedbackCategory = FeedbackCategory.BUG,
+    ) = SubmittedFeedback(
+        feedbackId = "fid-$issueNumber",
+        issueNumber = issueNumber,
+        issueUrl = "https://github.com/sceneview/sceneview/issues/$issueNumber",
+        category = category,
+        title = "ticket $issueNumber",
+        createdAt = createdAt,
+    )
+
+    @Test
+    fun `store is empty by default`() {
+        assertTrue(SubmittedFeedbackStore.all(context).isEmpty())
+    }
+
+    @Test
+    fun `add round-trips every field`() {
+        val e = entry(101, createdAt = 1_000L, category = FeedbackCategory.IDEA)
+
+        SubmittedFeedbackStore.add(context, e)
+
+        assertEquals(e, SubmittedFeedbackStore.all(context).single())
+    }
+
+    @Test
+    fun `entries are listed newest first regardless of insertion order`() {
+        SubmittedFeedbackStore.add(context, entry(1, createdAt = 1_000L))
+        SubmittedFeedbackStore.add(context, entry(2, createdAt = 3_000L))
+        SubmittedFeedbackStore.add(context, entry(3, createdAt = 2_000L))
+
+        assertEquals(
+            listOf(2, 3, 1),
+            SubmittedFeedbackStore.all(context).map { it.issueNumber },
+        )
+    }
+
+    @Test
+    fun `re-adding the same issue replaces the prior record`() {
+        SubmittedFeedbackStore.add(context, entry(7, createdAt = 1_000L))
+        SubmittedFeedbackStore.add(context, entry(7, createdAt = 5_000L))
+
+        val all = SubmittedFeedbackStore.all(context)
+        assertEquals(1, all.size)
+        assertEquals(5_000L, all.single().createdAt)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1, task 1B of the in-app feedback feature (umbrella #1930). Adds the
always-visible feedback entry point and the pre-recording flow to the Android
demo app.

- **Global adaptive FAB** — extended (icon + "Feedback" label) on the four tab
  screens, collapsed to an icon inside the full-screen demos. Overlaid once in
  `MainActivity` above the `NavHost` so it appears on every screen; bottom-start
  so it never collides with a demo's bottom-end settings FAB.
- **Full-screen flow** (`FeedbackFlow`): a one-time onboarding screen (flag
  persisted in `SharedPreferences`), the Bug/Idea picker, and the screen +
  microphone consent screen.
- The screen + audio recording is wired in task 1C (#1933) — for now the
  consent screen leads to a placeholder.

New package `io.github.sceneview.demo.feedback` (`FeedbackButton`,
`FeedbackFlow`, `FeedbackCategory`, `FeedbackPrefs`), 23 string resources, and
the `MainActivity` wiring.

## Test plan

- [x] `:samples:android-demo:compileDebugKotlin` succeeds
- [ ] Visual QA on an emulator — required before the phase-1 PRs merge to main
- [ ] End-to-end flow once recording (1C) and upload (1D) land

Part of #1930. Closes #1932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)