### PR TITLE
feat(android-demo): labelled-Slider controls for gesture-only continuous params (#1965)

### DIFF
--- a/changelog.d/1965-demo-slider-adoption.md
+++ b/changelog.d/1965-demo-slider-adoption.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Added labelled "Camera distance" sliders to the `CameraControlsDemo` and `ModelViewerDemo` Android demos (#1965): zoom was pinch-only — now discoverable and Maestro-testable (no pinch in Maestro) — and the sliders complement pinch-to-zoom rather than replacing it. `ModelViewerDemo`'s slider drives the same `DemoSettings.cameraDistance` deep-link hook (#1571).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraControlsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraControlsDemo.kt
@@ -24,10 +24,12 @@ import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import com.google.android.filament.utils.Manipulator
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
@@ -85,10 +88,22 @@ fun CameraControlsDemo(onBack: () -> Unit) {
     // from scratch at its home position. Both the mode chips and the Reset button go through it.
     var resetKey by remember { mutableIntStateOf(0) }
 
-    // Home camera at 1.5 m so the 0.3 m helmet fills a meaningful fraction of the
-    // viewport. Previous z = 4 made the model render at ~10% of frame — far too small.
-    // QA finding 2026-05-11.
-    val homePosition = remember { Position(0.0f, 0.0f, 1.5f) }
+    // Camera distance, in metres, driving the manipulator's home / flight-start
+    // position along -Z. A labelled "Camera distance" slider in the controls
+    // sheet exposes it (#1965): the underlying Filament `Manipulator` only zooms
+    // via a pinch gesture, which is invisible discoverability-wise and — crucially
+    // — untestable by Maestro (no pinch). The slider COMPLEMENTS pinch-to-zoom,
+    // it does not replace it. Default 1.5 m so the 0.3 m helmet fills a meaningful
+    // fraction of the viewport (QA finding 2026-05-11); seeded from the #1571
+    // `--ef camera_distance` / `?cameraDistance=` deep-link hook when present so a
+    // deep-linked launch frames at the requested zoom and the slider reflects it.
+    var cameraDistance by remember {
+        mutableFloatStateOf(DemoSettings.cameraDistance?.coerceIn(0.5f, 8f) ?: 1.5f)
+    }
+
+    // Home / target the manipulator orbits. `homePosition` tracks `cameraDistance`
+    // so the slider drives a live rebuild (see the `remember(...)` key below).
+    val homePosition = Position(0.0f, 0.0f, cameraDistance)
     val target = remember { Position(0.0f, 0.0f, 0.0f) }
 
     val engine = rememberEngine()
@@ -141,22 +156,39 @@ fun CameraControlsDemo(onBack: () -> Unit) {
                 style = MaterialTheme.typography.bodySmall
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = { resetKey++ }) {
+            // Camera-distance slider — complements pinch-to-zoom by making the
+            // zoom level discoverable and Maestro-testable (no pinch in Maestro).
+            Text(
+                text = "Camera distance: %.1f m".format(cameraDistance),
+                style = MaterialTheme.typography.labelLarge
+            )
+            Slider(
+                value = cameraDistance,
+                onValueChange = { cameraDistance = it },
+                valueRange = 0.5f..8f
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = {
+                // Reset both the orbit pose and the slider-driven distance.
+                cameraDistance = 1.5f
+                resetKey++
+            }) {
                 Text("Reset Camera")
             }
         }
     ) {
-        // key(selectedMode, resetKey) forces a fresh rememberCameraManipulator on either
-        // a mode change or a reset tap — the creator lambda captures the current mode and
-        // rebuilds the Manipulator from its home position. This is the only reliable way
-        // to swap Manipulator.Mode mid-session since Manipulator itself has no setMode API.
+        // key(selectedMode, resetKey, cameraDistance) forces a fresh rememberCameraManipulator
+        // on a mode change, a reset tap, or a "Camera distance" slider drag — the creator
+        // lambda captures the current mode and rebuilds the Manipulator from its home
+        // position. This is the only reliable way to swap Manipulator.Mode mid-session
+        // (Manipulator has no setMode API) and likewise to re-home it at a new distance.
         Box(modifier = Modifier.fillMaxSize()) {
-            androidx.compose.runtime.key(selectedMode, resetKey) {
+            androidx.compose.runtime.key(selectedMode, resetKey, cameraDistance) {
                 // Build the underlying Manipulator here and keep our own reference so the
                 // FREE_FLIGHT movement pad can drive it through keyDown/keyUp. ORBIT and MAP
                 // ignore the flight* builder values; FREE_FLIGHT needs flightStartPosition set
                 // away from the origin, otherwise the camera spawns inside the helmet (#1428).
-                val manipulator = remember(selectedMode, resetKey) {
+                val manipulator = remember(selectedMode, resetKey, cameraDistance) {
                     Manipulator.Builder()
                         .orbitHomePosition(homePosition)
                         .targetPosition(target)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,6 +29,7 @@ import io.github.sceneview.toAabb
 import io.github.sceneview.verticalFovDegreesForFocalLength
 import io.github.sceneview.demo.AssetSourceState
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
@@ -137,13 +140,27 @@ fun ModelViewerDemo(onBack: () -> Unit) {
         }
     }
 
+    // Auto-fit orbit radius for the current model — falls back to 1.4 m while
+    // the bounds are not yet measurable. The "Camera distance" slider below
+    // lets the user override this; `null` slider state means "use auto-fit".
+    val autoFitRadius = framing?.radius ?: 1.4f
+
+    // Camera-distance slider state. Wired directly to [DemoSettings.cameraDistance]
+    // — the SAME global override that `rememberHeroOrbitCameraManipulator` reads
+    // for the `--ef camera_distance <f>` / `?cameraDistance=<f>` deep-link hook
+    // (#1571). So a deep link launches this demo at the requested zoom AND the
+    // slider reflects it; dragging the slider drives the live camera distance.
+    // `null` ⇒ no override, the auto-fit `radius` is used. Maestro has no pinch
+    // gesture, so this slider is the only way QA flows can exercise zoom.
+    val sliderDistance = DemoSettings.cameraDistance
+
     // Camera orbits; model stays fixed. The orbit radius is auto-fit to the
     // model's intrinsic size (see `framing` above) so every model — bundled
-    // helmet or streamed Sketchfab pick — is framed identically. Falls back to
-    // 1.4 m while the model bounds are not yet measurable.
+    // helmet or streamed Sketchfab pick — is framed identically. A non-null
+    // `DemoSettings.cameraDistance` (slider or deep link) overrides it.
     val cameraManipulator = rememberHeroOrbitCameraManipulator(
         trigger = activeModelInstance != null,
-        radius = framing?.radius ?: 1.4f,
+        radius = autoFitRadius,
         yHeight = 0f,
         durationMillis = 20_000,
     )
@@ -166,6 +183,20 @@ fun ModelViewerDemo(onBack: () -> Unit) {
         onBack = onBack,
         assetSource = assetSource,
         firstFrameRendered = firstFrame.rendered,
+        controls = {
+            // Camera-distance slider — makes zoom discoverable without a pinch
+            // gesture (and Maestro-testable, see #1571). The displayed value is
+            // the slider override when set, otherwise the live auto-fit radius.
+            Text(
+                "Camera distance: %.1f m".format(sliderDistance ?: autoFitRadius),
+                style = MaterialTheme.typography.labelLarge
+            )
+            Slider(
+                value = sliderDistance ?: autoFitRadius,
+                onValueChange = { DemoSettings.cameraDistance = it },
+                valueRange = 0.5f..10f
+            )
+        }
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             SceneView(


### PR DESCRIPTION
Closes #1965 (part of #1620 thread 3).

Adopts the established labelled-Slider UX pattern (a value label + a Material 3 `Slider` in the demo `controls = { }` sheet — as in `ARPoseDemo`, `LightingDemo`, `ImageDemo`) for **camera distance**, which was previously pinch-only in two demos.

## Changes

- **CameraControlsDemo** — new "Camera distance" slider drives the raw Filament `Manipulator`'s home / flight-start distance. The distance is added to the existing `key(...)` / `remember(...)` block so a slider drag rebuilds the manipulator at the new home pose. Seeded from the `#1571` deep-link hook (`DemoSettings.cameraDistance`) so a deep-linked launch frames at the requested zoom. "Reset Camera" now also resets the slider to the 1.5 m default.
- **ModelViewerDemo** — new `controls = { }` sheet with a "Camera distance" slider wired **directly to `DemoSettings.cameraDistance`** — the SAME global override `rememberHeroOrbitCameraManipulator` reads for the `#1571` `--ef camera_distance` / `?cameraDistance=` deep link. A deep-linked launch sets the slider position and the slider drives the live camera distance. The label shows the slider override when set, else the live auto-fit radius.

## Skipped (with reasons)

- **GestureEditingDemo** — already ships a "Scale sensitivity" slider for its continuous scale param. A direct object-scale slider would fight `SceneScope.ModelNode`'s documented per-recomposition transform re-apply (the file's own comment explains why the live-transform poll is isolated). No auto-rotation exists, so a rotation-speed slider has nothing to drive. No change.
- **CollisionDemo** — discrete tap-to-highlight only; camera uses a fixed hand-tuned `rememberCameraManipulator` and the framing is already correct. No continuous param. No change.
- **SecondaryCameraDemo** — PiP uses four discrete angle presets (chips); main view uses the default camera. No continuous param that a slider would improve. No change.

## Self-review

1. **Correctness** — each slider drives the real camera-distance parameter (CameraControlsDemo via the `Manipulator` rebuild key; ModelViewerDemo via the `#1571` `DemoSettings.cameraDistance` state the hero-orbit manipulator already reads). Pinch-to-zoom still works on both — sliders complement gestures. ModelViewerDemo's slider shares state with the `#1571` deep-link hook; CameraControlsDemo seeds from it.
2. **Threading** — all slider state is Compose state on the main thread; manipulator/camera rebuilds happen during composition, frame-coherent.
3. **API consistency** — `Text` value label + `Slider` with explicit `valueRange` idiom matches `ARPoseDemo` / `LightingDemo` exactly; lives in `controls = { }`.
4. **Minimality** — only the two demos that genuinely benefit got a slider; three candidates skipped with reasons above.
5. **Cross-platform parity** — Android demo app only; no library API change.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin` — PASS
- `./gradlew :samples:android-demo:assembleDebug` — PASS
- `bash samples/android-demo/scripts/collate-demos.sh --check` — no-op
- `bash .claude/scripts/sync-versions.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)