### PR TITLE
docs(cheatsheet-ios): Jetpack XR hand/face tracking parity rows (#1904)

### DIFF
--- a/arsceneview/docs/JETPACK-XR-INTEGRATION.md
+++ b/arsceneview/docs/JETPACK-XR-INTEGRATION.md
@@ -150,9 +150,12 @@ Each slice is a separate PR.
 Cross-platform parity follow-ups:
 
 - iOS already covers hand tracking on visionOS via `HandTrackingProvider`
-  and face mesh via `ARFaceTrackingConfiguration`. Tracked in
-  [#1904](https://github.com/sceneview/sceneview/issues/1904) — pure
-  docs update once Slices 2 and 3 land.
+  and face mesh via `ARFaceTrackingConfiguration`. The cross-platform
+  parity table — mobile ARCore vs. Jetpack XR vs. ARKit phone vs.
+  visionOS vs. WebXR — lives in the iOS cheatsheet:
+  [`docs/docs/cheatsheet-ios.md`](../../docs/docs/cheatsheet-ios.md)
+  "Hand / Face / Body tracking parity (#1904)". Filed as
+  [#1904](https://github.com/sceneview/sceneview/issues/1904).
 - Web covers WebXR `hand-tracking` under issue #1778 — no work duplicated
   here.
 

--- a/changelog.d/1904-cheatsheet-ios-jetpack-xr.md
+++ b/changelog.d/1904-cheatsheet-ios-jetpack-xr.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Added a "Hand / Face / Body tracking parity" table to the iOS cheatsheet mapping mobile ARCore, Jetpack XR (`XrHandNode`/`XrFaceNode`), ARKit phone, visionOS, and WebXR — and cross-linked it from the Jetpack XR integration design notes (#1904).

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -516,6 +516,31 @@ will compile + render with visual fidelity differences only.
 
 ---
 
+## Hand / Face / Body tracking parity (#1904)
+
+SceneView spans two ARCore runtimes on Android plus ARKit on Apple, and
+each surfaces hand / face / body perception differently. This table maps
+every tracking primitive across all five SceneView surfaces so an AI
+assistant picks the right API for the requested platform. The Android
+Jetpack XR foundation landed in [#1738](https://github.com/sceneview/sceneview/issues/1738);
+the design notes live in [`arsceneview/docs/JETPACK-XR-INTEGRATION.md`](https://github.com/sceneview/sceneview/blob/main/arsceneview/docs/JETPACK-XR-INTEGRATION.md).
+
+| Feature | Mobile ARCore (Android phone) | Jetpack XR (Android XR headset) | ARKit phone (`SceneViewSwift`) | visionOS | WebXR |
+|---|---|---|---|---|---|
+| **Hand tracking** | Not available — ARCore phones have no hand perception | `XrHandNode` over `androidx.xr.arcore` `Hand` perception. Foundation (`XrFeatures` gate) shipped in #1738; node tracked in [#1902](https://github.com/sceneview/sceneview/issues/1902) (preview, `1.0.0-alpha14`) | Not available on iPhone/iPad — ARKit has no hand-tracking config; hand tracking is a visionOS-only `ARKit` provider | ARKit `HandTrackingProvider` + `ARKitSession` give per-joint skeletons in an `ImmersiveSpace`. **Not yet wrapped** by `SceneViewSwift` — tracked in [#1902](https://github.com/sceneview/sceneview/issues/1902); drop to raw `HandTrackingProvider` today | WebXR `hand-tracking` feature — tracked in [#1778](https://github.com/sceneview/sceneview/issues/1778) |
+| **Face tracking** | `AugmentedFaceNode` — front-camera, stable, includes the 468-point morphing face mesh | `XrFaceNode` over `androidx.xr.arcore` `Face` perception (headset, alpha). Tracked in [#1903](https://github.com/sceneview/sceneview/issues/1903) (preview, `1.0.0-alpha14`) | `AnchorNode.face()` — **shipped**. Wraps RealityKit `AnchorEntity(.face)` (`ARFaceTrackingConfiguration`); provides face *pose* only, **no mesh**. For the morphing-mesh overlay drop to a raw `ARFaceAnchor` + custom mesh entity | Same `AnchorNode.face()` path — `ARFaceTrackingConfiguration` runs on Vision Pro's front sensors | Not exposed by WebXR |
+| **Body tracking** | Not available — ARCore has no body perception (ML Kit / MediaPipe would be needed) | Not available — `androidx.xr.arcore` exposes only `Hand` + `Face`, no body. Deferred-scope decision recorded in #1738 | `AnchorNode.body()` — **shipped**. Wraps RealityKit `AnchorEntity(.body)` (`ARBodyTrackingConfiguration`); anchors at the detected body's root joint. **ARKit-only** — no Android counterpart on either runtime | `ARBodyTrackingConfiguration` is unavailable on visionOS; no body-tracking path | Not exposed by WebXR |
+
+**iOS maturity summary.** Face and body anchoring are **shipped today** in
+`SceneViewSwift` as `AnchorNode.face()` / `AnchorNode.body()` (pose-level
+anchors — no morphing face mesh, no per-joint skeleton). visionOS **hand
+tracking** is **not yet wrapped**: the ARKit `HandTrackingProvider` exists
+but a `SceneViewSwift` node is still pending — tracked in
+[#1902](https://github.com/sceneview/sceneview/issues/1902). Body tracking
+is an ARKit-exclusive feature with no equivalent on either Android runtime.
+
+---
+
 ## Android
 
 Building for Android with Jetpack Compose? See the [Android API Cheatsheet](cheatsheet.md).


### PR DESCRIPTION
Closes #1904.

## Summary

Pure-docs change. Adds a "Hand / Face / Body tracking parity" table to `docs/docs/cheatsheet-ios.md` mapping every hand/face/body perception primitive across all five SceneView surfaces, and cross-links it from the Jetpack XR design notes.

- **Hand tracking** — not on ARCore phones; Jetpack XR `XrHandNode` foundation shipped in #1738, node tracked in #1902; visionOS `HandTrackingProvider` exists but **not yet wrapped** by `SceneViewSwift` (tracked in #1902); WebXR `hand-tracking` tracked in #1778.
- **Face tracking** — Android `AugmentedFaceNode` (mesh) / Jetpack XR `XrFaceNode` (#1903); iOS `AnchorNode.face()` is **shipped** (pose only, no mesh).
- **Body tracking** — ARKit-exclusive: iOS `AnchorNode.body()` is **shipped**; no Android counterpart on either runtime (deferred-scope decision from #1738).

## Honest iOS maturity (verified against `SceneViewSwift/` source)

- `AnchorNode.face()` and `AnchorNode.body()` — shipped (pose-level anchors, no morphing mesh / no skeleton).
- visionOS hand tracking — no `SceneViewSwift` wrapper exists; raw `HandTrackingProvider` is the path today, pending #1902.

Cross-link added from `arsceneview/docs/JETPACK-XR-INTEGRATION.md` "Cross-platform parity follow-ups" to the new cheatsheet table.

## Test plan

- [ ] `sync-versions.sh` clean (verified — 0 errors)
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)