### PR TITLE
test(materials): register occlusion.mat in GenerateFilamat.sh drift guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,7 @@ website-static/materials/                 (3) — lit_colored, transparent_color
 **The `tools/GenerateFilamat.sh` workflow.** [`tools/GenerateFilamat.sh`](tools/GenerateFilamat.sh) is the single entry point for every Filament material in the repo. It auto-downloads the `matc` toolchain pinned to the Filament version in [`gradle/libs.versions.toml`](gradle/libs.versions.toml) and compiles each `.mat` to its `.filamat` blob — no manual `matc` install needed.
 
 ```
-bash tools/GenerateFilamat.sh                 # regenerate all 20 .filamat blobs in place
+bash tools/GenerateFilamat.sh                 # regenerate all 21 .filamat blobs in place
 bash tools/GenerateFilamat.sh --check         # diff against committed blobs; exit 1 on drift
 bash tools/GenerateFilamat.sh --mat <name>    # regenerate one (e.g. --mat opaque_colored)
 bash tools/GenerateFilamat.sh --ci-tolerant   # treat a matc download failure as WARN, not FAIL
@@ -262,7 +262,7 @@ The `matc` binary is cached at `~/.cache/sceneview/matc-<version>/` (overridable
 
 **The drift gate.** `bash .claude/scripts/quality-gate.sh` runs `GenerateFilamat.sh --check` on every pre-push gate. Editing a `.mat` source **without** recompiling its `.filamat` blob now **blocks the PR** — the gate reports the drifted blob(s) and fails. This catches the v4.1.0-class mistake before it ships.
 
-**The four matc flag profiles.** The committed blobs were compiled with four distinct profiles (recorded in each blob's MRPC chunk). `GenerateFilamat.sh` reproduces each one — including flag *order*, since matc embeds the verbatim flag string:
+**The five matc flag profiles.** The committed blobs were compiled with five distinct profiles (recorded in each blob's MRPC chunk). `GenerateFilamat.sh` reproduces each one — including flag *order*, since matc embeds the verbatim flag string:
 
 | Profile | Flags | Module |
 |---|---|---|
@@ -270,6 +270,7 @@ The `matc` binary is cached at `~/.cache/sceneview/matc-<version>/` (overridable
 | **B** — lean Android | `-a opengl -p mobile` | `sceneview/` unlit colored materials (2) |
 | **C** — ARCore | `--optimize-size -p mobile -a opengl -a vulkan` | `arsceneview/` (6) |
 | **D** — website / WebGL | `-p mobile -a opengl` | `website-static/materials/` (3) |
+| **E** — Android occluder | `-a vulkan -a opengl -p mobile` | `sceneview/` occlusion material (1) |
 
 When adding a new material, pick a profile by deployment target and add an entry to the `MATS` inventory in `GenerateFilamat.sh`. Each `.mat` source carries a short header block (purpose, used-by, parameters, profile) — read those headers to learn what an individual material does and where it is consumed.
 

--- a/changelog.d/1949-register-occlusion-mat.md
+++ b/changelog.d/1949-register-occlusion-mat.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- Registered the new `occlusion.mat`/`occlusion.filamat` (added by #1832) in the `tools/GenerateFilamat.sh` inventory under a new Profile E (`-a vulkan -a opengl -p mobile`), so the `.filamat` ABI drift guard now covers all 21 material blobs (#1949).

--- a/tools/GenerateFilamat.sh
+++ b/tools/GenerateFilamat.sh
@@ -10,14 +10,14 @@
 # version than the runtime expected). See CLAUDE.md "Filament runtime ↔
 # .filamat ABI invariant" and CONTRIBUTING.md.
 #
-# Inventory (20 mats → 20 filamats):
-#   sceneview/src/main/materials/         (11) → sceneview/src/main/assets/materials/
+# Inventory (21 mats → 21 filamats):
+#   sceneview/src/main/materials/         (12) → sceneview/src/main/assets/materials/
 #   arsceneview/src/main/materials/        (6) → arsceneview/src/main/assets/materials/
 #   website-static/materials/              (3) → website-static/materials/
 #
 # Usage:
-#   bash tools/GenerateFilamat.sh                 # regenerate all 20 filamats
-#   bash tools/GenerateFilamat.sh --check         # diff against committed blobs; exit 1 on drift
+#   bash tools/GenerateFilamat.sh                 # regenerate all 21 filamats
+#   bash tools/GenerateFilamat.sh --check         # diff all 21 against committed blobs; exit 1 on drift
 #   bash tools/GenerateFilamat.sh --mat <name>    # regenerate one (e.g. --mat opaque_colored)
 #   bash tools/GenerateFilamat.sh --ci-tolerant   # treat matc download failure as WARN, not FAIL
 #   bash tools/GenerateFilamat.sh --help
@@ -86,7 +86,7 @@ log "${CYAN}Filament version (pinned):${NC} $FILAMENT_VERSION"
 # Format: "<module>:<name>:<src-path>:<out-path>:<matc-flags>"
 # matc-flags is the full flag list (excluding -o and the source path).
 #
-# Why per-mat flags: the committed .filamat blobs were compiled with FOUR
+# Why per-mat flags: the committed .filamat blobs were compiled with FIVE
 # distinct profiles (visible in each blob's MRPC chunk via `strings`).
 # We preserve each blob's exact compile profile — including flag *order*,
 # because matc embeds the verbatim flag string and any reorder produces
@@ -104,6 +104,9 @@ log "${CYAN}Filament version (pinned):${NC} $FILAMENT_VERSION"
 #   Profile D — website-static (Filament.js / WebGL, 3 mats):
 #     "-p mobile -a opengl"
 #
+#   Profile E — Android occluder (sceneview occlusion, 1 mat):
+#     "-a vulkan -a opengl -p mobile"   (note flag order!)
+#
 # When adding a new material, pick a profile based on the deployment
 # target. Audit #1918 (Part A) reviewed the A-vs-B split: Profile B
 # (`-a opengl -p mobile`) is a deliberate size optimisation for the two
@@ -112,6 +115,7 @@ log "${CYAN}Filament version (pinned):${NC} $FILAMENT_VERSION"
 # intentional, not drift; left as-is. See the audit summary in the #1918 PR.
 MATS=(
     "sceneview:image_texture:sceneview/src/main/materials/image_texture.mat:sceneview/src/main/assets/materials/image_texture.filamat:-p all -a all"
+    "sceneview:occlusion:sceneview/src/main/materials/occlusion.mat:sceneview/src/main/assets/materials/occlusion.filamat:-a vulkan -a opengl -p mobile"
     "sceneview:opaque_colored:sceneview/src/main/materials/opaque_colored.mat:sceneview/src/main/assets/materials/opaque_colored.filamat:-p all -a all"
     "sceneview:opaque_textured:sceneview/src/main/materials/opaque_textured.mat:sceneview/src/main/assets/materials/opaque_textured.filamat:-p all -a all"
     "sceneview:opaque_unlit_colored:sceneview/src/main/materials/opaque_unlit_colored.mat:sceneview/src/main/assets/materials/opaque_unlit_colored.filamat:-a opengl -p mobile"

--- a/website-static/materials/README.md
+++ b/website-static/materials/README.md
@@ -37,7 +37,7 @@ These three blobs are part of the unified inventory in
 [`tools/GenerateFilamat.sh`](../../tools/GenerateFilamat.sh). Regenerate with:
 
 ```bash
-bash tools/GenerateFilamat.sh                        # all 20 blobs
+bash tools/GenerateFilamat.sh                        # all 21 blobs
 bash tools/GenerateFilamat.sh --mat unlit_colored    # one web blob
 ```
 


### PR DESCRIPTION
## Summary

Follow-up of #1832 (`MaterialLoader.createOcclusionInstance()`). PR #1832 shipped `occlusion.mat` + its compiled `occlusion.filamat` but never registered the new material in the `tools/GenerateFilamat.sh` `MATS` inventory. The `.filamat` ABI drift guard (`GenerateFilamat.sh --check`, wired into `quality-gate.sh` by #1916) therefore did **not** cover `occlusion.filamat` — a future `occlusion.mat` edit without a matching recompile, exactly the v4.1.0-class ABI footgun the guard exists to catch, would slip through.

## Changes

- **`tools/GenerateFilamat.sh`** — added `occlusion` to the `MATS` inventory. The committed `occlusion.filamat` blob's MRPC chunk (`strings occlusion.filamat`) shows it was compiled with `-a vulkan -a opengl -p mobile`, a flag set distinct from the four existing profiles, so this adds a new **Profile E** ("Android occluder") and assigns occlusion to it. Inventory count 20 → 21.
- **`CONTRIBUTING.md`** — bumped the blob count 20 → 21, added Profile E to the matc flag-profile table, updated "four → five profiles".
- **`website-static/materials/README.md`** — bumped the blob count 20 → 21.
- **`changelog.d/1949-register-occlusion-mat.md`** — `Tests` category fragment.

⛔ The committed `occlusion.filamat` was **not** regenerated or altered — only the inventory registration changed.

## Verification

- `bash tools/GenerateFilamat.sh --check` (matc 1.71.0, cached) — **all 21 blobs in sync**, including the newly-registered `[sceneview:occlusion] in sync (39765 bytes)`. The byte-identical match confirms Profile E's flag string (`-a vulkan -a opengl -p mobile`) reproduces the committed blob exactly.
- `bash -n tools/GenerateFilamat.sh` — syntax OK.
- `bash .claude/scripts/impact-check.sh` — the only 2 blockers (README/website node count "Claims 36, actual 38") pre-exist on clean `origin/main` and are unrelated to this materials-count change.

## Test plan

- [x] `occlusion` in `GenerateFilamat.sh` MATS inventory with the right profile (Profile E, `-a vulkan -a opengl -p mobile`)
- [x] `--check` covers `occlusion.filamat` (reports in sync, 39765 bytes)
- [x] Blob count updated in `CONTRIBUTING.md` (and `website-static/materials/README.md`)
- [ ] CI's `GenerateFilamat.sh --check` run (network-enabled) re-validates all 21 blobs

Closes #1949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)