### PR TITLE
QA: enforce web-perf Lighthouse budgets + wire into release gate

### DIFF
--- a/.claude/perf-baselines/web-perf.json
+++ b/.claude/perf-baselines/web-perf.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Web-demo Lighthouse perf baseline — feeds the budgets enforced by .claude/scripts/web-perf-qa.sh (#1898, follow-up of #1879).",
+  "_howToRecompute": [
+    "1. Run `bash .claude/scripts/web-perf-qa.sh` on every push to main (or piggyback on device-qa.yml's web job) for ~7 days.",
+    "2. Collect each run's web-perf-summary.json from the device-qa-report-web workflow artifact.",
+    "3. Append { date, fcp_ms, lcp_ms, cls, performanceScore } to the `samples` array below.",
+    "4. Set each budget to the 95th percentile of its metric across all samples (a perf-score budget is the 5th percentile — higher is better).",
+    "5. Copy the recomputed budgets into the BUDGET_* defaults + header table of web-perf-qa.sh, and bump `lastUpdated` here.",
+    "A fresh contributor can reproduce the budgets entirely from this file's `samples` array — no hidden state."
+  ],
+  "schemaVersion": 1,
+  "preset": "mobile",
+  "lastUpdated": "2026-05-21",
+  "budgets": {
+    "fcp_ms": 4000,
+    "lcp_ms": 4400,
+    "cls": 0.10,
+    "performanceScore": 0.65
+  },
+  "budgetRationale": "First cut — sized from the single #1879 smoke run plus safety margin, NOT yet a 7-day 95th-percentile baseline. Intentionally loose: catch a real regression, never fail a healthy run. Re-tighten once `samples` has real data.",
+  "samples": [
+    {
+      "date": "2026-05-14",
+      "source": "#1879 smoke test",
+      "fcp_ms": 3008,
+      "lcp_ms": 3178,
+      "cls": 0.0,
+      "performanceScore": 0.79
+    }
+  ]
+}

--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -46,11 +46,14 @@
 #   --advisory=<csv> Comma-separated platforms whose result is ADVISORY for the
 #                    release gate — a failure on an advisory leg surfaces as a
 #                    WARN (not a hard block) in release-checklist.sh section 14
-#                    (#1651). Default: `android,ar` — these legs run on the
-#                    chronically flaky SwiftShader emulator (#1643) and are
-#                    `continue-on-error: true` in device-qa.yml, so the release
-#                    gate must not be hard-blocked by them. The `web` leg is
-#                    intentionally NOT advisory: it is reliable and BLOCKING.
+#                    (#1651). Default: `android,ar,web-perf`. `android,ar` run
+#                    on the chronically flaky SwiftShader emulator (#1643) and
+#                    are `continue-on-error: true` in device-qa.yml, so the
+#                    release gate must not be hard-blocked by them. `web-perf`
+#                    is the Lighthouse perf sub-leg of `web` (#1879/#1898) —
+#                    advisory until its budgets are proven against real
+#                    baseline data. The `web` leg itself is intentionally NOT
+#                    advisory: it is reliable and BLOCKING.
 #                    Pass `--advisory=` (empty) to make every leg blocking.
 #   -h | --help      Show this help.
 #
@@ -93,7 +96,10 @@ OUT_DIR="$REPO_ROOT"
 # Advisory legs (#1651): a failure here is a release-gate WARN, not a block.
 # `android,ar` ride the flaky SwiftShader emulator and are continue-on-error
 # in device-qa.yml; `web` is reliable and stays BLOCKING.
-ADVISORY="android,ar"
+# `web-perf` (#1898) is the Lighthouse perf sub-leg — advisory at first, until
+# its budgets are proven stable against real baseline data. Promote it out of
+# this CSV to make a budget breach a hard release block.
+ADVISORY="android,ar,web-perf"
 ADVISORY_SET=false
 
 while [[ $# -gt 0 ]]; do
@@ -107,7 +113,7 @@ while [[ $# -gt 0 ]]; do
     --advisory=*) ADVISORY="${1#--advisory=}"; ADVISORY_SET=true; shift ;;
     --advisory)   ADVISORY="${2-}"; ADVISORY_SET=true; shift 2 ;;
     -h|--help)
-      sed -n '2,62p' "$SCRIPT_DIR/device-qa.sh" | sed 's/^# \{0,1\}//'
+      sed -n '2,71p' "$SCRIPT_DIR/device-qa.sh" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[device-qa] unknown argument: $1" >&2; exit 2 ;;
@@ -384,23 +390,37 @@ run_web() {
     record web failed "playwright rc=$rc" "$kept" "$(( $(date +%s) - started ))"
   fi
 
-  # Optional ADVISORY perf-QA sub-leg (item 5 of #1748, scaffolded in #1879).
-  # Runs Lighthouse against the web-demo and writes web-perf-summary.json
-  # alongside web-qa-summary.json. Continue-on-error: the perf scaffold is
-  # advisory until thresholds settle (tracked in the #1879 follow-up), so a
-  # missing tool / slow run NEVER blocks the device-QA gate. The perf summary
-  # is mirrored into $ARTIFACTS/ but is NOT embedded in the recorded `web`
-  # verdict above — its release-gate weight is decided by the follow-up.
+  # ADVISORY perf-QA sub-leg (item 5 of #1748, scaffolded in #1879, thresholds
+  # tuned + recorded in #1898). Runs Lighthouse against the web-demo and writes
+  # web-perf-summary.json with an ENFORCED per-metric budget. The result is now
+  # `record()`-ed as its own `web-perf` leg so a budget breach surfaces in
+  # device-qa-report.json -> releaseGate.advisoryFailed (web-perf is in the
+  # default ADVISORY CSV — a breach is a release WARN, not a hard block). The
+  # call is still continue-on-error: web-perf-qa.sh exits 0 even on a `failed`
+  # verdict (the breach is carried in the JSON), and a missing tool soft-skips.
   if [[ -x "$SCRIPT_DIR/web-perf-qa.sh" ]]; then
-    log "running advisory web-perf-qa (Lighthouse, scaffold from #1879)"
+    local perf_started; perf_started=$(date +%s)
+    log "running advisory web-perf-qa (Lighthouse, #1879/#1898)"
     bash "$SCRIPT_DIR/web-perf-qa.sh" --out "$webdir/test-results" \
       >> "$ARTIFACTS/web-output.txt" 2>&1 \
       || warn "web-perf-qa.sh exited non-zero — advisory, continuing"
     local perf_summary="$webdir/test-results/web-perf-summary.json"
+    local perf_kept="" perf_status="skipped" perf_reason="web-perf-qa.sh produced no summary"
     if [[ -f "$perf_summary" ]]; then
-      cp "$perf_summary" "$ARTIFACTS/web-perf-summary.json"
-      log "advisory perf summary: $ARTIFACTS/web-perf-summary.json"
+      perf_kept="$ARTIFACTS/web-perf-summary.json"
+      cp "$perf_summary" "$perf_kept"
+      log "advisory perf summary: $perf_kept"
+      # Read status + a human reason straight from the perf summary. python3 is
+      # already a hard dependency of web-perf-qa.sh, so it is safe to use here.
+      perf_status="$(python3 -c "import json;d=json.load(open('$perf_summary'));print(d.get('status','skipped'))" 2>/dev/null || echo skipped)"
+      perf_reason="$(python3 -c "
+import json
+d=json.load(open('$perf_summary'))
+br=d.get('breaches') or []
+print('; '.join(br) if br else (d.get('reason') or 'all metrics within budget'))
+" 2>/dev/null || echo 'could not read web-perf-summary.json')"
     fi
+    record web-perf "$perf_status" "$perf_reason" "$perf_kept" "$(( $(date +%s) - perf_started ))"
   fi
 }
 

--- a/.claude/scripts/web-perf-qa.sh
+++ b/.claude/scripts/web-perf-qa.sh
@@ -1,27 +1,66 @@
 #!/usr/bin/env bash
-# web-perf-qa.sh — ADVISORY perf QA for samples/web-demo via Lighthouse mobile.
+# web-perf-qa.sh — perf QA for samples/web-demo via Lighthouse mobile.
 #
-# Item 5 of #1748 (filed as #1879).
+# Item 5 of #1748 (filed as #1879). Threshold tuning is #1898.
 #
 # WHAT THIS IS
 # ------------
-# A scaffold that runs Lighthouse against the web-demo and emits a
-# machine-readable summary file (`web-perf-summary.json`) matching the shape
-# of `samples/web-demo/test-results/web-qa-summary.json`. The summary surfaces
+# Runs Lighthouse against the web-demo and emits a machine-readable summary
+# file (`web-perf-summary.json`) matching the shape of
+# `samples/web-demo/test-results/web-qa-summary.json`. The summary surfaces
 # three core Web-Vitals-adjacent metrics:
 #
 #   - firstContentfulPaint  (fcp_ms)
 #   - largestContentfulPaint (lcp_ms)
 #   - cumulativeLayoutShift  (cls)
 #
-# This is an ADVISORY check. NO thresholds are enforced — the verdict is
-# always `advisory` and the exit code is 0 on success, 0 on a soft skip
-# (lighthouse missing / dev server unreachable / chrome unavailable), and 1
-# only on hard misuse (bad flags). The device-qa.sh integration is also
-# advisory (continue-on-error) so a slow run never blocks the release gate.
+# THRESHOLD ENFORCEMENT (#1898)
+# -----------------------------
+# This script enforces a per-metric perf budget (mobile preset). Each measured
+# metric is compared against its budget; the run is `failed` if ANY metric
+# exceeds its budget, `passed` otherwise. The thresholds object is written into
+# `web-perf-summary.json` so the verdict is reproducible and auditable.
 #
-# Threshold tuning + a promotion to a blocking gate is tracked as a follow-up
-# of #1879.
+# Chosen budgets (mobile Lighthouse preset):
+#
+#   metric             budget    rationale
+#   ------------------ --------- --------------------------------------------
+#   fcp_ms             4000      #1879's real smoke test reported FCP ≈ 3008ms.
+#                                4000ms leaves ~33% headroom — noise (cold npx
+#                                cache, runner contention) stays green, a true
+#                                +1s regression fails the leg.
+#   lcp_ms             4400      #1879 reported LCP ≈ 3178ms. 4400ms is ~38%
+#                                headroom; Filament.js WASM init dominates LCP
+#                                so a slightly wider band than FCP avoids
+#                                flakes while still catching a real regression.
+#   cls                0.10      #1879 reported CLS ≈ 0 (a WebGL canvas does not
+#                                reflow). 0.10 is the Web-Vitals "good" cutoff —
+#                                any layout-shift creep above it is a real bug.
+#   performanceScore   0.65      #1879 reported a Lighthouse perf score of 0.79.
+#                                0.65 floor catches a broad regression (asset
+#                                bloat, blocking JS) without failing on the
+#                                normal CI-runner score spread (headless Chrome
+#                                on a shared 2-core box scores below desktop).
+#
+# These budgets are a first cut sized from the single #1879 smoke run plus
+# safety margin — not a 7-day 95th-percentile baseline. They are intentionally
+# loose: the goal is to catch a real regression, never to fail a healthy run.
+# Re-tighten them once `.claude/perf-baselines/web-perf.json` accumulates real
+# samples (see that file's header for the recompute recipe). Override any
+# budget at call time with the matching --budget-* flag.
+#
+# RELEASE-GATE WEIGHT
+# -------------------
+# The device-qa.sh integration records this as an ADVISORY leg (`web-perf`):
+# a budget breach surfaces in `device-qa-report.json` -> `releaseGate
+# .advisoryFailed` and release-checklist.sh section 14 reports it as a WARN,
+# not a hard block. Advisory-at-first per #1898 — promote `web-perf` out of
+# the device-qa.sh ADVISORY CSV to make it blocking once the budgets are
+# proven stable against real baseline data.
+#
+# A soft skip (lighthouse missing / dev server unreachable / chrome
+# unavailable) still emits `status: "skipped"` with exit 0 — a missing tool
+# must never block or false-fail the gate.
 #
 # WHY A SEPARATE SCRIPT (not a new device-qa.sh leg)
 # --------------------------------------------------
@@ -46,6 +85,8 @@
 # Usage:
 #   bash .claude/scripts/web-perf-qa.sh [--out <dir>] [--port <n>] [--url <u>]
 #                                       [--preset mobile|desktop]
+#                                       [--budget-fcp <ms>] [--budget-lcp <ms>]
+#                                       [--budget-cls <n>] [--budget-score <n>]
 #                                       [--keep-server] [-h | --help]
 #
 # Flags:
@@ -58,22 +99,32 @@
 #                     instead. Mirrors `WEB_DEMO_URL` in the Playwright
 #                     config.
 #   --preset <p>      Lighthouse form-factor. Default: mobile.
+#   --budget-fcp <ms>   FCP budget in ms.   Default: 4000.
+#   --budget-lcp <ms>   LCP budget in ms.   Default: 4400.
+#   --budget-cls <n>    CLS budget (0..1).  Default: 0.10.
+#   --budget-score <n>  Minimum Lighthouse perf score (0..1). Default: 0.65.
 #   --keep-server     Leave the dev-server running after the script exits.
 #                     Default behaviour stops it on EXIT.
 #
 # Exit codes:
-#   0  Lighthouse ran (advisory verdict written) OR tooling missing — soft
-#      skip, summary file written with `status: "skipped"`.
+#   0  Lighthouse ran — verdict written. Includes `status: "failed"` (a budget
+#      was breached): the non-zero signal is carried by the JSON, not the exit
+#      code, so the advisory device-qa.sh sub-leg never aborts the run. Also 0
+#      on a soft skip (tooling missing), summary written `status: "skipped"`.
 #   1  Invalid argument.
 #
 # Output JSON shape (web-perf-summary.json):
 #   {
 #     "schemaVersion": 1,
-#     "platform": "web",
+#     "platform": "web-perf",
 #     "tool": "lighthouse",
-#     "status": "passed" | "skipped",
-#     "verdict": "advisory",
-#     "thresholds": null,
+#     "status": "passed" | "failed" | "skipped",
+#     "verdict": "enforced",
+#     "thresholds": {
+#       "fcp_ms": <number>, "lcp_ms": <number>,
+#       "cls": <number>, "performanceScore": <number>
+#     },
+#     "breaches": [ "<metric> <value> > <budget>", ... ],   # empty when passed
 #     "preset": "mobile",
 #     "url": "http://localhost:8090/",
 #     "startedAt": "<ISO8601>",
@@ -99,19 +150,34 @@ URL=""
 PRESET="mobile"
 KEEP_SERVER=false
 
+# Perf budgets (mobile preset). See the header block for the rationale behind
+# each default. Overridable via the matching --budget-* flag.
+BUDGET_FCP=4000      # ms
+BUDGET_LCP=4400      # ms
+BUDGET_CLS=0.10      # 0..1
+BUDGET_SCORE=0.65    # 0..1 — minimum Lighthouse performance score
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --out=*)        OUT_DIR="${1#--out=}"; shift ;;
-    --out)          OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
-    --port=*)       PORT="${1#--port=}"; shift ;;
-    --port)         PORT="${2:?--port needs a value}"; shift 2 ;;
-    --url=*)        URL="${1#--url=}"; shift ;;
-    --url)          URL="${2:?--url needs a value}"; shift 2 ;;
-    --preset=*)     PRESET="${1#--preset=}"; shift ;;
-    --preset)       PRESET="${2:?--preset needs a value}"; shift 2 ;;
-    --keep-server)  KEEP_SERVER=true; shift ;;
+    --out=*)          OUT_DIR="${1#--out=}"; shift ;;
+    --out)            OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
+    --port=*)         PORT="${1#--port=}"; shift ;;
+    --port)           PORT="${2:?--port needs a value}"; shift 2 ;;
+    --url=*)          URL="${1#--url=}"; shift ;;
+    --url)            URL="${2:?--url needs a value}"; shift 2 ;;
+    --preset=*)       PRESET="${1#--preset=}"; shift ;;
+    --preset)         PRESET="${2:?--preset needs a value}"; shift 2 ;;
+    --budget-fcp=*)   BUDGET_FCP="${1#--budget-fcp=}"; shift ;;
+    --budget-fcp)     BUDGET_FCP="${2:?--budget-fcp needs a value}"; shift 2 ;;
+    --budget-lcp=*)   BUDGET_LCP="${1#--budget-lcp=}"; shift ;;
+    --budget-lcp)     BUDGET_LCP="${2:?--budget-lcp needs a value}"; shift 2 ;;
+    --budget-cls=*)   BUDGET_CLS="${1#--budget-cls=}"; shift ;;
+    --budget-cls)     BUDGET_CLS="${2:?--budget-cls needs a value}"; shift 2 ;;
+    --budget-score=*) BUDGET_SCORE="${1#--budget-score=}"; shift ;;
+    --budget-score)   BUDGET_SCORE="${2:?--budget-score needs a value}"; shift 2 ;;
+    --keep-server)    KEEP_SERVER=true; shift ;;
     -h|--help)
-      sed -n '2,90p' "$SCRIPT_DIR/web-perf-qa.sh" | sed 's/^# \{0,1\}//'
+      sed -n '2,138p' "$SCRIPT_DIR/web-perf-qa.sh" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[web-perf-qa] unknown argument: $1" >&2; exit 1 ;;
@@ -122,6 +188,18 @@ case "$PRESET" in
   mobile|desktop) ;;
   *) echo "[web-perf-qa] invalid --preset: $PRESET (mobile|desktop)" >&2; exit 1 ;;
 esac
+
+# Validate every budget is a non-negative number — a bad --budget-* flag must
+# fail fast (exit 1), not silently produce a meaningless verdict downstream.
+for _bv in "$BUDGET_FCP:--budget-fcp" "$BUDGET_LCP:--budget-lcp" \
+           "$BUDGET_CLS:--budget-cls" "$BUDGET_SCORE:--budget-score"; do
+  _val="${_bv%%:*}"; _flag="${_bv##*:}"
+  if ! [[ "$_val" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "[web-perf-qa] invalid $_flag: '$_val' (expected a non-negative number)" >&2
+    exit 1
+  fi
+done
+unset _bv _val _flag
 
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(cd "$OUT_DIR" && pwd)"
@@ -135,21 +213,31 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 STARTED_EPOCH_MS="$(python3 -c 'import time;print(int(time.time()*1000))')"
 
 # Emit a `skipped` summary and exit 0. Soft-skip is the default for any
-# missing precondition — this leg must never hard-block.
+# missing precondition — this leg must never hard-block. The thresholds object
+# is still written so a consumer of a skipped summary can see the budget that
+# WOULD have been enforced; only `status` records that no run happened.
 emit_skipped() {
   local reason="$1"
   warn "$reason — emitting skipped verdict"
-  python3 - "$SUMMARY" "$STARTED_AT" "$STARTED_EPOCH_MS" "$reason" "$PRESET" "$URL" <<'PYEOF'
+  python3 - "$SUMMARY" "$STARTED_AT" "$STARTED_EPOCH_MS" "$reason" "$PRESET" "$URL" \
+           "$BUDGET_FCP" "$BUDGET_LCP" "$BUDGET_CLS" "$BUDGET_SCORE" <<'PYEOF'
 import json, sys, time
 out, started, started_ms, reason, preset, url = sys.argv[1:7]
+b_fcp, b_lcp, b_cls, b_score = (float(x) for x in sys.argv[7:11])
 duration_ms = int(time.time() * 1000) - int(started_ms)
 summary = {
     "schemaVersion": 1,
-    "platform": "web",
+    "platform": "web-perf",
     "tool": "lighthouse",
     "status": "skipped",
-    "verdict": "advisory",
-    "thresholds": None,
+    "verdict": "skipped",
+    "thresholds": {
+        "fcp_ms": b_fcp,
+        "lcp_ms": b_lcp,
+        "cls": b_cls,
+        "performanceScore": b_score,
+    },
+    "breaches": [],
     "preset": preset,
     "url": url or None,
     "startedAt": started,
@@ -276,10 +364,16 @@ if [[ ! -s "$RAW_JSON" ]]; then
 fi
 
 # --- Parse + emit summary --------------------------------------------------
-python3 - "$SUMMARY" "$RAW_JSON" "$STARTED_AT" "$STARTED_EPOCH_MS" "$PRESET" "$URL" <<'PYEOF'
+# Threshold enforcement (#1898): compare each measured metric against its
+# budget. The run is `failed` if ANY metric breaches its budget. A metric that
+# Lighthouse could not measure (None) is NOT counted as a breach — a partial
+# Lighthouse run must not be reported as a regression.
+python3 - "$SUMMARY" "$RAW_JSON" "$STARTED_AT" "$STARTED_EPOCH_MS" "$PRESET" "$URL" \
+          "$BUDGET_FCP" "$BUDGET_LCP" "$BUDGET_CLS" "$BUDGET_SCORE" <<'PYEOF'
 import json, sys, time, os
 
 out, raw, started, started_ms, preset, url = sys.argv[1:7]
+b_fcp, b_lcp, b_cls, b_score = (float(x) for x in sys.argv[7:11])
 
 with open(raw) as fh:
     lh = json.load(fh)
@@ -302,13 +396,35 @@ if perf_score is not None:
 
 duration_ms = int(time.time() * 1000) - int(started_ms)
 
+thresholds = {
+    "fcp_ms": b_fcp,
+    "lcp_ms": b_lcp,
+    "cls": b_cls,
+    "performanceScore": b_score,
+}
+
+# Per-metric budget check. "lower is better" for fcp/lcp/cls; the perf score is
+# a floor (higher is better). A None metric is skipped — never a breach.
+breaches = []
+if fcp is not None and fcp > b_fcp:
+    breaches.append(f"fcp_ms {fcp} > {b_fcp}")
+if lcp is not None and lcp > b_lcp:
+    breaches.append(f"lcp_ms {lcp} > {b_lcp}")
+if cls is not None and cls > b_cls:
+    breaches.append(f"cls {cls} > {b_cls}")
+if perf_score is not None and perf_score < b_score:
+    breaches.append(f"performanceScore {perf_score} < {b_score}")
+
+status = "failed" if breaches else "passed"
+
 summary = {
     "schemaVersion": 1,
-    "platform": "web",
+    "platform": "web-perf",
     "tool": "lighthouse",
-    "status": "passed",
-    "verdict": "advisory",
-    "thresholds": None,
+    "status": status,
+    "verdict": "enforced",
+    "thresholds": thresholds,
+    "breaches": breaches,
     "preset": preset,
     "url": url,
     "startedAt": started,
@@ -327,13 +443,23 @@ with open(out, "w") as fh:
 # Human-readable echo.
 def fmt(v, unit=""):
     return "n/a" if v is None else f"{v}{unit}"
-print(f"[web-perf-qa] FCP: {fmt(fcp, ' ms')}")
-print(f"[web-perf-qa] LCP: {fmt(lcp, ' ms')}")
-print(f"[web-perf-qa] CLS: {fmt(cls)}")
-print(f"[web-perf-qa] performance score (Lighthouse 0..1): {fmt(perf_score)}")
-print(f"[web-perf-qa] verdict: advisory (thresholds not enforced — follow-up of #1879)")
+print(f"[web-perf-qa] FCP: {fmt(fcp, ' ms')}  (budget {b_fcp} ms)")
+print(f"[web-perf-qa] LCP: {fmt(lcp, ' ms')}  (budget {b_lcp} ms)")
+print(f"[web-perf-qa] CLS: {fmt(cls)}  (budget {b_cls})")
+print(f"[web-perf-qa] performance score (Lighthouse 0..1): {fmt(perf_score)}  "
+      f"(floor {b_score})")
+if breaches:
+    for b in breaches:
+        print(f"[web-perf-qa] BUDGET BREACH: {b}")
+    print(f"[web-perf-qa] verdict: FAILED — {len(breaches)} budget breach(es)")
+else:
+    print(f"[web-perf-qa] verdict: PASSED — all metrics within budget")
 PYEOF
 
 log "summary: $SUMMARY"
 log "raw lighthouse JSON: $RAW_JSON"
+# A budget breach is carried in the JSON (status:"failed"), not the exit code:
+# the advisory device-qa.sh sub-leg invokes this with `|| warn ...` and reads
+# the recorded leg's status — exit 0 keeps that integration clean. release
+# tooling and CI both consume web-perf-summary.json, never $?.
 exit 0

--- a/changelog.d/1898-web-perf-qa-thresholds.md
+++ b/changelog.d/1898-web-perf-qa-thresholds.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- QA: `web-perf-qa.sh` now enforces a tuned Lighthouse perf budget (mobile preset — FCP/LCP/CLS + perf-score) instead of always emitting an advisory verdict, and `device-qa.sh` records the result as an advisory `web-perf` leg so a budget breach surfaces in `device-qa-report.json`'s release gate (#1898, follow-up of #1879).


### PR DESCRIPTION
## Summary

Follow-up of #1879 / PR #1897 — promotes the `web-perf-qa.sh` Lighthouse
scaffold from always-advisory to threshold-enforcing, and wires its verdict
into the device-QA release gate.

- **Tuned thresholds** — `web-perf-qa.sh` now compares each measured metric
  against a mobile-preset perf budget and emits `status: "passed" | "failed"`
  with a `breaches[]` list and a populated `thresholds` object, replacing the
  always-`verdict:"advisory"` / `thresholds:null` scaffold. Budgets:
  - `fcp_ms` <= 4000 (~33% headroom over #1879's smoke FCP ~ 3008ms)
  - `lcp_ms` <= 4400 (~38% headroom over LCP ~ 3178ms - WASM init dominates)
  - `cls` <= 0.10 (the Web-Vitals "good" cutoff)
  - `performanceScore` >= 0.65 (floor under #1879's 0.79, allows CI-runner spread)

  Sized from #1879's single real smoke run plus safety margin - loose on
  purpose: catch a real regression, never false-fail a healthy run. Each
  budget is overridable via a `--budget-*` flag. The soft-skip path
  (`status:"skipped"`) is untouched.
- **Release-gate wiring** - `device-qa.sh` now `record()`s the perf sub-leg as
  its own advisory `web-perf` leg. A budget breach surfaces in
  `device-qa-report.json` -> `releaseGate.advisoryFailed`, which
  `release-checklist.sh` section 14 already reads - so a breach lands as a
  release **WARN**. Advisory at first per the issue; promote `web-perf` out of
  the `device-qa.sh` `ADVISORY` CSV to make it blocking once budgets are
  proven stable. The blocking `web` leg is unchanged - a real demo break still
  hard-blocks.
- **Reproducible baseline** - adds `.claude/perf-baselines/web-perf.json` with
  the seed sample (#1879 smoke) and an in-file recompute recipe so a fresh
  contributor can re-derive the 95th-percentile budgets from real data.

`web-perf-qa.sh` still exits 0 even on a `failed` verdict - the breach is
carried in the JSON, keeping the continue-on-error `device-qa.sh` sub-leg
integration clean.

## Test plan

- [x] `bash -n` clean on both scripts; `shellcheck -S warning` adds no new
      warnings (only the pre-existing SC2164 on untouched `cd` lines).
- [x] `--help` renders the full updated header; `--budget-*` / unknown-flag
      validation rejects bad input with exit 1.
- [x] Threshold logic verified with synthetic Lighthouse JSON - #1879's smoke
      values pass; a regression (FCP 5200, CLS 0.25, score 0.40) fails with
      precise per-metric breach messages.
- [x] Release-gate arithmetic verified - a failed `web-perf` leg yields
      `releaseGate.verdict:"warn"` + `advisoryFailed:["web-perf"]`,
      `blockingFailed:[]`.
- [x] `impact-check.sh` - only the pre-existing unrelated `README.md node
      count` blocker (this PR touches no node types).

Closes #1898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)