### PR TITLE
docs: fix stale 3D node-type count (36 → 38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ You get:
 - **Only** Compose-native 3D/AR SDK for Android — no alternative exists
 - **Compose-native successor** to Google Sceneform (archived 2021) — see [above](#the-compose-native-successor-to-sceneform)
 - **~5MB** footprint vs 50-100MB+ for Unity/Unreal
-- **36+ node types** as declarative composables
+- **38+ node types** as declarative composables
 - **MCP server** with 28+ tools — no other 3D SDK has this
 
 Listed on the [MCP Registry](https://registry.modelcontextprotocol.io). See the [MCP README](./mcp/README.md) for full setup and tool reference.

--- a/changelog.d/1971-node-count.md
+++ b/changelog.d/1971-node-count.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Corrected the stale 3D node-type count in `README.md` and the website (was 36/26, actual 38).

--- a/docs/docs/structured-data.json
+++ b/docs/docs/structured-data.json
@@ -106,7 +106,7 @@
     },
     "featureList": [
       "Compose-native SceneView{} and ARSceneView{} composables",
-      "26+ built-in node types (ModelNode, CubeNode, SphereNode, etc.)",
+      "38+ built-in node types (ModelNode, CubeNode, SphereNode, etc.)",
       "glTF/GLB 3D model loading with animations",
       "ARCore integration (plane detection, image tracking, face mesh, cloud anchors)",
       "Physics simulation (rigid body, gravity, collisions)",

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -136,7 +136,7 @@
         "name": "How do I add 3D to my Android Jetpack Compose app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.12.0\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 36+ node types, and adds only ~5MB to your APK."
+          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.12.0\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 38+ node types, and adds only ~5MB to your APK."
         }
       },
       {
@@ -815,7 +815,7 @@
   <section class="features" id="features">
     <div class="features__container">
       <h2 class="features__title reveal">What you can build</h2>
-      <p class="features__subtitle reveal">26+ node types, full ARCore + ARKit coverage, physics, post-processing, and Compose UI inside a 3D scene.</p>
+      <p class="features__subtitle reveal">38+ node types, full ARCore + ARKit coverage, physics, post-processing, and Compose UI inside a 3D scene.</p>
 
       <div class="features__grid">
         <div class="feature-card reveal">


### PR DESCRIPTION
## Summary
`impact-check.sh` reported a node-count drift on clean `origin/main`: README/website claimed **36** node types while the actual count is **38**. Two node types were added without bumping the hard-coded marketing count.

The true count is derived from `*Node.kt` sources: **24** in `sceneview/.../node` + **14** in `arsceneview/.../ar/node` = **38** (matches `impact-check.sh`).

## Changes
- `README.md` — `36+ node types` → `38+ node types`
- `website-static/index.html` — structured-data FAQ answer (`36+`) and the "What you can build" features subtitle (stale `26+`) → `38+`
- `docs/docs/structured-data.json` — `featureList` entry (stale `26+`) → `38+`
- `changelog.d/1971-node-count.md` — Docs changelog fragment

`llms.txt` already enumerates every one of the 38 node types — no additions needed.

## Verification
- `bash .claude/scripts/impact-check.sh` → `ALL CLEAR`; the node-count blocker is gone (`README.md node count` and `website-static/index.html node count` both PASS 38).

Closes #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)