### PR TITLE
build: fail-loud release guard for empty store secrets (#1915)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,36 @@ Open the project in Android Studio. Gradle sync will pull all dependencies autom
 
 For iOS (SceneViewSwift), open `SceneViewSwift/Package.swift` in Xcode and build from there.
 
+### Store secrets and the release-build guard
+
+The demo apps read two optional secrets — `SKETCHFAB_API_KEY` (Sketchfab
+carousels in the Explore tab) and `ARCORE_API_KEY` (AR Streetscape / Geospatial
+/ Cloud Anchor demos). They're resolved from an environment variable or, on
+developer machines, from the repo-root `local.properties`
+(`sketchfab.api.key` and `ARCORE_API_KEY` respectively).
+
+**Debug builds are permissive** — a missing key just disables those features at
+runtime, so you can build and contribute without either secret.
+
+**Release builds fail loud (#1915).** A release `assembleRelease` /
+`bundleRelease` (Android) or `Release` archive (iOS) *refuses to build* when a
+secret is empty or unsubstituted, instead of silently shipping a store APK with
+invisible Sketchfab carousels (the regression class behind #1909). This guard
+only fires on the release path — it never affects `assembleDebug` or PR-check
+builds.
+
+Forks have no access to the org GitHub Secrets, so to produce a release build
+without the keys, opt out of the guard:
+
+```bash
+# Android
+./gradlew :samples:android-demo:bundleRelease -PSV_ALLOW_MISSING_SECRETS=1
+# or export SV_ALLOW_MISSING_SECRETS=1
+
+# iOS
+xcodebuild archive ... SV_ALLOW_MISSING_SECRETS=1
+```
+
 ### Run tests
 
 ```bash

--- a/changelog.d/1915-sketchfab-build-guard.md
+++ b/changelog.d/1915-sketchfab-build-guard.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Release builds of the demo apps now fail loud when `SKETCHFAB_API_KEY` or `ARCORE_API_KEY` is empty (#1915): the Android `assembleRelease`/`bundleRelease` path and the iOS `Release` archive abort with a clear actionable error instead of silently shipping a store build with invisible Sketchfab carousels (the #1909 silent-fail class). Debug builds stay permissive; forks opt out with `SV_ALLOW_MISSING_SECRETS=1`.

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -6,6 +6,45 @@ plugins {
     alias(libs.plugins.roborazzi)
 }
 
+// Resolve store secrets once, at android-block scope, so both `defaultConfig`
+// (which injects them into the manifest / BuildConfig) and the release secret
+// guard below (#1915) can see the same resolved values.
+//
+// Each key is read from one of:
+//   1. its environment variable (CI / store-bound builds)
+//   2. repo-root local.properties (developer machines)
+//   3. fallback empty string (the feature stays disabled at runtime — and the
+//      #1915 release guard refuses to ship a store APK in that state)
+def loadFromLocalProperties = { String propertyName ->
+    def localPropsFile = rootProject.file("local.properties")
+    if (!localPropsFile.exists()) {
+        return ""
+    }
+    def localProps = new Properties()
+    localPropsFile.withInputStream { localProps.load(it) }
+    return localProps.getProperty(propertyName, "")
+}
+
+// ARCORE_API_KEY env var -> local.properties `ARCORE_API_KEY`. Injected into
+// AndroidManifest.xml as the `arcoreApiKey` placeholder. Empty => Streetscape /
+// Geospatial / Cloud Anchors stay disabled via the demo's `hasArcoreApiKey`
+// check. See arsceneview/STREETSCAPE_SETUP.md for how to provision your own key.
+def arcoreApiKey = System.getenv("ARCORE_API_KEY") ?: ""
+if (arcoreApiKey.isEmpty()) {
+    arcoreApiKey = loadFromLocalProperties("ARCORE_API_KEY")
+}
+
+// SKETCHFAB_API_KEY env var -> local.properties `sketchfab.api.key`. Injected
+// into BuildConfig so SketchfabService can authenticate against
+// api.sketchfab.com. Empty => Sketchfab features stay disabled
+// (SketchfabConfig.apiKey returns null, the service throws MissingApiKey).
+// TODO V1.1: route requests via the mcp-gateway proxy so end-users never see
+// the master key in the APK. See SketchfabConfig.kt.
+def sketchfabApiKey = System.getenv("SKETCHFAB_API_KEY") ?: ""
+if (sketchfabApiKey.isEmpty()) {
+    sketchfabApiKey = loadFromLocalProperties("sketchfab.api.key")
+}
+
 android {
     namespace = "io.github.sceneview.demo"
 
@@ -21,43 +60,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        // Inject the ARCore Cloud API key into AndroidManifest.xml as a manifest
-        // placeholder. The key MUST NEVER be committed — it's read from one of:
-        //   1. ARCORE_API_KEY environment variable (CI / store-bound builds)
-        //   2. local.properties → ARCORE_API_KEY (developer machines)
-        //   3. fallback empty string (Streetscape / Geospatial / Cloud Anchors
-        //      stay disabled at runtime via the demo's `hasArcoreApiKey` check)
-        // See arsceneview/STREETSCAPE_SETUP.md for how to provision your own key.
-        def arcoreApiKey = System.getenv("ARCORE_API_KEY") ?: ""
-        if (arcoreApiKey.isEmpty()) {
-            def localPropsFile = rootProject.file("local.properties")
-            if (localPropsFile.exists()) {
-                def localProps = new Properties()
-                localPropsFile.withInputStream { localProps.load(it) }
-                arcoreApiKey = localProps.getProperty("ARCORE_API_KEY", "")
-            }
-        }
+        // The key MUST NEVER be committed — see the resolution block above.
         manifestPlaceholders["arcoreApiKey"] = arcoreApiKey
-
-        // Inject the Sketchfab API key into BuildConfig so the demo's
-        // SketchfabService can authenticate against api.sketchfab.com without
-        // hard-coding a token in source. The key is read from one of:
-        //   1. SKETCHFAB_API_KEY environment variable (CI / store builds)
-        //   2. local.properties → sketchfab.api.key (developer machines)
-        //   3. fallback empty string (Sketchfab features stay disabled —
-        //      SketchfabConfig.apiKey returns null and the service throws
-        //      MissingApiKey).
-        // TODO V1.1: route requests via the mcp-gateway proxy so end-users
-        // never see the master key in the APK. See SketchfabConfig.kt.
-        def sketchfabApiKey = System.getenv("SKETCHFAB_API_KEY") ?: ""
-        if (sketchfabApiKey.isEmpty()) {
-            def localPropsFile = rootProject.file("local.properties")
-            if (localPropsFile.exists()) {
-                def localProps = new Properties()
-                localPropsFile.withInputStream { localProps.load(it) }
-                sketchfabApiKey = localProps.getProperty("sketchfab.api.key", "")
-            }
-        }
         buildConfigField "String", "SKETCHFAB_API_KEY", "\"${sketchfabApiKey}\""
     }
 
@@ -86,6 +90,57 @@ android {
             def keystoreFile = System.getenv("SCENEVIEW_DEMO_KEYSTORE_FILE")
             if (keystoreFile != null) {
                 signingConfig signingConfigs.release
+            }
+        }
+    }
+
+    // Build-time fail-loud guard for store secrets (#1915).
+    //
+    // An empty SKETCHFAB_API_KEY / ARCORE_API_KEY compiles silently — Gradle is
+    // happy with `""` — and ships a store APK whose Sketchfab carousels are
+    // invisible and whose Streetscape / Geospatial / Cloud Anchor demos are
+    // disabled, with nothing surfacing the cause. That is the exact silent-fail
+    // class that caused #1909 (empty carousels on Play Store for weeks).
+    //
+    // Refuse to assemble a RELEASE variant when either secret is empty. Debug
+    // builds stay permissive — developers without the keys still need to compile.
+    // Forks / PRs from forks (no access to org secrets) opt out by setting
+    // `SV_ALLOW_MISSING_SECRETS=1` in the environment, or pass
+    // `-PSV_ALLOW_MISSING_SECRETS=1` on the Gradle command line.
+    applicationVariants.configureEach { variant ->
+        if (variant.buildType.name != "release") {
+            return
+        }
+        def allowMissing = System.getenv("SV_ALLOW_MISSING_SECRETS") == "1" ||
+                (project.hasProperty("SV_ALLOW_MISSING_SECRETS") &&
+                        project.property("SV_ALLOW_MISSING_SECRETS").toString() == "1")
+        variant.assembleProvider.configure { assembleTask ->
+            assembleTask.doFirst {
+                if (allowMissing) {
+                    logger.warn("⚠️  SV_ALLOW_MISSING_SECRETS=1 — skipping release secret guard (#1915).")
+                    return
+                }
+                def missing = []
+                if (sketchfabApiKey == null || sketchfabApiKey.trim().isEmpty()) {
+                    missing << "SKETCHFAB_API_KEY"
+                }
+                if (arcoreApiKey == null || arcoreApiKey.trim().isEmpty()) {
+                    missing << "ARCORE_API_KEY"
+                }
+                if (!missing.isEmpty()) {
+                    throw new GradleException(
+                            "Release build refusing to ship without store secrets: " +
+                            "${missing.join(', ')}.\n" +
+                            "  An empty key compiles silently and ships a store APK with\n" +
+                            "  invisible Sketchfab carousels / disabled AR Geospatial demos\n" +
+                            "  (the #1909 silent-fail class).\n" +
+                            "  Fix: set the missing secret(s) as environment variables\n" +
+                            "  (CI: GitHub Secrets), or in the repo-root local.properties\n" +
+                            "  (SKETCHFAB_API_KEY -> sketchfab.api.key, ARCORE_API_KEY -> ARCORE_API_KEY).\n" +
+                            "  Forks without org secrets: pass -PSV_ALLOW_MISSING_SECRETS=1\n" +
+                            "  or export SV_ALLOW_MISSING_SECRETS=1 to override.")
+                }
+                logger.lifecycle("✅ Release secret guard (#1915): SKETCHFAB_API_KEY + ARCORE_API_KEY present.")
             }
         }
     }

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A70000010000000000000003 /* Build configuration list for PBXNativeTarget "SceneViewDemo" */;
 			buildPhases = (
+				A60000010000000000000003 /* Validate store secrets */,
 				A60000010000000000000001 /* Sources */,
 				A30000010000000000000001 /* Frameworks */,
 				A60000010000000000000002 /* Resources */,
@@ -525,6 +526,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A60000010000000000000003 /* Validate store secrets */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Validate store secrets";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Fail-loud guard for store secrets (#1915).\n#\n# An empty / unsubstituted SKETCHFAB_API_KEY compiles silently — Xcode is\n# happy with the literal placeholder \"$(SKETCHFAB_API_KEY)\" — and ships a\n# TestFlight / App Store build whose Explore tab Sketchfab carousels are\n# invisible, with nothing surfacing the cause. That is the exact silent-fail\n# class that caused #1909.\n#\n# Refuse to archive a RELEASE configuration when the key is empty or still the\n# unsubstituted placeholder. Debug builds stay permissive — developers without\n# the key still need to compile. Forks without the org secret opt out with\n# SV_ALLOW_MISSING_SECRETS=1.\nset -eu\nif [ \"${CONFIGURATION}\" != \"Release\" ]; then\n  echo \"note: store-secret guard skipped (CONFIGURATION=${CONFIGURATION}, not Release).\"\n  exit 0\nfi\nif [ \"${SV_ALLOW_MISSING_SECRETS:-0}\" = \"1\" ]; then\n  echo \"warning: SV_ALLOW_MISSING_SECRETS=1 — skipping release secret guard (#1915).\"\n  exit 0\nfi\nKEY=\"${SKETCHFAB_API_KEY:-}\"\nif [ -z \"${KEY}\" ] || [ \"${KEY}\" = '$(SKETCHFAB_API_KEY)' ]; then\n  echo \"error: Release archive refusing to ship — SKETCHFAB_API_KEY is empty or unsubstituted.\"\n  echo \"error:   An empty key ships a build with invisible Sketchfab carousels (the #1909 silent-fail class).\"\n  echo \"error:   Fix: pass SKETCHFAB_API_KEY=\\\"\\$SKETCHFAB_API_KEY\\\" to xcodebuild archive (CI: GitHub Secrets).\"\n  echo \"error:   Forks without the org secret: pass SV_ALLOW_MISSING_SECRETS=1 to override.\"\n  exit 1\nfi\necho \"note: release secret guard (#1915): SKETCHFAB_API_KEY present.\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A60000010000000000000001 /* Sources */ = {


### PR DESCRIPTION
## Summary

Adds a **build-time** fail-loud guard to the Android and iOS demo *release* build paths so a release build aborts loudly when `SKETCHFAB_API_KEY` / `ARCORE_API_KEY` is empty — instead of silently shipping a store build with invisible Sketchfab carousels and disabled AR Geospatial demos. This is the silent-fail class that caused #1909.

### Why this is not redundant with #1920

PR #1920 (merged) added the *defensive layer* for #1909: a CI-script guard (`verify-sketchfab-key.sh`) wired into workflows on tag pushes, plus runtime user banners on Android/iOS. But the **build files themselves still accepted an empty key without complaint** — `build.gradle` is happy with `buildConfigField "...", "\"\""` and Xcode is happy with the unsubstituted `$(SKETCHFAB_API_KEY)` placeholder. `verify-sketchfab-key.sh`'s own header explicitly notes: *"What this script does NOT check: Whether the demo's `BuildConfig.SKETCHFAB_API_KEY` field actually ends up populated... That's a Gradle-side concern."* This PR fills exactly that gap — the build aborts at the build step, independent of CI workflow wiring.

## Changes

- **Android** (`samples/android-demo/build.gradle`): hoists the secret resolution to `android`-block scope (no behavior change — same env-var → `local.properties` fallback) and adds an `applicationVariants` guard whose `doFirst` throws a clear `GradleException` on `assembleRelease`/`bundleRelease` when either secret is empty. Debug builds stay permissive.
- **iOS** (`samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj`): adds a `"Validate store secrets"` `PBXShellScriptBuildPhase` that runs before the Compile phase, failing the `Release` archive when `SKETCHFAB_API_KEY` is empty or still the unsubstituted `$(SKETCHFAB_API_KEY)` placeholder. Debug configs skip.
- Both honour `SV_ALLOW_MISSING_SECRETS=1` so forks without org secrets can still produce release builds.
- `CONTRIBUTING.md` documents the secrets and the fork opt-out.
- `changelog.d/1915-sketchfab-build-guard.md` (`<!-- category: Changed -->`).

## Verification

Android (full release build with the host Android SDK):

- [x] `assembleRelease` with both keys unset → **fails** with `Release build refusing to ship without store secrets: SKETCHFAB_API_KEY, ARCORE_API_KEY`
- [x] `assembleRelease` + `SV_ALLOW_MISSING_SECRETS=1` → **succeeds** (guard skipped)
- [x] `assembleDebug` with keys unset → **succeeds** (unaffected — no guard)
- [x] `assembleRelease` with both keys present → guard **passes**, build succeeds
- [x] Guard decision logic asserted across 7 cases (empty / partial / whitespace-only / null / both-present / opt-out)

iOS:

- [x] `plutil -lint` + `xcodebuild -list` parse the modified pbxproj cleanly (new build phase included)
- [x] Guard shell script exercised across Debug (skip), Release+empty (fail), Release+unsubstituted-placeholder (fail), Release+opt-out (skip), Release+valid-key (pass)

Other:

- [x] `bash .claude/scripts/impact-check.sh` — only pre-existing unrelated blocker (README node count 36 vs 38); no new issues
- [x] Demo `build.gradle` configures cleanly (`./gradlew :samples:android-demo:help`)

## Out of scope (per #1915)

- Validating the secret is a *working* token (needs a network call — `verify-sketchfab-key.sh` from #1920 already does the live probe).
- Long-term proxy that obsoletes `BuildConfig.SKETCHFAB_API_KEY` (#1910).

Closes #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)