### PR TITLE
feat(arsceneview): XrFaceNode — Jetpack XR face tracking + demo (#1903)

### DIFF
--- a/arsceneview/build.gradle
+++ b/arsceneview/build.gradle
@@ -119,9 +119,22 @@ dependencies {
     // ARCore
     api libs.arcore
 
+    // ARCore for Jetpack XR — preview SDK for hand / face tracking on Android XR
+    // headsets and glasses. Declared `compileOnly` so the `io.github.sceneview.ar.xr`
+    // subpackage can reference `androidx.xr.arcore.*` types at compile time WITHOUT
+    // bundling them into the runtime classpath of phone-only consumers. Apps that
+    // target Android XR add `implementation(libs.androidx.xr.arcore)` themselves and
+    // gate any XR code path on `XrFeatures.isAvailable(context)`. See
+    // arsceneview/docs/JETPACK-XR-INTEGRATION.md (#1738) — Slices 2 (#1902) / 3 (#1903).
+    compileOnly libs.androidx.xr.arcore
+
     // Unit tests (JVM — no device required)
     testImplementation 'junit:junit:4.13.2'
     testImplementation libs.robolectric
+    // The Xr*Node JVM tests exercise pure-Kotlin mesh/joint math on SceneView's
+    // own `Position` type and never load `androidx.xr.arcore`, so the XR artifact
+    // is intentionally NOT a test dependency — keeping the test classpath identical
+    // to a stock phone build (the negative path that matters for 99% of consumers).
 
     // Instrumented tests (require a connected device or emulator with ARCore-compatible
     // Filament. Filament Engine.create() runs JNI, so these can't be Robolectric.)

--- a/arsceneview/docs/JETPACK-XR-INTEGRATION.md
+++ b/arsceneview/docs/JETPACK-XR-INTEGRATION.md
@@ -141,11 +141,11 @@ opt-in marker until the upstream goes to a stable `1.0.0`.
 
 Each slice is a separate PR.
 
-| Slice | Scope                                                                                     | Issue                                          |
-|-------|-------------------------------------------------------------------------------------------|------------------------------------------------|
-| **1** | This design doc · `androidx.xr.arcore` dep declaration · `XrFeatures` availability check · stubs in `llms.txt` · CHANGELOG fragment | THIS PR — closes #1738                         |
-| **2** | `XrHandNode` + Compose state hook + `samples/android-demo/ARHandTrackingDemo.kt` + JVM tests for joint math · gated on `XrFeatures.isAvailable` | [#1902](https://github.com/sceneview/sceneview/issues/1902) |
-| **3** | `XrFaceNode` (Jetpack XR variant alongside existing `AugmentedFaceNode`) + demo + tests   | [#1903](https://github.com/sceneview/sceneview/issues/1903) |
+| Slice | Status | Scope                                                                                     | Issue                                          |
+|-------|--------|-------------------------------------------------------------------------------------------|------------------------------------------------|
+| **1** | ✅     | This design doc · `androidx.xr.arcore` dep declaration · `XrFeatures` availability check · stubs in `llms.txt` · CHANGELOG fragment | [#1908](https://github.com/sceneview/sceneview/pull/1908) — closed #1738 |
+| **2** | ✅     | `XrHandNode` + `XrHandSkeleton` joint math + `SceneScope.XrHandNode` composable + `samples/android-demo/ARHandTrackingDemo.kt` + JVM tests · gated on `XrFeatures.isAvailable` | [#1902](https://github.com/sceneview/sceneview/issues/1902) |
+| **3** | ✅     | `XrFaceNode` + `XrFaceMesh` mesh/region math + `SceneScope.XrFaceNode` composable + `samples/android-demo/ARXrFaceDemo.kt` + JVM tests · gated on `XrFeatures.isAvailable` | [#1903](https://github.com/sceneview/sceneview/issues/1903) |
 
 Cross-platform parity follow-ups:
 

--- a/arsceneview/src/main/java/io/github/sceneview/ar/xr/XrFaceMesh.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/xr/XrFaceMesh.kt
@@ -1,0 +1,276 @@
+package io.github.sceneview.ar.xr
+
+import io.github.sceneview.math.Position
+import kotlin.math.sqrt
+
+/**
+ * Pure-Kotlin face-mesh geometry and pose math for [XrFaceNode].
+ *
+ * This file deliberately contains **no Android, Filament or `androidx.xr.arcore`
+ * references** — every symbol operates on SceneView's own [Position] (a
+ * `Float3`) and plain primitives. That keeps the mesh-buffer adapter
+ * unit-testable on a stock JVM with no XR runtime on the classpath: the JVM
+ * tests in `XrFaceMeshTest` exercise it directly.
+ *
+ * The node wrapper ([XrFaceNode]) is the only place that touches the upstream
+ * preview `Face` / `FaceState` / `Pose` types — it reads the per-frame vertex,
+ * normal and index buffers reflectively and hands the flat float / int arrays
+ * to the functions here to validate, measure and centre the mesh.
+ *
+ * Preview status: the buffer layout mirrors `androidx.xr.arcore.Face`
+ * (`1.0.0-alpha14`); the upstream is alpha and may change the vertex stride or
+ * the index winding. See
+ * [arsceneview/docs/JETPACK-XR-INTEGRATION.md](https://github.com/sceneview/sceneview/blob/main/arsceneview/docs/JETPACK-XR-INTEGRATION.md).
+ */
+
+/**
+ * Stable identifiers for the named face *anchor regions* SceneView's face
+ * renderer attaches geometry to.
+ *
+ * These mirror the anchor regions the upstream `androidx.xr.arcore.Face` State
+ * exposes alongside the dense mesh — `FaceMeshRegion.NOSE_TIP`,
+ * `FOREHEAD_LEFT`, `FOREHEAD_RIGHT` — plus a [CENTER] entry sourced from the
+ * State's `meshCenterPose`. They are the headset equivalent of the
+ * front-camera regions `com.google.ar.core.AugmentedFace.RegionType` carries
+ * on phones. The dense mesh drives skin overlays; these named regions are the
+ * natural anchors for attaching a discrete model (glasses on the [NOSE_TIP],
+ * a hat above the forehead).
+ *
+ * The [ordinal] of each entry is also its index in the contiguous region-pose
+ * array produced by [XrFaceMesh.regionCount], so callers can use a flat
+ * `Array<Position?>` keyed by `region.ordinal` instead of a map.
+ *
+ * Each entry's [upstreamName] is the matching upstream `FaceMeshRegion`
+ * constant name (or `null` for [CENTER], which is read from `meshCenterPose`
+ * rather than the region-pose map) — [XrFaceNode] uses it to match poses by
+ * name so the mapping survives the alpha SDK renaming a region.
+ *
+ * @property upstreamName Name of the upstream `FaceMeshRegion` constant this
+ *                        region maps to, or `null` when it is sourced from
+ *                        the State's `meshCenterPose` instead.
+ */
+enum class XrFaceRegion(val upstreamName: String?) {
+    /** Centre of the face — read from the State's `meshCenterPose`. */
+    CENTER(null),
+
+    /** Tip of the nose — upstream `FaceMeshRegion.NOSE_TIP`. */
+    NOSE_TIP("NOSE_TIP"),
+
+    /** Left side of the forehead — upstream `FaceMeshRegion.FOREHEAD_LEFT`. */
+    FOREHEAD_LEFT("FOREHEAD_LEFT"),
+
+    /** Right side of the forehead — upstream `FaceMeshRegion.FOREHEAD_RIGHT`. */
+    FOREHEAD_RIGHT("FOREHEAD_RIGHT"),
+}
+
+/**
+ * A face-mesh snapshot decoded from the upstream preview buffers: a flat
+ * vertex array, an optional flat normal array and a triangle index array.
+ *
+ * Holds only primitive arrays and [Position] — no `androidx.xr.arcore` types —
+ * so [XrFaceNode] decodes the alpha SDK buffers into this and every downstream
+ * consumer (geometry upload, the JVM tests) works on a runtime-free value.
+ *
+ * @property vertices Flat XYZ vertex positions: `vertices[3*i .. 3*i+2]` is
+ *                    vertex `i`. `size` is a multiple of [VERTEX_STRIDE].
+ * @property normals  Flat XYZ per-vertex normals with the same layout as
+ *                    [vertices], or `null` when the upstream frame carried no
+ *                    normals (an unlit overlay does not need them).
+ * @property indices  Triangle indices into [vertices] — `size` is a multiple
+ *                    of 3, each run of 3 forming one triangle.
+ */
+data class XrFaceMeshData(
+    val vertices: FloatArray,
+    val normals: FloatArray?,
+    val indices: IntArray,
+) {
+    /** Number of vertices — `vertices.size / `[XrFaceMesh.VERTEX_STRIDE]. */
+    val vertexCount: Int get() = vertices.size / XrFaceMesh.VERTEX_STRIDE
+
+    /** Number of triangles — `indices.size / 3`. */
+    val triangleCount: Int get() = indices.size / XrFaceMesh.INDICES_PER_TRIANGLE
+
+    // Array properties need structural equals/hashCode — the generated ones
+    // compare by reference, which would make two equal meshes unequal.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is XrFaceMeshData) return false
+        if (!vertices.contentEquals(other.vertices)) return false
+        if (normals == null) {
+            if (other.normals != null) return false
+        } else if (other.normals == null || !normals.contentEquals(other.normals)) {
+            return false
+        }
+        return indices.contentEquals(other.indices)
+    }
+
+    override fun hashCode(): Int {
+        var result = vertices.contentHashCode()
+        result = 31 * result + (normals?.contentHashCode() ?: 0)
+        result = 31 * result + indices.contentHashCode()
+        return result
+    }
+}
+
+/**
+ * Pure-logic helpers describing the face mesh: buffer-layout constants, mesh
+ * validation, and the small amount of vector math [XrFaceNode] needs to lay a
+ * face overlay out.
+ *
+ * Stateless `object` — everything here is referentially transparent and
+ * trivially unit-testable.
+ */
+object XrFaceMesh {
+
+    /** Floats per vertex in a flat vertex / normal buffer — X, Y, Z. */
+    const val VERTEX_STRIDE: Int = 3
+
+    /** Index count per triangle. */
+    const val INDICES_PER_TRIANGLE: Int = 3
+
+    /** Number of named anchor regions — `XrFaceRegion.entries.size`. */
+    val regionCount: Int = XrFaceRegion.entries.size
+
+    /**
+     * Validates that a decoded [mesh] has a self-consistent buffer layout —
+     * the gate [XrFaceNode] applies before uploading anything to Filament so a
+     * malformed alpha-SDK frame is dropped rather than crashing the renderer.
+     *
+     * A mesh is valid when:
+     *  - the vertex array length is a multiple of [VERTEX_STRIDE];
+     *  - the normal array, when present, has exactly the same length as the
+     *    vertex array (one normal per vertex);
+     *  - the index array length is a multiple of [INDICES_PER_TRIANGLE];
+     *  - every index is within `0 until vertexCount`.
+     *
+     * An empty mesh (no vertices, no indices) is valid — it simply means the
+     * face is not currently tracked.
+     */
+    fun isValid(mesh: XrFaceMeshData): Boolean {
+        if (mesh.vertices.size % VERTEX_STRIDE != 0) return false
+        val normals = mesh.normals
+        if (normals != null && normals.size != mesh.vertices.size) return false
+        if (mesh.indices.size % INDICES_PER_TRIANGLE != 0) return false
+        val vertexCount = mesh.vertexCount
+        for (index in mesh.indices) {
+            if (index < 0 || index >= vertexCount) return false
+        }
+        return true
+    }
+
+    /**
+     * Reads vertex [index] out of a decoded [mesh] as a [Position].
+     *
+     * Returns `null` when [index] is out of `0 until `[XrFaceMeshData.vertexCount]
+     * so a caller iterating a stale index never produces a phantom vertex.
+     */
+    fun vertexAt(mesh: XrFaceMeshData, index: Int): Position? {
+        if (index < 0 || index >= mesh.vertexCount) return null
+        val base = index * VERTEX_STRIDE
+        return Position(
+            x = mesh.vertices[base],
+            y = mesh.vertices[base + 1],
+            z = mesh.vertices[base + 2],
+        )
+    }
+
+    /**
+     * The axis-aligned centroid of every vertex in [mesh] — the average of all
+     * vertex positions. This is the natural local anchor for a face overlay's
+     * geometry and a cheap proxy for the face centre.
+     *
+     * Returns `null` for an empty mesh (no vertices — face untracked).
+     */
+    fun centroid(mesh: XrFaceMeshData): Position? {
+        val count = mesh.vertexCount
+        if (count == 0) return null
+        var sx = 0f
+        var sy = 0f
+        var sz = 0f
+        for (i in 0 until count) {
+            val base = i * VERTEX_STRIDE
+            sx += mesh.vertices[base]
+            sy += mesh.vertices[base + 1]
+            sz += mesh.vertices[base + 2]
+        }
+        val inv = 1f / count
+        return Position(x = sx * inv, y = sy * inv, z = sz * inv)
+    }
+
+    /**
+     * The bounding-box extent of [mesh] — the per-axis span between the
+     * minimum and maximum vertex coordinates. A fully tracked adult face is
+     * roughly `0.12f..0.20f` meters wide; a near-zero extent means almost
+     * nothing is tracked.
+     *
+     * Returns `Position(0f, 0f, 0f)` for an empty mesh.
+     */
+    fun extent(mesh: XrFaceMeshData): Position {
+        val count = mesh.vertexCount
+        if (count == 0) return Position(0f, 0f, 0f)
+        var minX = Float.POSITIVE_INFINITY
+        var minY = Float.POSITIVE_INFINITY
+        var minZ = Float.POSITIVE_INFINITY
+        var maxX = Float.NEGATIVE_INFINITY
+        var maxY = Float.NEGATIVE_INFINITY
+        var maxZ = Float.NEGATIVE_INFINITY
+        for (i in 0 until count) {
+            val base = i * VERTEX_STRIDE
+            val x = mesh.vertices[base]
+            val y = mesh.vertices[base + 1]
+            val z = mesh.vertices[base + 2]
+            if (x < minX) minX = x
+            if (y < minY) minY = y
+            if (z < minZ) minZ = z
+            if (x > maxX) maxX = x
+            if (y > maxY) maxY = y
+            if (z > maxZ) maxZ = z
+        }
+        return Position(x = maxX - minX, y = maxY - minY, z = maxZ - minZ)
+    }
+
+    /**
+     * Euclidean distance between two region poses, in meters.
+     *
+     * Returns `0f` when either endpoint is `null` (region not currently
+     * tracked) so callers can skip a degenerate measurement.
+     */
+    fun regionDistance(from: Position?, to: Position?): Float {
+        if (from == null || to == null) return 0f
+        val dx = to.x - from.x
+        val dy = to.y - from.y
+        val dz = to.z - from.z
+        return sqrt(dx * dx + dy * dy + dz * dz)
+    }
+
+    /**
+     * Linearly interpolates between two positions by [t].
+     *
+     * Used to smooth a region's rendered position across frames: feeding the
+     * previous rendered position and the freshly tracked position with a small
+     * `t` (e.g. `0.5f`) damps the per-frame jitter the preview tracker emits.
+     *
+     * [t] is clamped to `0f..1f`; `t = 0f` returns [from], `t = 1f` returns [to].
+     * Returns `null` when either endpoint is `null` so an untracked region
+     * never produces a phantom interpolated position.
+     */
+    fun lerp(from: Position?, to: Position?, t: Float): Position? {
+        if (from == null || to == null) return null
+        val k = t.coerceIn(0f, 1f)
+        return Position(
+            x = from.x + (to.x - from.x) * k,
+            y = from.y + (to.y - from.y) * k,
+            z = from.z + (to.z - from.z) * k,
+        )
+    }
+
+    /**
+     * Counts how many of the [regionCount] slots are currently tracked
+     * (non-`null`). `0` means the face is fully untracked; [regionCount] means
+     * every named region has a pose this frame.
+     *
+     * [regions] is indexed by [XrFaceRegion.ordinal].
+     */
+    fun trackedRegionCount(regions: Array<Position?>): Int =
+        regions.count { it != null }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/xr/XrFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/xr/XrFaceNode.kt
@@ -1,0 +1,371 @@
+package io.github.sceneview.ar.xr
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.xr.arcore.Face
+import com.google.android.filament.Engine
+import com.google.android.filament.MaterialInstance
+import io.github.sceneview.NodeScope
+import io.github.sceneview.SceneScope
+import io.github.sceneview.math.Position
+import io.github.sceneview.node.Node
+import java.nio.FloatBuffer
+import java.nio.ShortBuffer
+
+/**
+ * Opt-in marker for the **preview** Jetpack XR layer of SceneView.
+ *
+ * Every public symbol that wraps `androidx.xr.arcore` (`1.0.0-alpha14` at the
+ * time of writing) carries this annotation. The upstream SDK is alpha and
+ * subject to breaking changes; requiring an explicit opt-in makes the preview
+ * status visible at every call site rather than burying it in a doc comment.
+ *
+ * Opt in per call site with `@OptIn(XrPreviewApi::class)`, or module-wide via
+ * the `-opt-in` compiler flag.
+ *
+ * See [arsceneview/docs/JETPACK-XR-INTEGRATION.md](https://github.com/sceneview/sceneview/blob/main/arsceneview/docs/JETPACK-XR-INTEGRATION.md)
+ * — tracking issue [#1738](https://github.com/sceneview/sceneview/issues/1738).
+ */
+@RequiresOptIn(
+    message = "Jetpack XR API is preview (androidx.xr.arcore 1.0.0-alpha14) and may change.",
+    level = RequiresOptIn.Level.WARNING,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class XrPreviewApi
+
+/**
+ * A scene-graph node that mirrors a face tracked by **ARCore for Jetpack XR**
+ * (`androidx.xr.arcore.Face`) on an Android XR headset or glasses.
+ *
+ * `XrFaceNode` is the Jetpack XR sibling of
+ * [io.github.sceneview.ar.node.AugmentedFaceNode] — the same "one node per
+ * tracked face, child nodes following named regions" shape, but driven by the
+ * headset's user-facing cameras instead of the phone's front (selfie) camera.
+ * The two coexist: phones keep using `AugmentedFaceNode`, Android XR devices
+ * get `XrFaceNode`.
+ *
+ * It exposes:
+ *  - one child [Node] per [XrFaceRegion] ([regionNodes]) whose transform
+ *    follows the live region pose — attach a model to [regionNode] of
+ *    [XrFaceRegion.NOSE_TIP] to anchor glasses, of [XrFaceRegion.CENTER] for
+ *    a full-face overlay;
+ *  - the decoded dense mesh ([mesh]) — a runtime-free [XrFaceMeshData] of
+ *    vertex / normal / index buffers — so a consumer can build its own
+ *    [io.github.sceneview.node.MeshNode] skin overlay. `XrFaceNode` does not
+ *    create any Filament mesh resource itself; building geometry stays a
+ *    deliberate, main-thread step the consumer owns.
+ *
+ * **Updating.** This node holds no `StateFlow` subscription of its own — the
+ * consumer drives it. Collect [Face.state] on the main dispatcher and call
+ * [update] with each emitted snapshot, or call the no-arg [update] to pull the
+ * current `Face.state.value`. The composable wrapper [SceneScope.XrFaceNode]
+ * does this for you.
+ *
+ * **Threading.** [update] only writes Filament `Node` transforms (position /
+ * quaternion) and decodes the mesh into plain arrays — it performs no Filament
+ * JNI resource creation — but, like every `Node` mutation, it MUST run on the
+ * main thread. Drive it from a Compose `LaunchedEffect` collecting the flow on
+ * `Dispatchers.Main` (the composable wrapper already does). See `CLAUDE.md`
+ * "Critical threading rule".
+ *
+ * **Availability.** Only meaningful when the Jetpack XR runtime is present —
+ * gate construction on [XrFeatures.isAvailable]. On a phone-only build the
+ * `androidx.xr.arcore` classes are absent and merely referencing [Face] would
+ * throw `NoClassDefFoundError` at class-load time, so never instantiate this
+ * node unless [XrFeatures.isAvailable] returned `true`.
+ *
+ * Preview: this API wraps `androidx.xr.arcore` `1.0.0-alpha14` and may change —
+ * see [XrPreviewApi].
+ *
+ * @property engine             The Filament [Engine] that owns the region child nodes.
+ * @property face               The upstream [Face] trackable this node mirrors.
+ * @property meshMaterialInstance Optional material the consumer would assign to a
+ *                              skin-overlay [io.github.sceneview.node.MeshNode]
+ *                              built from [mesh]. Mirrors the
+ *                              `AugmentedFaceNode` constructor parameter for API
+ *                              familiarity; `XrFaceNode` itself does not upload a
+ *                              mesh, so it merely stores this for the consumer.
+ */
+@XrPreviewApi
+open class XrFaceNode(
+    engine: Engine,
+    val face: Face,
+    val meshMaterialInstance: MaterialInstance? = null,
+    /**
+     * Optional per-frame callback fired after [update] has applied the latest
+     * region poses and decoded the mesh. Receives this node so the consumer can
+     * read [isTracking] / [mesh] / [regionNodes] and react.
+     */
+    private val onUpdated: ((XrFaceNode) -> Unit)? = null,
+) : Node(engine) {
+
+    /**
+     * One child [Node] per [XrFaceRegion], indexed by [XrFaceRegion.ordinal].
+     *
+     * Each region node's local transform is rewritten every [update] to the
+     * latest tracked pose. A region that is not tracked this frame has its node
+     * hidden ([Node.isVisible] = `false`) rather than left at a stale pose.
+     * Attach renderable geometry — or a loaded model — as children of these
+     * nodes.
+     */
+    val regionNodes: List<Node> = List(XrFaceMesh.regionCount) {
+        Node(engine).apply { parent = this@XrFaceNode }
+    }
+
+    /**
+     * Returns the region node for [region] — a convenience over
+     * `regionNodes[region.ordinal]`.
+     */
+    fun regionNode(region: XrFaceRegion): Node = regionNodes[region.ordinal]
+
+    /**
+     * Snapshot of each region's local position from the most recent [update],
+     * indexed by [XrFaceRegion.ordinal]. A `null` slot is a region that was not
+     * tracked. Pass this to [XrFaceMesh.trackedRegionCount] /
+     * [XrFaceMesh.regionDistance] — it is the bridge between the preview XR
+     * poses and the pure-logic face math.
+     */
+    val regionPositions: Array<Position?> = arrayOfNulls(XrFaceMesh.regionCount)
+
+    /**
+     * The dense face mesh decoded from the most recent [update] — a runtime-free
+     * [XrFaceMeshData] of vertex / normal / index buffers — or `null` until the
+     * first tracked frame with mesh data.
+     *
+     * Feed it to [XrFaceMesh.centroid] / [XrFaceMesh.extent] / [XrFaceMesh.isValid],
+     * or upload it to a [io.github.sceneview.node.MeshNode] to draw a skin
+     * overlay (a main-thread step the consumer owns).
+     */
+    var mesh: XrFaceMeshData? = null
+        private set
+
+    /** Whether the face was tracked in the most recent [update]. */
+    var isTracking: Boolean = false
+        private set
+
+    /**
+     * Pulls the current [Face.state] snapshot and applies it — equivalent to
+     * `update(readFaceRegions(face))` plus `mesh = readFaceMesh(face)`.
+     */
+    fun update() {
+        update(readFaceRegions(face), readFaceMesh(face))
+    }
+
+    /**
+     * Applies a pre-extracted set of region poses and an optional decoded mesh.
+     *
+     * [regions] is keyed by [XrFaceRegion]; a missing key is an untracked
+     * region. [meshData] is the decoded dense mesh or `null` when no mesh was
+     * available this frame. Use this overload when the consumer already
+     * collected [Face.state] and converted the poses (e.g. transformed into a
+     * different coordinate space) — it never touches the preview XR types.
+     *
+     * Must run on the main thread (writes `Node` transforms).
+     */
+    fun update(regions: Map<XrFaceRegion, Position>, meshData: XrFaceMeshData?) {
+        var tracked = 0
+        for (region in XrFaceRegion.entries) {
+            val node = regionNodes[region.ordinal]
+            val position = regions[region]
+            if (position != null) {
+                node.position = position
+                node.isVisible = true
+                regionPositions[region.ordinal] = position
+                tracked++
+            } else {
+                node.isVisible = false
+                regionPositions[region.ordinal] = null
+            }
+        }
+        // Only accept a mesh that passes the buffer-layout sanity check — a
+        // malformed alpha-SDK frame is dropped rather than carried forward.
+        mesh = meshData?.takeIf { XrFaceMesh.isValid(it) }
+        isTracking = tracked > 0 || (mesh?.vertexCount ?: 0) > 0
+        onUpdated?.invoke(this)
+    }
+
+    override fun destroy() {
+        // Region child nodes are owned by this node — destroy them before the
+        // parent chain tears down so their entities leave the Filament scene
+        // first (same ordering rationale as AugmentedFaceNode.destroy()).
+        regionNodes.forEach { runCatching { it.destroy() } }
+        super.destroy()
+    }
+}
+
+/**
+ * Reads the live named-region poses of [face] into a [XrFaceRegion]-keyed map.
+ *
+ * Bridges the upstream `androidx.xr.arcore` perception types to SceneView's own
+ * [Position]. The upstream `Face.State` exposes a `meshCenterPose` plus a
+ * `regionPoseMap: Map<FaceMeshRegion, Pose>`; this function matches the center
+ * pose to [XrFaceRegion.CENTER] and each upstream `FaceMeshRegion` to a
+ * SceneView [XrFaceRegion] **by constant name** ([XrFaceRegion.upstreamName])
+ * so the mapping survives the alpha SDK adding or renaming regions — an
+ * unrecognised upstream region is simply skipped.
+ *
+ * Every upstream access is reflective so this function never hard-references an
+ * individual `FaceMeshRegion` constant a future alpha might rename. It still
+ * requires the `androidx.xr.arcore` runtime to be present — only call it behind
+ * [XrFeatures.isAvailable].
+ *
+ * Returns an empty map when the face is not currently tracked or the upstream
+ * state cannot be read.
+ */
+@XrPreviewApi
+fun readFaceRegions(face: Face): Map<XrFaceRegion, Position> = runCatching {
+    // `Face.state` is a StateFlow<Face.State>; `.value` is the current snapshot.
+    val state: Any = face.state.value
+    val result = HashMap<XrFaceRegion, Position>(XrFaceMesh.regionCount)
+
+    // CENTER comes from `meshCenterPose`, not the region map.
+    runCatching {
+        val centerPose = state.javaClass.getMethod("getMeshCenterPose").invoke(state)
+        centerPose?.toPosition()?.let { result[XrFaceRegion.CENTER] = it }
+    }
+
+    // Named regions — `regionPoseMap: Map<FaceMeshRegion, Pose>`.
+    runCatching {
+        @Suppress("UNCHECKED_CAST")
+        val regionMap = state.javaClass.getMethod("getRegionPoseMap").invoke(state)
+            as? Map<Any, Any> ?: return@runCatching
+        val byName = XrFaceRegion.entries
+            .filter { it.upstreamName != null }
+            .associateBy { it.upstreamName }
+        for ((regionType, pose) in regionMap) {
+            // FaceMeshRegion exposes its constant name via toString().
+            val sceneRegion = byName[regionType.toString()]
+            val position = sceneRegion?.let { pose.toPosition() }
+            if (sceneRegion != null && position != null) {
+                result[sceneRegion] = position
+            }
+        }
+    }
+    result
+}.getOrDefault(emptyMap())
+
+/**
+ * Reads the dense face mesh of [face] into a runtime-free [XrFaceMeshData].
+ *
+ * The upstream `Face.State.meshData` is a `Mesh` of NIO buffers — a
+ * `ShortBuffer` of triangle indices, `FloatBuffer`s of vertices and normals.
+ * This copies them into plain Kotlin arrays so every downstream consumer (the
+ * geometry upload, the JVM tests) works on a value with no `androidx.xr.arcore`
+ * dependency.
+ *
+ * Every upstream access is reflective so a rename of the `meshData` property or
+ * the buffer accessors on the alpha SDK degrades to `null` (mesh hidden)
+ * instead of a hard crash. Returns `null` when the face is not tracked or the
+ * upstream mesh cannot be read.
+ */
+@XrPreviewApi
+fun readFaceMesh(face: Face): XrFaceMeshData? = runCatching {
+    val state: Any = face.state.value
+    val meshObj = state.javaClass.getMethod("getMeshData").invoke(state) ?: return null
+
+    val indicesBuffer = meshObj.javaClass.getMethod("getTriangleIndices").invoke(meshObj)
+        as? ShortBuffer ?: return null
+    val verticesBuffer = meshObj.javaClass.getMethod("getVertices").invoke(meshObj)
+        as? FloatBuffer ?: return null
+    val normalsBuffer = meshObj.javaClass.getMethod("getNormals").invoke(meshObj)
+        as? FloatBuffer
+
+    val vertices = verticesBuffer.toFloatArray()
+    val normals = normalsBuffer?.toFloatArray()
+    val indices = indicesBuffer.toIntArray()
+    XrFaceMeshData(vertices = vertices, normals = normals, indices = indices)
+}.getOrNull()
+
+/** Copies a [FloatBuffer]'s remaining contents into a fresh [FloatArray]. */
+private fun FloatBuffer.toFloatArray(): FloatArray {
+    val out = FloatArray(remaining())
+    duplicate().get(out)
+    return out
+}
+
+/** Copies a [ShortBuffer]'s remaining contents into a fresh [IntArray]. */
+private fun ShortBuffer.toIntArray(): IntArray {
+    val dup = duplicate()
+    return IntArray(dup.remaining()) { dup.get().toInt() and 0xFFFF }
+}
+
+/**
+ * Converts an upstream `androidx.xr.runtime.math.Pose` to a SceneView
+ * [Position] by reading its `translation` ( `Vector3` ) reflectively. Returns
+ * `null` if the pose shape is not what this preview integration expects.
+ */
+private fun Any.toPosition(): Position? = runCatching {
+    val translation = javaClass.getMethod("getTranslation").invoke(this)
+    val x = translation.javaClass.getMethod("getX").invoke(translation) as Float
+    val y = translation.javaClass.getMethod("getY").invoke(translation) as Float
+    val z = translation.javaClass.getMethod("getZ").invoke(translation) as Float
+    Position(x = x, y = y, z = z)
+}.getOrNull()
+
+/**
+ * Declarative [XrFaceNode] for use inside a `SceneView { }` / `ARSceneView { }`
+ * content block.
+ *
+ * Mirrors the `SceneScope.SphereNode(...)` etc. composable style: it creates
+ * and remembers the imperative [XrFaceNode], attaches it to the scene for the
+ * lifetime of the composition, and exposes the region child nodes through a
+ * [io.github.sceneview.NodeScope] `content` block so renderable geometry can
+ * be nested under them.
+ *
+ * **Pose refresh.** The composable re-reads the live face pose in a
+ * `SideEffect`, which runs after every successful (re)composition on the main
+ * thread. Consumers that recompose once per XR frame (e.g. by hoisting frame
+ * state from `onSessionUpdated`) get a per-frame face update for free, without
+ * spinning up a separate `StateFlow` collector. Consumers that need an update
+ * cadence decoupled from recomposition can instead collect [Face.state]
+ * themselves and call [XrFaceNode.update] on the imperative node.
+ *
+ * ```kotlin
+ * @OptIn(XrPreviewApi::class)
+ * SceneView {
+ *     if (XrFeatures.isAvailable(context)) {
+ *         XrFaceNode(face = Face.getUserFace(session)) {
+ *             // `this` is a NodeScope rooted at the face node — declare per-region
+ *             // geometry; each region node follows the tracked pose.
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Preview: see [XrPreviewApi].
+ *
+ * @param face                The upstream [Face] trackable to mirror.
+ * @param meshMaterialInstance Optional material for a consumer-built skin overlay.
+ * @param onUpdated           Optional callback fired after each update with the node.
+ * @param apply               Imperative configuration applied once on creation.
+ * @param content             Optional child nodes declared in a `NodeScope` rooted
+ *                            at the face node.
+ */
+@XrPreviewApi
+@Composable
+fun SceneScope.XrFaceNode(
+    face: Face,
+    meshMaterialInstance: MaterialInstance? = null,
+    onUpdated: ((XrFaceNode) -> Unit)? = null,
+    apply: XrFaceNode.() -> Unit = {},
+    content: (@Composable NodeScope.() -> Unit)? = null,
+) {
+    val node = remember(engine, face) {
+        XrFaceNode(
+            engine = engine,
+            face = face,
+            meshMaterialInstance = meshMaterialInstance,
+            onUpdated = onUpdated,
+        ).apply(apply)
+    }
+    // Re-read the live face pose on every recomposition. The consumer triggers a
+    // recomposition per XR frame (e.g. from `onSessionUpdated`), so SideEffect —
+    // which runs after a successful composition on the main thread — is the
+    // right place to push transforms without spinning up a coroutine collector.
+    SideEffect {
+        node.update()
+    }
+    NodeLifecycle(node, content)
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/xr/XrFaceMeshTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/xr/XrFaceMeshTest.kt
@@ -1,0 +1,258 @@
+package io.github.sceneview.ar.xr
+
+import io.github.sceneview.math.Position
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [XrFaceMesh] / [XrFaceMeshData] — the runtime-free
+ * face-mesh layout, validation and pose math behind [XrFaceNode].
+ *
+ * No Robolectric, no Filament, no `androidx.xr.arcore`: this file only touches
+ * SceneView's own [Position] type and plain primitive arrays, which is exactly
+ * the point of keeping the mesh math in its own file. These are the JVM tests
+ * the #1903 acceptance criteria asks for ("JVM unit tests for the face-mesh
+ * adapter — vertex / normal layout, pose conversion").
+ */
+class XrFaceMeshTest {
+
+    private val tolerance = 1e-5f
+
+    /** A small, valid 2-triangle quad mesh used across several tests. */
+    private fun quadMesh(withNormals: Boolean = true): XrFaceMeshData {
+        val vertices = floatArrayOf(
+            0f, 0f, 0f, // 0
+            1f, 0f, 0f, // 1
+            1f, 1f, 0f, // 2
+            0f, 1f, 0f, // 3
+        )
+        val normals = if (withNormals) {
+            floatArrayOf(
+                0f, 0f, 1f,
+                0f, 0f, 1f,
+                0f, 0f, 1f,
+                0f, 0f, 1f,
+            )
+        } else {
+            null
+        }
+        val indices = intArrayOf(0, 1, 2, 0, 2, 3)
+        return XrFaceMeshData(vertices = vertices, normals = normals, indices = indices)
+    }
+
+    @Test
+    fun `regionCount matches the XrFaceRegion enum size`() {
+        assertEquals(XrFaceRegion.entries.size, XrFaceMesh.regionCount)
+    }
+
+    @Test
+    fun `CENTER region has no upstream name, the others do`() {
+        assertNull(XrFaceRegion.CENTER.upstreamName)
+        assertEquals("NOSE_TIP", XrFaceRegion.NOSE_TIP.upstreamName)
+        assertEquals("FOREHEAD_LEFT", XrFaceRegion.FOREHEAD_LEFT.upstreamName)
+        assertEquals("FOREHEAD_RIGHT", XrFaceRegion.FOREHEAD_RIGHT.upstreamName)
+    }
+
+    @Test
+    fun `vertexCount and triangleCount derive from buffer sizes`() {
+        val mesh = quadMesh()
+        assertEquals(4, mesh.vertexCount)
+        assertEquals(2, mesh.triangleCount)
+    }
+
+    @Test
+    fun `vertexCount of an empty mesh is zero`() {
+        val empty = XrFaceMeshData(FloatArray(0), null, IntArray(0))
+        assertEquals(0, empty.vertexCount)
+        assertEquals(0, empty.triangleCount)
+    }
+
+    @Test
+    fun `a well-formed mesh is valid`() {
+        assertTrue(XrFaceMesh.isValid(quadMesh()))
+        assertTrue(XrFaceMesh.isValid(quadMesh(withNormals = false)))
+    }
+
+    @Test
+    fun `an empty mesh is valid`() {
+        assertTrue(XrFaceMesh.isValid(XrFaceMeshData(FloatArray(0), null, IntArray(0))))
+    }
+
+    @Test
+    fun `a vertex buffer not a multiple of the stride is invalid`() {
+        val mesh = XrFaceMeshData(floatArrayOf(0f, 0f, 0f, 1f), null, IntArray(0))
+        assertFalse(XrFaceMesh.isValid(mesh))
+    }
+
+    @Test
+    fun `a normal buffer of a different length than vertices is invalid`() {
+        val mesh = XrFaceMeshData(
+            vertices = floatArrayOf(0f, 0f, 0f),
+            normals = floatArrayOf(0f, 0f, 1f, 0f, 0f, 1f),
+            indices = IntArray(0),
+        )
+        assertFalse(XrFaceMesh.isValid(mesh))
+    }
+
+    @Test
+    fun `an index buffer not a multiple of three is invalid`() {
+        val mesh = XrFaceMeshData(
+            vertices = floatArrayOf(0f, 0f, 0f, 1f, 0f, 0f, 1f, 1f, 0f),
+            normals = null,
+            indices = intArrayOf(0, 1),
+        )
+        assertFalse(XrFaceMesh.isValid(mesh))
+    }
+
+    @Test
+    fun `an out-of-range index is invalid`() {
+        val mesh = XrFaceMeshData(
+            vertices = floatArrayOf(0f, 0f, 0f, 1f, 0f, 0f, 1f, 1f, 0f),
+            normals = null,
+            indices = intArrayOf(0, 1, 9), // 9 >= vertexCount 3
+        )
+        assertFalse(XrFaceMesh.isValid(mesh))
+    }
+
+    @Test
+    fun `a negative index is invalid`() {
+        val mesh = XrFaceMeshData(
+            vertices = floatArrayOf(0f, 0f, 0f, 1f, 0f, 0f, 1f, 1f, 0f),
+            normals = null,
+            indices = intArrayOf(0, 1, -1),
+        )
+        assertFalse(XrFaceMesh.isValid(mesh))
+    }
+
+    @Test
+    fun `vertexAt reads the requested vertex`() {
+        val mesh = quadMesh()
+        val v2 = XrFaceMesh.vertexAt(mesh, 2)
+        assertNotNull(v2)
+        assertEquals(1f, v2!!.x, tolerance)
+        assertEquals(1f, v2.y, tolerance)
+        assertEquals(0f, v2.z, tolerance)
+    }
+
+    @Test
+    fun `vertexAt returns null for an out-of-range index`() {
+        val mesh = quadMesh()
+        assertNull(XrFaceMesh.vertexAt(mesh, -1))
+        assertNull(XrFaceMesh.vertexAt(mesh, 4))
+    }
+
+    @Test
+    fun `centroid is the average of every vertex`() {
+        val mesh = quadMesh()
+        val c = XrFaceMesh.centroid(mesh)
+        assertNotNull(c)
+        assertEquals(0.5f, c!!.x, tolerance)
+        assertEquals(0.5f, c.y, tolerance)
+        assertEquals(0f, c.z, tolerance)
+    }
+
+    @Test
+    fun `centroid of an empty mesh is null`() {
+        assertNull(XrFaceMesh.centroid(XrFaceMeshData(FloatArray(0), null, IntArray(0))))
+    }
+
+    @Test
+    fun `extent is the per-axis bounding box span`() {
+        val mesh = quadMesh()
+        val e = XrFaceMesh.extent(mesh)
+        assertEquals(1f, e.x, tolerance)
+        assertEquals(1f, e.y, tolerance)
+        assertEquals(0f, e.z, tolerance)
+    }
+
+    @Test
+    fun `extent of an empty mesh is zero`() {
+        val e = XrFaceMesh.extent(XrFaceMeshData(FloatArray(0), null, IntArray(0)))
+        assertEquals(0f, e.x, tolerance)
+        assertEquals(0f, e.y, tolerance)
+        assertEquals(0f, e.z, tolerance)
+    }
+
+    @Test
+    fun `regionDistance is the euclidean distance`() {
+        val a = Position(0f, 0f, 0f)
+        val b = Position(3f, 4f, 0f)
+        assertEquals(5f, XrFaceMesh.regionDistance(a, b), tolerance)
+    }
+
+    @Test
+    fun `regionDistance returns zero when an endpoint is untracked`() {
+        val p = Position(1f, 2f, 3f)
+        assertEquals(0f, XrFaceMesh.regionDistance(null, p), tolerance)
+        assertEquals(0f, XrFaceMesh.regionDistance(p, null), tolerance)
+        assertEquals(0f, XrFaceMesh.regionDistance(null, null), tolerance)
+    }
+
+    @Test
+    fun `lerp at zero returns the start position`() {
+        val a = Position(1f, 2f, 3f)
+        val b = Position(9f, 9f, 9f)
+        val r = XrFaceMesh.lerp(a, b, 0f)!!
+        assertEquals(a.x, r.x, tolerance)
+        assertEquals(a.y, r.y, tolerance)
+        assertEquals(a.z, r.z, tolerance)
+    }
+
+    @Test
+    fun `lerp at one returns the end position`() {
+        val a = Position(1f, 2f, 3f)
+        val b = Position(9f, 9f, 9f)
+        val r = XrFaceMesh.lerp(a, b, 1f)!!
+        assertEquals(b.x, r.x, tolerance)
+        assertEquals(b.y, r.y, tolerance)
+        assertEquals(b.z, r.z, tolerance)
+    }
+
+    @Test
+    fun `lerp at half returns the midpoint`() {
+        val a = Position(0f, 0f, 0f)
+        val b = Position(4f, 8f, 12f)
+        val r = XrFaceMesh.lerp(a, b, 0.5f)!!
+        assertEquals(2f, r.x, tolerance)
+        assertEquals(4f, r.y, tolerance)
+        assertEquals(6f, r.z, tolerance)
+    }
+
+    @Test
+    fun `lerp clamps t outside the unit interval`() {
+        val a = Position(0f, 0f, 0f)
+        val b = Position(10f, 0f, 0f)
+        assertEquals(0f, XrFaceMesh.lerp(a, b, -2f)!!.x, tolerance)
+        assertEquals(10f, XrFaceMesh.lerp(a, b, 5f)!!.x, tolerance)
+    }
+
+    @Test
+    fun `lerp returns null when an endpoint is untracked`() {
+        assertNull(XrFaceMesh.lerp(null, Position(1f, 1f, 1f), 0.5f))
+        assertNull(XrFaceMesh.lerp(Position(1f, 1f, 1f), null, 0.5f))
+    }
+
+    @Test
+    fun `trackedRegionCount counts non-null slots`() {
+        val regions = arrayOfNulls<Position>(XrFaceMesh.regionCount)
+        assertEquals(0, XrFaceMesh.trackedRegionCount(regions))
+
+        regions[XrFaceRegion.CENTER.ordinal] = Position(0f, 0f, 0f)
+        regions[XrFaceRegion.NOSE_TIP.ordinal] = Position(0f, 0f, 0.05f)
+        assertEquals(2, XrFaceMesh.trackedRegionCount(regions))
+
+        for (i in regions.indices) regions[i] = Position(0f, 0f, 0f)
+        assertEquals(XrFaceMesh.regionCount, XrFaceMesh.trackedRegionCount(regions))
+    }
+
+    @Test
+    fun `XrFaceMeshData equality is structural across arrays`() {
+        assertEquals(quadMesh(), quadMesh())
+        assertEquals(quadMesh().hashCode(), quadMesh().hashCode())
+        assertFalse(quadMesh() == quadMesh(withNormals = false))
+    }
+}

--- a/changelog.d/1903-xr-face-node.md
+++ b/changelog.d/1903-xr-face-node.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- `XrFaceNode` — Jetpack XR face tracking (`androidx.xr.arcore.Face`) for Android XR headsets, the preview sibling of `AugmentedFaceNode`, plus the runtime-free `XrFaceMesh` adapter and an `ar-xr-face` sample demo (#1903).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -1831,7 +1831,7 @@ SceneView ships an opt-in layer for **ARCore for Jetpack XR** (`androidx.xr.arco
 
 **Status: preview.** Tracking issue [#1738](https://github.com/sceneview/sceneview/issues/1738). The upstream `androidx.xr.arcore` is at `1.0.0-alpha14` and subject to breaking changes. SceneView wraps it as an additive, opt-in surface — phone-only apps pay nothing for it. Integration approach: `arsceneview/docs/JETPACK-XR-INTEGRATION.md`.
 
-**Scope this release (Slice 1):** dependency declared (`libs.versions.toml` → `jetpackXrArCore = "1.0.0-alpha14"`, alias `androidx-xr-arcore`), runtime availability check published, design + slicing recorded. Hand tracking node + demo lands in Slice 2 ([#1902](https://github.com/sceneview/sceneview/issues/1902)), face tracking node in Slice 3 ([#1903](https://github.com/sceneview/sceneview/issues/1903)).
+**Scope this release:** Slice 1 — dependency declared (`libs.versions.toml` → `jetpackXrArCore = "1.0.0-alpha14"`, alias `androidx-xr-arcore`), `XrFeatures` runtime availability check, design + slicing recorded. Slice 2 ([#1902](https://github.com/sceneview/sceneview/issues/1902)) — `XrHandNode` hand-tracking node + `ar-hand-tracking` demo. Slice 3 ([#1903](https://github.com/sceneview/sceneview/issues/1903)) — `XrFaceNode` face-tracking node + `ar-xr-face` demo.
 
 **Opt-in dependency** (consumers add this themselves; `arsceneview/` declares it `compileOnly`):
 
@@ -1852,10 +1852,10 @@ import io.github.sceneview.ar.xr.XrFeatures
 val context = LocalContext.current
 val xrAvailable = remember { XrFeatures.isAvailable(context) }
 
-ARSceneView(modifier = Modifier.fillMaxSize()) {
+SceneView(modifier = Modifier.fillMaxSize()) {
     if (xrAvailable) {
-        // Slice 2 will add: XrHandNode(hand = …) { … }
-        // Slice 3 will add: XrFaceNode(face = …) { … }
+        // Slice 2: XrHandNode(hand = …, handedness = …) { … }
+        // Slice 3: XrFaceNode(face = …) { … }
     } else {
         // Fall back to mobile ARCore: AugmentedFaceNode, AugmentedImageNode, etc.
     }
@@ -1871,7 +1871,70 @@ Classpath presence is the foundation gate; the device-capability check (XR heads
 
 Mobile ARCore tracking (`AugmentedFaceNode`, `AugmentedImageNode`, `AnchorNode`, etc.) keeps working unchanged on phones — the Jetpack XR layer is strictly additive.
 
-**Cross-platform parity:** hand tracking on visionOS is covered by `HandTrackingProvider` in `SceneViewSwift`; web covers WebXR `hand-tracking` under issue #1778. Updates to `docs/docs/cheatsheet-ios.md` mirror this section once Slice 2 lands.
+### XrHandNode — hand tracking (Slice 2)
+
+`XrHandNode` mirrors a hand tracked by ARCore for Jetpack XR (`androidx.xr.arcore.Hand`) as a SceneView scene-graph node — the Jetpack XR sibling of `AugmentedFaceNode`. It exposes one child node per skeleton joint (~26 joints: wrist, palm, and 4–5 joints per finger); attach a `SphereNode` per joint and a `LineNode` per bone to render a hand skeleton, or anchor a model to a single joint.
+
+**Preview API.** Every `XrHandNode` symbol carries `@XrPreviewApi` (a `@RequiresOptIn` marker) because `androidx.xr.arcore` is alpha — opt in with `@OptIn(XrPreviewApi::class)`.
+
+Declarative form (a `@Composable SceneScope` extension — usable inside `SceneView { }` / `ARSceneView { }`):
+
+```kotlin
+import io.github.sceneview.ar.xr.XrFeatures
+import io.github.sceneview.ar.xr.XrHandNode
+import io.github.sceneview.ar.xr.XrHandedness
+import io.github.sceneview.ar.xr.XrPreviewApi
+import androidx.xr.arcore.Hand
+
+@OptIn(XrPreviewApi::class)
+@Composable
+fun HandSkeleton(session: androidx.xr.runtime.Session) {
+    SceneView {
+        XrHandNode(hand = Hand.right(session), handedness = XrHandedness.RIGHT) {
+            // `this` is a NodeScope rooted at the hand node — declare per-joint geometry.
+            SphereNode(radius = 0.008f)
+        }
+    }
+}
+```
+
+**Pure joint math** (`XrHandSkeleton`) is JVM-testable and runtime-free: `XrHandSkeleton.BONES`, `boneLength`, `boneMidpoint`, `lerp`, `totalBoneLength`, `trackedJointCount`. Sample: the `ar-hand-tracking` demo.
+
+### XrFaceNode — face tracking (Slice 3)
+
+`XrFaceNode` mirrors a face tracked by ARCore for Jetpack XR (`androidx.xr.arcore.Face`) as a SceneView scene-graph node — the Jetpack XR sibling of `AugmentedFaceNode`. The headset's user-facing cameras track the face, unlike the phone-only `AugmentedFaceNode` which is restricted to the front (selfie) camera. The two coexist: phones keep using `AugmentedFaceNode`, Android XR devices get `XrFaceNode`.
+
+It exposes one child node per named anchor region (`XrFaceRegion`: `CENTER`, `NOSE_TIP`, `FOREHEAD_LEFT`, `FOREHEAD_RIGHT`) whose transform follows the live pose — anchor glasses to `NOSE_TIP`, a hat above the forehead — plus the decoded dense mesh (`XrFaceMeshData`: vertex / normal / index buffers) so a consumer can upload its own `MeshNode` skin overlay. `XrFaceNode` creates no Filament mesh resource itself; building geometry stays a deliberate, main-thread step the consumer owns.
+
+**Preview API.** Every `XrFaceNode` symbol carries `@XrPreviewApi` (a `@RequiresOptIn` marker) because `androidx.xr.arcore` is alpha — opt in with `@OptIn(XrPreviewApi::class)`.
+
+Declarative form (a `@Composable SceneScope` extension — usable inside `SceneView { }` / `ARSceneView { }`):
+
+```kotlin
+import io.github.sceneview.ar.xr.XrFaceNode
+import io.github.sceneview.ar.xr.XrFeatures
+import io.github.sceneview.ar.xr.XrPreviewApi
+import androidx.xr.arcore.Face
+
+@OptIn(XrPreviewApi::class)
+@Composable
+fun FaceOverlay(session: androidx.xr.runtime.Session) {
+    SceneView {
+        // Mirror the live tracked face; one child node per XrFaceRegion.
+        XrFaceNode(face = Face.getUserFace(session)) {
+            // `this` is a NodeScope rooted at the face node — declare per-region geometry.
+        }
+    }
+}
+```
+
+The composable refreshes the face in a `SideEffect` (per recomposition) — recompose once per XR frame and the face follows for free. For an update cadence decoupled from recomposition, use the imperative node directly: collect `Face.state` on the main dispatcher and call `faceNode.update(...)`.
+
+**Threading:** `XrFaceNode.update()` writes only Filament `Node` transforms and decodes the mesh into plain arrays (no JNI resource creation) but, like every node mutation, MUST run on the main thread.
+
+**Pure mesh math** (`XrFaceMesh`) is JVM-testable and runtime-free: `XrFaceMesh.isValid` (buffer-layout sanity check), `vertexAt`, `centroid`, `extent`, `regionDistance`, `lerp`, `trackedRegionCount`. The `XrFaceRegion` enum, `XrFaceMeshData` and `XrFaceMesh` carry no `androidx.xr.arcore` dependency, so they are safe on a phone-only build. Sample: the `ar-xr-face` demo renders a static reference face mesh on phones (no public Android XR emulator yet) and points the developer at `XrFaceNode` for the live integration.
+
+**Cross-platform parity:** hand tracking on visionOS is covered by `HandTrackingProvider` in `SceneViewSwift`, face mesh by `ARFaceTrackingConfiguration`; web covers WebXR `hand-tracking` under issue #1778. Updates to `docs/docs/cheatsheet-ios.md` mirror this section ([#1904](https://github.com/sceneview/sceneview/issues/1904)).
 
 ---
 
@@ -3388,6 +3451,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `ar-scene-semantics` — Scene Semantics. 12-class outdoor scene labeling — HUD shows top-3 labels in view.
 - `ar-streetscape` — Streetscape Geometry. Geospatial building and terrain meshes.
 - `ar-terrain` — Terrain Anchors. Anchor models on geospatial terrain.
+- `ar-xr-face` — Face Tracking (Jetpack XR). Face mesh on Android XR headsets.
 
 <!-- END GENERATED DEMOS -->
 

--- a/llms.txt
+++ b/llms.txt
@@ -1831,7 +1831,7 @@ SceneView ships an opt-in layer for **ARCore for Jetpack XR** (`androidx.xr.arco
 
 **Status: preview.** Tracking issue [#1738](https://github.com/sceneview/sceneview/issues/1738). The upstream `androidx.xr.arcore` is at `1.0.0-alpha14` and subject to breaking changes. SceneView wraps it as an additive, opt-in surface — phone-only apps pay nothing for it. Integration approach: `arsceneview/docs/JETPACK-XR-INTEGRATION.md`.
 
-**Scope this release (Slice 1):** dependency declared (`libs.versions.toml` → `jetpackXrArCore = "1.0.0-alpha14"`, alias `androidx-xr-arcore`), runtime availability check published, design + slicing recorded. Hand tracking node + demo lands in Slice 2 ([#1902](https://github.com/sceneview/sceneview/issues/1902)), face tracking node in Slice 3 ([#1903](https://github.com/sceneview/sceneview/issues/1903)).
+**Scope this release:** Slice 1 — dependency declared (`libs.versions.toml` → `jetpackXrArCore = "1.0.0-alpha14"`, alias `androidx-xr-arcore`), `XrFeatures` runtime availability check, design + slicing recorded. Slice 2 ([#1902](https://github.com/sceneview/sceneview/issues/1902)) — `XrHandNode` hand-tracking node + `ar-hand-tracking` demo. Slice 3 ([#1903](https://github.com/sceneview/sceneview/issues/1903)) — `XrFaceNode` face-tracking node + `ar-xr-face` demo.
 
 **Opt-in dependency** (consumers add this themselves; `arsceneview/` declares it `compileOnly`):
 
@@ -1852,10 +1852,10 @@ import io.github.sceneview.ar.xr.XrFeatures
 val context = LocalContext.current
 val xrAvailable = remember { XrFeatures.isAvailable(context) }
 
-ARSceneView(modifier = Modifier.fillMaxSize()) {
+SceneView(modifier = Modifier.fillMaxSize()) {
     if (xrAvailable) {
-        // Slice 2 will add: XrHandNode(hand = …) { … }
-        // Slice 3 will add: XrFaceNode(face = …) { … }
+        // Slice 2: XrHandNode(hand = …, handedness = …) { … }
+        // Slice 3: XrFaceNode(face = …) { … }
     } else {
         // Fall back to mobile ARCore: AugmentedFaceNode, AugmentedImageNode, etc.
     }
@@ -1871,7 +1871,70 @@ Classpath presence is the foundation gate; the device-capability check (XR heads
 
 Mobile ARCore tracking (`AugmentedFaceNode`, `AugmentedImageNode`, `AnchorNode`, etc.) keeps working unchanged on phones — the Jetpack XR layer is strictly additive.
 
-**Cross-platform parity:** hand tracking on visionOS is covered by `HandTrackingProvider` in `SceneViewSwift`; web covers WebXR `hand-tracking` under issue #1778. Updates to `docs/docs/cheatsheet-ios.md` mirror this section once Slice 2 lands.
+### XrHandNode — hand tracking (Slice 2)
+
+`XrHandNode` mirrors a hand tracked by ARCore for Jetpack XR (`androidx.xr.arcore.Hand`) as a SceneView scene-graph node — the Jetpack XR sibling of `AugmentedFaceNode`. It exposes one child node per skeleton joint (~26 joints: wrist, palm, and 4–5 joints per finger); attach a `SphereNode` per joint and a `LineNode` per bone to render a hand skeleton, or anchor a model to a single joint.
+
+**Preview API.** Every `XrHandNode` symbol carries `@XrPreviewApi` (a `@RequiresOptIn` marker) because `androidx.xr.arcore` is alpha — opt in with `@OptIn(XrPreviewApi::class)`.
+
+Declarative form (a `@Composable SceneScope` extension — usable inside `SceneView { }` / `ARSceneView { }`):
+
+```kotlin
+import io.github.sceneview.ar.xr.XrFeatures
+import io.github.sceneview.ar.xr.XrHandNode
+import io.github.sceneview.ar.xr.XrHandedness
+import io.github.sceneview.ar.xr.XrPreviewApi
+import androidx.xr.arcore.Hand
+
+@OptIn(XrPreviewApi::class)
+@Composable
+fun HandSkeleton(session: androidx.xr.runtime.Session) {
+    SceneView {
+        XrHandNode(hand = Hand.right(session), handedness = XrHandedness.RIGHT) {
+            // `this` is a NodeScope rooted at the hand node — declare per-joint geometry.
+            SphereNode(radius = 0.008f)
+        }
+    }
+}
+```
+
+**Pure joint math** (`XrHandSkeleton`) is JVM-testable and runtime-free: `XrHandSkeleton.BONES`, `boneLength`, `boneMidpoint`, `lerp`, `totalBoneLength`, `trackedJointCount`. Sample: the `ar-hand-tracking` demo.
+
+### XrFaceNode — face tracking (Slice 3)
+
+`XrFaceNode` mirrors a face tracked by ARCore for Jetpack XR (`androidx.xr.arcore.Face`) as a SceneView scene-graph node — the Jetpack XR sibling of `AugmentedFaceNode`. The headset's user-facing cameras track the face, unlike the phone-only `AugmentedFaceNode` which is restricted to the front (selfie) camera. The two coexist: phones keep using `AugmentedFaceNode`, Android XR devices get `XrFaceNode`.
+
+It exposes one child node per named anchor region (`XrFaceRegion`: `CENTER`, `NOSE_TIP`, `FOREHEAD_LEFT`, `FOREHEAD_RIGHT`) whose transform follows the live pose — anchor glasses to `NOSE_TIP`, a hat above the forehead — plus the decoded dense mesh (`XrFaceMeshData`: vertex / normal / index buffers) so a consumer can upload its own `MeshNode` skin overlay. `XrFaceNode` creates no Filament mesh resource itself; building geometry stays a deliberate, main-thread step the consumer owns.
+
+**Preview API.** Every `XrFaceNode` symbol carries `@XrPreviewApi` (a `@RequiresOptIn` marker) because `androidx.xr.arcore` is alpha — opt in with `@OptIn(XrPreviewApi::class)`.
+
+Declarative form (a `@Composable SceneScope` extension — usable inside `SceneView { }` / `ARSceneView { }`):
+
+```kotlin
+import io.github.sceneview.ar.xr.XrFaceNode
+import io.github.sceneview.ar.xr.XrFeatures
+import io.github.sceneview.ar.xr.XrPreviewApi
+import androidx.xr.arcore.Face
+
+@OptIn(XrPreviewApi::class)
+@Composable
+fun FaceOverlay(session: androidx.xr.runtime.Session) {
+    SceneView {
+        // Mirror the live tracked face; one child node per XrFaceRegion.
+        XrFaceNode(face = Face.getUserFace(session)) {
+            // `this` is a NodeScope rooted at the face node — declare per-region geometry.
+        }
+    }
+}
+```
+
+The composable refreshes the face in a `SideEffect` (per recomposition) — recompose once per XR frame and the face follows for free. For an update cadence decoupled from recomposition, use the imperative node directly: collect `Face.state` on the main dispatcher and call `faceNode.update(...)`.
+
+**Threading:** `XrFaceNode.update()` writes only Filament `Node` transforms and decodes the mesh into plain arrays (no JNI resource creation) but, like every node mutation, MUST run on the main thread.
+
+**Pure mesh math** (`XrFaceMesh`) is JVM-testable and runtime-free: `XrFaceMesh.isValid` (buffer-layout sanity check), `vertexAt`, `centroid`, `extent`, `regionDistance`, `lerp`, `trackedRegionCount`. The `XrFaceRegion` enum, `XrFaceMeshData` and `XrFaceMesh` carry no `androidx.xr.arcore` dependency, so they are safe on a phone-only build. Sample: the `ar-xr-face` demo renders a static reference face mesh on phones (no public Android XR emulator yet) and points the developer at `XrFaceNode` for the live integration.
+
+**Cross-platform parity:** hand tracking on visionOS is covered by `HandTrackingProvider` in `SceneViewSwift`, face mesh by `ARFaceTrackingConfiguration`; web covers WebXR `hand-tracking` under issue #1778. Updates to `docs/docs/cheatsheet-ios.md` mirror this section ([#1904](https://github.com/sceneview/sceneview/issues/1904)).
 
 ---
 
@@ -3388,6 +3451,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `ar-scene-semantics` — Scene Semantics. 12-class outdoor scene labeling — HUD shows top-3 labels in view.
 - `ar-streetscape` — Streetscape Geometry. Geospatial building and terrain meshes.
 - `ar-terrain` — Terrain Anchors. Anchor models on geospatial terrain.
+- `ar-xr-face` — Face Tracking (Jetpack XR). Face mesh on Android XR headsets.
 
 <!-- END GENERATED DEMOS -->
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARXrFaceDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARXrFaceDemo.kt
@@ -1,0 +1,267 @@
+package io.github.sceneview.demo.demos
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.sceneview.SceneView
+import io.github.sceneview.ar.xr.XrFaceMesh
+import io.github.sceneview.ar.xr.XrFaceMeshData
+import io.github.sceneview.ar.xr.XrFaceRegion
+import io.github.sceneview.ar.xr.XrFeatures
+import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.math.Position
+import io.github.sceneview.rememberCameraManipulator
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.sample.rememberMaterialInstance
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Jetpack XR face-tracking demo (Slice 3 — issue #1903).
+ *
+ * On an **Android XR headset / glasses** with the `androidx.xr.arcore` runtime,
+ * a real app would mirror a live tracked face with
+ * `io.github.sceneview.ar.xr.XrFaceNode` — a child node per named region
+ * ([XrFaceRegion]) plus the decoded dense mesh — driven by
+ * `Face.getUserFace(session).state`. The headset's user-facing cameras track
+ * the face, unlike the front (selfie) camera the phone-only `AugmentedFaceNode`
+ * is restricted to.
+ *
+ * **There is no public Android XR emulator** at the time of writing, so this
+ * demo never assumes a live XR session. It uses [XrFeatures.isAvailable] to
+ * decide what to draw:
+ *
+ *  - **XR runtime absent** (the case for every phone in the audit matrix and
+ *    the Play Store build) — a static **reference face mesh** is rendered from
+ *    [referenceFaceMesh] / [referenceRegionPoses], so the demo is visually
+ *    meaningful on a phone and shows exactly what [XrFaceMesh]'s vertex / region
+ *    layout produces. A banner makes clear this is a static preview.
+ *  - **XR runtime present** — the same banner points the developer at
+ *    `XrFaceNode` for the live integration. (Wiring a live `Face` here would
+ *    require the XR artifact on this sample's classpath, which is intentionally
+ *    kept off — `arsceneview` declares it `compileOnly`.)
+ *
+ * Either way the demo cannot crash on a non-XR device, which is the merge bar
+ * for #1903 ("on a non-XR phone the demo shows a notice instead of crashing").
+ *
+ * The geometry exercises the real shipped API: [XrFaceMesh.vertexAt] to read
+ * the dense mesh vertices, [XrFaceMesh.isValid] to gate a malformed mesh, and
+ * [XrFaceRegion] for the named anchor regions.
+ */
+@Composable
+fun ARXrFaceDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+
+    val engine = rememberEngine()
+    val materialLoader = rememberMaterialLoader(engine)
+
+    // True only when a consumer has the Jetpack XR runtime on the classpath.
+    // Always false for this sample app (no `androidx.xr.arcore` dependency) and
+    // for any phone-only build — drives the banner copy below.
+    val xrAvailable = remember { XrFeatures.isAvailable(context) }
+
+    // Mesh-vertex accent (SceneView primary blue) and region accent (purple).
+    val vertexMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Primary)
+    val regionMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Accent)
+
+    val firstFrame = rememberFirstFrameState()
+
+    // Static reference face — the dense mesh plus the named-region anchor poses.
+    val mesh = remember { referenceFaceMesh() }
+    val regionPoses = remember { referenceRegionPoses() }
+
+    DemoScaffold(
+        title = stringResource(R.string.demo_ar_xr_face_title),
+        onBack = onBack,
+        firstFrameRendered = firstFrame.rendered,
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            SceneView(
+                modifier = Modifier.fillMaxSize(),
+                onFrame = firstFrame.onFrame,
+                engine = engine,
+                materialLoader = materialLoader,
+                cameraManipulator = rememberCameraManipulator(
+                    orbitHomePosition = Position(0f, 0f, 0.45f),
+                    targetPosition = Position(0f, 0f, 0f),
+                ),
+            ) {
+                // One small sphere per dense-mesh vertex — drawn only when the
+                // mesh passes the real XrFaceMesh.isValid buffer-layout check.
+                if (XrFaceMesh.isValid(mesh)) {
+                    for (i in 0 until mesh.vertexCount) {
+                        XrFaceMesh.vertexAt(mesh, i)?.let { position ->
+                            SphereNode(
+                                materialInstance = vertexMaterial,
+                                radius = VERTEX_RADIUS,
+                                position = position,
+                            )
+                        }
+                    }
+                }
+                // One larger sphere per named anchor region — where a real app
+                // anchors glasses (NOSE_TIP), a hat (forehead), an overlay (CENTER).
+                XrFaceRegion.entries.forEach { region ->
+                    regionPoses[region.ordinal]?.let { position ->
+                        SphereNode(
+                            materialInstance = regionMaterial,
+                            radius = REGION_RADIUS,
+                            position = position,
+                        )
+                    }
+                }
+            }
+
+            // Always-on banner — honest about the XR-device requirement and
+            // about the face mesh being a static reference, not a live face.
+            Surface(
+                color = Color.Black.copy(alpha = 0.45f),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(16.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = stringResource(
+                            if (xrAvailable) {
+                                R.string.demo_ar_xr_face_xr_available
+                            } else {
+                                R.string.demo_ar_xr_face_xr_required
+                            }
+                        ),
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Text(
+                        text = stringResource(R.string.demo_ar_xr_face_reference_note),
+                        color = Color.White.copy(alpha = 0.85f),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Rendered radius of each dense-mesh vertex sphere, in meters. */
+private const val VERTEX_RADIUS = 0.0035f
+
+/** Rendered radius of each named-region anchor sphere, in meters. */
+private const val REGION_RADIUS = 0.012f
+
+/** Number of horizontal rings in the static reference face mesh. */
+private const val REFERENCE_RINGS = 9
+
+/** Number of vertices per ring in the static reference face mesh. */
+private const val REFERENCE_RING_SEGMENTS = 14
+
+/**
+ * A static, anatomically-plausible reference **face mesh** — a half-ellipsoid
+ * front face shell expressed in meters in a face-local space (origin behind the
+ * nose, +X toward the face's left, +Y up, +Z out of the face).
+ *
+ * Returned as a runtime-free [XrFaceMeshData] — the same value an
+ * [io.github.sceneview.ar.xr.XrFaceNode] decodes from a live `Face` frame — so
+ * the demo's rendering code is a drop-in for both the static preview and a real
+ * headset session, and every [XrFaceMesh] helper applies unchanged.
+ *
+ * These coordinates are illustrative, not a calibrated face model; the demo's
+ * purpose is to show the [XrFaceMesh] vertex layout and named regions, not
+ * biometric accuracy.
+ */
+private fun referenceFaceMesh(): XrFaceMeshData {
+    // Ellipsoid radii — a face is taller than wide, with a shallow depth.
+    val halfWidth = 0.075f
+    val halfHeight = 0.105f
+    val depth = 0.055f
+
+    val vertices = ArrayList<Float>(REFERENCE_RINGS * REFERENCE_RING_SEGMENTS * 3)
+    val normals = ArrayList<Float>(REFERENCE_RINGS * REFERENCE_RING_SEGMENTS * 3)
+    val indices = ArrayList<Int>()
+
+    for (ring in 0 until REFERENCE_RINGS) {
+        // v in [0, 1] — top of the head (0) to the chin (1).
+        val v = ring.toFloat() / (REFERENCE_RINGS - 1)
+        val y = halfHeight - v * (2f * halfHeight)
+        // Ring radius tapers near the top and the chin.
+        val ringScale = sin(v * Math.PI).toFloat().coerceAtLeast(0.18f)
+        for (seg in 0 until REFERENCE_RING_SEGMENTS) {
+            // u sweeps the FRONT half only (-90deg..+90deg) — a face shell.
+            val u = -1f + 2f * seg.toFloat() / (REFERENCE_RING_SEGMENTS - 1)
+            val angle = u * (Math.PI / 2.0)
+            val x = halfWidth * ringScale * sin(angle).toFloat()
+            val z = depth * ringScale * cos(angle).toFloat()
+            vertices.add(x)
+            vertices.add(y)
+            vertices.add(z)
+            // Outward normal of the ellipsoid shell, roughly normalized.
+            val nx = x / halfWidth
+            val ny = y / halfHeight
+            val nz = z / depth
+            val len = sqrt(nx * nx + ny * ny + nz * nz).coerceAtLeast(1e-4f)
+            normals.add(nx / len)
+            normals.add(ny / len)
+            normals.add(nz / len)
+        }
+    }
+
+    // Triangulate adjacent rings into a quad strip.
+    for (ring in 0 until REFERENCE_RINGS - 1) {
+        for (seg in 0 until REFERENCE_RING_SEGMENTS - 1) {
+            val a = ring * REFERENCE_RING_SEGMENTS + seg
+            val b = a + 1
+            val c = a + REFERENCE_RING_SEGMENTS
+            val d = c + 1
+            indices.add(a); indices.add(c); indices.add(b)
+            indices.add(b); indices.add(c); indices.add(d)
+        }
+    }
+
+    return XrFaceMeshData(
+        vertices = vertices.toFloatArray(),
+        normals = normals.toFloatArray(),
+        indices = indices.toIntArray(),
+    )
+}
+
+/**
+ * The static reference poses of the named [XrFaceRegion] anchors, indexed by
+ * [XrFaceRegion.ordinal] — the array shape an [io.github.sceneview.ar.xr.XrFaceNode]
+ * exposes through `regionPositions`. No region is `null` here (the reference
+ * face is fully "tracked").
+ */
+private fun referenceRegionPoses(): Array<Position?> {
+    val p = arrayOfNulls<Position>(XrFaceMesh.regionCount)
+    fun set(region: XrFaceRegion, x: Float, y: Float, z: Float) {
+        p[region.ordinal] = Position(x, y, z)
+    }
+    set(XrFaceRegion.CENTER, 0.000f, 0.000f, 0.055f)
+    set(XrFaceRegion.NOSE_TIP, 0.000f, -0.010f, 0.075f)
+    set(XrFaceRegion.FOREHEAD_LEFT, 0.040f, 0.075f, 0.050f)
+    set(XrFaceRegion.FOREHEAD_RIGHT, -0.040f, 0.075f, 0.050f)
+    return p
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArXrFaceFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArXrFaceFragment.kt
@@ -1,0 +1,31 @@
+package io.github.sceneview.demo.fragments
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FaceRetouchingNatural
+import androidx.compose.runtime.Composable
+import io.github.sceneview.demo.DemoCategory
+import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.DemoStatus
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.ARXrFaceDemo
+
+/** Append-only fragment for the `ar-xr-face` demo. See [DemoFragment]. */
+object ArXrFaceFragment : DemoFragment {
+    override val entry: DemoEntry = DemoEntry(
+        id = "ar-xr-face",
+        titleRes = R.string.demo_ar_xr_face_title,
+        subtitleRes = R.string.demo_ar_xr_face_subtitle,
+        category = DemoCategory.AUGMENTED_REALITY,
+        icon = Icons.Filled.FaceRetouchingNatural,
+        // Live face tracking needs an Android XR headset — none in the audit
+        // matrix and no public emulator yet (#1903). The demo renders a static
+        // reference face mesh on phones, so it is honest "Coming Soon" rather
+        // than a regression.
+        status = DemoStatus.ComingSoon,
+    )
+
+    @Composable
+    override fun Screen(onBack: () -> Unit) {
+        ARXrFaceDemo(onBack)
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_xr_face.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_xr_face.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Strings for the `ar-xr-face` demo (registered by
+     `ArXrFaceFragment.kt`). Android's resource merger
+     fans every `res/values/*.xml` file in, so `R.string.demo_ar_xr_face_title` etc.
+     remains globally resolvable. Adding a new demo never needs to touch
+     this file or `strings.xml` — see #1870. -->
+<resources>
+    <string name="demo_ar_xr_face_title">Face Tracking (Jetpack XR)</string>
+    <string name="demo_ar_xr_face_subtitle">Face mesh on Android XR headsets</string>
+    <string name="demo_ar_xr_face_xr_required">Jetpack XR headset required for live face tracking</string>
+    <string name="demo_ar_xr_face_xr_available">Jetpack XR runtime detected — use XrFaceNode for live tracking</string>
+    <string name="demo_ar_xr_face_reference_note">Showing a static reference face mesh. On an Android XR headset, XrFaceNode mirrors a real tracked face.</string>
+</resources>


### PR DESCRIPTION
## Summary

Slice 3 of the Jetpack XR integration (umbrella #1738), the sibling of Slice 2 (`XrHandNode`, #1902 / PR #1977). The existing `AugmentedFaceNode` wraps **mobile ARCore** front-camera face tracking; this slice adds the Jetpack XR variant — `androidx.xr.arcore.Face` — for Android XR headsets, which use the headset's user-facing cameras. The two coexist: phones keep `AugmentedFaceNode`, XR headsets get `XrFaceNode`.

- **`XrFaceNode`** — preview node mirroring an `androidx.xr.arcore.Face`, the Jetpack XR sibling of `AugmentedFaceNode`. Exposes one child `Node` per named `XrFaceRegion` (`CENTER`, `NOSE_TIP`, `FOREHEAD_LEFT`, `FOREHEAD_RIGHT`) whose transform follows the live pose, plus the decoded dense mesh (`XrFaceMeshData`) so a consumer can build its own `MeshNode` skin overlay. Imperative `open class Node` subclass + a `SceneScope.XrFaceNode` `@Composable` with the `apply` + `content: NodeScope` style — mirrors `SceneScope.XrHandNode`.
- **`XrFaceMesh` / `XrFaceMeshData`** — runtime-free face-mesh layout, validation (`isValid` buffer-layout sanity check) and pose math (`vertexAt`, `centroid`, `extent`, `regionDistance`, `lerp`, `trackedRegionCount`). Holds **zero `androidx.xr.arcore` references** so it is JVM-testable and safe on a phone-only build. Covered by **26 JVM unit tests**.
- **`@XrPreviewApi`** marker reused from `XrHandNode` (Slice 2) — `androidx.xr.arcore` is `1.0.0-alpha14`. The upstream pose + mesh extraction (`readFaceRegions` / `readFaceMesh`) uses reflection so an alpha rename degrades to "face hidden" rather than a crash.
- **`ar-xr-face` demo** — append-only fragment (#1797), gated on `XrFeatures.isAvailable`. There is no public Android XR emulator, so the demo renders a **static reference face mesh** on non-XR phones (visually meaningful, never crashes) and points developers at `XrFaceNode` for the live headset integration.
- `llms.txt` "Jetpack XR Extensions" section documents `XrFaceNode`; `JETPACK-XR-INTEGRATION.md` slice table flips Slice 3 to done.

## Self-review — 5 angles

- **Correctness.** `readFaceRegions` / `readFaceMesh` are fully `runCatching`-wrapped, returning empty map / `null` on any shape mismatch. The reflective accessors match the real `androidx.xr.arcore.Face$State` API (`getMeshCenterPose`, `getRegionPoseMap`, `getMeshData`; `Mesh.getVertices/getNormals/getTriangleIndices`), verified by inspecting the alpha14 `.aar`. `update()` gates the mesh on `XrFaceMesh.isValid`. `XrFaceMesh` math verified by 26 JVM tests.
- **Threading.** `XrFaceNode.update()` writes only Filament `Node` transforms and decodes buffers into plain arrays — no Filament JNI resource creation; the composable refreshes in `SideEffect` (main thread, post-composition). KDoc states the main-thread requirement.
- **API consistency.** `XrFaceNode` mirrors `AugmentedFaceNode` (`face`, `meshMaterialInstance`, `onUpdated`, region child nodes) and `XrHandNode` (`destroy()` ordering, `@XrPreviewApi`, `SceneScope` composable). No edits to shared `SceneScope.kt` / `DemoRegistry.kt`.
- **Minimality.** One merged `compileOnly` dep line, 2 library files, 1 test, 1 demo + fragment + strings. No new node types beyond the tracking node.
- **Cross-platform parity.** Android-only; `llms.txt` notes visionOS `ARFaceTrackingConfiguration`, WebXR (#1778) and the iOS cheatsheet follow-up (#1904). No Apple / Web / Flutter / RN files touched.

## Verification

- `./gradlew :arsceneview:compileReleaseKotlin :arsceneview:testDebugUnitTest :samples:android-demo:compileDebugKotlin` — green (`XrFaceMeshTest` 26/26, `XrHandSkeletonTest` 18/18, `XrFeaturesTest` 1/1).
- `./gradlew :arsceneview:detekt :sceneview:detekt :sceneview-core:detekt` — green (no baseline addition needed).
- `bash .claude/scripts/impact-check.sh` — only the pre-existing "README.md node count" blocker remains (tracked as #1971, unchanged by this PR — README untouched).

## Visual QA

**Visual QA blocked — needs an Android XR device or emulator.** No public Android XR emulator exists at the time of writing. The non-XR fallback path (static reference face mesh on phones) builds and is exercised by the Android emulator demo suite. Live face tracking on an Android XR headset needs a follow-up on-device QA pass.

Closes #1903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)