### PR TITLE
fix(ar): depth occlusion now occludes — draw camera quad first to prime z-buffer

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
@@ -232,8 +232,44 @@ open class ARCameraStream(
                         standardMaterial.defaultInstance
                     }
                 )
+                applyCameraStreamPriority(value)
             }
         }
+
+    /**
+     * Coarse-level draw ordering for the camera-stream renderable (issue #1617).
+     *
+     * The two camera materials require **opposite** draw orders:
+     *
+     *  - **Flat** (`camera_stream_flat.mat`): an opaque background that does NOT
+     *    write `gl_FragDepth`. Drawing it **last** ([CAMERA_PRIORITY_BACKGROUND])
+     *    lets the early-Z reject every texel already covered by virtual geometry,
+     *    so the camera feed only fills the uncovered pixels — minimal overdraw.
+     *
+     *  - **Depth occlusion** (`camera_stream_depth.mat`): writes the real-world
+     *    per-pixel depth into the z-buffer via `gl_FragDepth`. For virtual
+     *    geometry to be *occluded* by real surfaces, that real-world depth MUST
+     *    already be in the buffer when the virtual objects are depth-tested —
+     *    i.e. the camera quad has to draw **first**
+     *    ([CAMERA_PRIORITY_DEPTH_PRIME]). Drawing it last (the old fixed
+     *    `priority(7)`) wrote the real-world depth *after* every virtual object
+     *    had already passed its depth test against an empty buffer, so nothing
+     *    was ever occluded — the user-visible symptom in #1617.
+     *
+     * Filament's `RenderableManager` priority runs 0 (drawn first) … 7 (drawn
+     * last); this is a JNI call so it must run on the main thread, which is
+     * guaranteed because [isDepthOcclusionEnabled] is only ever set from the
+     * composable / main-thread setup path.
+     */
+    private fun applyCameraStreamPriority(depthOcclusionEnabled: Boolean) {
+        setPriority(
+            if (depthOcclusionEnabled) {
+                CAMERA_PRIORITY_DEPTH_PRIME
+            } else {
+                CAMERA_PRIORITY_BACKGROUND
+            }
+        )
+    }
 
     private val vertexBuffer: VertexBuffer =
         VertexBuffer.Builder().vertexCount(VERTEX_COUNT).bufferCount(2).attribute(
@@ -266,9 +302,13 @@ open class ARCameraStream(
         RenderableManager.Builder(1)
             .castShadows(false)
             .receiveShadows(false)
-            // Always draw the camera feed last to avoid overdraw
             .culling(false)
-            .priority(7)
+            // Initial priority matches the flat (non-depth) material — drawn
+            // last to minimise overdraw. `isDepthOcclusionEnabled`'s setter
+            // re-prioritises to `CAMERA_PRIORITY_DEPTH_PRIME` when occlusion is
+            // turned on so the depth material draws first and primes the
+            // z-buffer (issue #1617).
+            .priority(CAMERA_PRIORITY_BACKGROUND)
             .geometry(0,
                 RenderableManager.PrimitiveType.TRIANGLES,
                 vertexBuffer,
@@ -411,6 +451,25 @@ open class ARCameraStream(
     }
 
     companion object {
+        /**
+         * Camera-stream draw priority while depth occlusion is OFF (issue #1617).
+         *
+         * Filament priority 7 = drawn **last**. The flat camera material is an
+         * opaque background, so drawing it last lets early-Z skip every texel
+         * already covered by virtual geometry — minimal overdraw.
+         */
+        const val CAMERA_PRIORITY_BACKGROUND = 7
+
+        /**
+         * Camera-stream draw priority while depth occlusion is ON (issue #1617).
+         *
+         * Filament priority 0 = drawn **first**. The depth camera material writes
+         * the real-world per-pixel depth via `gl_FragDepth`; it must run before
+         * any virtual geometry so those objects are depth-tested against the
+         * real world and correctly occluded.
+         */
+        const val CAMERA_PRIORITY_DEPTH_PRIME = 0
+
         private const val VERTEX_COUNT = 3
         private const val POSITION_BUFFER_INDEX = 0
         private val CAMERA_VERTICES = floatArrayOf(

--- a/arsceneview/src/test/java/io/github/sceneview/ar/camera/ARCameraStreamPriorityTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/camera/ARCameraStreamPriorityTest.kt
@@ -1,0 +1,82 @@
+package io.github.sceneview.ar.camera
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM sentinel for the camera-stream draw-priority contract that makes
+ * depth occlusion actually occlude (#1617).
+ *
+ * The bug: [ARCameraStream] always built its renderable with Filament
+ * `priority(7)` (drawn **last**). That is correct for the flat camera
+ * background — an opaque quad drawn last is rejected by early-Z wherever
+ * virtual geometry already drew, minimising overdraw.
+ *
+ * It is **wrong** for the depth-occlusion material: `camera_stream_depth.mat`
+ * writes the real-world per-pixel depth via `gl_FragDepth`. For virtual
+ * geometry to be hidden behind real surfaces, that real-world depth has to be
+ * in the z-buffer *before* the virtual objects are depth-tested — i.e. the
+ * camera quad must draw **first**. Drawing it last wrote the real-world depth
+ * after every virtual object had already passed its depth test against an
+ * empty buffer, so nothing was ever occluded.
+ *
+ * The real `RenderableManager.setPriority` is a Filament JNI call needing a
+ * native engine, which a pure-JVM unit test can't load. What we pin here is
+ * the *priority-selection logic* — the same `depthEnabled ? PRIME : BACKGROUND`
+ * decision the setter applies.
+ */
+class ARCameraStreamPriorityTest {
+
+    /** Mirror of `ARCameraStream.applyCameraStreamPriority`'s selection. */
+    private fun priorityFor(depthOcclusionEnabled: Boolean): Int =
+        if (depthOcclusionEnabled) {
+            ARCameraStream.CAMERA_PRIORITY_DEPTH_PRIME
+        } else {
+            ARCameraStream.CAMERA_PRIORITY_BACKGROUND
+        }
+
+    @Test
+    fun `priority constants stay inside Filament's valid 0-7 range`() {
+        assertTrue(
+            "background priority must be a valid Filament priority",
+            ARCameraStream.CAMERA_PRIORITY_BACKGROUND in 0..7
+        )
+        assertTrue(
+            "depth-prime priority must be a valid Filament priority",
+            ARCameraStream.CAMERA_PRIORITY_DEPTH_PRIME in 0..7
+        )
+    }
+
+    @Test
+    fun `depth occlusion ON draws the camera quad before virtual geometry`() {
+        // Filament priority 0 = drawn first. The depth material primes the
+        // z-buffer with real-world depth, so it MUST precede virtual geometry.
+        assertEquals(
+            "depth-on must use the lowest priority so it draws first",
+            0,
+            priorityFor(depthOcclusionEnabled = true)
+        )
+    }
+
+    @Test
+    fun `depth occlusion OFF draws the camera quad last to minimise overdraw`() {
+        // Filament priority 7 = drawn last. The flat opaque background is
+        // early-Z rejected wherever virtual geometry already drew.
+        assertEquals(
+            "depth-off must use the highest priority so it draws last",
+            7,
+            priorityFor(depthOcclusionEnabled = false)
+        )
+    }
+
+    @Test
+    fun `depth-prime priority is strictly earlier than the background priority`() {
+        // The whole fix hinges on this ordering: the depth camera quad has to
+        // render strictly before the flat-background ordering would have it.
+        assertTrue(
+            "depth-prime must sort before background in Filament draw order",
+            ARCameraStream.CAMERA_PRIORITY_DEPTH_PRIME < ARCameraStream.CAMERA_PRIORITY_BACKGROUND
+        )
+    }
+}

--- a/changelog.d/1617-depth-occlusion-fix.md
+++ b/changelog.d/1617-depth-occlusion-fix.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Depth occlusion now actually occludes (#1617): `ARCameraStream` draws the depth-aware camera quad **first** (Filament priority 0) when occlusion is enabled so the real-world depth written via `gl_FragDepth` primes the z-buffer before virtual geometry is depth-tested — previously the quad was always drawn last (priority 7), writing real-world depth too late to ever hide a virtual model behind real furniture.


### PR DESCRIPTION
## Summary

Fixes #1617 — the **Depth Occlusion** demo showed `DEPTH ON` but virtual models were never hidden behind real-world furniture.

## Root cause

`ARCameraStream` always builds its full-screen camera renderable with Filament `priority(7)` — **drawn last**.

- For the **flat** camera material that's correct: an opaque background quad drawn last is early-Z rejected wherever virtual geometry already drew → minimal overdraw.
- For the **depth-occlusion** material it's wrong. `camera_stream_depth.mat` writes the real-world per-pixel depth into the z-buffer via `gl_FragDepth`. For a virtual object to be *occluded* by a real surface, that real-world depth must already be in the buffer when the virtual object is depth-tested. Drawing the camera quad **last** wrote the real-world depth *after* every virtual object had already passed its depth test against an empty buffer — so nothing was ever occluded. The demo wiring (`isDepthOcclusionEnabled`, `config.depthMode = AUTOMATIC`, the `key(depthOn)` remount) was all correct; the failure was purely the library draw order.

## Fix

`isDepthOcclusionEnabled`'s setter now also re-prioritises the camera-stream renderable:

- **Depth ON** → `CAMERA_PRIORITY_DEPTH_PRIME` (0, drawn first) so the depth material primes the z-buffer with real-world depth before any virtual geometry.
- **Depth OFF** → `CAMERA_PRIORITY_BACKGROUND` (7, drawn last) — keeps the flat-background overdraw optimisation unchanged.

`RenderableManager.setPriority` is a Filament JNI call; it runs on the main thread because `isDepthOcclusionEnabled` is only set from the composable / main-thread setup path.

## Testing

- `:arsceneview:compileReleaseKotlin` + `:samples:android-demo:compileDebugKotlin` — pass
- `:arsceneview:testDebugUnitTest` — pass (new `ARCameraStreamPriorityTest` pins the priority-selection contract)
- `:arsceneview:detekt` — pass
- The fix is a render-order change; full visual confirmation needs a **depth-capable device** (e.g. Pixel 9). Device QA is still advised to confirm the placed model loses pixels behind a real surface.

## Test plan

- [ ] On a depth-capable device, place a model on a plane, then move a real object (table/hand) in front of it with `DEPTH ON` — the model should be occluded.
- [ ] Toggle `DEPTH OFF` — the model draws on top again (no occlusion), no regression in the flat camera background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)