### PR TITLE
feat(arsceneview): on-device runtime AugmentedImageDatabase

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/CameraImageBitmap.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/CameraImageBitmap.kt
@@ -1,0 +1,164 @@
+package io.github.sceneview.ar.arcore
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageFormat
+import android.graphics.Matrix
+import android.graphics.Rect
+import android.graphics.YuvImage
+import android.media.Image
+import com.google.ar.core.Frame
+import java.io.ByteArrayOutputStream
+
+/**
+ * Decodes a `YUV_420_888` [Image] (typically obtained from [cameraImage]) into an upright,
+ * `ARGB_8888` [Bitmap] suitable for `AugmentedImageDatabase.addImage` (#1553).
+ *
+ * ARCore's CPU camera image is always `YUV_420_888`, never `ARGB_8888`, so a captured camera
+ * frame cannot be handed to the augmented-image database directly — `addImage` requires an
+ * `ARGB_8888` bitmap. This extension performs the conversion CPU-side: it packs the three
+ * YUV planes into the interleaved `NV21` layout, runs Android's [YuvImage] JPEG encoder, then
+ * decodes the JPEG back into an `ARGB_8888` bitmap.
+ *
+ * The image is rotated by [rotationDegrees] so the result is upright regardless of device
+ * orientation — pass the value from `frame.imageRotationDegrees()` (or `0` if the camera image
+ * is already upright). `0`, `90`, `180` and `270` are the only meaningful values.
+ *
+ * This call performs non-trivial work (JPEG round-trip + a pixel-format conversion) and **must
+ * be run off the main thread** — it is intended to be paired with the background image
+ * processing that [RuntimeAugmentedImageDatabase.addImage] already requires.
+ *
+ * The passed [Image] is **not** closed by this method — the caller still owns it (close it via
+ * `use { }` exactly as [cameraImage]'s contract requires).
+ *
+ * @param rotationDegrees Clockwise rotation applied to make the result upright. Must be one of
+ *   `0`, `90`, `180`, `270`; any other value is treated as `0`.
+ * @param jpegQuality JPEG quality (1..100) used for the intermediate encode. Augmented-image
+ *   feature extraction is robust to mild compression, so the default `90` keeps the round-trip
+ *   fast without hurting tracking quality.
+ * @return an upright `ARGB_8888` bitmap, or `null` if the image is not `YUV_420_888`.
+ */
+fun Image.toArgbBitmap(rotationDegrees: Int = 0, jpegQuality: Int = DEFAULT_JPEG_QUALITY): Bitmap? {
+    if (format != ImageFormat.YUV_420_888) return null
+
+    val nv21 = yuv420ToNv21(this)
+    val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
+    val jpegStream = ByteArrayOutputStream()
+    yuvImage.compressToJpeg(Rect(0, 0, width, height), jpegQuality.coerceIn(1, 100), jpegStream)
+    val jpegBytes = jpegStream.toByteArray()
+
+    val decoded = BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.size) ?: return null
+    // ARCore's augmented-image database requires ARGB_8888 — BitmapFactory may hand back an
+    // RGB_565 bitmap on memory-constrained devices, so normalise unconditionally.
+    val argb = if (decoded.config == Bitmap.Config.ARGB_8888) {
+        decoded
+    } else {
+        decoded.copy(Bitmap.Config.ARGB_8888, false).also { decoded.recycle() }
+    }
+
+    val normalized = normalizeRotationDegrees(rotationDegrees)
+    if (normalized == 0) return argb
+
+    val matrix = Matrix().apply { postRotate(normalized.toFloat()) }
+    val rotated = Bitmap.createBitmap(argb, 0, 0, argb.width, argb.height, matrix, false)
+    if (rotated != argb) argb.recycle()
+    return rotated
+}
+
+/**
+ * Captures the current AR camera frame as an upright `ARGB_8888` [Bitmap] — the on-device
+ * "take a photo" primitive for the runtime augmented-image workflow (#1553).
+ *
+ * Combines [cameraImage] (CPU image acquisition) with [Image.toArgbBitmap] (YUV → ARGB
+ * conversion) in one call, and always closes the acquired native [Image] so the caller cannot
+ * leak it. Returns `null` when the camera image is not yet available (first frames after
+ * resume) or when the format is unexpectedly not `YUV_420_888`.
+ *
+ * Like [Image.toArgbBitmap] this performs a JPEG round-trip and **must be run off the main
+ * thread**. The returned bitmap is owned by the caller and should be `recycle()`d when no
+ * longer needed.
+ *
+ * ```kotlin
+ * onSessionUpdated = { _, frame ->
+ *     if (shouldCapture) {
+ *         val photo = withContext(Dispatchers.Default) { frame.captureCameraBitmap() }
+ *         // photo is ready for AugmentedImageDatabase.addImage(name, photo)
+ *     }
+ * }
+ * ```
+ *
+ * @param jpegQuality Forwarded to [Image.toArgbBitmap].
+ * @see RuntimeAugmentedImageDatabase
+ */
+fun Frame.captureCameraBitmap(jpegQuality: Int = DEFAULT_JPEG_QUALITY): Bitmap? =
+    cameraImage()?.use { it.toArgbBitmap(rotationDegrees = 0, jpegQuality = jpegQuality) }
+
+/** Default JPEG quality for the intermediate YUV → ARGB encode in [Image.toArgbBitmap]. */
+const val DEFAULT_JPEG_QUALITY: Int = 90
+
+/**
+ * Snaps an arbitrary clockwise rotation to the nearest valid quadrant (`0`, `90`, `180`,
+ * `270`). Negative inputs and inputs ≥ 360 are normalised into `[0, 360)` first.
+ *
+ * Extracted as `internal` pure logic so the rotation contract can be unit-tested without an
+ * Android [Image] / [Bitmap] (#1553).
+ */
+internal fun normalizeRotationDegrees(rotationDegrees: Int): Int {
+    val wrapped = ((rotationDegrees % 360) + 360) % 360
+    return when (wrapped) {
+        in 45 until 135 -> 90
+        in 135 until 225 -> 180
+        in 225 until 315 -> 270
+        else -> 0
+    }
+}
+
+/**
+ * Packs a `YUV_420_888` [Image]'s three planes into a single interleaved `NV21` byte array
+ * (`Y` plane followed by interleaved `V`/`U`), the layout [YuvImage] requires.
+ *
+ * Handles arbitrary `rowStride` / `pixelStride` — the chroma planes of a `YUV_420_888` image
+ * are frequently sub-sampled with a pixel stride of 2, so a naive flat copy corrupts colour.
+ */
+private fun yuv420ToNv21(image: Image): ByteArray {
+    val width = image.width
+    val height = image.height
+    val ySize = width * height
+    val nv21 = ByteArray(ySize + ySize / 2)
+
+    val yPlane = image.planes[0]
+    val uPlane = image.planes[1]
+    val vPlane = image.planes[2]
+
+    // Y plane — copy row by row to honour rowStride padding.
+    val yBuffer = yPlane.buffer
+    val yRowStride = yPlane.rowStride
+    var pos = 0
+    if (yRowStride == width) {
+        yBuffer.get(nv21, 0, ySize)
+        pos = ySize
+    } else {
+        for (row in 0 until height) {
+            yBuffer.position(row * yRowStride)
+            yBuffer.get(nv21, pos, width)
+            pos += width
+        }
+    }
+
+    // Interleaved V/U for NV21. Chroma planes are half-resolution in both dimensions.
+    val uBuffer = uPlane.buffer
+    val vBuffer = vPlane.buffer
+    val uvRowStride = uPlane.rowStride
+    val uvPixelStride = uPlane.pixelStride
+    val chromaHeight = height / 2
+    val chromaWidth = width / 2
+    for (row in 0 until chromaHeight) {
+        val rowStart = row * uvRowStride
+        for (col in 0 until chromaWidth) {
+            val uvIndex = rowStart + col * uvPixelStride
+            nv21[pos++] = vBuffer.get(uvIndex)
+            nv21[pos++] = uBuffer.get(uvIndex)
+        }
+    }
+    return nv21
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/RuntimeAugmentedImageDatabase.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/RuntimeAugmentedImageDatabase.kt
@@ -1,0 +1,298 @@
+package io.github.sceneview.ar.arcore
+
+import android.graphics.Bitmap
+import androidx.annotation.MainThread
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import com.google.ar.core.AugmentedImageDatabase
+import com.google.ar.core.Config
+import com.google.ar.core.Session
+import com.google.ar.core.exceptions.ImageInsufficientQualityException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Manages an [AugmentedImageDatabase] that grows **at runtime** — letting the user register a
+ * brand-new reference image on-device (e.g. from a photo they just took) without a pre-bundled
+ * `arcoreimg` database or a trip to a desktop tool (#1553, follow-up of #1437).
+ *
+ * The whole point of this helper is to make the "capture a photo → start tracking it" flow a
+ * couple of lines. Pair it with [Frame.captureCameraBitmap] to grab the live AR camera frame
+ * and with the `ARSceneView` `onSessionUpdated` callback to surface detected images:
+ *
+ * ```kotlin
+ * val runtimeDb = rememberRuntimeAugmentedImageDatabase()
+ *
+ * ARSceneView(
+ *     // Apply whatever the runtime DB currently holds on every (re)configure.
+ *     sessionConfiguration = { _, config -> runtimeDb.applyTo(config) },
+ *     onSessionCreated = { session -> runtimeDb.bind(session) },
+ *     onSessionUpdated = { _, frame ->
+ *         frame.getUpdatedAugmentedImages().forEach { /* place AugmentedImageNode */ }
+ *     }
+ * ) { /* ... */ }
+ *
+ * // Later, from a "Capture" button:
+ * scope.launch {
+ *     val photo = withContext(Dispatchers.Default) { frame.captureCameraBitmap() }
+ *     when (val result = runtimeDb.addImage("snapshot-1", photo!!)) {
+ *         is AddImageResult.Added       -> { /* now tracked */ }
+ *         is AddImageResult.LowQuality  -> showRetryHint()
+ *         is AddImageResult.Error       -> showError(result.cause)
+ *     }
+ * }
+ * ```
+ *
+ * ### Threading
+ *
+ * - [addImage] does the heavy ARCore feature-extraction off the main thread (it suspends on
+ *   [Dispatchers.Default]); calling it directly on the main thread would jank the renderer.
+ * - The resulting **session reconfigure runs on the main thread** — ARCore's
+ *   `Session.configure()` is not safe to call from a background coroutine. [addImage] handles
+ *   this internally (`withContext(Dispatchers.Main)`); callers must still call [addImage] from
+ *   a coroutine, which they will be doing anyway for the suspend signature.
+ *
+ * This class is **not** thread-safe for concurrent [addImage] calls — serialise them (a single
+ * UI "Capture" button naturally does). It is safe to read [imageNames] / [size] from any
+ * thread once a call has returned.
+ */
+class RuntimeAugmentedImageDatabase {
+
+    private data class Entry(val name: String, val bitmap: Bitmap, val widthInMeters: Float?)
+
+    private val entries = mutableListOf<Entry>()
+
+    private var session: Session? = null
+
+    /** Number of images currently registered in the runtime database. */
+    val size: Int get() = entries.size
+
+    /**
+     * Names of every image currently registered, in insertion order. Names are **not**
+     * guaranteed unique — ARCore allows duplicates — but callers are encouraged to keep them
+     * unique so [com.google.ar.core.AugmentedImage.getName] stays meaningful.
+     */
+    val imageNames: List<String> get() = entries.map { it.name }
+
+    /**
+     * Binds the live ARCore [Session] so [addImage] can rebuild and apply the database itself.
+     *
+     * Call this from `ARSceneView`'s `onSessionCreated`. Until a session is bound, [addImage]
+     * still validates and stores the image but cannot apply it live — it returns
+     * [AddImageResult.Added] and the image takes effect on the next [applyTo] (e.g. the next
+     * `sessionConfiguration` pass).
+     */
+    fun bind(session: Session) {
+        this.session = session
+    }
+
+    /** Drops the bound session reference — call from `onSessionPaused` / on teardown. */
+    fun unbind() {
+        this.session = null
+    }
+
+    /**
+     * Builds a fresh [AugmentedImageDatabase] for [session] from every registered entry and
+     * assigns it to [config] — the single place that knows how to translate the runtime
+     * entry list into ARCore's config.
+     *
+     * Call this from the `ARSceneView` `sessionConfiguration` callback so the database is
+     * re-applied whenever the session is (re)configured. Safe to call with an empty database
+     * (it assigns an empty [AugmentedImageDatabase], which simply tracks nothing).
+     *
+     * Must be called on the main thread — it mutates the [Config] that ARCore will hand to
+     * `Session.configure()`.
+     */
+    @MainThread
+    fun applyTo(config: Config, session: Session) {
+        config.augmentedImageDatabase = buildDatabase(session)
+    }
+
+    /**
+     * Validates [bitmap], registers it under [name], and — if a [Session] is bound — rebuilds
+     * the [AugmentedImageDatabase] and applies it live so ARCore starts tracking the new image
+     * immediately.
+     *
+     * The expensive ARCore feature extraction (20–30 ms per image, more for large bitmaps)
+     * runs on [Dispatchers.Default]; the session reconfigure that follows runs on
+     * [Dispatchers.Main]. This is a `suspend` function — call it from a coroutine.
+     *
+     * @param name Name metadata stored on the resulting [com.google.ar.core.AugmentedImage].
+     *   Does not have to be unique, but unique names keep detection callbacks unambiguous.
+     * @param bitmap The reference image. Must be `ARGB_8888` — see [Image.toArgbBitmap] /
+     *   [Frame.captureCameraBitmap] which already produce that format. The bitmap is retained
+     *   by this helper so it can rebuild the database after later [addImage] calls; do not
+     *   recycle it while it is registered.
+     * @param widthInMeters Optional known physical width of the printed/displayed image. When
+     *   provided ARCore estimates the pose immediately on detection (no need to view the image
+     *   from several angles); `null` trades a slower first detection for not having to measure.
+     * @return [AddImageResult.Added] on success, [AddImageResult.LowQuality] when ARCore
+     *   rejects the bitmap for lacking trackable features, or [AddImageResult.Error] for any
+     *   other failure (e.g. a non-`ARGB_8888` bitmap).
+     */
+    suspend fun addImage(
+        name: String,
+        bitmap: Bitmap,
+        widthInMeters: Float? = null
+    ): AddImageResult {
+        val invalid = validateRuntimeImage(name, bitmap, widthInMeters)
+        if (invalid != null) {
+            return AddImageResult.Error(IllegalArgumentException(invalid))
+        }
+
+        val boundSession = session
+        // Validate the image against ARCore's feature extractor off the main thread. We build a
+        // throwaway single-image database purely as a quality probe — `addImage` is the only
+        // ARCore API that surfaces ImageInsufficientQualityException.
+        val probeResult = withContext(Dispatchers.Default) {
+            if (boundSession == null) {
+                // No session yet — we cannot probe quality. Defer the real check to the next
+                // applyTo()/configure() and optimistically accept.
+                AddImageResult.Added
+            } else {
+                runCatching {
+                    AugmentedImageDatabase(boundSession).also { probe ->
+                        if (widthInMeters != null) {
+                            probe.addImage(name, bitmap, widthInMeters)
+                        } else {
+                            probe.addImage(name, bitmap)
+                        }
+                    }
+                }.fold(
+                    onSuccess = { AddImageResult.Added },
+                    onFailure = { error ->
+                        when (error) {
+                            is ImageInsufficientQualityException -> AddImageResult.LowQuality
+                            else -> AddImageResult.Error(error)
+                        }
+                    }
+                )
+            }
+        }
+
+        if (probeResult !is AddImageResult.Added) {
+            return probeResult
+        }
+
+        entries += Entry(name, bitmap, widthInMeters)
+
+        // Apply the rebuilt database on the main thread — Session.configure() is main-thread only.
+        boundSession?.let { live ->
+            withContext(Dispatchers.Main) {
+                live.configure { config -> applyTo(config, live) }
+            }
+        }
+        return AddImageResult.Added
+    }
+
+    /**
+     * Removes every registered image and — if a session is bound — applies the now-empty
+     * database on the main thread so ARCore stops tracking. Does not recycle the bitmaps; the
+     * caller still owns them.
+     */
+    suspend fun clear() {
+        entries.clear()
+        session?.let { live ->
+            withContext(Dispatchers.Main) {
+                live.configure { config -> applyTo(config, live) }
+            }
+        }
+    }
+
+    /**
+     * Rebuilds an [AugmentedImageDatabase] for [session] containing every registered entry.
+     *
+     * Synchronous — only call from a background thread or when the entry list is small.
+     * [applyTo] / [addImage] call this internally on the appropriate thread.
+     */
+    private fun buildDatabase(session: Session): AugmentedImageDatabase =
+        AugmentedImageDatabase(session).also { database ->
+            entries.forEach { entry ->
+                if (entry.widthInMeters != null) {
+                    database.addImage(entry.name, entry.bitmap, entry.widthInMeters)
+                } else {
+                    database.addImage(entry.name, entry.bitmap)
+                }
+            }
+        }
+}
+
+/**
+ * Creates and remembers a [RuntimeAugmentedImageDatabase] scoped to the composable lifecycle.
+ *
+ * The helper is `remember`ed across recompositions so registered images survive a recompose,
+ * and its bound [Session] reference is dropped automatically when the composable leaves the
+ * tree so no stale `Session` is retained.
+ *
+ * ```kotlin
+ * val runtimeDb = rememberRuntimeAugmentedImageDatabase()
+ * ARSceneView(
+ *     sessionConfiguration = { session, config -> runtimeDb.applyTo(config, session) },
+ *     onSessionCreated = { runtimeDb.bind(it) }
+ * ) { /* ... */ }
+ * ```
+ *
+ * @see RuntimeAugmentedImageDatabase
+ */
+@Composable
+fun rememberRuntimeAugmentedImageDatabase(): RuntimeAugmentedImageDatabase {
+    val database = remember { RuntimeAugmentedImageDatabase() }
+    DisposableEffect(database) {
+        onDispose { database.unbind() }
+    }
+    return database
+}
+
+/**
+ * Outcome of [RuntimeAugmentedImageDatabase.addImage].
+ *
+ * Modelled as a sealed hierarchy so callers can `when`-match exhaustively and give the user a
+ * specific message — the most common failure ([LowQuality]) is recoverable by retaking the
+ * photo, so it must be distinguishable from a hard error.
+ */
+sealed class AddImageResult {
+    /** The image was registered (and applied live if a session was bound). */
+    object Added : AddImageResult()
+
+    /**
+     * ARCore rejected the image because it has too few trackable features — typically a
+     * low-contrast, blurry, glare-covered or near-uniform photo. The user should retake it
+     * pointing at a more textured, well-lit, high-contrast subject.
+     */
+    object LowQuality : AddImageResult()
+
+    /**
+     * The image could not be added for a reason other than insufficient quality — e.g. a
+     * bitmap that is not `ARGB_8888`, a non-positive [widthInMeters], or an empty name.
+     */
+    data class Error(val cause: Throwable) : AddImageResult()
+}
+
+/**
+ * Pure-logic pre-flight validation for [RuntimeAugmentedImageDatabase.addImage] — checks the
+ * arguments ARCore would otherwise reject with a generic `IllegalArgumentException` deep inside
+ * a JNI call.
+ *
+ * Extracted as `internal` so the contract can be unit-tested without a live ARCore [Session]
+ * (#1553). Mirrors the constraints documented on [com.google.ar.core.AugmentedImageDatabase.addImage].
+ *
+ * @return `null` when the arguments are valid, or a human-readable reason string when they are
+ *   not (empty name, non-`ARGB_8888` bitmap, zero-sized bitmap, or non-positive width).
+ */
+internal fun validateRuntimeImage(
+    name: String,
+    bitmap: Bitmap,
+    widthInMeters: Float?
+): String? = when {
+    name.isBlank() ->
+        "Augmented image name must not be blank."
+    bitmap.config != Bitmap.Config.ARGB_8888 ->
+        "Augmented image bitmap must be ARGB_8888 (was ${bitmap.config}). " +
+            "Use Frame.captureCameraBitmap() or Image.toArgbBitmap() which already produce it."
+    bitmap.width <= 0 || bitmap.height <= 0 ->
+        "Augmented image bitmap must have a non-zero size (was ${bitmap.width}x${bitmap.height})."
+    widthInMeters != null && widthInMeters <= 0f ->
+        "widthInMeters must be strictly greater than zero (was $widthInMeters), or null."
+    else -> null
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/arcore/NormalizeRotationDegreesTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/arcore/NormalizeRotationDegreesTest.kt
@@ -1,0 +1,54 @@
+package io.github.sceneview.ar.arcore
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM regression test for [normalizeRotationDegrees] — the rotation-quadrant snapping used
+ * by [Image.toArgbBitmap] when making a captured AR camera frame upright (#1553).
+ *
+ * The Android `Bitmap` / `Image` work the conversion does is impossible to run under pure JVM,
+ * so the rotation contract was extracted into [normalizeRotationDegrees]; this test pins it:
+ *
+ *  - exact quadrant values pass through unchanged,
+ *  - off-quadrant values snap to the nearest quadrant,
+ *  - negative inputs and inputs ≥ 360 wrap into `[0, 360)` first.
+ */
+class NormalizeRotationDegreesTest {
+
+    @Test
+    fun `exact quadrant values pass through unchanged`() {
+        assertEquals(0, normalizeRotationDegrees(0))
+        assertEquals(90, normalizeRotationDegrees(90))
+        assertEquals(180, normalizeRotationDegrees(180))
+        assertEquals(270, normalizeRotationDegrees(270))
+    }
+
+    @Test
+    fun `off-quadrant values snap to the nearest quadrant`() {
+        assertEquals(0, normalizeRotationDegrees(44))
+        assertEquals(90, normalizeRotationDegrees(45))
+        assertEquals(90, normalizeRotationDegrees(134))
+        assertEquals(180, normalizeRotationDegrees(135))
+        assertEquals(270, normalizeRotationDegrees(314))
+        assertEquals(0, normalizeRotationDegrees(315))
+    }
+
+    @Test
+    fun `360 wraps to 0`() {
+        assertEquals(0, normalizeRotationDegrees(360))
+    }
+
+    @Test
+    fun `values above 360 wrap before snapping`() {
+        assertEquals(90, normalizeRotationDegrees(450)) // 450 - 360 = 90
+        assertEquals(180, normalizeRotationDegrees(540)) // 540 - 360 = 180
+    }
+
+    @Test
+    fun `negative values wrap into the positive range before snapping`() {
+        assertEquals(270, normalizeRotationDegrees(-90)) // -90 -> 270
+        assertEquals(180, normalizeRotationDegrees(-180)) // -180 -> 180
+        assertEquals(0, normalizeRotationDegrees(-360)) // -360 -> 0
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/arcore/ValidateRuntimeImageTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/arcore/ValidateRuntimeImageTest.kt
@@ -1,0 +1,67 @@
+package io.github.sceneview.ar.arcore
+
+import android.graphics.Bitmap
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Robolectric regression test for [validateRuntimeImage] — the pure-logic pre-flight checks for
+ * [RuntimeAugmentedImageDatabase.addImage] (#1553).
+ *
+ * ARCore's `AugmentedImageDatabase.addImage` rejects bad arguments with a generic
+ * `IllegalArgumentException` thrown deep inside a JNI call; [validateRuntimeImage] surfaces the
+ * same constraints in plain Kotlin so the failure reason is actionable and unit-testable.
+ * Robolectric provides a working `Bitmap` so the `ARGB_8888`/size checks can run on the JVM.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ValidateRuntimeImageTest {
+
+    private fun argb8888(width: Int = 64, height: Int = 64): Bitmap =
+        Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+
+    @Test
+    fun `valid ARGB_8888 bitmap with null width passes`() {
+        assertNull(validateRuntimeImage("photo", argb8888(), widthInMeters = null))
+    }
+
+    @Test
+    fun `valid ARGB_8888 bitmap with positive width passes`() {
+        assertNull(validateRuntimeImage("photo", argb8888(), widthInMeters = 0.15f))
+    }
+
+    @Test
+    fun `blank name is rejected`() {
+        val reason = validateRuntimeImage("   ", argb8888(), widthInMeters = null)
+        assertNotNull(reason)
+        assertTrue(reason!!.contains("name", ignoreCase = true))
+    }
+
+    @Test
+    fun `empty name is rejected`() {
+        assertNotNull(validateRuntimeImage("", argb8888(), widthInMeters = null))
+    }
+
+    @Test
+    fun `non ARGB_8888 bitmap is rejected`() {
+        val rgb565 = Bitmap.createBitmap(64, 64, Bitmap.Config.RGB_565)
+        val reason = validateRuntimeImage("photo", rgb565, widthInMeters = null)
+        assertNotNull(reason)
+        assertTrue(reason!!.contains("ARGB_8888"))
+    }
+
+    @Test
+    fun `zero width in meters is rejected`() {
+        val reason = validateRuntimeImage("photo", argb8888(), widthInMeters = 0f)
+        assertNotNull(reason)
+        assertTrue(reason!!.contains("widthInMeters"))
+    }
+
+    @Test
+    fun `negative width in meters is rejected`() {
+        assertNotNull(validateRuntimeImage("photo", argb8888(), widthInMeters = -1f))
+    }
+}

--- a/changelog.d/1553-runtime-augmented-images.md
+++ b/changelog.d/1553-runtime-augmented-images.md
@@ -1,0 +1,10 @@
+<!-- category: Added -->
+- **AR Augmented Images — on-device runtime registration.** New `RuntimeAugmentedImageDatabase`
+  helper (`rememberRuntimeAugmentedImageDatabase()`) lets you register a brand-new reference
+  image at runtime — e.g. from a photo the user just took — without a pre-bundled `arcoreimg`
+  database. `addImage(name, bitmap, widthInMeters)` runs the ARCore feature extraction off the
+  main thread and re-applies the session config on the main thread itself, returning a typed
+  `AddImageResult` (`Added` / `LowQuality` / `Error`) so low-quality captures are recoverable.
+  New `Frame.captureCameraBitmap()` and `Image.toArgbBitmap()` extensions grab the live AR
+  camera frame as an upright `ARGB_8888` bitmap ready for the database. The Image Tracking demo
+  now ships a "Capture this view" button demonstrating the full on-device flow (#1553).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -1690,6 +1690,49 @@ semantic blend slider over the overlay material, plus the top-3 label HUD.
 )
 ```
 
+### RuntimeAugmentedImageDatabase — register reference images on-device at runtime
+```kotlin
+// Grows an AugmentedImageDatabase at runtime — no pre-bundled `arcoreimg` database needed.
+@Composable fun rememberRuntimeAugmentedImageDatabase(): RuntimeAugmentedImageDatabase
+
+class RuntimeAugmentedImageDatabase {
+    val size: Int
+    val imageNames: List<String>
+    fun bind(session: Session)                          // call from onSessionCreated
+    fun unbind()                                        // call from onSessionPaused/teardown
+    fun applyTo(config: Config, session: Session)       // MAIN thread — call from sessionConfiguration
+    suspend fun addImage(name: String, bitmap: Bitmap,  // bitmap must be ARGB_8888
+                         widthInMeters: Float? = null): AddImageResult
+    suspend fun clear()
+}
+// addImage runs ARCore feature extraction off the main thread, then re-applies the session
+// config ON the main thread itself. Returns a typed result:
+sealed class AddImageResult { object Added; object LowQuality; data class Error(cause: Throwable) }
+
+// Grab the live AR camera frame as an upright ARGB_8888 bitmap (run OFF the main thread):
+fun Frame.captureCameraBitmap(jpegQuality: Int = 90): Bitmap?
+fun Image.toArgbBitmap(rotationDegrees: Int = 0, jpegQuality: Int = 90): Bitmap?
+```
+Usage — capture a photo on-device and start tracking it (closes #1553):
+```kotlin
+val runtimeDb = rememberRuntimeAugmentedImageDatabase()
+ARSceneView(
+    sessionConfiguration = { session, config -> runtimeDb.applyTo(config, session) },
+    onSessionCreated = { runtimeDb.bind(it) },
+    onSessionUpdated = { _, frame -> latestFrame = frame }
+) { /* AugmentedImageNode per detected image */ }
+// From a "Capture" button:
+scope.launch {
+    val photo = withContext(Dispatchers.Default) { latestFrame?.captureCameraBitmap() }
+    when (runtimeDb.addImage("snapshot", photo!!)) {
+        is AddImageResult.Added      -> { /* now tracked */ }
+        is AddImageResult.LowQuality -> showRetryHint()   // textured, high-contrast scene needed
+        is AddImageResult.Error      -> showError()
+    }
+}
+```
+Sample: `ARImageDemo` (Android demo registry id `ar-image`) — "Capture this view" button.
+
 ### AugmentedFaceNode — face mesh
 ```kotlin
 @Composable fun AugmentedFaceNode(

--- a/llms.txt
+++ b/llms.txt
@@ -1690,6 +1690,49 @@ semantic blend slider over the overlay material, plus the top-3 label HUD.
 )
 ```
 
+### RuntimeAugmentedImageDatabase — register reference images on-device at runtime
+```kotlin
+// Grows an AugmentedImageDatabase at runtime — no pre-bundled `arcoreimg` database needed.
+@Composable fun rememberRuntimeAugmentedImageDatabase(): RuntimeAugmentedImageDatabase
+
+class RuntimeAugmentedImageDatabase {
+    val size: Int
+    val imageNames: List<String>
+    fun bind(session: Session)                          // call from onSessionCreated
+    fun unbind()                                        // call from onSessionPaused/teardown
+    fun applyTo(config: Config, session: Session)       // MAIN thread — call from sessionConfiguration
+    suspend fun addImage(name: String, bitmap: Bitmap,  // bitmap must be ARGB_8888
+                         widthInMeters: Float? = null): AddImageResult
+    suspend fun clear()
+}
+// addImage runs ARCore feature extraction off the main thread, then re-applies the session
+// config ON the main thread itself. Returns a typed result:
+sealed class AddImageResult { object Added; object LowQuality; data class Error(cause: Throwable) }
+
+// Grab the live AR camera frame as an upright ARGB_8888 bitmap (run OFF the main thread):
+fun Frame.captureCameraBitmap(jpegQuality: Int = 90): Bitmap?
+fun Image.toArgbBitmap(rotationDegrees: Int = 0, jpegQuality: Int = 90): Bitmap?
+```
+Usage — capture a photo on-device and start tracking it (closes #1553):
+```kotlin
+val runtimeDb = rememberRuntimeAugmentedImageDatabase()
+ARSceneView(
+    sessionConfiguration = { session, config -> runtimeDb.applyTo(config, session) },
+    onSessionCreated = { runtimeDb.bind(it) },
+    onSessionUpdated = { _, frame -> latestFrame = frame }
+) { /* AugmentedImageNode per detected image */ }
+// From a "Capture" button:
+scope.launch {
+    val photo = withContext(Dispatchers.Default) { latestFrame?.captureCameraBitmap() }
+    when (runtimeDb.addImage("snapshot", photo!!)) {
+        is AddImageResult.Added      -> { /* now tracked */ }
+        is AddImageResult.LowQuality -> showRetryHint()   // textured, high-contrast scene needed
+        is AddImageResult.Error      -> showError()
+    }
+}
+```
+Sample: `ARImageDemo` (Android demo registry id `ar-image`) — "Capture this view" button.
+
 ### AugmentedFaceNode — face mesh
 ```kotlin
 @Composable fun AugmentedFaceNode(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageDemo.kt
@@ -7,17 +7,19 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -27,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,13 +38,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.AugmentedImage
-import com.google.ar.core.AugmentedImageDatabase
 import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
+import io.github.sceneview.ar.arcore.AddImageResult
+import io.github.sceneview.ar.arcore.captureCameraBitmap
+import io.github.sceneview.ar.arcore.rememberRuntimeAugmentedImageDatabase
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.R
@@ -54,17 +59,29 @@ import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
- * Augmented image tracking demo.
+ * Augmented image tracking demo with **on-device runtime image registration** (#1553).
  *
- * Configures an [AugmentedImageDatabase] with a reference image loaded from assets.
- * When ARCore detects the image in the camera feed, an [AugmentedImageNode] is placed
+ * Two ways to register an image to track are shown side by side:
+ *
+ *  1. **Pre-bundled** — a reference image loaded from assets is added to the
+ *     [io.github.sceneview.ar.arcore.RuntimeAugmentedImageDatabase] at session creation, and an
+ *     in-app "what to scan" card shows the actual target so the user knows where to point.
+ *  2. **Runtime capture** — the "Capture this view" button grabs the live AR camera frame as an
+ *     `ARGB_8888` bitmap ([Frame.captureCameraBitmap]) and feeds it straight into the same
+ *     runtime database. ARCore starts tracking the just-captured scene without any pre-bundled
+ *     `arcoreimg` database — fully on-device, no PC needed.
+ *
+ * Threading: [io.github.sceneview.ar.arcore.RuntimeAugmentedImageDatabase.addImage] does the
+ * YUV→ARGB conversion and ARCore feature extraction off the main thread, then re-applies the
+ * session config on the main thread itself — the demo only has to call it from a coroutine.
+ *
+ * When ARCore detects a registered image in the camera feed, an `AugmentedImageNode` is placed
  * at the image location with a 3D model attached.
- *
- * An in-app "what to scan" card shows the actual reference image so the user knows exactly
- * which target to point the camera at — no need to dig through the assets folder. The card
- * collapses to a chip once an image is recognised.
  */
 @Composable
 fun ARImageDemo(onBack: () -> Unit) {
@@ -72,15 +89,25 @@ fun ARImageDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
+    val scope = rememberCoroutineScope()
     // Replay a recorded ARCore dataset when the device-QA harness deep-links this demo
     // with `--es ar_playback_file <path>` (#1576). `null` for every normal launch - see
     // `rememberArPlaybackDataset` - so live AR is completely unchanged for real users.
     val arPlaybackDataset = rememberArPlaybackDataset()
 
+    // Runtime, growable augmented-image database. Holds the pre-bundled reference image AND any
+    // image the user captures on-device via the "Capture this view" button (#1553).
+    val runtimeDatabase = rememberRuntimeAugmentedImageDatabase()
+
     val detectedImages = remember { mutableStateListOf<AugmentedImage>() }
     var isTracking by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var imageCount by remember { mutableStateOf(0) }
+    var latestFrame by remember { mutableStateOf<Frame?>(null) }
+    // Status of the last on-device capture attempt — surfaced as a transient banner so the
+    // user gets specific feedback (added / low-quality / error) rather than a silent button.
+    var captureStatus by remember { mutableStateOf<String?>(null) }
+    var isCapturing by remember { mutableStateOf(false) }
     // "What to scan" card is expanded by default so a first-time user immediately sees the
     // reference image to point the camera at; it collapses to a chip once detection succeeds.
     var showScanGuide by remember { mutableStateOf(true) }
@@ -128,13 +155,21 @@ fun ARImageDemo(onBack: () -> Unit) {
                 sessionConfiguration = { session: Session, config: Config ->
                     config.planeFindingMode = Config.PlaneFindingMode.DISABLED
                     config.focusMode = Config.FocusMode.AUTO
-                    // Build an augmented image database with the pre-decoded reference bitmap.
-                    config.augmentedImageDatabase =
-                        AugmentedImageDatabase(session).apply {
-                            addImage("reference", referenceBitmap, 0.15f) // 15 cm physical width
-                        }
+                    // Apply whatever the runtime database currently holds. ARCore re-runs this
+                    // callback on every session (re)configure, so a runtime-captured image
+                    // registered via `addImage` survives a reconfigure too.
+                    runtimeDatabase.applyTo(config, session)
+                },
+                onSessionCreated = { session: Session ->
+                    // Bind the live session so RuntimeAugmentedImageDatabase.addImage can
+                    // rebuild + reconfigure on its own. Seed the pre-bundled reference image.
+                    runtimeDatabase.bind(session)
+                    scope.launch {
+                        runtimeDatabase.addImage("reference", referenceBitmap, 0.15f)
+                    }
                 },
                 onSessionUpdated = { _: Session, frame: Frame ->
+                    latestFrame = frame
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
                     frame.getUpdatedTrackables(AugmentedImage::class.java).forEach { image ->
                         if (image.trackingState == TrackingState.TRACKING &&
@@ -212,7 +247,7 @@ fun ARImageDemo(onBack: () -> Unit) {
                         )
                         Text(
                             text = "Display it on another screen or print it, " +
-                                "then aim the camera at it. Tap to hide.",
+                                "then aim the camera at it. Or capture your own image below.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(top = 12.dp)
@@ -238,41 +273,95 @@ fun ARImageDemo(onBack: () -> Unit) {
                 }
             }
 
-            // Status overlay
-            AnimatedVisibility(
-                visible = true,
-                enter = fadeIn(),
-                exit = fadeOut(),
-                modifier = Modifier.align(Alignment.BottomCenter)
+            // On-device capture controls — the #1553 "take a photo, add it to the database"
+            // flow. Grabs the live AR camera frame, registers it in the runtime database, and
+            // ARCore starts tracking that scene with no pre-bundled database.
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                // ForcedTrackingFailure.override shadows the real ARCore-reported reason
-                // when a developer has picked one in the debug menu (#1881). Read it here
-                // (not inside `onTrackingFailureChanged`) so flipping the override from
-                // the debug menu re-renders the overlay immediately, without waiting for
-                // the next ARCore tracking-failure callback. The forced reason wins over
-                // the live tracking state so QA can validate the message overlay even
-                // while a real image is being tracked.
-                val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
-                val trackingHint = trackingFailureMessage(effectiveReason)
-                val statusText = when {
-                    ForcedTrackingFailure.override != null ->
-                        trackingHint ?: "Scanning for images\u2026"
-                    imageCount > 0 -> "Tracking $imageCount image(s)"
-                    !isTracking -> trackingHint ?: "Scanning for images\u2026"
-                    else -> "Looking for reference image\u2026"
+                // Status overlay
+                AnimatedVisibility(
+                    visible = true,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    // ForcedTrackingFailure.override shadows the real ARCore-reported reason
+                    // when a developer has picked one in the debug menu (#1881). Read it here
+                    // (not inside `onTrackingFailureChanged`) so flipping the override from
+                    // the debug menu re-renders the overlay immediately, without waiting for
+                    // the next ARCore tracking-failure callback. The forced reason wins over
+                    // the live tracking state so QA can validate the message overlay even
+                    // while a real image is being tracked.
+                    val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
+                    val trackingHint = trackingFailureMessage(effectiveReason)
+                    val statusText = when {
+                        captureStatus != null -> captureStatus!!
+                        ForcedTrackingFailure.override != null ->
+                            trackingHint ?: "Scanning for images…"
+                        imageCount > 0 -> "Tracking $imageCount image(s)"
+                        !isTracking -> trackingHint ?: "Scanning for images…"
+                        else -> "Looking for reference image…"
+                    }
+                    Text(
+                        text = statusText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .background(
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                                shape = RoundedCornerShape(24.dp)
+                            )
+                            .padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
                 }
-                Text(
-                    text = statusText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier
-                        .padding(bottom = 32.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                            shape = RoundedCornerShape(24.dp)
-                        )
-                        .padding(horizontal = 24.dp, vertical = 12.dp)
-                )
+
+                Button(
+                    onClick = {
+                        val frame = latestFrame ?: return@Button
+                        isCapturing = true
+                        captureStatus = "Processing capture…"
+                        scope.launch {
+                            // Grab + convert the camera frame off the main thread — JPEG
+                            // round-trip + YUV->ARGB conversion would jank the renderer.
+                            val photo = withContext(Dispatchers.Default) {
+                                frame.captureCameraBitmap()
+                            }
+                            captureStatus = if (photo == null) {
+                                "Camera image not ready yet — try again"
+                            } else {
+                                // addImage runs feature extraction off-thread and re-applies
+                                // the session config on the main thread itself (#1553).
+                                when (val result = runtimeDatabase.addImage(
+                                    name = "capture-${runtimeDatabase.size}",
+                                    bitmap = photo
+                                )) {
+                                    is AddImageResult.Added ->
+                                        "Image added — point the camera back at this scene"
+                                    is AddImageResult.LowQuality ->
+                                        "Too few features — aim at a textured, " +
+                                            "high-contrast scene and retry"
+                                    is AddImageResult.Error ->
+                                        "Capture failed: ${result.cause.message}"
+                                }
+                            }
+                            isCapturing = false
+                        }
+                    },
+                    enabled = !isCapturing && latestFrame != null
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.CameraAlt,
+                        contentDescription = null
+                    )
+                    Text(
+                        text = "Capture this view",
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Lets users register a brand-new AR reference image **at runtime** — e.g. from a photo they just took — without a pre-bundled `arcoreimg` database or a desktop tool. Follow-up of #1437 (ask 2, which was deferred as too large for that scoped PR).

## New public API (`arsceneview`)

- **`RuntimeAugmentedImageDatabase`** + **`rememberRuntimeAugmentedImageDatabase()`** — manages a growable `AugmentedImageDatabase`. `addImage(name, bitmap, widthInMeters)` runs the ARCore feature extraction **off the main thread** and re-applies the session config **on the main thread** itself (`Session.configure()` is main-thread only). Returns a typed `AddImageResult` (`Added` / `LowQuality` / `Error`) so an insufficient-quality capture is recoverable by retaking the photo rather than failing silently.
- **`Frame.captureCameraBitmap()`** / **`Image.toArgbBitmap()`** — grab the live AR camera frame as an upright `ARGB_8888` bitmap ready for the database (`YUV_420_888` → `NV21` → JPEG → `ARGB_8888`, handles arbitrary chroma pixel/row strides).

## Demo

The **Image Tracking** demo (`ar-image`) now ships a "Capture this view" button demonstrating the full on-device capture → runtime registration → tracking flow.

## Threading

`addImage` is `suspend` — heavy work on `Dispatchers.Default`, the ARCore session reconfigure on `Dispatchers.Main`. The demo only has to call it from a coroutine.

## Tests

12 new pure-logic unit tests — `validateRuntimeImage` (ARGB_8888 / size / name / width pre-flight checks, Robolectric) and `normalizeRotationDegrees` (rotation-quadrant snapping).

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin` — green
- [x] `./gradlew :arsceneview:testDebugUnitTest` — green (12 new tests pass)
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — green
- [x] `detekt` on `:sceneview :arsceneview :sceneview-core` — clean
- [ ] On-device QA: capture a photo, verify the just-captured scene is tracked

Closes #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)