### PR TITLE
ci: Play Store observability — Android Vitals gate + reviews ingest

### DIFF
--- a/.claude/scripts/play-reviews-ingest.sh
+++ b/.claude/scripts/play-reviews-ingest.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# play-reviews-ingest.sh — ingest Play Store ratings & reviews, surface
+# user-reported bugs (#1692).
+#
+# WHY ───────────────────────────────────────────────────────────────────────
+# The empire dashboard already aggregates npm downloads and GitHub stars, but
+# the Play Store side of the demo app (rating, written reviews) is invisible
+# to any automation. User reviews in particular are a free, high-signal bug
+# feed that nobody is reading systematically.
+#
+# WHAT IT DOES ───────────────────────────────────────────────────────────────
+#   1. Pulls recent written reviews for `io.github.sceneview.demo` via the
+#      Android Publisher API `reviews.list` endpoint (the SAME service
+#      account + auth pattern play-store.yml already uses to publish).
+#   2. Computes the average star rating across the fetched reviews and a
+#      star-distribution histogram → a lightweight metrics snapshot the
+#      maintenance digest / empire dashboard can sit next to npm + GitHub.
+#   3. For any review whose text matches a crash/bug signal (`crash`,
+#      `freeze`, `black screen`, `won't open`, …) OR is a 1-star review with
+#      a non-trivial comment, emits a triage record with the review text,
+#      device, app version, and star rating.
+#
+# The CALLER (the maintenance workflow) is responsible for opening a
+# de-duplicated GitHub issue per flagged review — this script only produces
+# the data. De-dup is by Play `reviewId`, which is stable.
+#
+# API REALITY / DOCUMENTED GAPS (#1692) ──────────────────────────────────────
+#   - `reviews.list` only returns reviews **modified in roughly the last
+#     week** — this is a hard Google API limitation, not a bug here. The
+#     daily cadence of the maintenance workflow covers that window with
+#     overlap; de-dup by reviewId makes the overlap harmless.
+#   - The Play **Developer Reporting API does NOT expose installs / acquisitions
+#     / lifetime average rating** as a queryable metric set — those only come
+#     from the bulk CSV "statistics" reports dropped into a Cloud Storage
+#     bucket, which needs a separate GCS-bucket grant and a different auth
+#     path. Rather than fake an install count, this script reports the
+#     average rating it CAN compute from the fetched review window and
+#     documents the install gap. Vitals (crash/ANR) IS programmatic and is
+#     handled by `play-vitals.sh` (#1691).
+#
+# PERMISSION REQUIRED (manual, Play Console) ─────────────────────────────────
+# The deploy service account needs the read-only **"Reply to reviews"** /
+# **"View app information and download bulk reports"** Play Console
+# permission. `reviews.list` is read-only — this script never replies to a
+# review (replying is public content and implies a support commitment, see
+# #1692). No new WRITE scope is added.
+#
+# OUTPUT ─────────────────────────────────────────────────────────────────────
+# Writes a JSON document to the path given as $1 (default: play-reviews.json):
+#   {
+#     "schemaVersion": 1,
+#     "fetchedAt": "...", "reviewCount": N,
+#     "averageRating": 4.2, "starHistogram": {"1": .., ... "5": ..},
+#     "flagged": [ {reviewId, starRating, device, appVersion, text, signal} ]
+#   }
+# Also prints a human-readable summary to stdout.
+#
+# Usage:
+#   PLAY_STORE_SERVICE_ACCOUNT_JSON='<json>' \
+#     bash .claude/scripts/play-reviews-ingest.sh [output.json]
+#
+# Env overrides:
+#   PLAY_STORE_SERVICE_ACCOUNT_JSON  service-account JSON (required for data)
+#   PACKAGE_NAME                     default io.github.sceneview.demo
+#   REVIEWS_MAX                      max reviews to fetch, default 100
+#
+# Exit codes: always 0 — a monitor must never fail the workflow. A data-access
+# problem produces an empty/degraded JSON + a WARN line.
+#
+# Closes #1692.
+
+set -u
+
+OUT="${1:-play-reviews.json}"
+PACKAGE_NAME="${PACKAGE_NAME:-io.github.sceneview.demo}"
+REVIEWS_MAX="${REVIEWS_MAX:-100}"
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+write_degraded() {
+  # Emit a valid-but-empty JSON so the caller never chokes on a missing file.
+  python3 - "$OUT" "$1" << 'PYEOF' 2>/dev/null || echo '{"schemaVersion":1,"reviewCount":0,"flagged":[]}' > "$OUT"
+import json, sys, datetime
+out, reason = sys.argv[1], sys.argv[2]
+json.dump({
+    "schemaVersion": 1,
+    "fetchedAt": datetime.datetime.utcnow().isoformat() + "Z",
+    "reviewCount": 0,
+    "averageRating": None,
+    "starHistogram": {},
+    "flagged": [],
+    "degraded": reason,
+}, open(out, "w"), indent=2)
+PYEOF
+  echo -e "  ${YELLOW}[WARN]${NC} Play reviews ingest degraded: $1"
+}
+
+echo -e "${CYAN}=== Play Store reviews & ratings ingest (#1692) ===${NC}"
+echo -e "Package: ${GREEN}$PACKAGE_NAME${NC}"
+
+if [ -z "${PLAY_STORE_SERVICE_ACCOUNT_JSON:-}" ]; then
+  write_degraded "PLAY_STORE_SERVICE_ACCOUNT_JSON not set — cannot reach the Play API."
+  exit 0
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  write_degraded "python3 not available."
+  exit 0
+fi
+
+PACKAGE_NAME="$PACKAGE_NAME" REVIEWS_MAX="$REVIEWS_MAX" OUT="$OUT" python3 << 'PYEOF'
+import json, os, re, sys, datetime
+
+try:
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import AuthorizedSession
+except Exception as e:  # pragma: no cover
+    print(f"::warning::google-auth not installed ({e})")
+    json.dump({"schemaVersion": 1, "reviewCount": 0, "flagged": [],
+               "degraded": f"google-auth missing ({e})"},
+              open(os.environ["OUT"], "w"), indent=2)
+    sys.exit(0)
+
+PKG = os.environ["PACKAGE_NAME"]
+OUT = os.environ["OUT"]
+MAX = int(os.environ.get("REVIEWS_MAX", "100"))
+
+# Crash / bug signal patterns. A review hit by any of these — OR a 1-star
+# review with a non-trivial comment — becomes a triage candidate.
+BUG_SIGNALS = [
+    ("crash",         r"\bcrash(?:e[sd]|ing)?\b"),
+    ("freeze",        r"\bfreez(?:e[sd]?|ing)\b|\bfrozen\b|\bhang(?:s|ing|ed)?\b"),
+    ("black screen",  r"\bblack screen\b|\bblank screen\b|\bwhite screen\b"),
+    ("won't open",    r"\b(?:wo?n'?t|does ?n'?t|can'?t) (?:open|launch|start|load)\b"),
+    ("force close",   r"\bforce[ -]?close[sd]?\b|\bkeeps? (?:closing|stopping)\b"),
+    ("not working",   r"\bnot working\b|\bdoesn'?t work\b|\bbroken\b"),
+    ("error",         r"\berror\b"),
+]
+COMPILED = [(name, re.compile(pat, re.I)) for name, pat in BUG_SIGNALS]
+
+try:
+    info = json.loads(os.environ["PLAY_STORE_SERVICE_ACCOUNT_JSON"])
+    creds = service_account.Credentials.from_service_account_info(
+        info, scopes=["https://www.googleapis.com/auth/androidpublisher"],
+    )
+    sess = AuthorizedSession(creds)
+except Exception as e:
+    print(f"::warning::could not build Play API credentials ({e})")
+    json.dump({"schemaVersion": 1, "reviewCount": 0, "flagged": [],
+               "degraded": f"auth failed ({e})"}, open(OUT, "w"), indent=2)
+    sys.exit(0)
+
+BASE = f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{PKG}"
+
+reviews = []
+token = None
+try:
+    while len(reviews) < MAX:
+        params = {"maxResults": min(100, MAX - len(reviews))}
+        if token:
+            params["token"] = token
+        r = sess.get(f"{BASE}/reviews", params=params)
+        if r.status_code == 403:
+            print("::warning::Play reviews API 403 Forbidden — the service "
+                  "account lacks the 'Reply to reviews' / review-read "
+                  "permission. No new write scope needed; grant the read-only "
+                  "permission in the Play Console (#1692).")
+            json.dump({"schemaVersion": 1, "reviewCount": 0, "flagged": [],
+                       "degraded": "403 — missing review-read permission"},
+                      open(OUT, "w"), indent=2)
+            sys.exit(0)
+        r.raise_for_status()
+        data = r.json()
+        batch = data.get("reviews", [])
+        reviews.extend(batch)
+        token = data.get("tokenPagination", {}).get("nextPageToken")
+        if not token or not batch:
+            break
+except Exception as e:
+    print(f"::warning::Play reviews fetch failed ({e})")
+    json.dump({"schemaVersion": 1, "reviewCount": 0, "flagged": [],
+               "degraded": f"fetch failed ({e})"}, open(OUT, "w"), indent=2)
+    sys.exit(0)
+
+histogram = {str(i): 0 for i in range(1, 6)}
+stars_total = 0
+stars_count = 0
+flagged = []
+
+for rev in reviews:
+    review_id = rev.get("reviewId", "")
+    author = rev.get("authorName", "") or "(anonymous)"
+    # The newest user comment carries the review text + metadata.
+    user_comment = None
+    for c in rev.get("comments", []):
+        if "userComment" in c:
+            user_comment = c["userComment"]
+            break
+    if not user_comment:
+        continue
+
+    star = user_comment.get("starRating")
+    text = (user_comment.get("text") or "").strip()
+    if isinstance(star, int) and 1 <= star <= 5:
+        histogram[str(star)] += 1
+        stars_total += star
+        stars_count += 1
+
+    device_meta = user_comment.get("deviceMetadata", {}) or {}
+    device = (device_meta.get("productName")
+              or device_meta.get("manufacturer")
+              or user_comment.get("device") or "unknown")
+    app_version = user_comment.get("appVersionName") or (
+        str(user_comment.get("appVersionCode"))
+        if user_comment.get("appVersionCode") else "unknown")
+    android = user_comment.get("androidOsVersion")
+
+    # Bug-signal match, OR a 1-star review with a real comment (>= 12 chars).
+    signal = None
+    for name, rx in COMPILED:
+        if text and rx.search(text):
+            signal = name
+            break
+    if not signal and star == 1 and len(text) >= 12:
+        signal = "1-star"
+
+    if signal:
+        flagged.append({
+            "reviewId": review_id,
+            "author": author,
+            "starRating": star,
+            "device": device,
+            "androidOsVersion": android,
+            "appVersion": app_version,
+            "language": user_comment.get("reviewerLanguage", ""),
+            "text": text[:1500],
+            "signal": signal,
+        })
+
+avg = round(stars_total / stars_count, 2) if stars_count else None
+result = {
+    "schemaVersion": 1,
+    "source": "android-publisher-api/reviews.list",
+    "fetchedAt": datetime.datetime.utcnow().isoformat() + "Z",
+    "reviewCount": len(reviews),
+    "ratedReviewCount": stars_count,
+    "averageRating": avg,
+    "starHistogram": histogram,
+    "flagged": flagged,
+    # Honest documentation of the API gap (#1692).
+    "notes": (
+        "averageRating is computed over the reviews.list window only "
+        "(~last 7 days, a Google API limitation), NOT the lifetime Play "
+        "Console rating. Install base / acquisitions are not exposed by any "
+        "queryable Play API metric set — they require the bulk CSV reports "
+        "in a Cloud Storage bucket (separate grant), so they are not "
+        "ingested here."
+    ),
+}
+json.dump(result, open(OUT, "w"), indent=2)
+
+print(f"Fetched {len(reviews)} review(s); {stars_count} carry a star rating.")
+if avg is not None:
+    print(f"Average rating (fetched window): {avg} / 5")
+print(f"Star histogram: " + "  ".join(f"{k}*={v}" for k, v in histogram.items()))
+print(f"Flagged for triage: {len(flagged)}")
+PYEOF
+
+echo -e "${GREEN}Reviews ingest written to ${OUT}.${NC}"
+exit 0

--- a/.claude/scripts/play-vitals.sh
+++ b/.claude/scripts/play-vitals.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+#
+# play-vitals.sh — Android Vitals release-gate signal (#1691).
+#
+# WHY ───────────────────────────────────────────────────────────────────────
+# The device-QA harness (#1560) and `release-checklist.sh` validate the demo
+# app *before* release — on emulators. They have zero visibility into
+# REAL-WORLD stability once the app is live on the Play Store. Google Play's
+# Android Vitals exposes the actual crash rate and ANR rate across real user
+# devices, and the Play Developer Reporting API makes those numbers queryable.
+#
+# WHAT IT DOES ───────────────────────────────────────────────────────────────
+# Queries the **Play Developer Reporting API** (playdeveloperreporting.
+# googleapis.com) for `io.github.sceneview.demo`:
+#
+#   - crashRateMetricSet  → userPerceivedCrashRate28dUserWeighted
+#   - anrRateMetricSet    → userPerceivedAnrRate28dUserWeighted
+#
+# The 28-day user-weighted user-perceived rates are the SAME numbers Google
+# uses for the Play Console "bad behaviour thresholds" badge, so they are the
+# right release-gate signal. It then grades them:
+#
+#   crash rate  <  WARN_CRASH (default 1.09%)  → PASS
+#               >= WARN_CRASH                  → WARN
+#               >= FAIL_CRASH (default 2.50%)  → FAIL  (only when GATE_HARD=1)
+#   anr  rate   <  WARN_ANR   (default 0.47%)  → PASS
+#               >= WARN_ANR                    → WARN
+#               >= FAIL_ANR   (default 1.00%)  → FAIL  (only when GATE_HARD=1)
+#
+# The 1.09% / 0.47% soft thresholds mirror Google Play's own "bad behaviour"
+# thresholds; FAIL thresholds are deliberately looser headroom.
+#
+# ADVISORY-FIRST (#1691) ─────────────────────────────────────────────────────
+# Until a baseline is established the gate is ADVISORY: it never returns a
+# blocking exit code on its own. A breach above the FAIL threshold is only
+# turned into a hard `exit 1` when `GATE_HARD=1` is passed — that promotion to
+# blocking is a deliberate, separate decision once the numbers are trusted.
+# Any data-access problem (missing secret, 403 lacking the "View app quality
+# information" permission, API error, no data yet for a fresh app) degrades to
+# a WARN + `exit 0` — a missing metric must NEVER freeze a release.
+#
+# OUTPUT ─────────────────────────────────────────────────────────────────────
+#   - Human-readable lines on stdout.
+#   - If `VITALS_JSON_OUT` is set, a machine-readable JSON summary is written
+#     there (consumed by release-checklist.sh / the release summary).
+#
+# PERMISSION REQUIRED (manual, Play Console) ─────────────────────────────────
+# The deploy service account (`PLAY_STORE_SERVICE_ACCOUNT_JSON`) needs the
+# read-only **"View app quality information"** Play Console permission. No new
+# WRITE scope is added. Until that permission is granted the API returns 403
+# and this script degrades to WARN.
+#
+# Usage:
+#   PLAY_STORE_SERVICE_ACCOUNT_JSON='<json>' bash .claude/scripts/play-vitals.sh
+#   GATE_HARD=1 ... bash .claude/scripts/play-vitals.sh     # blocking mode
+#
+# Env overrides:
+#   PLAY_STORE_SERVICE_ACCOUNT_JSON  service-account JSON (required for data)
+#   PACKAGE_NAME                     default io.github.sceneview.demo
+#   VITALS_WINDOW_DAYS               lookback window, default 14
+#   WARN_CRASH / FAIL_CRASH          crash-rate thresholds (%), 1.09 / 2.50
+#   WARN_ANR   / FAIL_ANR            anr-rate thresholds (%),  0.47 / 1.00
+#   GATE_HARD                        1 = breach above FAIL → exit 1
+#   VITALS_JSON_OUT                  path to write the JSON summary
+#
+# Exit codes:
+#   0  data healthy, advisory WARN, or any data-access degradation
+#   1  GATE_HARD=1 AND a metric breached its FAIL threshold
+#
+# Closes #1691.
+
+set -u
+
+PACKAGE_NAME="${PACKAGE_NAME:-io.github.sceneview.demo}"
+VITALS_WINDOW_DAYS="${VITALS_WINDOW_DAYS:-14}"
+WARN_CRASH="${WARN_CRASH:-1.09}"
+FAIL_CRASH="${FAIL_CRASH:-2.50}"
+WARN_ANR="${WARN_ANR:-0.47}"
+FAIL_ANR="${FAIL_ANR:-1.00}"
+GATE_HARD="${GATE_HARD:-0}"
+VITALS_JSON_OUT="${VITALS_JSON_OUT:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+VERDICT="warn"          # pass | warn | blocked
+CRASH_RATE=""
+ANR_RATE=""
+DETAIL=""
+
+emit_json() {
+  # Best-effort machine-readable summary for release-checklist.sh.
+  [ -z "$VITALS_JSON_OUT" ] && return 0
+  python3 - "$VITALS_JSON_OUT" "$VERDICT" "$CRASH_RATE" "$ANR_RATE" \
+            "$WARN_CRASH" "$FAIL_CRASH" "$WARN_ANR" "$FAIL_ANR" \
+            "$VITALS_WINDOW_DAYS" "$DETAIL" << 'PYEOF' 2>/dev/null || true
+import json, sys
+(out, verdict, crash, anr, wc, fc, wa, fa, win, detail) = sys.argv[1:11]
+def num(x):
+    try: return float(x)
+    except Exception: return None
+json.dump({
+    "schemaVersion": 1,
+    "source": "play-developer-reporting-api",
+    "metricSet": ["crashRateMetricSet", "anrRateMetricSet"],
+    "metric": "userPerceived*Rate28dUserWeighted",
+    "windowDays": int(win),
+    "verdict": verdict,
+    "crashRatePct": num(crash),
+    "anrRatePct": num(anr),
+    "thresholds": {
+        "warnCrashPct": num(wc), "failCrashPct": num(fc),
+        "warnAnrPct": num(wa),   "failAnrPct": num(fa),
+    },
+    "detail": detail,
+}, open(out, "w"), indent=2)
+PYEOF
+}
+
+degrade() {
+  # Data-access problem: WARN, never block. Always exit 0.
+  VERDICT="warn"
+  DETAIL="$1"
+  echo -e "  ${YELLOW}[WARN]${NC} Android Vitals: $1"
+  echo -e "  ${YELLOW}      ${NC} advisory — release not blocked by an unreadable metric."
+  emit_json
+  exit 0
+}
+
+echo -e "${CYAN}=== Android Vitals release-gate (#1691) ===${NC}"
+echo -e "Package: ${GREEN}$PACKAGE_NAME${NC}  window: last ${VITALS_WINDOW_DAYS}d"
+
+# ── Pre-flight ──────────────────────────────────────────────────────────────
+if [ -z "${PLAY_STORE_SERVICE_ACCOUNT_JSON:-}" ]; then
+  degrade "PLAY_STORE_SERVICE_ACCOUNT_JSON not set — cannot reach the Reporting API."
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  degrade "python3 not available — cannot query the Reporting API."
+fi
+
+# ── Query the Play Developer Reporting API ──────────────────────────────────
+# A single python helper authenticates with the service account and queries
+# both metric sets. It prints one of:
+#   OK <crashRatePct> <anrRatePct>
+#   ERR <message>
+RESULT=$(PACKAGE_NAME="$PACKAGE_NAME" VITALS_WINDOW_DAYS="$VITALS_WINDOW_DAYS" \
+  python3 << 'PYEOF' 2>/dev/null
+import json, os, sys, datetime
+
+try:
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import AuthorizedSession
+except Exception as e:  # pragma: no cover - import guard
+    print(f"ERR google-auth not installed ({e})")
+    sys.exit(0)
+
+PKG = os.environ["PACKAGE_NAME"]
+WINDOW = int(os.environ.get("VITALS_WINDOW_DAYS", "14"))
+
+try:
+    info = json.loads(os.environ["PLAY_STORE_SERVICE_ACCOUNT_JSON"])
+except Exception as e:
+    print(f"ERR service-account JSON is not valid JSON ({e})")
+    sys.exit(0)
+
+try:
+    creds = service_account.Credentials.from_service_account_info(
+        info,
+        scopes=["https://www.googleapis.com/auth/playdeveloperreporting"],
+    )
+    sess = AuthorizedSession(creds)
+except Exception as e:
+    print(f"ERR could not build credentials ({e})")
+    sys.exit(0)
+
+BASE = "https://playdeveloperreporting.googleapis.com/v1beta1"
+
+# Reporting-API DAILY aggregation runs on PST and lags a couple of days; ask
+# for a generous window and take the most recent row that has data.
+today = datetime.date.today()
+start = today - datetime.timedelta(days=WINDOW + 3)
+
+
+def query(metric_set, metric):
+    """Query one metric set, return the most-recent non-null metric value (a
+    fraction 0..1) or None. Errors raise so the caller can report them."""
+    body = {
+        "timelineSpec": {
+            "aggregationPeriod": "DAILY",
+            "startTime": {"year": start.year, "month": start.month, "day": start.day},
+            "endTime": {"year": today.year, "month": today.month, "day": today.day},
+        },
+        "metrics": [metric],
+    }
+    url = f"{BASE}/apps/{PKG}/{metric_set}:query"
+    r = sess.post(url, json=body)
+    if r.status_code == 403:
+        raise PermissionError(
+            "403 Forbidden — the service account lacks the 'View app quality "
+            "information' Play Console permission"
+        )
+    r.raise_for_status()
+    rows = r.json().get("rows", [])
+    latest = None
+    for row in rows:
+        for mv in row.get("metrics", []):
+            if mv.get("metric") != metric:
+                continue
+            dv = mv.get("decimalValue") or {}
+            val = dv.get("value")
+            if val is None:
+                continue
+            # Keep the last row that carries a value (rows are time-ordered).
+            latest = float(val)
+    return latest
+
+
+try:
+    crash = query("crashRateMetricSet", "crashRate28dUserWeighted")
+    if crash is None:
+        crash = query("crashRateMetricSet", "userPerceivedCrashRate28dUserWeighted")
+    anr = query("anrRateMetricSet", "anrRate28dUserWeighted")
+    if anr is None:
+        anr = query("anrRateMetricSet", "userPerceivedAnrRate28dUserWeighted")
+except PermissionError as e:
+    print(f"ERR {e}")
+    sys.exit(0)
+except Exception as e:
+    print(f"ERR Reporting API request failed ({e})")
+    sys.exit(0)
+
+if crash is None and anr is None:
+    print("ERR no crash/ANR data yet — app may be too new or below the "
+          "Play Console reporting threshold")
+    sys.exit(0)
+
+# The Reporting API returns rates as fractions (0..1). Convert to percent.
+crash_pct = "" if crash is None else f"{crash * 100:.4f}"
+anr_pct = "" if anr is None else f"{anr * 100:.4f}"
+print(f"OK {crash_pct or 'NA'} {anr_pct or 'NA'}")
+PYEOF
+)
+
+case "$RESULT" in
+  "OK "*)
+    CRASH_RATE=$(echo "$RESULT" | awk '{print $2}')
+    ANR_RATE=$(echo "$RESULT" | awk '{print $3}')
+    [ "$CRASH_RATE" = "NA" ] && CRASH_RATE=""
+    [ "$ANR_RATE" = "NA" ] && ANR_RATE=""
+    ;;
+  "ERR "*)
+    degrade "${RESULT#ERR }"
+    ;;
+  *)
+    degrade "Reporting API helper produced no output."
+    ;;
+esac
+
+# ── Grade ───────────────────────────────────────────────────────────────────
+# `grade <name> <value> <warn> <fail>` echoes pass|warn|blocked.
+grade() {
+  local name="$1" val="$2" warn="$3" fail="$4"
+  if [ -z "$val" ]; then
+    echo -e "  ${YELLOW}[WARN]${NC} $name: no data in window" >&2
+    echo "warn"
+    return
+  fi
+  # Compare as floats via awk.
+  if awk -v v="$val" -v f="$fail" 'BEGIN{exit !(v>=f)}'; then
+    echo -e "  ${RED}[FAIL]${NC} $name: ${val}% (>= ${fail}% hard threshold)" >&2
+    echo "blocked"
+  elif awk -v v="$val" -v w="$warn" 'BEGIN{exit !(v>=w)}'; then
+    echo -e "  ${YELLOW}[WARN]${NC} $name: ${val}% (>= ${warn}% soft threshold)" >&2
+    echo "warn"
+  else
+    echo -e "  ${GREEN}[PASS]${NC} $name: ${val}% (< ${warn}% soft threshold)" >&2
+    echo "pass"
+  fi
+}
+
+CRASH_VERDICT=$(grade "crash rate" "$CRASH_RATE" "$WARN_CRASH" "$FAIL_CRASH")
+ANR_VERDICT=$(grade "ANR rate"   "$ANR_RATE"   "$WARN_ANR"   "$FAIL_ANR")
+
+# Worst verdict wins.
+VERDICT="pass"
+for v in "$CRASH_VERDICT" "$ANR_VERDICT"; do
+  case "$v" in
+    blocked) VERDICT="blocked" ;;
+    warn) [ "$VERDICT" != "blocked" ] && VERDICT="warn" ;;
+  esac
+done
+
+DETAIL="crash=${CRASH_RATE:-NA}% anr=${ANR_RATE:-NA}% (28d user-weighted, window ${VITALS_WINDOW_DAYS}d)"
+
+echo ""
+case "$VERDICT" in
+  pass)
+    echo -e "${GREEN}Android Vitals: prod stability healthy.${NC} $DETAIL"
+    ;;
+  warn)
+    echo -e "${YELLOW}Android Vitals: WARN — review prod stability before tagging.${NC} $DETAIL"
+    ;;
+  blocked)
+    echo -e "${RED}Android Vitals: a metric breached its hard threshold.${NC} $DETAIL"
+    ;;
+esac
+
+emit_json
+
+# ── Exit policy ─────────────────────────────────────────────────────────────
+# Advisory by default (#1691): only GATE_HARD=1 promotes a hard-threshold
+# breach to a blocking exit code. WARN never blocks.
+if [ "$VERDICT" = "blocked" ] && [ "$GATE_HARD" = "1" ]; then
+  echo -e "${RED}::error::Android Vitals gate FAILED (GATE_HARD=1) — fix prod stability before releasing.${NC}"
+  exit 1
+fi
+exit 0

--- a/.claude/scripts/release-checklist.sh
+++ b/.claude/scripts/release-checklist.sh
@@ -353,6 +353,48 @@ else
 fi
 echo ""
 
+# ─── 15. Android Vitals (prod stability) gate ───────────────────────────────
+# Device-QA (section 14) validates the demo app on EMULATORS before release.
+# Android Vitals is the complementary signal: the REAL crash & ANR rate across
+# live Play Store users, queried from the Play Developer Reporting API
+# (#1691). `play-vitals.sh` grades the 28-day user-perceived rates against
+# Google Play's own bad-behaviour thresholds.
+#
+# ADVISORY-FIRST: the gate is non-blocking until a baseline is trusted. It
+# only hard-blocks (FAIL → release blocker) when invoked with `GATE_HARD=1`.
+# Any data-access problem — missing `PLAY_STORE_SERVICE_ACCOUNT_JSON`, the 403
+# you get before the read-only "View app quality information" Play Console
+# permission is granted, a fresh app with no data — degrades to WARN and never
+# freezes a release. Set `PLAY_VITALS_HARD=1` to promote a hard-threshold
+# breach to a release blocker once the numbers are trusted.
+echo -e "${CYAN}--- Android Vitals (prod stability) ---${NC}"
+
+VITALS_SCRIPT="$REPO_ROOT/.claude/scripts/play-vitals.sh"
+if [ -x "$VITALS_SCRIPT" ]; then
+    VITALS_JSON="$(mktemp 2>/dev/null || echo /tmp/play-vitals-$$.json)"
+    VITALS_LOG="$(mktemp 2>/dev/null || echo /tmp/play-vitals-$$.log)"
+    # GATE_HARD is opt-in via PLAY_VITALS_HARD so the default checklist run
+    # stays advisory (#1691).
+    if GATE_HARD="${PLAY_VITALS_HARD:-0}" VITALS_JSON_OUT="$VITALS_JSON" \
+        bash "$VITALS_SCRIPT" > "$VITALS_LOG" 2>&1; then
+        VITALS_VERDICT=$(python3 -c "import json; print(json.load(open('$VITALS_JSON')).get('verdict','?'))" 2>/dev/null || echo "?")
+        VITALS_DETAIL=$(python3 -c "import json; print(json.load(open('$VITALS_JSON')).get('detail','') or '')" 2>/dev/null || echo "")
+        case "$VITALS_VERDICT" in
+            pass)  check "Android Vitals (crash/ANR)" "PASS" "$VITALS_DETAIL" ;;
+            warn)  check "Android Vitals (crash/ANR)" "WARN" "${VITALS_DETAIL:-advisory — review prod stability}" ;;
+            *)     check "Android Vitals (crash/ANR)" "WARN" "advisory — verdict '$VITALS_VERDICT' (see log)" ;;
+        esac
+    else
+        # Non-zero exit only happens under PLAY_VITALS_HARD=1 on a real breach.
+        VITALS_DETAIL=$(python3 -c "import json; print(json.load(open('$VITALS_JSON')).get('detail','') or '')" 2>/dev/null || echo "")
+        check "Android Vitals (crash/ANR)" "FAIL" "hard-threshold breach — ${VITALS_DETAIL:-see play-vitals.sh output}"
+    fi
+    rm -f "$VITALS_JSON" "$VITALS_LOG"
+else
+    check "Android Vitals (crash/ANR)" "WARN" "play-vitals.sh missing — prod stability not checked"
+fi
+echo ""
+
 # ─── Summary ───────────────────────────────────────────────────────────
 echo -e "${CYAN}=== Release Readiness Summary ===${NC}"
 echo ""

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -422,3 +422,162 @@ jobs:
           # The script's own guards (current branch, ahead>0, open PR)
           # protect every branch that still carries live work.
           bash .claude/scripts/cleanup-branches-worktrees.sh --yes --no-worktrees
+
+  # ── 9. Play Store reviews & ratings ingest ────────────────────────────────
+  # The empire dashboard aggregates npm downloads + GitHub stars, but the Play
+  # Store side of the demo app — rating + written reviews — was invisible to
+  # any automation. User reviews are a free, high-signal bug feed nobody was
+  # reading systematically (#1692).
+  #
+  # This job runs `play-reviews-ingest.sh`, which pulls recent reviews via the
+  # Android Publisher `reviews.list` API (the SAME `PLAY_STORE_SERVICE_ACCOUNT_JSON`
+  # service account play-store.yml already uses to publish — read-only, no new
+  # write scope). It computes the average rating + star histogram over the
+  # fetched window and flags reviews matching a crash/bug signal.
+  #
+  # For each flagged review it opens ONE de-duplicated tracking issue, keyed
+  # by the stable Play `reviewId` — same open/update tracking-issue pattern as
+  # the Pages-freshness (job 6) and deep-link-health (job 7) monitors above.
+  # Re-running the job never files the same review twice.
+  #
+  # NON-BLOCKING: the ingest script always exits 0; a missing secret, a 403
+  # before the read-only review permission is granted, or an API error all
+  # degrade to a WARN. Known API gap: `reviews.list` only returns reviews
+  # modified in roughly the last week, and install counts are NOT exposed by
+  # any queryable Play API — both are documented in the script header.
+  play-reviews:
+    name: Play Store reviews ingest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write       # open/update per-review triage issues
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Play API client
+        run: |
+          # Reuse play-store.yml's pinned requirements (google-auth + requests)
+          # — Dependabot already tracks that file via the `pip` ecosystem entry.
+          pip install --quiet -r .github/workflows/requirements/play-store.txt
+
+      - name: Ingest Play Store reviews
+        id: ingest
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          bash .claude/scripts/play-reviews-ingest.sh play-reviews.json | tee reviews-ingest.log
+
+      - name: Open de-duplicated triage issues for flagged reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ ! -f play-reviews.json ]; then
+            echo "::warning::play-reviews.json not produced — skipping triage."
+            exit 0
+          fi
+
+          # A degraded ingest (missing secret / 403 / API error) has no
+          # `flagged` entries — nothing to do, never fail the job.
+          FLAGGED_COUNT=$(python3 -c "import json;print(len(json.load(open('play-reviews.json')).get('flagged',[])))" 2>/dev/null || echo 0)
+          echo "Flagged reviews: $FLAGGED_COUNT"
+          [ "$FLAGGED_COUNT" -eq 0 ] && exit 0
+
+          # Emit one TSV line per flagged review: reviewId, star, signal,
+          # device, appVersion, language, text. The python side base64-encodes
+          # the text so newlines/tabs in a review body can't break the loop.
+          python3 - << 'PYEOF' > flagged.tsv
+          import base64, json
+          for r in json.load(open("play-reviews.json")).get("flagged", []):
+              text = base64.b64encode((r.get("text") or "").encode()).decode()
+              print("\t".join([
+                  r.get("reviewId", ""),
+                  str(r.get("starRating", "?")),
+                  r.get("signal", "?"),
+                  str(r.get("device", "unknown")),
+                  str(r.get("appVersion", "unknown")),
+                  str(r.get("language", "")),
+                  text,
+              ]))
+          PYEOF
+
+          while IFS=$'\t' read -r RID STAR SIGNAL DEVICE APPVER LANG TEXT_B64; do
+            [ -z "$RID" ] && continue
+            TEXT=$(echo "$TEXT_B64" | base64 -d 2>/dev/null || echo "(decode error)")
+            # De-dup key: the stable Play reviewId, carried verbatim in the
+            # issue title so a search is exact and idempotent.
+            SHORT_ID="${RID:0:18}"
+            TITLE="Play Store review — $SIGNAL signal (${STAR}★) [${SHORT_ID}]"
+            EXISTING=$(gh issue list --repo "${{ github.repository }}" --state all \
+              --search "${SHORT_ID} in:title" \
+              --json number --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$EXISTING" ]; then
+              echo "Review $SHORT_ID already tracked in #$EXISTING — skipping."
+              continue
+            fi
+            BODY=$(cat <<EOF
+          Automated Play Store review triage (#1692) flagged a user review as a
+          potential bug report.
+
+          | Field | Value |
+          |---|---|
+          | Star rating | ${STAR} / 5 |
+          | Bug signal | \`${SIGNAL}\` |
+          | Device | ${DEVICE} |
+          | App version | ${APPVER} |
+          | Language | ${LANG:-unknown} |
+          | Play review ID | \`${RID}\` |
+
+          **Review text**
+
+          > ${TEXT}
+
+          ---
+          Posted by the \`play-reviews\` maintenance job. De-duplicated by Play
+          review ID — this review will not be filed again. Triage: reproduce on
+          the listed device/version, then either fix or close as not-a-bug.
+          Replying to the review in the Play Console is a separate manual step
+          (this automation is read-only by design).
+          EOF
+            )
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label "bug,play-store,user-report" \
+              || echo "::warning::Could not create triage issue for review $SHORT_ID"
+          done < flagged.tsv
+
+      - name: Append review metrics to step summary
+        if: always()
+        run: |
+          {
+            echo "### Play Store reviews — $(date -u +%Y-%m-%d)"
+            echo ""
+            if [ -f play-reviews.json ]; then
+              python3 - << 'PYEOF'
+          import json
+          d = json.load(open("play-reviews.json"))
+          if d.get("degraded"):
+              print(f"_Ingest degraded: {d['degraded']}_")
+          else:
+              print(f"- Reviews fetched (≈last 7d window): **{d.get('reviewCount', 0)}**")
+              avg = d.get("averageRating")
+              print(f"- Average rating (fetched window): **{avg if avg is not None else 'n/a'} / 5**")
+              hist = d.get("starHistogram", {})
+              if hist:
+                  print("- Star histogram: " + "  ".join(f"{k}★={v}" for k, v in sorted(hist.items())))
+              print(f"- Flagged for triage: **{len(d.get('flagged', []))}**")
+          print("")
+          print("_Install base / lifetime rating are not exposed by a queryable "
+                "Play API — see play-reviews-ingest.sh._")
+          PYEOF
+            else
+              echo "_No review data produced this run._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,35 @@ green; then promote them to blocking by shrinking the `--advisory=` set. A red
 *blocking* leg means a demo crashes for a real user — fix it before tagging,
 no exceptions.
 
+#### Android Vitals release-gate (#1691)
+
+Device-QA validates the demo app on **emulators** *before* release. Android
+Vitals is the complementary post-release signal: the **real crash & ANR rate**
+across live Play Store users.
+
+- `release-checklist.sh` **section 15** runs `.claude/scripts/play-vitals.sh`,
+  which queries the **Play Developer Reporting API** for
+  `io.github.sceneview.demo` and grades the 28-day user-perceived crash & ANR
+  rates against Google Play's bad-behaviour thresholds (crash 1.09%, ANR 0.47%).
+- **Advisory-first**: the gate is `WARN`-only by default and never freezes a
+  release. A missing `PLAY_STORE_SERVICE_ACCOUNT_JSON` secret, the 403 you get
+  before the read-only **"View app quality information"** Play Console
+  permission is granted, or a fresh app with no data all degrade to `WARN`.
+  Set `PLAY_VITALS_HARD=1` to promote a hard-threshold breach to a release
+  blocker once the numbers are trusted.
+- Reuses the existing deploy service account — **no new write scope**.
+
+#### Play Store reviews → triage issues (#1692)
+
+`maintenance.yml`'s `play-reviews` job runs daily, ingesting Play Store
+ratings + written reviews via the Android Publisher `reviews.list` API (same
+deploy service account, read-only). Reviews matching a crash/bug signal —
+or 1-star reviews with a real comment — auto-open a **de-duplicated** triage
+issue (keyed by the stable Play `reviewId`) with the review text, device, and
+app version. **Documented API gaps:** `reviews.list` only returns reviews from
+≈the last week, and install counts are not exposed by any queryable Play API
+(only bulk CSV reports) — both are surfaced honestly rather than faked.
+
 ## About
 
 SceneView provides 3D and AR as declarative UI for Android (Jetpack Compose, Filament,

--- a/changelog.d/1691-1692-playstore-observability.md
+++ b/changelog.d/1691-1692-playstore-observability.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **Play Store CI observability.** A new `play-vitals.sh` release-gate (wired into `release-checklist.sh` section 15) grades the real-world crash & ANR rate from the Play Developer Reporting API — advisory by default, blocking under `PLAY_VITALS_HARD=1` (#1691). A new daily `play-reviews` job in `maintenance.yml` ingests Play Store ratings + reviews via the Android Publisher API and auto-opens a de-duplicated triage issue for any review matching a crash/bug signal (#1692). Both reuse the existing deploy service account read-only — no new write scope.


### PR DESCRIPTION
## Summary

Adds two real-world Play Store telemetry surfaces that complement the emulator-only device-QA harness (#1560). Both reuse the existing `PLAY_STORE_SERVICE_ACCOUNT_JSON` deploy service account **read-only** — no new write scope.

### #1691 — Android Vitals release-gate

- New `.claude/scripts/play-vitals.sh` queries the **Play Developer Reporting API** for `io.github.sceneview.demo` and grades the 28-day user-perceived **crash & ANR rates** against Google Play's own bad-behaviour thresholds (crash 1.09%, ANR 0.47%).
- Wired into `release-checklist.sh` as **section 15** — emits a graded `PASS` / `WARN` / `FAIL` verdict alongside the device-QA gate.
- **Advisory-first**: `WARN`-only by default, never freezes a release. A hard-threshold breach is only promoted to a release blocker under `PLAY_VITALS_HARD=1`, once a baseline is trusted.
- Degrades to `WARN` (never blocks) on any data-access problem: missing secret, the 403 you get before the read-only **"View app quality information"** Play Console permission is granted, or a fresh app with no data.

### #1692 — Play Store reviews & ratings ingest

- New `.claude/scripts/play-reviews-ingest.sh` pulls recent reviews via the **Android Publisher `reviews.list` API**, computes the average rating + star histogram, and flags reviews matching a crash/bug signal (`crash`, `freeze`, `black screen`, `won't open`, …) or 1-star reviews with a real comment.
- New daily **`play-reviews` job** in `maintenance.yml` opens a **de-duplicated** triage issue (keyed by the stable Play `reviewId`) per flagged review, with device + app-version + star-rating context — same open/update tracking-issue pattern as the existing Pages-freshness and deep-link-health monitors.
- Average rating + star histogram + flagged count are also written to the workflow step summary.

## Documented API gaps (honest, not faked)

The proposals asked for installs / lifetime ratings. Verified against the live API docs:

- **`reviews.list` only returns reviews modified in roughly the last week** — a hard Google API limitation. The daily cadence covers that window with overlap; de-dup by `reviewId` makes the overlap harmless.
- **Install base / acquisitions are NOT exposed by any queryable Play API metric set** — they only come from the bulk CSV "statistics" reports dropped into a Cloud Storage bucket (separate GCS-bucket grant + different auth path). Rather than fake an install count, the script reports the average rating it *can* compute from the fetched review window and documents the gap in its header and the `notes` field of its JSON output.
- Crash/ANR vitals **are** programmatic via the Reporting API — that is what #1691's `play-vitals.sh` uses.

## Test plan

- [x] YAML-lint `maintenance.yml` (valid)
- [x] `bash -n` + `shellcheck` on `play-vitals.sh` and `play-reviews-ingest.sh` (clean)
- [x] All 6 embedded Python heredoc blocks compile-checked
- [x] `check-workflow-scripts.sh` passes
- [x] `impact-check.sh` — only the pre-existing "README.md node count" blocker remains (unrelated)
- [x] Degraded-path smoke test: both scripts exit 0 with valid JSON when `PLAY_STORE_SERVICE_ACCOUNT_JSON` is unset
- [x] `play-vitals.sh` grade-function boundary cases verified
- [ ] First scheduled `play-reviews` run after the read-only review permission is granted in the Play Console
- [ ] First `release-checklist.sh` run with the "View app quality information" permission granted (currently degrades to WARN)

Closes #1691
Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)