### PR TITLE
feat(arsceneview): collaborative AR sessions / multiplayer (#1764)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeMessage.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeMessage.kt
@@ -1,0 +1,218 @@
+package io.github.sceneview.ar.collaborative
+
+/**
+ * A decoded message exchanged over a [CollaborativeTransport].
+ *
+ * This is the typed counterpart of the JSON-lines [CollaborativeWireFormat]:
+ * [CollaborativeWireFormat.parse] turns a wire line into one of these, and the
+ * `encode*` functions on [CollaborativeWireFormat] turn application state into
+ * wire lines. [CollaborativeSession] is the only thing that needs to construct
+ * these directly; most apps just observe [CollaborativeSession.participants]
+ * and [CollaborativeSession.placedNodes].
+ *
+ * All transforms are expressed in the **shared anchor's local space** so they
+ * are directly comparable across devices — see [CollaborativeSession].
+ */
+public sealed interface CollaborativeMessage {
+
+    /** The id of the peer that originated this message. */
+    public val peerId: String
+
+    /**
+     * A peer announcing it has joined the session.
+     *
+     * @param displayName a human-readable name for the peer (defaults to the
+     *   peer id when the sender did not provide one).
+     */
+    public data class Hello(
+        override val peerId: String,
+        public val displayName: String,
+    ) : CollaborativeMessage
+
+    /** A peer announcing it is leaving the session. */
+    public data class Bye(
+        override val peerId: String,
+    ) : CollaborativeMessage
+
+    /**
+     * The shared coordinate-frame anchor for the whole session.
+     *
+     * The host device hosts an ARCore Cloud Anchor via
+     * [io.github.sceneview.ar.node.CloudAnchorNode.host] and broadcasts the
+     * resulting [cloudAnchorId]. Every other peer resolves the *same* id so all
+     * devices agree on one coordinate frame.
+     *
+     * @param cloudAnchorId the ARCore Cloud Anchor ID to resolve.
+     * @param name          an app-meaningful name (e.g. a registry key).
+     */
+    public data class SharedAnchor(
+        override val peerId: String,
+        public val cloudAnchorId: String,
+        public val name: String,
+    ) : CollaborativeMessage
+
+    /**
+     * A participant's live camera pose, in shared-anchor local space.
+     *
+     * @param epochMs     wall-clock capture time — used for staleness checks.
+     * @param translation `[x,y,z]` translation in shared-anchor space.
+     * @param quaternion  `[x,y,z,w]` rotation in shared-anchor space.
+     */
+    public data class ParticipantPose(
+        override val peerId: String,
+        public val epochMs: Long,
+        public val translation: FloatArray,
+        public val quaternion: FloatArray,
+    ) : CollaborativeMessage {
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ParticipantPose) return false
+            return peerId == other.peerId &&
+                epochMs == other.epochMs &&
+                translation.contentEquals(other.translation) &&
+                quaternion.contentEquals(other.quaternion)
+        }
+
+        override fun hashCode(): Int {
+            var result = peerId.hashCode()
+            result = 31 * result + epochMs.hashCode()
+            result = 31 * result + translation.contentHashCode()
+            result = 31 * result + quaternion.contentHashCode()
+            return result
+        }
+    }
+
+    /**
+     * The transform of a placed object, in shared-anchor local space.
+     *
+     * Conflict policy is **last-writer-wins** keyed on [nodeKey]: a later
+     * `NodeState` for the same key fully replaces the earlier one.
+     *
+     * @param nodeKey     app-defined unique key for the placed node.
+     * @param modelKey    app-defined key for the model asset to instantiate.
+     * @param translation `[x,y,z]` translation in shared-anchor space.
+     * @param quaternion  `[x,y,z,w]` rotation in shared-anchor space.
+     * @param scale       `[x,y,z]` scale.
+     */
+    public data class NodeState(
+        override val peerId: String,
+        public val nodeKey: String,
+        public val modelKey: String,
+        public val translation: FloatArray,
+        public val quaternion: FloatArray,
+        public val scale: FloatArray,
+    ) : CollaborativeMessage {
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is NodeState) return false
+            return peerId == other.peerId &&
+                nodeKey == other.nodeKey &&
+                modelKey == other.modelKey &&
+                translation.contentEquals(other.translation) &&
+                quaternion.contentEquals(other.quaternion) &&
+                scale.contentEquals(other.scale)
+        }
+
+        override fun hashCode(): Int {
+            var result = peerId.hashCode()
+            result = 31 * result + nodeKey.hashCode()
+            result = 31 * result + modelKey.hashCode()
+            result = 31 * result + translation.contentHashCode()
+            result = 31 * result + quaternion.contentHashCode()
+            result = 31 * result + scale.contentHashCode()
+            return result
+        }
+    }
+}
+
+/**
+ * A remote participant in a collaborative AR session, as observed locally.
+ *
+ * Exposed via [CollaborativeSession.participants]. The local user is **not**
+ * included — the session only tracks remote peers.
+ *
+ * @param id          the peer's stable id.
+ * @param displayName the peer's human-readable name.
+ * @param translation `[x,y,z]` of the peer's last-known camera pose, in
+ *                    shared-anchor local space, or `null` if no pose has been
+ *                    received yet.
+ * @param quaternion  `[x,y,z,w]` of the peer's last-known camera rotation, in
+ *                    shared-anchor local space, or `null` if no pose yet.
+ * @param lastSeenEpochMs wall-clock time of the most recent message from this
+ *                    peer — use it to dim or drop stale participants.
+ */
+public data class Participant(
+    public val id: String,
+    public val displayName: String,
+    public val translation: FloatArray? = null,
+    public val quaternion: FloatArray? = null,
+    public val lastSeenEpochMs: Long = 0L,
+) {
+    /** `true` once at least one camera pose has been received for this peer. */
+    public val hasPose: Boolean get() = translation != null && quaternion != null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Participant) return false
+        return id == other.id &&
+            displayName == other.displayName &&
+            (translation?.contentEquals(other.translation) ?: (other.translation == null)) &&
+            (quaternion?.contentEquals(other.quaternion) ?: (other.quaternion == null)) &&
+            lastSeenEpochMs == other.lastSeenEpochMs
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + displayName.hashCode()
+        result = 31 * result + (translation?.contentHashCode() ?: 0)
+        result = 31 * result + (quaternion?.contentHashCode() ?: 0)
+        result = 31 * result + lastSeenEpochMs.hashCode()
+        return result
+    }
+}
+
+/**
+ * The transform of a node placed by some peer, in shared-anchor local space.
+ *
+ * Exposed via [CollaborativeSession.placedNodes]. Apps map [modelKey] to a
+ * concrete asset and reconcile their scene graph against this map every frame
+ * (instantiate new keys, move existing ones, remove vanished ones).
+ *
+ * @param nodeKey     app-defined unique key for the placed node.
+ * @param modelKey    app-defined key for the model asset to instantiate.
+ * @param translation `[x,y,z]` translation in shared-anchor space.
+ * @param quaternion  `[x,y,z,w]` rotation in shared-anchor space.
+ * @param scale       `[x,y,z]` scale.
+ * @param ownerPeerId the peer that last wrote this node's state.
+ */
+public data class PlacedNode(
+    public val nodeKey: String,
+    public val modelKey: String,
+    public val translation: FloatArray,
+    public val quaternion: FloatArray,
+    public val scale: FloatArray,
+    public val ownerPeerId: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlacedNode) return false
+        return nodeKey == other.nodeKey &&
+            modelKey == other.modelKey &&
+            translation.contentEquals(other.translation) &&
+            quaternion.contentEquals(other.quaternion) &&
+            scale.contentEquals(other.scale) &&
+            ownerPeerId == other.ownerPeerId
+    }
+
+    override fun hashCode(): Int {
+        var result = nodeKey.hashCode()
+        result = 31 * result + modelKey.hashCode()
+        result = 31 * result + translation.contentHashCode()
+        result = 31 * result + quaternion.contentHashCode()
+        result = 31 * result + scale.contentHashCode()
+        result = 31 * result + ownerPeerId.hashCode()
+        return result
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeSession.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeSession.kt
@@ -1,0 +1,435 @@
+package io.github.sceneview.ar.collaborative
+
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.google.android.filament.Engine
+import com.google.ar.core.Anchor
+import com.google.ar.core.Frame
+import com.google.ar.core.Pose
+import com.google.ar.core.Session
+import io.github.sceneview.ar.node.CloudAnchorNode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+/**
+ * Orchestrates a collaborative (multi-user) AR session: two or more devices
+ * see the **same** anchored content and each other's live camera poses.
+ *
+ * ### What it is — and is not
+ *
+ * ARCore has **no** `collaborationData` / `ParticipantManager` (unlike ARKit).
+ * Its entire shared-AR story is Cloud Anchors. `CollaborativeSession` is
+ * therefore built on the two pieces that *do* exist:
+ *
+ * 1. **A shared coordinate frame** via the existing [CloudAnchorNode] — one
+ *    device [host]s a Cloud Anchor, every other device [resolve]s the same id.
+ *    All content and pose data is then expressed relative to that one anchor.
+ * 2. **A pluggable [CollaborativeTransport]** that relays app state (the
+ *    shared anchor id, participant camera poses, placed-node transforms) as
+ *    JSON-lines [CollaborativeWireFormat] messages between peers.
+ *
+ * The merge / conflict logic lives in the pure-Kotlin [CollaborativeState];
+ * this class is the Android/ARCore/Compose wrapper around it.
+ *
+ * ### Architecture — mirrors `RerunBridge`
+ *
+ * Like [io.github.sceneview.ar.rerun.RerunBridge] this is a pluggable bridge:
+ *
+ * - A dedicated **supervisor [CoroutineScope]** owns all message I/O, so one
+ *   failing job never tears the session down.
+ * - The outbound queue is a **`CONFLATED` [Channel]** — [onFrame] may be
+ *   called from the AR render loop, so enqueuing is non-blocking and the
+ *   newest pose silently wins under backpressure.
+ * - A lifecycle-bound [rememberCollaborativeSession] helper wires `start` /
+ *   `stop` to the composition.
+ *
+ * ### Threading (⚠️ Filament JNI = main thread)
+ *
+ * - [host] / [resolve] call into ARCore + create [CloudAnchorNode]s and **must
+ *   run on the main thread** — they are documented as main-thread-only and the
+ *   composable host already satisfies this.
+ * - [onFrame] is designed to be called from the AR render callback (main
+ *   thread). It only *reads* the camera pose and does a non-blocking
+ *   `trySend` — no Filament/JNI mutation, no blocking I/O.
+ * - Inbound messages are merged on the supervisor scope; observers read the
+ *   results via the Compose-observable [participants] / [placedNodes].
+ *
+ * ### Usage
+ *
+ * Prefer [rememberCollaborativeSession]; this class is public so non-Compose
+ * hosts and unit tests can drive it directly.
+ *
+ * ```kotlin
+ * val transport = LoopbackCollaborativeTransport.LoopbackHub().join("me")
+ * val session = CollaborativeSession(transport, displayName = "Alice")
+ * session.start()
+ * // host (first device):
+ * session.host(arSession, anchor) { id, ok -> /* share id out of band */ }
+ * // or resolve (joining device):
+ * session.resolve(engine, arSession, cloudAnchorId)
+ * // every AR frame:
+ * arSceneView.onSessionUpdated = { s, frame -> session.onFrame(frame) }
+ * ```
+ *
+ * @param transport   the [CollaborativeTransport] relaying messages between peers.
+ * @param displayName a human-readable name broadcast to other peers.
+ * @param poseRateHz  maximum number of camera-pose broadcasts per second.
+ *   Later poses inside a tick are dropped. Default 10 Hz; `0` disables throttling.
+ * @param tag         Logcat tag for non-fatal warnings.
+ */
+public class CollaborativeSession
+@JvmOverloads
+public constructor(
+    private val transport: CollaborativeTransport,
+    private val displayName: String = transport.localPeerId,
+    private val poseRateHz: Int = DEFAULT_POSE_RATE_HZ,
+    private val tag: String = "CollaborativeSession",
+) {
+
+    public companion object {
+        /** Default camera-pose broadcast rate, in Hz. */
+        public const val DEFAULT_POSE_RATE_HZ: Int = 10
+    }
+
+    private val localPeerId: String = transport.localPeerId
+    private val state = CollaborativeState(localPeerId)
+
+    // All message I/O runs here. SupervisorJob so one failed send/merge job
+    // never cancels the whole session — same choice as RerunBridge.
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    // Conflated: enqueuing from the render loop never blocks; the newest
+    // outbound line wins if the writer is momentarily behind.
+    private val outbox = Channel<ByteArray>(capacity = Channel.CONFLATED)
+
+    private var incomingHandle: AutoCloseable? = null
+
+    @Volatile private var started = false
+    @Volatile private var lastPoseEmitNanos: Long = 0L
+    private val minPoseIntervalNanos: Long =
+        if (poseRateHz <= 0) 0L else 1_000_000_000L / poseRateHz
+
+    /**
+     * The shared coordinate-frame [CloudAnchorNode], once [host] has succeeded
+     * or [resolve] has completed. `null` until then. Parent your collaborative
+     * content to this node so every device renders it in the same place.
+     */
+    public var sharedAnchorNode: CloudAnchorNode? = null
+        private set
+
+    // ── Compose-observable state ──────────────────────────────────────────
+
+    private var _participants by mutableStateOf<List<Participant>>(emptyList())
+    /** Remote participants currently in the session. Excludes the local user. */
+    public val participants: List<Participant> get() = _participants
+
+    private var _placedNodes by mutableStateOf<List<PlacedNode>>(emptyList())
+    /**
+     * Every node placed by any peer, in shared-anchor local space. Reconcile
+     * your scene graph against this each frame: instantiate new keys, move
+     * existing ones, remove vanished ones.
+     */
+    public val placedNodes: List<PlacedNode> get() = _placedNodes
+
+    private var _sharedCloudAnchorId by mutableStateOf<String?>(null)
+    /**
+     * The ARCore Cloud Anchor ID for the session's shared frame, once a host
+     * has announced it. A joining device passes this to [resolve].
+     */
+    public val sharedCloudAnchorId: String? get() = _sharedCloudAnchorId
+
+    /** `true` between [start] and [stop]. */
+    public val isStarted: Boolean get() = started
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    /**
+     * Starts the session: subscribes to the transport, launches the writer
+     * loop, and broadcasts a `hello`. Idempotent — a second call is a no-op.
+     */
+    public fun start() {
+        if (started) return
+        started = true
+
+        incomingHandle = transport.incoming { peerId, bytes -> onTransportMessage(peerId, bytes) }
+
+        // Drop participants whose transport link died.
+        transport.peers
+            .onEach { live ->
+                if (state.retainParticipants(live)) publishParticipants()
+            }
+            .launchIn(scope)
+
+        // Writer loop — drains the conflated outbox to the transport.
+        scope.launch {
+            for (line in outbox) {
+                try {
+                    transport.send(line)
+                } catch (e: Exception) {
+                    logWarning("send failed: ${e.message}")
+                }
+            }
+        }
+
+        enqueue(CollaborativeWireFormat.hello(localPeerId, displayName))
+    }
+
+    /**
+     * Stops the session: broadcasts a `bye`, unsubscribes from the transport,
+     * and cancels the I/O scope. Does **not** close the [transport] itself —
+     * the transport's owner is responsible for that (the composable helper
+     * does it on dispose). Safe to call multiple times.
+     */
+    public fun stop() {
+        if (!started) return
+        started = false
+        try {
+            transport.send(CollaborativeWireFormat.bye(localPeerId).toByteArray())
+        } catch (e: Exception) {
+            logWarning("bye failed: ${e.message}")
+        }
+        try {
+            incomingHandle?.close()
+        } catch (e: Exception) {
+            logWarning("unsubscribe failed: ${e.message}")
+        }
+        incomingHandle = null
+        scope.cancel()
+        outbox.close()
+    }
+
+    // ── Shared anchor — host / resolve ────────────────────────────────────
+
+    /**
+     * Hosts [anchor] as the session's shared coordinate-frame Cloud Anchor and
+     * broadcasts the resulting id to every peer.
+     *
+     * **Main thread only** — creates a [CloudAnchorNode] and calls into ARCore.
+     *
+     * **Privacy.** Cloud Anchor hosting uploads visual features of the user's
+     * surroundings to Google. Surface a clear disclosure — see
+     * [CloudAnchorNode.host].
+     *
+     * @param session   the active ARCore [Session] (needs `CloudAnchorMode.ENABLED`).
+     * @param anchor    the local [Anchor] to promote to the shared frame.
+     * @param engine    the Filament [Engine] for the created node.
+     * @param ttlDays   Cloud Anchor lifetime, `1..365`. Default `1`.
+     * @param name      an app-meaningful name for the anchor (registry key).
+     * @param onHosted  called on completion with the cloud anchor id (or `null`
+     *   on failure) and a success flag.
+     */
+    @JvmOverloads
+    public fun host(
+        session: Session,
+        anchor: Anchor,
+        engine: Engine,
+        ttlDays: Int = 1,
+        name: String = "session",
+        onHosted: ((cloudAnchorId: String?, success: Boolean) -> Unit)? = null,
+    ) {
+        val node = CloudAnchorNode(engine, anchor)
+        sharedAnchorNode = node
+        node.host(session, ttlDays) { cloudAnchorId, hostState ->
+            val ok = cloudAnchorId != null && !hostState.isError
+            if (ok && cloudAnchorId != null) {
+                _sharedCloudAnchorId = cloudAnchorId
+                enqueue(CollaborativeWireFormat.anchor(localPeerId, cloudAnchorId, name))
+            } else {
+                logWarning("host failed: $hostState")
+            }
+            onHosted?.invoke(cloudAnchorId, ok)
+        }
+    }
+
+    /**
+     * Resolves the session's shared coordinate-frame Cloud Anchor by id — the
+     * id a host broadcast (see [sharedCloudAnchorId]) or one shared out of band.
+     *
+     * **Main thread only** — creates a [CloudAnchorNode] and calls into ARCore.
+     *
+     * @param engine        the Filament [Engine] for the created node.
+     * @param session       the active ARCore [Session].
+     * @param cloudAnchorId the Cloud Anchor ID to resolve.
+     * @param onResolved    called on completion with the resolved
+     *   [CloudAnchorNode] (or `null` on failure).
+     */
+    @JvmOverloads
+    public fun resolve(
+        engine: Engine,
+        session: Session,
+        cloudAnchorId: String,
+        onResolved: ((node: CloudAnchorNode?) -> Unit)? = null,
+    ) {
+        CloudAnchorNode.resolve(engine, session, cloudAnchorId) { resolveState, node ->
+            if (node != null && !resolveState.isError) {
+                sharedAnchorNode = node
+                _sharedCloudAnchorId = cloudAnchorId
+            } else {
+                logWarning("resolve failed: $resolveState")
+            }
+            onResolved?.invoke(node)
+        }
+    }
+
+    // ── Per-frame pose broadcast ──────────────────────────────────────────
+
+    /**
+     * Broadcasts the local camera pose for this AR [frame], expressed in the
+     * shared anchor's local space so every peer can place the "other phone"
+     * marker consistently.
+     *
+     * Call from the AR render callback (`onSessionUpdated`). Non-blocking and
+     * rate-limited to [poseRateHz]: it only reads the camera pose and does a
+     * `trySend`, so it is safe on the main render thread. A no-op until a
+     * shared anchor exists ([sharedAnchorNode] non-null) — without a shared
+     * frame, a pose is not comparable across devices.
+     */
+    public fun onFrame(frame: Frame) {
+        if (!started) return
+        val anchorPose = sharedAnchorNode?.anchor?.pose ?: return
+        if (!shouldEmitPose(frame.timestamp)) return
+        // Express the camera pose RELATIVE to the shared anchor:
+        //   relative = anchorPose⁻¹ ∘ cameraPose
+        // so the numbers mean the same thing on every device regardless of
+        // where each device started its own world origin.
+        val relative = anchorPose.inverse().compose(frame.camera.pose)
+        broadcastLocalPose(relative)
+    }
+
+    /**
+     * Lower-level overload that broadcasts an already-shared-anchor-relative
+     * [relativePose]. Useful for non-ARCore hosts or tests. [onFrame] is the
+     * convenient path for a real AR session.
+     */
+    public fun broadcastLocalPose(relativePose: Pose) {
+        if (!started) return
+        val t = floatArrayOf(relativePose.tx(), relativePose.ty(), relativePose.tz())
+        val q = floatArrayOf(
+            relativePose.qx(), relativePose.qy(), relativePose.qz(), relativePose.qw(),
+        )
+        enqueue(
+            CollaborativeWireFormat.pose(localPeerId, System.currentTimeMillis(), t, q),
+        )
+    }
+
+    // ── Placed-node broadcast ─────────────────────────────────────────────
+
+    /**
+     * Broadcasts that the local user placed (or moved) a node, so every peer
+     * can mirror it.
+     *
+     * Coordinates are in the **shared anchor's local space** — compute them as
+     * `sharedAnchorNode.anchor.pose.inverse().compose(worldPose)` before
+     * calling, or simply parent your content to [sharedAnchorNode] and read
+     * the child node's local transform.
+     *
+     * @param nodeKey     a unique app-defined key for the placed node.
+     * @param modelKey    an app-defined key telling peers which asset to load.
+     * @param translation `[x,y,z]` in shared-anchor space.
+     * @param quaternion  `[x,y,z,w]` in shared-anchor space.
+     * @param scale       `[x,y,z]`. Defaults to unit scale.
+     */
+    @JvmOverloads
+    public fun placeNode(
+        nodeKey: String,
+        modelKey: String,
+        translation: FloatArray,
+        quaternion: FloatArray,
+        scale: FloatArray = floatArrayOf(1f, 1f, 1f),
+    ) {
+        if (!started) return
+        // Reflect the local placement into our own state so placedNodes is a
+        // complete picture (it would otherwise only contain remote nodes —
+        // CollaborativeState ignores self-originated messages).
+        val placed = PlacedNode(nodeKey, modelKey, translation, quaternion, scale, localPeerId)
+        if (mergeLocalNode(placed)) publishNodes()
+        enqueue(
+            CollaborativeWireFormat.node(
+                localPeerId, nodeKey, modelKey, translation, quaternion, scale,
+            ),
+        )
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────
+
+    private val localNodes = LinkedHashMap<String, PlacedNode>()
+
+    private fun mergeLocalNode(placed: PlacedNode): Boolean {
+        val previous = localNodes.put(placed.nodeKey, placed)
+        return previous != placed
+    }
+
+    private fun onTransportMessage(peerId: String, bytes: ByteArray) {
+        // Marshal everything onto the session scope so merge + publish never
+        // race with the writer loop or the peers flow.
+        scope.launch {
+            val line = bytes.toString(Charsets.UTF_8)
+            val message = CollaborativeWireFormat.parse(line) ?: run {
+                logVerbose("dropped unparseable line from $peerId")
+                return@launch
+            }
+            if (state.apply(message)) {
+                publishParticipants()
+                publishNodes()
+                state.sharedAnchor?.let { _sharedCloudAnchorId = it.cloudAnchorId }
+            }
+        }
+    }
+
+    private fun publishParticipants() {
+        _participants = state.participants
+    }
+
+    private fun publishNodes() {
+        // placedNodes is the union of remote nodes (from CollaborativeState)
+        // and the local user's own placements (localNodes) — remote entries
+        // for a key shadow nothing, but a local key the network also knows
+        // about resolves to whichever side wrote last via lastWriterWins.
+        val merged = LinkedHashMap<String, PlacedNode>()
+        localNodes.forEach { (k, v) -> merged[k] = v }
+        state.placedNodes.forEach { merged[it.nodeKey] = it }
+        _placedNodes = merged.values.toList()
+    }
+
+    /**
+     * Enqueue a serialized line for the writer loop. Non-blocking: `trySend`
+     * onto the conflated outbox, so a render-loop caller is never blocked and
+     * the newest line wins under backpressure.
+     */
+    private fun enqueue(line: String) {
+        outbox.trySend(line.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun shouldEmitPose(timestampNanos: Long): Boolean {
+        if (minPoseIntervalNanos <= 0L) return true
+        val delta = timestampNanos - lastPoseEmitNanos
+        if (delta < minPoseIntervalNanos) return false
+        lastPoseEmitNanos = timestampNanos
+        return true
+    }
+
+    private fun logWarning(msg: String) {
+        try { Log.w(tag, msg) } catch (_: RuntimeException) { /* unit test stub */ }
+    }
+
+    private fun logVerbose(msg: String) {
+        try { Log.v(tag, msg) } catch (_: RuntimeException) { /* unit test stub */ }
+    }
+
+    /**
+     * Test-only hook: feed a raw wire line as if it arrived from [peerId],
+     * bypassing the transport. Lets `CollaborativeSessionTest` exercise the
+     * merge path without a real ARCore session.
+     */
+    internal fun testOnlyReceive(peerId: String, line: String) {
+        onTransportMessage(peerId, line.toByteArray(Charsets.UTF_8))
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeState.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeState.kt
@@ -1,0 +1,126 @@
+package io.github.sceneview.ar.collaborative
+
+/**
+ * The pure-Kotlin merge / conflict-resolution core of a [CollaborativeSession].
+ *
+ * It owns the authoritative local view of the session — the remote
+ * [participants] and the set of [placedNodes] — and applies incoming
+ * [CollaborativeMessage]s to it with a deterministic, **last-writer-wins**
+ * policy. It has **no** ARCore, Filament, Android, or coroutine dependency, so
+ * the entire sync-and-merge logic is unit-testable on plain JVM (see
+ * `CollaborativeStateTest`).
+ *
+ * [CollaborativeSession] is the thin Android/ARCore wrapper around this: it
+ * feeds wire messages in via [apply] and reads [participants] / [placedNodes]
+ * back out onto Compose-observable state. Keeping the merge logic separate is
+ * the same separation [io.github.sceneview.ar.rerun.RerunWireFormat] applies
+ * to serialization — pure code stays pure and fully covered by JVM tests.
+ *
+ * @param localPeerId the local device's peer id. Messages whose `peerId`
+ *   equals this are ignored (a peer never tracks itself as a participant).
+ */
+public class CollaborativeState(private val localPeerId: String) {
+
+    private val participantsById = LinkedHashMap<String, Participant>()
+    private val nodesByKey = LinkedHashMap<String, PlacedNode>()
+
+    /** The most recent shared anchor announced for the session, or `null`. */
+    public var sharedAnchor: CollaborativeMessage.SharedAnchor? = null
+        private set
+
+    /** A stable snapshot of every remote participant currently tracked. */
+    public val participants: List<Participant>
+        get() = participantsById.values.toList()
+
+    /** A stable snapshot of every placed node currently tracked. */
+    public val placedNodes: List<PlacedNode>
+        get() = nodesByKey.values.toList()
+
+    /**
+     * Applies one decoded [message] to the local state.
+     *
+     * @return `true` if the state changed (so the caller should publish a
+     *   fresh snapshot to observers), `false` if the message was a no-op
+     *   (e.g. it originated from the local peer, or duplicated existing state).
+     */
+    public fun apply(message: CollaborativeMessage): Boolean {
+        // A peer never tracks itself as a remote participant or re-applies its
+        // own placements — the local scene graph is already the source of
+        // truth for anything this device originated.
+        if (message.peerId == localPeerId) return false
+        return when (message) {
+            is CollaborativeMessage.Hello -> applyHello(message)
+            is CollaborativeMessage.Bye -> applyBye(message)
+            is CollaborativeMessage.SharedAnchor -> applySharedAnchor(message)
+            is CollaborativeMessage.ParticipantPose -> applyPose(message)
+            is CollaborativeMessage.NodeState -> applyNode(message)
+        }
+    }
+
+    /** Removes the participant with [peerId] (e.g. transport link dropped). */
+    public fun removeParticipant(peerId: String): Boolean =
+        participantsById.remove(peerId) != null
+
+    /** Drops every participant not present in [livePeerIds]. */
+    public fun retainParticipants(livePeerIds: Set<String>): Boolean {
+        val stale = participantsById.keys - livePeerIds - localPeerId
+        if (stale.isEmpty()) return false
+        stale.forEach { participantsById.remove(it) }
+        return true
+    }
+
+    private fun applyHello(message: CollaborativeMessage.Hello): Boolean {
+        val existing = participantsById[message.peerId]
+        val updated = (existing ?: Participant(message.peerId, message.displayName)).copy(
+            displayName = message.displayName,
+            lastSeenEpochMs = maxOf(existing?.lastSeenEpochMs ?: 0L, nowOr(existing)),
+        )
+        participantsById[message.peerId] = updated
+        return existing != updated
+    }
+
+    private fun applyBye(message: CollaborativeMessage.Bye): Boolean =
+        participantsById.remove(message.peerId) != null
+
+    private fun applySharedAnchor(message: CollaborativeMessage.SharedAnchor): Boolean {
+        if (sharedAnchor == message) return false
+        sharedAnchor = message
+        return true
+    }
+
+    private fun applyPose(message: CollaborativeMessage.ParticipantPose): Boolean {
+        val existing = participantsById[message.peerId]
+        // Drop out-of-order / stale poses: a later epoch always wins, an
+        // earlier one is silently ignored (UDP-style reordering safety).
+        if (existing != null && existing.lastSeenEpochMs > message.epochMs) return false
+        val updated = (existing ?: Participant(message.peerId, message.peerId)).copy(
+            translation = message.translation,
+            quaternion = message.quaternion,
+            lastSeenEpochMs = message.epochMs,
+        )
+        participantsById[message.peerId] = updated
+        return existing != updated
+    }
+
+    private fun applyNode(message: CollaborativeMessage.NodeState): Boolean {
+        val placed = PlacedNode(
+            nodeKey = message.nodeKey,
+            modelKey = message.modelKey,
+            translation = message.translation,
+            quaternion = message.quaternion,
+            scale = message.scale,
+            ownerPeerId = message.peerId,
+        )
+        val existing = nodesByKey[message.nodeKey]
+        if (existing == placed) return false
+        // Last-writer-wins: the newest NodeState for a key fully replaces it.
+        nodesByKey[message.nodeKey] = placed
+        return true
+    }
+
+    /** Removes the placed node with [nodeKey]. */
+    public fun removeNode(nodeKey: String): Boolean = nodesByKey.remove(nodeKey) != null
+
+    private fun nowOr(existing: Participant?): Long =
+        existing?.lastSeenEpochMs ?: 0L
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeTransport.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeTransport.kt
@@ -1,0 +1,81 @@
+package io.github.sceneview.ar.collaborative
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The pluggable network layer for a collaborative ([CollaborativeSession]) AR
+ * experience.
+ *
+ * ### Why this is an interface, not a concrete impl
+ *
+ * SceneView deliberately does **not** pick a networking stack for the app.
+ * Multi-user AR transport is a genuine product decision with real trade-offs:
+ *
+ * - **Nearby Connections** — offline same-room, no backend, but Android-only
+ *   and needs a pairing UX (and a Play Services dependency).
+ * - **Firebase Realtime DB** — trivial signaling but a backend dependency and
+ *   API keys baked into the app.
+ * - **WebRTC** — lowest latency, cross-network, but heavy.
+ * - **Raw sockets / your existing game backend** — whatever you already run.
+ *
+ * Forcing one of those onto every SceneView app would be wrong. Instead the
+ * library ships this interface plus one always-available reference impl,
+ * [LoopbackCollaborativeTransport], which connects peers **in-process** (no
+ * networking) so the API is demonstrable and unit-testable out of the box.
+ * Production transports (Nearby Connections, Firebase, …) are app- or
+ * plugin-provided and implement this same contract.
+ *
+ * On iOS the same abstraction maps cleanly onto RealityKit's
+ * `MultipeerConnectivityService`, so the interface shape is kept
+ * cross-platform-friendly.
+ *
+ * ### Contract
+ *
+ * - [send] is **non-blocking** — [CollaborativeSession] may call it from the
+ *   AR render callback, so an implementation must never block the caller
+ *   thread on I/O. Queue and flush on your own thread.
+ * - [incoming] handlers may be invoked on **any** thread. [CollaborativeSession]
+ *   marshals everything onto its own scope, so an impl is free to dispatch
+ *   from whatever I/O thread it owns.
+ * - [peers] is the set of currently-reachable remote peer ids. It does not
+ *   include the local peer.
+ * - [close] releases every resource; the transport is unusable afterwards.
+ *
+ * Messages are opaque byte arrays — the transport never inspects them. The
+ * serialization contract lives entirely in [CollaborativeWireFormat].
+ */
+public interface CollaborativeTransport {
+
+    /**
+     * This device's stable peer id within the session. Must be unique across
+     * all connected peers and stable for the transport's lifetime.
+     */
+    public val localPeerId: String
+
+    /**
+     * The set of remote peer ids currently reachable through this transport.
+     * Never includes [localPeerId]. Observed by
+     * [CollaborativeSession] to drop participants whose transport link died.
+     */
+    public val peers: StateFlow<Set<String>>
+
+    /**
+     * Broadcasts [message] to every connected peer.
+     *
+     * **Must not block the caller.** [CollaborativeSession] may invoke this
+     * from the AR render loop; the implementation is expected to enqueue and
+     * flush asynchronously.
+     */
+    public fun send(message: ByteArray)
+
+    /**
+     * Registers a [handler] invoked for every message received from a peer.
+     * The handler may be called on any thread.
+     *
+     * @return a handle whose [AutoCloseable.close] unregisters the handler.
+     */
+    public fun incoming(handler: (peerId: String, message: ByteArray) -> Unit): AutoCloseable
+
+    /** Releases all resources. The transport is unusable after this call. */
+    public fun close()
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeWireFormat.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/CollaborativeWireFormat.kt
@@ -1,0 +1,357 @@
+package io.github.sceneview.ar.collaborative
+
+/**
+ * JSON-lines wire format for the collaborative (multiplayer) AR layer.
+ *
+ * Every collaborative event is one JSON object on a single line, terminated
+ * by `\n`. A [CollaborativeTransport] relays these lines verbatim between
+ * peers; [CollaborativeSession] produces and consumes them.
+ *
+ * ### Why JSON-lines (and not protobuf / kotlinx.serialization)
+ *
+ * This mirrors [io.github.sceneview.ar.rerun.RerunWireFormat]: a `String`-in /
+ * `String`-out, hand-rolled serializer with **zero new runtime dependencies**.
+ * `kotlinx.serialization` is not on the `arsceneview` classpath and pulling it
+ * in for a small message bus would bloat every SceneView app. JSON-lines is
+ * also trivially framable on a byte stream (split on `\n`) and human-readable
+ * on the wire, which makes a loopback / fake transport easy to debug.
+ *
+ * ### Message types
+ *
+ * ```
+ * {"type":"hello",  "peer":"<id>", "name":"<display>"}
+ * {"type":"anchor", "peer":"<id>", "id":"<cloudAnchorId>", "name":"<key>"}
+ * {"type":"pose",   "peer":"<id>", "t":<epochMs>, "translation":[x,y,z], "quaternion":[x,y,z,w]}
+ * {"type":"node",   "peer":"<id>", "node":"<key>", "model":"<key>",
+ *                   "translation":[x,y,z], "quaternion":[x,y,z,w], "scale":[x,y,z]}
+ * {"type":"bye",    "peer":"<id>"}
+ * ```
+ *
+ * - `hello` / `bye` — a peer joining / leaving. `hello` carries an optional
+ *   human-readable display name.
+ * - `anchor` — the shared coordinate-frame anchor. The host broadcasts the
+ *   ARCore Cloud Anchor ID it obtained from [io.github.sceneview.ar.node.CloudAnchorNode.host]
+ *   so every other peer can resolve the *same* anchor and agree on a frame.
+ * - `pose` — a participant's live camera pose, expressed **in the shared
+ *   anchor's local space** so it is directly comparable across devices.
+ * - `node` — a placed object's transform, again in shared-anchor space. The
+ *   `model` field is an app-defined key telling the receiver which asset to
+ *   instantiate. Conflict policy is last-writer-wins per `node` key.
+ *
+ * All coordinates are in the shared anchor's local space. The translation /
+ * quaternion / scale ordering matches ARCore's `Pose` (`[x,y,z]` translation,
+ * `[x,y,z,w]` quaternion) and SceneView's `Scale` (`[x,y,z]`).
+ *
+ * This object is pure: no I/O, no threading, no Android framework — it can be
+ * unit-tested on plain JVM.
+ */
+public object CollaborativeWireFormat {
+
+    /** Discriminator values for the `"type"` field. */
+    public const val TYPE_HELLO: String = "hello"
+    public const val TYPE_ANCHOR: String = "anchor"
+    public const val TYPE_POSE: String = "pose"
+    public const val TYPE_NODE: String = "node"
+    public const val TYPE_BYE: String = "bye"
+
+    // ── Encoders ──────────────────────────────────────────────────────────
+
+    /** Encodes a `hello` message — a peer announcing itself to the session. */
+    public fun hello(peerId: String, displayName: String): String = buildString(96) {
+        append('{')
+        appendField("type", TYPE_HELLO)
+        append(',')
+        appendField("peer", peerId)
+        append(',')
+        appendField("name", displayName)
+        append("}\n")
+    }
+
+    /** Encodes a `bye` message — a peer leaving the session. */
+    public fun bye(peerId: String): String = buildString(48) {
+        append('{')
+        appendField("type", TYPE_BYE)
+        append(',')
+        appendField("peer", peerId)
+        append("}\n")
+    }
+
+    /**
+     * Encodes an `anchor` message carrying the shared ARCore Cloud Anchor ID.
+     *
+     * @param peerId        the host that hosted the anchor.
+     * @param cloudAnchorId the ARCore-issued Cloud Anchor ID.
+     * @param name          an app-meaningful name for the anchor (registry key).
+     */
+    public fun anchor(peerId: String, cloudAnchorId: String, name: String): String =
+        buildString(160) {
+            append('{')
+            appendField("type", TYPE_ANCHOR)
+            append(',')
+            appendField("peer", peerId)
+            append(',')
+            appendField("id", cloudAnchorId)
+            append(',')
+            appendField("name", name)
+            append("}\n")
+        }
+
+    /**
+     * Encodes a `pose` message — a participant's camera pose in shared-anchor
+     * local space.
+     *
+     * @param peerId       the participant whose pose this is.
+     * @param epochMs      wall-clock capture time, used for staleness checks.
+     * @param translation  `[x,y,z]` translation in shared-anchor space.
+     * @param quaternion   `[x,y,z,w]` rotation in shared-anchor space.
+     */
+    public fun pose(
+        peerId: String,
+        epochMs: Long,
+        translation: FloatArray,
+        quaternion: FloatArray,
+    ): String {
+        require(translation.size == 3) { "translation must have 3 components" }
+        require(quaternion.size == 4) { "quaternion must have 4 components" }
+        return buildString(160) {
+            append('{')
+            appendField("type", TYPE_POSE)
+            append(',')
+            appendField("peer", peerId)
+            append(",\"t\":")
+            append(epochMs)
+            append(',')
+            appendVec("translation", translation)
+            append(',')
+            appendVec("quaternion", quaternion)
+            append("}\n")
+        }
+    }
+
+    /**
+     * Encodes a `node` message — a placed object's transform in shared-anchor
+     * local space.
+     *
+     * @param peerId       the peer that placed / moved the node.
+     * @param nodeKey      app-defined unique key for the placed node.
+     * @param modelKey     app-defined key for the model asset to instantiate.
+     * @param translation  `[x,y,z]` translation in shared-anchor space.
+     * @param quaternion   `[x,y,z,w]` rotation in shared-anchor space.
+     * @param scale        `[x,y,z]` scale.
+     */
+    public fun node(
+        peerId: String,
+        nodeKey: String,
+        modelKey: String,
+        translation: FloatArray,
+        quaternion: FloatArray,
+        scale: FloatArray,
+    ): String {
+        require(translation.size == 3) { "translation must have 3 components" }
+        require(quaternion.size == 4) { "quaternion must have 4 components" }
+        require(scale.size == 3) { "scale must have 3 components" }
+        return buildString(224) {
+            append('{')
+            appendField("type", TYPE_NODE)
+            append(',')
+            appendField("peer", peerId)
+            append(',')
+            appendField("node", nodeKey)
+            append(',')
+            appendField("model", modelKey)
+            append(',')
+            appendVec("translation", translation)
+            append(',')
+            appendVec("quaternion", quaternion)
+            append(',')
+            appendVec("scale", scale)
+            append("}\n")
+        }
+    }
+
+    // ── Decoder ───────────────────────────────────────────────────────────
+
+    /**
+     * Parses one JSON-lines string into a [CollaborativeMessage].
+     *
+     * Returns `null` for blank lines or for any line we don't recognise —
+     * callers should silently ignore those and keep reading, so a future
+     * message-type addition never crashes an older peer. Hand-parsed (no JSON
+     * library) to keep the runtime dependency-free, matching [hello] etc.
+     */
+    public fun parse(line: String): CollaborativeMessage? {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) return null
+        val type = stringField(trimmed, "type") ?: return null
+        val peer = stringField(trimmed, "peer") ?: return null
+        return when (type) {
+            TYPE_HELLO -> CollaborativeMessage.Hello(
+                peerId = peer,
+                displayName = stringField(trimmed, "name") ?: peer,
+            )
+            TYPE_BYE -> CollaborativeMessage.Bye(peerId = peer)
+            TYPE_ANCHOR -> parseAnchor(trimmed, peer)
+            TYPE_POSE -> parsePose(trimmed, peer)
+            TYPE_NODE -> parseNode(trimmed, peer)
+            else -> null
+        }
+    }
+
+    private fun parseAnchor(line: String, peer: String): CollaborativeMessage? {
+        val id = stringField(line, "id") ?: return null
+        return CollaborativeMessage.SharedAnchor(
+            peerId = peer,
+            cloudAnchorId = id,
+            name = stringField(line, "name") ?: id,
+        )
+    }
+
+    private fun parsePose(line: String, peer: String): CollaborativeMessage? {
+        val t = floatVec(line, "translation") ?: return null
+        val q = floatVec(line, "quaternion") ?: return null
+        if (t.size != 3 || q.size != 4) return null
+        return CollaborativeMessage.ParticipantPose(
+            peerId = peer,
+            epochMs = longField(line, "t") ?: 0L,
+            translation = t,
+            quaternion = q,
+        )
+    }
+
+    private fun parseNode(line: String, peer: String): CollaborativeMessage? {
+        val nodeKey = stringField(line, "node")
+        val modelKey = stringField(line, "model")
+        val transform = parseTransform(line) ?: return null
+        if (nodeKey == null || modelKey == null) return null
+        return CollaborativeMessage.NodeState(
+            peerId = peer,
+            nodeKey = nodeKey,
+            modelKey = modelKey,
+            translation = transform.translation,
+            quaternion = transform.quaternion,
+            scale = transform.scale,
+        )
+    }
+
+    /** A `translation`/`quaternion`/`scale` triple parsed off one line. */
+    private class Transform(
+        val translation: FloatArray,
+        val quaternion: FloatArray,
+        val scale: FloatArray,
+    )
+
+    /** Parses + size-validates the translation/quaternion/scale triple. */
+    private fun parseTransform(line: String): Transform? {
+        val t = floatVec(line, "translation") ?: return null
+        val q = floatVec(line, "quaternion") ?: return null
+        val s = floatVec(line, "scale") ?: return null
+        val sizesValid = t.size == 3 && q.size == 4 && s.size == 3
+        return if (sizesValid) Transform(t, q, s) else null
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private fun StringBuilder.appendField(name: String, value: String) {
+        append('"')
+        append(name)
+        append("\":\"")
+        appendEscaped(value)
+        append('"')
+    }
+
+    private fun StringBuilder.appendVec(name: String, vec: FloatArray) {
+        append('"')
+        append(name)
+        append("\":[")
+        for (i in vec.indices) {
+            if (i > 0) append(',')
+            appendFloat(vec[i])
+        }
+        append(']')
+    }
+
+    /**
+     * Writes a float as a plain JSON number. Non-finite values (NaN / Infinity)
+     * would break the JSON line; we emit `0` instead so the line stays
+     * parseable rather than silently corrupting the whole stream.
+     */
+    private fun StringBuilder.appendFloat(f: Float) {
+        if (!f.isFinite()) append('0') else append(f)
+    }
+
+    /** Minimal JSON string escaper — matches `RerunWireFormat`. */
+    private fun StringBuilder.appendEscaped(s: String) {
+        for (c in s) {
+            when {
+                c == '"' -> append("\\\"")
+                c == '\\' -> append("\\\\")
+                c == '\n' -> append("\\n")
+                c == '\r' -> append("\\r")
+                c == '\t' -> append("\\t")
+                c.code < 0x20 -> append("\\u").append(c.code.toString(16).padStart(4, '0'))
+                else -> append(c)
+            }
+        }
+    }
+
+    /** Extracts a quoted string field by name, or `null` if absent. */
+    private fun stringField(line: String, name: String): String? {
+        val key = "\"$name\":\""
+        val start = line.indexOf(key).takeIf { it >= 0 } ?: return null
+        val from = start + key.length
+        val sb = StringBuilder()
+        var i = from
+        while (i < line.length) {
+            val c = line[i]
+            if (c == '\\' && i + 1 < line.length) {
+                when (val next = line[i + 1]) {
+                    '"', '\\', '/' -> sb.append(next)
+                    'n' -> sb.append('\n')
+                    'r' -> sb.append('\r')
+                    't' -> sb.append('\t')
+                    'u' -> {
+                        if (i + 5 >= line.length) return null
+                        sb.append(line.substring(i + 2, i + 6).toInt(16).toChar())
+                        i += 4
+                    }
+                    else -> sb.append(next)
+                }
+                i += 2
+                continue
+            }
+            if (c == '"') return sb.toString()
+            sb.append(c)
+            i++
+        }
+        return null
+    }
+
+    /** Extracts an integer (`long`) field by name, or `null` if absent. */
+    private fun longField(line: String, name: String): Long? {
+        val key = "\"$name\":"
+        val start = line.indexOf(key).takeIf { it >= 0 } ?: return null
+        var i = start + key.length
+        while (i < line.length && line[i].isWhitespace()) i++
+        val numStart = i
+        if (i < line.length && (line[i] == '-' || line[i] == '+')) i++
+        while (i < line.length && line[i].isDigit()) i++
+        if (numStart == i) return null
+        return line.substring(numStart, i).toLongOrNull()
+    }
+
+    /** Extracts a `[a,b,c]` float-array field by name, or `null` if absent. */
+    private fun floatVec(line: String, name: String): FloatArray? {
+        val key = "\"$name\":["
+        val start = line.indexOf(key).takeIf { it >= 0 } ?: return null
+        val from = start + key.length
+        val end = line.indexOf(']', from).takeIf { it >= 0 } ?: return null
+        val body = line.substring(from, end).trim()
+        if (body.isEmpty()) return FloatArray(0)
+        val parts = body.split(',')
+        val out = FloatArray(parts.size)
+        for (i in parts.indices) {
+            out[i] = parts[i].trim().toFloatOrNull() ?: return null
+        }
+        return out
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/LoopbackCollaborativeTransport.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/LoopbackCollaborativeTransport.kt
@@ -1,0 +1,145 @@
+package io.github.sceneview.ar.collaborative
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * An in-process / loopback [CollaborativeTransport] reference implementation.
+ *
+ * Every transport created from the same [LoopbackHub] joins the same virtual
+ * session: a message [send]-by one peer is delivered synchronously to every
+ * **other** peer on the hub. No sockets, no Play Services, no permissions —
+ * which makes it perfect for:
+ *
+ * - **Unit tests** — spin up two transports on one hub and assert that one
+ *   side's broadcast reaches the other (see `CollaborativeSessionTest`).
+ * - **Single-device demos** — drive two [CollaborativeSession]s in the same
+ *   process to prove the API end-to-end without a second phone.
+ * - **A drop-in default** so `rememberCollaborativeSession` is never blocked
+ *   on the app first wiring real networking.
+ *
+ * It is **not** a production transport: it cannot reach another device. For
+ * real multiplayer, implement [CollaborativeTransport] over Nearby
+ * Connections, Firebase, WebRTC, or your existing game backend — the rest of
+ * the collaborative stack ([CollaborativeSession], [CollaborativeWireFormat])
+ * is transport-agnostic and unchanged.
+ *
+ * ### Threading
+ *
+ * Delivery is synchronous on the calling thread — [send] directly invokes
+ * every peer's handlers before returning. That is intentional: it keeps tests
+ * deterministic (no scheduler to await) and the volume on a loopback link is
+ * trivially small. [CollaborativeSession] still marshals everything onto its
+ * own supervisor scope, so synchronous delivery here does not leak threading
+ * concerns upward. Handler lists use [CopyOnWriteArrayList] so a handler may
+ * register / unregister during dispatch without a `ConcurrentModification`.
+ */
+public class LoopbackCollaborativeTransport private constructor(
+    override val localPeerId: String,
+    private val hub: LoopbackHub,
+) : CollaborativeTransport {
+
+    private val handlers = CopyOnWriteArrayList<(String, ByteArray) -> Unit>()
+    private val _peers = MutableStateFlow<Set<String>>(emptySet())
+    override val peers: StateFlow<Set<String>> = _peers.asStateFlow()
+
+    @Volatile private var closed = false
+
+    override fun send(message: ByteArray) {
+        if (closed) return
+        hub.broadcast(from = localPeerId, message = message)
+    }
+
+    override fun incoming(
+        handler: (peerId: String, message: ByteArray) -> Unit,
+    ): AutoCloseable {
+        handlers.add(handler)
+        return AutoCloseable { handlers.remove(handler) }
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        handlers.clear()
+        hub.leave(this)
+    }
+
+    /** Called by the hub when a message addressed to this peer arrives. */
+    internal fun deliver(fromPeerId: String, message: ByteArray) {
+        if (closed) return
+        for (handler in handlers) {
+            handler(fromPeerId, message)
+        }
+    }
+
+    /** Called by the hub whenever the peer roster changes. */
+    internal fun updatePeers(allPeerIds: Set<String>) {
+        _peers.value = allPeerIds - localPeerId
+    }
+
+    /**
+     * A virtual session that wires together every [LoopbackCollaborativeTransport]
+     * created from it. Think of it as the "local network" for loopback peers.
+     *
+     * Create one hub, then call [join] once per simulated device. All joined
+     * transports see each other in [CollaborativeTransport.peers] and exchange
+     * messages through [CollaborativeTransport.send].
+     *
+     * ```kotlin
+     * val hub = LoopbackCollaborativeTransport.LoopbackHub()
+     * val alice = hub.join("alice")
+     * val bob   = hub.join("bob")
+     * // alice.send(...) is now delivered to bob, and vice versa.
+     * ```
+     */
+    public class LoopbackHub {
+
+        // peerId -> transport. ConcurrentHashMap so join/leave from different
+        // threads (e.g. two test coroutines) never corrupt the roster.
+        private val members = ConcurrentHashMap<String, LoopbackCollaborativeTransport>()
+
+        /**
+         * Creates a new loopback transport with the given [peerId] and joins
+         * it to this hub.
+         *
+         * @throws IllegalArgumentException if [peerId] is blank or already in
+         *   use on this hub — peer ids must be unique per the
+         *   [CollaborativeTransport] contract.
+         */
+        public fun join(peerId: String): LoopbackCollaborativeTransport {
+            require(peerId.isNotBlank()) { "peerId must not be blank" }
+            val transport = LoopbackCollaborativeTransport(peerId, this)
+            val previous = members.putIfAbsent(peerId, transport)
+            require(previous == null) { "peerId '$peerId' is already joined to this hub" }
+            publishRoster()
+            return transport
+        }
+
+        /** Number of transports currently joined to this hub. */
+        public val peerCount: Int get() = members.size
+
+        internal fun broadcast(from: String, message: ByteArray) {
+            for ((peerId, transport) in members) {
+                if (peerId == from) continue
+                // Defensive copy: a transport must never be able to mutate a
+                // payload another transport still holds a reference to.
+                transport.deliver(from, message.copyOf())
+            }
+        }
+
+        internal fun leave(transport: LoopbackCollaborativeTransport) {
+            members.remove(transport.localPeerId, transport)
+            publishRoster()
+        }
+
+        private fun publishRoster() {
+            val roster = members.keys.toSet()
+            for (transport in members.values) {
+                transport.updatePeers(roster)
+            }
+        }
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/rememberCollaborativeSession.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/collaborative/rememberCollaborativeSession.kt
@@ -1,0 +1,78 @@
+package io.github.sceneview.ar.collaborative
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+
+/**
+ * Creates and remembers a [CollaborativeSession] bound to the composable
+ * lifecycle.
+ *
+ * The session is [CollaborativeSession.start]ed in a [DisposableEffect] and
+ * [CollaborativeSession.stop]ped — broadcasting a `bye` to peers — when the
+ * composable leaves the tree. This mirrors [io.github.sceneview.ar.rerun.rememberRerunBridge]:
+ * a lifecycle-bound helper so the I/O scope is never leaked across recompositions.
+ *
+ * ### Transport ownership
+ *
+ * If you pass [closeTransportOnDispose] `= true` (the default) the helper also
+ * closes the [transport] on dispose. Pass `false` when the transport outlives
+ * the composable (e.g. a Nearby Connections link shared by several screens).
+ *
+ * ### Typical usage
+ *
+ * ```kotlin
+ * @Composable
+ * fun MultiplayerARScreen() {
+ *     // Loopback for a single-process demo / test; swap for a real transport
+ *     // (Nearby Connections, Firebase, WebRTC) in production.
+ *     val transport = remember { LoopbackCollaborativeTransport.LoopbackHub().join("me") }
+ *     val session = rememberCollaborativeSession(transport, displayName = "Alice")
+ *
+ *     ARSceneView(
+ *         modifier = Modifier.fillMaxSize(),
+ *         onSessionUpdated = { _, frame -> session.onFrame(frame) },
+ *     ) {
+ *         // Parent collaborative content to session.sharedAnchorNode and
+ *         // reconcile against session.placedNodes / session.participants.
+ *     }
+ * }
+ * ```
+ *
+ * @param transport               the [CollaborativeTransport] relaying peer messages.
+ * @param displayName             a human-readable name broadcast to peers.
+ *   Defaults to the transport's local peer id.
+ * @param poseRateHz              camera-pose broadcast rate. Default
+ *   [CollaborativeSession.DEFAULT_POSE_RATE_HZ].
+ * @param closeTransportOnDispose close [transport] when the composable is
+ *   disposed. Default `true`.
+ */
+@Composable
+public fun rememberCollaborativeSession(
+    transport: CollaborativeTransport,
+    displayName: String = transport.localPeerId,
+    poseRateHz: Int = CollaborativeSession.DEFAULT_POSE_RATE_HZ,
+    closeTransportOnDispose: Boolean = true,
+): CollaborativeSession {
+    // Rebuild the session if any session-defining input changes. The transport
+    // identity is a key so swapping transports gives a fresh session.
+    val session = remember(transport, displayName, poseRateHz) {
+        CollaborativeSession(
+            transport = transport,
+            displayName = displayName,
+            poseRateHz = poseRateHz,
+        )
+    }
+
+    DisposableEffect(session) {
+        session.start()
+        onDispose {
+            session.stop()
+            if (closeTransportOnDispose) {
+                transport.close()
+            }
+        }
+    }
+
+    return session
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeSessionTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeSessionTest.kt
@@ -1,0 +1,206 @@
+package io.github.sceneview.ar.collaborative
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Integration tests for [CollaborativeSession] driven over two
+ * [LoopbackCollaborativeTransport]s on a shared hub — no ARCore, no Android.
+ *
+ * The session merges inbound messages on a background supervisor scope, so
+ * assertions poll [until] for the expected state with a short timeout rather
+ * than asserting synchronously.
+ */
+class CollaborativeSessionTest {
+
+    private val sessions = mutableListOf<CollaborativeSession>()
+
+    @After
+    fun tearDown() {
+        sessions.forEach { runCatching { it.stop() } }
+        sessions.clear()
+    }
+
+    private fun session(
+        transport: CollaborativeTransport,
+        displayName: String,
+    ): CollaborativeSession =
+        CollaborativeSession(transport, displayName = displayName).also { sessions.add(it) }
+
+    /** Polls [condition] until true or the timeout elapses. */
+    private fun until(timeoutMs: Long = 2000L, condition: () -> Boolean) = runBlocking {
+        withTimeout(timeoutMs) {
+            while (!condition()) delay(10)
+        }
+    }
+
+    @Test
+    fun `hello propagates a participant to the other session`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        val bob = session(hub.join("bob"), "Bob")
+
+        alice.start()
+        bob.start()
+
+        // Each side announced itself with a hello on start().
+        until { bob.participants.any { it.id == "alice" } }
+        until { alice.participants.any { it.id == "bob" } }
+
+        assertEquals("Alice", bob.participants.first { it.id == "alice" }.displayName)
+        assertEquals("Bob", alice.participants.first { it.id == "bob" }.displayName)
+    }
+
+    @Test
+    fun `a session never lists itself as a participant`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        alice.start()
+        // Give the hello a moment to round-trip (it shouldn't, but be sure).
+        runBlocking { delay(100) }
+        assertTrue(alice.participants.none { it.id == "alice" })
+    }
+
+    @Test
+    fun `pose broadcast updates the peer's participant transform`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        val bob = session(hub.join("bob"), "Bob")
+        alice.start()
+        bob.start()
+        until { bob.participants.any { it.id == "alice" } }
+
+        // Feed Bob a pose as if it came from Alice (bypasses ARCore Pose).
+        bob.testOnlyReceive(
+            "alice",
+            CollaborativeWireFormat.pose(
+                peerId = "alice",
+                epochMs = 500L,
+                translation = floatArrayOf(1.5f, 0f, -2f),
+                quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+            ),
+        )
+        until { bob.participants.firstOrNull { it.id == "alice" }?.hasPose == true }
+        val alicePose = bob.participants.first { it.id == "alice" }
+        assertEquals(1.5f, alicePose.translation!![0], 1e-5f)
+        assertEquals(-2f, alicePose.translation!![2], 1e-5f)
+    }
+
+    @Test
+    fun `placeNode broadcasts to peers and reflects locally`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        val bob = session(hub.join("bob"), "Bob")
+        alice.start()
+        bob.start()
+
+        alice.placeNode(
+            nodeKey = "robot-1",
+            modelKey = "robot",
+            translation = floatArrayOf(0f, 0f, -1f),
+            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+        )
+
+        // The placing session reflects its own placement immediately.
+        assertTrue(alice.placedNodes.any { it.nodeKey == "robot-1" })
+        // The peer receives it over the transport.
+        until { bob.placedNodes.any { it.nodeKey == "robot-1" } }
+        val node = bob.placedNodes.first { it.nodeKey == "robot-1" }
+        assertEquals("robot", node.modelKey)
+        assertEquals("alice", node.ownerPeerId)
+    }
+
+    @Test
+    fun `shared anchor id propagates from a received anchor message`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val bob = session(hub.join("bob"), "Bob")
+        bob.start()
+        assertNull(bob.sharedCloudAnchorId)
+
+        bob.testOnlyReceive(
+            "alice",
+            CollaborativeWireFormat.anchor("alice", "cloud-id-42", "room"),
+        )
+        until { bob.sharedCloudAnchorId == "cloud-id-42" }
+    }
+
+    @Test
+    fun `bye removes the peer from participants`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        val bob = session(hub.join("bob"), "Bob")
+        alice.start()
+        bob.start()
+        until { bob.participants.any { it.id == "alice" } }
+
+        alice.stop()
+        until { bob.participants.none { it.id == "alice" } }
+    }
+
+    @Test
+    fun `start is idempotent`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        alice.start()
+        assertTrue(alice.isStarted)
+        alice.start() // second call is a harmless no-op
+        assertTrue(alice.isStarted)
+    }
+
+    @Test
+    fun `stop flips isStarted false`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        alice.start()
+        alice.stop()
+        assertFalse(alice.isStarted)
+    }
+
+    @Test
+    fun `last-writer-wins across two peers for the same node key`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val carol = session(hub.join("carol"), "Carol")
+        carol.start()
+
+        carol.testOnlyReceive(
+            "alice",
+            CollaborativeWireFormat.node(
+                "alice", "shared-cube", "cube",
+                floatArrayOf(1f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(1f, 1f, 1f),
+            ),
+        )
+        until { carol.placedNodes.any { it.nodeKey == "shared-cube" } }
+
+        carol.testOnlyReceive(
+            "bob",
+            CollaborativeWireFormat.node(
+                "bob", "shared-cube", "cube",
+                floatArrayOf(9f, 9f, 9f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(3f, 3f, 3f),
+            ),
+        )
+        until {
+            carol.placedNodes.firstOrNull { it.nodeKey == "shared-cube" }?.ownerPeerId == "bob"
+        }
+        val node = carol.placedNodes.first { it.nodeKey == "shared-cube" }
+        assertEquals(9f, node.translation[0], 1e-5f)
+        assertEquals(3f, node.scale[0], 1e-5f)
+    }
+
+    @Test
+    fun `enqueue before start does not crash and onFrame is a no-op without anchor`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val alice = session(hub.join("alice"), "Alice")
+        // broadcastLocalPose / placeNode before start() are silently ignored.
+        alice.placeNode(
+            "n", "m", floatArrayOf(0f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f),
+        )
+        assertTrue(alice.placedNodes.isEmpty())
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeStateTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeStateTest.kt
@@ -1,0 +1,187 @@
+package io.github.sceneview.ar.collaborative
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure-Kotlin merge core [CollaborativeState] — last-writer-
+ * wins, self-message filtering, staleness handling. No ARCore, no Android.
+ */
+class CollaborativeStateTest {
+
+    private val local = "me"
+
+    @Test
+    fun `ignores messages from the local peer`() {
+        val state = CollaborativeState(local)
+        val changed = state.apply(CollaborativeMessage.Hello(local, "Me"))
+        assertFalse(changed)
+        assertTrue(state.participants.isEmpty())
+    }
+
+    @Test
+    fun `hello adds a remote participant`() {
+        val state = CollaborativeState(local)
+        assertTrue(state.apply(CollaborativeMessage.Hello("p1", "Alice")))
+        assertEquals(1, state.participants.size)
+        assertEquals("Alice", state.participants.first().displayName)
+    }
+
+    @Test
+    fun `bye removes a participant`() {
+        val state = CollaborativeState(local)
+        state.apply(CollaborativeMessage.Hello("p1", "Alice"))
+        assertTrue(state.apply(CollaborativeMessage.Bye("p1")))
+        assertTrue(state.participants.isEmpty())
+    }
+
+    @Test
+    fun `pose updates participant transform`() {
+        val state = CollaborativeState(local)
+        state.apply(CollaborativeMessage.Hello("p1", "Alice"))
+        val changed = state.apply(
+            CollaborativeMessage.ParticipantPose(
+                peerId = "p1",
+                epochMs = 100L,
+                translation = floatArrayOf(1f, 2f, 3f),
+                quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+            ),
+        )
+        assertTrue(changed)
+        val p = state.participants.first()
+        assertTrue(p.hasPose)
+        assertEquals(2f, p.translation!![1], 1e-6f)
+        assertEquals(100L, p.lastSeenEpochMs)
+    }
+
+    @Test
+    fun `pose creates participant even without a prior hello`() {
+        val state = CollaborativeState(local)
+        assertTrue(
+            state.apply(
+                CollaborativeMessage.ParticipantPose(
+                    peerId = "p9",
+                    epochMs = 1L,
+                    translation = floatArrayOf(0f, 0f, 0f),
+                    quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+                ),
+            ),
+        )
+        assertEquals(1, state.participants.size)
+    }
+
+    @Test
+    fun `stale pose is dropped`() {
+        val state = CollaborativeState(local)
+        state.apply(
+            CollaborativeMessage.ParticipantPose(
+                "p1", 200L, floatArrayOf(1f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f),
+            ),
+        )
+        // An earlier-timestamped pose must NOT overwrite the newer one.
+        val changed = state.apply(
+            CollaborativeMessage.ParticipantPose(
+                "p1", 100L, floatArrayOf(9f, 9f, 9f), floatArrayOf(0f, 0f, 0f, 1f),
+            ),
+        )
+        assertFalse(changed)
+        assertEquals(1f, state.participants.first().translation!![0], 1e-6f)
+    }
+
+    @Test
+    fun `node placement is recorded`() {
+        val state = CollaborativeState(local)
+        val changed = state.apply(
+            CollaborativeMessage.NodeState(
+                peerId = "p1",
+                nodeKey = "cube-1",
+                modelKey = "cube",
+                translation = floatArrayOf(1f, 0f, 0f),
+                quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+                scale = floatArrayOf(1f, 1f, 1f),
+            ),
+        )
+        assertTrue(changed)
+        assertEquals(1, state.placedNodes.size)
+        assertEquals("cube", state.placedNodes.first().modelKey)
+    }
+
+    @Test
+    fun `last writer wins for the same node key`() {
+        val state = CollaborativeState(local)
+        state.apply(
+            CollaborativeMessage.NodeState(
+                "p1", "cube-1", "cube",
+                floatArrayOf(1f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(1f, 1f, 1f),
+            ),
+        )
+        // A different peer moves the same node — its state must replace p1's.
+        state.apply(
+            CollaborativeMessage.NodeState(
+                "p2", "cube-1", "cube",
+                floatArrayOf(5f, 5f, 5f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(2f, 2f, 2f),
+            ),
+        )
+        assertEquals(1, state.placedNodes.size)
+        val node = state.placedNodes.first()
+        assertEquals("p2", node.ownerPeerId)
+        assertEquals(5f, node.translation[0], 1e-6f)
+        assertEquals(2f, node.scale[0], 1e-6f)
+    }
+
+    @Test
+    fun `duplicate node state is a no-op`() {
+        val state = CollaborativeState(local)
+        val msg = CollaborativeMessage.NodeState(
+            "p1", "cube-1", "cube",
+            floatArrayOf(1f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(1f, 1f, 1f),
+        )
+        assertTrue(state.apply(msg))
+        assertFalse(state.apply(msg))
+    }
+
+    @Test
+    fun `shared anchor is captured`() {
+        val state = CollaborativeState(local)
+        assertNull(state.sharedAnchor)
+        assertTrue(
+            state.apply(CollaborativeMessage.SharedAnchor("host", "ca-1", "session")),
+        )
+        assertEquals("ca-1", state.sharedAnchor!!.cloudAnchorId)
+    }
+
+    @Test
+    fun `retainParticipants drops peers absent from the live roster`() {
+        val state = CollaborativeState(local)
+        state.apply(CollaborativeMessage.Hello("p1", "A"))
+        state.apply(CollaborativeMessage.Hello("p2", "B"))
+        // p2's transport link died — only p1 is live now.
+        val changed = state.retainParticipants(setOf("p1"))
+        assertTrue(changed)
+        assertEquals(1, state.participants.size)
+        assertEquals("p1", state.participants.first().id)
+    }
+
+    @Test
+    fun `retainParticipants is a no-op when nothing is stale`() {
+        val state = CollaborativeState(local)
+        state.apply(CollaborativeMessage.Hello("p1", "A"))
+        assertFalse(state.retainParticipants(setOf("p1", "p2")))
+    }
+
+    @Test
+    fun `removeNode removes a placed node`() {
+        val state = CollaborativeState(local)
+        state.apply(
+            CollaborativeMessage.NodeState(
+                "p1", "cube-1", "cube",
+                floatArrayOf(0f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f), floatArrayOf(1f, 1f, 1f),
+            ),
+        )
+        assertTrue(state.removeNode("cube-1"))
+        assertTrue(state.placedNodes.isEmpty())
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeWireFormatTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/CollaborativeWireFormatTest.kt
@@ -1,0 +1,221 @@
+package io.github.sceneview.ar.collaborative
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Golden-JSON + round-trip tests for [CollaborativeWireFormat].
+ *
+ * Pure JVM — no ARCore, no Android. Mirrors the `RerunWireFormatTest`
+ * approach: assert exact serialized output and that every encoder/decoder
+ * pair round-trips.
+ */
+class CollaborativeWireFormatTest {
+
+    @Test
+    fun `hello emits canonical JSON line`() {
+        val line = CollaborativeWireFormat.hello("peer-1", "Alice")
+        assertEquals(
+            "{\"type\":\"hello\",\"peer\":\"peer-1\",\"name\":\"Alice\"}\n",
+            line,
+        )
+    }
+
+    @Test
+    fun `bye emits canonical JSON line`() {
+        val line = CollaborativeWireFormat.bye("peer-1")
+        assertEquals("{\"type\":\"bye\",\"peer\":\"peer-1\"}\n", line)
+    }
+
+    @Test
+    fun `anchor emits canonical JSON line`() {
+        val line = CollaborativeWireFormat.anchor("host", "ca-xyz", "session")
+        assertEquals(
+            "{\"type\":\"anchor\",\"peer\":\"host\",\"id\":\"ca-xyz\",\"name\":\"session\"}\n",
+            line,
+        )
+    }
+
+    @Test
+    fun `pose emits canonical JSON line`() {
+        val line = CollaborativeWireFormat.pose(
+            peerId = "p2",
+            epochMs = 1234L,
+            translation = floatArrayOf(0.1f, 1.7f, -0.2f),
+            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+        )
+        assertEquals(
+            "{\"type\":\"pose\",\"peer\":\"p2\",\"t\":1234," +
+                "\"translation\":[0.1,1.7,-0.2],\"quaternion\":[0.0,0.0,0.0,1.0]}\n",
+            line,
+        )
+    }
+
+    @Test
+    fun `node emits canonical JSON line`() {
+        val line = CollaborativeWireFormat.node(
+            peerId = "p3",
+            nodeKey = "cube-1",
+            modelKey = "cube",
+            translation = floatArrayOf(1f, 2f, 3f),
+            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+            scale = floatArrayOf(1f, 1f, 1f),
+        )
+        assertEquals(
+            "{\"type\":\"node\",\"peer\":\"p3\",\"node\":\"cube-1\",\"model\":\"cube\"," +
+                "\"translation\":[1.0,2.0,3.0],\"quaternion\":[0.0,0.0,0.0,1.0]," +
+                "\"scale\":[1.0,1.0,1.0]}\n",
+            line,
+        )
+    }
+
+    @Test
+    fun `every line terminates with newline`() {
+        assertTrue(CollaborativeWireFormat.hello("a", "A").endsWith("\n"))
+        assertTrue(CollaborativeWireFormat.bye("a").endsWith("\n"))
+        assertTrue(CollaborativeWireFormat.anchor("a", "id", "n").endsWith("\n"))
+    }
+
+    @Test
+    fun `hello round-trips`() {
+        val msg = CollaborativeWireFormat.parse(CollaborativeWireFormat.hello("p", "Bob"))
+        assertTrue(msg is CollaborativeMessage.Hello)
+        msg as CollaborativeMessage.Hello
+        assertEquals("p", msg.peerId)
+        assertEquals("Bob", msg.displayName)
+    }
+
+    @Test
+    fun `bye round-trips`() {
+        val msg = CollaborativeWireFormat.parse(CollaborativeWireFormat.bye("p"))
+        assertTrue(msg is CollaborativeMessage.Bye)
+        assertEquals("p", msg!!.peerId)
+    }
+
+    @Test
+    fun `anchor round-trips`() {
+        val msg = CollaborativeWireFormat.parse(
+            CollaborativeWireFormat.anchor("host", "cloud-id", "room"),
+        )
+        assertTrue(msg is CollaborativeMessage.SharedAnchor)
+        msg as CollaborativeMessage.SharedAnchor
+        assertEquals("host", msg.peerId)
+        assertEquals("cloud-id", msg.cloudAnchorId)
+        assertEquals("room", msg.name)
+    }
+
+    @Test
+    fun `pose round-trips`() {
+        val line = CollaborativeWireFormat.pose(
+            peerId = "p",
+            epochMs = 99L,
+            translation = floatArrayOf(1f, 2f, 3f),
+            quaternion = floatArrayOf(0f, 0f, 0.7071f, 0.7071f),
+        )
+        val msg = CollaborativeWireFormat.parse(line)
+        assertTrue(msg is CollaborativeMessage.ParticipantPose)
+        msg as CollaborativeMessage.ParticipantPose
+        assertEquals("p", msg.peerId)
+        assertEquals(99L, msg.epochMs)
+        assertEquals(3, msg.translation.size)
+        assertEquals(2f, msg.translation[1], 1e-6f)
+        assertEquals(0.7071f, msg.quaternion[3], 1e-6f)
+    }
+
+    @Test
+    fun `node round-trips`() {
+        val line = CollaborativeWireFormat.node(
+            peerId = "p",
+            nodeKey = "n-7",
+            modelKey = "robot",
+            translation = floatArrayOf(-1f, 0f, 5f),
+            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+            scale = floatArrayOf(2f, 2f, 2f),
+        )
+        val msg = CollaborativeWireFormat.parse(line)
+        assertTrue(msg is CollaborativeMessage.NodeState)
+        msg as CollaborativeMessage.NodeState
+        assertEquals("n-7", msg.nodeKey)
+        assertEquals("robot", msg.modelKey)
+        assertEquals(2f, msg.scale[0], 1e-6f)
+        assertEquals(5f, msg.translation[2], 1e-6f)
+    }
+
+    @Test
+    fun `parse returns null for blank line`() {
+        assertNull(CollaborativeWireFormat.parse(""))
+        assertNull(CollaborativeWireFormat.parse("   \n"))
+    }
+
+    @Test
+    fun `parse returns null for unknown type`() {
+        assertNull(
+            CollaborativeWireFormat.parse(
+                "{\"type\":\"future-message\",\"peer\":\"p\"}",
+            ),
+        )
+    }
+
+    @Test
+    fun `parse returns null for missing peer`() {
+        assertNull(CollaborativeWireFormat.parse("{\"type\":\"hello\",\"name\":\"X\"}"))
+    }
+
+    @Test
+    fun `parse returns null for malformed pose vector`() {
+        // translation has only 2 components — not a valid pose.
+        assertNull(
+            CollaborativeWireFormat.parse(
+                "{\"type\":\"pose\",\"peer\":\"p\",\"t\":1," +
+                    "\"translation\":[1.0,2.0],\"quaternion\":[0.0,0.0,0.0,1.0]}",
+            ),
+        )
+    }
+
+    @Test
+    fun `hello defaults display name to peer id when name absent`() {
+        val msg = CollaborativeWireFormat.parse("{\"type\":\"hello\",\"peer\":\"px\"}")
+        assertNotNull(msg)
+        assertEquals("px", (msg as CollaborativeMessage.Hello).displayName)
+    }
+
+    @Test
+    fun `escapes quote in display name`() {
+        val line = CollaborativeWireFormat.hello("p", "Al\"ice")
+        assertTrue(line.contains("Al\\\"ice"))
+        val msg = CollaborativeWireFormat.parse(line) as CollaborativeMessage.Hello
+        assertEquals("Al\"ice", msg.displayName)
+    }
+
+    @Test
+    fun `non-finite floats serialize as zero to keep line parseable`() {
+        val line = CollaborativeWireFormat.pose(
+            peerId = "p",
+            epochMs = 0L,
+            translation = floatArrayOf(Float.NaN, Float.POSITIVE_INFINITY, 1f),
+            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+        )
+        val msg = CollaborativeWireFormat.parse(line) as CollaborativeMessage.ParticipantPose
+        assertEquals(0f, msg.translation[0], 0f)
+        assertEquals(0f, msg.translation[1], 0f)
+        assertEquals(1f, msg.translation[2], 0f)
+    }
+
+    @Test
+    fun `pose rejects wrong-size translation at encode time`() {
+        try {
+            CollaborativeWireFormat.pose(
+                peerId = "p",
+                epochMs = 0L,
+                translation = floatArrayOf(1f, 2f),
+                quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+            )
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("translation"))
+        }
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/LoopbackCollaborativeTransportTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/collaborative/LoopbackCollaborativeTransportTest.kt
@@ -1,0 +1,143 @@
+package io.github.sceneview.ar.collaborative
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Unit tests for [LoopbackCollaborativeTransport] — the in-process reference
+ * transport. Verifies delivery, peer roster, isolation, and lifecycle.
+ */
+class LoopbackCollaborativeTransportTest {
+
+    @Test
+    fun `message reaches every other peer but not the sender`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        val b = hub.join("b")
+        val c = hub.join("c")
+
+        val receivedByA = CopyOnWriteArrayList<String>()
+        val receivedByB = CopyOnWriteArrayList<String>()
+        val receivedByC = CopyOnWriteArrayList<String>()
+        a.incoming { _, m -> receivedByA.add(m.toString(Charsets.UTF_8)) }
+        b.incoming { _, m -> receivedByB.add(m.toString(Charsets.UTF_8)) }
+        c.incoming { _, m -> receivedByC.add(m.toString(Charsets.UTF_8)) }
+
+        a.send("hello-from-a".toByteArray())
+
+        assertTrue("sender must not receive its own message", receivedByA.isEmpty())
+        assertEquals(listOf("hello-from-a"), receivedByB)
+        assertEquals(listOf("hello-from-a"), receivedByC)
+    }
+
+    @Test
+    fun `peers flow excludes the local peer and tracks the roster`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        assertEquals(emptySet<String>(), a.peers.value)
+
+        val b = hub.join("b")
+        assertEquals(setOf("b"), a.peers.value)
+        assertEquals(setOf("a"), b.peers.value)
+
+        b.close()
+        assertEquals(emptySet<String>(), a.peers.value)
+    }
+
+    @Test
+    fun `delivered carries the originating peer id`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        val b = hub.join("b")
+        var fromPeer: String? = null
+        b.incoming { peer, _ -> fromPeer = peer }
+        a.send("x".toByteArray())
+        assertEquals("a", fromPeer)
+    }
+
+    @Test
+    fun `closed transport neither sends nor receives`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        val b = hub.join("b")
+        val received = CopyOnWriteArrayList<String>()
+        b.incoming { _, m -> received.add(m.toString(Charsets.UTF_8)) }
+
+        b.close()
+        a.send("after-close".toByteArray())
+        assertTrue(received.isEmpty())
+    }
+
+    @Test
+    fun `incoming handle unregisters the handler`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        val b = hub.join("b")
+        val received = CopyOnWriteArrayList<String>()
+        val handle = b.incoming { _, m -> received.add(m.toString(Charsets.UTF_8)) }
+
+        a.send("first".toByteArray())
+        handle.close()
+        a.send("second".toByteArray())
+
+        assertEquals(listOf("first"), received)
+    }
+
+    @Test
+    fun `joining a duplicate peer id fails`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        hub.join("dup")
+        try {
+            hub.join("dup")
+            throw AssertionError("expected IllegalArgumentException for duplicate peer id")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("dup"))
+        }
+    }
+
+    @Test
+    fun `joining a blank peer id fails`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        try {
+            hub.join("  ")
+            throw AssertionError("expected IllegalArgumentException for blank peer id")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("blank"))
+        }
+    }
+
+    @Test
+    fun `peerCount reflects joins and leaves`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        assertEquals(0, hub.peerCount)
+        val a = hub.join("a")
+        hub.join("b")
+        assertEquals(2, hub.peerCount)
+        a.close()
+        assertEquals(1, hub.peerCount)
+    }
+
+    @Test
+    fun `a mutated payload does not leak to other peers`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        val a = hub.join("a")
+        val b = hub.join("b")
+        var receivedFirst: Byte = 0
+        b.incoming { _, m -> receivedFirst = m[0] }
+
+        val payload = byteArrayOf(7, 8, 9)
+        a.send(payload)
+        payload[0] = 99 // mutate after send
+
+        assertEquals("receiver must hold an isolated copy", 7.toByte(), receivedFirst)
+    }
+
+    @Test
+    fun `localPeerId is the joined id`() {
+        val hub = LoopbackCollaborativeTransport.LoopbackHub()
+        assertEquals("zed", hub.join("zed").localPeerId)
+    }
+}

--- a/changelog.d/1764-collaborative-ar.md
+++ b/changelog.d/1764-collaborative-ar.md
@@ -1,0 +1,16 @@
+<!-- category: Added -->
+- **Collaborative AR — multi-user sessions.** New `io.github.sceneview.ar.collaborative`
+  package brings shared-coordinate-frame multiplayer to ARCore. `CollaborativeSession`
+  (and the lifecycle-bound `rememberCollaborativeSession()` helper) orchestrates a shared
+  AR experience on top of the existing `CloudAnchorNode`: one device hosts the shared
+  Cloud Anchor, every other resolves the same id, and participant camera poses + placed-node
+  transforms are relayed between peers as JSON-lines messages. The networking layer is a
+  pluggable `CollaborativeTransport` interface — SceneView deliberately does not pick a
+  stack — shipped alongside an always-available, no-networking `LoopbackCollaborativeTransport`
+  reference impl that makes the API unit-testable and demonstrable on a single device.
+  `CollaborativeWireFormat` is pure Kotlin with zero new runtime dependencies, and the
+  whole merge core (`CollaborativeState`, last-writer-wins) is covered by 52 JVM unit
+  tests. The new `ar-collaborative` sample demo proves the full sync end-to-end without a
+  second phone. ARCore has no `collaborationData` API (unlike ARKit) — this is the honest,
+  buildable shape of multi-user AR on Android. A production Nearby Connections transport is
+  filed as a follow-up (#1764).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -1886,6 +1886,81 @@ registry.list().filterNot { it.isExpired() }.forEach { entry ->
 
 Threading: safe to call from the main thread — `SharedPreferences.edit().apply()` is non-blocking.
 
+### Collaborative AR — multi-user sessions (`io.github.sceneview.ar.collaborative`)
+
+Two or more devices see the **same** anchored content and each other's live camera poses.
+
+**ARCore reality check.** ARCore has NO `collaborationData` / `ParticipantManager` (unlike ARKit's `ARSession.collaborationData`). Its entire shared-AR story is Cloud Anchors. SceneView's collaborative layer is therefore built on the two pieces that DO exist: a shared coordinate frame via the existing `CloudAnchorNode` (one device hosts, every other resolves the same id), plus a **pluggable transport** relaying app state. SceneView does NOT pick a networking stack — it ships the interface plus an in-process reference impl.
+
+```kotlin
+// Pluggable network layer — app supplies one, or uses the loopback reference impl.
+interface CollaborativeTransport {
+    val localPeerId: String
+    val peers: StateFlow<Set<String>>                 // remote peers, never includes self
+    fun send(message: ByteArray)                      // non-blocking — may be called from the render loop
+    fun incoming(handler: (peerId: String, ByteArray) -> Unit): AutoCloseable
+    fun close()
+}
+
+// In-process reference transport — always available, no networking, no permissions.
+// Perfect for unit tests + single-device demos. Swap for Nearby Connections /
+// Firebase / WebRTC in production.
+val hub = LoopbackCollaborativeTransport.LoopbackHub()
+val transport = hub.join("my-peer-id")               // join one per simulated device
+
+// Orchestrator over CloudAnchorNode + the transport. Mirrors RerunBridge:
+// supervisor IO scope, CONFLATED outbox, lifecycle-bound remember* helper.
+@Composable fun rememberCollaborativeSession(
+    transport: CollaborativeTransport,
+    displayName: String = transport.localPeerId,
+    poseRateHz: Int = 10,                             // camera-pose broadcast rate
+    closeTransportOnDispose: Boolean = true
+): CollaborativeSession
+
+class CollaborativeSession {
+    val participants: List<Participant>               // Compose-observable, remote peers only
+    val placedNodes: List<PlacedNode>                 // every peer's placed objects, shared-anchor space
+    val sharedAnchorNode: CloudAnchorNode?            // the shared coordinate frame
+    val sharedCloudAnchorId: String?
+
+    fun start(); fun stop()
+    fun host(session: Session, anchor: Anchor, engine: Engine,
+             ttlDays: Int = 1, name: String = "session",
+             onHosted: ((cloudAnchorId: String?, success: Boolean) -> Unit)? = null)
+    fun resolve(engine: Engine, session: Session, cloudAnchorId: String,
+                onResolved: ((node: CloudAnchorNode?) -> Unit)? = null)
+    fun onFrame(frame: Frame)                         // call from onSessionUpdated — broadcasts camera pose
+    fun placeNode(nodeKey: String, modelKey: String,
+                  translation: FloatArray, quaternion: FloatArray,
+                  scale: FloatArray = floatArrayOf(1f, 1f, 1f))
+}
+```
+
+**Usage** — one device hosts the shared anchor, the rest resolve it; every device broadcasts its camera pose each frame and mirrors `placedNodes`:
+
+```kotlin
+@Composable
+fun MultiplayerARScreen() {
+    val transport = remember { LoopbackCollaborativeTransport.LoopbackHub().join("me") }
+    val session = rememberCollaborativeSession(transport, displayName = "Alice")
+    ARSceneView(
+        modifier = Modifier.fillMaxSize(),
+        onSessionUpdated = { _, frame -> session.onFrame(frame) },
+    ) {
+        // Parent collaborative content to session.sharedAnchorNode (the shared
+        // Cloud Anchor) and reconcile your scene against session.placedNodes
+        // and session.participants every frame.
+    }
+}
+```
+
+- **Wire format** — `CollaborativeWireFormat`: JSON-lines (`hello` / `anchor` / `pose` / `node` / `bye`), pure Kotlin, zero new runtime deps, fully unit-tested. All transforms are in the shared anchor's local space so they are comparable across devices.
+- **Conflict policy** — last-writer-wins per node key (`PlacedNode`); stale (out-of-order) poses are dropped by epoch.
+- **Threading** — `host`/`resolve` are main-thread only (ARCore + Filament JNI). `onFrame`/`placeNode` are non-blocking (conflated channel) so they are safe in the AR render callback. All merge work runs on a supervisor IO scope.
+- **Privacy** — the shared anchor is an ARCore Cloud Anchor; the same disclosure requirement as `CloudAnchorNode.host` applies (feature points uploaded to Google).
+
+**Cross-platform:** Android-only today. The `CollaborativeTransport` abstraction maps cleanly onto RealityKit's `MultipeerConnectivityService` on iOS — the interface shape is kept cross-platform-friendly. A production **Nearby Connections** transport (offline same-room, no backend) is tracked as a follow-up — see the `ar-collaborative` sample demo, which proves the full sync end-to-end on one device via the loopback transport.
+
 ### TrackableNode — generic trackable
 ```kotlin
 @Composable fun TrackableNode(
@@ -3736,6 +3811,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 ### Augmented Reality
 
 - `ar-cloud-anchor` — Cloud Anchors. Persistent multi-user anchors.
+- `ar-collaborative` — Collaborative AR. Multi-user session sync over a pluggable transport.
 - `ar-depth-collider` — Depth Collider. Virtual balls bounce off the real floor / table (depth-driven physics).
 - `ar-depth-occlusion` — Depth Occlusion. Real-world depth masks virtual objects.
 - `ar-depth-of-field` — AR Depth of Field. Tap to focus — real-world bokeh blur.

--- a/llms.txt
+++ b/llms.txt
@@ -1886,6 +1886,81 @@ registry.list().filterNot { it.isExpired() }.forEach { entry ->
 
 Threading: safe to call from the main thread — `SharedPreferences.edit().apply()` is non-blocking.
 
+### Collaborative AR — multi-user sessions (`io.github.sceneview.ar.collaborative`)
+
+Two or more devices see the **same** anchored content and each other's live camera poses.
+
+**ARCore reality check.** ARCore has NO `collaborationData` / `ParticipantManager` (unlike ARKit's `ARSession.collaborationData`). Its entire shared-AR story is Cloud Anchors. SceneView's collaborative layer is therefore built on the two pieces that DO exist: a shared coordinate frame via the existing `CloudAnchorNode` (one device hosts, every other resolves the same id), plus a **pluggable transport** relaying app state. SceneView does NOT pick a networking stack — it ships the interface plus an in-process reference impl.
+
+```kotlin
+// Pluggable network layer — app supplies one, or uses the loopback reference impl.
+interface CollaborativeTransport {
+    val localPeerId: String
+    val peers: StateFlow<Set<String>>                 // remote peers, never includes self
+    fun send(message: ByteArray)                      // non-blocking — may be called from the render loop
+    fun incoming(handler: (peerId: String, ByteArray) -> Unit): AutoCloseable
+    fun close()
+}
+
+// In-process reference transport — always available, no networking, no permissions.
+// Perfect for unit tests + single-device demos. Swap for Nearby Connections /
+// Firebase / WebRTC in production.
+val hub = LoopbackCollaborativeTransport.LoopbackHub()
+val transport = hub.join("my-peer-id")               // join one per simulated device
+
+// Orchestrator over CloudAnchorNode + the transport. Mirrors RerunBridge:
+// supervisor IO scope, CONFLATED outbox, lifecycle-bound remember* helper.
+@Composable fun rememberCollaborativeSession(
+    transport: CollaborativeTransport,
+    displayName: String = transport.localPeerId,
+    poseRateHz: Int = 10,                             // camera-pose broadcast rate
+    closeTransportOnDispose: Boolean = true
+): CollaborativeSession
+
+class CollaborativeSession {
+    val participants: List<Participant>               // Compose-observable, remote peers only
+    val placedNodes: List<PlacedNode>                 // every peer's placed objects, shared-anchor space
+    val sharedAnchorNode: CloudAnchorNode?            // the shared coordinate frame
+    val sharedCloudAnchorId: String?
+
+    fun start(); fun stop()
+    fun host(session: Session, anchor: Anchor, engine: Engine,
+             ttlDays: Int = 1, name: String = "session",
+             onHosted: ((cloudAnchorId: String?, success: Boolean) -> Unit)? = null)
+    fun resolve(engine: Engine, session: Session, cloudAnchorId: String,
+                onResolved: ((node: CloudAnchorNode?) -> Unit)? = null)
+    fun onFrame(frame: Frame)                         // call from onSessionUpdated — broadcasts camera pose
+    fun placeNode(nodeKey: String, modelKey: String,
+                  translation: FloatArray, quaternion: FloatArray,
+                  scale: FloatArray = floatArrayOf(1f, 1f, 1f))
+}
+```
+
+**Usage** — one device hosts the shared anchor, the rest resolve it; every device broadcasts its camera pose each frame and mirrors `placedNodes`:
+
+```kotlin
+@Composable
+fun MultiplayerARScreen() {
+    val transport = remember { LoopbackCollaborativeTransport.LoopbackHub().join("me") }
+    val session = rememberCollaborativeSession(transport, displayName = "Alice")
+    ARSceneView(
+        modifier = Modifier.fillMaxSize(),
+        onSessionUpdated = { _, frame -> session.onFrame(frame) },
+    ) {
+        // Parent collaborative content to session.sharedAnchorNode (the shared
+        // Cloud Anchor) and reconcile your scene against session.placedNodes
+        // and session.participants every frame.
+    }
+}
+```
+
+- **Wire format** — `CollaborativeWireFormat`: JSON-lines (`hello` / `anchor` / `pose` / `node` / `bye`), pure Kotlin, zero new runtime deps, fully unit-tested. All transforms are in the shared anchor's local space so they are comparable across devices.
+- **Conflict policy** — last-writer-wins per node key (`PlacedNode`); stale (out-of-order) poses are dropped by epoch.
+- **Threading** — `host`/`resolve` are main-thread only (ARCore + Filament JNI). `onFrame`/`placeNode` are non-blocking (conflated channel) so they are safe in the AR render callback. All merge work runs on a supervisor IO scope.
+- **Privacy** — the shared anchor is an ARCore Cloud Anchor; the same disclosure requirement as `CloudAnchorNode.host` applies (feature points uploaded to Google).
+
+**Cross-platform:** Android-only today. The `CollaborativeTransport` abstraction maps cleanly onto RealityKit's `MultipeerConnectivityService` on iOS — the interface shape is kept cross-platform-friendly. A production **Nearby Connections** transport (offline same-room, no backend) is tracked as a follow-up — see the `ar-collaborative` sample demo, which proves the full sync end-to-end on one device via the loopback transport.
+
 ### TrackableNode — generic trackable
 ```kotlin
 @Composable fun TrackableNode(
@@ -3736,6 +3811,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 ### Augmented Reality
 
 - `ar-cloud-anchor` — Cloud Anchors. Persistent multi-user anchors.
+- `ar-collaborative` — Collaborative AR. Multi-user session sync over a pluggable transport.
 - `ar-depth-collider` — Depth Collider. Virtual balls bounce off the real floor / table (depth-driven physics).
 - `ar-depth-occlusion` — Depth Occlusion. Real-world depth masks virtual objects.
 - `ar-depth-of-field` — AR Depth of Field. Tap to focus — real-world bokeh blur.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCollaborativeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCollaborativeDemo.kt
@@ -1,0 +1,215 @@
+package io.github.sceneview.demo.demos
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import io.github.sceneview.ar.collaborative.CollaborativeSession
+import io.github.sceneview.ar.collaborative.LoopbackCollaborativeTransport
+import io.github.sceneview.demo.DemoScaffold
+
+/**
+ * Collaborative AR demo — proves the multi-user sync stack end-to-end on a
+ * **single device, no networking**.
+ *
+ * Real multiplayer AR needs two phones and a [io.github.sceneview.ar.collaborative.CollaborativeTransport]
+ * implementation (Nearby Connections / Firebase / WebRTC). To keep this demo
+ * always-runnable in the showcase app and in CI, it instead drives **two**
+ * [CollaborativeSession]s — "Alice" and "Bob" — through an in-process
+ * [LoopbackCollaborativeTransport.LoopbackHub]. Tapping *Alice places a cube*
+ * broadcasts a node placement from Alice's session; the panel then shows that
+ * same node appearing in Bob's `placedNodes` (and vice versa) — exactly the
+ * data flow that would cross the network between two real devices.
+ *
+ * The production wiring is identical: swap the loopback transport for a real
+ * one and parent your content to `CollaborativeSession.sharedAnchorNode` (an
+ * ARCore Cloud Anchor). See the `ar-cloud-anchor` demo for the shared-frame
+ * half and `llms.txt` "Collaborative AR" for the full recipe.
+ */
+@Composable
+fun ARCollaborativeDemo(onBack: () -> Unit) {
+    // One in-process hub wiring two simulated peers together.
+    val hub = remember { LoopbackCollaborativeTransport.LoopbackHub() }
+    val alice = remember {
+        CollaborativeSession(hub.join("alice"), displayName = "Alice")
+    }
+    val bob = remember {
+        CollaborativeSession(hub.join("bob"), displayName = "Bob")
+    }
+
+    // Start both sessions for the lifetime of the screen; stop on dispose so
+    // each broadcasts a `bye` and the supervisor scopes are released.
+    DisposableEffect(alice, bob) {
+        alice.start()
+        bob.start()
+        onDispose {
+            alice.stop()
+            bob.stop()
+        }
+    }
+
+    // Monotonic counters so each placement gets a unique node key.
+    var aliceCubeCount by remember { mutableIntStateOf(0) }
+    var bobCubeCount by remember { mutableIntStateOf(0) }
+
+    DemoScaffold(title = "Collaborative AR", onBack = onBack) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Two in-process sessions over a loopback transport",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = "ARCore has no collaboration API — multi-user AR is a shared " +
+                    "Cloud Anchor (one coordinate frame) plus a pluggable transport " +
+                    "relaying state. This demo runs both peers in one process so the " +
+                    "sync is visible with no second phone and no networking.",
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = {
+                        aliceCubeCount++
+                        alice.placeNode(
+                            nodeKey = "alice-cube-$aliceCubeCount",
+                            modelKey = "cube",
+                            translation = floatArrayOf(
+                                0.15f * aliceCubeCount, 0f, -0.5f,
+                            ),
+                            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                ) { Text("Alice places a cube") }
+                Button(
+                    onClick = {
+                        bobCubeCount++
+                        bob.placeNode(
+                            nodeKey = "bob-cube-$bobCubeCount",
+                            modelKey = "sphere",
+                            translation = floatArrayOf(
+                                -0.15f * bobCubeCount, 0f, -0.5f,
+                            ),
+                            quaternion = floatArrayOf(0f, 0f, 0f, 1f),
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                ) { Text("Bob places a sphere") }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                SessionCard(
+                    title = "Alice's session",
+                    session = alice,
+                    modifier = Modifier.weight(1f),
+                )
+                SessionCard(
+                    title = "Bob's session",
+                    session = bob,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Each card is one CollaborativeSession's view. A cube placed " +
+                    "by Alice appears in Bob's list (and vice versa) — that is the " +
+                    "exact data that would travel over a real transport between two " +
+                    "phones sharing a Cloud Anchor.",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}
+
+/** Renders one [CollaborativeSession]'s observed participants + placed nodes. */
+@Composable
+private fun SessionCard(
+    title: String,
+    session: CollaborativeSession,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier, shape = RoundedCornerShape(12.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleSmall)
+
+            Text(
+                text = "Participants: ${session.participants.size}",
+                style = MaterialTheme.typography.labelMedium,
+            )
+            session.participants.forEach { participant ->
+                Text(
+                    text = "  • ${participant.displayName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+
+            Spacer(Modifier.width(2.dp))
+            Text(
+                text = "Placed nodes: ${session.placedNodes.size}",
+                style = MaterialTheme.typography.labelMedium,
+            )
+            session.placedNodes.forEach { node ->
+                Text(
+                    text = "  • ${node.nodeKey} (${node.modelKey}) by ${node.ownerPeerId}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+            if (session.placedNodes.isEmpty()) {
+                Box(
+                    modifier = Modifier.padding(start = 8.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = "  (none yet)",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArCollaborativeFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArCollaborativeFragment.kt
@@ -1,0 +1,25 @@
+package io.github.sceneview.demo.fragments
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.runtime.Composable
+import io.github.sceneview.demo.DemoCategory
+import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.ARCollaborativeDemo
+
+/** Append-only fragment for the `ar-collaborative` demo. See [DemoFragment]. */
+object ArCollaborativeFragment : DemoFragment {
+    override val entry: DemoEntry = DemoEntry(
+        id = "ar-collaborative",
+        titleRes = R.string.demo_ar_collaborative_title,
+        subtitleRes = R.string.demo_ar_collaborative_subtitle,
+        category = DemoCategory.AUGMENTED_REALITY,
+        icon = Icons.Filled.Groups,
+    )
+
+    @Composable
+    override fun Screen(onBack: () -> Unit) {
+        ARCollaborativeDemo(onBack)
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_collaborative.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_collaborative.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Strings for the `ar-collaborative` demo (registered by
+     `ArCollaborativeFragment.kt`). Android's resource merger
+     fans every `res/values/*.xml` file in, so `R.string.demo_ar_collaborative_title` etc.
+     remains globally resolvable. Adding a new demo never needs to touch
+     this file or `strings.xml` — see #1870. -->
+<resources>
+    <string name="demo_ar_collaborative_title">Collaborative AR</string>
+    <string name="demo_ar_collaborative_subtitle">Multi-user session sync over a pluggable transport</string>
+</resources>


### PR DESCRIPTION
Closes #1764.

## Summary

Adds the `io.github.sceneview.ar.collaborative` package — shared-coordinate-frame multiplayer AR. Two or more devices see the **same** anchored content and each other's live camera poses.

**ARCore reality check.** ARCore has **no** `collaborationData` / `ParticipantManager` (unlike ARKit's `ARSession.collaborationData`). Its entire shared-AR story is Cloud Anchors. This PR therefore builds multiplayer on the two pieces that *do* exist:

1. **A shared coordinate frame** via the existing `CloudAnchorNode` — one device hosts a Cloud Anchor, every other resolves the same id.
2. **A pluggable `CollaborativeTransport`** relaying app state (the shared anchor id, participant camera poses, placed-node transforms) between peers.

The architecture mirrors the in-repo `RerunBridge` precedent: a pluggable bridge, a dedicated supervisor IO scope, a `CONFLATED` outbound channel for render-loop backpressure safety, and a lifecycle-bound `remember*` Compose helper.

## What ships

- **`CollaborativeTransport`** — the pluggable network-layer interface. SceneView deliberately does not pick a networking stack.
- **`LoopbackCollaborativeTransport`** — an always-available, no-networking reference impl. Connects peers in-process via a `LoopbackHub`, which makes the whole API unit-testable and demonstrable on a single device.
- **`CollaborativeWireFormat`** — pure-Kotlin JSON-lines serializer (`hello` / `anchor` / `pose` / `node` / `bye`), zero new runtime dependencies (same approach as `RerunWireFormat`).
- **`CollaborativeState`** — the pure-Kotlin merge core: last-writer-wins per node key, stale-pose rejection by epoch, self-message filtering. No ARCore/Android/coroutine dependency.
- **`CollaborativeSession` + `rememberCollaborativeSession`** — the orchestrator over `CloudAnchorNode` + a transport. `host`/`resolve` the shared anchor, broadcast camera poses each frame, expose Compose-observable `participants` / `placedNodes`.
- **`ar-collaborative` sample demo** — runs two simulated peers ("Alice"/"Bob") over the loopback transport in one process, proving the full sync end-to-end with no second phone and no networking.
- **52 JVM unit tests** — wire format round-trips, merge state, loopback delivery/isolation, session integration over loopback.
- `llms.txt` + `docs/docs/llms.txt` "Collaborative AR" section; `changelog.d/1764-collaborative-ar.md`.

## Threading

- `host` / `resolve` are main-thread only (ARCore + Filament JNI) — the composable host satisfies this.
- `onFrame` / `placeNode` are non-blocking (`trySend` onto a conflated channel) so they are safe in the AR render callback.
- All inbound-message merge work runs on a supervisor IO scope.

## Scope decision

Per the pinned design analysis on #1764, a production **Nearby Connections** transport was intentionally deferred — it adds a Play Services dependency that would bloat this PR, and the rest of the stack is transport-agnostic. Filed as follow-up #2008. The `CollaborativeTransport` contract is finalized here; #2008 only adds one more implementation of it.

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin` — green
- [x] `./gradlew :arsceneview:testDebugUnitTest` — 52 new collaborative tests pass, 0 failures
- [x] `./gradlew :samples:android-demo:compileDebugKotlin` — green
- [x] `detekt` on `:arsceneview :sceneview :sceneview-core` — green
- [x] `collate-demos.sh --check` — in sync (57 fragments)
- [ ] On-device two-phone validation deferred to the Nearby Connections transport (#2008) — single-device loopback sync is covered by the `ar-collaborative` demo + integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)