### PR TITLE
ci: fix release.yml — secrets context is invalid in step if: (unblocks v4.13.0 publish)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -313,15 +313,19 @@ jobs:
       # Auth: a PAT with `repo` scope. `PERSONAL_TOKEN` already exists as a
       # repo secret (used for cross-repo automation) and is the default;
       # `PAGES_REBUILD_TOKEN` is honoured first if a dedicated token is
-      # ever provisioned. The `if:` tests `secrets.*` directly — secrets are
-      # available to step `if:` conditions, whereas an `env:` set on the
-      # SAME step is NOT yet in scope when the `if:` is evaluated (the bug
-      # that kept this step permanently skipped before #1826).
+      # ever provisioned. NOTE: the `secrets` context is NOT allowed in a
+      # step `if:` expression — referencing it there makes the whole
+      # workflow file invalid ("Unrecognized named-value: 'secrets'"). The
+      # token presence check is done inside the `run:` script via
+      # `$PAGES_TOKEN` instead.
       - name: Trigger GitHub Pages build (legacy auto-build skips bot pushes)
-        if: ${{ secrets.PAGES_REBUILD_TOKEN != '' || secrets.PERSONAL_TOKEN != '' }}
         env:
           PAGES_TOKEN: ${{ secrets.PAGES_REBUILD_TOKEN || secrets.PERSONAL_TOKEN }}
         run: |
+          if [ -z "$PAGES_TOKEN" ]; then
+            echo "::warning::No Pages rebuild token configured — skipping."
+            exit 0
+          fi
           echo "Requesting a GitHub Pages build for sceneview/sceneview.github.io..."
           HTTP=$(curl -sS -o /tmp/pages-build.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,11 +202,21 @@ jobs:
       # `/api/` docs on `sceneview.github.io` that the live site never
       # rebuilds — the same drift class as #1826. Force a build via the
       # Pages REST API. Mirrors the step in `docs.yml`.
+      # NOTE: the `secrets` context is NOT allowed in a step `if:` expression
+      # (only `github`, `env`, `steps`, `inputs`, etc. are). Referencing
+      # `secrets.*` here makes the WHOLE workflow file invalid
+      # ("Unrecognized named-value: 'secrets'") and every release run fails
+      # at startup with 0 jobs. The token check is therefore done inside the
+      # `run:` script via `$PAGES_TOKEN` instead.
       - name: Trigger GitHub Pages build (legacy auto-build skips bot pushes)
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && (secrets.PAGES_REBUILD_TOKEN != '' || secrets.PERSONAL_TOKEN != '') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
           PAGES_TOKEN: ${{ secrets.PAGES_REBUILD_TOKEN || secrets.PERSONAL_TOKEN }}
         run: |
+          if [ -z "$PAGES_TOKEN" ]; then
+            echo "::warning::No Pages rebuild token configured — skipping."
+            exit 0
+          fi
           echo "Requesting a GitHub Pages build for sceneview/sceneview.github.io..."
           HTTP=$(curl -sS -o /tmp/pages-build.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/changelog.d/hotfix-release-yml.md
+++ b/changelog.d/hotfix-release-yml.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Fixed the release pipeline: the `secrets` context is not allowed in a GitHub Actions step `if:` expression, which made `release.yml` (and `docs.yml`) invalid workflow files and blocked the v4.13.0 publish. The token-presence check is now done inside the step's `run:` script.


### PR DESCRIPTION
## Root cause

The release pipeline is broken — **v4.13.0 failed to publish** to Maven Central / npm.

PR #1979 (#1826 Pages auto-build fix) added a *"Trigger GitHub Pages build"* step to both `release.yml` and `docs.yml`. Its `if:` condition referenced the `secrets` context:

```yaml
if: ${{ startsWith(github.ref, 'refs/tags/v') && (secrets.PAGES_REBUILD_TOKEN != '' || secrets.PERSONAL_TOKEN != '') }}
```

The `secrets` context is **not allowed in a step `if:` expression** (only `github`, `env`, `steps`, `inputs`, etc. are). This makes the *entire* workflow file invalid — GitHub rejects it with **"Unrecognized named-value: 'secrets'"** — so every release run fails at startup with **0 jobs**. v4.13.0 never published.

## Fix

- **`release.yml`** — step `if:` reduced to `if: ${{ startsWith(github.ref, 'refs/tags/v') }}`; token-presence check moved into the `run:` script (`$PAGES_TOKEN` empty → `::warning::` + `exit 0`).
- **`docs.yml`** — identical step had the same bug; `if:` removed entirely (no other gate needed), same `run:`-script guard added. The stale comment claiming "secrets are available to step `if:` conditions" was corrected.
- `secrets` in `env:` is **fine** and is left untouched on both steps.
- Added `changelog.d/hotfix-release-yml.md`.

## Verification

- `python3 -c "import yaml; ..."` — both files parse OK
- `grep -rn 'if:.*secrets\.' .github/workflows/` — returns nothing
- `actionlint .github/workflows/release.yml .github/workflows/docs.yml` — exit 0, clean

## Note for reviewers

`release.yml` may produce a *failed* run on this PR branch — that is **expected**: `release.yml` was an invalid workflow file until this merge. It is not a required check; the PR merges on CI Gate / quality-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)