### PR TITLE
test(qa): record Android device-QA leg + cross-platform recording parity

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -281,6 +281,14 @@ run_android() {
   bash "$SCRIPT_DIR/qa-android-demos.sh" --install --flow "$flow" 2>&1 \
     | tee "$ARTIFACTS/android-output.txt" || rc=$?
 
+  # Surface the host-side `adb emu screenrecord` capture (#1671) alongside the
+  # iOS/web recordings so the autonomous QA runner finds all three in one place.
+  local android_rec="$REPO_ROOT/tools/qa-screenshots/android/android-qa-${flow}.webm"
+  if [[ -s "$android_rec" ]]; then
+    cp "$android_rec" "$ARTIFACTS/" 2>/dev/null \
+      && log "android recording: $ARTIFACTS/$(basename "$android_rec")"
+  fi
+
   # Maestro has no flat summary JSON; the wrapper's exit code is the verdict.
   if [[ $rc -eq 0 ]]; then
     record android passed "flow=$flow" "" "$(( $(date +%s) - started ))"
@@ -310,6 +318,14 @@ run_ios() {
   bash "$SCRIPT_DIR/ios-device-qa.sh" --install --flow "$flow" \
     > "$ARTIFACTS/ios-output.txt" 2>&1 || rc=$?
   cat "$ARTIFACTS/ios-output.txt"
+
+  # Surface the `simctl io recordVideo` capture alongside the android/web
+  # recordings so the autonomous QA runner finds all three in one place.
+  local ios_rec="$REPO_ROOT/tools/qa-screenshots/ios/ios-qa-${flow}.mov"
+  if [[ -s "$ios_rec" ]]; then
+    cp "$ios_rec" "$ARTIFACTS/" 2>/dev/null \
+      && log "ios recording: $ARTIFACTS/$(basename "$ios_rec")"
+  fi
 
   if [[ $rc -eq 0 ]]; then
     record ios passed "flow=$flow" "" "$(( $(date +%s) - started ))"

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -10,7 +10,10 @@
 #
 # This script just orchestrates the pieces around `maestro test`:
 #   1. (optional) build + install the demo APK
-#   2. run the Maestro catalog (or a single category subflow)
+#   2. (best-effort) screen-record the run via host-side `adb emu screenrecord`
+#      — parity with the iOS / web QA legs; skipped silently on a physical
+#      device or when the emulator console is unavailable (#1671)
+#   3. run the Maestro catalog (or a single category subflow)
 #
 # Usage:
 #   bash .claude/scripts/qa-android-demos.sh [--install] [--flow <name>]
@@ -58,7 +61,7 @@ while [[ $# -gt 0 ]]; do
     --install) INSTALL=true; shift ;;
     --flow)    FLOW="${2:?--flow needs a name}"; shift 2 ;;
     -h|--help)
-      sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[qa] unknown argument: $1" >&2; exit 2 ;;
@@ -127,6 +130,28 @@ fi
 # --- Crash gate: clear logcat so the post-run FATAL/ANR sweep is scoped -----
 adb logcat -c 2>/dev/null || true
 
+# --- Optional screen recording (best-effort) -------------------------------
+# Record the whole QA run for visual review — parity with the iOS leg
+# (`simctl io recordVideo`) and the web leg (Playwright `page.screencast`).
+# Uses the HOST-SIDE `adb emu screenrecord` console path (#1671): unlike the
+# guest-side `adb shell screenrecord` it captures the emulator's presented
+# framebuffer directly, so it is immune to the Emulator 36.x gfxstream
+# regression that records `-gpu host` Filament content as near-empty. Strictly
+# best-effort: a recording failure never fails the QA run (e.g. a physical
+# device, where the emulator console is unavailable). The .webm lands under
+# tools/qa-screenshots/android/ (gitignored).
+QA_VIDEO=""
+QA_VIDEO_DIR="${ANDROID_QA_VIDEO_DIR:-tools/qa-screenshots/android}"
+mkdir -p "$QA_VIDEO_DIR"
+# `--time-limit` is a hard encoder cap. Maestro's catalog run is long, so cap
+# generously (overridable via ANDROID_QA_REC_LIMIT for short single flows).
+if REC_TMP="$(android_cli_screenrecord_start "${ANDROID_SERIAL:-}" "${ANDROID_QA_REC_LIMIT:-1800}")"; then
+  QA_VIDEO="$QA_VIDEO_DIR/android-qa-${FLOW}.webm"
+  echo "[qa] recording the QA run -> $QA_VIDEO"
+else
+  echo "[qa] screen recording unavailable (host-side 'adb emu screenrecord' needs an emulator) — continuing without it"
+fi
+
 # --- Run the Maestro flow --------------------------------------------------
 echo "[qa] running Maestro flow: $FLOW_FILE"
 MAESTRO_RC=0
@@ -144,6 +169,19 @@ if [[ "$MAESTRO_RC" -ne 0 ]]; then
     adb wait-for-device 2>/dev/null || true
     MAESTRO_RC=0
     maestro_run "$FLOW_FILE" || MAESTRO_RC=$?
+  fi
+fi
+
+# --- Stop the screen recording --------------------------------------------
+# Stop the host-side emulator recording and move the finished .webm into the
+# QA video dir. Best-effort throughout — a recording failure never affects the
+# QA verdict.
+if [[ -n "$QA_VIDEO" ]]; then
+  android_cli_screenrecord_stop "${ANDROID_SERIAL:-}" || true
+  if [[ -n "${REC_TMP:-}" && -s "$REC_TMP" ]]; then
+    mv "$REC_TMP" "$QA_VIDEO" 2>/dev/null \
+      && echo "[qa] recording saved: $QA_VIDEO" \
+      || echo "[qa] recording could not be moved from $REC_TMP" >&2
   fi
 fi
 

--- a/changelog.d/1675-qa-tooling-audit.md
+++ b/changelog.d/1675-qa-tooling-audit.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- Device-QA: the Android leg now screen-records each run via host-side `adb emu screenrecord`, completing cross-platform parity with the iOS (`simctl io recordVideo`) and web (Playwright `page.screencast`) legs. Host-side capture is immune to the Emulator 36.x gfxstream regression that recorded `-gpu host` Filament content as near-empty. The Android and iOS QA recordings are now surfaced into `device-qa-artifacts/` alongside the web screencasts.


### PR DESCRIPTION
## Summary

Closes the May 2026 cross-platform QA tooling audit (#1675).

Most audit items were already actioned by earlier PRs (#1677 ANR-resistant emulator config, #1679 `--enable-unsafe-swiftshader`, #1681 iOS `recordVideo`, #1682 web `page.screencast`). This PR fixes the one concrete remaining gap in #1671: **the Android device-QA leg recorded nothing**.

The `android_cli_screenrecord_start/stop` helpers were added to `lib/android-cli.sh` for #1671 but had **no caller** — dead code. The iOS leg records each run via `simctl io recordVideo` and the web leg via Playwright `page.screencast`; the Android leg had no equivalent.

## Changes

- **`qa-android-demos.sh`** — brackets the Maestro run with the host-side `adb emu screenrecord` console capture (best-effort: a recording failure never fails the QA run, e.g. on a physical device where the emulator console is unavailable). One `.webm` lands under `tools/qa-screenshots/android/` (gitignored). Host-side capture is immune to the Emulator 36.x gfxstream regression that records `-gpu host` Filament content as near-empty.
- **`device-qa.sh`** — surfaces both the Android (`.webm`) and iOS (`.mov`) recordings into `device-qa-artifacts/`, alongside the existing web screencasts, so the autonomous QA runner finds all three legs' video in one place.

Cross-platform device-QA now records **and surfaces** every run on all three legs (Android / iOS / Web).

## Audit findings — already resolved (no change needed)

- `--enable-unsafe-swiftshader` already present in `playwright.config.ts` (#1679).
- 35.6.11 emulator pin already removed from `setup-ar-emulator.sh` (#1671 partial).
- iOS `.xcresult` parsing — `ios.yml` already detects failures by exit code via `pipefail` (#1515), not the stdout `Failing tests:` line Xcode 26 removed.
- Web canvas render assertions already covered by `helpers.ts:sampleCanvas` luminance-variance check.

## Remaining follow-ups (kept in #1673, not in scope here)

- iOS: AXe label-based automation helper + XCUITest Test Plans — larger reworks needing simulator verification, tracked in the still-open #1673.
- Android Studio Journeys (#1672) — gated on an AGP 9 evaluation.

## Test plan

- [x] `bash -n` + `shellcheck -x` on both changed scripts — no new warnings
- [x] `bash .claude/scripts/impact-check.sh` — ALL CLEAR
- [x] `qa-android-demos.sh --help` renders the full usage block

🤖 Generated with [Claude Code](https://claude.com/claude-code)