### PR TITLE
feat(android-demo): predictable per-demo reset path via DemoScaffold

### DIFF
--- a/changelog.d/1966-demo-reset-path.md
+++ b/changelog.d/1966-demo-reset-path.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Demo app: `DemoScaffold` now exposes an opt-in `onReset` parameter that renders a consistent, always-in-the-same-place **Reset** action in the demo's top app bar, giving every demo a predictable path back to its initial state and re-arming its core interaction. A brief confirmation snackbar ("Demo reset — ready to try again") tells the user the demo is ready for re-interaction. Wired into the owner-flagged AR Depth Occlusion demo. (#1966)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -33,6 +34,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
@@ -135,6 +139,21 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
  * - `onResetSettings != null` → a "Reset" text button is shown in the sheet
  *   header. Tapping it lets a demo clear any in-memory tweaks back to its
  *   defaults. `null` hides the button entirely so demos opt in.
+ *
+ * Predictable demo reset (#1966):
+ * - `onReset != null` → a single, **consistent** reset action is rendered in the
+ *   top app bar (a `Refresh` icon, always in the same place across every demo).
+ *   Tapping it returns the demo to its initial state and re-arms its core
+ *   interaction (clear placed anchors, drop highlights, re-centre the camera,
+ *   etc.). A brief confirmation snackbar ("Demo reset — ready to try again")
+ *   then tells the user the demo is ready for re-interaction. `null` hides the
+ *   action entirely so demos opt in.
+ *
+ *   This complements (does not replace) [io.github.sceneview.demo.common.SceneActionBar]:
+ *   a demo whose reset is *contextual* (only meaningful once something is placed)
+ *   can still use the bottom-start action bar, while `onReset` gives every demo
+ *   one always-available, always-discoverable reset path in a fixed location —
+ *   the predictable re-interaction path #1966 asks for.
  */
 @Composable
 fun DemoScaffold(
@@ -145,10 +164,15 @@ fun DemoScaffold(
     firstFrameRendered: androidx.compose.runtime.State<Boolean>? = null,
     peekHeader: String? = null,
     onResetSettings: (() -> Unit)? = null,
+    onReset: (() -> Unit)? = null,
     scene: @Composable BoxScope.() -> Unit
 ) {
     val haptic = rememberHapticFeedback()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val resetScope = rememberCoroutineScope()
+    val resetConfirmation = stringResource(R.string.demo_reset_done)
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {
@@ -187,6 +211,37 @@ fun DemoScaffold(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.cd_back_button)
                         )
+                    }
+                },
+                actions = {
+                    // Predictable, always-in-the-same-place reset action (#1966).
+                    // Every demo that opts in surfaces this single Refresh icon
+                    // in the top bar, so users have one consistent path back to
+                    // a demo's initial state regardless of which demo they are
+                    // in. A brief snackbar then confirms the demo is re-armed.
+                    if (onReset != null) {
+                        val resetCd = stringResource(R.string.demo_reset_cd)
+                        IconButton(
+                            onClick = {
+                                haptic.medium()
+                                onReset()
+                                resetScope.launch {
+                                    snackbarHostState.currentSnackbarData?.dismiss()
+                                    snackbarHostState.showSnackbar(
+                                        message = resetConfirmation,
+                                        duration = SnackbarDuration.Short,
+                                    )
+                                }
+                            },
+                            modifier = Modifier
+                                .semantics { contentDescription = resetCd }
+                                .testTag(DemoScaffoldTestTags.RESET_ACTION),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Refresh,
+                                contentDescription = null,
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -335,6 +390,7 @@ object DemoScaffoldTestTags {
     const val SETTINGS_PEEK = "demo-settings-peek"
     const val SETTINGS_SHEET = "demo-settings-sheet"
     const val SETTINGS_RESET = "demo-settings-reset"
+    const val RESET_ACTION = "demo-reset-action"
     const val QA_PILL = "demo-qa-pill"
     const val ASSET_SOURCE_CHIP = "demo-asset-source-chip"
     const val FIRST_FRAME_SCRIM = "demo-first-frame-scrim"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
@@ -145,6 +145,14 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
     DemoScaffold(
         title = stringResource(R.string.demo_ar_depth_occlusion_title),
         onBack = onBack,
+        // Predictable reset path (#1966) — a consistent top-bar Refresh action,
+        // in the same place as in every other demo, detaches any placed anchor
+        // and re-arms plane placement so the user can re-tap a surface. The
+        // bottom-start "Clear" action stays as the contextual shortcut.
+        onReset = {
+            placedAnchor?.let { runCatching { it.detach() } }
+            placedAnchor = null
+        },
         controls = {
             // One-line hint instead of a multi-paragraph "How to test" card:
             // the sheet is now just the real control (the depth toggle) plus a

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -237,6 +237,9 @@
     <string name="demo_settings_fab_cd">Demo settings</string>
     <string name="demo_settings_reset">Reset</string>
     <string name="demo_settings_reset_cd">Reset demo settings to defaults</string>
+    <!-- Predictable per-demo reset action (#1966) -->
+    <string name="demo_reset_cd">Reset this demo to its initial state</string>
+    <string name="demo_reset_done">Demo reset — ready to try again</string>
     <string name="about_star_on_github">Star on GitHub</string>
     <string name="about_made_with">Made with</string>
     <string name="about_made_by"> by Thomas Gorisse</string>


### PR DESCRIPTION
## Summary

Sub-issue of #1620 (thread 4 — re-interaction / reset behaviour). Demos currently vary in how — or whether — they let the user reset and re-trigger their core interaction. The owner flagged AR Depth Occlusion: re-tapping after placement gives no feedback and the only reset (`Clear`) is buried in the Settings sheet.

This adds **one shared, opt-in mechanism** at the `DemoScaffold` level so every demo can inherit a consistent reset affordance — no per-demo rewrite.

- New `DemoScaffold(onReset: (() -> Unit)? = null)` parameter. When set, a single **Reset** action (`Refresh` icon) is rendered in the demo top app bar — always in the same place across every demo, so the reset path is predictable and discoverable.
- Tapping it returns the demo to its initial state / re-arms its core interaction, then shows a brief confirmation snackbar (`"Demo reset — ready to try again"`) so the user knows the demo is ready for re-interaction.
- Fully backward-compatible: `onReset` defaults to `null`, so the 60 existing `DemoScaffold` call-sites are untouched. Demos opt in with one line.
- Complements (does not replace) the contextual bottom-start `SceneActionBar` from #1964 — `onReset` is the always-available, fixed-location path.
- Wired into the owner-flagged `ARDepthOcclusionDemo` as a proof of concept; other demos can opt in incrementally.
- New string resources + `DemoScaffoldTestTags.RESET_ACTION` for deterministic UI tests.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` succeeds
- [ ] Visual QA NOT performed (no device/emulator access in this environment) — change is conservative and backward-compatible
- [ ] On a device: open AR Depth Occlusion, place the helmet, tap the top-bar Reset icon, confirm placement re-arms and the snackbar appears

Closes #1966

🤖 Generated with [Claude Code](https://claude.com/claude-code)