### PR TITLE
feat(arsceneview): AR Record interpretation API (#1441)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecordInterpreter.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecordInterpreter.kt
@@ -1,0 +1,428 @@
+package io.github.sceneview.ar.recording
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.google.ar.core.Frame
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingFailureReason
+import com.google.ar.core.TrackingState
+import kotlin.math.sqrt
+
+/**
+ * Replays an **AR Record** dataset and interprets what happened during the session —
+ * the analysis half of the record/playback loop (#1441).
+ *
+ * ### What "interpretation" means here
+ *
+ * [ARRecorder] captures a real ARCore session into an MP4 and
+ * [io.github.sceneview.ar.ARSceneView]'s `playbackDataset` parameter replays it 1:1.
+ * Replay alone just re-renders the camera feed — it does not tell you *whether the
+ * session tracked well*. `ARRecordInterpreter` closes that gap: feed it every frame of
+ * a replay and it accumulates an [ARRecordInterpretation] — a quantified summary of the
+ * camera trajectory, the tracking-quality timeline, and the planes ARCore discovered.
+ *
+ * This is the deterministic, desk-side counterpart to on-device QA: record a hard
+ * tracking stress-case once (e.g. the in-car drive of #1441), then replay + interpret it
+ * on every CI run and assert the metrics never regress.
+ *
+ * ### What it computes
+ *
+ * From each replayed [Frame] the interpreter reads only the camera pose and the
+ * trackables ARCore already attached to the frame — no extra ARCore work, no I/O:
+ *
+ *  - **Trajectory** — total path length the device camera travelled and the axis-aligned
+ *    bounding extent of that path. Surfaces a stationary capture vs a walk-through vs a
+ *    fast drive at a glance.
+ *  - **Tracking quality** — how many frames tracked vs were lost, and, for the lost
+ *    frames, a per-[TrackingFailureReason] breakdown. A high `INSUFFICIENT_FEATURES`
+ *    share points at a textureless scene; a high `EXCESSIVE_MOTION` share points at a
+ *    capture that moved too fast (the classic in-car failure mode).
+ *  - **Planes** — the count of distinct horizontal / vertical planes seen and their
+ *    combined area, so a "did ARCore find the ground?" question has a numeric answer.
+ *
+ * ### Usage
+ *
+ * ```kotlin
+ * val interpreter = rememberARRecordInterpreter()
+ * ARSceneView(
+ *     playbackDataset = recordedDataset,
+ *     onSessionUpdated = { session, frame -> interpreter.ingest(session, frame) },
+ *     content = { /* … */ }
+ * )
+ * // When the dataset reaches its end (rememberARPlaybackStatus == FINISHED):
+ * val report = interpreter.interpretation
+ * println("tracked ${report.trackedFrameRatio * 100}% of ${report.frameCount} frames")
+ * ```
+ *
+ * The same instance can interpret several datasets in a row — call [reset] between them.
+ *
+ * ### Threading
+ *
+ * [ingest] must be called from `onSessionUpdated`, i.e. the render thread that owns the
+ * ARCore [Frame]. The accumulated [interpretation] is published through a Compose
+ * `MutableState`, so a UI-thread reader observing it recomposes correctly. The interpreter
+ * does **no** Filament JNI work, so there is no main-thread constraint beyond the one
+ * `onSessionUpdated` already imposes.
+ *
+ * @see ARRecorder
+ * @see io.github.sceneview.ar.rerun.RerunBridge
+ */
+public class ARRecordInterpreter {
+
+    private val core = ARRecordInterpreterCore()
+
+    private var _interpretation by mutableStateOf(ARRecordInterpretation.EMPTY)
+
+    /**
+     * The interpretation accumulated so far. Backed by a Compose `MutableState`, so a
+     * composable reading it recomposes as new frames are ingested. Equals
+     * [ARRecordInterpretation.EMPTY] until the first [ingest] call (or after [reset]).
+     */
+    public val interpretation: ARRecordInterpretation
+        get() = _interpretation
+
+    /**
+     * Ingest one replayed AR frame. Call from `onSessionUpdated` with the `session` and
+     * `frame` ARCore hands you.
+     *
+     * Only meaningful while a `playbackDataset` is bound — on a **live** session this
+     * still works (it just interprets the live feed), but the point of the API is the
+     * deterministic replay. The call is cheap: it reads the camera pose and the frame's
+     * already-attached plane trackables, then folds them into the running summary. No new
+     * ARCore acquire calls, no allocation beyond the immutable summary snapshot.
+     *
+     * JNI-backed getters ([Frame.getCamera], [Frame.getUpdatedTrackables]) can throw if the
+     * session handle closes concurrently; such [RuntimeException]s are swallowed and the
+     * frame is skipped. JVM [Error]s propagate unchanged.
+     *
+     * @param session the ARCore session (currently unused beyond presence; accepted to
+     *   match the stateless `recordFrame(session, frame)` / `logFrame(session, frame)`
+     *   side-channel shape used elsewhere in `arsceneview`).
+     * @param frame the frame from `onSessionUpdated`.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    public fun ingest(session: Session, frame: Frame) {
+        val sample: FrameSample = try {
+            frameSampleOf(frame)
+        } catch (_: RuntimeException) {
+            // A JNI-backed getter threw because the session handle closed concurrently —
+            // skip this frame. JVM Errors are not caught and propagate unchanged.
+            return
+        }
+        _interpretation = core.fold(sample)
+    }
+
+    /**
+     * Discard all accumulated state so the next [ingest] starts a fresh interpretation.
+     * Use between datasets when one [ARRecordInterpreter] interprets several recordings.
+     * After this, [interpretation] is [ARRecordInterpretation.EMPTY] again.
+     */
+    public fun reset() {
+        core.reset()
+        _interpretation = ARRecordInterpretation.EMPTY
+    }
+
+    /**
+     * Read the camera pose + plane trackables off a [Frame] into a plain
+     * [FrameSample]. Isolated so [ingest]'s pure folding logic ([ARRecordInterpreterCore])
+     * never touches an un-mockable native ARCore type — the fold is unit-tested directly
+     * against hand-built [FrameSample]s.
+     */
+    private fun frameSampleOf(frame: Frame): FrameSample {
+        val camera = frame.camera
+        val tracking = camera.trackingState == TrackingState.TRACKING
+        val pose = camera.pose
+        val failure: TrackingFailureReason? =
+            camera.trackingFailureReason.takeIf { it != TrackingFailureReason.NONE }
+        val planes: List<PlaneSample> = frame
+            .getUpdatedTrackables(com.google.ar.core.Plane::class.java)
+            .asSequence()
+            .filter { it.trackingState == TrackingState.TRACKING }
+            // Subsumed planes are merged into their parent — counting both double-counts
+            // area and plane count, so drop the subsumed child (matches RerunBridge).
+            .filter { it.subsumedBy == null }
+            .map { plane ->
+                PlaneSample(
+                    id = System.identityHashCode(plane),
+                    extentX = plane.extentX,
+                    extentZ = plane.extentZ,
+                    vertical = plane.type != com.google.ar.core.Plane.Type.HORIZONTAL_UPWARD_FACING &&
+                        plane.type != com.google.ar.core.Plane.Type.HORIZONTAL_DOWNWARD_FACING,
+                )
+            }
+            .toList()
+        return FrameSample(
+            timestampNanos = frame.timestamp,
+            tracking = tracking,
+            failureReason = failure,
+            cameraX = pose.tx(),
+            cameraY = pose.ty(),
+            cameraZ = pose.tz(),
+            planes = planes,
+        )
+    }
+}
+
+/**
+ * Creates and remembers an [ARRecordInterpreter] tied to the composable lifecycle (#1441).
+ *
+ * The interpreter holds no native resources, so there is nothing to release on dispose —
+ * the [DisposableEffect] is purely a marker so the lifecycle ownership reads the same as
+ * [rememberARRecorder].
+ */
+@Composable
+public fun rememberARRecordInterpreter(): ARRecordInterpreter {
+    val interpreter = remember { ARRecordInterpreter() }
+    DisposableEffect(interpreter) {
+        onDispose { /* no native resources to free */ }
+    }
+    return interpreter
+}
+
+/**
+ * A single replayed AR frame reduced to the plain values [ARRecordInterpreterCore] needs.
+ *
+ * Decouples the pure folding logic from ARCore's final native [Frame] / [com.google.ar.core.Camera]
+ * / [com.google.ar.core.Pose] types (which can't be mocked without mockito-inline), so the
+ * interpretation math is unit-testable on plain JVM.
+ *
+ * @property timestampNanos the frame timestamp in nanoseconds (`Frame.getTimestamp()`).
+ * @property tracking `true` if the camera was [TrackingState.TRACKING] this frame.
+ * @property failureReason the [TrackingFailureReason] when not tracking, or `null` when
+ *   tracking (ARCore reports `NONE` while tracking; this maps `NONE` to `null`).
+ * @property cameraX camera world-space X translation.
+ * @property cameraY camera world-space Y translation.
+ * @property cameraZ camera world-space Z translation.
+ * @property planes the planes ARCore had attached to the frame, already de-subsumed.
+ */
+public data class FrameSample(
+    val timestampNanos: Long,
+    val tracking: Boolean,
+    val failureReason: TrackingFailureReason?,
+    val cameraX: Float,
+    val cameraY: Float,
+    val cameraZ: Float,
+    val planes: List<PlaneSample> = emptyList(),
+)
+
+/**
+ * A single ARCore plane reduced to the values the interpreter aggregates.
+ *
+ * @property id a stable identity for the plane within one interpretation, used to count
+ *   *distinct* planes across frames (a plane reappears every frame it is updated).
+ * @property extentX the plane's X extent in metres (`Plane.getExtentX()`).
+ * @property extentZ the plane's Z extent in metres (`Plane.getExtentZ()`).
+ * @property vertical `true` for a vertical plane, `false` for a horizontal one.
+ */
+public data class PlaneSample(
+    val id: Int,
+    val extentX: Float,
+    val extentZ: Float,
+    val vertical: Boolean,
+)
+
+/**
+ * Quantified interpretation of a replayed AR Record (#1441) — the output of
+ * [ARRecordInterpreter].
+ *
+ * Every field is a plain number so it can be asserted in a CI regression test, printed in
+ * a debug overlay, or logged. [EMPTY] is the zero value before any frame is ingested.
+ *
+ * @property frameCount total frames ingested.
+ * @property trackedFrameCount frames where the camera was [TrackingState.TRACKING].
+ * @property durationSeconds wall-clock span of the dataset (last minus first timestamp).
+ * @property trajectoryLengthMeters total path length the camera travelled, summed over
+ *   consecutive **tracked** frames (lost-frame jumps are not counted as travel).
+ * @property trajectoryExtentMeters the diagonal of the axis-aligned bounding box of every
+ *   tracked camera position — how far the capture roamed end to end.
+ * @property failureReasonFrameCounts per-[TrackingFailureReason] count of lost frames.
+ *   Only non-zero reasons appear. Empty when the whole dataset tracked.
+ * @property horizontalPlaneCount distinct horizontal planes ARCore discovered.
+ * @property verticalPlaneCount distinct vertical planes ARCore discovered.
+ * @property planeAreaMeters2 combined area of every distinct plane, using each plane's
+ *   largest observed extent.
+ */
+public data class ARRecordInterpretation(
+    val frameCount: Int,
+    val trackedFrameCount: Int,
+    val durationSeconds: Double,
+    val trajectoryLengthMeters: Float,
+    val trajectoryExtentMeters: Float,
+    val failureReasonFrameCounts: Map<TrackingFailureReason, Int>,
+    val horizontalPlaneCount: Int,
+    val verticalPlaneCount: Int,
+    val planeAreaMeters2: Float,
+) {
+    /**
+     * Fraction of ingested frames that tracked, in `0.0 .. 1.0`. `0.0` for an empty
+     * interpretation. A value well below `1.0` flags a hard tracking dataset — inspect
+     * [failureReasonFrameCounts] for the dominant cause.
+     */
+    public val trackedFrameRatio: Double
+        get() = if (frameCount == 0) 0.0 else trackedFrameCount.toDouble() / frameCount
+
+    /** Total distinct planes discovered — [horizontalPlaneCount] + [verticalPlaneCount]. */
+    public val planeCount: Int
+        get() = horizontalPlaneCount + verticalPlaneCount
+
+    public companion object {
+        /** The zero interpretation — before any frame is ingested, or after a [reset]. */
+        public val EMPTY: ARRecordInterpretation = ARRecordInterpretation(
+            frameCount = 0,
+            trackedFrameCount = 0,
+            durationSeconds = 0.0,
+            trajectoryLengthMeters = 0f,
+            trajectoryExtentMeters = 0f,
+            failureReasonFrameCounts = emptyMap(),
+            horizontalPlaneCount = 0,
+            verticalPlaneCount = 0,
+            planeAreaMeters2 = 0f,
+        )
+    }
+}
+
+/**
+ * Pure, ARCore-free folding core behind [ARRecordInterpreter] (#1441).
+ *
+ * Accumulates [FrameSample]s into an [ARRecordInterpretation]. Holds no Android or ARCore
+ * type, so it is fully unit-testable on plain JVM — the value of splitting it out is that
+ * every trajectory / tracking-ratio / plane-area calculation gets a deterministic test
+ * without needing a device or a mocked native [Frame].
+ *
+ * Not thread-safe: [fold] is called from the single render thread that owns
+ * `onSessionUpdated`, matching how [ARRecorder] and `RerunBridge` are driven.
+ */
+public class ARRecordInterpreterCore {
+
+    private var frameCount = 0
+    private var trackedFrameCount = 0
+    private var firstTimestampNanos: Long? = null
+    private var lastTimestampNanos: Long = 0L
+
+    private var trajectoryLength = 0f
+    private var hasPreviousTrackedPosition = false
+    private var prevX = 0f
+    private var prevY = 0f
+    private var prevZ = 0f
+
+    private var minX = Float.POSITIVE_INFINITY
+    private var minY = Float.POSITIVE_INFINITY
+    private var minZ = Float.POSITIVE_INFINITY
+    private var maxX = Float.NEGATIVE_INFINITY
+    private var maxY = Float.NEGATIVE_INFINITY
+    private var maxZ = Float.NEGATIVE_INFINITY
+    private var hasAnyTrackedPosition = false
+
+    private val failureCounts = LinkedHashMap<TrackingFailureReason, Int>()
+
+    /** Per-plane-id largest observed extent, so a plane that grows is not double-counted. */
+    private val planeExtents = LinkedHashMap<Int, PlaneExtent>()
+
+    /**
+     * Fold one [sample] into the running interpretation and return the updated snapshot.
+     *
+     * The returned [ARRecordInterpretation] is an immutable value — callers may publish it
+     * straight into a Compose `State` without defensive copying.
+     */
+    public fun fold(sample: FrameSample): ARRecordInterpretation {
+        frameCount++
+
+        if (firstTimestampNanos == null) firstTimestampNanos = sample.timestampNanos
+        // Guard against a dataset whose timestamps are not monotonically increasing —
+        // duration is the span of the extremes, never a negative diff.
+        lastTimestampNanos = maxOf(lastTimestampNanos, sample.timestampNanos)
+
+        if (sample.tracking) {
+            trackedFrameCount++
+            accumulateTrajectory(sample.cameraX, sample.cameraY, sample.cameraZ)
+        } else {
+            hasPreviousTrackedPosition = false
+            sample.failureReason?.let { reason ->
+                failureCounts[reason] = (failureCounts[reason] ?: 0) + 1
+            }
+        }
+
+        for (plane in sample.planes) {
+            val current = planeExtents[plane.id]
+            planeExtents[plane.id] = PlaneExtent(
+                extentX = maxOf(current?.extentX ?: 0f, plane.extentX),
+                extentZ = maxOf(current?.extentZ ?: 0f, plane.extentZ),
+                vertical = plane.vertical,
+            )
+        }
+
+        return snapshot()
+    }
+
+    /** Reset every accumulator so the core can interpret a fresh dataset. */
+    public fun reset() {
+        frameCount = 0
+        trackedFrameCount = 0
+        firstTimestampNanos = null
+        lastTimestampNanos = 0L
+        trajectoryLength = 0f
+        hasPreviousTrackedPosition = false
+        prevX = 0f; prevY = 0f; prevZ = 0f
+        minX = Float.POSITIVE_INFINITY; minY = Float.POSITIVE_INFINITY; minZ = Float.POSITIVE_INFINITY
+        maxX = Float.NEGATIVE_INFINITY; maxY = Float.NEGATIVE_INFINITY; maxZ = Float.NEGATIVE_INFINITY
+        hasAnyTrackedPosition = false
+        failureCounts.clear()
+        planeExtents.clear()
+    }
+
+    private fun accumulateTrajectory(x: Float, y: Float, z: Float) {
+        if (hasPreviousTrackedPosition) {
+            val dx = x - prevX
+            val dy = y - prevY
+            val dz = z - prevZ
+            trajectoryLength += sqrt(dx * dx + dy * dy + dz * dz)
+        }
+        prevX = x; prevY = y; prevZ = z
+        hasPreviousTrackedPosition = true
+
+        minX = minOf(minX, x); minY = minOf(minY, y); minZ = minOf(minZ, z)
+        maxX = maxOf(maxX, x); maxY = maxOf(maxY, y); maxZ = maxOf(maxZ, z)
+        hasAnyTrackedPosition = true
+    }
+
+    private fun snapshot(): ARRecordInterpretation {
+        val durationSeconds = firstTimestampNanos?.let { first ->
+            (lastTimestampNanos - first).coerceAtLeast(0L) / 1_000_000_000.0
+        } ?: 0.0
+
+        val extent = if (hasAnyTrackedPosition) {
+            val dx = maxX - minX
+            val dy = maxY - minY
+            val dz = maxZ - minZ
+            sqrt(dx * dx + dy * dy + dz * dz)
+        } else {
+            0f
+        }
+
+        var horizontal = 0
+        var vertical = 0
+        var area = 0f
+        for (plane in planeExtents.values) {
+            if (plane.vertical) vertical++ else horizontal++
+            area += plane.extentX * plane.extentZ
+        }
+
+        return ARRecordInterpretation(
+            frameCount = frameCount,
+            trackedFrameCount = trackedFrameCount,
+            durationSeconds = durationSeconds,
+            trajectoryLengthMeters = trajectoryLength,
+            trajectoryExtentMeters = extent,
+            failureReasonFrameCounts = LinkedHashMap(failureCounts),
+            horizontalPlaneCount = horizontal,
+            verticalPlaneCount = vertical,
+            planeAreaMeters2 = area,
+        )
+    }
+
+    private data class PlaneExtent(val extentX: Float, val extentZ: Float, val vertical: Boolean)
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecordInterpreterCoreTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/recording/ARRecordInterpreterCoreTest.kt
@@ -1,0 +1,196 @@
+package io.github.sceneview.ar.recording
+
+import com.google.ar.core.TrackingFailureReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for [ARRecordInterpreterCore] — the pure folding core behind the
+ * AR Record interpretation feature (#1441).
+ *
+ * These target [ARRecordInterpreterCore.fold] directly against hand-built [FrameSample]s,
+ * so they need neither a device nor a mocked native ARCore [com.google.ar.core.Frame].
+ * The ARCore-facing [ARRecordInterpreter.ingest] is a thin reader that converts a real
+ * `Frame` into a [FrameSample] and delegates here — any interpretation bug surfaces in
+ * these tests.
+ */
+class ARRecordInterpreterCoreTest {
+
+    private val core = ARRecordInterpreterCore()
+
+    private fun frame(
+        timestampNanos: Long = 0L,
+        tracking: Boolean = true,
+        failureReason: TrackingFailureReason? = null,
+        x: Float = 0f,
+        y: Float = 0f,
+        z: Float = 0f,
+        planes: List<PlaneSample> = emptyList(),
+    ) = FrameSample(
+        timestampNanos = timestampNanos,
+        tracking = tracking,
+        failureReason = failureReason,
+        cameraX = x, cameraY = y, cameraZ = z,
+        planes = planes,
+    )
+
+    @Test
+    fun `empty core yields the EMPTY interpretation`() {
+        assertEquals(ARRecordInterpretation.EMPTY, ARRecordInterpreterCore().run {
+            // no fold call — read the canonical empty value
+            ARRecordInterpretation.EMPTY
+        })
+    }
+
+    @Test
+    fun `frame count and tracked count accumulate`() {
+        core.fold(frame(tracking = true))
+        core.fold(frame(tracking = false, failureReason = TrackingFailureReason.INSUFFICIENT_LIGHT))
+        val result = core.fold(frame(tracking = true))
+
+        assertEquals(3, result.frameCount)
+        assertEquals(2, result.trackedFrameCount)
+    }
+
+    @Test
+    fun `tracked frame ratio reflects tracked over total`() {
+        repeat(3) { core.fold(frame(tracking = true)) }
+        val result = core.fold(frame(tracking = false))
+
+        // 3 tracked of 4 total
+        assertEquals(0.75, result.trackedFrameRatio, 1e-9)
+    }
+
+    @Test
+    fun `tracked frame ratio is zero for an empty interpretation`() {
+        assertEquals(0.0, ARRecordInterpretation.EMPTY.trackedFrameRatio, 1e-9)
+    }
+
+    @Test
+    fun `duration is the span between first and last timestamp`() {
+        core.fold(frame(timestampNanos = 1_000_000_000L))
+        core.fold(frame(timestampNanos = 2_500_000_000L))
+        val result = core.fold(frame(timestampNanos = 4_000_000_000L))
+
+        // 4.0s - 1.0s = 3.0s
+        assertEquals(3.0, result.durationSeconds, 1e-9)
+    }
+
+    @Test
+    fun `non-monotonic timestamps never produce a negative duration`() {
+        core.fold(frame(timestampNanos = 5_000_000_000L))
+        // an out-of-order earlier timestamp must not make duration negative
+        val result = core.fold(frame(timestampNanos = 1_000_000_000L))
+
+        assertTrue("duration must never be negative", result.durationSeconds >= 0.0)
+        assertEquals(0.0, result.durationSeconds, 1e-9)
+    }
+
+    @Test
+    fun `trajectory length sums distance over consecutive tracked frames`() {
+        core.fold(frame(x = 0f, y = 0f, z = 0f))
+        core.fold(frame(x = 3f, y = 0f, z = 0f)) // +3
+        val result = core.fold(frame(x = 3f, y = 4f, z = 0f)) // +4
+
+        assertEquals(7f, result.trajectoryLengthMeters, 1e-4f)
+    }
+
+    @Test
+    fun `a lost frame breaks the trajectory so the jump is not counted as travel`() {
+        core.fold(frame(x = 0f, y = 0f, z = 0f, tracking = true))
+        // tracking lost — camera teleports while relocalizing
+        core.fold(frame(x = 100f, y = 0f, z = 0f, tracking = false))
+        // tracking regained at a far position — the 100m jump must NOT count
+        core.fold(frame(x = 100f, y = 0f, z = 0f, tracking = true))
+        val result = core.fold(frame(x = 102f, y = 0f, z = 0f, tracking = true)) // +2
+
+        assertEquals(2f, result.trajectoryLengthMeters, 1e-4f)
+    }
+
+    @Test
+    fun `trajectory extent is the diagonal of the bounding box of tracked positions`() {
+        core.fold(frame(x = 0f, y = 0f, z = 0f))
+        core.fold(frame(x = 1f, y = 2f, z = 2f))
+        val result = core.fold(frame(x = -1f, y = 0f, z = 0f))
+
+        // bbox: x in [-1,1] (2), y in [0,2] (2), z in [0,2] (2) -> sqrt(12)
+        assertEquals(kotlin.math.sqrt(12f), result.trajectoryExtentMeters, 1e-4f)
+    }
+
+    @Test
+    fun `failure reasons are counted per reason`() {
+        core.fold(frame(tracking = false, failureReason = TrackingFailureReason.EXCESSIVE_MOTION))
+        core.fold(frame(tracking = false, failureReason = TrackingFailureReason.EXCESSIVE_MOTION))
+        val result = core.fold(
+            frame(tracking = false, failureReason = TrackingFailureReason.INSUFFICIENT_FEATURES)
+        )
+
+        assertEquals(2, result.failureReasonFrameCounts[TrackingFailureReason.EXCESSIVE_MOTION])
+        assertEquals(1, result.failureReasonFrameCounts[TrackingFailureReason.INSUFFICIENT_FEATURES])
+    }
+
+    @Test
+    fun `a fully tracked dataset has no failure reasons`() {
+        repeat(5) { core.fold(frame(tracking = true)) }
+        val result = core.fold(frame(tracking = true))
+
+        assertTrue(result.failureReasonFrameCounts.isEmpty())
+    }
+
+    @Test
+    fun `planes are counted once across frames and split by orientation`() {
+        val floor = PlaneSample(id = 1, extentX = 2f, extentZ = 3f, vertical = false)
+        val wall = PlaneSample(id = 2, extentX = 1f, extentZ = 4f, vertical = true)
+
+        // same planes reappear every frame they update
+        core.fold(frame(planes = listOf(floor)))
+        core.fold(frame(planes = listOf(floor, wall)))
+        val result = core.fold(frame(planes = listOf(floor, wall)))
+
+        assertEquals(1, result.horizontalPlaneCount)
+        assertEquals(1, result.verticalPlaneCount)
+        assertEquals(2, result.planeCount)
+    }
+
+    @Test
+    fun `plane area uses the largest observed extent so a growing plane is not double-counted`() {
+        // same plane id, growing extents across frames
+        core.fold(frame(planes = listOf(PlaneSample(id = 1, extentX = 1f, extentZ = 1f, vertical = false))))
+        core.fold(frame(planes = listOf(PlaneSample(id = 1, extentX = 2f, extentZ = 3f, vertical = false))))
+        val result = core.fold(
+            frame(planes = listOf(PlaneSample(id = 1, extentX = 1.5f, extentZ = 2f, vertical = false)))
+        )
+
+        // largest X = 2, largest Z = 3 -> area 6, counted once
+        assertEquals(6f, result.planeAreaMeters2, 1e-4f)
+        assertEquals(1, result.planeCount)
+    }
+
+    @Test
+    fun `reset clears all accumulators back to EMPTY`() {
+        core.fold(frame(x = 5f, tracking = true, planes = listOf(
+            PlaneSample(id = 1, extentX = 2f, extentZ = 2f, vertical = false)
+        )))
+        core.fold(frame(tracking = false, failureReason = TrackingFailureReason.BAD_STATE))
+
+        core.reset()
+        val afterReset = core.fold(frame(tracking = true))
+
+        assertEquals(1, afterReset.frameCount)
+        assertEquals(1, afterReset.trackedFrameCount)
+        assertEquals(0f, afterReset.trajectoryLengthMeters, 1e-4f)
+        assertEquals(0, afterReset.planeCount)
+        assertTrue(afterReset.failureReasonFrameCounts.isEmpty())
+    }
+
+    @Test
+    fun `interpretation snapshot is a stable immutable value`() {
+        val first = core.fold(frame(tracking = true))
+        core.fold(frame(tracking = false, failureReason = TrackingFailureReason.INSUFFICIENT_LIGHT))
+
+        // the earlier snapshot must not mutate after a later fold
+        assertEquals(1, first.frameCount)
+        assertTrue(first.failureReasonFrameCounts.isEmpty())
+    }
+}

--- a/changelog.d/1441-ar-record-interpretation.md
+++ b/changelog.d/1441-ar-record-interpretation.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- AR Record interpretation: new `ARRecordInterpreter` (+ `rememberARRecordInterpreter()`) folds every frame of a replayed AR Record dataset into an `ARRecordInterpretation` — camera trajectory length & extent, tracked-frame ratio with a per-`TrackingFailureReason` breakdown, and discovered plane count & area — turning a record/playback session into a quantified, CI-assertable tracking-quality report ([#1441](https://github.com/sceneview/sceneview/issues/1441)).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -3284,6 +3284,45 @@ ARSceneView(playbackDatasetUri = pickedUri) { /* … */ }
 
 See [`ARRecorder.kt`](arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt).
 
+### AR Record interpretation — quantify a replayed session (#1441)
+
+Replay alone re-renders the camera feed; it does not tell you *whether the session
+tracked well*. `ARRecordInterpreter` is the analysis half: feed it every replayed frame
+and it folds the camera pose + plane trackables into an `ARRecordInterpretation` — a
+quantified, CI-assertable tracking-quality report. This is the deterministic, desk-side
+counterpart to on-device QA: record a hard tracking stress-case once, then replay +
+interpret it on every CI run and assert the metrics never regress.
+
+```kotlin
+import io.github.sceneview.ar.recording.rememberARRecordInterpreter
+
+val interpreter = rememberARRecordInterpreter()
+ARSceneView(
+    playbackDataset = recordedDataset,
+    onSessionUpdated = { session, frame -> interpreter.ingest(session, frame) },
+    content = { /* … */ }
+)
+// When rememberARPlaybackStatus(arSession) reports PlaybackStatus.FINISHED:
+val report = interpreter.interpretation
+// report.frameCount / trackedFrameCount / trackedFrameRatio (0.0..1.0)
+// report.durationSeconds
+// report.trajectoryLengthMeters   — total camera path length over tracked frames
+// report.trajectoryExtentMeters   — diagonal of the bounding box of the path
+// report.failureReasonFrameCounts — Map<TrackingFailureReason, Int> of lost frames
+// report.horizontalPlaneCount / verticalPlaneCount / planeCount / planeAreaMeters2
+```
+
+- `ingest(session, frame)` is the stateless side-channel shape used by `ARRecorder.recordFrame`
+  and `RerunBridge.logFrame` — call it from `onSessionUpdated`. It does no Filament JNI work,
+  no extra ARCore acquire calls, and no allocation beyond the immutable snapshot.
+- A lost frame breaks the trajectory so a relocalization teleport is **not** counted as travel.
+- Planes are de-subsumed and counted once across frames; `planeAreaMeters2` uses each plane's
+  largest observed extent so a growing plane is not double-counted.
+- Call `interpreter.reset()` to interpret another dataset with the same instance.
+- The pure folding core (`ARRecordInterpreterCore`, ARCore-free) is JVM-unit-tested directly.
+
+See [`ARRecordInterpreter.kt`](arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecordInterpreter.kt).
+
 ### iOS — `ARRecorder` (record-only via ReplayKit, v4.3.0+)
 
 iOS gets the record half via `ReplayKit.RPScreenRecorder`. There is no replay half because ARKit has no deterministic playback API (see `cheatsheet-ios.md` parity table, #1036). The MP4 plays back in the Photos app or any QuickTime player; it cannot be fed back into `ARSession`.

--- a/llms.txt
+++ b/llms.txt
@@ -3284,6 +3284,45 @@ ARSceneView(playbackDatasetUri = pickedUri) { /* … */ }
 
 See [`ARRecorder.kt`](arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt).
 
+### AR Record interpretation — quantify a replayed session (#1441)
+
+Replay alone re-renders the camera feed; it does not tell you *whether the session
+tracked well*. `ARRecordInterpreter` is the analysis half: feed it every replayed frame
+and it folds the camera pose + plane trackables into an `ARRecordInterpretation` — a
+quantified, CI-assertable tracking-quality report. This is the deterministic, desk-side
+counterpart to on-device QA: record a hard tracking stress-case once, then replay +
+interpret it on every CI run and assert the metrics never regress.
+
+```kotlin
+import io.github.sceneview.ar.recording.rememberARRecordInterpreter
+
+val interpreter = rememberARRecordInterpreter()
+ARSceneView(
+    playbackDataset = recordedDataset,
+    onSessionUpdated = { session, frame -> interpreter.ingest(session, frame) },
+    content = { /* … */ }
+)
+// When rememberARPlaybackStatus(arSession) reports PlaybackStatus.FINISHED:
+val report = interpreter.interpretation
+// report.frameCount / trackedFrameCount / trackedFrameRatio (0.0..1.0)
+// report.durationSeconds
+// report.trajectoryLengthMeters   — total camera path length over tracked frames
+// report.trajectoryExtentMeters   — diagonal of the bounding box of the path
+// report.failureReasonFrameCounts — Map<TrackingFailureReason, Int> of lost frames
+// report.horizontalPlaneCount / verticalPlaneCount / planeCount / planeAreaMeters2
+```
+
+- `ingest(session, frame)` is the stateless side-channel shape used by `ARRecorder.recordFrame`
+  and `RerunBridge.logFrame` — call it from `onSessionUpdated`. It does no Filament JNI work,
+  no extra ARCore acquire calls, and no allocation beyond the immutable snapshot.
+- A lost frame breaks the trajectory so a relocalization teleport is **not** counted as travel.
+- Planes are de-subsumed and counted once across frames; `planeAreaMeters2` uses each plane's
+  largest observed extent so a growing plane is not double-counted.
+- Call `interpreter.reset()` to interpret another dataset with the same instance.
+- The pure folding core (`ARRecordInterpreterCore`, ARCore-free) is JVM-unit-tested directly.
+
+See [`ARRecordInterpreter.kt`](arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecordInterpreter.kt).
+
 ### iOS — `ARRecorder` (record-only via ReplayKit, v4.3.0+)
 
 iOS gets the record half via `ReplayKit.RPScreenRecorder`. There is no replay half because ARKit has no deterministic playback API (see `cheatsheet-ios.md` parity table, #1036). The MP4 plays back in the Photos app or any QuickTime player; it cannot be fed back into `ARSession`.


### PR DESCRIPTION
## Summary

Implements the **AR Record interpretation** feature from #1441 — the *analysis* half of the record/playback loop.

[`ARRecorder`](arsceneview/src/main/java/io/github/sceneview/ar/recording/ARRecorder.kt) records an ARCore session into an MP4 and `ARSceneView(playbackDataset = …)` replays it 1:1 — but replay alone just re-renders the camera feed, it tells you nothing about *whether the session tracked well*. The new `ARRecordInterpreter` closes that gap: feed it every replayed frame and it folds the camera pose + plane trackables into an `ARRecordInterpretation` — a quantified, CI-assertable tracking-quality report.

This is the deterministic, desk-side counterpart to on-device QA: record a hard tracking stress-case once (e.g. the in-car drive datasets called out in #1441), then replay + interpret it on every CI run and assert the metrics never regress.

### What it computes

- **Trajectory** — total camera path length over tracked frames + bounding-box extent. A lost frame breaks the trajectory so a relocalization teleport is not counted as travel.
- **Tracking quality** — tracked-frame ratio + a per-`TrackingFailureReason` breakdown of the lost frames (a high `EXCESSIVE_MOTION` share is the classic in-car failure mode; `INSUFFICIENT_FEATURES` points at a textureless scene).
- **Planes** — distinct horizontal / vertical plane count + combined area (de-subsumed, counted once across frames, using each plane's largest observed extent).

### API shape

- `ARRecordInterpreter.ingest(session, frame)` — call from `onSessionUpdated`; matches the stateless side-channel shape of `ARRecorder.recordFrame` / `RerunBridge.logFrame`.
- `rememberARRecordInterpreter()` — mirrors `rememberARRecorder()`.
- `ARRecordInterpreterCore` — the pure, ARCore-free folding core, JVM-unit-tested directly.
- No Filament JNI work, no extra ARCore acquire calls, no allocation beyond the immutable snapshot.

## Scope

Foundational library-level slice — confined to `arsceneview/` + `llms.txt`. A "Replay + analyse" **demo mode** (overlaying the interpretation on the replayed video in `samples/android-demo`) and a richer per-frame timeline are deliberately left out of this PR; see the follow-up issue. iOS has no deterministic ARKit replay API (see `cheatsheet-ios.md` #1036), so this is inherently Android-only — consistent with the existing `playbackDataset` asymmetry.

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin :sceneview:compileReleaseKotlin` — clean
- [x] `./gradlew :arsceneview:testDebugUnitTest --tests "io.github.sceneview.ar.recording.*"` — 82 tests pass (15 new `ARRecordInterpreterCoreTest` + 67 existing)
- [x] `./gradlew :arsceneview:detekt` — clean
- [x] `bash .claude/scripts/impact-check.sh` — ALL CLEAR

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)