### PR TITLE
docs(web): flag builder-DSL vs Node-scene-graph divergence in llms.txt

### DIFF
--- a/changelog.d/895-web-node-hierarchy.md
+++ b/changelog.d/895-web-node-hierarchy.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- `llms.txt`: added an explicit **"Web API model — builder DSL, NOT a Node scene-graph"** section to the SceneView Web reference, with a concept-mapping table (Android/iOS `Node` ↔ Web builder DSL) and correct-vs-incorrect code examples. This stops AI assistants from generating Android-style `Node`-tree code that does not compile against `sceneview-web`, and documents that a node scene-graph for Web is a tracked v5 milestone effort ([#895](https://github.com/sceneview/sceneview/issues/895)).

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -4790,6 +4790,52 @@ After loading, the library registers itself on `window.sceneview`.
 
 ---
 
+### ⚠️ Web API model — builder DSL, NOT a Node scene-graph
+
+**The Web target does NOT have a `Node` class or a node scene-graph.** This is a
+deliberate, documented divergence from SceneView Android (`io.github.sceneview.node.Node`)
+and SceneView Apple (`SceneViewSwift` entities). Do **not** generate Android/iOS-style
+node-tree code for `sceneview-web` — it will not compile.
+
+| Concept | Android / iOS | Web (`sceneview-web`) |
+|---|---|---|
+| Add a model | `ModelNode(...)` added to a `Node` tree | `model("url.glb") { ... }` inside the `configure` block, or `sceneView.loadModel(url)` |
+| Add a primitive | `CubeNode` / `SphereNode` / … | `geometry { cube(); … }`, or `sceneView.addGeometry(GeometryConfig)` |
+| Add a light | `LightNode(...)` | `light { directional(); … }`, or `sceneView.addLight(LightConfig)` |
+| Configure the camera | `CameraNode(...)` | `camera { eye(...); target(...) }` (a `CameraConfig`) |
+| Parent / child hierarchy | `node.parent = other` / `node.childNodes` | **not available** — content is flat, placed in world space |
+| Per-content transform | `node.position` / `node.rotation` / `node.scale` (mutable, reactive) | set once via the `*Config` `position(...)` / `rotation(...)` / `scale(...)` builders; not re-mutable after `create()` |
+| Transform inheritance | composed parent→child via Filament `TransformManager` | none — every asset is a world-space leaf |
+
+The Web target is configured by a **fire-and-forget builder DSL**: you describe the
+scene inside `SceneView.create(canvas) { … }` and the library builds it once. Content
+is loaded into a flat internal list (no persistent, addressable, mutable `Node`
+objects). The 4 `*Config` classes (`ModelConfig`, `GeometryConfig`, `LightConfig`,
+`CameraConfig`) are builder *inputs*, not scene-graph nodes — they are consumed when
+the scene is built and are not retained as handles.
+
+**Correct Web code** (parity with the Android example, NOT a node tree):
+
+```kotlin
+// ✅ Web — builder DSL
+SceneView.create(canvas, configure = {
+    camera { eye(0.0, 1.5, 5.0); target(0.0, 0.0, 0.0) }
+    light  { directional(); intensity(100_000.0) }
+    model("models/damaged_helmet.glb")
+    geometry { cube(); size(1.0); position(2.0, 0.0, 0.0); color(1.0, 0.0, 0.0, 1.0) }
+}) { sceneView -> sceneView.startRendering() }
+
+// ❌ Web — Android/iOS Node code does NOT compile here:
+// val node = ModelNode(modelInstance); node.parent = sceneNode   // no Node class on Web
+```
+
+A node scene-graph for the Web target (`Node` base type, parent/child, composed
+transforms — bringing the Web API to parity with Android/iOS) is tracked as a
+**v5 milestone** effort. Until then, this builder-DSL model is the complete and
+correct Web API.
+
+---
+
 ### SceneView (Kotlin/JS class — 3D scene)
 
 ```kotlin

--- a/llms.txt
+++ b/llms.txt
@@ -4790,6 +4790,52 @@ After loading, the library registers itself on `window.sceneview`.
 
 ---
 
+### ⚠️ Web API model — builder DSL, NOT a Node scene-graph
+
+**The Web target does NOT have a `Node` class or a node scene-graph.** This is a
+deliberate, documented divergence from SceneView Android (`io.github.sceneview.node.Node`)
+and SceneView Apple (`SceneViewSwift` entities). Do **not** generate Android/iOS-style
+node-tree code for `sceneview-web` — it will not compile.
+
+| Concept | Android / iOS | Web (`sceneview-web`) |
+|---|---|---|
+| Add a model | `ModelNode(...)` added to a `Node` tree | `model("url.glb") { ... }` inside the `configure` block, or `sceneView.loadModel(url)` |
+| Add a primitive | `CubeNode` / `SphereNode` / … | `geometry { cube(); … }`, or `sceneView.addGeometry(GeometryConfig)` |
+| Add a light | `LightNode(...)` | `light { directional(); … }`, or `sceneView.addLight(LightConfig)` |
+| Configure the camera | `CameraNode(...)` | `camera { eye(...); target(...) }` (a `CameraConfig`) |
+| Parent / child hierarchy | `node.parent = other` / `node.childNodes` | **not available** — content is flat, placed in world space |
+| Per-content transform | `node.position` / `node.rotation` / `node.scale` (mutable, reactive) | set once via the `*Config` `position(...)` / `rotation(...)` / `scale(...)` builders; not re-mutable after `create()` |
+| Transform inheritance | composed parent→child via Filament `TransformManager` | none — every asset is a world-space leaf |
+
+The Web target is configured by a **fire-and-forget builder DSL**: you describe the
+scene inside `SceneView.create(canvas) { … }` and the library builds it once. Content
+is loaded into a flat internal list (no persistent, addressable, mutable `Node`
+objects). The 4 `*Config` classes (`ModelConfig`, `GeometryConfig`, `LightConfig`,
+`CameraConfig`) are builder *inputs*, not scene-graph nodes — they are consumed when
+the scene is built and are not retained as handles.
+
+**Correct Web code** (parity with the Android example, NOT a node tree):
+
+```kotlin
+// ✅ Web — builder DSL
+SceneView.create(canvas, configure = {
+    camera { eye(0.0, 1.5, 5.0); target(0.0, 0.0, 0.0) }
+    light  { directional(); intensity(100_000.0) }
+    model("models/damaged_helmet.glb")
+    geometry { cube(); size(1.0); position(2.0, 0.0, 0.0); color(1.0, 0.0, 0.0, 1.0) }
+}) { sceneView -> sceneView.startRendering() }
+
+// ❌ Web — Android/iOS Node code does NOT compile here:
+// val node = ModelNode(modelInstance); node.parent = sceneNode   // no Node class on Web
+```
+
+A node scene-graph for the Web target (`Node` base type, parent/child, composed
+transforms — bringing the Web API to parity with Android/iOS) is tracked as a
+**v5 milestone** effort. Until then, this builder-DSL model is the complete and
+correct Web API.
+
+---
+
 ### SceneView (Kotlin/JS class — 3D scene)
 
 ```kotlin


### PR DESCRIPTION
## Summary

- The Web target (`sceneview-web`) has **no `Node` class or scene-graph** — it is configured by a fire-and-forget builder DSL, a deliberate divergence from the Android/iOS `Node` model. AI assistants reading `llms.txt` were generating Android-style `Node`-tree code that does not compile against `sceneview-web` (the core complaint in #895).
- Adds an explicit **"Web API model — builder DSL, NOT a Node scene-graph"** section to the SceneView Web reference in `llms.txt`: a concept-mapping table (Android/iOS `Node` ↔ Web builder DSL) plus correct-vs-incorrect code examples.
- Documents that a real node scene-graph for Web is a tracked **v5 milestone** effort (#2024).
- Documentation-only — **no Kotlin source touched, no breaking change.**

## Why this is the right burn-down outcome for #895

#895 offered two fix paths: **(1) align** the Web API to a `Node` model, or **(2) document** the divergence. After investigating `sceneview-web/` thoroughly:

- A faithful `Node` foundation (base type + parent/child + composed transforms + `ModelNode`/`GeometryNode`/`LightNode`/`CameraNode` subtypes + `TransformManager.setParent` binding + `@JsExport` surface changes) restructures how `SceneView` loads and owns content. It is a genuine architectural effort — too large to land well in one PR, and a half-baked partial node tree would be worse than the current honest builder DSL.
- The *immediate* harm in #895 is AI-generated code that does not compile. **Documenting the divergence fixes that now.** SceneView is an AI-first SDK — an accurate, explicit `llms.txt` is the highest-leverage fix available without the v5 refactor.

So: this PR ships the **documentation** half of #895's fix path and closes it; the **alignment** half is scoped concretely into the new v5 issue #2024.

## Test plan

- [x] `bash .claude/scripts/impact-check.sh` — ALL CLEAR
- [x] Documentation-only — no compilation impacted (no `.kt` file changed)
- [x] Changelog fragment added (`changelog.d/895-web-node-hierarchy.md`)

Closes #895