### PR TITLE
fix(feedback-worker): close security + correctness blockers from review

### DIFF
--- a/changelog.d/1930-feedback-worker-hardening.md
+++ b/changelog.d/1930-feedback-worker-hardening.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- feedback-worker: closed security + correctness blockers from review — enforce the 30 MB upload cap before buffering the body (streaming guard + `Content-Length` validation), SHA-256 IP hashing in the rate limiter, fenced-code Markdown rendering of user text/transcripts on the public issue, base64 Whisper input verified + multi-MB-safe, orphaned-R2 cleanup on D1 failure, incremental retention cron, cached GitHub installation token, and admin-token brute-force rate limiting ([#1930](https://github.com/sceneview/sceneview/issues/1930)).

--- a/feedback-worker/migrations/0001_feedback.sql
+++ b/feedback-worker/migrations/0001_feedback.sql
@@ -16,5 +16,5 @@ CREATE TABLE IF NOT EXISTS feedback (
   media_purged  INTEGER NOT NULL DEFAULT 0                        -- 1 once R2 media is deleted
 );
 
-CREATE INDEX idx_feedback_created ON feedback (created_at);
-CREATE INDEX idx_feedback_status  ON feedback (status);
+CREATE INDEX IF NOT EXISTS idx_feedback_created ON feedback (created_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_status  ON feedback (status);

--- a/feedback-worker/src/github.ts
+++ b/feedback-worker/src/github.ts
@@ -47,11 +47,29 @@ async function appJwt(env: Env): Promise<string> {
   return `${signingInput}.${base64Url(new Uint8Array(sig))}`;
 }
 
-/** Exchange the App JWT for an installation access token. */
+/**
+ * Module-scope cache of installation tokens, keyed by installation id. A GitHub
+ * installation token lives ~1 hour; minting a fresh one means signing a JWT and
+ * a token round-trip on every feedback submission. The cached token is reused
+ * until `SKEW_MS` before its real `expires_at`, then re-minted.
+ *
+ * The cache lives only as long as the isolate — a cold start just re-mints.
+ */
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+/** Re-mint this far before the real expiry to absorb clock skew + latency. */
+const SKEW_MS = 5 * 60 * 1000;
+
+/** Exchange the App JWT for an installation access token (cached). */
 async function installationToken(env: Env): Promise<string> {
+  const installId = env.GITHUB_INSTALLATION_ID;
+  const cached = tokenCache.get(installId);
+  if (cached && cached.expiresAt - SKEW_MS > Date.now()) {
+    return cached.token;
+  }
+
   const jwt = await appJwt(env);
   const res = await fetch(
-    `${GH_API}/app/installations/${env.GITHUB_INSTALLATION_ID}/access_tokens`,
+    `${GH_API}/app/installations/${installId}/access_tokens`,
     {
       method: "POST",
       headers: {
@@ -65,7 +83,15 @@ async function installationToken(env: Env): Promise<string> {
     // Status only — the response body can echo request detail / secrets.
     throw new Error(`installation token request failed: ${res.status}`);
   }
-  const json = (await res.json()) as { token: string };
+  const json = (await res.json()) as { token: string; expires_at?: string };
+  // `expires_at` is an ISO-8601 string; fall back to a conservative 50 min if
+  // GitHub ever omits it so a missing field never produces a stale cache hit.
+  const expiresAt = json.expires_at
+    ? Date.parse(json.expires_at)
+    : Date.now() + 50 * 60 * 1000;
+  if (Number.isFinite(expiresAt)) {
+    tokenCache.set(installId, { token: json.token, expiresAt });
+  }
   return json.token;
 }
 

--- a/feedback-worker/src/index.ts
+++ b/feedback-worker/src/index.ts
@@ -2,7 +2,11 @@ import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { getCookie, setCookie } from "hono/cookie";
 import type { Env } from "./env.js";
-import { isRateLimited, issueQuotaExceeded } from "./rate-limit.js";
+import {
+  adminAttemptLimited,
+  isRateLimited,
+  issueQuotaExceeded,
+} from "./rate-limit.js";
 import { transcribe } from "./transcribe.js";
 import { buildIssue, type Category, type FeedbackContext } from "./issue.js";
 import { createIssue } from "./github.js";
@@ -20,6 +24,31 @@ const app = new Hono<{ Bindings: Env }>();
 /** Upload ceiling — a short screen recording is well under this. */
 const MAX_UPLOAD = 30 * 1024 * 1024; // 30 MB
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Wrap a request body stream in a counting `TransformStream` that aborts once
+ * `limit` bytes have flowed through it. This caps how much can be buffered into
+ * the 128 MB isolate by `formData()` even when `Content-Length` is missing or
+ * forged — the stream is torn down before the body is fully read into memory.
+ */
+function limitedBody(
+  body: ReadableStream<Uint8Array>,
+  limit: number,
+): ReadableStream<Uint8Array> {
+  let seen = 0;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        seen += chunk.byteLength;
+        if (seen > limit) {
+          controller.error(new Error("upload_too_large"));
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+}
 
 /** Pick a File-valued multipart field; null if absent or a plain string. */
 function fileField(form: FormData, name: string): File | null {
@@ -77,8 +106,16 @@ app.get("/health", (c) =>
 
 // ── POST /v1/feedback — receive a feedback submission ────────────────────────
 app.post("/v1/feedback", async (c) => {
-  // Reject oversized uploads before reading the body.
-  const cl = parseInt(c.req.header("content-length") ?? "0", 10);
+  // Reject oversized uploads BEFORE buffering the body into the isolate.
+  // `Content-Length` is client-controlled and may be absent or forged, so a
+  // present numeric value over the cap is rejected outright; a missing or
+  // non-numeric value is also rejected (a well-behaved multipart upload always
+  // sends one). The streaming guard below is the real backstop for the rest.
+  const clHeader = c.req.header("content-length");
+  const cl = Number(clHeader);
+  if (clHeader === undefined || !Number.isFinite(cl) || cl < 0) {
+    return c.json({ error: "length_required" }, 411);
+  }
   if (cl > MAX_UPLOAD) return c.json({ error: "payload_too_large" }, 413);
 
   // Rate limit by IP (hashed — never stored raw).
@@ -88,11 +125,26 @@ app.post("/v1/feedback", async (c) => {
     return c.json({ error: "rate_limited" }, 429, { "Retry-After": "60" });
   }
 
+  // Hard ceiling: wrap the raw body in a counting stream that aborts once
+  // MAX_UPLOAD bytes have flowed, so a forged Content-Length cannot OOM the
+  // isolate by streaming an unbounded body into `formData()`.
   let form: FormData;
   try {
-    form = await c.req.formData();
+    const raw = c.req.raw.body;
+    const req = raw
+      ? new Request(c.req.raw.url, {
+          method: c.req.raw.method,
+          headers: c.req.raw.headers,
+          body: limitedBody(raw, MAX_UPLOAD),
+          // Streaming request bodies require an explicit half-duplex hint.
+          duplex: "half",
+        } as RequestInit & { duplex: "half" })
+      : c.req.raw;
+    form = await req.formData();
   } catch {
-    return c.json({ error: "invalid_multipart" }, 400);
+    // A multipart parse error and a tripped size guard are indistinguishable
+    // here; both mean the body could not be safely consumed.
+    return c.json({ error: "invalid_or_oversized_multipart" }, 413);
   }
 
   const category = String(form.get("category") ?? "");
@@ -169,6 +221,13 @@ app.post("/v1/feedback", async (c) => {
     });
   } catch (e) {
     console.error("D1 insert failed", e);
+    // The media is already in R2 but no row references it — retention sweeps
+    // by D1 row, so without this cleanup the objects would be un-purgeable
+    // forever. Best-effort delete both keys before returning.
+    await Promise.allSettled([
+      videoKey ? c.env.MEDIA.delete(videoKey) : Promise.resolve(),
+      audioKey ? c.env.MEDIA.delete(audioKey) : Promise.resolve(),
+    ]);
     return c.json({ error: "storage_failed" }, 502);
   }
 
@@ -216,6 +275,12 @@ app.get("/feedback/:id", async (c) => {
   // clean URL, so the token never lingers in browser history, logs or Referer.
   const queryToken = c.req.query("token");
   if (queryToken !== undefined) {
+    // Feedback UUIDs appear publicly on the GitHub issues, so the viewer URL is
+    // guessable — rate-limit token attempts per IP to blunt a brute-force.
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    if (await adminAttemptLimited(ip, c.env.RL_KV)) {
+      return c.json({ error: "rate_limited" }, 429, { "Retry-After": "60" });
+    }
     if (
       c.env.ADMIN_TOKEN &&
       (await constantTimeEqual(queryToken, c.env.ADMIN_TOKEN))
@@ -227,6 +292,9 @@ app.get("/feedback/:id", async (c) => {
         path: "/feedback",
         maxAge: 28800,
       });
+    } else {
+      // Audit trail — a failed admin-token attempt against a guessable URL.
+      console.warn(`failed admin-token attempt for feedback ${id}`);
     }
     return c.redirect(`/feedback/${id}`, 302);
   }
@@ -287,6 +355,10 @@ export { app };
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
-    ctx.waitUntil(purgeExpiredMedia(env));
+    ctx.waitUntil(
+      purgeExpiredMedia(env)
+        .then((n) => console.log(`retention cron: purged ${n} record(s)`))
+        .catch((e) => console.error("retention cron failed", e)),
+    );
   },
 };

--- a/feedback-worker/src/issue.ts
+++ b/feedback-worker/src/issue.ts
@@ -14,13 +14,38 @@ function neutralize(text: string): string {
   return text.replace(/([@#])(?=[\w-])/g, "$1\u200b");
 }
 
-/** Escape a value for a single Markdown table cell. */
+/** Escape every Markdown-significant character in an inline string. */
+function escapeMarkdown(s: string): string {
+  return s.replace(/[\\`*_{}[\]()#+\-.!|~<>]/g, "\\$&");
+}
+
+/**
+ * Escape a value for a single Markdown table cell. The context values are
+ * client-controlled, so all Markdown specials are escaped — not just `|` —
+ * to stop link/image injection through the context table.
+ */
 function cell(value: unknown): string {
-  return String(value ?? "")
-    .replace(/[\r\n]+/g, " ")
-    .replace(/\|/g, "\\|")
-    .trim()
-    .slice(0, 300);
+  return escapeMarkdown(
+    String(value ?? "")
+      .replace(/[\r\n]+/g, " ")
+      .trim()
+      .slice(0, 300),
+  );
+}
+
+/**
+ * Render an untrusted free-text block (the user's typed description or the
+ * Whisper transcript) inside a fenced code block. A code fence renders the
+ * content verbatim, so `![img](url)` tracking pixels and `[txt](url)` phishing
+ * links can never auto-load or become clickable on the public issue tracker.
+ *
+ * Breakout guard: any run of three-or-more backticks in the content is broken
+ * with a zero-width space so it cannot terminate the fence early and escape
+ * back into Markdown rendering. The fence itself uses a 4-backtick delimiter.
+ */
+function fencedBlock(text: string): string {
+  const safe = text.replace(/`{3,}/g, (run) => run.split("").join("​"));
+  return ["````text", safe, "````"].join("\n");
 }
 
 /** Friendly labels + stable display order for known context keys. */
@@ -71,16 +96,27 @@ export function buildIssue(input: {
     "",
   ];
 
+  // The transcript and the typed text are untrusted free text. They are
+  // rendered inside fenced code blocks so a `![img](url)` tracking pixel can
+  // never auto-load and a `[txt](url)` phishing link can never become
+  // clickable on the public sceneview/sceneview tracker. neutralize() still
+  // breaks @mentions / #refs that would otherwise show literally.
   if (transcript.trim()) {
-    lines.push("### What the user said", "");
-    for (const l of neutralize(transcript.trim()).split("\n")) {
-      lines.push(`> ${l}`);
-    }
-    lines.push("");
+    lines.push(
+      "### What the user said",
+      "",
+      fencedBlock(neutralize(transcript.trim())),
+      "",
+    );
   }
 
   if (text.trim()) {
-    lines.push("### Description", "", neutralize(text.trim()), "");
+    lines.push(
+      "### Description",
+      "",
+      fencedBlock(neutralize(text.trim())),
+      "",
+    );
   }
 
   if (!transcript.trim() && !text.trim()) {

--- a/feedback-worker/src/rate-limit.ts
+++ b/feedback-worker/src/rate-limit.ts
@@ -14,17 +14,27 @@
 const MAX_REQUESTS_PER_MINUTE = 5;
 const BUCKET_TTL_SECONDS = 120;
 
-/** Non-cryptographic salt — only makes KV keys non-reversible at a glance. */
+/** Salt — keeps the salted-IP digest non-reversible without the worker secret. */
 const HASH_SALT = "sv-fb-2026:";
 
-function hashIp(ip: string): string {
-  const salted = HASH_SALT + ip;
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < salted.length; i++) {
-    hash ^= salted.charCodeAt(i);
-    hash = (hash * 0x01000193) >>> 0;
-  }
-  return hash.toString(36);
+/**
+ * Hash a client IP into a KV bucket key. SHA-256 (truncated to a wide hex
+ * prefix) — a 32-bit non-cryptographic hash collides in practice, so unrelated
+ * users could share a rate bucket or an attacker could mine a collision to
+ * dodge the limiter. 96 bits of digest is collision-safe for this use.
+ *
+ * `ip` comes from `cf-connecting-ip`, which Cloudflare's edge sets and
+ * overwrites on every request, so it is trustworthy (not spoofable by clients).
+ */
+async function hashIp(ip: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(HASH_SALT + ip),
+  );
+  const hex = [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex.slice(0, 24); // 96-bit prefix — collision-safe
 }
 
 function minuteBucket(): string {
@@ -35,7 +45,7 @@ export async function isRateLimited(
   ip: string,
   kv: KVNamespace,
 ): Promise<{ limited: boolean; remaining: number; limit: number }> {
-  const key = `rl:${hashIp(ip)}:${minuteBucket()}`;
+  const key = `rl:${await hashIp(ip)}:${minuteBucket()}`;
 
   try {
     const current = await kv.get(key);
@@ -63,6 +73,32 @@ export async function isRateLimited(
       remaining: MAX_REQUESTS_PER_MINUTE,
       limit: MAX_REQUESTS_PER_MINUTE,
     };
+  }
+}
+
+/**
+ * Per-IP cap on admin-token attempts against the viewer. Feedback UUIDs appear
+ * publicly on the GitHub issues, so the `/feedback/<id>?token=` viewer URL is
+ * guessable — without a cap an attacker can brute-force the admin token.
+ * Returns true once the per-minute attempt cap is reached; fails open on a KV
+ * error so an infrastructure failure never locks maintainers out.
+ */
+const MAX_ADMIN_ATTEMPTS_PER_MINUTE = 10;
+
+export async function adminAttemptLimited(
+  ip: string,
+  kv: KVNamespace,
+): Promise<boolean> {
+  const key = `adminrl:${await hashIp(ip)}:${minuteBucket()}`;
+  try {
+    const current = await kv.get(key);
+    const count = current ? parseInt(current, 10) : 0;
+    if (count >= MAX_ADMIN_ATTEMPTS_PER_MINUTE) return true;
+    await kv.put(key, String(count + 1), { expirationTtl: BUCKET_TTL_SECONDS });
+    return false;
+  } catch (e) {
+    console.error("admin-rate-limit KV error — failing open", e);
+    return false;
   }
 }
 

--- a/feedback-worker/src/retention.ts
+++ b/feedback-worker/src/retention.ts
@@ -1,33 +1,76 @@
 import type { Env } from "./env.js";
 
+/** Max rows drained per cron tick — a backlog drains incrementally. */
+const PURGE_BATCH = 500;
+
 /**
  * Delete R2 media older than 90 days. The feedback row, its transcript and its
  * `status` are left untouched — only the heavy audio/video expires, so the
  * record stays honest about whether the GitHub issue was ever created.
- * Returns the number of records purged.
+ *
+ * Each object is deleted independently and its key column is NULLed per-object,
+ * so a single bad/permission-denied key can never strand its sibling. The
+ * SELECT is `LIMIT`ed so a large backlog drains over successive cron ticks
+ * instead of timing out the worker in one pass.
+ *
+ * Returns the number of records fully purged (both keys cleared).
  */
 export async function purgeExpiredMedia(env: Env): Promise<number> {
   const rows = await env.DB.prepare(
     `SELECT id, video_key, audio_key FROM feedback
      WHERE media_purged = 0
-       AND created_at < datetime('now', '-90 days')`,
-  ).all<{ id: string; video_key: string | null; audio_key: string | null }>();
+       AND created_at < datetime('now', '-90 days')
+     LIMIT ?`,
+  )
+    .bind(PURGE_BATCH)
+    .all<{ id: string; video_key: string | null; audio_key: string | null }>();
 
   let purged = 0;
   for (const row of rows.results) {
-    try {
-      if (row.video_key) await env.MEDIA.delete(row.video_key);
-      if (row.audio_key) await env.MEDIA.delete(row.audio_key);
-      await env.DB.prepare(
-        `UPDATE feedback
-         SET media_purged = 1, video_key = NULL, audio_key = NULL
-         WHERE id = ?`,
-      )
-        .bind(row.id)
-        .run();
-      purged++;
-    } catch (e) {
-      console.error(`media purge failed for ${row.id}`, e);
+    let videoCleared = !row.video_key;
+    let audioCleared = !row.audio_key;
+
+    if (row.video_key) {
+      try {
+        await env.MEDIA.delete(row.video_key);
+        await env.DB.prepare(
+          `UPDATE feedback SET video_key = NULL WHERE id = ?`,
+        )
+          .bind(row.id)
+          .run();
+        videoCleared = true;
+      } catch (e) {
+        console.error(`video purge failed for ${row.id}`, e);
+      }
+    }
+
+    if (row.audio_key) {
+      try {
+        await env.MEDIA.delete(row.audio_key);
+        await env.DB.prepare(
+          `UPDATE feedback SET audio_key = NULL WHERE id = ?`,
+        )
+          .bind(row.id)
+          .run();
+        audioCleared = true;
+      } catch (e) {
+        console.error(`audio purge failed for ${row.id}`, e);
+      }
+    }
+
+    // Only flag the row purged once BOTH objects are gone — otherwise a
+    // retry on the next tick still sees the stranded sibling.
+    if (videoCleared && audioCleared) {
+      try {
+        await env.DB.prepare(
+          `UPDATE feedback SET media_purged = 1 WHERE id = ?`,
+        )
+          .bind(row.id)
+          .run();
+        purged++;
+      } catch (e) {
+        console.error(`media_purged flag failed for ${row.id}`, e);
+      }
     }
   }
   return purged;

--- a/feedback-worker/src/transcribe.ts
+++ b/feedback-worker/src/transcribe.ts
@@ -1,12 +1,23 @@
 import type { Env } from "./env.js";
 
-/** Base64-encode an ArrayBuffer (chunked to stay within argument limits). */
+/** The Whisper model used. `whisper-large-v3-turbo` takes a base64 string. */
+export const WHISPER_MODEL = "@cf/openai/whisper-large-v3-turbo";
+
+/**
+ * Base64-encode an ArrayBuffer without a giant argument spread.
+ *
+ * `String.fromCharCode(...bigArray)` spreads every byte onto the call stack and
+ * throws `RangeError: Maximum call stack size exceeded` for a multi-MB audio
+ * buffer. This builds the binary string one byte at a time over fixed-size
+ * chunks, so a 30 MB clip encodes safely.
+ */
 function toBase64(buf: ArrayBuffer): string {
   const bytes = new Uint8Array(buf);
   let bin = "";
   const CHUNK = 0x8000;
   for (let i = 0; i < bytes.length; i += CHUNK) {
-    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+    const end = Math.min(i + CHUNK, bytes.length);
+    for (let j = i; j < end; j++) bin += String.fromCharCode(bytes[j]);
   }
   return btoa(bin);
 }
@@ -18,8 +29,12 @@ export interface Transcription {
 }
 
 /**
- * Transcribe an audio clip with Workers AI (Whisper large-v3-turbo).
- * Language is auto-detected — the user speaks in their own language.
+ * Transcribe an audio clip with Workers AI.
+ *
+ * `@cf/openai/whisper-large-v3-turbo` takes the audio as a **base64 string**
+ * (the older `@cf/openai/whisper` model is the one that takes a uint8 array —
+ * the two contracts are not interchangeable). Language is auto-detected so the
+ * user can speak in their own language.
  *
  * Never throws: on failure it returns an empty transcript so the feedback
  * still produces an issue, with the private recording as the fallback signal.
@@ -33,7 +48,7 @@ export async function transcribe(
       model: string,
       inputs: unknown,
     ) => Promise<{ text?: string; transcription_info?: { language?: string } }>;
-    const result = await run("@cf/openai/whisper-large-v3-turbo", {
+    const result = await run(WHISPER_MODEL, {
       audio: toBase64(audio),
     });
     return {

--- a/feedback-worker/src/viewer.ts
+++ b/feedback-worker/src/viewer.ts
@@ -106,7 +106,7 @@ export function renderViewer(row: FeedbackRow, admin: boolean): string {
   }
 
   const inner = `<h1>Feedback</h1>
-    <span class="badge ${row.category}">${esc(row.category)}</span>
+    <span class="badge ${esc(row.category)}">${esc(row.category)}</span>
     <p class="muted">Received ${esc(row.created_at)} UTC · status: ${esc(
       row.status,
     )}</p>

--- a/feedback-worker/test/feedback.test.ts
+++ b/feedback-worker/test/feedback.test.ts
@@ -118,6 +118,38 @@ function feedbackForm(category = "bug"): FormData {
   return fd;
 }
 
+/**
+ * POST a multipart form to /v1/feedback with a correct `Content-Length`
+ * header — a real native HTTP client always sends one for a buffered body,
+ * and the worker now requires it (411 Length Required otherwise).
+ * `headerOverride` lets a test forge/omit the header to exercise the guard.
+ */
+async function postFeedback(
+  fd: FormData,
+  env: Env,
+  headerOverride?: Record<string, string | undefined>,
+): Promise<Response> {
+  // Serialise the body so we can measure its real length, then replay it.
+  const probe = new Request("https://w/v1/feedback", { method: "POST", body: fd });
+  const ct = probe.headers.get("content-type") ?? "multipart/form-data";
+  const bytes = new Uint8Array(await probe.arrayBuffer());
+  const headers: Record<string, string> = {
+    "content-type": ct,
+    "content-length": String(bytes.byteLength),
+  };
+  if (headerOverride) {
+    for (const [k, v] of Object.entries(headerOverride)) {
+      if (v === undefined) delete headers[k];
+      else headers[k] = v;
+    }
+  }
+  return app.request(
+    "/v1/feedback",
+    { method: "POST", body: bytes, headers },
+    env,
+  );
+}
+
 function feedbackRow(id: string): Record<string, unknown> {
   return {
     id,
@@ -147,22 +179,15 @@ describe("feedback worker", () => {
   it("rejects an invalid category", async () => {
     const fd = new FormData();
     fd.set("category", "nonsense");
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: fd },
-      asEnv(makeEnv()),
-    );
+    fd.set("text", "something");
+    const res = await postFeedback(fd, asEnv(makeEnv()));
     expect(res.status).toBe(400);
   });
 
   it("creates a GitHub issue on the happy path", async () => {
     stubGitHub();
     const env = makeEnv();
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: feedbackForm("bug") },
-      asEnv(env),
-    );
+    const res = await postFeedback(feedbackForm("bug"), asEnv(env));
     expect(res.status).toBe(201);
     const json = (await res.json()) as { ok: boolean; issue: number };
     expect(json.ok).toBe(true);
@@ -179,11 +204,7 @@ describe("feedback worker", () => {
   it("returns 202 and records an error when issue creation fails", async () => {
     stubGitHub({ issueFails: true });
     const env = makeEnv();
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: feedbackForm("bug") },
-      asEnv(env),
-    );
+    const res = await postFeedback(feedbackForm("bug"), asEnv(env));
     expect(res.status).toBe(202);
     const json = (await res.json()) as { ok: boolean; issue: number | null };
     expect(json.ok).toBe(true);
@@ -198,11 +219,7 @@ describe("feedback worker", () => {
     const env = makeEnv();
     const statuses: number[] = [];
     for (let i = 0; i < 6; i++) {
-      const res = await app.request(
-        "/v1/feedback",
-        { method: "POST", body: feedbackForm("idea") },
-        asEnv(env),
-      );
+      const res = await postFeedback(feedbackForm("idea"), asEnv(env));
       statuses.push(res.status);
     }
     expect(statuses.filter((s) => s === 429).length).toBe(1);
@@ -218,11 +235,7 @@ describe("feedback worker", () => {
     env.RL_KV.put = async () => {
       throw new Error("KV put() limit exceeded for the day.");
     };
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: feedbackForm("bug") },
-      asEnv(env),
-    );
+    const res = await postFeedback(feedbackForm("bug"), asEnv(env));
     expect(res.status).toBe(201);
     expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
   });
@@ -311,11 +324,7 @@ describe("feedback worker", () => {
     const fd = new FormData();
     fd.set("category", "idea");
     fd.set("context", "{}");
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: fd },
-      asEnv(makeEnv()),
-    );
+    const res = await postFeedback(fd, asEnv(makeEnv()));
     expect(res.status).toBe(400);
   });
 
@@ -323,18 +332,58 @@ describe("feedback worker", () => {
     const fd = new FormData();
     fd.set("category", "bug");
     fd.set("context", "{}");
-    // 31 MB — over the 30 MB ceiling; the guard reads File.size, not the header.
+    // 31 MB — over the 30 MB ceiling. The honest Content-Length is over the
+    // cap, so the pre-buffer guard rejects it with 413.
     fd.set(
       "video",
       new File([new Uint8Array(31 * 1024 * 1024)], "screen.mp4", {
         type: "video/mp4",
       }),
     );
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: fd },
-      asEnv(makeEnv()),
+    const res = await postFeedback(fd, asEnv(makeEnv()));
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects a request with a missing Content-Length header (411)", async () => {
+    // A real native HTTP client always sends Content-Length for a buffered
+    // body; a missing one is a malformed/abusive request and is rejected
+    // BEFORE the body is buffered into the isolate.
+    const res = await postFeedback(feedbackForm("bug"), asEnv(makeEnv()), {
+      "content-length": undefined,
+    });
+    expect(res.status).toBe(411);
+  });
+
+  it("rejects a non-numeric Content-Length header (411)", async () => {
+    const res = await postFeedback(feedbackForm("bug"), asEnv(makeEnv()), {
+      "content-length": "not-a-number",
+    });
+    expect(res.status).toBe(411);
+  });
+
+  it("rejects a forged Content-Length over the cap before buffering (413)", async () => {
+    // A small body but a forged huge Content-Length — rejected up-front.
+    const res = await postFeedback(feedbackForm("bug"), asEnv(makeEnv()), {
+      "content-length": String(99 * 1024 * 1024),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("aborts the stream when the body exceeds the cap despite a small Content-Length", async () => {
+    // Forge a tiny Content-Length but stream a 31 MB body: the counting
+    // TransformStream must trip and the request is rejected, not OOM'd.
+    const fd = new FormData();
+    fd.set("category", "bug");
+    fd.set("context", "{}");
+    fd.set(
+      "video",
+      new File([new Uint8Array(31 * 1024 * 1024)], "screen.mp4", {
+        type: "video/mp4",
+      }),
     );
+    const res = await postFeedback(fd, asEnv(makeEnv()), {
+      "content-length": "1024",
+    });
     expect(res.status).toBe(413);
   });
 
@@ -344,11 +393,7 @@ describe("feedback worker", () => {
     // Pre-fill the current hour's global issue-quota bucket to the cap.
     const bucket = Math.floor(Date.now() / 3_600_000).toString(36);
     env.RL_KV._store.set(`issuequota:${bucket}`, "30");
-    const res = await app.request(
-      "/v1/feedback",
-      { method: "POST", body: feedbackForm("bug") },
-      asEnv(env),
-    );
+    const res = await postFeedback(feedbackForm("bug"), asEnv(env));
     expect(res.status).toBe(202);
     const json = (await res.json()) as { ok: boolean; issue: number | null };
     expect(json.ok).toBe(true);
@@ -356,6 +401,34 @@ describe("feedback worker", () => {
     expect(env.DB._statements.map((s) => s.sql).join(" | ")).toContain(
       "status = 'error'",
     );
+  });
+
+  it("deletes orphaned R2 media when the D1 insert fails", async () => {
+    const env = makeEnv();
+    // The media is stored in R2, then the D1 insert throws — the media must
+    // be cleaned up so it is not stranded un-purgeable forever.
+    env.DB._shouldFail = true;
+    const res = await postFeedback(feedbackForm("bug"), asEnv(env));
+    expect(res.status).toBe(502);
+    expect(env.MEDIA._store.size).toBe(0);
+  });
+
+  it("rate-limits brute-force admin-token attempts on the viewer", async () => {
+    const env = makeEnv();
+    const id = crypto.randomUUID();
+    env.DB._rows = [feedbackRow(id)];
+    const statuses: number[] = [];
+    // 11 wrong-token attempts — the 11th must be rate-limited (cap is 10/min).
+    for (let i = 0; i < 11; i++) {
+      const res = await app.request(
+        `/feedback/${id}?token=wrong-${i}`,
+        {},
+        asEnv(env),
+      );
+      statuses.push(res.status);
+    }
+    expect(statuses.slice(0, 10).every((s) => s === 302)).toBe(true);
+    expect(statuses[10]).toBe(429);
   });
 
   it("retention purges expired media and keeps the record", async () => {

--- a/feedback-worker/test/issue.test.ts
+++ b/feedback-worker/test/issue.test.ts
@@ -76,8 +76,56 @@ describe("buildIssue", () => {
       context: { appVersion: "4.11.1", demoId: "lighting" },
       viewerUrl: "https://w/feedback/abc",
     });
-    expect(r.body).toContain("| App version | 4.11.1 |");
+    // Context values are Markdown-escaped (dots in the version are escaped).
+    expect(r.body).toContain("| App version | 4\\.11\\.1 |");
     expect(r.body).toContain("| Demo | lighting |");
     expect(r.body).toContain("https://w/feedback/abc");
+  });
+
+  it("renders user text inside a fenced code block (no Markdown injection)", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "",
+      text: "![pixel](https://evil.example/track.gif)",
+      context: {},
+      viewerUrl: "u",
+    });
+    // The image is rendered verbatim inside a fence, never as live Markdown.
+    expect(r.body).toContain("````text");
+    expect(r.body).toContain("![pixel](https://evil.example/track.gif)");
+    // The fenced description block keeps the literal text on its own line.
+    expect(r.body).toContain(
+      "\n![pixel](https://evil.example/track.gif)\n",
+    );
+  });
+
+  it("neutralises a fence-breakout attempt in the transcript", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "ok\n```\n[phish](https://evil.example)\n```\nmore",
+      text: "",
+      context: {},
+      viewerUrl: "u",
+    });
+    // A raw 3-backtick run inside the content must not survive intact —
+    // it cannot terminate the 4-backtick fence early.
+    expect(r.body).not.toContain("\n```\n");
+    // The 4-backtick fence delimiter itself is still present.
+    expect(r.body).toContain("````text");
+  });
+
+  it("escapes Markdown link syntax in context values", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "t",
+      text: "",
+      context: { device: "[click](https://evil.example)" },
+      viewerUrl: "u",
+    });
+    expect(r.body).not.toContain("[click](https://evil.example)");
+    expect(r.body).toContain("\\[click\\]");
   });
 });

--- a/feedback-worker/test/rate-limit.test.ts
+++ b/feedback-worker/test/rate-limit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { isRateLimited, adminAttemptLimited } from "../src/rate-limit.js";
+import { createMockKV } from "./helpers/mock-kv.js";
+
+describe("rate-limit IP hashing", () => {
+  it("hashes the IP into a SHA-256 hex bucket key (not raw, not FNV)", async () => {
+    const kv = createMockKV();
+    await isRateLimited("203.0.113.7", kv);
+    const keys = [...kv._store.keys()];
+    expect(keys).toHaveLength(1);
+    const key = keys[0];
+    // rl:<24-hex-prefix>:<minutebucket>
+    expect(key).toMatch(/^rl:[0-9a-f]{24}:/);
+    // The raw IP must never appear in the KV key.
+    expect(key).not.toContain("203.0.113.7");
+  });
+
+  it("gives unrelated IPs distinct rate buckets", async () => {
+    const kv = createMockKV();
+    await isRateLimited("198.51.100.1", kv);
+    await isRateLimited("198.51.100.2", kv);
+    const buckets = new Set(
+      [...kv._store.keys()].map((k) => k.split(":")[1]),
+    );
+    expect(buckets.size).toBe(2);
+  });
+
+  it("the same IP always maps to the same bucket", async () => {
+    const kvA = createMockKV();
+    const kvB = createMockKV();
+    await isRateLimited("192.0.2.55", kvA);
+    await isRateLimited("192.0.2.55", kvB);
+    const a = [...kvA._store.keys()][0].split(":")[1];
+    const b = [...kvB._store.keys()][0].split(":")[1];
+    expect(a).toBe(b);
+  });
+
+  it("isRateLimited caps after 5 requests, then fails open on KV error", async () => {
+    const kv = createMockKV();
+    for (let i = 0; i < 5; i++) {
+      expect((await isRateLimited("10.0.0.1", kv)).limited).toBe(false);
+    }
+    expect((await isRateLimited("10.0.0.1", kv)).limited).toBe(true);
+
+    kv.put = async () => {
+      throw new Error("KV write quota exhausted");
+    };
+    // Fresh IP — a put failure must fail open, never throw.
+    expect((await isRateLimited("10.0.0.2", kv)).limited).toBe(false);
+  });
+
+  it("adminAttemptLimited caps at 10 attempts per IP per minute", async () => {
+    const kv = createMockKV();
+    for (let i = 0; i < 10; i++) {
+      expect(await adminAttemptLimited("172.16.0.9", kv)).toBe(false);
+    }
+    expect(await adminAttemptLimited("172.16.0.9", kv)).toBe(true);
+    // A different IP is unaffected.
+    expect(await adminAttemptLimited("172.16.0.10", kv)).toBe(false);
+  });
+
+  it("adminAttemptLimited fails open on a KV error", async () => {
+    const kv = createMockKV();
+    kv.get = async () => {
+      throw new Error("KV unavailable");
+    };
+    expect(await adminAttemptLimited("172.16.0.11", kv)).toBe(false);
+  });
+});

--- a/feedback-worker/test/transcribe.test.ts
+++ b/feedback-worker/test/transcribe.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { transcribe, WHISPER_MODEL } from "../src/transcribe.js";
+import type { Env } from "../src/env.js";
+
+/**
+ * Build a minimal Env whose AI.run records the model + inputs it was called
+ * with, so a test can assert the exact contract handed to Workers AI.
+ */
+function captureEnv(result: unknown): {
+  env: Env;
+  calls: { model: string; inputs: unknown }[];
+} {
+  const calls: { model: string; inputs: unknown }[] = [];
+  const env = {
+    AI: {
+      run: async (model: string, inputs: unknown) => {
+        calls.push({ model, inputs });
+        return result;
+      },
+    },
+  } as unknown as Env;
+  return { env, calls };
+}
+
+describe("transcribe", () => {
+  it("calls whisper-large-v3-turbo with the audio as a base64 STRING", async () => {
+    const { env, calls } = captureEnv({
+      text: "the spinner never stops",
+      transcription_info: { language: "en" },
+    });
+    const audio = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+    const out = await transcribe(env, audio);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe(WHISPER_MODEL);
+    expect(calls[0].model).toBe("@cf/openai/whisper-large-v3-turbo");
+
+    // The large-v3-turbo model contract expects a base64 string, NOT a
+    // uint8 array — the two are not interchangeable.
+    const inputs = calls[0].inputs as { audio: unknown };
+    expect(typeof inputs.audio).toBe("string");
+    expect(Array.isArray(inputs.audio)).toBe(false);
+    // Round-trips back to the original bytes.
+    const decoded = Uint8Array.from(atob(inputs.audio as string), (ch) =>
+      ch.charCodeAt(0),
+    );
+    expect([...decoded]).toEqual([1, 2, 3, 4, 5]);
+
+    expect(out.text).toBe("the spinner never stops");
+    expect(out.language).toBe("en");
+  });
+
+  it("base64-encodes a multi-MB buffer without a call-stack overflow", async () => {
+    const { env, calls } = captureEnv({ text: "" });
+    // 5 MB — a naive String.fromCharCode(...spread) would RangeError here.
+    const big = new Uint8Array(5 * 1024 * 1024);
+    await expect(transcribe(env, big.buffer)).resolves.toBeDefined();
+    expect(typeof (calls[0].inputs as { audio: unknown }).audio).toBe(
+      "string",
+    );
+  });
+
+  it("returns an empty transcript (never throws) when AI.run fails", async () => {
+    const env = {
+      AI: {
+        run: async () => {
+          throw new Error("Workers AI unavailable");
+        },
+      },
+    } as unknown as Env;
+    const out = await transcribe(env, new Uint8Array([1]).buffer);
+    expect(out.text).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

A 6-agent review of the in-app feedback Cloudflare worker (`feedback-worker/`, already deployed at `sceneview-feedback.mcp-tools-lab.workers.dev`) found release blockers. This PR closes every blocker and major finding. Refs #1930.

## Blockers fixed

- **Upload-cap DoS** — the 30 MB cap was enforced via `File.size` *after* `formData()` had buffered the whole body into the 128 MB isolate; a forged/missing `Content-Length` + huge body would OOM the worker. Now `Content-Length` is validated up front (`411` on missing/non-numeric, `413` over cap) **and** the raw body is wrapped in a counting `TransformStream` that aborts past 30 MB before `formData()` runs.
- **Weak IP hash** — `rate-limit.ts` `hashIp` used 32-bit FNV-1a (practically collidable, lets unrelated users share a bucket). Replaced with `crypto.subtle.digest("SHA-256", …)` truncated to a 96-bit hex prefix; salt kept. Comment notes `cf-connecting-ip` is trustworthy on the real Cloudflare edge.
- **Markdown injection into the public GitHub issue** — user `text` and the Whisper transcript were interpolated verbatim, so `![img](url)` tracking pixels and `[txt](url)` phishing links rendered live on `sceneview/sceneview`. Both are now rendered inside fenced code blocks with backtick-breakout guarding; `cell()` escapes all Markdown specials, not just `|`.
- **Whisper input format** — verified `@cf/openai/whisper-large-v3-turbo` takes a **base64 string** per the current Cloudflare docs (the uint8-array form is the older `@cf/openai/whisper` model — the existing code was already correct). Hardened the base64 encoder against a call-stack overflow on multi-MB buffers (no giant argument spread) and added a test asserting the exact shape passed to `AI.run`.

## Majors fixed

- **Orphaned R2 media** — on a D1-insert failure the already-stored media is now best-effort `MEDIA.delete()`d so it is not stranded un-purgeable.
- **Retention cron** — `LIMIT 500` so a backlog drains incrementally; video and audio are deleted independently and each key column is NULLed per-object so one bad key can't strand its sibling.
- **`scheduled()`** — now logs the purge count and `.catch()`es failures.
- **GitHub token caching** — the installation token is cached in module scope keyed by installation id, re-minted 5 min before its real `expires_at`.
- **Admin brute-force** — the `?token=` viewer path is rate-limited per IP and every failed attempt is `console.warn`'d for an audit trail.
- `viewer.ts` wraps `row.category` in `esc()`; the migration uses `CREATE INDEX IF NOT EXISTS`.

## Tests

`npm run typecheck` + `npm test` green — **22 → 40 tests passing**. New coverage for every blocker fix: streaming size guard, `Content-Length` validation, SHA-256 bucketing, fenced-code Markdown rendering / fence-breakout, Whisper `AI.run` shape, orphaned-R2 cleanup, admin brute-force limiting.

Minor findings (the `202` quota-vs-error conflation, empty-string `Content-Length`, dead `'purged'` status enum, discarded transcribe `language`) are deferred to #2028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)