### PR TITLE
fix(android-demo): close feedback feature blockers from review

### DIFF
--- a/changelog.d/1930-feedback-android-hardening.md
+++ b/changelog.d/1930-feedback-android-hardening.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- In-app feedback (Android demo): hardened the screen-recording feedback feature after a review — capped the recording so a long clip can no longer 413, added an in-demo feedback entry point, fixed the demo-id context key, made the upload error messages specific, and survived process death mid-flow ([#1930](https://github.com/sceneview/sceneview/issues/1930)).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,6 +139,9 @@ fuel-coroutines = { group = "com.github.kittinunf.fuel", name = "fuel-coroutines
 
 # OkHttp (HTTP client used by Sketchfab service in android-demo)
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+# MockWebServer — JVM-only test double for the feedback uploader / ticket-status
+# OkHttp calls (#1930 review). Same okhttp version as the runtime client.
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver3", version.ref = "okhttp" }
 
 # Kotlinx Serialization (JSON parsing for Sketchfab API responses)
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -50,9 +50,9 @@ if (sketchfabApiKey.isEmpty()) {
 // to `<base>/v1/feedback`. Resolution order: env var -> local.properties
 // `feedback.worker.url` -> the default constant below.
 //
-// ⚠️ MAINTAINER: the worker is not deployed yet. The default below is the
-// PLANNED workers.dev subdomain — once the worker is published, set the real
-// URL here (or via the env var / local.properties) so released APKs hit it.
+// The worker is deployed at sceneview-feedback.mcp-tools-lab.workers.dev (the
+// default constant below). Override via the env var / local.properties to
+// point a build at a staging worker.
 def feedbackWorkerUrl = System.getenv("FEEDBACK_WORKER_URL") ?: ""
 if (feedbackWorkerUrl.isEmpty()) {
     feedbackWorkerUrl = loadFromLocalProperties("feedback.worker.url")
@@ -268,6 +268,11 @@ dependencies {
     testImplementation libs.androidx.test.junit
     testImplementation platform(libs.androidx.compose.bom)
     testImplementation libs.androidx.compose.ui
+
+    // MockWebServer — JVM test double for the in-app feedback HTTP calls
+    // (FeedbackUploader / FeedbackTicketStatus, #1930 review).
+    testImplementation libs.okhttp.mockwebserver
+    testImplementation libs.kotlin.coroutines.test
 
     // UiAutomator-based interaction tests. Drives the real demo app process through
     // DemoHostActivity (debug flavour) — no ComposeTestRule, no Filament thread-adoption

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -214,6 +215,28 @@ fun DemoScaffold(
                     }
                 },
                 actions = {
+                    // In-app feedback entry point — #1930 requires the feedback
+                    // button "on the 4 tabs AND inside every demo", and a bug
+                    // hit inside a demo is the highest-value feedback case. A
+                    // top-app-bar action is the right slot: a FAB would collide
+                    // with the demo controls `Tune` FAB at the bottom-end.
+                    // Tapping it raises FeedbackOpenRequest, which
+                    // SceneViewDemoApp observes to open the shared FeedbackFlow.
+                    val feedbackCd = stringResource(R.string.feedback_action_cd)
+                    IconButton(
+                        onClick = {
+                            haptic.selection()
+                            io.github.sceneview.demo.feedback.FeedbackOpenRequest.request()
+                        },
+                        modifier = Modifier
+                            .semantics { contentDescription = feedbackCd }
+                            .testTag(DemoScaffoldTestTags.FEEDBACK_ACTION),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Feedback,
+                            contentDescription = null,
+                        )
+                    }
                     // Predictable, always-in-the-same-place reset action (#1966).
                     // Every demo that opts in surfaces this single Refresh icon
                     // in the top bar, so users have one consistent path back to
@@ -391,6 +414,7 @@ object DemoScaffoldTestTags {
     const val SETTINGS_SHEET = "demo-settings-sheet"
     const val SETTINGS_RESET = "demo-settings-reset"
     const val RESET_ACTION = "demo-reset-action"
+    const val FEEDBACK_ACTION = "demo-feedback-action"
     const val QA_PILL = "demo-qa-pill"
     const val ASSET_SOURCE_CHIP = "demo-asset-source-chip"
     const val FIRST_FRAME_SCRIM = "demo-first-frame-scrim"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -1,6 +1,8 @@
 package io.github.sceneview.demo
 
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -43,12 +45,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import io.github.sceneview.demo.feedback.FeedbackButton
 import io.github.sceneview.demo.feedback.FeedbackFlow
+import io.github.sceneview.demo.feedback.FeedbackOpenRequest
 import io.github.sceneview.demo.feedback.FeedbackRecorder
 import io.github.sceneview.demo.feedback.FeedbackRecordingService
 import io.github.sceneview.demo.feedback.RecordingState
 import io.github.sceneview.demo.feedback.RecordingStopPill
+import io.github.sceneview.demo.feedback.isMicPermanentlyDenied
 import io.github.sceneview.demo.feedback.rememberFeedbackRecordingLauncher
 import io.github.sceneview.demo.feedback.sweepStaleFeedbackMedia
 
@@ -276,10 +282,14 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
             )
         }
 
-        // Feedback entry point — shown only on the four tab screens. Demo
-        // screens place their own controls in every corner (movement pads, AR
-        // action buttons), so a floating FAB there would collide; an in-demo
-        // feedback entry point is a separate follow-up (#1932).
+        // Feedback entry points (#1930):
+        //  - the tab host ("list" — RootScreen, all four tabs) gets the
+        //    extended FAB rendered below;
+        //  - every demo screen gets a top-app-bar feedback action in
+        //    DemoScaffold, which raises FeedbackOpenRequest (observed here).
+        // A demo screen places its own controls in every corner (movement
+        // pads, AR action buttons, the Tune FAB), so a floating FAB there
+        // would collide — the top-bar action is the right slot.
         val context = LocalContext.current
         val currentEntry by navController.currentBackStackEntryAsState()
         val onListScreen = currentEntry?.destination?.route == "list"
@@ -300,7 +310,7 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
         var feedbackOpen by rememberSaveable { mutableStateOf(false) }
         val recordingState by FeedbackRecorder.state.collectAsState()
         val isRecording = recordingState is RecordingState.Recording
-        val startRecording = rememberFeedbackRecordingLauncher()
+        val feedbackLauncher = rememberFeedbackRecordingLauncher()
 
         // A finished or failed recording re-opens the flow at its review step.
         LaunchedEffect(recordingState) {
@@ -308,6 +318,36 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                 recordingState is RecordingState.Failed
             ) {
                 feedbackOpen = true
+            }
+        }
+
+        // A demo screen's top-app-bar feedback action raises this flag — open
+        // the shared flow and consume the request (#1930).
+        val feedbackRequested by FeedbackOpenRequest.requested.collectAsState()
+        LaunchedEffect(feedbackRequested) {
+            if (feedbackRequested) {
+                feedbackOpen = true
+                FeedbackOpenRequest.consume()
+            }
+        }
+
+        // Whether the microphone permission is permanently denied and whether
+        // the foreground-service notification control will be visible — both
+        // re-evaluated when the feedback flow opens so the UI can adapt
+        // (route to settings / surface the in-app-Stop hint). #1930 review.
+        val micPermanentlyDenied = remember(feedbackOpen) {
+            activity?.let { isMicPermanentlyDenied(it) } ?: false
+        }
+        val notificationControlAvailable = remember(feedbackOpen) {
+            if (Build.VERSION.SDK_INT >= 33) {
+                ContextCompat.checkSelfPermission(
+                    context,
+                    android.Manifest.permission.POST_NOTIFICATIONS,
+                ) == PackageManager.PERMISSION_GRANTED
+            } else {
+                // Pre-13: notifications need no runtime permission, but the
+                // channel can still be disabled by the user.
+                NotificationManagerCompat.from(context).areNotificationsEnabled()
             }
         }
 
@@ -339,7 +379,9 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                     feedbackOpen = false
                     FeedbackRecorder.reset()
                 },
-                onStartRecording = startRecording,
+                launcher = feedbackLauncher,
+                micPermanentlyDenied = micPermanentlyDenied,
+                notificationControlAvailable = notificationControlAvailable,
             )
         }
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/AudioDemux.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/AudioDemux.kt
@@ -7,6 +7,12 @@ import android.media.MediaMuxer
 import java.io.File
 import java.nio.ByteBuffer
 
+/** Smallest demux buffer when [MediaFormat.KEY_MAX_INPUT_SIZE] is absent. */
+private const val DEMUX_BUFFER_MIN = 256 * 1024
+
+/** Hard ceiling on the demux buffer — a single AAC sample never approaches this. */
+private const val DEMUX_BUFFER_MAX = 4 * 1024 * 1024
+
 /**
  * Copy the audio track out of [source] (an mp4 screen recording) into a
  * standalone [dest] file — a plain track copy, no re-encode. The feedback
@@ -14,6 +20,11 @@ import java.nio.ByteBuffer
  *
  * Returns [dest] on success, or null if [source] has no audio track or the
  * copy fails (in which case the screen recording is still usable on its own).
+ *
+ * The sample buffer is sized from [MediaFormat.KEY_MAX_INPUT_SIZE] when the
+ * extractor reports it, and grows-and-retries otherwise — a fixed buffer would
+ * throw `BufferOverflowException` on a larger-than-expected AAC sample and drop
+ * the audio entirely (no transcription).
  */
 fun demuxAudioTrack(source: File, dest: File): File? {
     val extractor = MediaExtractor()
@@ -38,11 +49,30 @@ fun demuxAudioTrack(source: File, dest: File): File? {
         val outTrack = muxer.addTrack(audioFormat)
         muxer.start()
 
-        val buffer = ByteBuffer.allocate(256 * 1024)
+        // Seed the buffer from the format's declared max input size when present;
+        // otherwise start at a sane minimum and grow on demand below.
+        var bufferSize = if (audioFormat.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+            audioFormat.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE)
+                .coerceIn(DEMUX_BUFFER_MIN, DEMUX_BUFFER_MAX)
+        } else {
+            DEMUX_BUFFER_MIN
+        }
+        var buffer = ByteBuffer.allocate(bufferSize)
         val info = MediaCodec.BufferInfo()
         while (true) {
-            val size = extractor.readSampleData(buffer, 0)
-            if (size < 0) break
+            var size = extractor.readSampleData(buffer, 0)
+            // readSampleData returns -1 at EOS. It can also return -1 (or throw
+            // IllegalArgumentException, handled by the outer catch) when the
+            // sample does not fit — grow-and-retry guards the latter.
+            if (size < 0) {
+                // Distinguish genuine EOS from a too-small buffer: a sample
+                // still pending has a non-negative sampleTime.
+                if (extractor.sampleTime < 0 || bufferSize >= DEMUX_BUFFER_MAX) break
+                bufferSize = (bufferSize * 2).coerceAtMost(DEMUX_BUFFER_MAX)
+                buffer = ByteBuffer.allocate(bufferSize)
+                size = extractor.readSampleData(buffer, 0)
+                if (size < 0) break
+            }
             info.offset = 0
             info.size = size
             info.presentationTimeUs = extractor.sampleTime

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
@@ -16,7 +16,8 @@ import java.util.Locale
  *   current destination (#1934) so the maintainer knows exactly which demo a
  *   bug is in. Defaults to [FeedbackRecorder.currentDemoId], which is kept in
  *   sync with live navigation even while the feedback dialog is dismissed for
- *   recording.
+ *   recording. Emitted under the `demoId` key — the one the feedback worker
+ *   recognises and renders as the named "Demo" row.
  */
 fun captureFeedbackContext(
     context: Context,
@@ -36,11 +37,12 @@ fun captureFeedbackContext(
         put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
         put("locale", Locale.getDefault().toLanguageTag())
         if (freeRamMb != null) put("freeRamMb", freeRamMb.toString())
-        // The exact demo / screen the feedback is about. `demo` is the demo id
-        // (omitted when the user is on a tab screen); `route` is the Compose
-        // navigation route, always present, so the maintainer can tell a
-        // tab-screen report apart from an in-demo one.
-        if (!demoId.isNullOrBlank()) put("demo", demoId)
-        put("route", if (!demoId.isNullOrBlank()) "demo/$demoId" else "list")
+        // The exact demo the feedback is about, under the `demoId` key the
+        // worker recognises (rendered as the named "Demo" row in the issue's
+        // Context table — see feedback-worker/src/issue.ts CONTEXT_LABELS).
+        // Omitted when the user is on a tab screen, so the worker simply does
+        // not render the row. A `route` key was dropped: the worker has no
+        // label for it, so it would surface as a raw, unlabelled table row.
+        if (!demoId.isNullOrBlank()) put("demoId", demoId)
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -86,7 +87,7 @@ private sealed interface UploadUiState {
      */
     data class Sending(val progress: Float? = null) : UploadUiState
     data class Sent(val issueNumber: Int?) : UploadUiState
-    data object Failed : UploadUiState
+    data class Failed(val errorKind: FeedbackUploader.ErrorKind) : UploadUiState
 }
 
 /**
@@ -97,14 +98,28 @@ private sealed interface UploadUiState {
  * The recording itself happens with the dialog dismissed (so the user can
  * demonstrate the bug); [FeedbackRecorder] bridges the recording state back in.
  *
- * @param onStartRecording requests the screen + mic permissions and starts the
- *   recording service; see [rememberFeedbackRecordingLauncher].
+ * @param launcher requests the screen + mic permissions and starts the
+ *   recording service; see [rememberFeedbackRecordingLauncher]. Also exposes
+ *   an [FeedbackRecordingLauncher.openAppSettings] path for a permanently-denied
+ *   microphone permission.
+ * @param micPermanentlyDenied `true` when the microphone permission is
+ *   "Don't ask again"-denied — the flow then routes the user to app settings
+ *   instead of looping a no-op "Retry".
+ * @param notificationControlAvailable `false` when the foreground-service
+ *   notification (a documented stop affordance) will be silent — the flow then
+ *   surfaces a one-time hint that the in-app Stop pill is the way to finish.
  */
 @Composable
-fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
+fun FeedbackFlow(
+    onDismiss: () -> Unit,
+    launcher: FeedbackRecordingLauncher,
+    micPermanentlyDenied: Boolean = false,
+    notificationControlAvailable: Boolean = true,
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val recState by FeedbackRecorder.state.collectAsState()
+    val onStartRecording: () -> Unit = launcher.startRecording
 
     var step by rememberSaveable {
         mutableStateOf(
@@ -112,65 +127,105 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
             else FeedbackStep.ONBOARDING,
         )
     }
-    var category by rememberSaveable { mutableStateOf<FeedbackCategory?>(null) }
+    var category by rememberSaveable {
+        // Restore the in-flight category if the process was killed during the
+        // MediaProjection consent dialog — otherwise an "Idea" silently becomes
+        // a "Bug" on the way back (#1930 review).
+        mutableStateOf(FeedbackRecorder.category ?: FeedbackCategoryStore.load(context))
+    }
     var note by rememberSaveable { mutableStateOf("") }
+    // uploadState is rememberSaveable-friendly only as an enum-ish marker: the
+    // actual upload coroutine cannot survive a process death. On restore, if
+    // `step` was SENDING but there is no live upload, we drop back to REVIEW so
+    // the user is never stranded on a spinner with no way out (handled below).
     var uploadState by remember { mutableStateOf<UploadUiState>(UploadUiState.Sending()) }
+    // True once the user actually launched an upload coroutine in THIS
+    // composition — distinguishes "genuinely sending" from "step==SENDING was
+    // restored after process death".
+    var uploadLaunched by remember { mutableStateOf(false) }
 
-    // The previously submitted tickets — read once per dialog open. Used to
-    // surface the "My feedback" entry and to populate the tracking screen.
-    val tickets = remember { SubmittedFeedbackStore.all(context) }
+    // Recover from a process death mid-send: `step` is rememberSaveable, the
+    // upload coroutine is not. Without this the user is stuck on the SENDING
+    // spinner forever (#1930 review).
+    LaunchedEffect(Unit) {
+        if (step == FeedbackStep.SENDING && !uploadLaunched) {
+            step = FeedbackStep.REVIEW
+        }
+    }
+
+    // The previously submitted tickets — re-read whenever the flow shows the
+    // category or tickets step, so a just-submitted ticket appears without
+    // having to close and re-open the dialog (#1930 review).
+    var ticketsRefresh by remember { mutableStateOf(0) }
+    val tickets = remember(ticketsRefresh) { SubmittedFeedbackStore.all(context) }
+    LaunchedEffect(step) {
+        if (step == FeedbackStep.CATEGORY || step == FeedbackStep.TICKETS) {
+            ticketsRefresh++
+        }
+    }
 
     fun send() {
         val recording = (FeedbackRecorder.state.value as? RecordingState.Done)?.recording
         val chosen = FeedbackRecorder.category ?: category ?: FeedbackCategory.BUG
         val text = note.trim()
-        // Capture the context — including the current demo route (#1934) —
+        // Capture the context — including the current demo id (#1934) —
         // before switching to the SENDING step.
         val feedbackContext = captureFeedbackContext(context)
         uploadState = UploadUiState.Sending()
+        uploadLaunched = true
         step = FeedbackStep.SENDING
         scope.launch {
-            val result = FeedbackUploader.upload(
-                category = chosen,
-                note = text,
-                context = feedbackContext,
-                recording = recording,
-                onProgress = { fraction ->
-                    // Keep showing the determinate bar only while still
-                    // uploading; once at 100% the worker is processing, so
-                    // fall back to the indeterminate spinner.
-                    val current = uploadState
-                    if (current is UploadUiState.Sending) {
-                        uploadState = UploadUiState.Sending(
-                            progress = fraction.takeIf { it < 1f },
+            // Mark the recording media as held so a dialog dismiss during
+            // SENDING cannot delete the file out from under the upload read.
+            if (recording != null) FeedbackRecorder.beginUpload()
+            try {
+                val result = FeedbackUploader.upload(
+                    category = chosen,
+                    note = text,
+                    context = feedbackContext,
+                    recording = recording,
+                    onProgress = { fraction ->
+                        // Keep showing the determinate bar only while still
+                        // uploading; once at 100% the worker is processing, so
+                        // fall back to the indeterminate spinner.
+                        val current = uploadState
+                        if (current is UploadUiState.Sending) {
+                            uploadState = UploadUiState.Sending(
+                                progress = fraction.takeIf { it < 1f },
+                            )
+                        }
+                    },
+                )
+                uploadState = if (result.ok) {
+                    UploadUiState.Sent(result.issueNumber)
+                } else {
+                    UploadUiState.Failed(result.errorKind)
+                }
+                if (result.ok) {
+                    // Index the new ticket locally so "My feedback" can track
+                    // it. Skipped when the worker stored the feedback but
+                    // opened no issue (e.g. its hourly issue quota was hit) —
+                    // there is then nothing to link to.
+                    if (result.issueNumber != null && result.issueUrl != null) {
+                        SubmittedFeedbackStore.add(
+                            context,
+                            SubmittedFeedback(
+                                feedbackId = result.feedbackId ?: "",
+                                issueNumber = result.issueNumber,
+                                issueUrl = result.issueUrl,
+                                category = chosen,
+                                title = text,
+                                createdAt = System.currentTimeMillis(),
+                            ),
                         )
                     }
-                },
-            )
-            uploadState = if (result.ok) {
-                UploadUiState.Sent(result.issueNumber)
-            } else {
-                UploadUiState.Failed
-            }
-            if (result.ok) {
-                // Index the new ticket locally so "My feedback" can track it.
-                // Skipped when the worker stored the feedback but opened no
-                // issue (e.g. its hourly issue quota was hit) — there is then
-                // nothing to link to.
-                if (result.issueNumber != null && result.issueUrl != null) {
-                    SubmittedFeedbackStore.add(
-                        context,
-                        SubmittedFeedback(
-                            feedbackId = result.feedbackId ?: "",
-                            issueNumber = result.issueNumber,
-                            issueUrl = result.issueUrl,
-                            category = chosen,
-                            title = text,
-                            createdAt = System.currentTimeMillis(),
-                        ),
-                    )
+                    FeedbackRecorder.reset()
+                    FeedbackCategoryStore.save(context, null)
                 }
-                FeedbackRecorder.reset()
+            } finally {
+                // Release the media: deletes the files if a reset() landed
+                // while the upload was in flight.
+                if (recording != null) FeedbackRecorder.endUpload()
             }
         }
     }
@@ -187,6 +242,13 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
             color = MaterialTheme.colorScheme.surface,
         ) {
             val doneRecording = (recState as? RecordingState.Done)?.recording
+            // Set the in-flight category on the process-wide recorder AND
+            // mirror it to prefs, so it survives a process death during the
+            // MediaProjection consent dialog (#1930 review).
+            fun rememberCategory(value: FeedbackCategory?) {
+                FeedbackRecorder.category = value
+                FeedbackCategoryStore.save(context, value)
+            }
             when {
                 step == FeedbackStep.SENDING -> SendingStep(
                     state = uploadState,
@@ -195,10 +257,18 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
                 )
 
                 recState is RecordingState.Failed -> FailedStep(
+                    micPermanentlyDenied = micPermanentlyDenied,
                     onClose = onDismiss,
                     onRetry = {
                         FeedbackRecorder.reset()
                         onStartRecording()
+                    },
+                    onOpenSettings = launcher.openAppSettings,
+                    onSkipRecording = {
+                        // Drop the failed recording state and continue with a
+                        // text-only submission rather than dead-ending.
+                        FeedbackRecorder.reset()
+                        step = FeedbackStep.REVIEW
                     },
                 )
 
@@ -233,14 +303,15 @@ fun FeedbackFlow(onDismiss: () -> Unit, onStartRecording: () -> Unit) {
                     )
                     FeedbackStep.CONSENT -> ConsentStep(
                         category = category ?: FeedbackCategory.BUG,
+                        notificationControlAvailable = notificationControlAvailable,
                         onClose = onDismiss,
                         onBack = { step = FeedbackStep.CATEGORY },
                         onAgree = {
-                            FeedbackRecorder.category = category
+                            rememberCategory(category)
                             onStartRecording()
                         },
                         onSkip = {
-                            FeedbackRecorder.category = category
+                            rememberCategory(category)
                             step = FeedbackStep.REVIEW
                         },
                     )
@@ -320,6 +391,7 @@ private fun CategoryStep(
 @Composable
 private fun ConsentStep(
     category: FeedbackCategory,
+    notificationControlAvailable: Boolean,
     onClose: () -> Unit,
     onBack: () -> Unit,
     onAgree: () -> Unit,
@@ -361,6 +433,12 @@ private fun ConsentStep(
         }
         Spacer(Modifier.height(16.dp))
         PrivacyNote()
+        if (!notificationControlAvailable) {
+            // The foreground-service notification is silenced — tell the user
+            // the in-app Stop pill is the way to finish (#1930 review).
+            Spacer(Modifier.height(12.dp))
+            NotificationWarning()
+        }
     }
 }
 
@@ -417,7 +495,19 @@ private fun SendingStep(
     onRetry: () -> Unit,
 ) {
     when (state) {
-        is UploadUiState.Sending -> FeedbackStepScaffold(onClose = null) {
+        is UploadUiState.Sending -> FeedbackStepScaffold(
+            // A close affordance is always present while sending — the upload
+            // runs in a coroutine that is cancelled when the dialog is
+            // dismissed, so the user is never trapped on the spinner (#1930
+            // review). It also doubles as the recovery exit if a process death
+            // dropped the upload.
+            onClose = onClose,
+            actions = {
+                TextButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.feedback_sending_cancel))
+                }
+            },
+        ) {
             Spacer(Modifier.height(64.dp))
             CircularProgressIndicator(
                 modifier = Modifier
@@ -474,7 +564,7 @@ private fun SendingStep(
             )
         }
 
-        UploadUiState.Failed -> FeedbackStepScaffold(
+        is UploadUiState.Failed -> FeedbackStepScaffold(
             onClose = onClose,
             actions = {
                 PrimaryButton(
@@ -491,13 +581,65 @@ private fun SendingStep(
             Spacer(Modifier.height(24.dp))
             StepTitle(stringResource(R.string.feedback_send_failed_title))
             Spacer(Modifier.height(12.dp))
-            StepBody(stringResource(R.string.feedback_send_failed_body))
+            // Tailored copy per failure kind — a 413 user must not be told to
+            // "check your connection" forever (#1930 review).
+            StepBody(
+                stringResource(
+                    when (state.errorKind) {
+                        FeedbackUploader.ErrorKind.TOO_LARGE ->
+                            R.string.feedback_send_failed_too_large
+                        FeedbackUploader.ErrorKind.RATE_LIMITED ->
+                            R.string.feedback_send_failed_rate_limited
+                        FeedbackUploader.ErrorKind.SERVER ->
+                            R.string.feedback_send_failed_server
+                        else -> R.string.feedback_send_failed_body
+                    },
+                ),
+            )
         }
     }
 }
 
 @Composable
-private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
+private fun FailedStep(
+    micPermanentlyDenied: Boolean,
+    onClose: () -> Unit,
+    onRetry: () -> Unit,
+    onOpenSettings: () -> Unit,
+    onSkipRecording: () -> Unit,
+) {
+    // When the microphone permission is "Don't ask again"-denied, a plain
+    // "Retry" just loops a no-op (the system shows no dialog). Route the user to
+    // app settings, or let them continue with a text-only note (#1930 review).
+    if (micPermanentlyDenied) {
+        FeedbackStepScaffold(
+            onClose = onClose,
+            actions = {
+                PrimaryButton(
+                    text = stringResource(R.string.feedback_record_open_settings),
+                    onClick = onOpenSettings,
+                )
+                TextButton(
+                    onClick = onSkipRecording,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.feedback_record_skip))
+                }
+            },
+        ) {
+            Spacer(Modifier.height(16.dp))
+            FeedbackHeroIcon(
+                Icons.Outlined.Mic,
+                Modifier.align(Alignment.CenterHorizontally),
+                error = true,
+            )
+            Spacer(Modifier.height(24.dp))
+            StepTitle(stringResource(R.string.feedback_record_denied_title))
+            Spacer(Modifier.height(12.dp))
+            StepBody(stringResource(R.string.feedback_record_denied_body))
+        }
+        return
+    }
     FeedbackStepScaffold(
         onClose = onClose,
         actions = {
@@ -505,6 +647,9 @@ private fun FailedStep(onClose: () -> Unit, onRetry: () -> Unit) {
                 text = stringResource(R.string.feedback_record_retry),
                 onClick = onRetry,
             )
+            TextButton(onClick = onSkipRecording, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.feedback_record_skip))
+            }
         },
     ) {
         Spacer(Modifier.height(16.dp))
@@ -913,6 +1058,33 @@ private fun PrivacyNote() {
     }
 }
 
+/** One-time hint shown on the consent step when the foreground-service
+ *  notification will be silent — the in-app Stop pill is then the stop path. */
+@Composable
+private fun NotificationWarning() {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Outlined.ErrorOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                stringResource(R.string.feedback_notif_warning),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
 @Composable
 private fun RecordingSummary(recording: FeedbackRecording) {
     Surface(
@@ -944,6 +1116,15 @@ private fun RecordingSummary(recording: FeedbackRecording) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (recording.capped) {
+                    // The clip hit the size/duration cap and was auto-stopped —
+                    // tell the user so the cut-off is not a surprise (#1930).
+                    Text(
+                        stringResource(R.string.feedback_recording_capped),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
             }
         }
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecorder.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 
 /** A finished screen + microphone recording. */
 data class FeedbackRecording(
@@ -12,6 +13,8 @@ data class FeedbackRecording(
     /** Audio track demuxed out of [video] for transcription; null if demux failed. */
     val audio: File?,
     val durationMs: Long,
+    /** True when the clip was auto-stopped at the size/duration cap (#1933 review). */
+    val capped: Boolean = false,
 )
 
 /** Lifecycle of an in-app feedback recording. */
@@ -35,8 +38,32 @@ object FeedbackRecorder {
     private val _state = MutableStateFlow<RecordingState>(RecordingState.Idle)
     val state: StateFlow<RecordingState> = _state.asStateFlow()
 
+    /**
+     * Monotonic id for the current recording attempt. Bumped on every
+     * [setRecording]; the recording service captures it before its background
+     * demux and a [setDone] / [setFailed] from a superseded attempt — e.g. when
+     * the user re-records quickly — is dropped rather than clobbering the new
+     * state (#1933 review).
+     */
+    private val sessionCounter = AtomicLong(0L)
+
+    /** Begin a fresh recording attempt and return its session id. */
+    fun beginSession(): Long {
+        val id = sessionCounter.incrementAndGet()
+        _state.value = RecordingState.Recording
+        return id
+    }
+
+    /** Current (latest) recording session id. */
+    val currentSession: Long get() = sessionCounter.get()
+
+    /** True when [session] is still the active attempt. */
+    fun isCurrentSession(session: Long): Boolean = session == sessionCounter.get()
+
     /** Category of the in-progress feedback — set by the UI before recording
-     *  starts, so it survives the dialog being dismissed during capture. */
+     *  starts, so it survives the dialog being dismissed during capture.
+     *  Mirrored to [FeedbackCategoryStore] so it also survives process death
+     *  during the MediaProjection consent dialog (#1933 review). */
     var category: FeedbackCategory? = null
 
     /**
@@ -50,26 +77,144 @@ object FeedbackRecorder {
     @Volatile
     var currentDemoId: String? = null
 
+    /**
+     * True while an upload coroutine still holds the recording files open.
+     * [reset] must not delete media in this window — a dialog dismiss during
+     * SENDING would otherwise pull the file out from under an in-flight read
+     * (#1930 review). The upload path clears it in a `finally` and deletes the
+     * media itself once it is done.
+     */
+    @Volatile
+    private var uploadInProgress = false
+
+    /** Mark that an upload has started reading the recording media. */
+    fun beginUpload() {
+        uploadInProgress = true
+    }
+
+    /**
+     * Mark the upload finished and release the recording media. Call from the
+     * upload coroutine's `finally`. Deletes the files if a [reset] was requested
+     * while the upload was in flight.
+     */
+    fun endUpload() {
+        uploadInProgress = false
+        val deferred = mediaDeferredForDeletion
+        if (deferred != null) {
+            mediaDeferredForDeletion = null
+            deferred.video.delete()
+            deferred.audio?.delete()
+        }
+    }
+
+    /** Recording whose deletion was deferred because an upload held it open. */
+    @Volatile
+    private var mediaDeferredForDeletion: FeedbackRecording? = null
+
+    /** Marks the state as recording without minting a new session (legacy). */
     fun setRecording() {
         _state.value = RecordingState.Recording
     }
 
-    fun setDone(recording: FeedbackRecording) {
+    /**
+     * Publish a finished recording. Ignored when [session] is not the active
+     * attempt — a stale demux thread from a superseded recording must not
+     * clobber the current state.
+     */
+    fun setDone(recording: FeedbackRecording, session: Long = sessionCounter.get()) {
+        if (session != sessionCounter.get()) {
+            // Superseded attempt — discard its media and drop the callback.
+            recording.video.delete()
+            recording.audio?.delete()
+            return
+        }
         _state.value = RecordingState.Done(recording)
     }
 
-    fun setFailed(reason: String) {
+    /** Publish a recording failure. Ignored when [session] is superseded. */
+    fun setFailed(reason: String, session: Long = sessionCounter.get()) {
+        if (session != sessionCounter.get()) return
         _state.value = RecordingState.Failed(reason)
     }
 
-    /** Clear the state and delete any media left by a finished recording. */
+    /**
+     * Clear the state and delete any media left by a finished recording.
+     *
+     * If an upload is currently reading the media ([uploadInProgress]), the
+     * deletion is deferred — [endUpload] performs it once the upload coroutine
+     * has released the files. This prevents a dialog dismiss during SENDING from
+     * deleting the file out from under an in-flight read (#1930 review).
+     */
     fun reset() {
-        (_state.value as? RecordingState.Done)?.recording?.let { rec ->
-            rec.video.delete()
-            rec.audio?.delete()
+        val recording = (_state.value as? RecordingState.Done)?.recording
+        if (uploadInProgress && recording != null) {
+            // An upload is still reading these files — hand them to endUpload()
+            // for deletion instead of pulling them now.
+            mediaDeferredForDeletion = recording
+        } else {
+            recording?.let { rec ->
+                rec.video.delete()
+                rec.audio?.delete()
+            }
         }
         category = null
         _state.value = RecordingState.Idle
+    }
+}
+
+/**
+ * Process-wide one-shot signal asking the host to open the [FeedbackFlow].
+ *
+ * The feedback flow itself is owned by `SceneViewDemoApp` (it wraps the whole
+ * `NavHost` in a `Box`), but a feedback entry point also lives in `DemoScaffold`
+ * — the shared scaffold for every demo screen (#1930 requires the button "on
+ * the 4 tabs AND inside every demo"). A demo's top-app-bar feedback action has
+ * no direct handle on the host's `feedbackOpen` state, so it raises this flag;
+ * `SceneViewDemoApp` observes it, opens the flow, and clears it.
+ */
+object FeedbackOpenRequest {
+    private val _requested = MutableStateFlow(false)
+    val requested: StateFlow<Boolean> = _requested.asStateFlow()
+
+    /** Ask the host to open the feedback flow. */
+    fun request() {
+        _requested.value = true
+    }
+
+    /** Clear the flag once the host has handled it. */
+    fun consume() {
+        _requested.value = false
+    }
+}
+
+/**
+ * Persists the in-flight feedback [FeedbackCategory] across process death.
+ *
+ * The MediaProjection consent dialog is a separate system activity; on a
+ * memory-tight device the demo process can be killed while it is up. The
+ * category lives on [FeedbackRecorder] (process memory) and would be lost — an
+ * "Idea" would silently become a "Bug" on the way back. This small prefs mirror
+ * survives that (#1933 review).
+ */
+object FeedbackCategoryStore {
+    private const val PREFS = "sceneview_feedback"
+    private const val KEY_CATEGORY = "inflight_category"
+
+    fun save(context: Context, category: FeedbackCategory?) {
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        if (category == null) {
+            prefs.edit().remove(KEY_CATEGORY).apply()
+        } else {
+            prefs.edit().putString(KEY_CATEGORY, category.name).apply()
+        }
+    }
+
+    fun load(context: Context): FeedbackCategory? {
+        val raw = context.applicationContext
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(KEY_CATEGORY, null) ?: return null
+        return runCatching { FeedbackCategory.valueOf(raw) }.getOrNull()
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingLauncher.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingLauncher.kt
@@ -2,22 +2,76 @@ package io.github.sceneview.demo.feedback
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.media.projection.MediaProjectionManager
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 
 /**
- * Provides a `startRecording` lambda that requests the microphone (and, on
- * Android 13+, the notification) permission, then the screen-capture
- * permission, and finally hands the granted MediaProjection token to
- * [FeedbackRecordingService]. Any denial publishes a [RecordingState.Failed].
+ * Controls returned by [rememberFeedbackRecordingLauncher].
+ *
+ * @property startRecording requests the mic (and, on Android 13+, the
+ *   notification) permission, then the screen-capture permission, then hands
+ *   the granted MediaProjection token to [FeedbackRecordingService]. Any denial
+ *   publishes a [RecordingState.Failed].
+ * @property openAppSettings opens this app's system settings page so a user who
+ *   permanently denied the microphone permission can grant it by hand. The
+ *   per-app-permission picker has no in-app dialog once a runtime permission is
+ *   "Don't ask again"-denied, so this is the only recovery path (#1933 review).
  */
+class FeedbackRecordingLauncher(
+    val startRecording: () -> Unit,
+    val openAppSettings: () -> Unit,
+)
+
+/** Opens the system app-details settings page for [context]'s package. */
+private fun openAppDetailsSettings(context: Context) {
+    runCatching {
+        context.startActivity(
+            Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", context.packageName, null),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+}
+
+/**
+ * True when [Manifest.permission.RECORD_AUDIO] is permanently denied — i.e. it
+ * is not granted and the system will not show a request dialog again (the user
+ * chose "Don't ask again", or it is policy-restricted). The system permission
+ * request then returns instantly with no UI, so the flow must route the user to
+ * app settings instead of looping a no-op "Retry".
+ */
+fun isMicPermanentlyDenied(activity: Activity): Boolean {
+    val granted = ContextCompat.checkSelfPermission(
+        activity,
+        Manifest.permission.RECORD_AUDIO,
+    ) == PackageManager.PERMISSION_GRANTED
+    if (granted) return false
+    // After at least one denial, `shouldShowRequestPermissionRationale` is
+    // false only when the user picked "Don't ask again". On a never-asked
+    // permission it is also false — but that case is harmless: the first
+    // request still shows the dialog. The flow only consults this after a
+    // denial has already been observed.
+    return !ActivityCompat.shouldShowRequestPermissionRationale(
+        activity,
+        Manifest.permission.RECORD_AUDIO,
+    )
+}
+
 @Composable
-fun rememberFeedbackRecordingLauncher(): () -> Unit {
+fun rememberFeedbackRecordingLauncher(): FeedbackRecordingLauncher {
     val context = LocalContext.current
 
     val projectionLauncher = rememberLauncherForActivityResult(
@@ -46,15 +100,18 @@ fun rememberFeedbackRecordingLauncher(): () -> Unit {
         }
     }
 
-    return remember(permissionLauncher) {
-        {
-            val perms = buildList {
-                add(Manifest.permission.RECORD_AUDIO)
-                if (Build.VERSION.SDK_INT >= 33) {
-                    add(Manifest.permission.POST_NOTIFICATIONS)
+    return remember(permissionLauncher, context) {
+        FeedbackRecordingLauncher(
+            startRecording = {
+                val perms = buildList {
+                    add(Manifest.permission.RECORD_AUDIO)
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        add(Manifest.permission.POST_NOTIFICATIONS)
+                    }
                 }
-            }
-            permissionLauncher.launch(perms.toTypedArray())
-        }
+                permissionLauncher.launch(perms.toTypedArray())
+            },
+            openAppSettings = { openAppDetailsSettings(context) },
+        )
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackRecordingService.kt
@@ -20,6 +20,7 @@ import androidx.core.content.ContextCompat
 import io.github.sceneview.demo.MainActivity
 import io.github.sceneview.demo.R
 import java.io.File
+import java.util.concurrent.Executors
 
 /**
  * Foreground service that captures the screen + microphone with MediaProjection
@@ -35,6 +36,17 @@ class FeedbackRecordingService : Service() {
     private var recorder: MediaRecorder? = null
     private var videoFile: File? = null
     private var startedAt = 0L
+
+    /** True once the recorder auto-stopped at the size/duration cap. */
+    private var cappedHit = false
+
+    /** Session id of this recording — captured before the post-stop demux so a
+     *  stale callback from a superseded recording is dropped (#1933 review). */
+    private var session = 0L
+
+    /** Single-thread executor for the post-stop audio demux. Cancelled in
+     *  [onDestroy] so a demux can never outlive the service (#1933 review). */
+    private val demuxExecutor = Executors.newSingleThreadExecutor()
 
     /** Guards [stopRecording] against the notification / pill / projection-callback
      *  all triggering a stop. */
@@ -81,7 +93,11 @@ class FeedbackRecordingService : Service() {
             NotificationChannel(
                 CHANNEL_ID,
                 getString(R.string.feedback_recording_channel),
-                NotificationManager.IMPORTANCE_LOW,
+                // DEFAULT (not LOW) so the stop control is more prominent — the
+                // notification is a documented stop affordance and on a
+                // full-screen demo it may be the only one if the user denied
+                // POST_NOTIFICATIONS-adjacent visibility (#1933 review).
+                NotificationManager.IMPORTANCE_DEFAULT,
             ),
         )
 
@@ -161,9 +177,33 @@ class FeedbackRecordingService : Service() {
             rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
             rec.setVideoSize(width, height)
             rec.setVideoFrameRate(30)
-            rec.setVideoEncodingBitRate(3_500_000)
+            rec.setVideoEncodingBitRate(VIDEO_BITRATE)
+            // Hard caps so the clip can never exceed the worker's 30 MB upload
+            // limit (a silent 413). The size cap leaves headroom for the
+            // multipart envelope and the separately-uploaded demuxed audio; the
+            // duration cap is a secondary guard. Both must be set after
+            // setOutputFile and before prepare(). On the cap being approached /
+            // reached the recorder auto-stops gracefully (#1933 review).
+            rec.setMaxFileSize(MAX_FILE_SIZE_BYTES)
+            rec.setMaxDuration(MAX_DURATION_MS)
+            rec.setOnInfoListener { _, what, _ ->
+                when (what) {
+                    MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_APPROACHING,
+                    MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED,
+                    MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED -> {
+                        cappedHit = true
+                        // Finish the clip on the main thread — stopRecording
+                        // touches the MediaRecorder which is not thread-safe.
+                        Handler(Looper.getMainLooper()).post { stopRecording() }
+                    }
+                }
+            }
             rec.prepare()
+            rec.start()
 
+            // Create the VirtualDisplay only AFTER start() succeeds — an
+            // encoder-busy start() failure must not leave a display feeding a
+            // dead recorder (#1933 review).
             virtualDisplay = mp.createVirtualDisplay(
                 "feedback-capture",
                 width,
@@ -174,10 +214,9 @@ class FeedbackRecordingService : Service() {
                 null,
                 null,
             )
-            rec.start()
             recorder = rec
             startedAt = System.currentTimeMillis()
-            FeedbackRecorder.setRecording()
+            session = FeedbackRecorder.beginSession()
         } catch (e: Exception) {
             FeedbackRecorder.setFailed(e.message ?: "could not start recording")
             cleanup()
@@ -190,6 +229,8 @@ class FeedbackRecordingService : Service() {
         stopping = true
 
         val out = videoFile
+        val capped = cappedHit
+        val recordingSession = session
         val duration = if (startedAt > 0) System.currentTimeMillis() - startedAt else 0L
         val stopped = try {
             recorder?.stop()
@@ -200,17 +241,30 @@ class FeedbackRecordingService : Service() {
         }
         cleanup()
         if (stopped && out != null && out.exists() && out.length() > 0L) {
-            // Demux the audio track off the main thread, then publish the result.
+            // Demux the audio track off the main thread, then publish the
+            // result. The work runs on a managed executor (cancelled in
+            // onDestroy) and is wrapped so an exception is reported as a
+            // recording failure rather than crashing the process (#1933 review).
             val cache = cacheDir
-            Thread {
-                val audio = File(cache, "feedback-audio-${System.currentTimeMillis()}.m4a")
-                FeedbackRecorder.setDone(
-                    FeedbackRecording(out, demuxAudioTrack(out, audio), duration),
-                )
-            }.start()
+            demuxExecutor.execute {
+                runCatching {
+                    val audio = File(cache, "feedback-audio-${System.currentTimeMillis()}.m4a")
+                    FeedbackRecorder.setDone(
+                        FeedbackRecording(out, demuxAudioTrack(out, audio), duration, capped),
+                        recordingSession,
+                    )
+                }.onFailure {
+                    // Demux failed — the video alone is still useful; publish it
+                    // without an audio track rather than losing the recording.
+                    FeedbackRecorder.setDone(
+                        FeedbackRecording(out, null, duration, capped),
+                        recordingSession,
+                    )
+                }
+            }
         } else {
             out?.delete()
-            FeedbackRecorder.setFailed("recording incomplete")
+            FeedbackRecorder.setFailed("recording incomplete", recordingSession)
         }
         stopForegroundAndSelf()
     }
@@ -224,6 +278,7 @@ class FeedbackRecordingService : Service() {
     }
 
     private fun cleanup() {
+        runCatching { recorder?.setOnInfoListener(null) }
         runCatching { recorder?.release() }
         recorder = null
         runCatching { virtualDisplay?.release() }
@@ -241,6 +296,8 @@ class FeedbackRecordingService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         cleanup()
+        // Cancel any in-flight demux so it cannot outlive the service.
+        demuxExecutor.shutdownNow()
     }
 
     companion object {
@@ -249,6 +306,18 @@ class FeedbackRecordingService : Service() {
         private const val ACTION_STOP = "io.github.sceneview.demo.feedback.STOP"
         private const val EXTRA_RESULT_CODE = "result_code"
         private const val EXTRA_DATA = "data"
+
+        private const val VIDEO_BITRATE = 3_500_000
+
+        /**
+         * Hard cap on the recorded mp4 (28 MB). The worker rejects uploads over
+         * 30 MB with a 413; this leaves ~2 MB of headroom for the multipart
+         * envelope and the separately-uploaded demuxed audio track.
+         */
+        private const val MAX_FILE_SIZE_BYTES = 28L * 1024 * 1024
+
+        /** Secondary cap on the clip length (~120 s). */
+        private const val MAX_DURATION_MS = 120_000
 
         /** Start recording with a granted MediaProjection token. */
         fun start(context: Context, resultCode: Int, data: Intent) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackTicketStatus.kt
@@ -14,63 +14,121 @@ enum class TicketState { OPEN, CLOSED, UNKNOWN }
  * Reads the live Open/Closed state of a feedback ticket straight from GitHub's
  * public REST API — the issue is the source of truth, never re-implemented.
  *
- * Results are cached in memory for [CACHE_TTL_MS] so reopening the "My feedback"
- * screen does not burn the unauthenticated 60 req/h GitHub limit. [TicketState.UNKNOWN]
- * results (offline, rate-limited) are deliberately not cached, so the next call
- * — a later screen open, or a row scrolled back into view — retries.
+ * The unauthenticated GitHub API budget is only 60 requests/hour, so this
+ * deliberately paces and caches its calls:
+ *
+ *  - A successful OPEN / CLOSED result is cached for [CACHE_TTL_MS].
+ *  - When GitHub reports the rate limit is exhausted (a 403/429 with
+ *    `X-RateLimit-Remaining: 0`), a "rate-limited until reset" sentinel is
+ *    cached so every other tracked row stops hammering the dead budget until
+ *    `X-RateLimit-Reset` passes — without it, 50 rate-limited rows would retry
+ *    forever.
+ *  - A 200 whose body does not parse is cached as a short-lived negative, so a
+ *    permanently-broken response is not retried in a tight loop.
  */
 object FeedbackTicketStatus {
     private const val REPO = "sceneview/sceneview"
     private val CACHE_TTL_MS = TimeUnit.MINUTES.toMillis(5)
 
-    private data class Cached(val state: TicketState, val at: Long)
+    /** How long an unparseable-success negative result stays cached. */
+    private val NEGATIVE_TTL_MS = TimeUnit.MINUTES.toMillis(10)
+
+    /** Fallback rate-limit cooldown when GitHub sends no usable reset header. */
+    private val RATE_LIMIT_FALLBACK_MS = TimeUnit.MINUTES.toMillis(10)
+
+    private data class Cached(val state: TicketState, val expiresAt: Long)
+
     private val cache = mutableMapOf<Int, Cached>()
 
-    private val client by lazy {
+    /**
+     * Process-wide "the GitHub budget is exhausted until this epoch-ms"
+     * sentinel. While set and in the future, [fetch] short-circuits to
+     * [TicketState.UNKNOWN] for every issue without making a request.
+     */
+    @Volatile
+    private var rateLimitedUntil = 0L
+
+    private val defaultClient by lazy {
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .readTimeout(10, TimeUnit.SECONDS)
             .build()
     }
 
+    /** OkHttp client used for the GitHub call. Overridable in tests. */
+    internal var client: OkHttpClient = defaultClient
+
+    /** Base of the GitHub issues API. Overridable in tests (MockWebServer). */
+    internal var apiBaseUrl: String = "https://api.github.com"
+
+    /** Test-only — clears every cache entry and the rate-limit sentinel and
+     *  restores the default client / base URL. */
+    internal fun resetForTest() {
+        synchronized(cache) { cache.clear() }
+        rateLimitedUntil = 0L
+        client = defaultClient
+        apiBaseUrl = "https://api.github.com"
+    }
+
     /** Fetch (or return cached) the state of issue [issueNumber]; never throws. */
     suspend fun fetch(issueNumber: Int): TicketState = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+
         synchronized(cache) {
             cache[issueNumber]?.let {
-                if (System.currentTimeMillis() - it.at < CACHE_TTL_MS) {
-                    return@withContext it.state
-                }
+                if (now < it.expiresAt) return@withContext it.state
             }
         }
 
+        // The whole budget is known-exhausted — don't spend a request just to
+        // get another 403. Every tracked row sees this until the reset passes.
+        if (now < rateLimitedUntil) return@withContext TicketState.UNKNOWN
+
         val request = Request.Builder()
-            .url("https://api.github.com/repos/$REPO/issues/$issueNumber")
+            .url("${apiBaseUrl.trimEnd('/')}/repos/$REPO/issues/$issueNumber")
             .header("Accept", "application/vnd.github+json")
             // GitHub rejects API requests that carry no User-Agent.
             .header("User-Agent", "SceneView-Demo")
             .build()
 
-        val state = try {
+        try {
             client.newCall(request).execute().use { response ->
+                val remaining = response.header("X-RateLimit-Remaining")?.toIntOrNull()
+                if ((response.code == 403 || response.code == 429) && remaining == 0) {
+                    // Budget exhausted — park every row until the reset epoch.
+                    val resetMs = response.header("X-RateLimit-Reset")
+                        ?.toLongOrNull()
+                        ?.let { it * 1000L }
+                    rateLimitedUntil = resetMs?.takeIf { it > now }
+                        ?: (now + RATE_LIMIT_FALLBACK_MS)
+                    return@use TicketState.UNKNOWN
+                }
                 if (!response.isSuccessful) {
-                    TicketState.UNKNOWN
-                } else {
-                    when (JSONObject(response.body.string()).optString("state")) {
-                        "open" -> TicketState.OPEN
-                        "closed" -> TicketState.CLOSED
-                        else -> TicketState.UNKNOWN
+                    // A transient non-success (404, network blip) — not cached
+                    // so a later open retries.
+                    return@use TicketState.UNKNOWN
+                }
+                val parsed = runCatching {
+                    JSONObject(response.body.string()).optString("state")
+                }.getOrNull()
+                when (parsed) {
+                    "open" -> cacheState(issueNumber, TicketState.OPEN, now + CACHE_TTL_MS)
+                    "closed" -> cacheState(issueNumber, TicketState.CLOSED, now + CACHE_TTL_MS)
+                    else -> {
+                        // 200 but unparseable / unexpected body — cache a
+                        // short-lived UNKNOWN so it is not retried in a loop.
+                        cacheState(issueNumber, TicketState.UNKNOWN, now + NEGATIVE_TTL_MS)
                     }
                 }
             }
         } catch (e: Exception) {
+            // Offline / timeout — not cached, the next open retries.
             TicketState.UNKNOWN
         }
+    }
 
-        if (state != TicketState.UNKNOWN) {
-            synchronized(cache) {
-                cache[issueNumber] = Cached(state, System.currentTimeMillis())
-            }
-        }
-        state
+    private fun cacheState(issueNumber: Int, state: TicketState, expiresAt: Long): TicketState {
+        synchronized(cache) { cache[issueNumber] = Cached(state, expiresAt) }
+        return state
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackUploader.kt
@@ -10,6 +10,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.Response
 import okio.Buffer
 import okio.BufferedSink
 import okio.ForwardingSink
@@ -24,9 +25,9 @@ object FeedbackUploader {
     /**
      * Endpoint of the feedback worker — `<base>/v1/feedback`. The base URL is a
      * single configurable [BuildConfig] field (`FEEDBACK_WORKER_URL`), set in
-     * `samples/android-demo/build.gradle`. The worker is not deployed yet; until
-     * the maintainer sets the real URL there, this points at the planned
-     * workers.dev subdomain.
+     * `samples/android-demo/build.gradle`. The worker is deployed at
+     * `sceneview-feedback.mcp-tools-lab.workers.dev`; the build can still point
+     * the field at a staging URL via the env var / `local.properties`.
      */
     private val endpoint: String by lazy {
         BuildConfig.FEEDBACK_WORKER_URL.trimEnd('/') + "/v1/feedback"
@@ -41,16 +42,42 @@ object FeedbackUploader {
             .build()
     }
 
+    /** Why an upload failed — drives a tailored error message in the UI. */
+    enum class ErrorKind {
+        /** No failure. */
+        NONE,
+
+        /** Network unreachable / timeout — "check your connection". */
+        NETWORK,
+
+        /** 413 — the recording was too large for the worker's upload cap. */
+        TOO_LARGE,
+
+        /** 429 — too many submissions; retry later (see [Result.retryAfterSeconds]). */
+        RATE_LIMITED,
+
+        /** 5xx — a transient worker-side error. */
+        SERVER,
+
+        /** Any other non-success (4xx) or an unparseable success body. */
+        OTHER,
+    }
+
     /**
      * Outcome of an upload. [ok] is true when the worker accepted the feedback.
      * [issueNumber] / [issueUrl] are null when the worker stored the feedback
      * but did not open a GitHub issue (e.g. the hourly issue quota was hit).
+     * On a failure, [errorKind] explains what went wrong so the UI can show
+     * tailored copy, and [retryAfterSeconds] carries the worker's `Retry-After`
+     * hint for a 429.
      */
     data class Result(
         val ok: Boolean,
         val issueNumber: Int?,
         val issueUrl: String?,
         val feedbackId: String?,
+        val errorKind: ErrorKind = ErrorKind.NONE,
+        val retryAfterSeconds: Int? = null,
     )
 
     /**
@@ -101,22 +128,46 @@ object FeedbackUploader {
             .build()
         try {
             client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    return@withContext Result(false, null, null, null)
-                }
-                val json = runCatching {
-                    JSONObject(response.body.string())
-                }.getOrNull()
-                Result(
-                    ok = json?.optBoolean("ok") == true,
-                    issueNumber = json?.optInt("issue", 0)?.takeIf { it > 0 },
-                    issueUrl = json?.optString("url")?.takeIf { it.isNotBlank() },
-                    feedbackId = json?.optString("id")?.takeIf { it.isNotBlank() },
-                )
+                parseResponse(response)
             }
         } catch (e: Exception) {
-            Result(false, null, null, null)
+            Result(false, null, null, null, ErrorKind.NETWORK)
         }
+    }
+
+    /**
+     * Map an HTTP [Response] to a [Result]. Extracted so the status-code →
+     * [ErrorKind] mapping and the JSON parsing are unit-testable. Reads (and
+     * therefore consumes) the response body.
+     */
+    internal fun parseResponse(response: Response): Result {
+        if (!response.isSuccessful) {
+            val kind = when (response.code) {
+                413 -> ErrorKind.TOO_LARGE
+                429 -> ErrorKind.RATE_LIMITED
+                in 500..599 -> ErrorKind.SERVER
+                else -> ErrorKind.OTHER
+            }
+            val retryAfter = response.header("Retry-After")
+                ?.trim()
+                ?.toIntOrNull()
+                ?.takeIf { it in 1..3600 }
+            return Result(false, null, null, null, kind, retryAfter)
+        }
+        val json = runCatching {
+            JSONObject(response.body.string())
+        }.getOrNull()
+        if (json == null) {
+            // A 200 with an unparseable body — treat as a failure rather than a
+            // silent success that strands the user with no issue link.
+            return Result(false, null, null, null, ErrorKind.OTHER)
+        }
+        return Result(
+            ok = json.optBoolean("ok"),
+            issueNumber = json.optInt("issue", 0).takeIf { it > 0 },
+            issueUrl = json.optString("url").takeIf { it.isNotBlank() },
+            feedbackId = json.optString("id").takeIf { it.isNotBlank() },
+        )
     }
 
     /**
@@ -150,7 +201,7 @@ object FeedbackUploader {
     }
 
     /** A [ForwardingSink] that reports the running fraction of [total] written. */
-    private class CountingSink(
+    internal class CountingSink(
         delegate: Sink,
         private val total: Long,
         private val onProgress: (Float) -> Unit,

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -339,4 +339,16 @@
     <string name="feedback_tickets_no_app">No app available to open the issue</string>
     <string name="feedback_tickets_open_a11y">Open issue on GitHub</string>
     <string name="feedback_tickets_status_loading">Loading status</string>
+    <!-- In-app feedback — review-blocker hardening (issue #1930) -->
+    <string name="feedback_recording_capped">Recording length limit reached — your clip was saved. You can send it as is, or record a shorter one.</string>
+    <string name="feedback_send_failed_too_large">Your recording is too large to send. Record a shorter clip and try again.</string>
+    <string name="feedback_send_failed_rate_limited">Too many submissions right now. Please try again in a minute.</string>
+    <string name="feedback_send_failed_server">The feedback service is having trouble. Please try again shortly.</string>
+    <string name="feedback_record_denied_title">Microphone access needed</string>
+    <string name="feedback_record_denied_body">Recording needs microphone access. Enable it in app settings, or skip recording and send a written note instead.</string>
+    <string name="feedback_record_open_settings">Open settings</string>
+    <string name="feedback_record_skip">Send a note instead</string>
+    <string name="feedback_notif_warning">If you can\'t see a notification, use the Stop button at the top of the screen to finish recording.</string>
+    <string name="feedback_sending_cancel">Cancel</string>
+    <string name="feedback_action_cd">Send feedback</string>
 </resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackContextTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackContextTest.kt
@@ -37,36 +37,37 @@ class FeedbackContextTest {
     }
 
     @Test
-    fun `on a tab screen the route is list and no demo id is set`() {
+    fun `on a tab screen no demoId is set`() {
         val ctx = captureFeedbackContext(context, demoId = null)
 
-        assertEquals("list", ctx["route"])
-        assertFalse(ctx.containsKey("demo"))
+        // The worker only renders the named "Demo" row when `demoId` is present,
+        // so a tab-screen report simply omits the key — no `route` key exists.
+        assertFalse(ctx.containsKey("demoId"))
+        assertFalse(ctx.containsKey("route"))
     }
 
     @Test
-    fun `inside a demo the demo id and the demo route are both captured`() {
+    fun `inside a demo the demoId is captured under the worker's key`() {
         val ctx = captureFeedbackContext(context, demoId = "model-viewer")
 
-        assertEquals("model-viewer", ctx["demo"])
-        assertEquals("demo/model-viewer", ctx["route"])
+        assertEquals("model-viewer", ctx["demoId"])
+        // `route` is never emitted — the worker has no label for it.
+        assertFalse(ctx.containsKey("route"))
     }
 
     @Test
     fun `a blank demo id is treated as a tab screen`() {
         val ctx = captureFeedbackContext(context, demoId = "  ")
 
-        assertEquals("list", ctx["route"])
-        assertFalse(ctx.containsKey("demo"))
+        assertFalse(ctx.containsKey("demoId"))
     }
 
     @Test
-    fun `the demo id defaults to the recorder's tracked route`() {
+    fun `the demoId defaults to the recorder's tracked demo`() {
         FeedbackRecorder.currentDemoId = "lighting"
 
         val ctx = captureFeedbackContext(context)
 
-        assertEquals("lighting", ctx["demo"])
-        assertEquals("demo/lighting", ctx["route"])
+        assertEquals("lighting", ctx["demoId"])
     }
 }

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackRecorderTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackRecorderTest.kt
@@ -1,0 +1,146 @@
+package io.github.sceneview.demo.feedback
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * State-machine tests for [FeedbackRecorder] — the process-wide bridge between
+ * the recording service and the Compose feedback flow (#1930 review).
+ *
+ * Covers: the monotonic session id that drops a stale [FeedbackRecorder.setDone]
+ * from a superseded recording, and the upload-in-progress guard that defers
+ * media deletion so a dialog dismiss can't pull the file from under an upload.
+ */
+class FeedbackRecorderTest {
+
+    private val tmpFiles = mutableListOf<File>()
+
+    private fun newFile(name: String): File =
+        File.createTempFile(name, ".tmp").also {
+            it.writeText("x")
+            tmpFiles += it
+        }
+
+    @Before
+    fun setUp() {
+        FeedbackRecorder.reset()
+    }
+
+    @After
+    fun tearDown() {
+        FeedbackRecorder.reset()
+        tmpFiles.forEach { it.delete() }
+        tmpFiles.clear()
+    }
+
+    @Test
+    fun `begin session transitions to Recording and mints a fresh id`() {
+        val first = FeedbackRecorder.beginSession()
+        assertEquals(RecordingState.Recording, FeedbackRecorder.state.value)
+
+        val second = FeedbackRecorder.beginSession()
+        assertTrue("session id is monotonic", second > first)
+        assertTrue(FeedbackRecorder.isCurrentSession(second))
+        assertFalse(FeedbackRecorder.isCurrentSession(first))
+    }
+
+    @Test
+    fun `setDone for the current session publishes the recording`() {
+        val session = FeedbackRecorder.beginSession()
+        val video = newFile("video")
+        val recording = FeedbackRecording(video, null, 1_000L)
+
+        FeedbackRecorder.setDone(recording, session)
+
+        val state = FeedbackRecorder.state.value
+        assertTrue(state is RecordingState.Done)
+        assertSame(recording, (state as RecordingState.Done).recording)
+    }
+
+    @Test
+    fun `setDone from a superseded session is dropped and its media deleted`() {
+        val staleSession = FeedbackRecorder.beginSession()
+        // The user re-records quickly — a new session supersedes the stale one.
+        FeedbackRecorder.beginSession()
+
+        val staleVideo = newFile("stale-video")
+        val staleAudio = newFile("stale-audio")
+        FeedbackRecorder.setDone(
+            FeedbackRecording(staleVideo, staleAudio, 500L),
+            staleSession,
+        )
+
+        // The stale callback must not clobber the new Recording state...
+        assertEquals(RecordingState.Recording, FeedbackRecorder.state.value)
+        // ...and its orphaned media must be cleaned up.
+        assertFalse("stale video deleted", staleVideo.exists())
+        assertFalse("stale audio deleted", staleAudio.exists())
+    }
+
+    @Test
+    fun `setFailed from a superseded session is dropped`() {
+        val staleSession = FeedbackRecorder.beginSession()
+        FeedbackRecorder.beginSession()
+
+        FeedbackRecorder.setFailed("stale failure", staleSession)
+
+        assertEquals(RecordingState.Recording, FeedbackRecorder.state.value)
+    }
+
+    @Test
+    fun `reset deletes the finished recording media`() {
+        val session = FeedbackRecorder.beginSession()
+        val video = newFile("video")
+        val audio = newFile("audio")
+        FeedbackRecorder.setDone(FeedbackRecording(video, audio, 1_000L), session)
+
+        FeedbackRecorder.reset()
+
+        assertEquals(RecordingState.Idle, FeedbackRecorder.state.value)
+        assertFalse(video.exists())
+        assertFalse(audio.exists())
+        assertNull(FeedbackRecorder.category)
+    }
+
+    @Test
+    fun `reset during an upload defers deletion until endUpload`() {
+        val session = FeedbackRecorder.beginSession()
+        val video = newFile("video")
+        val audio = newFile("audio")
+        FeedbackRecorder.setDone(FeedbackRecording(video, audio, 1_000L), session)
+
+        // An upload starts reading the media, then the dialog is dismissed.
+        FeedbackRecorder.beginUpload()
+        FeedbackRecorder.reset()
+
+        // The state is cleared, but the files survive while the upload holds them.
+        assertEquals(RecordingState.Idle, FeedbackRecorder.state.value)
+        assertTrue("video still readable mid-upload", video.exists())
+        assertTrue("audio still readable mid-upload", audio.exists())
+
+        // Once the upload releases the media, the deferred deletion runs.
+        FeedbackRecorder.endUpload()
+        assertFalse(video.exists())
+        assertFalse(audio.exists())
+    }
+
+    @Test
+    fun `endUpload without a deferred reset leaves the media in place`() {
+        val session = FeedbackRecorder.beginSession()
+        val video = newFile("video")
+        FeedbackRecorder.setDone(FeedbackRecording(video, null, 1_000L), session)
+
+        FeedbackRecorder.beginUpload()
+        FeedbackRecorder.endUpload()
+
+        // No reset happened — endUpload must not delete anything.
+        assertTrue(video.exists())
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackTicketStatusTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackTicketStatusTest.kt
@@ -1,0 +1,122 @@
+package io.github.sceneview.demo.feedback
+
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cache-semantics tests for [FeedbackTicketStatus] (#1930 review).
+ *
+ * The unauthenticated GitHub API budget is only 60 requests/hour, so the
+ * crucial behaviours are: a successful OPEN/CLOSED is cached, a rate-limit hit
+ * is cached process-wide so 50 rows stop hammering the dead budget, and a
+ * 200-with-garbage-body is cached as a short-lived negative rather than retried
+ * forever.
+ *
+ * Runs under Robolectric so `org.json` resolves to a real implementation.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FeedbackTicketStatusTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        FeedbackTicketStatus.resetForTest()
+        server = MockWebServer()
+        server.start()
+        FeedbackTicketStatus.client = OkHttpClient.Builder()
+            .connectTimeout(2, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+        FeedbackTicketStatus.apiBaseUrl = server.url("/").toString().trimEnd('/')
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+        FeedbackTicketStatus.resetForTest()
+    }
+
+    @Test
+    fun `an open issue resolves to OPEN`() = runTest {
+        server.enqueue(MockResponse.Builder().code(200).body("""{"state":"open"}""").build())
+
+        assertEquals(TicketState.OPEN, FeedbackTicketStatus.fetch(1))
+    }
+
+    @Test
+    fun `a closed issue resolves to CLOSED`() = runTest {
+        server.enqueue(MockResponse.Builder().code(200).body("""{"state":"closed"}""").build())
+
+        assertEquals(TicketState.CLOSED, FeedbackTicketStatus.fetch(2))
+    }
+
+    @Test
+    fun `a successful result is cached - the second fetch makes no request`() = runTest {
+        server.enqueue(MockResponse.Builder().code(200).body("""{"state":"open"}""").build())
+
+        assertEquals(TicketState.OPEN, FeedbackTicketStatus.fetch(3))
+        assertEquals(TicketState.OPEN, FeedbackTicketStatus.fetch(3))
+
+        // Only the first fetch hit the network — the second was served from cache.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `a rate-limit hit parks every issue without further requests`() = runTest {
+        // GitHub reports the budget is exhausted.
+        server.enqueue(
+            MockResponse.Builder()
+                .code(403)
+                .addHeader("X-RateLimit-Remaining", "0")
+                .addHeader(
+                    "X-RateLimit-Reset",
+                    ((System.currentTimeMillis() / 1000) + 3600).toString(),
+                )
+                .body("""{"message":"API rate limit exceeded"}""")
+                .build(),
+        )
+
+        // First issue trips the rate-limit sentinel.
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(10))
+        // Every other tracked issue now short-circuits — no request is made.
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(11))
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(12))
+
+        assertEquals("only the first issue hit the network", 1, server.requestCount)
+    }
+
+    @Test
+    fun `a 200 with an unparseable body is cached as a negative`() = runTest {
+        server.enqueue(MockResponse.Builder().code(200).body("not json at all").build())
+
+        // First call hits the network and gets UNKNOWN.
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(20))
+        // Second call is served from the short-lived negative cache — no retry
+        // loop against an unparseable response.
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(20))
+
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `a 404 is not cached so a later fetch retries`() = runTest {
+        server.enqueue(MockResponse.Builder().code(404).body("""{"message":"Not Found"}""").build())
+        server.enqueue(MockResponse.Builder().code(200).body("""{"state":"open"}""").build())
+
+        assertEquals(TicketState.UNKNOWN, FeedbackTicketStatus.fetch(30))
+        // The transient failure was not cached — the retry sees the new result.
+        assertEquals(TicketState.OPEN, FeedbackTicketStatus.fetch(30))
+
+        assertEquals(2, server.requestCount)
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackUploaderTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/feedback/FeedbackUploaderTest.kt
@@ -1,0 +1,168 @@
+package io.github.sceneview.demo.feedback
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import okio.blackholeSink
+import okio.buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for [FeedbackUploader] — the HTTP-status → [FeedbackUploader.ErrorKind]
+ * mapping, success-body parsing, and the upload-progress byte accounting
+ * (#1930 review).
+ *
+ * Runs under Robolectric so `org.json` resolves to a real implementation
+ * rather than the unmocked Android stub.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FeedbackUploaderTest {
+
+    private fun response(
+        code: Int,
+        body: String = "",
+        headers: Map<String, String> = emptyMap(),
+    ): Response {
+        val builder = Response.Builder()
+            .request(Request.Builder().url("https://example.test/v1/feedback").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("msg")
+            .body(body.toResponseBody("application/json".toMediaType()))
+        headers.forEach { (k, v) -> builder.header(k, v) }
+        return builder.build()
+    }
+
+    // ── Status-code → ErrorKind mapping ──────────────────────────────────────
+
+    @Test
+    fun `413 maps to TOO_LARGE`() {
+        val result = FeedbackUploader.parseResponse(response(413, """{"error":"x"}"""))
+        assertFalse(result.ok)
+        assertEquals(FeedbackUploader.ErrorKind.TOO_LARGE, result.errorKind)
+    }
+
+    @Test
+    fun `429 maps to RATE_LIMITED and reads Retry-After`() {
+        val result = FeedbackUploader.parseResponse(
+            response(429, headers = mapOf("Retry-After" to "45")),
+        )
+        assertFalse(result.ok)
+        assertEquals(FeedbackUploader.ErrorKind.RATE_LIMITED, result.errorKind)
+        assertEquals(45, result.retryAfterSeconds)
+    }
+
+    @Test
+    fun `a 5xx maps to SERVER`() {
+        val result = FeedbackUploader.parseResponse(response(503))
+        assertEquals(FeedbackUploader.ErrorKind.SERVER, result.errorKind)
+    }
+
+    @Test
+    fun `a generic 4xx maps to OTHER`() {
+        val result = FeedbackUploader.parseResponse(response(400))
+        assertEquals(FeedbackUploader.ErrorKind.OTHER, result.errorKind)
+    }
+
+    @Test
+    fun `an absurd Retry-After is ignored`() {
+        val result = FeedbackUploader.parseResponse(
+            response(429, headers = mapOf("Retry-After" to "999999")),
+        )
+        assertNull(result.retryAfterSeconds)
+    }
+
+    // ── Success-body parsing ─────────────────────────────────────────────────
+
+    @Test
+    fun `a successful response parses issue number and url`() {
+        val result = FeedbackUploader.parseResponse(
+            response(
+                200,
+                """{"ok":true,"issue":1234,"url":"https://gh/i/1234","id":"fb-1"}""",
+            ),
+        )
+        assertTrue(result.ok)
+        assertEquals(1234, result.issueNumber)
+        assertEquals("https://gh/i/1234", result.issueUrl)
+        assertEquals("fb-1", result.feedbackId)
+        assertEquals(FeedbackUploader.ErrorKind.NONE, result.errorKind)
+    }
+
+    @Test
+    fun `a 200 that stored feedback but opened no issue has a null issue number`() {
+        val result = FeedbackUploader.parseResponse(
+            response(200, """{"ok":true,"id":"fb-2"}"""),
+        )
+        assertTrue(result.ok)
+        assertNull(result.issueNumber)
+        assertNull(result.issueUrl)
+        assertEquals("fb-2", result.feedbackId)
+    }
+
+    @Test
+    fun `a 200 with an unparseable body is treated as a failure`() {
+        val result = FeedbackUploader.parseResponse(response(200, "<html>not json</html>"))
+        assertFalse(result.ok)
+        assertEquals(FeedbackUploader.ErrorKind.OTHER, result.errorKind)
+    }
+
+    // ── CountingSink byte accounting ─────────────────────────────────────────
+
+    @Test
+    fun `CountingSink reports the running fraction up to 1f`() {
+        val total = 1_000L
+        val fractions = mutableListOf<Float>()
+        val sink = FeedbackUploader.CountingSink(
+            blackholeSink(),
+            total,
+        ) { fractions += it }
+        val buffered = sink.buffer()
+
+        // Write the payload in four equal chunks.
+        repeat(4) {
+            buffered.write(ByteArray(250))
+            buffered.flush()
+        }
+
+        assertTrue("progress was reported", fractions.isNotEmpty())
+        assertEquals("reaches 100%", 1.0f, fractions.last(), 0.0001f)
+        // Progress is monotonically non-decreasing.
+        for (i in 1 until fractions.size) {
+            assertTrue("monotonic", fractions[i] >= fractions[i - 1])
+        }
+    }
+
+    @Test
+    fun `CountingSink never reports more than 1f even past the declared total`() {
+        val fractions = mutableListOf<Float>()
+        val sink = FeedbackUploader.CountingSink(blackholeSink(), 100L) { fractions += it }
+        val buffered = sink.buffer()
+
+        buffered.write(ByteArray(500)) // 5x the declared total
+        buffered.flush()
+
+        assertTrue(fractions.all { it <= 1.0f })
+    }
+
+    @Test
+    fun `CountingSink forwards every byte to the delegate`() {
+        val captured = Buffer()
+        val sink = FeedbackUploader.CountingSink(captured, 8L) {}
+        val buffered = sink.buffer()
+
+        buffered.write(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+        buffered.flush()
+
+        assertEquals(8L, captured.size)
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the Android in-app feedback feature (umbrella #1930) after a 6-agent review found release blockers. One PR, no scope creep.

### Blockers fixed
- **Uncapped recording → guaranteed 413** — `FeedbackRecordingService` now sets `setMaxFileSize(28 MB)` + `setMaxDuration(120 s)`, auto-stops gracefully via `OnInfoListener`, and tells the user the clip was capped. A >68 s clip could previously exceed the worker's 30 MB cap and be silently lost.
- **Unbounded demux buffer** — `AudioDemux` sizes its buffer from `MediaFormat.KEY_MAX_INPUT_SIZE` and grows-and-retries, instead of a fixed 256 KB buffer that `BufferOverflowException`-ed on a larger AAC sample.
- **Demux re-entrancy race** — the post-stop demux runs on a managed executor (cancelled in `onDestroy`), wrapped in try/catch, gated by a monotonic session id so a stale callback from a quick re-record can't clobber new state.
- **VirtualDisplay before recorder confirmed** — the `VirtualDisplay` is now created only after `MediaRecorder.start()` succeeds.
- **Feedback button missing inside demos** — added a top-app-bar feedback action to the shared `DemoScaffold`, so the button is reachable inside every demo, not just the tab host (a top-bar action, not a FAB, to avoid colliding with the demo `Tune` FAB).
- **demo-id context key mismatch** — `FeedbackContext` now emits the demo under the worker-recognised `demoId` key and drops the unlabelled `route` key; the test asserts the correct key.

### Majors fixed
- Process-death resilience: the in-flight `category` is persisted to prefs; a process death mid-`SENDING` recovers to `REVIEW` instead of stranding a spinner; the `SENDING` step always has a working cancel/close.
- Notification-permission gap: a one-time hint surfaces the in-app Stop pill when the foreground-service notification is silenced; channel bumped to `IMPORTANCE_DEFAULT`.
- A permanently-denied microphone permission routes the user to app settings (or a text-only path) instead of looping a no-op Retry.
- Upload errors now carry an `ErrorKind` (413/429/5xx/network) with tailored copy and `Retry-After` handling.
- `FeedbackTicketStatus` caches a rate-limited sentinel and unparseable-success negatives so rate-limited rows stop retrying against the 60 req/h budget.
- The "My feedback" list is re-read reactively so a just-submitted ticket appears.
- `FeedbackRecorder.reset()` defers media deletion while an upload still holds the file.
- Added JVM unit tests: uploader response parsing + `CountingSink` byte accounting, `FeedbackTicketStatus` cache semantics (MockWebServer), and the `FeedbackRecorder` state machine.
- Fixed the stale "worker not deployed" KDoc / `build.gradle` comment.

Lower-priority findings (orientation change mid-recording, opaque projection-revoked message, FAB overflow, manual ticket refresh) are batched into #2030.

## Test plan
- [x] `./gradlew :samples:android-demo:compileDebugKotlin`
- [x] `./gradlew :samples:android-demo:assembleDebug`
- [x] `./gradlew :samples:android-demo:testDebugUnitTest` (full suite green; 16 new feedback tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)