### PR TITLE
fix(flutter-ios): break method-channel retain cycle with [weak self]

### DIFF
--- a/changelog.d/2069-flutter-ios-retain-cycle.md
+++ b/changelog.d/2069-flutter-ios-retain-cycle.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **flutter ios: actually break the method-channel retain cycle ([#2069](https://github.com/sceneview/sceneview/issues/2069)).** the platform-view's `setMethodCallHandler` now installs the handler with a `[weak self]` capture; a bare method reference strong-held `self`, so the previously added `deinit` could never run and the platform view, hosting controller, and RealityKit/AR scene still leaked on every create/dispose cycle.

--- a/flutter/sceneview_flutter/ios/Classes/SceneViewPlugin.swift
+++ b/flutter/sceneview_flutter/ios/Classes/SceneViewPlugin.swift
@@ -117,14 +117,20 @@ class SceneViewPlatformView: NSObject, FlutterPlatformView {
             sceneState.autoCenterContent = autoCenter
         }
 
-        channel.setMethodCallHandler(handleMethodCall)
+        // Install the handler with a `[weak self]` capture so the channel does
+        // not strong-hold the platform view. A bare `handleMethodCall` method
+        // reference would strong-capture `self`, forming a retain cycle
+        // (self -> channel -> handler -> self) that pins the retain count
+        // above zero forever, so `deinit` would never run (issue #2069).
+        channel.setMethodCallHandler { [weak self] call, result in
+            self?.handleMethodCall(call, result: result)
+        }
     }
 
     deinit {
-        // Detach the channel handler so the retained handler block (which
-        // captures `self`) is released — otherwise the platform view, its
-        // UIHostingController, and the RealityKit scene leak on every
-        // create/dispose cycle (issue #2052).
+        // `deinit` now fires naturally because the handler no longer pins
+        // `self`. Still detach the channel handler as hygiene — the channel
+        // may outlive the platform view (issue #2052).
         channel.setMethodCallHandler(nil)
     }
 
@@ -286,14 +292,20 @@ class ARSceneViewPlatformView: NSObject, FlutterPlatformView {
         )
         super.init()
 
-        channel.setMethodCallHandler(handleMethodCall)
+        // Install the handler with a `[weak self]` capture so the channel does
+        // not strong-hold the platform view. A bare `handleMethodCall` method
+        // reference would strong-capture `self`, forming a retain cycle
+        // (self -> channel -> handler -> self) that pins the retain count
+        // above zero forever, so `deinit` would never run (issue #2069).
+        channel.setMethodCallHandler { [weak self] call, result in
+            self?.handleMethodCall(call, result: result)
+        }
     }
 
     deinit {
-        // Detach the channel handler so the retained handler block (which
-        // captures `self`) is released — otherwise the platform view, its
-        // UIHostingController, the ARSession, and the RealityKit scene leak
-        // on every create/dispose cycle (issue #2052).
+        // `deinit` now fires naturally because the handler no longer pins
+        // `self`. Still detach the channel handler as hygiene — the channel
+        // may outlive the platform view (issue #2052).
         channel.setMethodCallHandler(nil)
     }
 


### PR DESCRIPTION
## Summary

The `deinit` added in #2064 (for #2052) calling `channel.setMethodCallHandler(nil)` on `SceneViewPlatformView` / `ARSceneViewPlatformView` is **inert**. Both classes install the method-channel handler with a bare `handleMethodCall` method reference, which strong-captures `self`. That forms a retain cycle:

```
SceneViewPlatformView (self) -> channel (private let)
  -> handler closure (setMethodCallHandler)
  -> self
```

`deinit` only runs at retain count zero, but the cycle pins it permanently above zero, so `deinit` never fires and the cleanup never runs. The platform views, their `UIHostingController`s, and the RealityKit / AR scenes leak on every create/dispose cycle.

## Fix

Install the handler with a `[weak self]` capture so the channel no longer strong-holds the view:

```swift
channel.setMethodCallHandler { [weak self] call, result in
    self?.handleMethodCall(call, result: result)
}
```

The `setMethodCallHandler(nil)` reset in `deinit` is kept as hygiene — `deinit` now fires naturally, and the channel may outlive the view.

## Notes

- Applied to both call sites: `SceneViewPlatformView` (3D) and `ARSceneViewPlatformView` (AR).
- The RN iOS plugin (`react-native/.../SceneViewModule.swift`) uses `RCTViewManager` + `UIView` subclasses with `@objc` prop setters — no `FlutterMethodChannel`, no `setMethodCallHandler` — so it does **not** have the identical defect.
- CI does not compile the Flutter plugin's iOS target (#2065), so this was reasoned through manually.

## Test plan

- [ ] Build the Flutter plugin iOS target (blocked on #2065 in CI; verify locally).
- [ ] Repeatedly create/dispose a `SceneView` / `ARSceneView` platform view and confirm `deinit` fires (e.g. an `os_log` in `deinit`, or Instruments allocations).

Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)