### PR TITLE
ci: harden build-apks concurrency + pre-push-check pipe failure detection (#2098)

### DIFF
--- a/.claude/scripts/pre-push-check.sh
+++ b/.claude/scripts/pre-push-check.sh
@@ -83,12 +83,23 @@ fi
 
 # 5. Version sync
 echo -e "\n${YELLOW}[7/10] Checking version sync...${NC}"
-MISMATCHES=$(bash .claude/scripts/sync-versions.sh 2>/dev/null | grep "MISMATCH" | grep -v "migration.md" | grep -v "Errors" | wc -l | tr -d ' ')
-if [ "$MISMATCHES" = "0" ]; then
-    echo -e "${GREEN}  ✓ All versions aligned${NC}"
-else
-    echo -e "${RED}  ✗ $MISMATCHES version mismatch(es)${NC}"
+# Capture sync-versions.sh output and exit code separately, so a crash of the
+# script is not swallowed by the pipeline (a piped crash would falsely report
+# "0 mismatches"). `set -o pipefail` is deliberately NOT used globally — many
+# grep-no-match pipes elsewhere in this script rely on the lenient default.
+# sync-versions.sh exits 0 (aligned), 1 (mismatches found — expected), or 2+ (crash).
+SYNC_OUTPUT=$(bash .claude/scripts/sync-versions.sh 2>/dev/null) && SYNC_EXIT=0 || SYNC_EXIT=$?
+if [ "$SYNC_EXIT" -gt 1 ]; then
+    echo -e "${RED}  ✗ sync-versions.sh crashed (exit $SYNC_EXIT) — cannot verify versions${NC}"
     ERRORS=$((ERRORS + 1))
+else
+    MISMATCHES=$(echo "$SYNC_OUTPUT" | grep "MISMATCH" | grep -v "migration.md" | grep -v "Errors" | wc -l | tr -d ' ')
+    if [ "$MISMATCHES" = "0" ]; then
+        echo -e "${GREEN}  ✓ All versions aligned${NC}"
+    else
+        echo -e "${RED}  ✗ $MISMATCHES version mismatch(es)${NC}"
+        ERRORS=$((ERRORS + 1))
+    fi
 fi
 
 # 6. Website JS syntax

--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -25,10 +25,12 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
-# Cancel in-progress runs for the same branch/PR
+# This workflow uploads GitHub Release assets via softprops/action-gh-release on
+# tag pushes. A re-pushed/moved tag must NOT cancel an in-flight asset upload, or
+# the Release is left partial. Matches release.yml / play-store.yml / app-store.yml.
 concurrency:
   group: build-apks-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Two CI-hygiene defects from a fresh audit (distinct from #2089).

1. **`.github/workflows/build-apks.yml`** — `concurrency.cancel-in-progress` flipped `true` → `false`. This workflow uploads GitHub Release assets via `softprops/action-gh-release`; a re-pushed/moved tag could cancel an in-flight asset upload and leave a partial Release. Now matches `release.yml`, `play-store.yml`, and `app-store.yml`, which all correctly use `false`.

2. **`.claude/scripts/pre-push-check.sh`** — the version-sync check piped `sync-versions.sh` straight into `grep | wc -l` without `pipefail`, so a crash of `sync-versions.sh` was swallowed and the check falsely reported "0 mismatches" (false green). Fixed by capturing the script's stdout and exit code into a variable first, then branching: exit `0`/`1` are normal (aligned / mismatches found), exit `2+` is treated as a crash and counts as an error. `set -o pipefail` is deliberately **not** enabled globally — many `grep`-no-match pipes elsewhere in the script rely on the lenient default.

## Test plan

- [x] `bash -n .claude/scripts/pre-push-check.sh` passes
- [x] YAML change is a one-line value flip
- [ ] CI green on PR

Closes #2098