### PR TITLE
ci: stop cancel-in-progress cascade from killing open PRs' in-flight CI (#2089)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,21 @@ on:
         type: boolean
         default: false
 
-# Cancel in-progress runs for the same branch/PR to save resources
+# Cancel only a genuinely superseded run, never an unrelated PR's CI (#2089).
+#
+# The old `group: ci-${{ github.ref }}` keyed on `refs/pull/N/merge` for PRs.
+# Merging any PR to `main` makes GitHub recompute EVERY other open PR's merge
+# ref, re-firing their `pull_request` event under the SAME group key — so
+# `cancel-in-progress` killed their in-flight ~30-49 min `Unit tests` job, a
+# cancelled check that left `CI Gate` red and blocked squash auto-merge
+# (bit #2062 and #1818).
+#
+# Keying on the PR HEAD sha instead means a run is cancelled ONLY when a new
+# commit is genuinely pushed to that same PR — a base-ref recompute keeps the
+# head sha unchanged, so other PRs' runs are left alone. `push`/`dispatch`
+# events have no `pull_request` context and fall back to `github.ref`.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml`'s `concurrency` block keyed on `ci-${{ github.ref }}`. For PR events `github.ref` is `refs/pull/N/merge`. When any PR merges to `main`, GitHub recomputes the merge ref of every other open PR, re-firing their `pull_request` event under the **same** group key — and `cancel-in-progress: true` then cancelled their in-flight ~30-49 min `Unit tests` job. A cancelled check leaves `CI Gate` red, so squash auto-merge can never fire and the PR is stuck. This bit #2062 and #1818.

## Fix

Key the concurrency group on the PR **head sha** (`github.event.pull_request.head.sha`) instead of the merge ref, with a fallback to `github.ref` for `push` / `workflow_dispatch` events:

```yaml
concurrency:
  group: ci-${{ github.event.pull_request.head.sha || github.ref }}
  cancel-in-progress: true
```

A run is now cancelled **only** when a new commit is genuinely pushed to that same PR (its head sha changes). A base-ref recompute caused by an unrelated merge keeps each PR's head sha unchanged, so their in-flight CI is left alone. Within-PR superseding still works — pushing a fresh commit produces a new head sha and cancels the stale run as before. No test is weakened.

`cancel-in-progress: true` is kept so genuine within-PR push-spam still self-cancels; only the cross-PR cascade is eliminated.

## Verify

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -> YAML well-formed.

Closes #2089