### PR TITLE
fix(android-demo): surface model-resolution failure instead of hanging on Streaming (#2088)

### DIFF
--- a/changelog.d/2088-demo-streaming-hang.md
+++ b/changelog.d/2088-demo-streaming-hang.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **`materials` and `scene-gallery` Android demos no longer hang on "Streaming…" ([#2088](https://github.com/sceneview/sceneview/issues/2088)).** A failed model resolution is now captured into an error state and surfaced with an error scrim and a Retry button, instead of being swallowed into a `null` path that left the loading scrim spinning forever. Both demos are flagged `DemoStatus.KnownIssue` so the Samples grid shows an honest known-issue chip.

--- a/llms.txt
+++ b/llms.txt
@@ -3962,7 +3962,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `custom-mesh` — Custom Mesh. Custom vertex and index buffers.
 - `debug-overlay` — Debug Overlay. Performance stats overlay.
 - `double-pendulum` — Double Pendulum. Chaotic two-link physics, shared KMP simulation.
-- `materials` — PBR Materials. PBR metallic and roughness spectrum.
+- `materials` — PBR Materials. KHR_materials_* extension showcase — sheen, transmission, iridescence.
 - `occlusion-material` — Occlusion Material. Invisible depth-writing surface hides content behind it.
 - `physics` — Physics. Gravity, collisions, and rigid bodies.
 - `post-processing` — Post Processing. SSAO, anti-aliasing, and tone mapping.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -65,6 +66,67 @@ fun LoadingScrim(loading: Boolean, label: String = "Loading…") {
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
+        }
+    }
+}
+
+/**
+ * Error overlay that covers the 3D viewport when a model fails to resolve or load.
+ *
+ * Streamed demos ([io.github.sceneview.demo.demos.SceneGalleryDemo],
+ * [io.github.sceneview.demo.demos.MaterialsDemo]) used to wrap their
+ * `resolver.resolve()` call in `runCatching { … }.getOrNull()`. On a
+ * `FallbackUnavailable` throw (or any failure) the resolved path stayed `null`
+ * forever and the [LoadingScrim] hung on "Streaming…" with nothing surfaced to
+ * the user (#2088). [ErrorScrim] replaces that dead-end with an honest error
+ * card and a [onRetry] button — the Android counterpart of the iOS demo's
+ * `loadError` state.
+ *
+ * Render it as the last child of the [Box] that wraps the SceneView, mutually
+ * exclusive with [LoadingScrim] (show the error scrim when an error state is
+ * set, the loading scrim otherwise).
+ *
+ * @param message Short human-readable failure reason (e.g. the exception
+ *                message). Shown under the headline.
+ * @param onRetry Invoked when the user taps the retry button — re-trigger the
+ *                resolve/load by clearing the error state.
+ */
+@Composable
+fun ErrorScrim(
+    message: String,
+    onRetry: () -> Unit,
+    label: String = "Couldn't load model",
+    retryLabel: String = "Retry",
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.55f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.92f))
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Button(onClick = onRetry) {
+                Text(retryLabel)
+            }
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.ErrorScrim
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
@@ -77,6 +78,11 @@ fun MaterialsDemo(onBack: () -> Unit) {
     var selectedIndex by remember { mutableStateOf(0) }
     val selectedSlug = slugs.getOrNull(selectedIndex)
 
+    // Bumped by the error scrim's Retry button. It is a `produceState` key so a
+    // tap re-runs the resolve coroutine for the same slug instead of leaving the
+    // demo stuck on a failed resolution forever (#2088).
+    var retryTick by remember { mutableStateOf(0) }
+
     LaunchedEffect(resolver) {
         runCatching { resolver.prefetchAll("materials") }
     }
@@ -97,18 +103,25 @@ fun MaterialsDemo(onBack: () -> Unit) {
     val fallbackEnvironment = rememberEnvironment(environmentLoader)
     val activeEnvironment = hdrEnvironment ?: fallbackEnvironment
 
-    val resolvedPath: String? by produceState<String?>(
-        initialValue = null,
+    // A failed resolve is surfaced as [MaterialResolveState.Error] instead of
+    // being swallowed into a `null` path that hangs the loading scrim forever
+    // (#2088). `retryTick` re-runs the resolve when the user taps Retry.
+    val resolveState: MaterialResolveState by produceState<MaterialResolveState>(
+        initialValue = MaterialResolveState.Loading,
         key1 = resolver,
         key2 = selectedSlug?.uid,
+        key3 = retryTick,
     ) {
-        value = null
+        value = MaterialResolveState.Loading
         val slug = selectedSlug ?: return@produceState
         value = runCatching { resolver.resolve(slug) }
-            .getOrNull()
-            ?.toURI()
-            ?.toString()
+            .fold(
+                onSuccess = { MaterialResolveState.Resolved(it.toURI().toString()) },
+                onFailure = { MaterialResolveState.Error(it.message ?: it.javaClass.simpleName) },
+            )
     }
+    val resolvedPath = (resolveState as? MaterialResolveState.Resolved)?.path
+    val resolveError = (resolveState as? MaterialResolveState.Error)?.message
 
     val modelInstance = resolvedPath?.let { path ->
         rememberModelInstance(modelLoader, path)
@@ -185,10 +198,33 @@ fun MaterialsDemo(onBack: () -> Unit) {
                     )
                 }
             }
-            LoadingScrim(
-                loading = modelInstance == null,
-                label = stringResource(R.string.demo_materials_loading),
-            )
+            // Mutually exclusive with LoadingScrim: a resolve failure shows the
+            // error scrim (with Retry) instead of hanging on "Streaming…" (#2088).
+            if (resolveError != null) {
+                ErrorScrim(
+                    message = resolveError,
+                    onRetry = { retryTick++ },
+                    label = stringResource(R.string.demo_materials_error),
+                    retryLabel = stringResource(R.string.demo_materials_retry),
+                )
+            } else {
+                LoadingScrim(
+                    loading = modelInstance == null,
+                    label = stringResource(R.string.demo_materials_loading),
+                )
+            }
         }
     }
+}
+
+/** Resolution lifecycle for a streamed material slug. See [MaterialsDemo]. */
+private sealed interface MaterialResolveState {
+    /** Resolve coroutine in flight. */
+    data object Loading : MaterialResolveState
+
+    /** Resolve succeeded — [path] is a `file://` URL ready for the model loader. */
+    data class Resolved(val path: String) : MaterialResolveState
+
+    /** Resolve failed — [message] is a short human-readable reason. */
+    data class Error(val message: String) : MaterialResolveState
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SceneGalleryDemo.kt
@@ -24,6 +24,7 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.demo.AssetSourceState
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.sketchfab.SketchfabConfig
+import io.github.sceneview.demo.ErrorScrim
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberFirstFrameState
@@ -76,6 +77,11 @@ fun SceneGalleryDemo(onBack: () -> Unit) {
     var selectedIndex by remember { mutableStateOf(0) }
     val selectedSlug = slugs.getOrNull(selectedIndex)
 
+    // Bumped by the error scrim's Retry button. It is a `produceState` key so a
+    // tap re-runs the resolve coroutine for the same slug instead of leaving the
+    // demo stuck on a failed resolution forever (#2088).
+    var retryTick by remember { mutableStateOf(0) }
+
     // Warm every gallery slug in parallel on first frame so chip taps switch
     // instantly after the cold-start download. The resolver is idempotent
     // (cache-hit -> touches lastModified only) so re-running is cheap.
@@ -89,19 +95,26 @@ fun SceneGalleryDemo(onBack: () -> Unit) {
 
     // Resolve the slug to a local file. produceState delegates IO + retries to
     // the resolver; the `key1 = selectedSlug` rebinds the file when the user
-    // picks a new chip without leaking any prior coroutine.
-    val resolvedPath: String? by produceState<String?>(
-        initialValue = null,
+    // picks a new chip without leaking any prior coroutine. A failed resolve is
+    // surfaced as [ResolveState.Error] instead of being swallowed into a `null`
+    // path that hangs the loading scrim forever (#2088). `retryTick` re-runs the
+    // resolve when the user taps Retry.
+    val resolveState: ResolveState by produceState<ResolveState>(
+        initialValue = ResolveState.Loading,
         key1 = resolver,
         key2 = selectedSlug?.uid,
+        key3 = retryTick,
     ) {
-        value = null
+        value = ResolveState.Loading
         val slug = selectedSlug ?: return@produceState
         value = runCatching { resolver.resolve(slug) }
-            .getOrNull()
-            ?.toURI()
-            ?.toString()
+            .fold(
+                onSuccess = { ResolveState.Resolved(it.toURI().toString()) },
+                onFailure = { ResolveState.Error(it.message ?: it.javaClass.simpleName) },
+            )
     }
+    val resolvedPath = (resolveState as? ResolveState.Resolved)?.path
+    val resolveError = (resolveState as? ResolveState.Error)?.message
 
     val modelInstance = resolvedPath?.let { path ->
         // `rememberModelInstance(modelLoader, fileLocation)` accepts a `file://`
@@ -196,10 +209,33 @@ fun SceneGalleryDemo(onBack: () -> Unit) {
                     )
                 }
             }
-            LoadingScrim(
-                loading = modelInstance == null,
-                label = stringResource(R.string.demo_scene_gallery_loading),
-            )
+            // Mutually exclusive with LoadingScrim: a resolve failure shows the
+            // error scrim (with Retry) instead of hanging on "Streaming…" (#2088).
+            if (resolveError != null) {
+                ErrorScrim(
+                    message = resolveError,
+                    onRetry = { retryTick++ },
+                    label = stringResource(R.string.demo_scene_gallery_error),
+                    retryLabel = stringResource(R.string.demo_scene_gallery_retry),
+                )
+            } else {
+                LoadingScrim(
+                    loading = modelInstance == null,
+                    label = stringResource(R.string.demo_scene_gallery_loading),
+                )
+            }
         }
     }
+}
+
+/** Resolution lifecycle for a streamed gallery slug. See [SceneGalleryDemo]. */
+private sealed interface ResolveState {
+    /** Resolve coroutine in flight. */
+    data object Loading : ResolveState
+
+    /** Resolve succeeded — [path] is a `file://` URL ready for the model loader. */
+    data class Resolved(val path: String) : ResolveState
+
+    /** Resolve failed — [message] is a short human-readable reason. */
+    data class Error(val message: String) : ResolveState
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/MaterialsFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/MaterialsFragment.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.runtime.Composable
 import io.github.sceneview.demo.DemoCategory
 import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.DemoStatus
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.demos.MaterialsDemo
 
@@ -16,6 +17,10 @@ object MaterialsFragment : DemoFragment {
         subtitleRes = R.string.demo_materials_subtitle,
         category = DemoCategory.ADVANCED,
         icon = Icons.Filled.Palette,
+        // Streamed Sketchfab slugs can fail to resolve; the demo now surfaces an
+        // error scrim with Retry rather than hanging, but the model may still be
+        // unavailable, so the grid carries a known-issue chip (#2088).
+        status = DemoStatus.KnownIssue,
     )
 
     @Composable

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/SceneGalleryFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/SceneGalleryFragment.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.Collections
 import androidx.compose.runtime.Composable
 import io.github.sceneview.demo.DemoCategory
 import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.DemoStatus
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.demos.SceneGalleryDemo
 
@@ -16,6 +17,10 @@ object SceneGalleryFragment : DemoFragment {
         subtitleRes = R.string.demo_scene_gallery_subtitle,
         category = DemoCategory.BASICS_3D,
         icon = Icons.Filled.Collections,
+        // Streamed Sketchfab slugs can fail to resolve; the demo now surfaces an
+        // error scrim with Retry rather than hanging, but the model may still be
+        // unavailable, so the grid carries a known-issue chip (#2088).
+        status = DemoStatus.KnownIssue,
     )
 
     @Composable

--- a/samples/android-demo/src/main/res/values/strings_demo_materials.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_materials.xml
@@ -6,7 +6,9 @@
      this file or `strings.xml` — see #1870. -->
 <resources>
     <string name="demo_materials_title">PBR Materials</string>
-    <string name="demo_materials_subtitle">PBR metallic and roughness spectrum</string>
+    <string name="demo_materials_subtitle">KHR_materials_* extension showcase — sheen, transmission, iridescence</string>
     <string name="demo_materials_credit">by %1$s · CC-BY 4.0</string>
     <string name="demo_materials_loading">Streaming material…</string>
+    <string name="demo_materials_error">Couldn\'t load this material</string>
+    <string name="demo_materials_retry">Retry</string>
 </resources>

--- a/samples/android-demo/src/main/res/values/strings_demo_scene_gallery.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_scene_gallery.xml
@@ -9,4 +9,6 @@
     <string name="demo_scene_gallery_subtitle">Themed Sketchfab bundles streamed on demand</string>
     <string name="demo_scene_gallery_credit">by %1$s · CC-BY 4.0</string>
     <string name="demo_scene_gallery_loading">Streaming model…</string>
+    <string name="demo_scene_gallery_error">Couldn\'t load this model</string>
+    <string name="demo_scene_gallery_retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary

`materials` and `scene-gallery` Android demos hung on "Streaming…" forever when a streamed Sketchfab model failed to resolve.

`SceneGalleryDemo.kt` and `MaterialsDemo.kt` wrapped `resolver.resolve()` in `runCatching{}.getOrNull()`. On a `FallbackUnavailable` throw (or any failure) `resolvedPath` stayed `null` forever, `modelInstance` never resolved, and `LoadingScrim(loading = modelInstance == null)` spun on "Streaming…" with no error surfaced. The iOS demo at least sets a `loadError` state — this brings Android to parity.

## Changes

- **Surface the failure** — both demos now capture the resolve outcome into a sealed `ResolveState` / `MaterialResolveState` (`Loading` / `Resolved` / `Error`). A failure renders a new `ErrorScrim` (error card + **Retry** button) over the viewport instead of the infinite loading scrim. Retry bumps a `retryTick` `produceState` key so the resolve re-runs.
- **`ErrorScrim`** added to `DemoHelpers.kt` — reusable error overlay, mutually exclusive with `LoadingScrim`, mirroring the iOS `loadError` UX.
- **Registry honesty** — `MaterialsFragment` / `SceneGalleryFragment` flipped to `DemoStatus.KnownIssue` so the Samples grid shows an honest known-issue chip.
- **Stale subtitle** — corrected the `materials` demo subtitle (it no longer is a metallic/roughness sphere spectrum). The `MaterialsDemo.kt` "three curated slugs" docstring was already accurate (3 `materials` slugs exist in `SampleAssets`) and was left unchanged.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes
- [ ] On a device with no Sketchfab key and a missing bundled fallback, both demos show the error scrim + Retry instead of an infinite "Streaming…" spinner

Closes #2088

🤖 Generated with [Claude Code](https://claude.com/claude-code)