### PR TITLE
fix(android-demo): remember per-demo bottom-sheet detent across process death (#2084)

### DIFF
--- a/changelog.d/2084-sheet-detent.md
+++ b/changelog.d/2084-sheet-detent.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Demo settings sheet remembers its last detent per demo ([#2084](https://github.com/sceneview/sceneview/issues/2084)).** The demo-app settings bottom sheet now reopens at the detent (partially-expanded vs fully-expanded) the user last left it at, individually for each demo. The detent is persisted in `SharedPreferences` keyed by demo title, so it survives navigating away from the demo and full process death. A demo never opened before still defaults to the partial detent.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -65,6 +66,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.haptic.SceneViewHaptic
 import io.github.sceneview.haptic.rememberHapticFeedback
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -104,7 +107,10 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
  *   `null` so legacy demos stay untouched.
  *
  * Gestures:
- * - **Tap FAB / tap peek chip** → opens the sheet at its partial detent.
+ * - **Tap FAB / tap peek chip** → opens the sheet at the detent this demo was
+ *   last left at — partial for a demo never opened before, or whatever detent
+ *   the user last settled it on (#2084, persisted per demo across process
+ *   death via [DemoSheetDetentStore]).
  * - **Long-press peek chip** → toggles `DemoSettings.qaMode` (deterministic
  *   captures for screenshot suites). Previously this gesture lived on the
  *   top-app-bar title; moved to the peek chip so the title can carry the demo
@@ -292,6 +298,7 @@ fun DemoScaffold(
 
             if (controls != null) {
                 DemoSettingsLayer(
+                    demoTitle = title,
                     controlsContent = controls,
                     haptic = haptic,
                     peekHeader = peekHeader,
@@ -424,15 +431,32 @@ object DemoScaffoldTestTags {
  * Peek chip + FAB + ModalBottomSheet — pulled into its own composable so the
  * sheet `LaunchedEffect`s scope to the `expanded` state without re-running on
  * every recomposition of the parent Scaffold body.
+ *
+ * [demoTitle] keys the per-demo last-detent memory (#2084): when the sheet is
+ * (re-)created it opens at the detent the user last settled it at for *this*
+ * demo, persisted in [DemoSheetDetentStore] so it survives navigation away from
+ * the demo and full process death — a demo never seen before defaults to the
+ * partial detent (unchanged behaviour).
  */
 @Composable
 private fun BoxScope.DemoSettingsLayer(
+    demoTitle: String,
     controlsContent: @Composable ColumnScope.() -> Unit,
     haptic: SceneViewHaptic,
     peekHeader: String? = null,
     onResetSettings: (() -> Unit)? = null,
 ) {
+    val context = androidx.compose.ui.platform.LocalContext.current
     var expanded by rememberSaveable { mutableStateOf(false) }
+    // Per-demo last-detent memory (#2084): read the persisted detent so the
+    // sheet can reopen where the user last left it for this demo. Resolved
+    // against the persistent settings store ([DemoSheetDetentStore]), so it
+    // survives navigating away from the demo and process death — not just
+    // config changes. A demo never opened before resolves to
+    // `PartiallyExpanded`, the unchanged default.
+    val restoredDetent: SheetValue = remember(demoTitle) {
+        DemoSheetDetentStore.lastDetent(context, demoTitle)
+    }
     val sheetState: SheetState = rememberModalBottomSheetState(
         // partially expanded is the default open state — keeps ~45 % of viewport
         // visible so the showcase stays alive while you tweak settings.
@@ -452,7 +476,8 @@ private fun BoxScope.DemoSettingsLayer(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         // Peek chip — only shown while the sheet is closed. Tap opens the sheet
-        // at the partial detent (same as tapping the FAB). Long-press toggles
+        // at this demo's last-used detent (#2084, same as tapping the FAB).
+        // Long-press toggles
         // QA mode (deterministic captures for screenshot suites — previously
         // on the top-bar title). The chip is intentionally semi-transparent so
         // it disappears against busy 3D scenes but stays legible on plain
@@ -575,8 +600,9 @@ private fun BoxScope.DemoSettingsLayer(
 
         // Medium-tick haptic when the user moves between detents.
         //
-        // `rememberModalBottomSheetState` starts at `SheetValue.Hidden`, so this
-        // effect fires once with `Hidden` *before* the sheet has animated open.
+        // The `SheetState` starts at `SheetValue.Hidden` (the sheet animates
+        // open from hidden to its restored #2084 detent), so this effect fires
+        // once with `Hidden` *before* the sheet has animated open.
         // Treating that initial value as a dismiss would slam `expanded = false`
         // and kill the sheet on every demo (#1420). Only honour `Hidden` as a
         // dismiss after the sheet has actually settled in a shown detent at
@@ -584,12 +610,39 @@ private fun BoxScope.DemoSettingsLayer(
         // handled by `onDismissRequest`, this branch just keeps `expanded` in
         // sync if the sheet collapses by any other path.
         var hasShown by remember { mutableStateOf(false) }
+
+        // #2084: restore this demo's last-used detent. `rememberModalBottomSheetState`
+        // always animates open to `PartiallyExpanded`, so when the persisted
+        // detent is `Expanded` we expand the sheet the rest of the way as a
+        // one-shot, right after it first settles in a shown detent. Keyed to
+        // `expanded` so it re-arms each time the sheet is (re-)opened. A
+        // never-seen demo resolves to `PartiallyExpanded` → this is a no-op and
+        // the unchanged default behaviour holds.
+        LaunchedEffect(expanded) {
+            if (restoredDetent == SheetValue.Expanded) {
+                snapshotFlow { sheetState.currentValue }
+                    .filter { it != SheetValue.Hidden }
+                    .first()
+                if (sheetState.currentValue != SheetValue.Expanded) {
+                    sheetState.expand()
+                }
+            }
+        }
+
         LaunchedEffect(sheetState.currentValue) {
             when (sheetState.currentValue) {
                 SheetValue.Expanded,
                 SheetValue.PartiallyExpanded -> {
                     hasShown = true
                     haptic.selection()
+                    // #2084: persist the detent the user just settled on so this
+                    // demo's sheet reopens here next time — including after the
+                    // demo screen leaves composition or the process is killed.
+                    DemoSheetDetentStore.setLastDetent(
+                        context,
+                        demoTitle,
+                        sheetState.currentValue,
+                    )
                 }
                 SheetValue.Hidden -> {
                     if (hasShown) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSheetDetentStore.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSheetDetentStore.kt
@@ -1,0 +1,76 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package io.github.sceneview.demo
+
+import android.content.Context
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+
+/**
+ * Per-demo memory of the last settled detent of the demo settings
+ * [androidx.compose.material3.ModalBottomSheet] — issue #2084, the final open
+ * sub-item of the bottom-sheet umbrella (#1154 Stage 3).
+ *
+ * Without this the sheet always re-opens at [SheetValue.PartiallyExpanded]. A
+ * power user who, for a control-heavy demo (e.g. `DynamicSkyDemo`), always wants
+ * the **fully-expanded** sheet had to re-drag it up on every single open. This
+ * store records the detent the user last left the sheet at, **per demo**, so
+ * each demo reopens its sheet exactly where it was last used.
+ *
+ * **Why SharedPreferences, not `rememberSaveable`.** `rememberSaveable` only
+ * survives configuration changes and process death *while the saved-state
+ * bundle is retained* — it is lost once the user navigates away from the demo
+ * (the composable leaves composition) or the bundle is dropped. A genuinely
+ * "sticky per-demo" preference must outlive the demo screen's lifecycle, so it
+ * lives in a persistent settings store. The footprint is a couple of
+ * single-byte ints — `SharedPreferences` is the right tool (DataStore would add
+ * ~1.5 MB to the APK for no real gain — same call as [RecentSearchesStore]).
+ *
+ * **Per-demo key strategy (#2084 design decision — option b).** The umbrella's
+ * hard rule is "38 demo call-sites × 0 call-site changes", so we cannot thread
+ * an explicit `demoId` through [DemoScaffold]. Instead the key is derived from
+ * the `title: String` already passed to every [DemoScaffold] call — call sites
+ * stay byte-identical and the public signature is unchanged. Demo titles are
+ * unique (each is a distinct human-readable screen name), so a title is a
+ * stable per-demo key. The title is namespaced under a `detent.` prefix inside
+ * a dedicated prefs file so it can never collide with another setting.
+ */
+object DemoSheetDetentStore {
+    private const val PREFS = "sceneview_demo_sheet_detent"
+    private const val KEY_PREFIX = "detent."
+
+    // SheetValue is not Parcelable/persistable directly; map to a stable int.
+    private const val PARTIALLY_EXPANDED = 0
+    private const val EXPANDED = 1
+
+    /**
+     * The detent the demo titled [demoTitle] should reopen its settings sheet
+     * at. [SheetValue.PartiallyExpanded] for a demo never seen before (the
+     * unchanged default behaviour) — [SheetValue.Expanded] only once the user
+     * has settled the sheet there at least once.
+     */
+    fun lastDetent(context: Context, demoTitle: String): SheetValue =
+        when (prefs(context).getInt(KEY_PREFIX + demoTitle, PARTIALLY_EXPANDED)) {
+            EXPANDED -> SheetValue.Expanded
+            else -> SheetValue.PartiallyExpanded
+        }
+
+    /**
+     * Persist [detent] as the last settled detent for the demo titled
+     * [demoTitle]. [SheetValue.Hidden] is ignored — only the two *shown*
+     * detents are meaningful to restore; a dismissed sheet must still reopen at
+     * whichever shown detent the user last left it.
+     */
+    fun setLastDetent(context: Context, demoTitle: String, detent: SheetValue) {
+        val encoded = when (detent) {
+            SheetValue.Expanded -> EXPANDED
+            SheetValue.PartiallyExpanded -> PARTIALLY_EXPANDED
+            SheetValue.Hidden -> return
+        }
+        prefs(context).edit().putInt(KEY_PREFIX + demoTitle, encoded).apply()
+    }
+
+    // applicationContext — prefs access must never pin an Activity context.
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}


### PR DESCRIPTION
## Summary

The demo-app settings `ModalBottomSheet` (`DemoScaffold` v2) always re-opened at the **partial detent**. A power user who, for a control-heavy demo (e.g. `DynamicSkyDemo`), always wants the **fully-expanded** sheet had to re-drag it up on every single open — and after process death the `rememberModalBottomSheetState` detent was lost entirely. This is the final open sub-item of the bottom-sheet umbrella #1154 (Stage 3).

## How / where the detent is persisted

- **New `DemoSheetDetentStore`** — a `SharedPreferences`-backed object (same lightweight pattern as `FeedbackPrefs` / `RecentSearchesStore`; no DataStore dependency for two single-byte ints). It maps each demo's last *settled* detent (`PartiallyExpanded` / `Expanded`) to a stable int and back.
- **Per-demo key strategy — option (b) from the issue.** The umbrella's hard rule is "38 demo call-sites × 0 call-site changes", so an explicit `demoId` is **not** threaded through `DemoScaffold`. The key is derived from the `title: String` already passed to every `DemoScaffold` call — call sites stay byte-identical, the public signature is unchanged. Demo titles are unique (each a distinct screen name), namespaced under a `detent.` prefix in a dedicated prefs file so they can't collide with other settings.
- **Restore.** `DemoSettingsLayer` reads the persisted detent when the sheet layer composes. Since `rememberModalBottomSheetState` always animates open to `PartiallyExpanded` with no `initialValue` hook, a one-shot `LaunchedEffect` (keyed to `expanded`, re-arms per open) `expand()`s the sheet once it has first settled, when the persisted detent is `Expanded`.
- **Persist.** The existing `currentValue` `LaunchedEffect` now writes the settled detent to `DemoSheetDetentStore` on every detent change. The value lives in the persistent store, so it survives navigating away from the demo and full process death — not just config changes.
- A demo never opened before resolves to `PartiallyExpanded` → no-op, **unchanged default behaviour**.

## Files changed

- `samples/android-demo/.../DemoSheetDetentStore.kt` — new persistence store.
- `samples/android-demo/.../DemoScaffold.kt` — `DemoSettingsLayer` takes `demoTitle`, restores + persists the detent.
- `changelog.d/2084-sheet-detent.md` — `Fixed` fragment.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` passes.
- [ ] Visual smoke on a device: open `DynamicSkyDemo`, expand the settings sheet fully, close, re-open → opens expanded. A fresh demo still opens at the partial detent. Kill the process and reopen → expanded detent restored.

Closes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)