### PR TITLE
fix(ios-demo): guard iOS-only SwiftUI APIs so the macOS target archives (#1794)

### DIFF
--- a/changelog.d/1794-macos-swiftui-guards.md
+++ b/changelog.d/1794-macos-swiftui-guards.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **macOS demo target archives again ([#1794](https://github.com/sceneview/sceneview/issues/1794)).** Guarded iOS-only SwiftUI APIs in the shared `samples/ios-demo` Swift source so the `SceneViewDemo` macOS target compiles: added cross-platform `Color.systemBackground` / `secondarySystemBackground` / `tertiarySystemBackground` helpers and a `navigationBarTitleInline()` modifier in `Theme.swift`, `#if os(iOS)`-guarded the iOS 18 `.zoom(sourceID:in:)` navigation transition and the `topBarTrailing` toolbar placement.

--- a/samples/ios-demo/SceneViewDemo/Theme.swift
+++ b/samples/ios-demo/SceneViewDemo/Theme.swift
@@ -25,11 +25,13 @@ enum SceneViewTheme {
 
     // MARK: - Semantic Colors
 
-    /// Surface for elevated cards/sheets
-    static let surfaceElevated = Color(.systemBackground)
+    /// Surface for elevated cards/sheets — `systemBackground` on iOS,
+    /// `windowBackgroundColor` on macOS.
+    static let surfaceElevated = Color.systemBackground
 
-    /// Secondary surface (grouped backgrounds)
-    static let surfaceGrouped = Color(.secondarySystemBackground)
+    /// Secondary surface (grouped backgrounds) — `secondarySystemBackground`
+    /// on iOS, `underPageBackgroundColor` on macOS.
+    static let surfaceGrouped = Color.secondarySystemBackground
 
     // MARK: - Typography
 
@@ -98,9 +100,60 @@ extension Color {
     }
 }
 
+// MARK: - Cross-platform System Colors
+
+extension Color {
+    /// `UIColor.systemBackground` on iOS; `NSColor.windowBackgroundColor` on macOS.
+    static var systemBackground: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .systemBackground)
+        #elseif canImport(AppKit)
+        Color(nsColor: .windowBackgroundColor)
+        #else
+        Color(white: 1)
+        #endif
+    }
+
+    /// `UIColor.secondarySystemBackground` on iOS;
+    /// `NSColor.underPageBackgroundColor` on macOS.
+    static var secondarySystemBackground: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .secondarySystemBackground)
+        #elseif canImport(AppKit)
+        Color(nsColor: .underPageBackgroundColor)
+        #else
+        Color(white: 0.95)
+        #endif
+    }
+
+    /// `UIColor.tertiarySystemBackground` on iOS;
+    /// `NSColor.controlBackgroundColor` on macOS.
+    static var tertiarySystemBackground: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .tertiarySystemBackground)
+        #elseif canImport(AppKit)
+        Color(nsColor: .controlBackgroundColor)
+        #else
+        Color(white: 0.92)
+        #endif
+    }
+}
+
 // MARK: - View Modifiers
 
 extension View {
+    /// Applies `.navigationBarTitleDisplayMode(.inline)` on iOS; a no-op on
+    /// macOS, where the modifier is unavailable. Lets shared SwiftUI code
+    /// request an inline navigation title without per-call-site `#if os`.
+    @ViewBuilder
+    func navigationBarTitleInline() -> some View {
+        #if os(iOS)
+        self.navigationBarTitleDisplayMode(.inline)
+        #else
+        self
+        #endif
+    }
+
     /// Apply SceneView card styling
     func sceneViewCard() -> some View {
         self

--- a/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
@@ -79,9 +79,7 @@ struct ComingSoonScreen: View {
             .frame(maxWidth: .infinity)
         }
         .navigationTitle("Coming soon")
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
+        .navigationBarTitleInline()
     }
 }
 

--- a/samples/ios-demo/SceneViewDemo/Views/CreditsSheet.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/CreditsSheet.swift
@@ -56,11 +56,17 @@ struct CreditsSheet: View {
                 .padding(.vertical, 16)
             }
             .navigationTitle("Streamed model credits")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleInline()
             .toolbar {
+                #if os(iOS)
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
+                #else
+                ToolbarItem(placement: .automatic) {
+                    Button("Done") { dismiss() }
+                }
+                #endif
             }
         }
     }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARLightingDemo.swift
@@ -88,7 +88,7 @@ struct ARLightingDemo: View {
             }
         }
         .navigationTitle("AR Lighting")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleInline()
     }
 
     // MARK: - AR Scene

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
@@ -135,7 +135,7 @@ struct OrbitalARDemo: View {
             }
         }
         .navigationTitle("Orbital AR")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleInline()
         .onDisappear {
             orbitTimer?.invalidate()
             orbitTimer = nil

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
@@ -133,7 +133,7 @@ struct ARTab: View {
             NavigationStack {
                 demo.destination
                     .navigationTitle(demo.title)
-                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationBarTitleInline()
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Close") { presentedDemo = nil }
@@ -418,7 +418,7 @@ struct ARTab: View {
                 .padding(16)
             }
             .navigationTitle("Pick a model")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleInline()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") { showModelPicker = false }

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
@@ -328,10 +328,14 @@ struct ExploreTab: View {
                     // matchedTransitionSource lives on the FeaturedSketchfabCard
                     // identified by `(viewingFeedID, model.uid)` since the same
                     // Sketchfab model can appear in more than one carousel.
+                    // `.zoom(sourceID:in:)` is unavailable on macOS, where the
+                    // destination simply pushes with the default transition.
+                    #if os(iOS)
                     .navigationTransition(.zoom(
                         sourceID: "sketchfab-hero-\(viewingFeedID ?? "any")-\(model.uid)",
                         in: heroNamespace
                     ))
+                    #endif
             }
             .sheet(item: $selectedCategory) { category in
                 CategorySheet(category: category) { query in
@@ -684,7 +688,7 @@ private struct FeaturedSketchfabCard: View {
                         switch phase {
                         case .empty:
                             ZStack {
-                                Color(.tertiarySystemBackground)
+                                Color.tertiarySystemBackground
                                 ProgressView()
                                     .controlSize(.small)
                             }
@@ -694,13 +698,13 @@ private struct FeaturedSketchfabCard: View {
                                 .aspectRatio(contentMode: .fill)
                         case .failure:
                             ZStack {
-                                Color(.tertiarySystemBackground)
+                                Color.tertiarySystemBackground
                                 Image(systemName: "photo")
                                     .font(.title2)
                                     .foregroundStyle(.secondary)
                             }
                         @unknown default:
-                            Color(.tertiarySystemBackground)
+                            Color.tertiarySystemBackground
                         }
                     }
                     .frame(width: 200, height: 160)
@@ -813,9 +817,7 @@ private struct SamplePromoCard: View {
         NavigationLink {
             destination()
                 .navigationTitle(title)
-                #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
-                #endif
+                .navigationBarTitleInline()
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 ZStack(alignment: .bottomLeading) {
@@ -982,9 +984,7 @@ private struct CategorySheet: View {
                 Spacer()
             }
             .navigationTitle("Category")
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
+            .navigationBarTitleInline()
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button("Done") { dismiss() }
@@ -1045,7 +1045,7 @@ private struct ModelCard: View {
                 .padding(.horizontal, 4)
             }
             .padding(8)
-            .background(Color(.secondarySystemBackground))
+            .background(Color.secondarySystemBackground)
             .clipShape(RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(.plain)
@@ -1122,9 +1122,7 @@ struct ModelViewerScreen: View {
             }
         }
         .navigationTitle(model.name)
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
+        .navigationBarTitleInline()
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 Button {
@@ -1420,9 +1418,7 @@ struct SketchfabModelViewerScreen: View {
             }
         }
         .navigationTitle(model.name)
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
+        .navigationBarTitleInline()
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -183,9 +183,7 @@ struct SamplesTab: View {
         case .available:
             scene.destination
                 .navigationTitle(scene.title)
-                #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
-                #endif
+                .navigationBarTitleInline()
         case .comingSoon:
             ComingSoonScreen(
                 title: scene.title,


### PR DESCRIPTION
## Summary

The `SceneViewDemo` macOS target failed to archive because shared SwiftUI code used UIKit / iOS-only APIs that don't exist on macOS. This surfaced once the macOS deploy job ran for the first time (`MACOS_PROVISIONING_PROFILE_BASE64` secret added).

Fixes:

- **`systemBackground` / `secondarySystemBackground` / `tertiarySystemBackground`** — added cross-platform `Color.systemBackground`, `Color.secondarySystemBackground`, `Color.tertiarySystemBackground` helpers in `Theme.swift` (resolve to `UIColor` system colors on iOS, `NSColor.windowBackgroundColor` / `.underPageBackgroundColor` / `.controlBackgroundColor` on macOS). Routed `Theme.swift` and `ExploreTab.swift` call sites through them.
- **`navigationBarTitleDisplayMode(.inline)`** — added a `navigationBarTitleInline()` `View` extension (inline on iOS, no-op on macOS). Routed every call site through it, removing scattered per-site `#if os(iOS)` blocks.
- **`topBarTrailing` toolbar placement** — `#if os(iOS)`-guarded in `CreditsSheet.swift`, with a `.automatic` placement fallback on macOS.
- **`.zoom(sourceID:in:)`** (iOS 18 matched-geometry navigation transition) — `#if os(iOS)`-guarded in `ExploreTab.swift`; macOS gets the default push transition.

No UI restyling — compile-only cross-platform fix. A sweep of the whole `samples/ios-demo/` Swift source confirmed the remaining iOS-only APIs (`UIApplication`, `UIGraphicsImageRenderer`, `presentationCornerRadius`, etc.) are already inside `#if os(iOS)` blocks or file-level guards (`ARTab.swift`, AR demos, `RerunDebugDemo.swift`).

## Verification

Both observed locally with Xcode 26.3 (code-signing off; `SV_ALLOW_MISSING_SECRETS=1` to bypass the unrelated Release `Validate store secrets` script-phase guard for a missing `SKETCHFAB_API_KEY` — that guard is not a Swift compile error):

- macOS: `xcodebuild archive -destination 'generic/platform=macOS' -scheme SceneViewDemo` → **ARCHIVE SUCCEEDED**
- iOS: `xcodebuild build -destination 'generic/platform=iOS' -scheme SceneViewDemo` → **BUILD SUCCEEDED**

Note: this fixes the *compile* only. The separate macOS App Store 2.2.0 "Beta Testing" rejection is a product-polish concern, out of scope here.

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)