### PR TITLE
fix(ar): post-callback depth mode detection + MaterialsDemo empty-slug hang (#2122)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARScene.kt
@@ -869,7 +869,11 @@ fun ARSceneView(
                 // surface any silent support-gated downgrade to `onConfigDowngraded` (#2096).
                 val requestedCameraConfig = sessionCameraConfigRef.get()?.invoke(session)
                 requestedCameraConfig?.let { session.cameraConfig = it }
-                val requestedDepthMode = depthModeRef.get()
+                // Snapshot the requested depth mode AFTER the user `sessionConfiguration`
+                // callback runs, so a callback-driven override is captured (#2122 / #2096 gap 1).
+                // Initialise from the typed param; the configure lambda overwrites this after the
+                // callback executes.
+                var effectiveRequestedDepthMode: Config.DepthMode? = depthModeRef.get()
                 session.configure { config ->
                     // Apply the typed `*Mode` params (#1766) BEFORE the user callback so the
                     // callback still wins. Each param defaults to ARCore's recommended value
@@ -894,7 +898,7 @@ fun ARSceneView(
                         ?: Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
                     // depthMode support-gating is already centralised inside ArSession.configure
                     // (auto-downgrades unsupported requests to DISABLED).
-                    config.depthMode = requestedDepthMode ?: Config.DepthMode.DISABLED
+                    config.depthMode = effectiveRequestedDepthMode ?: Config.DepthMode.DISABLED
                     config.instantPlacementMode = instantPlacementModeRef.get()
                         ?: Config.InstantPlacementMode.DISABLED
                     config.geospatialMode = geospatialModeRef.get() ?: Config.GeospatialMode.DISABLED
@@ -908,14 +912,26 @@ fun ARSceneView(
                     config.semanticMode = semanticModeRef.get() ?: Config.SemanticMode.DISABLED
                     config.focusMode = focusModeRef.get() ?: Config.FocusMode.AUTO
                     sessionConfigurationRef.get()?.invoke(session, config)
+                    // Capture the post-callback depth mode — this is what the consumer
+                    // ultimately requested (the callback may have overridden the typed param).
+                    effectiveRequestedDepthMode = config.depthMode.takeIf {
+                        it != Config.DepthMode.DISABLED
+                    }
                 }
                 // Surface any silent support-gated downgrade (#2096). The session has just been
                 // configured: diff the requested camera config / depth mode against what ARCore
                 // actually applied and notify the consumer once per downgrade. Runs on the same
                 // (main) thread as the sibling `onSessionCreated` dispatch below.
+                //
+                // `effectiveRequestedDepthMode` now reflects the post-callback requested value
+                // (#2122 gap 1). `session.cameraConfig` is what ARCore last committed; comparing
+                // it against `requestedCameraConfig` (the selector's return value, set before
+                // configure) detects a camera-config mismatch (#2122 gap 2 — limited to the
+                // selector-driven path; callback-driven camera config changes are not tracked
+                // because ARCore validates on assignment, not silently post-configure).
                 onConfigDowngradedRef.get()?.let { onDowngraded ->
                     detectConfigDowngrades(
-                        requestedDepthMode = requestedDepthMode,
+                        requestedDepthMode = effectiveRequestedDepthMode,
                         effectiveDepthMode = session.config.depthMode,
                         requestedCameraConfig = requestedCameraConfig,
                         effectiveCameraConfig = session.cameraConfig

--- a/changelog.d/2122-arconfig-materials-fixes.md
+++ b/changelog.d/2122-arconfig-materials-fixes.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- **ARSceneView:** `detectConfigDowngrades` now captures the post-`sessionConfiguration`-callback depth mode, so a callback-driven depth-mode request that gets silently downgraded is correctly surfaced as `ARConfigDowngrade.DepthMode`. (#2122 / #2096 gap 1)
+- **MaterialsDemo:** fixed infinite "Loading…" scrim when the `materials` registry category is empty (null selected slug now exits to an `Empty` state instead of staying in `Loading` forever). (#2122)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -106,6 +106,8 @@ fun MaterialsDemo(onBack: () -> Unit) {
     // A failed resolve is surfaced as [MaterialResolveState.Error] instead of
     // being swallowed into a `null` path that hangs the loading scrim forever
     // (#2088). `retryTick` re-runs the resolve when the user taps Retry.
+    // A null slug (empty registry category) exits to [MaterialResolveState.Empty]
+    // so the loading scrim is not shown forever (#2122).
     val resolveState: MaterialResolveState by produceState<MaterialResolveState>(
         initialValue = MaterialResolveState.Loading,
         key1 = resolver,
@@ -113,7 +115,10 @@ fun MaterialsDemo(onBack: () -> Unit) {
         key3 = retryTick,
     ) {
         value = MaterialResolveState.Loading
-        val slug = selectedSlug ?: return@produceState
+        val slug = selectedSlug ?: run {
+            value = MaterialResolveState.Empty
+            return@produceState
+        }
         value = runCatching { resolver.resolve(slug) }
             .fold(
                 onSuccess = { MaterialResolveState.Resolved(it.toURI().toString()) },
@@ -122,6 +127,7 @@ fun MaterialsDemo(onBack: () -> Unit) {
     }
     val resolvedPath = (resolveState as? MaterialResolveState.Resolved)?.path
     val resolveError = (resolveState as? MaterialResolveState.Error)?.message
+    val isEmpty = resolveState is MaterialResolveState.Empty
 
     val modelInstance = resolvedPath?.let { path ->
         rememberModelInstance(modelLoader, path)
@@ -200,6 +206,8 @@ fun MaterialsDemo(onBack: () -> Unit) {
             }
             // Mutually exclusive with LoadingScrim: a resolve failure shows the
             // error scrim (with Retry) instead of hanging on "Streaming…" (#2088).
+            // An empty registry category (no slugs) shows nothing — the viewport
+            // is already blank; do not show "Loading…" forever (#2122).
             if (resolveError != null) {
                 ErrorScrim(
                     message = resolveError,
@@ -207,7 +215,7 @@ fun MaterialsDemo(onBack: () -> Unit) {
                     label = stringResource(R.string.demo_materials_error),
                     retryLabel = stringResource(R.string.demo_materials_retry),
                 )
-            } else {
+            } else if (!isEmpty) {
                 LoadingScrim(
                     loading = modelInstance == null,
                     label = stringResource(R.string.demo_materials_loading),
@@ -221,6 +229,12 @@ fun MaterialsDemo(onBack: () -> Unit) {
 private sealed interface MaterialResolveState {
     /** Resolve coroutine in flight. */
     data object Loading : MaterialResolveState
+
+    /**
+     * No slug available (empty registry category — the materials category has no entries).
+     * The viewport stays blank; the loading scrim is not shown (#2122).
+     */
+    data object Empty : MaterialResolveState
 
     /** Resolve succeeded — [path] is a `file://` URL ready for the model loader. */
     data class Resolved(val path: String) : MaterialResolveState


### PR DESCRIPTION
## Summary
- **ARScene** (`arsceneview`): `detectConfigDowngrades` now snapshots the requested depth mode *after* the `sessionConfiguration` callback runs, so a callback-driven depth-mode change that gets silently downgraded is correctly surfaced as `ARConfigDowngrade.DepthMode` (gap 1 from the #2096 audit)
- **MaterialsDemo** (`samples/android-demo`): `selectedSlug == null` (empty materials registry category) now transitions to a new `MaterialResolveState.Empty` instead of silently staying in `Loading`, so the "Streaming…" scrim no longer hangs forever

Fixes #2122.

## Test plan
- [ ] CI unit tests pass (`arsceneview:testDebugUnitTest`) — confirmed locally
- [ ] Compilation clean (`arsceneview:compileReleaseKotlin`, `samples:android-demo:compileReleaseKotlin`) — confirmed locally
- [ ] MaterialsDemo with a non-empty registry: behaves as before (Loading scrim shows until model loads)
- [ ] MaterialsDemo with empty `materials` category: empty viewport, no infinite spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)