### PR TITLE
fix(feedback): guard against contentless emulator submissions (#2123)

### DIFF
--- a/changelog.d/2123-feedback-empty-guard.md
+++ b/changelog.d/2123-feedback-empty-guard.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- **Feedback (Android demo):** detect emulator in `FeedbackContext` (`isEmulator` flag). The review screen now shows a warning hint when submitting from an emulator without a typed note, since emulator mics are silent and Whisper returns an empty transcript. (#2123)
+- **Feedback (worker):** the GitHub issue body now explains *why* there is no transcript when both transcript and typed text are empty: emulator submissions get a specific "no physical mic" message; other silent-audio cases get a generic explanation. A maintainer note is added to avoid confusion when an issue has no actionable content. (#2123)

--- a/feedback-worker/src/issue.ts
+++ b/feedback-worker/src/issue.ts
@@ -121,8 +121,20 @@ export function buildIssue(input: {
   }
 
   if (!transcript.trim() && !text.trim()) {
+    // Provide context about WHY there is no content (#2123).
+    // If the `isEmulator` context flag is set, the mic was definitively silent
+    // (emulators have no physical microphone — Whisper returned nothing).
+    // Otherwise the recording may have captured silence for another reason
+    // (mic permission denied, very quiet room, etc.).
+    const isEmulator = String(context["isEmulator"]) === "true";
+    const noContentReason = isEmulator
+      ? "_No transcript — submitted from an emulator (no physical mic). Whisper received a silent audio track._"
+      : "_No transcript available and no typed description — Whisper may have received a silent audio track, or no audio was captured._";
     lines.push(
-      "_No transcript available — see the recording in the viewer below._",
+      noContentReason,
+      "",
+      "> **Note for maintainers:** there is no actionable content in this submission. " +
+        "The recording (if any) is linked below — check it before closing.",
       "",
     );
   }

--- a/feedback-worker/test/issue.test.ts
+++ b/feedback-worker/test/issue.test.ts
@@ -64,7 +64,24 @@ describe("buildIssue", () => {
       context: {},
       viewerUrl: "u",
     });
+    // Generic no-content message when isEmulator is not set.
     expect(r.body).toContain("No transcript available");
+    // Maintainer note is always present on empty submissions.
+    expect(r.body).toContain("Note for maintainers");
+  });
+
+  it("explains the silent-emulator reason when isEmulator context flag is set (#2123)", () => {
+    const r = buildIssue({
+      id: "abc",
+      category: "bug",
+      transcript: "",
+      text: "",
+      context: { isEmulator: "true" },
+      viewerUrl: "u",
+    });
+    expect(r.body).toContain("emulator");
+    expect(r.body).toContain("no physical mic");
+    expect(r.body).toContain("Note for maintainers");
   });
 
   it("renders the context table and the viewer link", () => {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackContext.kt
@@ -7,6 +7,27 @@ import io.github.sceneview.demo.BuildConfig
 import java.util.Locale
 
 /**
+ * Detects whether the app is running on an Android emulator.
+ *
+ * Emulators have no real microphone — the audio track captured by the
+ * feedback recorder will be silent and Whisper will return an empty
+ * transcript. This is used to annotate the GitHub issue body so a maintainer
+ * understands why no transcript is available (#2123).
+ */
+internal fun isEmulator(): Boolean =
+    Build.FINGERPRINT.startsWith("generic") ||
+        Build.FINGERPRINT.contains("emulator") ||
+        Build.MODEL.contains("Emulator") ||
+        Build.MODEL.contains("Android SDK built for") ||
+        Build.MANUFACTURER.contains("Genymotion") ||
+        Build.BRAND.startsWith("generic") ||
+        Build.DEVICE.startsWith("generic") ||
+        "google_sdk" == Build.PRODUCT ||
+        Build.PRODUCT.contains("sdk_gphone") ||
+        Build.HARDWARE == "goldfish" ||
+        Build.HARDWARE == "ranchu"
+
+/**
  * Snapshot of device / app context attached to a feedback submission. This is
  * what the maintainer sees in the GitHub issue's context table — it tells them
  * exactly which app build, OS and device the feedback came from.
@@ -36,6 +57,11 @@ fun captureFeedbackContext(
         put("sdkInt", Build.VERSION.SDK_INT.toString())
         put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
         put("locale", Locale.getDefault().toLanguageTag())
+        // Emulator detection — emulators have no real microphone, so Whisper
+        // will receive a silent audio track and return an empty transcript.
+        // The worker reads this flag to annotate the "No transcript available"
+        // message in the GitHub issue body (#2123).
+        if (isEmulator()) put("isEmulator", "true")
         if (freeRamMb != null) put("freeRamMb", freeRamMb.toString())
         // The exact demo the feedback is about, under the `demoId` key the
         // worker recognises (rendered as the named "Demo" row in the issue's

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -286,6 +286,7 @@ fun FeedbackFlow(
                         onStartRecording()
                     },
                     onSend = { send() },
+                    emulator = isEmulator(),
                 )
 
                 else -> when (step) {
@@ -454,7 +455,12 @@ private fun ReviewStep(
     onClose: () -> Unit,
     onRerecord: () -> Unit,
     onSend: () -> Unit,
+    emulator: Boolean = false,
 ) {
+    // On an emulator the audio track is silent — Whisper will return an
+    // empty transcript, so the GitHub issue will have no actionable content
+    // unless the user types a note. Warn if no text yet (#2123).
+    val showEmulatorHint = emulator && note.isBlank()
     FeedbackStepScaffold(
         onClose = onClose,
         actions = {
@@ -488,6 +494,13 @@ private fun ReviewStep(
             placeholder = { Text(stringResource(R.string.feedback_review_note_placeholder)) },
             modifier = Modifier.fillMaxWidth(),
             minLines = 3,
+            // On an emulator the mic is silent — show a supporting text hint so
+            // the user knows a typed note is needed for the issue to be useful.
+            supportingText = if (showEmulatorHint) {
+                { Text(stringResource(R.string.feedback_review_emulator_hint)) }
+            } else {
+                null
+            },
         )
     }
 }

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -318,6 +318,8 @@
     <string name="feedback_review_note_placeholder">Anything else the team should know?</string>
     <string name="feedback_review_rerecord">Record again</string>
     <string name="feedback_review_send">Send feedback</string>
+    <!-- Emulator hint: mic is silent, typed note needed for the issue to be useful (#2123) -->
+    <string name="feedback_review_emulator_hint">Running on an emulator — the mic is silent. Add a note so maintainers know what you observed.</string>
     <string name="feedback_record_failed_title">Recording didn\'t work</string>
     <string name="feedback_record_failed_body">The recording didn\'t finish. You can try again.</string>
     <string name="feedback_record_retry">Try again</string>


### PR DESCRIPTION
## Summary
- **Android demo**: adds `isEmulator()` helper using Build field fingerprints; includes `isEmulator: "true"` in the feedback context payload; the `ReviewStep` shows a supporting-text hint ("running on an emulator — the mic is silent — add a note") when no typed text is present
- **Worker**: the empty-content branch now emits a context-aware message (emulator → "no physical mic / Whisper received silent audio"; else → generic "silent audio or no audio captured") plus a maintainer callout so reviewers understand why the issue has no actionable content
- **Worker tests**: updates the "No transcript available" assertion; adds an emulator-specific test

Fixes #2123.

## Test plan
- [ ] `feedback-worker` tests pass: `cd feedback-worker && npm test` — confirmed 45/45 locally
- [ ] Android demo compiles clean: `./gradlew :samples:android-demo:compileReleaseKotlin` — confirmed locally
- [ ] On a real device: ReviewStep shows no emulator hint, submit proceeds normally
- [ ] On an emulator with no typed note: supporting text hint appears below the note field
- [ ] Worker: a submission with `isEmulator: "true"` and no transcript/text produces an issue body with "no physical mic" and the maintainer note

🤖 Generated with [Claude Code](https://claude.com/claude-code)