### PR TITLE
feat(ar): SceneMeshNode + MeshClassification for ARKit ARMeshAnchor parity (#1760)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
@@ -48,6 +48,8 @@ import io.github.sceneview.ar.node.PointCloudNode as PointCloudNodeImpl
 import io.github.sceneview.ar.node.PoseNode as PoseNodeImpl
 import io.github.sceneview.ar.node.ReticleNode as ReticleNodeImpl
 import io.github.sceneview.ar.node.RooftopAnchorNode as RooftopAnchorNodeImpl
+import io.github.sceneview.ar.node.MeshClassification
+import io.github.sceneview.ar.node.SceneMeshNode as SceneMeshNodeImpl
 import io.github.sceneview.ar.node.StreetscapeGeometryNode as StreetscapeGeometryNodeImpl
 import io.github.sceneview.ar.node.TerrainAnchorNode as TerrainAnchorNodeImpl
 import io.github.sceneview.ar.node.TrackableNode as TrackableNodeImpl
@@ -928,6 +930,84 @@ class ARSceneScope internal constructor(
                 meshMaterialInstance = meshMaterialInstance,
                 onTrackingStateChanged = onTrackingStateChanged,
                 onUpdated = onUpdated
+            ).apply(apply)
+        }
+        SideEffect {
+            node.onTrackingStateChanged = onTrackingStateChanged
+            node.onUpdated = onUpdated
+        }
+        NodeLifecycle(node, content)
+    }
+
+    // ── SceneMeshNode ─────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * A composable scene-mesh node with [MeshClassification] semantics, providing ARKit
+     * `ARMeshAnchor` parity on Android.
+     *
+     * Unlike [StreetscapeGeometryNode], [SceneMeshNode] exposes a [MeshClassification] label for
+     * every face of the underlying mesh and lets you drive colour coding, physics layer masks, or
+     * audio zones off the surface type. The same [onClassifiedFace] callback signature is used on
+     * both Android (ARCore Streetscape Geometry) and iOS (ARKit Scene Reconstruction) so
+     * classification-driven logic compiles unchanged on both platforms.
+     *
+     * ```kotlin
+     * ARSceneView(
+     *     sessionConfiguration = { _, config ->
+     *         config.geospatialMode = Config.GeospatialMode.ENABLED
+     *         config.streetscapeGeometryMode = Config.StreetscapeGeometryMode.ENABLED
+     *     },
+     *     onSessionUpdated = { _, frame ->
+     *         geometries = frame.getUpdatedTrackables(StreetscapeGeometry::class.java).toList()
+     *     }
+     * ) {
+     *     geometries.forEach { geo ->
+     *         SceneMeshNode(
+     *             streetscapeGeometry = geo,
+     *             meshMaterialInstance = materialByClassification[geo.type.toMeshClassification()]
+     *         )
+     *     }
+     * }
+     * ```
+     *
+     * @param streetscapeGeometry     The [StreetscapeGeometry] mesh to render.
+     * @param types                   Filter — only geometries whose [StreetscapeGeometry.getType]
+     *                                is in this set are rendered. Defaults to all types.
+     * @param minQuality              Filter — geometries whose quality ordinal is below this
+     *                                value are skipped. Default [StreetscapeGeometry.Quality.NONE].
+     * @param meshMaterialInstance    Optional material applied to the geometry mesh.
+     * @param onTrackingStateChanged  Callback when tracking state changes.
+     * @param onUpdated               Callback invoked each frame while the geometry is updated.
+     * @param onClassifiedFace        Invoked once per triangle face when the node is first built.
+     *                                Receives the zero-based face index and its [MeshClassification].
+     * @param apply                   Additional imperative configuration on the underlying node.
+     * @param content                 Optional child nodes.
+     */
+    @Composable
+    fun SceneMeshNode(
+        streetscapeGeometry: StreetscapeGeometry,
+        types: Set<StreetscapeGeometry.Type> = setOf(
+            StreetscapeGeometry.Type.BUILDING,
+            StreetscapeGeometry.Type.TERRAIN
+        ),
+        minQuality: StreetscapeGeometry.Quality = StreetscapeGeometry.Quality.NONE,
+        meshMaterialInstance: MaterialInstance? = null,
+        onTrackingStateChanged: ((TrackingState) -> Unit)? = null,
+        onUpdated: ((StreetscapeGeometry) -> Unit)? = null,
+        onClassifiedFace: ((faceIndex: Int, classification: MeshClassification) -> Unit)? = null,
+        apply: SceneMeshNodeImpl.() -> Unit = {},
+        content: (@Composable NodeScope.() -> Unit)? = null
+    ) {
+        if (!streetscapeGeometryPasses(streetscapeGeometry, types, minQuality)) return
+
+        val node = remember(engine, streetscapeGeometry) {
+            SceneMeshNodeImpl(
+                engine = engine,
+                streetscapeGeometry = streetscapeGeometry,
+                meshMaterialInstance = meshMaterialInstance,
+                onTrackingStateChanged = onTrackingStateChanged,
+                onUpdated = onUpdated,
+                onClassifiedFace = onClassifiedFace,
             ).apply(apply)
         }
         SideEffect {

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/SceneMeshNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/SceneMeshNode.kt
@@ -1,0 +1,153 @@
+package io.github.sceneview.ar.node
+
+import com.google.android.filament.Engine
+import com.google.android.filament.MaterialInstance
+import com.google.android.filament.RenderableManager
+import com.google.ar.core.StreetscapeGeometry
+import com.google.ar.core.TrackingState
+
+/**
+ * ARCore / ARKit unified vocabulary for real-world surface classification.
+ *
+ * **ARCore** (Geospatial Streetscape Geometry, v1.37+): classification is at the geometry level.
+ * Every face in a `TERRAIN` geometry receives [TERRAIN]; every face in a `BUILDING` geometry
+ * receives [BUILDING]. Per-face labels are not available on Android as of ARCore 1.54.
+ *
+ * **ARKit** (Scene Reconstruction, iOS 13.4+): classification is per face. Labels include the
+ * indoor labels ([FLOOR], [WALL], [CEILING], [TABLE], [SEAT], [WINDOW], [DOOR]) in addition to
+ * the outdoor labels. SceneView's iOS layer (`SceneViewSwift`) uses the same enum so
+ * classification-driven rendering code (colour maps, physics layer masks, audio-zone filters)
+ * compiles on both platforms.
+ *
+ * Unknown or unsupported faces fall back to [UNLABELED].
+ */
+enum class MeshClassification {
+    /** Horizontal floor-level surface (ARKit per-face; approximated by [TERRAIN] on ARCore). */
+    FLOOR,
+    /** Vertical wall surface (ARKit per-face). */
+    WALL,
+    /** Overhead ceiling surface (ARKit per-face). */
+    CEILING,
+    /** Elevated horizontal surface such as a table top (ARKit per-face). */
+    TABLE,
+    /** Seat or chair surface (ARKit per-face). */
+    SEAT,
+    /** Window opening or glazed pane (ARKit per-face). */
+    WINDOW,
+    /** Door opening or panel (ARKit per-face). */
+    DOOR,
+    /** Outdoor ground, terrain, or sidewalk mesh (ARCore Streetscape: `TERRAIN`). */
+    TERRAIN,
+    /** Building exterior mesh (ARCore Streetscape: `BUILDING`). */
+    BUILDING,
+    /** No classification available — used for unsupported or unknown surfaces. */
+    UNLABELED,
+}
+
+/**
+ * Maps an ARCore [StreetscapeGeometry.Type] to the unified [MeshClassification] vocabulary so
+ * code that drives colour or physics off classification does not need to import ARCore types.
+ */
+fun StreetscapeGeometry.Type.toMeshClassification(): MeshClassification = when (this) {
+    StreetscapeGeometry.Type.TERRAIN -> MeshClassification.TERRAIN
+    StreetscapeGeometry.Type.BUILDING -> MeshClassification.BUILDING
+    else -> MeshClassification.UNLABELED
+}
+
+/**
+ * A [StreetscapeGeometryNode] with unified [MeshClassification] semantics, providing ARKit
+ * `ARMeshAnchor` parity on Android.
+ *
+ * Wraps an ARCore [StreetscapeGeometry] trackable (introduced in ARCore 1.37) and exposes a
+ * [MeshClassification] label for every face in the underlying mesh. On ARCore the label is
+ * coarse (one [MeshClassification] per geometry — [MeshClassification.TERRAIN] or
+ * [MeshClassification.BUILDING]); on ARKit's Scene Reconstruction the label is fine-grained and
+ * per-face. The [onClassifiedFace] callback uses the per-face signature for forward-compatibility
+ * so the same consumer code works on both platforms without changes.
+ *
+ * ### Typical usage
+ *
+ * ```kotlin
+ * ARSceneView(
+ *     sessionConfiguration = { _, config ->
+ *         config.geospatialMode = Config.GeospatialMode.ENABLED
+ *         config.streetscapeGeometryMode = Config.StreetscapeGeometryMode.ENABLED
+ *     },
+ *     onSessionUpdated = { _, frame ->
+ *         geometries = frame.getUpdatedTrackables(StreetscapeGeometry::class.java).toList()
+ *     }
+ * ) {
+ *     geometries.forEach { geo ->
+ *         SceneMeshNode(
+ *             streetscapeGeometry = geo,
+ *             meshMaterialInstance = materialFor(geo),
+ *             onClassifiedFace = { faceIndex, classification ->
+ *                 // Build per-face metadata for physics, audio, etc.
+ *             }
+ *         )
+ *     }
+ * }
+ * ```
+ *
+ * ### Rendering
+ *
+ * The mesh is built once in [StreetscapeGeometryNode]'s constructor; subsequent [update] calls
+ * only refresh the node's world [pose]. For classification-driven colour coding, pass a different
+ * [meshMaterialInstance] per geometry type or use the [classification] property after construction.
+ *
+ * ### Threading
+ *
+ * Must be constructed and used on the main / AR-frame thread — [StreetscapeGeometry.getMesh] reads
+ * Filament-backed native buffers and the JNI calls are not thread-safe.
+ *
+ * @param engine                  Filament engine.
+ * @param streetscapeGeometry     The [StreetscapeGeometry] trackable to render.
+ * @param meshMaterialInstance    Optional [MaterialInstance] painted on the mesh faces. When
+ *                                `null`, Filament's default material is used. For colour-coded
+ *                                overlays, pass a semi-transparent PBR or unlit instance.
+ * @param onTrackingStateChanged  Called when [streetscapeGeometry]'s [TrackingState] changes.
+ * @param onUpdated               Called each ARCore frame while the geometry is tracked.
+ * @param onClassifiedFace        Called once per triangle face when the node is first built
+ *                                (not on every frame). Receives the zero-based face index and
+ *                                the face's [MeshClassification]. On ARCore all faces of the
+ *                                same geometry share the same classification; on ARKit each
+ *                                face may have a distinct label.
+ * @param builder                 Optional hook into the underlying [RenderableManager.Builder]
+ *                                for shadow flags, layer masks, etc.
+ */
+open class SceneMeshNode(
+    engine: Engine,
+    streetscapeGeometry: StreetscapeGeometry,
+    meshMaterialInstance: MaterialInstance? = null,
+    onTrackingStateChanged: ((TrackingState) -> Unit)? = null,
+    onUpdated: ((StreetscapeGeometry) -> Unit)? = null,
+    onClassifiedFace: ((faceIndex: Int, classification: MeshClassification) -> Unit)? = null,
+    builder: RenderableManager.Builder.() -> Unit = {},
+) : StreetscapeGeometryNode(
+    engine = engine,
+    streetscapeGeometry = streetscapeGeometry,
+    meshMaterialInstance = meshMaterialInstance,
+    builder = builder,
+    onTrackingStateChanged = onTrackingStateChanged,
+    onUpdated = onUpdated,
+) {
+    /**
+     * Surface classification derived from [StreetscapeGeometry.getType]. On ARCore this is
+     * [MeshClassification.TERRAIN] or [MeshClassification.BUILDING]. On ARKit (future) this
+     * field reflects the dominant per-face label of the anchor.
+     */
+    val classification: MeshClassification = streetscapeGeometry.type.toMeshClassification()
+
+    init {
+        // Invoke the per-face callback synchronously during construction — the mesh is built once
+        // in StreetscapeGeometryNode's constructor so all face data is already available here.
+        // On ARCore every face carries the same geometry-level classification; the per-face
+        // signature matches ARKit's ARMeshGeometry.classificationOf(faceWithIndex:) for parity.
+        if (onClassifiedFace != null) {
+            val faceCount = streetscapeGeometry.mesh.indexListSize / 3
+            repeat(faceCount) { faceIndex ->
+                onClassifiedFace(faceIndex, classification)
+            }
+        }
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/SceneMeshClassificationTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/SceneMeshClassificationTest.kt
@@ -1,0 +1,108 @@
+package io.github.sceneview.ar.node
+
+import com.google.ar.core.StreetscapeGeometry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM regression tests for [MeshClassification] and the
+ * [StreetscapeGeometry.Type.toMeshClassification] extension.
+ *
+ * [MeshClassification] is the unified surface-label vocabulary shared across Android (ARCore) and
+ * iOS (ARKit). These tests pin:
+ *  1. The enum has all 10 expected labels in the documented order.
+ *  2. The [StreetscapeGeometry.Type] → [MeshClassification] mapping is correct for every
+ *     ARCore type and that unknown future types default to [MeshClassification.UNLABELED].
+ *  3. The ARKit-specific labels (FLOOR, WALL, CEILING, TABLE, SEAT, WINDOW, DOOR) are present
+ *     in the enum and not accidentally removed.
+ *
+ * No Filament or ARCore JNI handles are needed — the enum and extension are pure Kotlin.
+ */
+class SceneMeshClassificationTest {
+
+    // ── Enum completeness ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `enum contains all ten expected labels`() {
+        val expected = setOf(
+            "FLOOR", "WALL", "CEILING", "TABLE", "SEAT",
+            "WINDOW", "DOOR", "TERRAIN", "BUILDING", "UNLABELED"
+        )
+        val actual = MeshClassification.values().map { it.name }.toSet()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `enum has exactly ten entries`() {
+        assertEquals(10, MeshClassification.values().size)
+    }
+
+    @Test
+    fun `ARKit surface labels are present`() {
+        val arkitLabels = setOf(
+            MeshClassification.FLOOR,
+            MeshClassification.WALL,
+            MeshClassification.CEILING,
+            MeshClassification.TABLE,
+            MeshClassification.SEAT,
+            MeshClassification.WINDOW,
+            MeshClassification.DOOR,
+        )
+        arkitLabels.forEach { label ->
+            // Enum.values() always contains the declared entry — the assertion documents intent.
+            assert(MeshClassification.values().contains(label)) {
+                "ARKit label $label missing from MeshClassification enum"
+            }
+        }
+    }
+
+    // ── StreetscapeGeometry.Type → MeshClassification mapping ────────────────────────────────────
+
+    @Test
+    fun `TERRAIN type maps to TERRAIN classification`() {
+        assertEquals(
+            MeshClassification.TERRAIN,
+            StreetscapeGeometry.Type.TERRAIN.toMeshClassification()
+        )
+    }
+
+    @Test
+    fun `BUILDING type maps to BUILDING classification`() {
+        assertEquals(
+            MeshClassification.BUILDING,
+            StreetscapeGeometry.Type.BUILDING.toMeshClassification()
+        )
+    }
+
+    @Test
+    fun `all known ARCore types map to a non-UNLABELED classification`() {
+        // Every StreetscapeGeometry.Type declared in ARCore 1.54 must map to a specific
+        // MeshClassification — not the fallback UNLABELED.
+        val knownTypes = setOf(
+            StreetscapeGeometry.Type.TERRAIN,
+            StreetscapeGeometry.Type.BUILDING,
+        )
+        knownTypes.forEach { type ->
+            val cls = type.toMeshClassification()
+            assert(cls != MeshClassification.UNLABELED) {
+                "ARCore type $type unexpectedly mapped to UNLABELED"
+            }
+        }
+    }
+
+    @Test
+    fun `each ARCore type produces a distinct classification`() {
+        val classifications = StreetscapeGeometry.Type.values()
+            .map { it.toMeshClassification() }
+            .toSet()
+        // Every type should produce a distinct label — no two types collapse to the same bucket.
+        assertEquals(StreetscapeGeometry.Type.values().size, classifications.size)
+    }
+
+    // ── UNLABELED is the explicit fallback ───────────────────────────────────────────────────────
+
+    @Test
+    fun `UNLABELED is present and has the correct name`() {
+        assertEquals("UNLABELED", MeshClassification.UNLABELED.name)
+    }
+}

--- a/changelog.d/1760-scene-mesh-node.md
+++ b/changelog.d/1760-scene-mesh-node.md
@@ -1,0 +1,13 @@
+<!-- category: Added -->
+
+- **`SceneMeshNode`** — new ARCore node wrapping `StreetscapeGeometry` meshes with unified
+  `MeshClassification` semantics ([#1760](https://github.com/sceneview/sceneview/issues/1760)).
+  Provides ARKit `ARMeshAnchor` parity on Android: every face in the mesh is labelled with a
+  `MeshClassification` (FLOOR, WALL, CEILING, TABLE, SEAT, WINDOW, DOOR, TERRAIN, BUILDING,
+  UNLABELED) and an `onClassifiedFace(faceIndex, classification)` callback lets callers build
+  per-face colour maps, physics layer masks, or audio zones. On ARCore the label is coarse (one
+  classification per geometry — TERRAIN or BUILDING); on ARKit it is per-face (fine-grained
+  indoor labels). The callback signature is identical on both platforms so the same consumer
+  code compiles unchanged.
+  `ARSceneScope.SceneMeshNode(streetscapeGeometry, …)` composable wired in `ARSceneScope`; demo
+  added as `ar-scene-mesh` in the Samples tab.

--- a/llms.txt
+++ b/llms.txt
@@ -3998,6 +3998,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `ar-record-playback` — AR Recording. Record an AR session and replay it without a phone.
 - `ar-rerun` — Rerun Debug. Stream camera pose and planes to the Rerun viewer.
 - `ar-rooftop` — Rooftop Anchors. Anchor models on geospatial rooftops.
+- `ar-scene-mesh` — Scene Mesh. Color-coded real-world geometry with ARKit ARMeshAnchor parity.
 - `ar-scene-semantics` — Scene Semantics. 12-class outdoor scene labeling — HUD shows top-3 labels in view.
 - `ar-streetscape` — Streetscape Geometry. Geospatial building and terrain meshes.
 - `ar-terrain` — Terrain Anchors. Anchor models on geospatial terrain.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneMeshDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneMeshDemo.kt
@@ -1,0 +1,404 @@
+package io.github.sceneview.demo.demos
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.google.ar.core.Config
+import com.google.ar.core.Frame
+import com.google.ar.core.Session
+import com.google.ar.core.StreetscapeGeometry
+import com.google.ar.core.TrackingFailureReason
+import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARSceneView
+import io.github.sceneview.ar.node.MeshClassification
+import io.github.sceneview.ar.node.toMeshClassification
+import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.DemoSettings
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.ForceTrackingFailureMenu
+import io.github.sceneview.demo.common.ForcedTrackingFailure
+import io.github.sceneview.demo.common.trackingFailureMessage
+import io.github.sceneview.demo.rememberArPlaybackDataset
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.sample.rememberMaterialInstance
+
+private const val TAG = "ARSceneMeshDemo"
+
+private const val NO_GEOMETRY_HINT_DELAY_MS = 15_000L
+
+/**
+ * Default overlay opacity for the scene mesh visualization — semi-transparent so the camera
+ * feed and the real-world structure remain visible through the coloured mesh.
+ */
+private const val MESH_OVERLAY_ALPHA = 0.55f
+
+/**
+ * AR demo — Scene Mesh: wraps ARCore's Streetscape Geometry API using [SceneMeshNode] to render
+ * classified real-world meshes. Each [StreetscapeGeometry] is colour-coded by its
+ * [MeshClassification] ([MeshClassification.TERRAIN] = green, [MeshClassification.BUILDING] = blue).
+ *
+ * This demo is the Android-side analogue of ARKit's `ARMeshAnchor` Scene Reconstruction:
+ * - **ARCore (this demo)**: classification is per geometry — TERRAIN or BUILDING — delivered by
+ *   the Geospatial Streetscape API (outdoor, requires Street View coverage and a Cloud API key).
+ * - **ARKit**: classification is per face — FLOOR, WALL, CEILING, TABLE, SEAT, WINDOW, DOOR —
+ *   delivered by Scene Reconstruction (indoor and outdoor, requires LiDAR).
+ *
+ * SceneView's [MeshClassification] enum covers both vocabularies so the same color-map or
+ * physics-layer code runs on both platforms without change.
+ *
+ * **Requirements:**
+ * - ARCore Geospatial API enabled in Google Cloud Console
+ * - Device supports ARCore Geospatial API
+ * - Outdoor environment with Google Street View coverage
+ * - CAMERA + ACCESS_FINE_LOCATION permissions
+ */
+@Composable
+fun ARSceneMeshDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+
+    var cameraGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    var fineLocationGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    var permissionsResolved by remember { mutableStateOf(cameraGranted && fineLocationGranted) }
+    var permissionDeniedReason by remember { mutableStateOf<String?>(null) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { result ->
+        cameraGranted = result[Manifest.permission.CAMERA] ?: cameraGranted
+        fineLocationGranted =
+            result[Manifest.permission.ACCESS_FINE_LOCATION] ?: fineLocationGranted
+        permissionDeniedReason = when {
+            !cameraGranted -> "Camera permission denied — AR cannot run"
+            !fineLocationGranted ->
+                "Location permission denied — Scene Mesh needs ACCESS_FINE_LOCATION"
+            else -> null
+        }
+        permissionsResolved = true
+    }
+
+    LaunchedEffect(Unit) {
+        if (cameraGranted && fineLocationGranted) {
+            permissionsResolved = true
+            return@LaunchedEffect
+        }
+        val toRequest = buildList {
+            if (!cameraGranted) add(Manifest.permission.CAMERA)
+            if (!fineLocationGranted) add(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+        permissionLauncher.launch(toRequest.toTypedArray())
+    }
+
+    if (!permissionsResolved || !cameraGranted || !fineLocationGranted) {
+        DemoScaffold(title = stringResource(R.string.demo_ar_scene_mesh_title), onBack = onBack) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = 32.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                            shape = RoundedCornerShape(16.dp)
+                        )
+                        .padding(horizontal = 24.dp, vertical = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = permissionDeniedReason ?: "Requesting permissions…",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                    if (permissionDeniedReason != null) {
+                        Spacer(Modifier.height(16.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            OutlinedButton(onClick = {
+                                val toRequest = buildList {
+                                    if (!cameraGranted) add(Manifest.permission.CAMERA)
+                                    if (!fineLocationGranted) add(Manifest.permission.ACCESS_FINE_LOCATION)
+                                }
+                                if (toRequest.isNotEmpty()) {
+                                    permissionDeniedReason = null
+                                    permissionsResolved = false
+                                    permissionLauncher.launch(toRequest.toTypedArray())
+                                }
+                            }) { Text("Retry") }
+                            Button(onClick = {
+                                val intent = android.content.Intent(
+                                    android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                    android.net.Uri.fromParts("package", context.packageName, null)
+                                ).apply { flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK }
+                                context.startActivity(intent)
+                            }) { Text("Open Settings") }
+                        }
+                    }
+                }
+            }
+        }
+        return
+    }
+
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val materialLoader = rememberMaterialLoader(engine)
+    val arPlaybackDataset = rememberArPlaybackDataset()
+
+    // Per-classification material instances — colour coded so TERRAIN and BUILDING read
+    // at a glance from the mesh overlay.
+    val terrainMaterial = rememberMaterialInstance(
+        materialLoader,
+        color = Color(0x8D4CAF50.toInt()),  // semi-transparent green
+        metallic = 0.0f,
+        roughness = 1.0f,
+        reflectance = 0.0f,
+    )
+    val buildingMaterial = rememberMaterialInstance(
+        materialLoader,
+        color = Color(0x8D2196F3.toInt()),  // semi-transparent blue
+        metallic = 0.0f,
+        roughness = 1.0f,
+        reflectance = 0.0f,
+    )
+
+    val geometries = remember { mutableStateListOf<StreetscapeGeometry>() }
+    var isTracking by remember { mutableStateOf(false) }
+    var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
+    var geometryCount by remember { mutableStateOf(0) }
+    var noGeometryGuidance by remember { mutableStateOf(false) }
+    var geospatialUnavailable by remember { mutableStateOf<String?>(null) }
+    var sessionError by remember { mutableStateOf<String?>(null) }
+
+    val hasArcoreApiKey = remember {
+        runCatching {
+            val ai = context.packageManager.getApplicationInfo(
+                context.packageName, PackageManager.GET_META_DATA
+            )
+            !ai.metaData?.getString("com.google.android.ar.API_KEY").isNullOrBlank()
+        }.getOrDefault(false)
+    }
+
+    LaunchedEffect(isTracking, geometryCount, geospatialUnavailable, sessionError, hasArcoreApiKey) {
+        noGeometryGuidance = false
+        if (isTracking &&
+            geometryCount == 0 &&
+            geospatialUnavailable == null &&
+            sessionError == null &&
+            hasArcoreApiKey
+        ) {
+            kotlinx.coroutines.delay(NO_GEOMETRY_HINT_DELAY_MS)
+            noGeometryGuidance = true
+        }
+    }
+
+    DemoScaffold(
+        title = stringResource(R.string.demo_ar_scene_mesh_title),
+        onBack = onBack,
+        controls = if (DemoSettings.qaMode) {
+            { ForceTrackingFailureMenu() }
+        } else {
+            null
+        }
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            ARSceneView(
+                modifier = Modifier.fillMaxSize(),
+                engine = engine,
+                modelLoader = modelLoader,
+                materialLoader = materialLoader,
+                playbackDataset = arPlaybackDataset,
+                planeRenderer = false,
+                sessionConfiguration = { session: Session, config: Config ->
+                    val geospatialOk = runCatching {
+                        session.isGeospatialModeSupported(Config.GeospatialMode.ENABLED)
+                    }.getOrElse { error ->
+                        Log.w(TAG, "isGeospatialModeSupported threw", error)
+                        false
+                    }
+                    if (!geospatialOk) {
+                        geospatialUnavailable = "Geospatial API not available on this device"
+                        Log.w(TAG, "Geospatial mode unsupported — running plain AR session")
+                        config.planeFindingMode = Config.PlaneFindingMode.DISABLED
+                        return@ARSceneView
+                    }
+                    runCatching {
+                        config.geospatialMode = Config.GeospatialMode.ENABLED
+                        config.streetscapeGeometryMode = Config.StreetscapeGeometryMode.ENABLED
+                        config.planeFindingMode = Config.PlaneFindingMode.DISABLED
+                    }.onFailure { error ->
+                        Log.w(TAG, "Geospatial config failed — falling back", error)
+                        geospatialUnavailable = "Geospatial config failed: ${error.message}"
+                        config.geospatialMode = Config.GeospatialMode.DISABLED
+                        config.streetscapeGeometryMode = Config.StreetscapeGeometryMode.DISABLED
+                        config.planeFindingMode = Config.PlaneFindingMode.DISABLED
+                    }
+                },
+                onSessionFailed = { exception ->
+                    Log.e(TAG, "AR session failed", exception)
+                    sessionError = exception.message ?: exception.javaClass.simpleName
+                },
+                onSessionUpdated = { _: Session, frame: Frame ->
+                    isTracking = frame.camera.trackingState == TrackingState.TRACKING
+                    frame.getUpdatedTrackables(StreetscapeGeometry::class.java).forEach { geo ->
+                        if (geo.trackingState == TrackingState.TRACKING) {
+                            if (geometries.none { it == geo }) geometries.add(geo)
+                        }
+                    }
+                    geometries.removeAll { it.trackingState == TrackingState.STOPPED }
+                    geometryCount = geometries.size
+                },
+                onTrackingFailureChanged = { reason -> trackingFailureReason = reason }
+            ) {
+                geometries.forEach { geo ->
+                    // Colour-code by classification so TERRAIN and BUILDING are visually distinct.
+                    val material = when (geo.type.toMeshClassification()) {
+                        MeshClassification.TERRAIN -> terrainMaterial
+                        MeshClassification.BUILDING -> buildingMaterial
+                        else -> buildingMaterial
+                    }
+                    SceneMeshNode(
+                        streetscapeGeometry = geo,
+                        meshMaterialInstance = material,
+                    )
+                }
+            }
+
+            // Classification legend — only visible once geometry is rendering.
+            if (geometryCount > 0) {
+                MeshClassificationLegend(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(start = 16.dp, bottom = 72.dp)
+                )
+            }
+
+            // Status overlay.
+            val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
+            AnimatedVisibility(
+                visible = true,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                val statusText = when {
+                    sessionError != null -> "AR session error: $sessionError"
+                    !hasArcoreApiKey ->
+                        "ARCore Cloud API key not configured — see samples/android-demo/ARCORE_CLOUD_SETUP.md"
+                    geospatialUnavailable != null ->
+                        "${geospatialUnavailable!!} — needs outdoor area with Street View coverage + Cloud API key"
+                    ForcedTrackingFailure.override != null ->
+                        trackingFailureMessage(effectiveReason) ?: "Scanning…"
+                    geometryCount > 0 -> "Rendering $geometryCount mesh(es)"
+                    !isTracking -> trackingFailureMessage(effectiveReason)
+                        ?: "Scanning environment…"
+                    noGeometryGuidance -> stringResource(R.string.demo_ar_scene_mesh_no_geometry_hint)
+                    else -> "Looking for scene mesh…"
+                }
+                Text(
+                    text = statusText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier
+                        .padding(bottom = 32.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                            shape = RoundedCornerShape(24.dp)
+                        )
+                        .padding(horizontal = 24.dp, vertical = 12.dp)
+                )
+            }
+        }
+    }
+}
+
+/** Small overlay legend mapping the two ARCore surface types to their overlay colour. */
+@Composable
+private fun MeshClassificationLegend(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        color = Color.Black.copy(alpha = 0.6f),
+        contentColor = Color.White,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Text(
+                text = "Scene Mesh",
+                style = MaterialTheme.typography.labelMedium
+            )
+            Spacer(Modifier.height(4.dp))
+            LegendRow(
+                color = Color(0xFF4CAF50),
+                label = "Terrain"
+            )
+            LegendRow(
+                color = Color(0xFF2196F3),
+                label = "Building"
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendRow(color: Color, label: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.padding(vertical = 2.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(color)
+        )
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArSceneMeshFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArSceneMeshFragment.kt
@@ -1,0 +1,28 @@
+package io.github.sceneview.demo.fragments
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridOn
+import androidx.compose.runtime.Composable
+import io.github.sceneview.demo.DemoCategory
+import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.DemoStatus
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.ARSceneMeshDemo
+
+/** Append-only fragment for the `ar-scene-mesh` demo. See [DemoFragment]. */
+object ArSceneMeshFragment : DemoFragment {
+    override val entry: DemoEntry = DemoEntry(
+        id = "ar-scene-mesh",
+        titleRes = R.string.demo_ar_scene_mesh_title,
+        subtitleRes = R.string.demo_ar_scene_mesh_subtitle,
+        category = DemoCategory.AUGMENTED_REALITY,
+        icon = Icons.Filled.GridOn,
+        // Requires outdoor location with Street View coverage + Cloud API key.
+        status = DemoStatus.Working,
+    )
+
+    @Composable
+    override fun Screen(onBack: () -> Unit) {
+        ARSceneMeshDemo(onBack)
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_scene_mesh.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_scene_mesh.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Strings for the `ar-scene-mesh` demo (registered by ArSceneMeshFragment.kt).
+     Android's resource merger fans every res/values/*.xml file in, so
+     R.string.demo_ar_scene_mesh_title etc. remains globally resolvable.
+     Adding a new demo never needs to touch strings.xml — see #1870. -->
+<resources>
+    <string name="demo_ar_scene_mesh_title">Scene Mesh</string>
+    <string name="demo_ar_scene_mesh_subtitle">Color-coded real-world geometry with ARKit ARMeshAnchor parity</string>
+    <!-- Shown after ~15 s of tracking with no geometry found (#1615). -->
+    <string name="demo_ar_scene_mesh_no_geometry_hint">No scene mesh found. This demo needs an outdoor location with Google Street View coverage — point at nearby buildings. It will not find geometry indoors.</string>
+</resources>


### PR DESCRIPTION
## Summary

- New `SceneMeshNode` class — wraps `StreetscapeGeometry` with a unified `MeshClassification` enum providing ARKit `ARMeshAnchor` parity on Android (#1760)
- New `MeshClassification` enum (TERRAIN, BUILDING, FLOOR, WALL, CEILING, TABLE, SEAT, WINDOW, DOOR, UNLABELED) + `StreetscapeGeometry.Type.toMeshClassification()` extension
- `onClassifiedFace(faceIndex, classification)` callback matching ARKit's `ARMeshGeometry.classificationOf(faceWithIndex:)` — same signature on both platforms
- `ARSceneScope.SceneMeshNode { }` composable wired in `ARSceneScope`
- `ar-scene-mesh` demo in the Samples tab with colour-coded mesh overlay (TERRAIN = green, BUILDING = blue)

**ARCore vs ARKit parity notes:**
- ARCore: label is coarse (per geometry — TERRAIN or BUILDING). Per-face labels are not available in ARCore 1.54
- ARKit: label is per-face with fine-grained indoor labels (FLOOR, WALL, CEILING, TABLE, SEAT, WINDOW, DOOR)
- Same `onClassifiedFace` callback signature on both platforms → classification-driven rendering code compiles unchanged

## Test plan
- [ ] Build `arsceneview` — no compile errors
- [ ] Build `samples:android-demo` — no compile errors
- [ ] `ar-scene-mesh` demo appears in AR category of Samples tab
- [ ] Colour-coded mesh overlay renders (requires outdoor location with Street View coverage)
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)