### PR TITLE
fix(android-demo): honour -PversionName in build.gradle (#2125)

### DIFF
--- a/changelog.d/2125-versionname-param.md
+++ b/changelog.d/2125-versionname-param.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `samples/android-demo/build.gradle`: honour `-PversionName` from Play Store workflow — versionName was hardcoded, causing Play Console to show the stale name from the build.gradle source instead of the release tag name.

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -72,7 +72,7 @@ android {
         minSdk 28
         targetSdk 36
         versionCode project.hasProperty('versionCode') ? project.property('versionCode').toInteger() : 350
-        versionName "4.14.0"
+        versionName project.hasProperty('versionName') ? project.property('versionName') : "4.15.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Summary

- `samples/android-demo/build.gradle`: `versionName` was hardcoded as a string literal, causing Play Console to display the stale version embedded at build time instead of the release tag name passed via `-PversionName` from `play-store.yml`.
- Mirrors the existing `-PversionCode` pattern already on the same line.
- This is why Play Console showed "4.9.0" for all recent bundles (342–346) even though the tags were v4.13.0+.

## Test plan

- [ ] Trigger `play-store.yml` for the next release — Play Console should now display the correct release tag version name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)