### PR TITLE
fix(ios-demo): add .environment(.studio) to ModelViewer/Physics/SpatialAudio demos (#2114)

### DIFF
--- a/changelog.d/2114-ios-demo-studio-env.md
+++ b/changelog.d/2114-ios-demo-studio-env.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **iOS demo (samples):** `ModelViewerDemo`, `PhysicsDemo`, and `SpatialAudioDemo` now set `.environment(.studio)` on their `SceneView` — matching the android-demo IBL fix (#2110) so metallic glTF models are consistently lit across the iOS demo catalog. (#2114)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -77,6 +77,7 @@ struct ModelViewerDemo: View {
             }
             .cameraControls(.orbit)
             .autoRotate(speed: 0.3)
+            .environment(.studio) // parity with android-demo IBL fix (#2114)
             .ignoresSafeArea()
             .id("model-viewer-\(streamedDisplayName ?? "bundled")")
         } else {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
@@ -52,6 +52,7 @@ struct PhysicsDemo: View {
                 setupScene(root: root)
             }
             .cameraControls(.orbit)
+            .environment(.studio) // parity with android-demo IBL fix (#2114)
             .id(sceneKey)
             .ignoresSafeArea()
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SpatialAudioDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SpatialAudioDemo.swift
@@ -79,6 +79,7 @@ struct SpatialAudioDemo: View {
                 coordinator.attach(to: root)
             }
             .cameraControls(.orbit)
+            .environment(.studio) // parity with android-demo IBL fix (#2114)
             .ignoresSafeArea()
 
             if let loadError {


### PR DESCRIPTION
## Summary

- `ModelViewerDemo`, `PhysicsDemo`, and `SpatialAudioDemo` now set `.environment(.studio)` on their `SceneView`, matching the android-demo IBL fix (#2110)
- Metallic glTF models were inconsistently lit across the iOS demo catalog: some demos used `.studio`, others used RealityKit's dim default IBL
- AR demos (`OrbitalARDemo`) are intentionally excluded — the AR session provides real-world lighting

## Test plan
- [ ] Build `SceneViewDemo` — no compile errors
- [ ] ModelViewer demo: metallic models render with studio IBL (not dim default)
- [ ] Physics demo: falling cubes/models render with studio IBL
- [ ] Spatial Audio demo: model renders with studio IBL

Closes #2114

🤖 Generated with [Claude Code](https://claude.com/claude-code)