### PR TITLE
test(ios-maestro): fix ar-recording crash-gate text in ar.yaml

### DIFF
--- a/.maestro/ios/ar.yaml
+++ b/.maestro/ios/ar.yaml
@@ -50,7 +50,7 @@ appId: io.github.sceneview.demo
     env:
       DEMO_ID: ar-recording
       DEMO_NAME: AR Recording
-      ASSERT_TEXT: "AR requires a physical device"
+      ASSERT_TEXT: "AR recording is device-only"
 - runFlow:
     file: flows/ar-demo.yaml
     env:


### PR DESCRIPTION
## Summary

- `ARRecorderDemo` on the iOS simulator shows **"AR recording is device-only"** (not "AR requires a physical device")
- The `ar.yaml` Maestro flow had the wrong `ASSERT_TEXT` for the `ar-recording` entry, causing the flow to time out waiting for text that never appears on the simulator

## Test plan

- [ ] Run `maestro test .maestro/ios/ar.yaml` on the iOS simulator and verify `ar-recording` no longer times out
- [ ] The flow asserts "AR recording is device-only" which is visible in `ARRecorderDemo`'s simulator placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)