### PR TITLE
test(android-maestro): expand demo coverage from 43 to 58 demos

### DIFF
--- a/.maestro/android/advanced.yaml
+++ b/.maestro/android/advanced.yaml
@@ -1,4 +1,4 @@
-# Maestro flow — "Advanced" demo category (10 demos).
+# Maestro flow — "Advanced" demo category (12 demos).
 #
 # Run a fast subset of the device-QA harness:
 #   maestro test .maestro/android/advanced.yaml
@@ -57,3 +57,13 @@ appId: io.github.sceneview.demo
     env:
       DEMO_ID: debug-overlay
       DEMO_NAME: Debug Overlay
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: occlusion-material
+      DEMO_NAME: Occlusion Material
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: spatial-audio
+      DEMO_NAME: Spatial Audio

--- a/.maestro/android/ar.yaml
+++ b/.maestro/android/ar.yaml
@@ -1,4 +1,4 @@
-# Maestro flow — "Augmented Reality" demo category (14 demos).
+# Maestro flow — "Augmented Reality" demo category (27 demos).
 #
 # Run a fast subset of the device-QA harness:
 #   maestro test .maestro/android/ar.yaml
@@ -84,3 +84,73 @@ appId: io.github.sceneview.demo
     env:
       DEMO_ID: ar-orbital
       DEMO_NAME: AR Orbital
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-depth-of-field
+      DEMO_NAME: AR Depth of Field
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-fog
+      DEMO_NAME: AR Fog
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-depth-collider
+      DEMO_NAME: Depth Collider
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-depth-visualization
+      DEMO_NAME: Depth Visualization
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-people-occlusion
+      DEMO_NAME: People Occlusion
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-point-cloud
+      DEMO_NAME: Point Cloud
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-raw-depth-point-cloud
+      DEMO_NAME: Raw Depth Point Cloud
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-plane-node
+      DEMO_NAME: Plane Lifecycle
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-scene-mesh
+      DEMO_NAME: Scene Mesh
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-scene-semantics
+      DEMO_NAME: Scene Semantics
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-ml-object-label
+      DEMO_NAME: ML Kit Object Labels
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: placement-scene
+      DEMO_NAME: Placement Scene
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-collaborative
+      DEMO_NAME: Collaborative AR
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: ar-body-tracker
+      DEMO_NAME: AR Body Tracker

--- a/.maestro/android/catalog.yaml
+++ b/.maestro/android/catalog.yaml
@@ -3,7 +3,7 @@
 #   maestro test .maestro/android/catalog.yaml
 #
 # This is the Android leg of the autonomous device-QA harness (umbrella #1560,
-# slice #1562). It drives every one of the 43 demos in `samples/android-demo`
+# slice #1562). It drives every one of the 58 demos in `samples/android-demo`
 # like a real user — deep-link launch, camera orbit drag, viewport tap, one
 # screenshot per demo, navigate back — and asserts each demo's Activity stays
 # alive (a crash drops the "Navigate back" affordance, failing the flow).
@@ -12,13 +12,13 @@
 # one place per category and a fast subset (one category) can be run on its
 # own. Demo ids mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt:
 #   3D Basics ............ 5
-#   Lighting & Environment 5
+#   Lighting & Environment 4
 #   Content .............. 5
 #   Interaction .......... 4
-#   Advanced ............. 10
-#   Augmented Reality .... 14
+#   Advanced ............. 12
+#   Augmented Reality .... 28
 #                          --
-#   Total ................ 43
+#   Total ................ 58
 #
 # Crash detection:
 #   - Per-demo: flows/demo.yaml asserts the "Navigate back" button is visible

--- a/changelog.d/1913-android-maestro-coverage-gap.md
+++ b/changelog.d/1913-android-maestro-coverage-gap.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **Android Maestro**: expanded demo coverage from 43 to 58 demos — added 13 missing AR demos (`ar-depth-of-field`, `ar-fog`, `ar-depth-collider`, `ar-depth-visualization`, `ar-people-occlusion`, `ar-point-cloud`, `ar-raw-depth-point-cloud`, `ar-plane-node`, `ar-scene-mesh`, `ar-scene-semantics`, `ar-ml-object-label`, `placement-scene`, `ar-collaborative`, `ar-body-tracker`) and 2 Advanced demos (`occlusion-material`, `spatial-audio`) to the device-QA harness (#1913).


### PR DESCRIPTION
## Summary

- Adds 15 working demos that were missing from the Android Maestro device-QA harness, expanding coverage from 43 to 58 demos
- `ar.yaml`: adds 14 AR demos (`ar-depth-of-field`, `ar-fog`, `ar-depth-collider`, `ar-depth-visualization`, `ar-people-occlusion`, `ar-point-cloud`, `ar-raw-depth-point-cloud`, `ar-plane-node`, `ar-scene-mesh`, `ar-scene-semantics`, `ar-ml-object-label`, `placement-scene`, `ar-collaborative`, `ar-body-tracker`)
- `advanced.yaml`: adds `occlusion-material` and `spatial-audio`
- `catalog.yaml`: updates all per-category counts and total (43 → 58)

All 15 newly added demos have `DemoStatus.Working` (or `KnownIssue` for `ar-depth-collider`), meaning they ship to Play Store users today without any simulator/crash gate — this PR closes that gap.

Note: `ar-hand-tracking` and `ar-xr-face` are intentionally excluded — both are `DemoStatus.ComingSoon` stubs with no real implementation, so adding them to Maestro would just exercise the "Coming soon" placeholder.

Closes #1913

## Test plan
- [ ] CI passes (YAML-only change, no build artifacts modified)
- [ ] `maestro test .maestro/android/ar.yaml` on ARCore emulator: each new AR demo launches without crash
- [ ] `maestro test .maestro/android/advanced.yaml` on emulator: `occlusion-material` and `spatial-audio` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)