### PR TITLE
test(ios-demo): sync deep-link registry to full 60-demo Android catalog

### DIFF
--- a/.maestro/ios/ar.yaml
+++ b/.maestro/ios/ar.yaml
@@ -94,3 +94,80 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: ar-terrain
+# ── Newer Android AR demos (added after the 42-id widening, routed to placeholder) ──
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-pose
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-record-playback
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-image-stabilization
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-depth-of-field
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-fog
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-depth-collider
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-depth-visualization
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-people-occlusion
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-point-cloud
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-raw-depth-point-cloud
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-plane-node
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-scene-mesh
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-scene-semantics
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-ml-object-label
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: placement-scene
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-collaborative
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-body-tracker
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-hand-tracking
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: ar-xr-face

--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -12,26 +12,40 @@
 # It delegates to the per-category flows so the demo list lives in exactly one
 # place per category and a fast subset can be run on its own.
 #
-# Coverage vs the Android slice (#1562, 42 demos):
-#   iOS coverage is the subset of Android `DemoRegistry.kt` ALL_DEMOS ids that
-#   `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` —
-#   42 ids (#1579 widened the registry to the full Android catalog):
+# Coverage vs the Android slice (#1562, 60 demos):
+#   iOS coverage mirrors Android's `DemoRegistry.kt` id set — all 60 ids are
+#   registered in `DemoDeepLinkRegistry.allowedIds` so every
+#   `sceneview://demo/<id>` QR code resolves on iOS (coming-soon demos route
+#   to a placeholder instead of silently 404-ing):
 #     3D Basics ............ 5   (model-viewer, geometry, animation, multi-model,
 #                                 scene-gallery)
-#     Lighting ............. 4   (lighting, movable-light, dynamic-sky, fog)
-#     Content .............. 4   (text, lines-paths, image, billboard)
-#     Interaction .......... 2   (camera-controls, collision*)
-#     Advanced ............. 9   (physics, double-pendulum, custom-mesh, shape,
+#     Lighting ............. 5   (lighting, movable-light, dynamic-sky, fog,
+#                                 environment*)
+#     Content .............. 6   (text, lines-paths, image, billboard,
+#                                 video*, texture-streaming*)
+#     Interaction .......... 4   (camera-controls, collision*, gesture-editing*,
+#                                 view-node*)
+#     Advanced ............. 11  (physics, double-pendulum, custom-mesh, shape,
 #                                 materials, spatial-audio, post-processing*,
-#                                 reflection-probes*, secondary-camera*)
+#                                 reflection-probes*, secondary-camera*,
+#                                 occlusion-material*, debug-overlay*)
 #     Augmented Reality .... 6   (ar-placement, ar-instant-placement, ar-orbital,
 #                                 ar-lighting, ar-recording, ar-rerun — launch-only)
-#     Deep-link placeholders 12  (ar-image*, ar-face*, ar-cloud-anchor*,
+#     AR placeholders ...... 28  (ar-image*, ar-face*, ar-cloud-anchor*,
 #                                 ar-depth-occlusion*, ar-eis*, ar-pose-placement*,
 #                                 ar-rooftop*, ar-streetscape*, ar-terrain*,
-#                                 gesture-editing*, video*, view-node*)
+#                                 ar-pose*, ar-record-playback*, ar-image-stabilization*,
+#                                 ar-depth-of-field*, ar-fog*, ar-depth-collider*,
+#                                 ar-depth-visualization*, ar-people-occlusion*,
+#                                 ar-point-cloud*, ar-raw-depth-point-cloud*,
+#                                 ar-plane-node*, ar-scene-mesh*, ar-scene-semantics*,
+#                                 ar-ml-object-label*, placement-scene*,
+#                                 ar-collaborative*, ar-body-tracker*,
+#                                 ar-hand-tracking*, ar-xr-face*)
 #                                --  (* = routes to DeepLinkPlaceholder)
-#     Total ................ 42
+#     Total ................ 65  (includes 5 iOS-specific ids: ar-lighting,
+#                                 ar-eis, ar-pose-placement, ar-recording,
+#                                 movable-light)
 #
 # Why deep-link ingress, not Samples-tab navigation:
 #   The iOS Samples-tab presents demos in a `.fullScreenCover` with NO Close

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -31,6 +31,14 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: secondary-camera
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: occlusion-material
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: debug-overlay
 # ── Content / other (no iOS destination yet) ────────────────────────────────
 - runFlow:
     file: flows/placeholder.yaml
@@ -44,3 +52,12 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: view-node
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: texture-streaming
+# ── Lighting (no iOS destination yet) ───────────────────────────────────────
+- runFlow:
+    file: flows/placeholder.yaml
+    env:
+      DEMO_ID: environment

--- a/changelog.d/1579-ios-registry-full-sync.md
+++ b/changelog.d/1579-ios-registry-full-sync.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **iOS deep-link registry**: sync `DemoDeepLinkRegistry.allowedIds` to the full Android catalog (65 IDs covering all 60 Android demo IDs) — 23 new AR and 3D demo IDs added so QR codes for newer demos no longer silently 404 on iOS; corresponding placeholder flows added to Maestro `.maestro/ios/` for CI smoke coverage.

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -33,13 +33,21 @@ enum DemoDeepLinkRegistry {
         "model-viewer", "geometry", "animation", "multi-model", "scene-gallery",
         // ── Lighting ────────────────────────────────────────────────────
         "lighting", "movable-light", "fog", "dynamic-sky",
+        // Coming-soon Lighting (routed to placeholder)
+        "environment",
         // ── Content ─────────────────────────────────────────────────────
         "text", "lines-paths", "image", "billboard",
+        // Coming-soon Content (routed to placeholder)
+        "video", "texture-streaming",
         // ── Interaction ─────────────────────────────────────────────────
         "camera-controls", "collision",
+        // Coming-soon Interaction (routed to placeholder)
+        "gesture-editing", "view-node",
         // ── Advanced ────────────────────────────────────────────────────
         "physics", "double-pendulum", "custom-mesh", "materials", "spatial-audio",
         "post-processing", "reflection-probes", "secondary-camera", "shape",
+        // Coming-soon Advanced (routed to placeholder)
+        "occlusion-material", "debug-overlay",
         // ── AR (iOS-only on device) ──────────────────────────────────────
         "ar-placement", "ar-instant-placement", "ar-orbital", "ar-lighting",
         "ar-recording", "ar-rerun",
@@ -47,8 +55,13 @@ enum DemoDeepLinkRegistry {
         "ar-image", "ar-face", "ar-cloud-anchor", "ar-depth-occlusion",
         "ar-eis", "ar-pose-placement", "ar-rooftop", "ar-streetscape",
         "ar-terrain",
-        // Coming-soon 3D (routed to placeholder)
-        "gesture-editing", "video", "view-node",
+        // Newer AR demos (Android-side additions, routed to placeholder on iOS)
+        "ar-pose", "ar-record-playback", "ar-image-stabilization",
+        "ar-depth-of-field", "ar-fog", "ar-depth-collider", "ar-depth-visualization",
+        "ar-people-occlusion", "ar-point-cloud", "ar-raw-depth-point-cloud",
+        "ar-plane-node", "ar-scene-mesh", "ar-scene-semantics", "ar-ml-object-label",
+        "placement-scene", "ar-collaborative", "ar-body-tracker",
+        "ar-hand-tracking", "ar-xr-face",
     ]
 
     /// Resolve a demo id to its presented `View`. Returns a fallback


### PR DESCRIPTION
## Summary

- Expands `DemoDeepLinkRegistry.allowedIds` from 42 to 65 IDs — now covers all 60 Android `DemoRegistry.kt` IDs (5 iOS-specific IDs remain for backward-compat: `ar-lighting`, `ar-eis`, `ar-pose-placement`, `ar-recording`, `movable-light`)
- 23 new IDs added, all routing to `DeepLinkPlaceholder` — QR codes for newer Android demos no longer silently 404 on iOS
- Maestro flows updated: `ar.yaml` +19 AR placeholder entries, `placeholders.yaml` +5 non-AR entries, `catalog.yaml` updated coverage comment

**New IDs added**: `ar-depth-of-field`, `ar-fog`, `ar-depth-collider`, `ar-depth-visualization`, `ar-people-occlusion`, `ar-point-cloud`, `ar-raw-depth-point-cloud`, `ar-plane-node`, `ar-scene-mesh`, `ar-scene-semantics`, `ar-ml-object-label`, `placement-scene`, `ar-collaborative`, `ar-body-tracker`, `ar-hand-tracking`, `ar-xr-face`, `ar-pose`, `ar-record-playback`, `ar-image-stabilization`, `occlusion-material`, `debug-overlay`, `environment`, `texture-streaming`

## Test plan
- [ ] CI passes (Swift + YAML only, no build artifacts)
- [ ] `maestro test .maestro/ios/ar.yaml` — new placeholder entries launch DeepLinkPlaceholder without crash
- [ ] `maestro test .maestro/ios/placeholders.yaml` — new placeholder entries pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)