### PR TITLE
feat(ios-demo): implement Collision & Hit Test + Gesture Editing demos

### DIFF
--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -20,7 +20,7 @@
 #                                 scene-gallery)
 #     Lighting ............. 4   (lighting, movable-light, dynamic-sky, fog)
 #     Content .............. 4   (text, lines-paths, image, billboard)
-#     Interaction .......... 2   (camera-controls, collision*)
+#     Interaction .......... 2   (camera-controls, collision)
 #     Advanced ............. 9   (physics, double-pendulum, custom-mesh, shape,
 #                                 materials, spatial-audio, post-processing*,
 #                                 reflection-probes*, secondary-camera*)

--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -20,16 +20,16 @@
 #                                 scene-gallery)
 #     Lighting ............. 4   (lighting, movable-light, dynamic-sky, fog)
 #     Content .............. 4   (text, lines-paths, image, billboard)
-#     Interaction .......... 2   (camera-controls, collision)
+#     Interaction .......... 3   (camera-controls, collision, gesture-editing)
 #     Advanced ............. 9   (physics, double-pendulum, custom-mesh, shape,
 #                                 materials, spatial-audio, post-processing*,
 #                                 reflection-probes*, secondary-camera*)
 #     Augmented Reality .... 6   (ar-placement, ar-instant-placement, ar-orbital,
 #                                 ar-lighting, ar-recording, ar-rerun — launch-only)
-#     Deep-link placeholders 12  (ar-image*, ar-face*, ar-cloud-anchor*,
+#     Deep-link placeholders 11  (ar-image*, ar-face*, ar-cloud-anchor*,
 #                                 ar-depth-occlusion*, ar-eis*, ar-pose-placement*,
 #                                 ar-rooftop*, ar-streetscape*, ar-terrain*,
-#                                 gesture-editing*, video*, view-node*)
+#                                 video*, view-node*)
 #                                --  (* = routes to DeepLinkPlaceholder)
 #     Total ................ 42
 #

--- a/.maestro/ios/interaction.yaml
+++ b/.maestro/ios/interaction.yaml
@@ -3,8 +3,8 @@
 # Run a fast subset of the iOS device-QA harness:
 #   maestro test .maestro/ios/interaction.yaml
 #
-# `camera-controls` and `collision` are live on iOS; `gesture-editing` and
-# `view-node` are still "Coming soon" and are covered by placeholders.yaml.
+# `camera-controls`, `collision`, and `gesture-editing` are live on iOS;
+# `view-node` is still "Coming soon" and is covered by placeholders.yaml.
 #
 # Demo ids mirror Android `DemoRegistry.kt` ALL_DEMOS.
 appId: io.github.sceneview.demo
@@ -21,3 +21,9 @@ appId: io.github.sceneview.demo
       DEMO_ID: collision
       DEMO_NAME: Collision & Hit Test
       ASSERT_TEXT: "Tap a shape to highlight it"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: gesture-editing
+      DEMO_NAME: Gesture Editing
+      ASSERT_TEXT: "Edit Mode"

--- a/.maestro/ios/interaction.yaml
+++ b/.maestro/ios/interaction.yaml
@@ -3,11 +3,8 @@
 # Run a fast subset of the iOS device-QA harness:
 #   maestro test .maestro/ios/interaction.yaml
 #
-# Only `camera-controls` is ported to iOS today; the Android Interaction
-# category's `gesture-editing` / `collision` / `view-node` demos are still
-# "Coming soon" on iOS (see SamplesTab.allScenes()). `gesture-editing` is a
-# registered deep-link id without a destination, so it routes to the
-# `DeepLinkPlaceholder` and is covered by placeholders.yaml.
+# `camera-controls` and `collision` are live on iOS; `gesture-editing` and
+# `view-node` are still "Coming soon" and are covered by placeholders.yaml.
 #
 # Demo ids mirror Android `DemoRegistry.kt` ALL_DEMOS.
 appId: io.github.sceneview.demo
@@ -18,3 +15,9 @@ appId: io.github.sceneview.demo
       DEMO_ID: camera-controls
       DEMO_NAME: Camera Controls
       ASSERT_TEXT: "Recenter pivot on orbit"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: collision
+      DEMO_NAME: Collision & Hit Test
+      ASSERT_TEXT: "Tap a shape to highlight it"

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -27,11 +27,7 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: secondary-camera
-# ── Content / other (no iOS destination yet) ────────────────────────────────
-- runFlow:
-    file: flows/placeholder.yaml
-    env:
-      DEMO_ID: gesture-editing
+# ── Content / Interaction (no iOS destination yet) ──────────────────────────
 - runFlow:
     file: flows/placeholder.yaml
     env:

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -14,11 +14,7 @@
 # ASSERT_TEXT and drop it from here.
 appId: io.github.sceneview.demo
 ---
-# ── Advanced / Interaction (no iOS destination yet) ──────────────────────────
-- runFlow:
-    file: flows/placeholder.yaml
-    env:
-      DEMO_ID: collision
+# ── Advanced (no iOS destination yet) ───────────────────────────────────────
 - runFlow:
     file: flows/placeholder.yaml
     env:

--- a/changelog.d/910-ios-collision-demo.md
+++ b/changelog.d/910-ios-collision-demo.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **iOS — Collision & Hit Test demo**: port the `collision` demo from placeholder to a full implementation — five `GeometryNode` shapes (cubes and spheres) are tap-highlighted via `SceneView.onEntityTapped`; an on-screen "Reset Colors" button clears all highlights; Maestro `interaction.yaml` promoted from `placeholder.yaml` smoke to a real `demo.yaml` flow (#910).

--- a/changelog.d/910-ios-gesture-editing-demo.md
+++ b/changelog.d/910-ios-gesture-editing-demo.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **iOS — Gesture Editing demo**: port the `gesture-editing` demo from placeholder to a full implementation — a `ModelNode` (ferrari_f40) is draggable, pinch-scalable, and two-finger-rotatable in Edit Mode; camera orbits freely in View Mode; settings sheet shows a mode toggle, Reset button, and live transform readout (#910).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		C10000000000000000000062 /* DoublePendulumDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000062 /* DoublePendulumDemo.swift */; };
 		C10000000000000000000018 /* CameraControlsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000018 /* CameraControlsDemo.swift */; };
 		C100000000000000000000C1 /* CollisionHitTestDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000C1 /* CollisionHitTestDemo.swift */; };
+		C100000000000000000000CE /* GestureEditingDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000CE /* GestureEditingDemo.swift */; };
 		C10000000000000000000020 /* SceneGalleryDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000020 /* SceneGalleryDemo.swift */; };
 		C10000000000000000000021 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000021 /* Theme.swift */; };
 		C10000000000000000000022 /* RerunDebugDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000022 /* RerunDebugDemo.swift */; };
@@ -178,6 +179,7 @@
 		C20000000000000000000062 /* DoublePendulumDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoublePendulumDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000018 /* CameraControlsDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraControlsDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000C1 /* CollisionHitTestDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollisionHitTestDemo.swift; sourceTree = "<group>"; };
+		C200000000000000000000CE /* GestureEditingDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureEditingDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000020 /* SceneGalleryDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneGalleryDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000021 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C20000000000000000000022 /* RerunDebugDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerunDebugDemo.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				C20000000000000000000062 /* DoublePendulumDemo.swift */,
 				C20000000000000000000018 /* CameraControlsDemo.swift */,
 				C200000000000000000000C1 /* CollisionHitTestDemo.swift */,
+				C200000000000000000000CE /* GestureEditingDemo.swift */,
 				C20000000000000000000020 /* SceneGalleryDemo.swift */,
 				C20000000000000000000022 /* RerunDebugDemo.swift */,
 				C20000000000000000000025 /* OrbitalARDemo.swift */,
@@ -686,6 +689,7 @@
 				C10000000000000000000062 /* DoublePendulumDemo.swift in Sources */,
 				C10000000000000000000018 /* CameraControlsDemo.swift in Sources */,
 				C100000000000000000000C1 /* CollisionHitTestDemo.swift in Sources */,
+				C100000000000000000000CE /* GestureEditingDemo.swift in Sources */,
 				C10000000000000000000020 /* SceneGalleryDemo.swift in Sources */,
 				C10000000000000000000021 /* Theme.swift in Sources */,
 				C10000000000000000000022 /* RerunDebugDemo.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		C10000000000000000000017 /* PhysicsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000017 /* PhysicsDemo.swift */; };
 		C10000000000000000000062 /* DoublePendulumDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000062 /* DoublePendulumDemo.swift */; };
 		C10000000000000000000018 /* CameraControlsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000018 /* CameraControlsDemo.swift */; };
+		C100000000000000000000C1 /* CollisionHitTestDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000C1 /* CollisionHitTestDemo.swift */; };
 		C10000000000000000000020 /* SceneGalleryDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000020 /* SceneGalleryDemo.swift */; };
 		C10000000000000000000021 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000021 /* Theme.swift */; };
 		C10000000000000000000022 /* RerunDebugDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000022 /* RerunDebugDemo.swift */; };
@@ -176,6 +177,7 @@
 		C20000000000000000000017 /* PhysicsDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicsDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000062 /* DoublePendulumDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoublePendulumDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000018 /* CameraControlsDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraControlsDemo.swift; sourceTree = "<group>"; };
+		C200000000000000000000C1 /* CollisionHitTestDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollisionHitTestDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000020 /* SceneGalleryDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneGalleryDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000021 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C20000000000000000000022 /* RerunDebugDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerunDebugDemo.swift; sourceTree = "<group>"; };
@@ -396,6 +398,7 @@
 				C20000000000000000000017 /* PhysicsDemo.swift */,
 				C20000000000000000000062 /* DoublePendulumDemo.swift */,
 				C20000000000000000000018 /* CameraControlsDemo.swift */,
+				C200000000000000000000C1 /* CollisionHitTestDemo.swift */,
 				C20000000000000000000020 /* SceneGalleryDemo.swift */,
 				C20000000000000000000022 /* RerunDebugDemo.swift */,
 				C20000000000000000000025 /* OrbitalARDemo.swift */,
@@ -682,6 +685,7 @@
 				C10000000000000000000017 /* PhysicsDemo.swift in Sources */,
 				C10000000000000000000062 /* DoublePendulumDemo.swift in Sources */,
 				C10000000000000000000018 /* CameraControlsDemo.swift in Sources */,
+				C100000000000000000000C1 /* CollisionHitTestDemo.swift in Sources */,
 				C10000000000000000000020 /* SceneGalleryDemo.swift in Sources */,
 				C10000000000000000000021 /* Theme.swift in Sources */,
 				C10000000000000000000022 /* RerunDebugDemo.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -94,6 +94,7 @@ enum DemoDeepLinkRegistry {
 
         // ── Interaction ──────────────────────────────────────────────
         case "camera-controls": CameraControlsDemo()
+        case "collision":       CollisionHitTestDemo()
 
         // ── Advanced ─────────────────────────────────────────────────
         case "custom-mesh":     CustomMeshDemo()

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -93,8 +93,9 @@ enum DemoDeepLinkRegistry {
         case "text":          TextDemo()
 
         // ── Interaction ──────────────────────────────────────────────
-        case "camera-controls": CameraControlsDemo()
-        case "collision":       CollisionHitTestDemo()
+        case "camera-controls":  CameraControlsDemo()
+        case "collision":        CollisionHitTestDemo()
+        case "gesture-editing":  GestureEditingDemo()
 
         // ── Advanced ─────────────────────────────────────────────────
         case "custom-mesh":     CustomMeshDemo()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/CollisionHitTestDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/CollisionHitTestDemo.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import RealityKit
+import SceneViewSwift
+
+/// Collision-based hit testing demo.
+///
+/// Mirrors the Android `CollisionDemo` — five shapes (cubes and spheres)
+/// are placed in a row. Tapping a shape highlights it; the "Reset Colors"
+/// overlay button clears all highlights.
+///
+/// The demo uses `SceneView.onEntityTapped` which resolves to
+/// `SpatialTapGesture().targetedToAnyEntity()` under the hood (see
+/// `SceneView.swift`, `tapGesture`). Each `GeometryNode` calls
+/// `generateCollisionShapes(recursive: false)` at construction time, so
+/// RealityKit can fire the hit-test without extra setup.
+struct CollisionHitTestDemo: View {
+    @State private var highlightedIndices: Set<Int> = []
+    @State private var sceneKey = UUID()
+
+    private struct ShapeSpec {
+        let index: Int
+        let isSphere: Bool
+        let x: Float
+    }
+
+    private let shapes: [ShapeSpec] = [
+        ShapeSpec(index: 0, isSphere: false, x: -0.60),
+        ShapeSpec(index: 1, isSphere: true,  x: -0.30),
+        ShapeSpec(index: 2, isSphere: false, x:  0.00),
+        ShapeSpec(index: 3, isSphere: true,  x:  0.30),
+        ShapeSpec(index: 4, isSphere: false, x:  0.60),
+    ]
+
+    /// Default color — SceneView primary blue.
+    private static let defaultColor = UIColor(red: 0.24, green: 0.48, blue: 1.0, alpha: 1.0)
+    /// Highlighted color — SceneView accent purple.
+    private static let highlightColor = UIColor(red: 0.56, green: 0.25, blue: 0.94, alpha: 1.0)
+
+    var body: some View {
+        ZStack {
+            SceneView { root in
+                buildScene(root: root)
+            }
+            .onEntityTapped { entity in
+                guard let idxStr = entity.name?.components(separatedBy: "_").last,
+                      let idx = Int(idxStr) else { return }
+                if highlightedIndices.contains(idx) {
+                    highlightedIndices.remove(idx)
+                } else {
+                    highlightedIndices.insert(idx)
+                }
+                // Swap material on the entity in-place.
+                if let modelEntity = entity as? ModelEntity {
+                    let color = highlightedIndices.contains(idx)
+                        ? Self.highlightColor
+                        : Self.defaultColor
+                    let material = UnlitMaterial(color: color)
+                    modelEntity.model?.materials = [material]
+                }
+                #if os(iOS)
+                SceneViewHaptic.shared.light()
+                #endif
+            }
+            .cameraControls(.orbit)
+            .environment(.studio)
+            .id(sceneKey)
+            .ignoresSafeArea()
+            .background(Color.black)
+
+            // On-screen "Reset Colors" overlay button — mirrors Android's
+            // SceneActionBar CTA so the user always has a way to clear highlights
+            // without opening the settings sheet.
+            VStack {
+                Spacer()
+                HStack {
+                    Text("Tap a shape to highlight it")
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.6))
+                    Spacer()
+                    Button {
+                        highlightedIndices.removeAll()
+                        sceneKey = UUID()  // force scene rebuild to reset materials
+                        #if os(iOS)
+                        SceneViewHaptic.shared.medium()
+                        #endif
+                    } label: {
+                        Label("Reset Colors", systemImage: "paintbrush.fill")
+                            .font(.caption.weight(.semibold))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(.ultraThinMaterial)
+                            .clipShape(Capsule())
+                    }
+                    .foregroundStyle(.white)
+                    .accessibilityLabel("Reset all shape highlights")
+                }
+                .padding()
+            }
+        }
+    }
+
+    // MARK: - Scene building
+
+    /// Builds the five shapes from the spec list. Called on initial layout
+    /// and whenever `sceneKey` changes (Reset).
+    private func buildScene(root: Entity) {
+        for spec in shapes {
+            let color = highlightedIndices.contains(spec.index)
+                ? Self.highlightColor
+                : Self.defaultColor
+            let node: GeometryNode
+            if spec.isSphere {
+                node = GeometryNode.sphere(radius: 0.15, color: color, unlit: true)
+            } else {
+                node = GeometryNode.cube(size: 0.25, color: color, unlit: true)
+            }
+            // Name encodes the spec index so onEntityTapped can look it up.
+            node.entity.name = "shape_\(spec.index)"
+            node.entity.position = SIMD3<Float>(spec.x, 0, -2)
+            root.addChild(node.entity)
+        }
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import RealityKit
+import SceneViewSwift
+
+/// Demonstrates per-entity gesture editing of a 3D model.
+///
+/// Mirrors SceneView Android's `GestureEditingDemo`.
+///
+/// In **Edit Mode** the camera is locked and the user can:
+/// - **Drag** (one finger) — move the model in the XZ ground plane
+/// - **Pinch** — scale the model up or down
+/// - **Rotate** (two-finger twist) — spin the model around its Y axis
+///
+/// In **View Mode** the camera orbits freely (standard `.orbit` mode).
+///
+/// Toggles between modes via a gear-sheet control. A **Reset** button restores
+/// the model to its original position / rotation / scale.
+struct GestureEditingDemo: View {
+
+    // MARK: - State
+
+    @State private var loadedModel: ModelNode?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    /// Live reference to the model's RealityKit entity — updated each scene build
+    /// so gesture handlers can mutate the entity directly without rebuilding the scene.
+    @State private var modelEntityRef: Entity?
+
+    /// When `true` camera is locked and gestures move/scale/rotate the model.
+    /// When `false` camera orbits freely.
+    @State private var isEditable = true
+
+    // Transform state (mirrors entity transform; preserved across scene rebuilds)
+    @State private var modelPosition = SIMD3<Float>(0, 0, -2)
+    @State private var modelScale: Float = 0.6
+    @State private var modelRotationY: Float = 0
+
+    // Gesture tracking
+    @State private var lastDragTranslation: CGSize = .zero
+    @State private var pinchBaseScale: Float = 0.6
+    @State private var isPinching = false
+    @State private var lastRotationAngle: Double = 0
+    @State private var isRotating = false
+
+    // MARK: - Body
+
+    var body: some View {
+        sceneWithOverlays
+            .demoSettingsSheet { settingsSheet }
+    }
+
+    // MARK: - Scene
+
+    @ViewBuilder
+    private var sceneWithOverlays: some View {
+        ZStack {
+            sceneView
+
+            if isEditable {
+                gestureOverlay
+            }
+
+            topHint
+            loadingOverlay
+        }
+        .background(Color.black)
+        .task { await loadModel() }
+    }
+
+    private var sceneView: some View {
+        SceneView { root in
+            if let model = loadedModel {
+                model.entity.position = modelPosition
+                model.entity.scale = SIMD3(repeating: modelScale)
+                model.entity.orientation = simd_quatf(angle: modelRotationY, axis: [0, 1, 0])
+                root.addChild(model.entity)
+                // Capture entity for direct mutation by gesture overlay
+                DispatchQueue.main.async { modelEntityRef = model.entity }
+            }
+
+            // Ground plane for depth reference
+            let floor = GeometryNode.plane(width: 6, depth: 6, color: .darkGray)
+            floor.entity.position = SIMD3(0, -0.45, -2)
+            root.addChild(floor.entity)
+        }
+        // Don't include isEditable in the id — camera mode changes without scene rebuild
+        .id("gesture-\(loadedModel != nil)")
+        .cameraControls(isEditable ? .none : .orbit)
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Gesture overlay (edit mode only)
+
+    private var gestureOverlay: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .simultaneousGesture(dragGesture)
+            .simultaneousGesture(pinchGesture)
+            .simultaneousGesture(rotateGesture)
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 4)
+            .onChanged { value in
+                let dx = Float(value.translation.width - lastDragTranslation.width) * 0.003
+                let dz = Float(value.translation.height - lastDragTranslation.height) * 0.003
+                modelPosition.x += dx
+                modelPosition.z += dz
+                lastDragTranslation = value.translation
+                // Direct entity mutation — no SceneView rebuild
+                modelEntityRef?.position = modelPosition
+            }
+            .onEnded { _ in
+                lastDragTranslation = .zero
+            }
+    }
+
+    private var pinchGesture: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                let mag = Float(value.magnification)
+                if !isPinching {
+                    pinchBaseScale = modelScale
+                    isPinching = true
+                }
+                let s = max(0.1, min(4.0, pinchBaseScale * mag))
+                modelScale = s
+                modelEntityRef?.scale = SIMD3(repeating: s)
+            }
+            .onEnded { value in
+                let s = max(0.1, min(4.0, pinchBaseScale * Float(value.magnification)))
+                modelScale = s
+                modelEntityRef?.scale = SIMD3(repeating: s)
+                isPinching = false
+            }
+    }
+
+    private var rotateGesture: some Gesture {
+        RotateGesture()
+            .onChanged { value in
+                let delta = Float(value.rotation.radians - lastRotationAngle)
+                modelRotationY -= delta
+                lastRotationAngle = value.rotation.radians
+                modelEntityRef?.orientation = simd_quatf(angle: modelRotationY, axis: [0, 1, 0])
+            }
+            .onEnded { _ in
+                lastRotationAngle = 0
+            }
+    }
+
+    // MARK: - Overlays
+
+    private var topHint: some View {
+        VStack {
+            HStack(spacing: 6) {
+                Image(systemName: isEditable ? "hand.draw.fill" : "camera.fill")
+                Text(isEditable ? "Drag · Pinch · Rotate" : "Orbit mode — tap ⚙️ to edit")
+                    .font(.caption)
+            }
+            .foregroundStyle(.white.opacity(0.8))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(.ultraThinMaterial)
+            .clipShape(Capsule())
+            .padding(.top, 12)
+            .allowsHitTesting(false)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var loadingOverlay: some View {
+        if isLoading {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .tint(.white)
+                .scaleEffect(1.4)
+        }
+        if let err = loadError {
+            Text(err)
+                .font(.caption2)
+                .foregroundStyle(.white)
+                .padding(8)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    // MARK: - Settings sheet
+
+    @ViewBuilder
+    private var settingsSheet: some View {
+        VStack(spacing: 18) {
+            Toggle(isOn: $isEditable) {
+                Label("Edit Mode", systemImage: "hand.pinch")
+            }
+            .tint(.orange)
+
+            HStack {
+                Spacer()
+                Button {
+                    resetTransform()
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Scale: \(String(format: "%.2f", modelScale))×")
+                Text("Rotation: \(Int(modelRotationY * 180 / .pi))°")
+                Text("Position: (\(String(format: "%.2f", modelPosition.x)), \(String(format: "%.2f", modelPosition.z)))")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func resetTransform() {
+        modelPosition = SIMD3(0, 0, -2)
+        modelScale = 0.6
+        modelRotationY = 0
+        pinchBaseScale = 0.6
+        modelEntityRef?.position = modelPosition
+        modelEntityRef?.scale = SIMD3(repeating: modelScale)
+        modelEntityRef?.orientation = simd_quatf(angle: 0, axis: [0, 1, 0])
+    }
+
+    @MainActor
+    private func loadModel() async {
+        do {
+            // Ferrari F40 — bundled PBR USDZ, looks great when scaled/rotated
+            let node = try await ModelNode.load("ferrari_f40")
+            loadedModel = node
+            isLoading = false
+        } catch {
+            loadError = "Model unavailable"
+            isLoading = false
+        }
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/CollisionHitTestScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/CollisionHitTestScene.swift
@@ -2,10 +2,10 @@
 // @title       Collision & Hit Test
 // @subtitle    Hit testing and collision detection
 // @category    interaction
-// @available   false
+// @available   true
 // @icon        capsule.fill
 import SwiftUI
 
 enum CollisionHitTestScene: DemoScene {
-    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+    @MainActor static var destination: AnyView { AnyView(CollisionHitTestDemo()) }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/GestureEditingScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/GestureEditingScene.swift
@@ -2,10 +2,10 @@
 // @title       Gesture Editing
 // @subtitle    Move, scale, and rotate with gestures
 // @category    interaction
-// @available   false
+// @available   true
 // @icon        hand.pinch.fill
 import SwiftUI
 
 enum GestureEditingScene: DemoScene {
-    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+    @MainActor static var destination: AnyView { AnyView(GestureEditingDemo()) }
 }


### PR DESCRIPTION
## Summary

Ports two demos on iOS from placeholder to full SwiftUI implementations, reducing the parity gap tracked in #910:

- **Collision & Hit Test** (`collision`): Five `GeometryNode` shapes (3 cubes + 2 spheres) tap-highlight via `SceneView.onEntityTapped`; "Reset Colors" overlay button clears highlights
- **Gesture Editing** (`gesture-editing`): A `ModelNode` (ferrari_f40) is draggable, pinch-scalable, and two-finger-rotatable in Edit Mode; camera orbits freely in View Mode; settings sheet has mode toggle + Reset + live transform readout

Both demos also update the Maestro QA flows: promoted from `placeholder.yaml` smoke to full `demo.yaml`/`demo-settings.yaml` flows in `interaction.yaml`.

## Test plan

**Collision & Hit Test:**
- [ ] Build iOS demo — `CollisionHitTestDemo` compiles without errors
- [ ] Open `sceneview://demo/collision` — five shapes render (not placeholder)
- [ ] Tap a cube or sphere — turns purple; tap again — returns to blue
- [ ] Tap "Reset Colors" — all shapes return to blue + haptic fires

**Gesture Editing:**
- [ ] Open `sceneview://demo/gesture-editing` — ferrari_f40 loads in Edit Mode
- [ ] Drag with one finger — model translates in XZ plane
- [ ] Pinch — model scales; two-finger twist — model rotates
- [ ] Toggle "Edit Mode" off in settings sheet — camera orbits freely
- [ ] Tap "Reset" in settings sheet — transform returns to original

**SamplesTab:**
- [ ] SamplesTab → Interaction — shows "Collision & Hit Test" and "Gesture Editing" as live demos (not "Coming soon")

**Maestro:**
- [ ] `maestro test .maestro/ios/interaction.yaml` — all three flows pass

Closes #910 (partial — three total Interaction demos promoted in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)