### PR TITLE
feat(ios-demo): implement HDR Environment demo (#910)

### DIFF
--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -12,40 +12,27 @@
 # It delegates to the per-category flows so the demo list lives in exactly one
 # place per category and a fast subset can be run on its own.
 #
-# Coverage vs the Android slice (#1562, 60 demos):
-#   iOS coverage mirrors Android's `DemoRegistry.kt` id set — all 60 ids are
-#   registered in `DemoDeepLinkRegistry.allowedIds` so every
-#   `sceneview://demo/<id>` QR code resolves on iOS (coming-soon demos route
-#   to a placeholder instead of silently 404-ing):
+# Coverage vs the Android slice (#1562, 42 demos):
+#   iOS coverage is the subset of Android `DemoRegistry.kt` ALL_DEMOS ids that
+#   `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` —
+#   42 ids (#1579 widened the registry to the full Android catalog):
 #     3D Basics ............ 5   (model-viewer, geometry, animation, multi-model,
 #                                 scene-gallery)
-#     Lighting ............. 5   (lighting, movable-light, dynamic-sky, fog,
-#                                 environment*)
-#     Content .............. 6   (text, lines-paths, image, billboard,
-#                                 video*, texture-streaming*)
-#     Interaction .......... 4   (camera-controls, collision*, gesture-editing*,
-#                                 view-node*)
-#     Advanced ............. 11  (physics, double-pendulum, custom-mesh, shape,
+#     Lighting ............. 5   (lighting, movable-light, dynamic-sky, environment,
+                                fog)
+#     Content .............. 4   (text, lines-paths, image, billboard)
+#     Interaction .......... 2   (camera-controls, collision*)
+#     Advanced ............. 9   (physics, double-pendulum, custom-mesh, shape,
 #                                 materials, spatial-audio, post-processing*,
-#                                 reflection-probes*, secondary-camera*,
-#                                 occlusion-material*, debug-overlay*)
+#                                 reflection-probes*, secondary-camera*)
 #     Augmented Reality .... 6   (ar-placement, ar-instant-placement, ar-orbital,
 #                                 ar-lighting, ar-recording, ar-rerun — launch-only)
-#     AR placeholders ...... 28  (ar-image*, ar-face*, ar-cloud-anchor*,
+#     Deep-link placeholders 12  (ar-image*, ar-face*, ar-cloud-anchor*,
 #                                 ar-depth-occlusion*, ar-eis*, ar-pose-placement*,
 #                                 ar-rooftop*, ar-streetscape*, ar-terrain*,
-#                                 ar-pose*, ar-record-playback*, ar-image-stabilization*,
-#                                 ar-depth-of-field*, ar-fog*, ar-depth-collider*,
-#                                 ar-depth-visualization*, ar-people-occlusion*,
-#                                 ar-point-cloud*, ar-raw-depth-point-cloud*,
-#                                 ar-plane-node*, ar-scene-mesh*, ar-scene-semantics*,
-#                                 ar-ml-object-label*, placement-scene*,
-#                                 ar-collaborative*, ar-body-tracker*,
-#                                 ar-hand-tracking*, ar-xr-face*)
+#                                 gesture-editing*, video*, view-node*)
 #                                --  (* = routes to DeepLinkPlaceholder)
-#     Total ................ 65  (includes 5 iOS-specific ids: ar-lighting,
-#                                 ar-eis, ar-pose-placement, ar-recording,
-#                                 movable-light)
+#     Total ................ 43
 #
 # Why deep-link ingress, not Samples-tab navigation:
 #   The iOS Samples-tab presents demos in a `.fullScreenCover` with NO Close

--- a/.maestro/ios/lighting.yaml
+++ b/.maestro/ios/lighting.yaml
@@ -6,11 +6,6 @@
 # Each demo is exercised by the reusable flows/demo.yaml subflow. Demo ids are
 # the subset of Android `DemoRegistry.kt` ALL_DEMOS that
 # `DemoDeepLinkRegistry.allowedIds` exposes for `sceneview://demo/<id>` on iOS.
-#
-# Note — `environment` is a registered deep-link id but has no iOS destination
-# wired in `DemoDeepLinkRegistry`, so it routes to the `DeepLinkPlaceholder`
-# (not a real demo). It is covered by content.yaml's placeholder smoke set
-# rather than here, to keep this flow purely the lighting demos that exist.
 appId: io.github.sceneview.demo
 ---
 - runFlow:
@@ -31,6 +26,12 @@ appId: io.github.sceneview.demo
       DEMO_ID: dynamic-sky
       DEMO_NAME: Dynamic Sky
       ASSERT_TEXT: "12:00"
+- runFlow:
+    file: flows/demo-settings.yaml
+    env:
+      DEMO_ID: environment
+      DEMO_NAME: HDR Environment
+      ASSERT_TEXT: "Environment"
 - runFlow:
     file: flows/demo-settings.yaml
     env:

--- a/changelog.d/910-ios-environment-demo.md
+++ b/changelog.d/910-ios-environment-demo.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **iOS — HDR Environment demo**: port the `environment` demo from placeholder to a full SwiftUI implementation — `SceneViewDemo` now shows a `.demoSettingsSheet` with a grid of environment presets (`.studio`, `.outdoor`, `.sunset`, `.night`, `.warm`, `.autumn`, `.nightSky`) switchable at runtime; Maestro `lighting.yaml` promoted from placeholder to `demo-settings.yaml` smoke (#910).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		C10000000000000000000036 /* ARPlacementDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000036 /* ARPlacementDemo.swift */; };
 		C10000000000000000000037 /* ARInstantPlacementDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000037 /* ARInstantPlacementDemo.swift */; };
 		C10000000000000000000038 /* SpatialAudioDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000038 /* SpatialAudioDemo.swift */; };
+		C10000000000000000000039 /* EnvironmentDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000039 /* EnvironmentDemo.swift */; };
+		595BE7B36EE44F0893381277 /* EnvironmentScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8B5CCC5464FAB8141C76F /* EnvironmentScene.swift */; };
 		C10000000000000000000030 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000030 /* FavoritesManager.swift */; };
 		C10000000000000000000050 /* DemoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000050 /* DemoSheet.swift */; };
 		C10000000000000000000051 /* CreditsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000051 /* CreditsSheet.swift */; };
@@ -190,6 +192,7 @@
 		C20000000000000000000036 /* ARPlacementDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPlacementDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000037 /* ARInstantPlacementDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARInstantPlacementDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000038 /* SpatialAudioDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatialAudioDemo.swift; sourceTree = "<group>"; };
+		C20000000000000000000039 /* EnvironmentDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentDemo.swift; sourceTree = "<group>"; };
 		F60000000000000000000001 /* bell.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = bell.wav; sourceTree = "<group>"; };
 		F60000000000000000000002 /* CREDITS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CREDITS.md; sourceTree = "<group>"; };
 		C20000000000000000000030 /* FavoritesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
@@ -256,6 +259,7 @@
 		1C735A08AAE451562DEFBAF5 /* CustomMeshScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomMeshScene.swift; path = SceneViewDemo/Views/Demos/Scenes/CustomMeshScene.swift; sourceTree = SOURCE_ROOT; };
 		F3AB5B3BF75EEDAC30A88D74 /* DoublePendulumScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DoublePendulumScene.swift; path = SceneViewDemo/Views/Demos/Scenes/DoublePendulumScene.swift; sourceTree = SOURCE_ROOT; };
 		0A1E32030EDEC9FCFD1E4FB0 /* DynamicSkyScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DynamicSkyScene.swift; path = SceneViewDemo/Views/Demos/Scenes/DynamicSkyScene.swift; sourceTree = SOURCE_ROOT; };
+		A3B8B5CCC5464FAB8141C76F /* EnvironmentScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EnvironmentScene.swift; path = SceneViewDemo/Views/Demos/Scenes/EnvironmentScene.swift; sourceTree = SOURCE_ROOT; };
 		E7A2252AA18DB87570FD8BEB /* FogScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FogScene.swift; path = SceneViewDemo/Views/Demos/Scenes/FogScene.swift; sourceTree = SOURCE_ROOT; };
 		290876CFB45E70811AA137B6 /* GeometryScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GeometryScene.swift; path = SceneViewDemo/Views/Demos/Scenes/GeometryScene.swift; sourceTree = SOURCE_ROOT; };
 		2B57E9A1481A8D84910B567A /* GestureEditingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GestureEditingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/GestureEditingScene.swift; sourceTree = SOURCE_ROOT; };
@@ -407,6 +411,7 @@
 				C20000000000000000000036 /* ARPlacementDemo.swift */,
 				C20000000000000000000037 /* ARInstantPlacementDemo.swift */,
 				C20000000000000000000038 /* SpatialAudioDemo.swift */,
+				C20000000000000000000039 /* EnvironmentDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -703,6 +708,7 @@
 				C10000000000000000000036 /* ARPlacementDemo.swift in Sources */,
 				C10000000000000000000037 /* ARInstantPlacementDemo.swift in Sources */,
 				C10000000000000000000038 /* SpatialAudioDemo.swift in Sources */,
+				C10000000000000000000039 /* EnvironmentDemo.swift in Sources */,
 				ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */,
 				C10000000000000000000050 /* DemoSheet.swift in Sources */,
 				C10000000000000000000051 /* CreditsSheet.swift in Sources */,
@@ -731,6 +737,7 @@
 				4174B93766B7BD3B8D98783F /* CustomMeshScene.swift in Sources */,
 				BD016517EAC148510B51E258 /* DoublePendulumScene.swift in Sources */,
 				CDDC40367454570BA7AF147F /* DynamicSkyScene.swift in Sources */,
+				595BE7B36EE44F0893381277 /* EnvironmentScene.swift in Sources */,
 				FED589255E75D35A9DACBA0A /* FogScene.swift in Sources */,
 				A8F7A49A69BCF88DD6C97314 /* GeometryScene.swift in Sources */,
 				0FE3731854F188786E79ED57 /* GestureEditingScene.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -32,9 +32,7 @@ enum DemoDeepLinkRegistry {
         // ── 3D Basics ───────────────────────────────────────────────────
         "model-viewer", "geometry", "animation", "multi-model", "scene-gallery",
         // ── Lighting ────────────────────────────────────────────────────
-        "lighting", "movable-light", "fog", "dynamic-sky",
-        // Coming-soon Lighting (routed to placeholder)
-        "environment",
+        "lighting", "movable-light", "fog", "dynamic-sky", "environment",
         // ── Content ─────────────────────────────────────────────────────
         "text", "lines-paths", "image", "billboard",
         // Coming-soon Content (routed to placeholder)
@@ -97,6 +95,7 @@ enum DemoDeepLinkRegistry {
         case "lighting":      LightingDemo()
         case "movable-light": MovableLightDemo()
         case "dynamic-sky":   DynamicSkyDemo()
+        case "environment":   EnvironmentDemo()
         case "fog":           FogDemo()
 
         // ── Content ──────────────────────────────────────────────────

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/EnvironmentDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/EnvironmentDemo.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import RealityKit
+import SceneViewSwift
+
+/// HDR environment switching demo.
+///
+/// Loads the bundled hero model (metallic/reflective) and lets the user
+/// switch between the seven bundled HDR environments. Each environment
+/// changes the scene's image-based lighting, making reflections and
+/// overall scene tone update instantly.
+///
+/// Mirrors the Android `EnvironmentDemo` (`samples/android-demo/.../EnvironmentDemo.kt`):
+/// the same hero model (reflective, PBR) is held static while the environment
+/// rotates so A/B comparison is easy — if both the model and the environment
+/// moved simultaneously, the reflections would be ambiguous.
+///
+/// The `.environment(_:)` modifier + `SceneEnvironment` presets are the iOS
+/// SceneViewSwift API; the Android demo uses `rememberEnvironmentLoader` /
+/// `createHDREnvironment` from the Filament backend — different renderer,
+/// same concept.
+struct EnvironmentDemo: View {
+    @State private var selectedEnvironment: SceneEnvironment = .studio
+    @State private var loadedNode: ModelNode?
+    @State private var loadError: String?
+
+    var body: some View {
+        content
+            .demoSettingsSheet {
+                environmentPicker
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        ZStack {
+            if let loadedNode {
+                SceneView { root in
+                    loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
+                    root.addChild(loadedNode.entity)
+                }
+                .environment(selectedEnvironment)
+                .cameraControls(.orbit)
+                .autoRotate(speed: 0.15)
+                .ignoresSafeArea()
+                // Re-mount the RealityView when the environment changes so the new
+                // EnvironmentResource is applied cleanly. A `.id` keyed on the
+                // environment name is simpler than patching ImageBasedLightComponent
+                // in place and avoids any cached-resource aliasing edge cases.
+                .id("environment-\(selectedEnvironment.name)")
+            } else {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .tint(.white)
+                    if let loadError {
+                        Text(loadError)
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 24)
+                    } else {
+                        Text("Loading model…")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+            }
+        }
+        .background(Color.black)
+        .task {
+            await loadHero()
+        }
+    }
+
+    @ViewBuilder
+    private var environmentPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Environment")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100))], spacing: 8) {
+                ForEach(SceneEnvironment.allPresets, id: \.name) { env in
+                    Button {
+                        selectedEnvironment = env
+                        #if os(iOS)
+                        SceneViewHaptic.shared.light()
+                        #endif
+                    } label: {
+                        Text(env.name)
+                            .font(.caption.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(selectedEnvironment.name == env.name
+                                          ? Color.accentColor
+                                          : Color(.systemFill))
+                            )
+                            .foregroundStyle(selectedEnvironment.name == env.name
+                                             ? Color.white
+                                             : Color.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Environment: \(env.name)")
+                    .accessibilityAddTraits(selectedEnvironment.name == env.name ? .isSelected : [])
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    }
+
+    @MainActor
+    private func loadHero() async {
+        loadError = nil
+        do {
+            // Use the same cyberpunk_hovercar hero as ModelViewerDemo — it has high
+            // specular roughness variation so environmental lighting reads clearly.
+            let node = try await ModelNode.load("cyberpunk_hovercar")
+            _ = node.scaleToUnits(0.6)
+            _ = node.centerOrigin()
+            loadedNode = node
+        } catch {
+            loadError = "Could not load model: \(error.localizedDescription)"
+        }
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/EnvironmentScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/EnvironmentScene.swift
@@ -1,0 +1,11 @@
+// @sceneId     environment
+// @title       HDR Environment
+// @subtitle    Switch between bundled HDR environments
+// @category    lighting
+// @available   true
+// @icon        sun.haze.fill
+import SwiftUI
+
+enum EnvironmentScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(EnvironmentDemo()) }
+}


### PR DESCRIPTION
## Summary

- Ports the `environment` demo from a "Coming Soon" placeholder to a full SwiftUI implementation
- 7 HDR environment presets switchable via a settings sheet gear FAB
- Loads `cyberpunk_hovercar` model as the test subject
- Updates `EnvironmentScene.swift` `@available true` so the demo appears live in the Samples tab
- Wires `case "environment":` in `DemoDeepLinkRegistry` so deep-link QR codes resolve
- Adds Maestro QA flow entry (`demo-settings.yaml` variant, asserts the gear FAB and sheet content)
- Adds `changelog.d/910-ios-environment-demo.md` fragment

Supersedes #2148 (rebased on top of #2147 sync PR to resolve conflict in `DemoDeepLinkRegistry.swift` and `catalog.yaml`).

Part of iOS demo parity umbrella issue #910.

## Test plan

- [ ] Build `SceneViewDemo` target on iPhone simulator — compiles clean
- [ ] `sceneview://demo/environment` deep-link opens `EnvironmentDemo`
- [ ] Settings sheet shows 7 environment chips; tapping one changes the IBL
- [ ] Maestro: `maestro test .maestro/ios/lighting.yaml` passes the `environment` flow
- [ ] `EnvironmentScene` appears as a live (non-Coming-Soon) tile in the Samples tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)