### PR TITLE
chore(deps): bump Filament 1.71.0 → 1.71.4

### DIFF
--- a/changelog.d/2156-filament-1.71.4.md
+++ b/changelog.d/2156-filament-1.71.4.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Bump Filament from 1.71.0 to 1.71.4 (patch — no `.filamat` recompile needed; includes Metal async resource loading, bounds-check fixes in `filaflat`, and iOS arm64 simulator support in Xcode 16+) (#2156).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ kotlinMath = "1.8.0"
 # integration approach and slicing plan (issue #1738).
 jetpackXrArCore = "1.0.0-alpha14"
 
-# Filament 1.71.0 — must match the binary version of .filamat files committed
+# Filament 1.71.4 — must match the binary version of .filamat files committed
 # under sceneview/src/main/assets/materials/ and website-static/materials/.
 # Those were recompiled to material-binary version 71 in commit `efd296f1`
 # (Apr 11) when Filament was first bumped 1.70.2 → 1.71.0. The follow-up
@@ -36,12 +36,13 @@ jetpackXrArCore = "1.0.0-alpha14"
 # .filamat were still v70 — they are not. That mismatch caused v4.1.0 to
 # SIGABRT at material-load on Lighting / Geometry / Animation / MovableLight /
 # MultiModel demos (Filament 1.70.2 cannot parse v71 packages). v4.1.1
-# restores the consistent pair: 1.71.0 runtime + v71 .filamat. To downgrade
-# back to 1.70.2 in the future, you MUST first run matc 1.70.2 against
-# `sceneview/src/main/materials/*.mat` and commit the regenerated v70 .filamat.
+# restores the consistent pair: 1.71.0 runtime + v71 .filamat.
+# 1.71.1–1.71.4 are patch releases with no material-format version change
+# (no MATERIAL_VERSION bump) — the .filamat blobs compiled at 1.71.0 remain
+# valid at 1.71.4. No matc recompile is required for this patch bump.
 # Session #800 / #961 track future Filament bumps with the same paired-update
 # guarantee.
-filament = "1.71.0"
+filament = "1.71.4"
 arCore = "1.54.0"
 
 # Networking


### PR DESCRIPTION
## Summary
Bump Filament from 1.71.0 to 1.71.4.

**No `.filamat` recompile needed**: verified no `MATERIAL_VERSION` constant change between 1.71.0 and 1.71.4. The `.filamat` blobs compiled at 1.71.0 (material-binary version 71) remain valid.

Notable patch changes:
- Metal: add support for asynchronous resource loading (1.71.3)
- `filaflat`: fix missing bounds checks in `MaterialChunk::getTextShader` (1.71.1)
- iOS: add Apple silicon (`arm64`) iOS Simulator support; Xcode 16+ now required (1.71.4)
- Various bug fixes and stability improvements

Closes #2156

## Test plan
- [ ] CI: `Build libraries & samples` passes (compileReleaseKotlin)
- [ ] CI: `Unit tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)