### PR TITLE
fix(docs): include hidden files in site artifact so .well-known/ survives deploy (#2155)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -276,6 +276,13 @@ jobs:
           name: sceneview-site
           path: site
           retention-days: 1
+          # Include dot-prefixed directories (e.g. `.well-known/`) in the
+          # artifact. By default upload-artifact@v4+ uses @actions/glob which
+          # excludes hidden files/dirs, so `.well-known/assetlinks.json` and
+          # `apple-app-site-association` would be silently stripped from the
+          # archive — causing the DEPLOY job's patch step to error with
+          # "site/.well-known/assetlinks.json missing" (#2155).
+          include-hidden-files: true
 
   deploy:
     name: Deploy to sceneview.github.io

--- a/changelog.d/2155-docs-well-known-artifact-hidden-files.md
+++ b/changelog.d/2155-docs-well-known-artifact-hidden-files.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Fix `.well-known/assetlinks.json` and `apple-app-site-association` returning HTTP 404 on `sceneview.github.io` — `upload-artifact@v7` silently stripped dot-prefixed directories unless `include-hidden-files: true` is set, causing the deploy job's patch step to fail (#2155).


### PR DESCRIPTION
## Summary

- Adds `include-hidden-files: true` to the `upload-artifact@v7` step in `docs.yml` so `.well-known/` survives the build→deploy artifact transfer
- Root cause: `upload-artifact@v4+` uses `@actions/glob` which silently excludes dot-prefixed directories, stripping `.well-known/assetlinks.json` and `apple-app-site-association` from the artifact
- This caused the DEPLOY job's post-peaceiris patch step (added in #2160) to error with "site/.well-known/assetlinks.json missing — build artifact is broken", leaving the deep-link manifests at HTTP 404 on sceneview.github.io

## Test plan

- [ ] docs.yml passes on merge: build verifies `site/.well-known/assetlinks.json` ✅, deploy job's patch step finds the file and pushes `.well-known/` to `sceneview/sceneview.github.io`
- [ ] `https://sceneview.github.io/.well-known/assetlinks.json` returns HTTP 200 after the next deploy
- [ ] `https://sceneview.github.io/.well-known/apple-app-site-association` returns HTTP 200 after the next deploy

Closes #2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)