### PR TITLE
feat(ios-demo): add Texture Streaming demo — PBR material preset switcher (#910)

### DIFF
--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -21,7 +21,7 @@
 #     Lighting ............. 5   (lighting, movable-light, dynamic-sky, fog,
 #                                 environment)
 #     Content .............. 6   (text, lines-paths, image, billboard,
-#                                 video, texture-streaming*)
+#                                 video*, texture-streaming)
 #     Interaction .......... 4   (camera-controls, collision, gesture-editing,
 #                                 view-node*)
 #     Advanced ............. 11  (physics, double-pendulum, custom-mesh, shape,

--- a/.maestro/ios/content.yaml
+++ b/.maestro/ios/content.yaml
@@ -40,3 +40,9 @@ appId: io.github.sceneview.demo
       DEMO_ID: video
       DEMO_NAME: Video Texture
       ASSERT_TEXT: "Playing"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: texture-streaming
+      DEMO_NAME: Texture Streaming
+      ASSERT_TEXT: "Material"

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -36,7 +36,4 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: view-node
-- runFlow:
-    file: flows/placeholder.yaml
-    env:
-      DEMO_ID: texture-streaming
+# texture-streaming: live demo since #2163 — moved to content.yaml

--- a/changelog.d/910-ios-texture-streaming-demo.md
+++ b/changelog.d/910-ios-texture-streaming-demo.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- iOS demo: add Texture Streaming demo (`sceneview://demo/texture-streaming`) — interactive PBR material preset switcher (Gold/Silver/Copper/Ceramic/Plastic/Rubber) on a sphere using `PhysicallyBasedMaterial`; teaches runtime material swap without geometry rebuild (#910).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		C10000000000000000000038 /* SpatialAudioDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000038 /* SpatialAudioDemo.swift */; };
 		C10000000000000000000039 /* EnvironmentDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000039 /* EnvironmentDemo.swift */; };
 		595BE7B36EE44F0893381277 /* EnvironmentScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8B5CCC5464FAB8141C76F /* EnvironmentScene.swift */; };
+		C100000000000000000000E0 /* TextureStreamingDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000E0 /* TextureStreamingDemo.swift */; };
+		C100000000000000000000E1 /* TextureStreamingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000E1 /* TextureStreamingScene.swift */; };
 		C100000000000000000000F0 /* ARImageTrackingDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000F0 /* ARImageTrackingDemo.swift */; };
 		C100000000000000000000F1 /* ARAugmentedFacesDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000F1 /* ARAugmentedFacesDemo.swift */; };
 		C100000000000000000000F2 /* ARDepthOcclusionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000F2 /* ARDepthOcclusionDemo.swift */; };
@@ -205,6 +207,8 @@
 		C20000000000000000000037 /* ARInstantPlacementDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARInstantPlacementDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000038 /* SpatialAudioDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatialAudioDemo.swift; sourceTree = "<group>"; };
 		C20000000000000000000039 /* EnvironmentDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentDemo.swift; sourceTree = "<group>"; };
+		C200000000000000000000E0 /* TextureStreamingDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureStreamingDemo.swift; sourceTree = "<group>"; };
+		C200000000000000000000E1 /* TextureStreamingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextureStreamingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/TextureStreamingScene.swift; sourceTree = SOURCE_ROOT; };
 		C200000000000000000000F0 /* ARImageTrackingDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARImageTrackingDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000F1 /* ARAugmentedFacesDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARAugmentedFacesDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000F2 /* ARDepthOcclusionDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARDepthOcclusionDemo.swift; sourceTree = "<group>"; };
@@ -442,6 +446,7 @@
 				C200000000000000000000D0 /* ShapeExtrudeDemo.swift */,
 				C200000000000000000000D1 /* ReflectionProbesDemo.swift */,
 				C200000000000000000000D2 /* VideoTextureDemo.swift */,
+				C200000000000000000000E0 /* TextureStreamingDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -765,6 +770,7 @@
 				C100000000000000000000D0 /* ShapeExtrudeDemo.swift in Sources */,
 				C100000000000000000000D1 /* ReflectionProbesDemo.swift in Sources */,
 				C100000000000000000000D2 /* VideoTextureDemo.swift in Sources */,
+				C100000000000000000000E0 /* TextureStreamingDemo.swift in Sources */,
 				ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */,
 				C10000000000000000000050 /* DemoSheet.swift in Sources */,
 				C10000000000000000000051 /* CreditsSheet.swift in Sources */,
@@ -813,6 +819,7 @@
 				A3BAB0EC281F966421D8019A /* SpatialAudioScene.swift in Sources */,
 				1CFD879D196F1D23142D7ACD /* TextScene.swift in Sources */,
 				A928A0266FD0B8196F11DF4A /* VideoTextureScene.swift in Sources */,
+				C100000000000000000000E1 /* TextureStreamingScene.swift in Sources */,
 				9D72C9CAE331B90315010DC3 /* ViewNodeScene.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -99,11 +99,12 @@ enum DemoDeepLinkRegistry {
         case "fog":           FogDemo()
 
         // ── Content ──────────────────────────────────────────────────
-        case "billboard":     BillboardDemo()
-        case "image":         ImageDemo()
-        case "lines-paths":   LinesPathsDemo()
-        case "text":          TextDemo()
-        case "video":         VideoTextureDemo()
+        case "billboard":         BillboardDemo()
+        case "image":             ImageDemo()
+        case "lines-paths":       LinesPathsDemo()
+        case "text":              TextDemo()
+        case "texture-streaming": TextureStreamingDemo()
+        case "video":             VideoTextureDemo()
 
         // ── Interaction ──────────────────────────────────────────────
         case "camera-controls":  CameraControlsDemo()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/TextureStreamingScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/TextureStreamingScene.swift
@@ -1,0 +1,11 @@
+// @sceneId     texture-streaming
+// @title       Texture Streaming
+// @subtitle    Swap PBR materials at runtime without rebuilding geometry
+// @category    content
+// @available   true
+// @icon        circle.dotted.and.circle
+import SwiftUI
+
+enum TextureStreamingScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(TextureStreamingDemo()) }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/TextureStreamingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/TextureStreamingDemo.swift
@@ -61,7 +61,7 @@ struct TextureStreamingDemo: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    // MARK: — Scene (RealityView)
+    // MARK: — RealityView overlay
 
     @ViewBuilder
     private var sphereOverlay: some View {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/TextureStreamingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/TextureStreamingDemo.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import RealityKit
+import SceneViewSwift
+
+/// iOS equivalent of Android's `TextureStreamingDemo` — showcases how
+/// material / texture data can be swapped on an already-loaded model
+/// without rebuilding geometry.
+///
+/// On Android / Filament the demo constructs a fresh `MaterialInstance`
+/// per variant and reassigns it to a `SphereNode`; on iOS the same swap
+/// is a `PhysicallyBasedMaterial` property update on an already-placed
+/// `ModelEntity`.  Both teach the same concept: real-time material
+/// parameter streaming is instantaneous (no geometry rebuild, no GPU
+/// stall).
+///
+/// Coverage: `sceneview://demo/texture-streaming`
+struct TextureStreamingDemo: View {
+
+    // MARK: — Material variants (mirrors Android's MaterialVariant list)
+
+    private struct MaterialPreset: Identifiable {
+        let id: String
+        let label: String
+        let baseColor: UIColor
+        let roughness: Float        // 0 = mirror-smooth  1 = matte
+        let metallic: Float         // 0 = dielectric     1 = metallic
+    }
+
+    private static let presets: [MaterialPreset] = [
+        MaterialPreset(id: "gold",       label: "Gold",      baseColor: UIColor(red: 1.00, green: 0.76, blue: 0.34, alpha: 1), roughness: 0.15, metallic: 1.0),
+        MaterialPreset(id: "silver",     label: "Silver",    baseColor: UIColor(red: 0.75, green: 0.75, blue: 0.78, alpha: 1), roughness: 0.10, metallic: 1.0),
+        MaterialPreset(id: "copper",     label: "Copper",    baseColor: UIColor(red: 0.72, green: 0.45, blue: 0.20, alpha: 1), roughness: 0.20, metallic: 1.0),
+        MaterialPreset(id: "ceramic",    label: "Ceramic",   baseColor: UIColor(red: 0.93, green: 0.90, blue: 0.85, alpha: 1), roughness: 0.60, metallic: 0.0),
+        MaterialPreset(id: "plastic",    label: "Plastic",   baseColor: UIColor(red: 0.20, green: 0.50, blue: 0.80, alpha: 1), roughness: 0.40, metallic: 0.0),
+        MaterialPreset(id: "rubber",     label: "Rubber",    baseColor: UIColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1), roughness: 0.90, metallic: 0.0),
+    ]
+
+    // MARK: — State
+
+    @State private var selectedIndex: Int = 0
+
+    // MARK: — Body
+
+    var body: some View {
+        ZStack {
+            SceneView { scene in
+                // Place a sphere entity; material applied / updated below.
+            }
+            .overlay(sphereOverlay)
+            .ignoresSafeArea()
+
+            // Controls overlay at the bottom.
+            VStack {
+                Spacer()
+                controlsOverlay
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+                    .padding()
+            }
+        }
+        .navigationTitle("Texture Streaming")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: — Scene (RealityView)
+
+    @ViewBuilder
+    private var sphereOverlay: some View {
+        RealityView { content in
+            let entity = makeSphereEntity(preset: Self.presets[selectedIndex])
+            entity.name = "sphere"
+            content.add(entity)
+        } update: { content in
+            guard let entity = content.entities.first(where: { $0.name == "sphere" }),
+                  var model = entity.components[ModelComponent.self] else { return }
+            let preset = Self.presets[selectedIndex]
+            var pbr = PhysicallyBasedMaterial()
+            pbr.baseColor = .init(tint: preset.baseColor)
+            pbr.roughness = .init(floatLiteral: preset.roughness)
+            pbr.metallic  = .init(floatLiteral: preset.metallic)
+            model.materials = [pbr]
+            entity.components.set(model)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Controls
+
+    @ViewBuilder
+    private var controlsOverlay: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Material")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Self.presets.indices, id: \.self) { index in
+                        let preset = Self.presets[index]
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                selectedIndex = index
+                            }
+                        } label: {
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(Color(preset.baseColor))
+                                    .frame(width: 12, height: 12)
+                                Text(preset.label)
+                                    .font(.subheadline)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(selectedIndex == index ? .accentColor : .secondary)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(selectedIndex == index ? Color.accentColor : Color.clear, lineWidth: 2)
+                        )
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+
+            let preset = Self.presets[selectedIndex]
+            Text(String(format: "Metallic: %.2f   Roughness: %.2f", preset.metallic, preset.roughness))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+        }
+    }
+
+    // MARK: — Helpers
+
+    private func makeSphereEntity(preset: MaterialPreset) -> ModelEntity {
+        var pbr = PhysicallyBasedMaterial()
+        pbr.baseColor = .init(tint: preset.baseColor)
+        pbr.roughness = .init(floatLiteral: preset.roughness)
+        pbr.metallic  = .init(floatLiteral: preset.metallic)
+        let mesh = MeshResource.generateSphere(radius: 0.3)
+        let entity = ModelEntity(mesh: mesh, materials: [pbr])
+        entity.position = [0, 0, -0.8]
+        return entity
+    }
+}


### PR DESCRIPTION
## Summary

- New `TextureStreamingDemo` showcases runtime material parameter streaming: 6 PBR material presets (Gold, Silver, Copper, Ceramic, Plastic, Rubber) hot-swapped on a RealityKit `ModelEntity` sphere without rebuilding geometry.
- Bottom controls: horizontal chip row to switch presets; detail text shows metallic/roughness values.
- Reachable via `sceneview://demo/texture-streaming`.
- `TextureStreamingScene.swift` wires the demo into the Samples tab with `@available true`.
- Maestro flow in `content.yaml` asserts "Material" (always-visible chip row label).

Rebased on main with conflict resolution (replaces #2164).

## Test plan

- [ ] Build on iOS simulator: compiles without errors or warnings
- [ ] `sceneview://demo/texture-streaming` launches and shows the sphere with material chip row
- [ ] Tapping each chip hot-swaps the sphere material (Gold → metallic/shiny, Rubber → dark/matte)
- [ ] `check-deprecated-api.sh` passes (MARK comment fix)
- [ ] Maestro: `maestro test .maestro/ios/content.yaml` passes (texture-streaming asserts "Material")

Closes part of #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)