### PR TITLE
feat(ios-demo): implement DebugOverlayDemo — sphere stress test with live FPS overlay (#910)

### DIFF
--- a/.maestro/ios/advanced.yaml
+++ b/.maestro/ios/advanced.yaml
@@ -57,3 +57,9 @@ appId: io.github.sceneview.demo
       DEMO_ID: occlusion-material
       DEMO_NAME: Occlusion Material
       ASSERT_TEXT: "Show occluder plane"
+- runFlow:
+    file: flows/demo.yaml
+    env:
+      DEMO_ID: debug-overlay
+      DEMO_NAME: Debug Overlay
+      ASSERT_TEXT: "FPS:"

--- a/.maestro/ios/catalog.yaml
+++ b/.maestro/ios/catalog.yaml
@@ -24,17 +24,17 @@
 #                                 video, texture-streaming)
 #     Interaction .......... 4   (camera-controls, collision, gesture-editing,
 #                                 view-node*)
-#     Advanced ............. 11  (physics, double-pendulum, custom-mesh, shape,
+#     Advanced ............. 12  (physics, double-pendulum, custom-mesh, shape,
 #                                 materials, spatial-audio, reflection-probes,
-#                                 occlusion-material, post-processing*,
-#                                 secondary-camera*, debug-overlay*)
+#                                 occlusion-material, debug-overlay,
+#                                 post-processing*, secondary-camera*)
 #     Augmented Reality .... 12  (ar-placement, ar-instant-placement, ar-orbital,
 #                                 ar-lighting, ar-recording, ar-rerun — launch-only;
 #                                 ar-image, ar-face, ar-depth-occlusion,
 #                                 ar-people-occlusion, ar-body-tracker, ar-scene-mesh
 #                                 — show device-required screen on simulator)
-#     Deep-link placeholders 26  (4 non-AR: post-processing*, secondary-camera*,
-#                                 debug-overlay*, view-node*; 22 AR-only ids)
+#     Deep-link placeholders 25  (3 non-AR: post-processing*, secondary-camera*,
+#                                 view-node*; 22 AR-only ids)
 #                                --  (* = routes to DeepLinkPlaceholder)
 #     Total ................ 49
 #

--- a/.maestro/ios/placeholders.yaml
+++ b/.maestro/ios/placeholders.yaml
@@ -23,10 +23,6 @@ appId: io.github.sceneview.demo
     file: flows/placeholder.yaml
     env:
       DEMO_ID: secondary-camera
-- runFlow:
-    file: flows/placeholder.yaml
-    env:
-      DEMO_ID: debug-overlay
 # ── Content / Interaction (no iOS destination yet) ──────────────────────────
 - runFlow:
     file: flows/placeholder.yaml

--- a/changelog.d/910-ios-debug-overlay-demo.md
+++ b/changelog.d/910-ios-debug-overlay-demo.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- **iOS demo: Debug Overlay** — RealityKit sphere stress test with live FPS stats, frame time, node/triangle counts, and a rolling FPS sparkline. Matches Android's `DebugOverlayDemo`: preset buttons (1/10/100/500/1 000 spheres), progressive spawn, and a 10-second stress ramp from 1 → 1 000 spheres. `sceneview://demo/debug-overlay` now routes to the real demo instead of the coming-soon placeholder. (#910)

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		C100000000000000000000D2 /* VideoTextureDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D2 /* VideoTextureDemo.swift */; };
 		C100000000000000000000D3 /* OcclusionMaterialDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D3 /* OcclusionMaterialDemo.swift */; };
 		C100000000000000000000D4 /* OcclusionMaterialScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D4 /* OcclusionMaterialScene.swift */; };
+		C100000000000000000000D5 /* DebugOverlayDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D5 /* DebugOverlayDemo.swift */; };
+		C100000000000000000000D6 /* DebugOverlayScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D6 /* DebugOverlayScene.swift */; };
 		E500000000000000000000D3 /* sample.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = E600000000000000000000D3 /* sample.mp4 */; };
 		C10000000000000000000030 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000030 /* FavoritesManager.swift */; };
 		C10000000000000000000050 /* DemoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000050 /* DemoSheet.swift */; };
@@ -215,6 +217,7 @@
 		C200000000000000000000D1 /* ReflectionProbesDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionProbesDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000D2 /* VideoTextureDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTextureDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000D3 /* OcclusionMaterialDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OcclusionMaterialDemo.swift; sourceTree = "<group>"; };
+		C200000000000000000000D5 /* DebugOverlayDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOverlayDemo.swift; sourceTree = "<group>"; };
 		E600000000000000000000D3 /* sample.mp4 */ = {isa = PBXFileReference; lastKnownFileType = video.mpeg4; path = sample.mp4; sourceTree = "<group>"; };
 		F60000000000000000000001 /* bell.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = bell.wav; sourceTree = "<group>"; };
 		F60000000000000000000002 /* CREDITS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CREDITS.md; sourceTree = "<group>"; };
@@ -297,6 +300,7 @@
 		D7DC3F5EC4E236A2116CB086 /* PostProcessingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostProcessingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/PostProcessingScene.swift; sourceTree = SOURCE_ROOT; };
 		BAC5EEABA6D7A33E6E4C2ED2 /* ReflectionProbesScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReflectionProbesScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ReflectionProbesScene.swift; sourceTree = SOURCE_ROOT; };
 		C200000000000000000000D4 /* OcclusionMaterialScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OcclusionMaterialScene.swift; path = SceneViewDemo/Views/Demos/Scenes/OcclusionMaterialScene.swift; sourceTree = SOURCE_ROOT; };
+		C200000000000000000000D6 /* DebugOverlayScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DebugOverlayScene.swift; path = SceneViewDemo/Views/Demos/Scenes/DebugOverlayScene.swift; sourceTree = SOURCE_ROOT; };
 		0EA61BCBF55BC370123347AE /* SceneGalleryScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneGalleryScene.swift; path = SceneViewDemo/Views/Demos/Scenes/SceneGalleryScene.swift; sourceTree = SOURCE_ROOT; };
 		599FF550976F81CB5AFE68BF /* SecondaryCameraScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SecondaryCameraScene.swift; path = SceneViewDemo/Views/Demos/Scenes/SecondaryCameraScene.swift; sourceTree = SOURCE_ROOT; };
 		1B0C8E686D511E4A17E75291 /* ShapeExtrudeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShapeExtrudeScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ShapeExtrudeScene.swift; sourceTree = SOURCE_ROOT; };
@@ -447,6 +451,7 @@
 				C200000000000000000000D1 /* ReflectionProbesDemo.swift */,
 				C200000000000000000000D2 /* VideoTextureDemo.swift */,
 				C200000000000000000000D3 /* OcclusionMaterialDemo.swift */,
+				C200000000000000000000D5 /* DebugOverlayDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -772,6 +777,8 @@
 				C100000000000000000000D2 /* VideoTextureDemo.swift in Sources */,
 				C100000000000000000000D3 /* OcclusionMaterialDemo.swift in Sources */,
 				C100000000000000000000D4 /* OcclusionMaterialScene.swift in Sources */,
+				C100000000000000000000D5 /* DebugOverlayDemo.swift in Sources */,
+				C100000000000000000000D6 /* DebugOverlayScene.swift in Sources */,
 				ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */,
 				C10000000000000000000050 /* DemoSheet.swift in Sources */,
 				C10000000000000000000051 /* CreditsSheet.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -44,9 +44,8 @@ enum DemoDeepLinkRegistry {
         // ── Advanced ────────────────────────────────────────────────────
         "physics", "double-pendulum", "custom-mesh", "materials", "spatial-audio",
         "post-processing", "reflection-probes", "secondary-camera", "shape",
-        "occlusion-material",
+        "occlusion-material", "debug-overlay",
         // Coming-soon Advanced (routed to placeholder)
-        "debug-overlay",
         // ── AR (iOS-only on device) ──────────────────────────────────────
         "ar-placement", "ar-instant-placement", "ar-orbital", "ar-lighting",
         "ar-recording", "ar-rerun",
@@ -116,6 +115,7 @@ enum DemoDeepLinkRegistry {
         case "double-pendulum": DoublePendulumDemo()
         case "materials":       MaterialsDemo()
         case "physics":         PhysicsDemo()
+        case "debug-overlay":     DebugOverlayDemo()
         case "occlusion-material": OcclusionMaterialDemo()
         case "shape":           ShapeExtrudeDemo()
         case "reflection-probes": ReflectionProbesDemo()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/DebugOverlayDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/DebugOverlayDemo.swift
@@ -1,0 +1,311 @@
+import SwiftUI
+import RealityKit
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// iOS equivalent of Android's `DebugOverlayDemo` — real-time performance stress test.
+///
+/// Spawns RealityKit `ModelEntity` spheres progressively and shows live FPS,
+/// frame time, node count, and estimated triangle count via a custom SwiftUI
+/// overlay (including a rolling FPS sparkline). A stress-test button ramps from
+/// 1 → 1 000 spheres over 10 s so you can watch the FPS drop in real time.
+///
+/// Triangle estimate: each `MeshResource.generateSphere` at the default detail
+/// level produces ~768 triangles (12 subdivisions × 2 tris/face × 32 faces).
+/// The exact value is device-dependent; the estimate is intentionally honest.
+///
+/// Coverage: `sceneview://demo/debug-overlay`
+struct DebugOverlayDemo: View {
+
+    // MARK: — State
+
+    @State private var targetCount = 1
+    @State private var currentCount = 0
+    @State private var isStressRunning = false
+    @State private var stressAborted = false
+    @StateObject private var fps = FPSCounter()
+
+    // Fixed grid layout dimensions — positions are stable regardless of
+    // current sphere count so add/remove doesn't re-centre existing entities.
+    private static let maxCount = 1_000
+    private static let cols  = 10
+    private static let rows  = 10
+    private static let layers = 10
+    private static let spacing: Float = 0.15
+    private static let radius: Float  = 0.035
+
+    // MARK: — Body
+
+    var body: some View {
+        ZStack {
+            sphereScene
+                .ignoresSafeArea()
+
+            VStack(alignment: .leading) {
+                statsOverlay
+                    .padding([.top, .horizontal])
+                Spacer()
+                controlsOverlay
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+                    .padding()
+            }
+        }
+        .navigationTitle("Debug Overlay")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear  { fps.start() }
+        .onDisappear { fps.stop() }
+        .task(id: targetCount)     { await spawnProgressively() }
+        .task(id: isStressRunning) { await runStressRamp() }
+    }
+
+    // MARK: — 3D scene
+
+    @ViewBuilder
+    private var sphereScene: some View {
+        RealityView { content in
+            let root = Entity()
+            root.name = "sphereRoot"
+            content.add(root)
+
+            // Directional light so spheres are shaded — without an explicit
+            // light they render as flat silhouettes against the grey backdrop.
+            var lightComponent = DirectionalLightComponent(color: .white,
+                                                           intensity: 1_500,
+                                                           isRealWorldProxy: false)
+            lightComponent.canCastShadow = false
+            let lightEntity = Entity()
+            lightEntity.components.set(lightComponent)
+            lightEntity.orientation = simd_quatf(angle: -.pi / 4, axis: [1, 0, 0])
+            content.add(lightEntity)
+        } update: { content in
+            guard let root = content.entities.first(where: { $0.name == "sphereRoot" })
+            else { return }
+            let existing = root.children.count
+            if existing < currentCount {
+                for i in existing..<currentCount {
+                    root.addChild(DebugOverlayDemo.makeSphere(index: i))
+                }
+            } else if existing > currentCount {
+                root.children.suffix(existing - currentCount).forEach { root.removeChild($0) }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Stats overlay
+
+    @ViewBuilder
+    private var statsOverlay: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            let fpsValue = fps.currentFPS
+            let fpsColor: Color = fpsValue >= 55 ? .green : fpsValue >= 30 ? .yellow : .red
+            Text(String(format: "FPS: %.1f", fpsValue)).foregroundStyle(fpsColor)
+            Text(String(format: "Frame: %.1f ms", fps.frameTimeMs))
+            Text("Nodes: \(currentCount)")
+            Text("Tris: ≈\(formatThousands(Int64(currentCount) * 768))")
+            sparklineView
+                .frame(height: 28)
+        }
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(.white)
+        .padding(8)
+        .background(.black.opacity(0.65))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var sparklineView: some View {
+        Canvas { context, size in
+            let history = fps.history
+            guard history.count > 1 else { return }
+            let maxFPS: CGFloat = 120
+            // 60 fps reference line
+            let refY = size.height - (60.0 / maxFPS) * size.height
+            context.stroke(
+                Path { p in
+                    p.move(to: CGPoint(x: 0, y: refY))
+                    p.addLine(to: CGPoint(x: size.width, y: refY))
+                },
+                with: .color(.white.opacity(0.3)),
+                lineWidth: 1
+            )
+            // FPS sparkline
+            var linePath = Path()
+            for (i, value) in history.enumerated() {
+                let x = size.width * CGFloat(i) / CGFloat(history.count - 1)
+                let y = size.height - (value / maxFPS) * size.height
+                if i == 0 { linePath.move(to: CGPoint(x: x, y: y)) }
+                else { linePath.addLine(to: CGPoint(x: x, y: y)) }
+            }
+            context.stroke(linePath, with: .color(.green), lineWidth: 2)
+        }
+    }
+
+    // MARK: — Controls overlay
+
+    @ViewBuilder
+    private var controlsOverlay: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Nodes: \(currentCount) / \(targetCount)")
+                .font(.caption.bold())
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+            if currentCount < targetCount {
+                ProgressView(value: Float(currentCount), total: Float(max(targetCount, 1)))
+                    .padding(.horizontal, 16)
+                Text("Spawning \(currentCount) / \(targetCount)…")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 16)
+            }
+            if stressAborted {
+                Text("Stress test aborted (device limit).")
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 16)
+            }
+
+            let busy = currentCount < targetCount || isStressRunning
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach([1, 10, 100, 500, 1_000], id: \.self) { preset in
+                        Button(action: { stressAborted = false; targetCount = preset }) {
+                            Text("\(preset)").font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(busy)
+                    }
+                    Button("Reset") { stressAborted = false; targetCount = 1 }
+                        .buttonStyle(.bordered)
+                        .disabled(busy)
+                }
+                .padding(.horizontal, 16)
+            }
+
+            Button {
+                stressAborted = false
+                isStressRunning.toggle()
+                if isStressRunning { targetCount = 1 }
+            } label: {
+                Text(isStressRunning ? "Stop stress test" : "Stress test (1 → 1 000)")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+        }
+    }
+
+    // MARK: — Progressive spawn task
+
+    private func spawnProgressively() async {
+        if currentCount > targetCount { currentCount = targetCount; return }
+        do {
+            while currentCount < targetCount {
+                currentCount = min(currentCount + 16, targetCount)
+                try await Task.sleep(nanoseconds: 16_000_000)
+            }
+        } catch { /* task cancelled by new targetCount */ }
+    }
+
+    // MARK: — Stress ramp task
+
+    private func runStressRamp() async {
+        guard isStressRunning else { return }
+        let start = Date()
+        let duration: TimeInterval = 10
+        do {
+            while isStressRunning {
+                let progress = min(Date().timeIntervalSince(start) / duration, 1.0)
+                let want = 1 + Int(Double(Self.maxCount - 1) * progress)
+                if want != targetCount { targetCount = want }
+                if progress >= 1.0 { isStressRunning = false; break }
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+        } catch { /* task cancelled by stop button */ }
+    }
+
+    // MARK: — Sphere factory (static, fixed grid layout)
+
+    private static func makeSphere(index i: Int) -> ModelEntity {
+        let col   = i % cols
+        let row   = (i / cols) % rows
+        let layer = i / (cols * rows)
+        let xOff  = -(Float(cols  - 1) / 2) * spacing
+        let yOff  = -(Float(rows  - 1) / 2) * spacing
+        let zOff  =  (Float(layers - 1) / 2) * spacing
+        var mat = SimpleMaterial(color: .systemBlue, isMetallic: false)
+        mat.roughness = MaterialScalarParameter(floatLiteral: 0.5)
+        let mesh   = MeshResource.generateSphere(radius: radius)
+        let entity = ModelEntity(mesh: mesh, materials: [mat])
+        entity.position = [
+            Float(col)   * spacing + xOff,
+            Float(row)   * spacing + yOff,
+            -(Float(layer) * spacing) + zOff - 1.2
+        ]
+        return entity
+    }
+}
+
+// MARK: — FPS Counter
+
+private final class FPSCounter: ObservableObject {
+    @Published var currentFPS: Double = 0
+    @Published var frameTimeMs: Double = 0
+    @Published var history: [CGFloat] = []
+
+    private var link: CADisplayLink?
+    private var frameCount = 0
+    private var lastTime: CFTimeInterval = 0
+    private var historyBuffer: [Float] = []
+
+    func start() {
+        guard link == nil else { return }
+        lastTime = CACurrentMediaTime()
+        let l = CADisplayLink(target: self, selector: #selector(tick(_:)))
+        l.add(to: .main, forMode: .common)
+        link = l
+    }
+
+    func stop() { link?.invalidate(); link = nil }
+
+    @objc private func tick(_ dl: CADisplayLink) {
+        frameCount += 1
+        let now = dl.timestamp
+        let delta = now - lastTime
+        guard delta >= 0.5 else { return }
+        let newFPS = Double(frameCount) / delta
+        currentFPS = newFPS
+        frameTimeMs = (delta / Double(frameCount)) * 1_000
+        historyBuffer.append(Float(newFPS))
+        if historyBuffer.count > 120 { historyBuffer.removeFirst() }
+        history = historyBuffer.map { CGFloat($0) }
+        frameCount = 0
+        lastTime = now
+    }
+
+    deinit { stop() }
+}
+
+// MARK: — Helpers
+
+private func formatThousands(_ v: Int64) -> String {
+    let s = String(v)
+    guard s.count > 3 else { return s }
+    var result = ""
+    var i = s.startIndex
+    let first = s.count % 3
+    if first > 0 {
+        result = String(s[i..<s.index(i, offsetBy: first)])
+        i = s.index(i, offsetBy: first)
+    }
+    while i < s.endIndex {
+        if !result.isEmpty { result += "," }
+        let end = s.index(i, offsetBy: 3)
+        result += s[i..<end]
+        i = end
+    }
+    return result
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/DebugOverlayScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/DebugOverlayScene.swift
@@ -1,0 +1,11 @@
+// @sceneId     debug-overlay
+// @title       Debug Overlay
+// @subtitle    Real-time FPS stats — sphere stress test
+// @category    advanced
+// @available   true
+// @icon        chart.line.uptrend.xyaxis
+import SwiftUI
+
+enum DebugOverlayScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(DebugOverlayDemo()) }
+}


### PR DESCRIPTION
## Summary

- Adds `DebugOverlayDemo.swift` — iOS equivalent of Android's `DebugOverlayDemo`. Uses a bare `RealityView` (no ARKit) to spawn up to 1 000 PBR spheres in a deterministic 10×10×10 grid
- Live HUD: FPS (colour-coded green/yellow/red), frame time, node count, triangle estimate (×768/sphere), and a 120-sample sparkline drawn via SwiftUI `Canvas`
- Controls: preset count chips (1/10/100/500/1 000), Reset, and a 10-second stress ramp from 1 → 1 000 spheres; progressive spawn batches 16 spheres per 16 ms frame
- FPS measured via `CADisplayLink`, sampled every 0.5 s
- `sceneview://demo/debug-overlay` now routes to the real demo — deep link wired in `DemoDeepLinkRegistry`
- Maestro: moved from `placeholders.yaml` to `advanced.yaml` (`ASSERT_TEXT: "FPS:"`) — catalog comment updated (Advanced 11→12, non-AR placeholders 4→3, total 49 unchanged)

Closes #910 (partial — debug-overlay item)

## Test plan

- [ ] Build + run on iPhone 16e simulator (iOS 17+): `sceneview://demo/debug-overlay` opens the demo
- [ ] FPS counter updates in real-time, sparkline draws, colour changes green→yellow→red under load
- [ ] Preset buttons spawn the correct count, Reset drops back to 1
- [ ] Stress test ramps 1→1 000 over 10 s and stops cleanly
- [ ] `maestro test .maestro/ios/advanced.yaml` — debug-overlay flow passes (`ASSERT_TEXT: "FPS:"`)
- [ ] `maestro test .maestro/ios/placeholders.yaml` — no debug-overlay flow (removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)