### PR TITLE
fix(ios-demo): rename stale ArEisScene → ArImageStabilizationScene, ArPosePlacementScene → ArPoseScene (#2173)

### DIFF
--- a/changelog.d/2173-ios-scene-ids-canonical.md
+++ b/changelog.d/2173-ios-scene-ids-canonical.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **iOS demo** — renamed placeholder scenes `ArEisScene` → `ArImageStabilizationScene` and `ArPosePlacementScene` → `ArPoseScene` so their `@sceneId` directives match the canonical Android IDs (`ar-image-stabilization`, `ar-pose`) used by QR codes and deep links; closes the gap left by #2174 which fixed `allowedIds` but not the scene catalogue.

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -12,13 +12,13 @@
 		96C00DAEDB204FF3E420ED1B /* ArAugmentedFacesScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63582A5C1EEB276B6E9CA85 /* ArAugmentedFacesScene.swift */; };
 		3DC54357982F78B8C2E02FC8 /* ArCloudAnchorsScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8550BB2028D4FF4056AEBB75 /* ArCloudAnchorsScene.swift */; };
 		88B30D69A8295299DB46B027 /* ArDepthOcclusionScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF95C7E0A3E7A2D62A427A8 /* ArDepthOcclusionScene.swift */; };
-		F8F105D8987BA5BE425F235B /* ArEisScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC170938E2C9FC35AB334CA3 /* ArEisScene.swift */; };
+		D5DD1737713F4BE9511234D8 /* ArImageStabilizationScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139814091E71EF04428D632C /* ArImageStabilizationScene.swift */; };
 		0556583EF5AF44854433ED30 /* ArImageTrackingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9894E9E0B48C546F7045302 /* ArImageTrackingScene.swift */; };
 		AB01222A63039941E8E2398B /* ArInstantPlacementScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEA6C6F0910C858DADF4F25 /* ArInstantPlacementScene.swift */; };
 		5E207E2F7A55D2D96DBD1814 /* ArLightingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD64719EA56EB8B83AAC04D4 /* ArLightingScene.swift */; };
 		E3564B14080F27209FF35DC5 /* ArOrbitalScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600043FF3AFFE79411B7DD8A /* ArOrbitalScene.swift */; };
 		50708BAB945D780C4BB6300A /* ArPlacementScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127E970FECE22BF0FC5D8867 /* ArPlacementScene.swift */; };
-		D173BD9A8BA6B6CAB5E32796 /* ArPosePlacementScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A57335287821ECC80BC2A0 /* ArPosePlacementScene.swift */; };
+		1E9AB7FFE1217027A6D3D792 /* ArPoseScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E303E39EE615A5EEC66FBD /* ArPoseScene.swift */; };
 		AFB627071014C9E0F4C577BC /* ArRecordingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = E722280A1A01A2AA17A2137A /* ArRecordingScene.swift */; };
 		A6AA5F59463038402CB1B9CF /* ArRerunScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D804E81126D31E56CEECA9 /* ArRerunScene.swift */; };
 		4D7BABB3B6EF11E48A1622BF /* ArRooftopAnchorsScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D34E4A9940EE1E38BB98F41 /* ArRooftopAnchorsScene.swift */; };
@@ -271,13 +271,13 @@
 		F63582A5C1EEB276B6E9CA85 /* ArAugmentedFacesScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArAugmentedFacesScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArAugmentedFacesScene.swift; sourceTree = SOURCE_ROOT; };
 		8550BB2028D4FF4056AEBB75 /* ArCloudAnchorsScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArCloudAnchorsScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArCloudAnchorsScene.swift; sourceTree = SOURCE_ROOT; };
 		CEF95C7E0A3E7A2D62A427A8 /* ArDepthOcclusionScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArDepthOcclusionScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArDepthOcclusionScene.swift; sourceTree = SOURCE_ROOT; };
-		CC170938E2C9FC35AB334CA3 /* ArEisScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArEisScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArEisScene.swift; sourceTree = SOURCE_ROOT; };
+		139814091E71EF04428D632C /* ArImageStabilizationScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArImageStabilizationScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArImageStabilizationScene.swift; sourceTree = SOURCE_ROOT; };
 		F9894E9E0B48C546F7045302 /* ArImageTrackingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArImageTrackingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArImageTrackingScene.swift; sourceTree = SOURCE_ROOT; };
 		DEEA6C6F0910C858DADF4F25 /* ArInstantPlacementScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArInstantPlacementScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArInstantPlacementScene.swift; sourceTree = SOURCE_ROOT; };
 		FD64719EA56EB8B83AAC04D4 /* ArLightingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArLightingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArLightingScene.swift; sourceTree = SOURCE_ROOT; };
 		600043FF3AFFE79411B7DD8A /* ArOrbitalScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArOrbitalScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArOrbitalScene.swift; sourceTree = SOURCE_ROOT; };
 		127E970FECE22BF0FC5D8867 /* ArPlacementScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArPlacementScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArPlacementScene.swift; sourceTree = SOURCE_ROOT; };
-		15A57335287821ECC80BC2A0 /* ArPosePlacementScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArPosePlacementScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArPosePlacementScene.swift; sourceTree = SOURCE_ROOT; };
+		D9E303E39EE615A5EEC66FBD /* ArPoseScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArPoseScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArPoseScene.swift; sourceTree = SOURCE_ROOT; };
 		E722280A1A01A2AA17A2137A /* ArRecordingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArRecordingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArRecordingScene.swift; sourceTree = SOURCE_ROOT; };
 		54D804E81126D31E56CEECA9 /* ArRerunScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArRerunScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArRerunScene.swift; sourceTree = SOURCE_ROOT; };
 		4D34E4A9940EE1E38BB98F41 /* ArRooftopAnchorsScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArRooftopAnchorsScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArRooftopAnchorsScene.swift; sourceTree = SOURCE_ROOT; };
@@ -795,13 +795,13 @@
 				96C00DAEDB204FF3E420ED1B /* ArAugmentedFacesScene.swift in Sources */,
 				3DC54357982F78B8C2E02FC8 /* ArCloudAnchorsScene.swift in Sources */,
 				88B30D69A8295299DB46B027 /* ArDepthOcclusionScene.swift in Sources */,
-				F8F105D8987BA5BE425F235B /* ArEisScene.swift in Sources */,
+				D5DD1737713F4BE9511234D8 /* ArImageStabilizationScene.swift in Sources */,
 				0556583EF5AF44854433ED30 /* ArImageTrackingScene.swift in Sources */,
 				AB01222A63039941E8E2398B /* ArInstantPlacementScene.swift in Sources */,
 				5E207E2F7A55D2D96DBD1814 /* ArLightingScene.swift in Sources */,
 				E3564B14080F27209FF35DC5 /* ArOrbitalScene.swift in Sources */,
 				50708BAB945D780C4BB6300A /* ArPlacementScene.swift in Sources */,
-				D173BD9A8BA6B6CAB5E32796 /* ArPosePlacementScene.swift in Sources */,
+				1E9AB7FFE1217027A6D3D792 /* ArPoseScene.swift in Sources */,
 				AFB627071014C9E0F4C577BC /* ArRecordingScene.swift in Sources */,
 				A6AA5F59463038402CB1B9CF /* ArRerunScene.swift in Sources */,
 				4D7BABB3B6EF11E48A1622BF /* ArRooftopAnchorsScene.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArImageStabilizationScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArImageStabilizationScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-eis
+// @sceneId     ar-image-stabilization
 // @title       Image Stabilization (EIS)
 // @subtitle    EIS for smoother AR camera feed
 // @category    ar
@@ -7,6 +7,6 @@
 // @iosOnly     true
 import SwiftUI
 
-enum ArEisScene: DemoScene {
+enum ArImageStabilizationScene: DemoScene {
     @MainActor static var destination: AnyView { AnyView(EmptyView()) }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArPoseScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArPoseScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-pose-placement
+// @sceneId     ar-pose
 // @title       Pose Placement
 // @subtitle    Free pose positioning
 // @category    ar
@@ -7,6 +7,6 @@
 // @iosOnly     true
 import SwiftUI
 
-enum ArPosePlacementScene: DemoScene {
+enum ArPoseScene: DemoScene {
     @MainActor static var destination: AnyView { AnyView(EmptyView()) }
 }


### PR DESCRIPTION
## Summary

The placeholder `@sceneId` directives in two coming-soon AR demo scene files used stale IDs that don't match the canonical Android deep-link IDs:

| Old file | Old `@sceneId` | New file | New `@sceneId` |
|---|---|---|---|
| `ArEisScene.swift` | `ar-eis` | `ArImageStabilizationScene.swift` | `ar-image-stabilization` |
| `ArPosePlacementScene.swift` | `ar-pose-placement` | `ArPoseScene.swift` | `ar-pose` |

**Why it matters:** `collate-ios-demos.sh` (the Xcode build phase) re-generates `GeneratedScenes.swift` from the `@sceneId` headers. A QR code scanning `sceneview://demo/ar-image-stabilization` would be accepted by `DemoDeepLinkRegistry.allowedIds` (canonical form) but show no matching card in the Samples tab — while the Samples tab showed a "Coming soon" card for the stale `ar-eis` slug that no real QR code points to.

## Relation to #2174

PR #2174 fixed `DemoDeepLinkRegistry.allowedIds` to remove `ar-eis` and `ar-pose-placement`. This PR fixes the scene catalogue source (the `*Scene.swift` `@sceneId` headers + `project.pbxproj` file refs). Together they close the stale-ID gap from both sides.

Closes part of #2173.

## Test plan

- [x] `project.pbxproj` references updated — no stale `ArEisScene` / `ArPosePlacementScene` references remain
- [x] New scene files carry canonical `@sceneId` values matching Android `DemoRegistry.kt`
- [x] `collate-ios-demos.sh` will produce `GeneratedScenes.swift` with `ar-image-stabilization` and `ar-pose` cards
- [x] No code-logic changes — docs/catalogue only

🤖 Generated with [Claude Code](https://claude.com/claude-code)