### PR TITLE
fix(ios-demo): Swift 6 concurrency error blocking v4.15.2 iOS deploy

### DIFF
--- a/changelog.d/2202-ios-deploy-swift6-concurrency.md
+++ b/changelog.d/2202-ios-deploy-swift6-concurrency.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **iOS App Store deploy:** patch Swift 6 strict-concurrency error in `ARPlaneNodeDemo.swift:97` that broke the v4.15.2 `app-store.yml` archive step. The `private enum AssocKey { static var delegate = 0 }` global (used only as an `objc_setAssociatedObject` key) is now `nonisolated(unsafe) static var delegate: UInt8 = 0` — canonical opt-out for the "address-of-global as key" idiom. Fixes the v4.15.2 iOS deploy red without re-tagging.

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlaneNodeDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlaneNodeDemo.swift
@@ -94,7 +94,12 @@ struct ARPlaneNodeDemo: View {
         }
     }
 
-    private enum AssocKey { static var delegate = 0 }
+    // `objc_setAssociatedObject` needs the address of a global var as its
+    // key. Swift 6's strict-concurrency mode flags any `static var` as
+    // "non-isolated global shared mutable state" — even though we never
+    // mutate this byte, only take its address. `nonisolated(unsafe)` is the
+    // canonical opt-out for this exact "used as objc key" idiom.
+    private enum AssocKey { nonisolated(unsafe) static var delegate: UInt8 = 0 }
 
     private func makeMarker(for plane: ARPlaneAnchor, in arView: ARView) -> AnchorEntity {
         let anchor = AnchorEntity(world: plane.transform)


### PR DESCRIPTION
## Summary

v4.15.2's `app-store.yml` ARCHIVE step failed (exit code 65) on a pre-existing Swift 6 strict-concurrency error in `ARPlaneNodeDemo.swift:97`:

\`\`\`
error: static property 'delegate' is not concurrency-safe because it is nonisolated global shared mutable state
\`\`\`

The pattern is the canonical "global byte used as objc associated-object key" idiom — `objc_setAssociatedObject(&key, …)` needs the address of a global variable, and Swift can't tell that we only take the address (never mutate the value).

## Fix

\`\`\`swift
// before
private enum AssocKey { static var delegate = 0 }

// after
private enum AssocKey { nonisolated(unsafe) static var delegate: UInt8 = 0 }
\`\`\`

`nonisolated(unsafe)` is the canonical Swift 6 opt-out for this exact idiom. Semantics unchanged — we still take the address of a process-global byte.

## Scope

Pre-existing bug from the iOS demo wave (umbrella [#910](https://github.com/sceneview/sceneview/issues/910)). v4.15.2's multi-agent review pass didn't audit iOS Swift 6 compliance — filing forward as the first changelog fragment for v4.15.3.

## Validation

- The error is reproducible by running `xcodebuild archive` on macOS with Xcode 16+ (Swift 6 toolchain).
- Maven Central + npm + Play Store deploys of v4.15.2 unaffected (already succeeded / in progress).
- iOS TestFlight upload is gated on this fix landing in a v4.15.3 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)