### PR TITLE
fix(infra): self-hosted runner v3 — RUNNER_HOME without spaces

### DIFF
--- a/.claude/scripts/setup-self-hosted-runner.sh
+++ b/.claude/scripts/setup-self-hosted-runner.sh
@@ -1,17 +1,32 @@
 #!/usr/bin/env bash
-# Self-hosted macOS GitHub Actions runner for SceneView (v2 — launchctl bootstrap).
+# Self-hosted macOS GitHub Actions runner for SceneView (v3 — no spaces in path).
 #
-# WHY V2 (and not actions/runner svc.sh):
-#   svc.sh shells out to `launchctl load`, which is broken on macOS 11+ for
-#   user-scoped LaunchAgents (it returns `Load failed: 5: Input/output error`
-#   and silently leaves no plist behind — see actions/runner issue 1424).
-#   v2 bypasses svc.sh, writes the LaunchAgent plist itself, and uses the
-#   modern `launchctl bootstrap` API. Same result, actually works.
+# WHY V3 (and not v2):
+#   v2 installed to `~/Library/Application Support/sceneview-runner/`. macOS
+#   convention, BUT that path contains a space. actions/runner generates step
+#   scripts inside its `_work/_temp/` subtree and invokes them as
+#   `/bin/bash -e <script-path>`. With a space in the path, bash splits the
+#   argv and fails: `/bin/bash: /Users/.../Library/Application: No such file
+#   or directory`. Every workflow step failed in 34 s. v3 puts the runner in
+#   `~/sceneview-runner/` (no spaces, anywhere). Verified on the pilot
+#   `bridge-ios-compile` PR #2204 run id 26418464635.
+#
+# WHY V2 (still relevant — kept from v2 history):
+#   actions/runner's bundled svc.sh shells out to `launchctl load`, broken
+#   on macOS 11+ for user-scoped LaunchAgents (`Load failed: 5: Input/output
+#   error`). v2 bypassed svc.sh and uses the modern `launchctl bootstrap`
+#   API. v3 keeps that, only changes the install path.
+#
+# MIGRATION FROM V2
+#   The installer detects an existing v2 install at the old spaces-path,
+#   de-registers it, removes its LaunchAgent, then installs fresh at the
+#   new path. The old directory is left in place — remove manually with
+#   `rm -rf ~/Library/Application\ Support/sceneview-runner` if desired.
 #
 # WHAT IT INSTALLS
-#   ~/Library/Application Support/sceneview-runner/      actions/runner files
-#   ~/Library/LaunchAgents/io.github.sceneview.runner.plist            runner
-#   ~/Library/LaunchAgents/io.github.sceneview.runner-heartbeat.plist  heartbeat
+#   ~/sceneview-runner/                                       actions/runner
+#   ~/Library/LaunchAgents/io.github.sceneview.runner.plist          runner
+#   ~/Library/LaunchAgents/io.github.sceneview.runner-heartbeat.plist heartbeat
 #
 # OPT IN A WORKFLOW (one line per job in any .github/workflows/*.yml):
 #   runs-on: ${{ vars.SELF_HOSTED_MACOS_ONLINE == 'true' && 'sceneview-mac' || 'macos-15' }}
@@ -27,7 +42,8 @@ set -euo pipefail
 REPO="sceneview/sceneview"
 RUNNER_VERSION="2.334.0"   # baseline; the runner auto-updates after first connect
 RUNNER_LABEL="sceneview-mac"
-RUNNER_HOME="${HOME}/Library/Application Support/sceneview-runner"
+RUNNER_HOME="${HOME}/sceneview-runner"
+RUNNER_HOME_V2_LEGACY="${HOME}/Library/Application Support/sceneview-runner"
 RUNNER_NAME="sceneview-mac-$(hostname -s)"
 
 # Runner LaunchAgent (replaces broken svc.sh)
@@ -155,6 +171,21 @@ fi
 if ! gh auth status >/dev/null 2>&1; then
   err "gh not authenticated. Run: gh auth login --scopes 'repo,workflow'"
   exit 1
+fi
+
+# v2 -> v3 migration: if a v2 install exists at the spaces-path, unload its
+# LaunchAgent, de-register the runner, leave its files in place for manual
+# removal. The new install then proceeds at the v3 path.
+if [[ -f "${RUNNER_HOME_V2_LEGACY}/.runner" ]]; then
+  log "Detected v2 install at ${RUNNER_HOME_V2_LEGACY} — migrating to v3 path..."
+  launchctl bootout "${GUI_DOMAIN}/${RUNNER_PLIST_LABEL}" 2>/dev/null || true
+  launchctl bootout "${GUI_DOMAIN}/${HEARTBEAT_LABEL}" 2>/dev/null || true
+  pkill -f "${RUNNER_HOME_V2_LEGACY}/run.sh" 2>/dev/null || true
+  REM_TOKEN_V2="$(gh api -X POST "/repos/${REPO}/actions/runners/remove-token" --jq .token 2>/dev/null || echo "")"
+  if [[ -n "${REM_TOKEN_V2}" ]]; then
+    (cd "${RUNNER_HOME_V2_LEGACY}" && ./config.sh remove --token "${REM_TOKEN_V2}" 2>/dev/null || true)
+  fi
+  log "  v2 runner de-registered. Old files left at ${RUNNER_HOME_V2_LEGACY} — remove manually if desired."
 fi
 
 ARCH="$(uname -m)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,12 +334,17 @@ bash .claude/scripts/setup-self-hosted-runner.sh
 bash .claude/scripts/setup-self-hosted-runner.sh --check
 ```
 
-The installer (a) downloads `actions/runner` for `osx-arm64`/`osx-x64`,
-(b) registers it with label `sceneview-mac`, (c) writes a user
-LaunchAgent plist directly and `launchctl bootstrap`s it (the v1
-attempt to delegate to `actions/runner`'s `svc.sh` was a dead end —
-`svc.sh` shells out to the deprecated `launchctl load` which fails with
-`Input/output error` on macOS 11+, see actions/runner issue 1424).
+The installer (a) downloads `actions/runner` for `osx-arm64`/`osx-x64`
+into `~/sceneview-runner/` (deliberately *outside* `~/Library/Application
+Support/` — that path contains a space, and the runner's generated step
+scripts get invoked as `/bin/bash -e <path>` which splits on space and
+fails with `No such file or directory`; v2 hit exactly this on the
+pilot bridge-ios-compile run id 26418464635), (b) registers it with
+label `sceneview-mac`, (c) writes a user LaunchAgent plist directly
+and `launchctl bootstrap`s it (the v1 attempt to delegate to
+`actions/runner`'s `svc.sh` was a dead end — `svc.sh` shells out to
+the deprecated `launchctl load` which fails with `Input/output error`
+on macOS 11+, see actions/runner issue 1424).
 The plist uses `KeepAlive=true` so the runner survives reboots, login,
 sleep/wake, and the runner's own auto-update cycle (the runner exits
 to install a new version, launchd restarts it, new version takes over —

--- a/changelog.d/runner-v3-no-spaces-path.md
+++ b/changelog.d/runner-v3-no-spaces-path.md
@@ -1,0 +1,5 @@
+<!-- category: Fixed -->
+- `setup-self-hosted-runner.sh` v3 — install path moved from `~/Library/Application Support/sceneview-runner/` to `~/sceneview-runner/`. v2 picked the macOS-convention location which contains a space, breaking the runner's step-script invocation (`/bin/bash -e <path>` splits on the space → `No such file or directory`). The pilot `bridge-ios-compile` PR [#2204](https://github.com/sceneview/sceneview/pull/2204) failed in 34 seconds on the `Select Xcode` step because of this exact issue (run id 26418464635). v3 keeps the LaunchAgent bootstrap design unchanged, only relocates the runner files. The installer auto-detects an existing v2 install at the legacy path, de-registers it from GitHub, and unloads its LaunchAgent before installing fresh — old files are left in place for manual `rm -rf`.
+
+<!-- category: Changed -->
+- Until the v3 runner is reinstalled, set the repo variable `SELF_HOSTED_MACOS_ONLINE=false` (`gh variable set SELF_HOSTED_MACOS_ONLINE -R sceneview/sceneview --body "false"`) so every opted-in workflow falls back to `macos-15`. Re-running the v3 installer marks it `true` again automatically via the heartbeat.


### PR DESCRIPTION
## Summary

Fixes the bug that broke the pilot opt-in PR [#2204](https://github.com/sceneview/sceneview/pull/2204).

Pilot job [run 26418464635](https://github.com/sceneview/sceneview/actions/runs/26418464635) was correctly routed to `sceneview-mac-Thomass-Laptop` but failed in 34 seconds on the `Select Xcode` step with:

```
/bin/bash: /Users/thomasgorisse/Library/Application: No such file or directory
```

## Root cause

v2 installed the runner to `~/Library/Application Support/sceneview-runner/`. macOS convention, BUT that path contains a space. `actions/runner` generates step scripts inside its `_work/_temp/` subtree and invokes them as `/bin/bash -e <path>`. With a space in the path, bash splits argv and dies before any step body runs.

## Fix

`RUNNER_HOME` moves to `~/sceneview-runner/`. No spaces anywhere in the absolute path. LaunchAgent bootstrap design unchanged from v2.

## Migration

Automatic. The installer detects an existing v2 install at the legacy path, unloads its LaunchAgent, de-registers the runner from GitHub, then installs fresh at the new path. Old files left in place for manual `rm -rf` when ready.

## Until Thomas re-installs

The kill switch is in place — the heartbeat was bootout-ed and the repo variable was set to `false`:

```
gh variable set SELF_HOSTED_MACOS_ONLINE -R sceneview/sceneview --body "false"
```

Every opted-in workflow falls back to `macos-15` (= original behaviour). No contributor impact. Just no runner cost savings until reinstall.

## Test plan

- [ ] Thomas runs `bash .claude/scripts/setup-self-hosted-runner.sh` (v3 auto-detects v2 and migrates)
- [ ] `--check` shows the runner at the new path and `state = running`
- [ ] Re-trigger pilot PR #2204 → the `Select Xcode` step now executes (no path-split error)
- [ ] After v3 install: `gh variable set SELF_HOSTED_MACOS_ONLINE -R sceneview/sceneview --body "true"` if not auto-restored by the heartbeat

## Open items not in this PR

- Pilot PR #2204 can merge whenever (with kill switch in place, it routes to `macos-15` and behaves identically to today). It validates the **routing pattern**, which works. The runner-side execution will be validated by re-running it post-v3 install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
