### PR TITLE
ci(detekt): exempt @Composable from LongMethod — fixes flaky cold-cache Lint

### DIFF
--- a/buildSrc/config/detekt/detekt.yml
+++ b/buildSrc/config/detekt/detekt.yml
@@ -25,6 +25,14 @@ complexity:
     allowedLines: 800
   CyclomaticComplexMethod:
     allowedComplexity: 25
+  LongMethod:
+    # Compose scene-root composables (SceneView, ARSceneView) legitimately
+    # exceed the 60-line Java-style default — they expose dozens of named
+    # parameters with KDoc and orchestrate the scene lifecycle in a single
+    # builder-pattern function. Exempt @Composable functions so SDK
+    # consumers writing their own scene roots aren't blocked by detekt either.
+    ignoreAnnotated:
+      - 'Composable'
 
 style:
   MagicNumber:


### PR DESCRIPTION
## Summary

Compose scene-root composables (`SceneView`, `ARSceneView`) legitimately exceed the 60-line Java-style default — they expose dozens of named parameters with KDoc and orchestrate the scene lifecycle in a single builder-pattern function.

`ARSceneView` (468 lines) was triggering detekt's `LongMethod` rule, but only on **cold-cache** CI runs — `:arsceneview:detekt` is gradle-cacheable so warm runs masked the issue as flaky.

Exempting `@Composable` is the principled fix: it's also a follow-on for any SDK consumer who writes their own scene-root composable.

Surfaced by the QA session 2026-05-26 (PRs #2244, #2245, #2246 all hit it).

## Test plan

- [x] `./gradlew :sceneview:detekt :arsceneview:detekt :sceneview-core:detekt --rerun-tasks --no-configuration-cache` ✅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)