### PR TITLE
feat(android-demo): immersive AR camera — hide nav bar + system bars during live session (#2238)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -74,6 +74,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -152,6 +156,14 @@ import java.util.UUID
 @Composable
 fun ArViewTabContent(
     onDemoClick: (String) -> Unit,
+    /**
+     * Invoked whenever the live AR camera session is entered or exited. The
+     * caller (typically [RootScreen]) uses this to hide the bottom
+     * NavigationBar + system bars while the camera is active so the AR
+     * viewport gets the full screen (#2238). Default no-op keeps the
+     * composable usable in tests / previews that don't host a Scaffold.
+     */
+    onSessionActiveChange: (Boolean) -> Unit = {},
 ) {
     val context = LocalContext.current
 
@@ -180,6 +192,33 @@ fun ArViewTabContent(
     // launcher screen and re-prompt for everything. Anchors themselves are
     // not Parcelable so we accept the loss of placed models across a kill.
     var sessionStarted by rememberSaveable { mutableStateOf(false) }
+
+    // Immersive-mode wiring (#2238) — when the live AR session is active:
+    //   1. Tell [RootScreen] to hide its bottom NavigationBar (reclaims ~90 px
+    //      of viewport for the camera);
+    //   2. Hide the system status + nav bars via WindowInsetsControllerCompat
+    //      so the AR view goes truly fullscreen.
+    // Both reverse on exit / back / dispose so the user lands on the launcher
+    // screen with all chrome restored.
+    val view = LocalView.current
+    DisposableEffect(sessionStarted) {
+        onSessionActiveChange(sessionStarted)
+        val window = (view.context as? android.app.Activity)?.window
+        val controller = window?.let { WindowCompat.getInsetsController(it, view) }
+        if (sessionStarted && controller != null) {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+        } else {
+            controller?.show(WindowInsetsCompat.Type.systemBars())
+        }
+        onDispose {
+            // On composable dispose (tab swap, process tear-down) always
+            // restore chrome so the next screen renders normally.
+            controller?.show(WindowInsetsCompat.Type.systemBars())
+            onSessionActiveChange(false)
+        }
+    }
     var arCoreAvailability by remember {
         mutableStateOf<ArCoreApk.Availability?>(null)
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
@@ -83,17 +83,32 @@ import io.github.sceneview.demo.ui.explore.ExploreTabScreen
 @Composable
 fun RootScreen(onDemoClick: (String) -> Unit) {
     var selectedTab by rememberSaveable { mutableStateOf(RootTab.Explore) }
+    // Tracks whether the AR View tab is in a live camera session. When `true`
+    // the bottom NavigationBar is hidden so the AR camera goes truly
+    // fullscreen — pre-#2238 the nav bar always stayed visible and ate ~90 px
+    // of the live camera viewport. ArViewTabContent invokes the setter
+    // whenever its internal `sessionStarted` flag flips (start / exit / back
+    // gesture). The flag is intentionally NOT rememberSaveable: a config
+    // change or process death should land the user back on the launcher
+    // screen with the nav bar visible, not on an orphaned immersive shell.
+    var arSessionActive by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                RootTab.entries.forEach { tab ->
-                    NavigationBarItem(
-                        selected = selectedTab == tab,
-                        onClick = { selectedTab = tab },
-                        icon = { Icon(tab.icon, contentDescription = null) },
-                        label = { Text(stringResource(tab.labelRes)) },
-                    )
+            // Conditional rendering rather than just `visible = !arSessionActive`
+            // because the bottomBar slot reserves layout space when present —
+            // hiding it via Modifier.alpha or visibility would still steal ~90 px
+            // from the live AR camera viewport (#2238).
+            if (!arSessionActive) {
+                NavigationBar {
+                    RootTab.entries.forEach { tab ->
+                        NavigationBarItem(
+                            selected = selectedTab == tab,
+                            onClick = { selectedTab = tab },
+                            icon = { Icon(tab.icon, contentDescription = null) },
+                            label = { Text(stringResource(tab.labelRes)) },
+                        )
+                    }
                 }
             }
         },
@@ -108,7 +123,10 @@ fun RootScreen(onDemoClick: (String) -> Unit) {
                     curatedSamples = curatedSamplesForExplore(),
                     onSampleClick = { sample -> onDemoClick(sample.id) },
                 )
-                RootTab.ArView -> ArViewTabContent(onDemoClick = onDemoClick)
+                RootTab.ArView -> ArViewTabContent(
+                    onDemoClick = onDemoClick,
+                    onSessionActiveChange = { arSessionActive = it },
+                )
                 RootTab.Samples -> DemoListScreen(onDemoClick = onDemoClick)
                 RootTab.About -> AboutTabContent()
             }


### PR DESCRIPTION
## Summary

When the user enters the live AR camera (Start AR Camera or any Tap to Place flow), the bottom NavigationBar of RootScreen and the system status/nav bars all stayed visible — combined they ate ~90 px of vertical space that should belong to the camera viewport (screen-record QA 2026-05-26, frames f_057 → f_069).

Per Thomas's QA at 4:56–5:13:
> « le design avec le bouton en bas, c'est bien, c'est ce qui éclate. […] mais à ce moment-là, il faut montrer plus clairement que ça peut être au milieu d'autres infos, et puis avec un bouton fullscreen ou quelque chose. »

## Change

Tiny callback chain — no nav graph refactor:

- `ArViewTabContent` gains `onSessionActiveChange: (Boolean) -> Unit`, invoked by a `DisposableEffect(sessionStarted)`. Same effect hides the system bars via `WindowInsetsControllerCompat` (`BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` so the user can still swipe them down if needed).
- `RootScreen` holds the local `arSessionActive` flag and **conditionally renders** the bottom `NavigationBar` (Scaffold's bottomBar slot reserves layout space even when invisible — alpha-fading it would still steal the 90 px).
- On dispose / exit / back gesture: system bars restored, `arSessionActive` resets → user lands on launcher screen with all chrome back.

The flag is intentionally NOT `rememberSaveable` — process death should drop the user on the launcher with chrome restored, not in an orphaned immersive shell.

Exit paths unchanged: existing top-end Close button (X) + system back gesture via `BackHandler` (line 316).

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator — open AR View → Start AR Camera → confirm bottom tab bar + status bar gone; tap X → confirm everything restored
- [ ] Back-gesture exit (Android 13+ predictive back) still restores chrome
- [ ] CI green

Closes #2238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)