### PR TITLE
fix(android-demo): hide 'Tap a surface' until a plane is actually trackable (#2234)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -281,6 +281,14 @@ fun ArViewTabContent(
     var isTracking by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var latestFrame by remember { mutableStateOf<Frame?>(null) }
+    // True once at least one detected ARCore plane has reached
+    // [TrackingState.TRACKING]. The camera frame's own tracking state flips
+    // long before any plane is detected, so `isTracking` alone is not enough
+    // to know whether the user actually has a surface to tap (#2234). Without
+    // this gate the "Tap a surface" prompt showed for ~10–20 s before any
+    // real surface was actually trackable — confusing in the screen-record QA
+    // (2026-05-26, frames f_061 → f_069).
+    var anyPlaneTracked by remember { mutableStateOf(false) }
 
     // Force-rebuild key for the ARSceneView. Bumping this UUID recomposes the
     // whole AR subtree, which is the only way to discard ARCore state without
@@ -330,9 +338,14 @@ fun ArViewTabContent(
                     config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
                     config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
                 },
-                onSessionUpdated = { _, frame ->
+                onSessionUpdated = { session, frame ->
                     latestFrame = frame
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
+                    // Recompute "is there any plane the user can actually tap?"
+                    // each frame (#2234). Detection is cheap — ARCore caches
+                    // the trackable set internally and we only scan Planes.
+                    anyPlaneTracked = session.getAllTrackables(Plane::class.java)
+                        .any { it.trackingState == TrackingState.TRACKING }
                 },
                 onTrackingFailureChanged = { reason ->
                     trackingFailureReason = reason
@@ -444,12 +457,21 @@ fun ArViewTabContent(
                 val onePlacedLabel = stringResource(R.string.ar_status_one_placed)
                 val nPlacedLabel = stringResource(R.string.ar_status_n_placed, placed)
                 Text(
+                    // State machine (#2234):
+                    //   1. Camera not tracking yet OR tracking failure → "Scanning…"
+                    //      (or specific failure reason).
+                    //   2. Camera tracking but no plane has reached TRACKING yet →
+                    //      keep "Scanning…" — the user has nothing to tap on yet,
+                    //      and the "Tap a surface" prompt would be a lie.
+                    //   3. At least one plane tracked, nothing placed → "Tap a
+                    //      surface to place {Model}".
+                    //   4. ≥ 1 placed → "N placed · tap to add".
                     text = when {
                         !isTracking -> trackingFailureReason?.let { friendly(it) }
                             ?: scanningLabel
-                        placed == 0 -> tapToPlaceLabel
-                        placed == 1 -> onePlacedLabel
-                        else -> nPlacedLabel
+                        placed > 0 -> if (placed == 1) onePlacedLabel else nPlacedLabel
+                        anyPlaneTracked -> tapToPlaceLabel
+                        else -> scanningLabel
                     },
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Medium,


### PR DESCRIPTION
## Summary

`isTracking` flipped true the moment the ARCore camera frame reached `TrackingState.TRACKING` — long before any plane was detected. The status pill therefore showed **"Tap a surface to place {Model}"** for ~10–20 s while the user had nothing real to tap on (screen-record QA 2026-05-26, frames f_061 → f_069).

## Change

New derived state `anyPlaneTracked`, recomputed each frame from `session.getAllTrackables(Plane::class.java).any { it.trackingState == TRACKING }`. Status pill state machine becomes:

| Condition | Pill text |
|---|---|
| Camera not tracking / failure | "Scanning…" (or specific failure reason) |
| Camera tracking, no plane yet | **"Scanning…"** (was: misleadingly "Tap a surface…") |
| ≥ 1 plane tracked, none placed | "Tap a surface to place {Model}" |
| ≥ 1 placed | "N placed · tap to add" |

No new strings. The per-frame trackable scan is cheap (ARCore caches the set internally; we only iterate Planes).

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator: launch AR View → Start AR Camera → status pill must show "Scanning…" until ARCore actually detects a plane (~3–5 s in virtualscene), THEN flip to "Tap a surface to place {Model}"
- [ ] CI green

Closes #2234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)