### PR TITLE
feat(android-demo): debounced live search on Explore Sketchfab field (#2228)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -168,6 +168,27 @@ fun ExploreTabScreen(
         }
     }
 
+    // Debounced live search (#2228). Each keystroke restarts this effect; the
+    // 350 ms delay is structurally cancelled by the next change, so we only
+    // actually fire `activeSearchQuery = ...` once the user has paused.
+    //
+    // Only the explicit Enter press (`onSearchSubmit`, below) records the
+    // query into `recentSearches` — live keystroke fragments would spam the
+    // history with "m", "ma", "mar", … and overwhelm the dropdown.
+    //
+    // The 2-character minimum filters out single-letter noise; an empty
+    // field is handled by `onSearchQueryChange` which immediately resets
+    // both `activeSearchQuery` and `searchResults`. Trimming the comparison
+    // avoids re-running on trailing-space whitespace changes.
+    LaunchedEffect(searchQuery) {
+        val trimmed = searchQuery.trim()
+        if (trimmed.length < 2 || SketchfabConfig.apiKey == null) return@LaunchedEffect
+        kotlinx.coroutines.delay(350)
+        if (trimmed != activeSearchQuery) {
+            activeSearchQuery = trimmed
+        }
+    }
+
     // Execute search when activeSearchQuery changes (#1239). `null` results
     // means "in flight"; an empty list means "0 hits"; non-empty means we
     // have results to render. CancellationException is re-thrown so the


### PR DESCRIPTION
## Summary

Sketchfab search on Explore only fired on the IME "Search" action (Enter). Typing "mario" sat dead for ~20 s in the screen-record QA (frames f_003 → f_007, 2026-05-26) — users tap something and expect results to start streaming as they type, the way every modern mobile search field works.

Thomas at 0:08 → 0:27:
> « En fait, on ne voit pas qu'il y a quelque chose qui se passe. Vraiment, ça devrait afficher la liste directement en dessous […]. Il faut taper Entrée, mais ce n'est pas très clair. On a l'habitude, quand on tape quelque chose, ça part en live. »

## Change

Add a debounced `LaunchedEffect(searchQuery)`:
- Waits 350 ms after each keystroke (Compose's structured concurrency cancels the delay on the next keystroke — natural debounce, no manual coroutine plumbing).
- 2-character minimum filters single-letter noise.
- `trim()` avoids re-running on trailing whitespace.
- Sets `activeSearchQuery = trimmed` only when actually different — no redundant HTTP work.

The existing `LaunchedEffect(activeSearchQuery)` (#1239) keeps doing the actual HTTP search — this PR only changes **when** `activeSearchQuery` is set, not **how** the search executes.

Recent-searches history (`onSearchSubmit` on Enter) is unchanged: live keystroke fragments would spam the dropdown with "m", "ma", "mar", … so only explicit Enter records.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator: open Explore → type "mario" character by character → "Search results" section appears ~350 ms after stopping (without Enter)
- [ ] CI green

Closes #2228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)