### PR TITLE
fix(android-demo): Explore — dedicated search-results view (#2229)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -313,12 +313,17 @@ private fun ExploreBody(
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         Spacer(Modifier.height(0.dp))
-        Text(
-            text = stringResource(R.string.explore_heading),
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        // Hide the page title when the user is actively searching (#2229) —
+        // it's noise that pushes the results below the fold. The SearchField
+        // below carries the "what is this page" affordance on its own.
+        if (!isSearching) {
+            Text(
+                text = stringResource(R.string.explore_heading),
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
 
         SearchField(
             value = searchQuery,
@@ -341,11 +346,15 @@ private fun ExploreBody(
             SketchfabDisabledBanner(keyRejected = keyRejected)
         }
 
-        if (apiKeyAvailable) {
+        // FiltersBar (Animated chip) and the "Try a sample" carousel both
+        // belong to the browse experience — when searching, the screen is
+        // dedicated to results so they get hidden too (#2229). The full
+        // browse layout returns the moment the query clears.
+        if (apiKeyAvailable && !isSearching) {
             FiltersBar(animatedOnly = animatedOnly, onToggle = onToggleAnimated)
         }
 
-        if (curatedSamples.isNotEmpty()) {
+        if (curatedSamples.isNotEmpty() && !isSearching) {
             CarouselSection(title = stringResource(R.string.explore_try_a_sample)) {
                 val state = rememberLazyListState()
                 LazyRow(


### PR DESCRIPTION
## Summary

When the user typed a Sketchfab query on Explore, the page kept showing heading + Animated filter chip + "Try a sample" carousel above the search results. Results got buried below the fold and read as mixed-in with the browse content (screen-record QA, frame f_008 at 0:38).

Thomas at 0:31:
> « Donc là, je tape, on ne voit même pas l'odeur en bas. Je cherche, les résultats qui se retrouvent au milieu d'autres trucs. On ne sait pas trop pourquoi, donc ça, il faut corriger. »

## Change

Wrap each browse-only section in `if (!isSearching)`:

| Section | Why hidden when searching |
|---|---|
| `explore_heading` page title | SearchField carries the "what is this page" affordance — title is noise |
| `FiltersBar` (Animated chip) | Sketchfab `search` endpoint doesn't accept `animated` (per #1239 KDoc) |
| `curatedSamples` carousel ("Try a sample") | Browse affordance, not search |
| 3 feeds (Trending / Staff picks / Recently added) | Already gated on `!isSearching` since #1239 |

Result: search results section gets the full vertical viewport. Browse layout snaps back the instant `activeSearchQuery` clears (which, with #2228 debounce, is < 2 chars or cleared field).

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator: Explore → type "mario" → confirm heading + carousel + chip all hidden, only "Search results" section visible
- [ ] Clear field → browse layout returns
- [ ] CI green

Closes #2229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)