### PR TITLE
feat(build): 16KB page-size alignment — library modules + migration docs (#2226)

### DIFF
--- a/arsceneview/build.gradle
+++ b/arsceneview/build.gradle
@@ -46,6 +46,11 @@ if (project.properties['filamentPluginEnabled']?.toBoolean()) {
 android {
     namespace = 'io.github.sceneview.ar'
 
+    // Align native library ELF PT_LOAD segments to 16 KB so consumers' APKs are accepted
+    // by Google Play on 16 KB-page-size devices (Android 15+, enforced by Play since Jan 2026).
+    // Consumers must also add this to their own app-level build.gradle (#2226).
+    experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
+
     compileSdk 36
 
     defaultConfig {

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -799,3 +799,30 @@ override fun onCreate(savedInstanceState: Bundle?) {
     setContent { /* ... */ }
 }
 ```
+
+## 16 KB page-size alignment (API 35+, required for Play Store)
+
+Google Play has enforced 16 KB ELF page-size alignment for all APKs targeting Android 15+
+(API 35) since January 2026. SceneView adds the AGP flag to its own library modules; your
+**app-level** `build.gradle` / `build.gradle.kts` must also opt in:
+
+```groovy
+// app/build.gradle (Groovy DSL)
+android {
+    experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
+    // …
+}
+```
+
+```kotlin
+// app/build.gradle.kts (Kotlin DSL)
+android {
+    experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
+    // …
+}
+```
+
+This rewrites ELF `PT_LOAD` alignment headers for **all** native `.so` files packaged
+into the APK/AAB at build time, including the Filament and ARCore prebuilt libraries.
+Without this flag, Play Store will reject the upload with:
+`Artifact does not support 16KB page size`.

--- a/sceneview/build.gradle
+++ b/sceneview/build.gradle
@@ -42,6 +42,12 @@ if (project.properties['filamentPluginEnabled']?.toBoolean()) {
 android {
     namespace = 'io.github.sceneview'
 
+    // Align native library ELF PT_LOAD segments to 16 KB so consumers' APKs are accepted
+    // by Google Play on 16 KB-page-size devices (Android 15+, enforced by Play since Jan 2026).
+    // Filament ships prebuilt .so files; this property rewrites ELF PT_LOAD alignment headers
+    // at pack time. Consumers must also add this to their own app-level build.gradle (#2226).
+    experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
+
     compileSdk 36
 
     defaultConfig {


### PR DESCRIPTION
## Summary

- Add `experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"` to `sceneview/build.gradle` and `arsceneview/build.gradle`
- Add 16 KB page-size section to `docs/docs/migration.md` with consumer-side instructions
- `sceneview-core` is KMP/JVM (no Android block) — intentionally skipped

## Background

Play Store enforces 16KB ELF page alignment for apps targeting Android 15+ since January 2026. The demo app already carries this flag (added in v4.16.2). This PR adds it to the published library modules so it's triggered for all consumers transitively.

Closes #2226

## Test plan

- [ ] `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` passes
- [ ] CI green
🤖 Generated with [Claude Code](https://claude.com/claude-code)