### PR TITLE
feat(android-demo): Sketchfab download — determinate progress bar with bytes + percent (#2232)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
@@ -211,22 +211,33 @@ class SketchfabService private constructor(
      * marker) and the cached path is returned without hitting the network.
      *
      * @param uid Sketchfab model uid.
-     * @param progress Optional 0..1 progress callback. Fired once with `1.0`
-     *   when the binary finishes — richer progress hooks will arrive in V1.1.
+     * @param onProgress Optional progress callback fired periodically during
+     *   the streaming download. `bytesRead` accumulates from `0L` to the
+     *   final body size; `totalBytes` is the `Content-Length` reported by the
+     *   server (or `-1L` if the server omitted it — rare but possible for
+     *   chunked-transfer responses). The callback is invoked on the IO
+     *   dispatcher; if the UI needs to update from it, hop to the main
+     *   thread inside the callback. Fired once with `(size, size)` at the
+     *   end so the UI can settle on 100 % even when the body Content-Length
+     *   was unknown (#2232).
      */
     suspend fun downloadModel(
         uid: String,
-        progress: ((Float) -> Unit)? = null,
+        onProgress: ((bytesRead: Long, totalBytes: Long) -> Unit)? = null,
     ): File = withContext(Dispatchers.IO) {
         val cacheFile = cacheFileFor(uid)
         if (cacheFile.exists()) {
             cacheFile.setLastModified(System.currentTimeMillis())
+            // Cache hit — fire a single 100 % progress event so the UI exits
+            // its loading state immediately instead of waiting for the model
+            // parser to start. `length()` is used as both `read` and `total`
+            // so the bar settles at 1.0 rather than flashing 0 %.
+            onProgress?.invoke(cacheFile.length(), cacheFile.length())
             return@withContext cacheFile
         }
 
         val remoteUrl = downloadUrl(uid)
-        downloadBinary(remoteUrl, cacheFile)
-        progress?.invoke(1f)
+        downloadBinary(remoteUrl, cacheFile, onProgress)
         pruneCacheIfNeeded()
         cacheFile
     }
@@ -297,7 +308,11 @@ class SketchfabService private constructor(
         }
     }
 
-    private fun downloadBinary(remoteUrl: String, destination: File) {
+    private fun downloadBinary(
+        remoteUrl: String,
+        destination: File,
+        onProgress: ((bytesRead: Long, totalBytes: Long) -> Unit)? = null,
+    ) {
         // The signed CDN URL must NOT carry the Sketchfab auth header.
         val request = Request.Builder().url(remoteUrl).get().build()
         client.newCall(request).execute().use { response ->
@@ -305,6 +320,10 @@ class SketchfabService private constructor(
                 throw SketchfabError.DownloadFailed("HTTP ${response.code}")
             }
             val body = response.body
+            // contentLength() returns -1L for chunked-transfer responses
+            // (rare but possible) — surfaced as-is so the UI can render a
+            // determinate bar when known and fall back to indeterminate.
+            val total = body.contentLength()
             destination.parentFile?.mkdirs()
             // Stream into a per-call unique temp file, then atomically rename
             // onto `destination`. Concurrent downloads of the same uid (the
@@ -317,7 +336,28 @@ class SketchfabService private constructor(
             )
             try {
                 temp.outputStream().use { out ->
-                    body.byteStream().use { input -> input.copyTo(out) }
+                    body.byteStream().use { input ->
+                        // Manual chunked copy with progress (#2232). 16 KB
+                        // buffer matches OkHttp's internal default and keeps
+                        // the callback frequency reasonable (~60 Hz on 4G,
+                        // ~600 Hz on 5G — still well under any UI debounce
+                        // budget). Coalescing on the UI side handles bursty
+                        // emissions.
+                        val buffer = ByteArray(16 * 1024)
+                        var totalRead = 0L
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read == -1) break
+                            out.write(buffer, 0, read)
+                            totalRead += read
+                            onProgress?.invoke(totalRead, total)
+                        }
+                        // Always fire a final 100 % event so the UI can
+                        // settle on "done" even when contentLength was -1L
+                        // (chunked transfer — totalRead becomes the de-facto
+                        // total once the stream ends).
+                        onProgress?.invoke(totalRead, totalRead)
+                    }
                 }
                 if (!temp.renameTo(destination)) {
                     temp.copyTo(destination, overwrite = true)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/SketchfabModelViewerScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
@@ -417,10 +418,27 @@ private fun DownloadingContent(
     heroModifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+
+    // Download progress, populated by SketchfabService.downloadModel's
+    // `onProgress` callback. `null` means "no Content-Length yet, render
+    // indeterminate spinner"; `0f..1f` drives the determinate
+    // LinearProgressIndicator below. (#2232)
+    var progress by remember(model.uid) { mutableStateOf<Float?>(null) }
+    var bytesRead by remember(model.uid) { mutableStateOf(0L) }
+    var totalBytes by remember(model.uid) { mutableStateOf(0L) }
+
     LaunchedEffect(model.uid) {
         val result = withContext(Dispatchers.IO) {
             runCatching {
-                SketchfabService.getInstance(context).downloadModel(model.uid)
+                SketchfabService.getInstance(context).downloadModel(model.uid) { read, total ->
+                    // `total` is -1L for chunked-transfer responses (rare);
+                    // in that case we keep `progress` null and show only the
+                    // indeterminate spinner + bytes count. When `total` is
+                    // known the bar tracks the ratio.
+                    bytesRead = read
+                    totalBytes = total
+                    progress = if (total > 0L) (read.toFloat() / total).coerceIn(0f, 1f) else null
+                }
             }
         }
         result.fold(
@@ -472,7 +490,20 @@ private fun DownloadingContent(
                     .padding(horizontal = 20.dp, vertical = 16.dp),
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
+                    // Determinate LinearProgressIndicator when the server
+                    // reported a Content-Length; falls back to the legacy
+                    // indeterminate spinner otherwise (#2232).
+                    val p = progress
+                    if (p != null) {
+                        LinearProgressIndicator(
+                            progress = { p },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 4.dp),
+                        )
+                    } else {
+                        CircularProgressIndicator()
+                    }
                     Spacer(Modifier.height(12.dp))
                     Text(
                         text = stringResource(R.string.sketchfab_loading_model, model.name),
@@ -480,8 +511,20 @@ private fun DownloadingContent(
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     Spacer(Modifier.height(4.dp))
+                    // Show bytes (and percent if known) so a 20-second 5G
+                    // download (Scifi Girl, 195k polys ~28 MB) doesn't feel
+                    // like the app froze (#2232).
                     Text(
-                        text = stringResource(R.string.sketchfab_streaming_from),
+                        text = if (totalBytes > 0L) {
+                            val mbRead = bytesRead / 1_000_000.0
+                            val mbTotal = totalBytes / 1_000_000.0
+                            val pct = (p ?: 0f).times(100f).toInt()
+                            "%.1f / %.1f MB · %d%%".format(mbRead, mbTotal, pct)
+                        } else if (bytesRead > 0L) {
+                            "%.1f MB".format(bytesRead / 1_000_000.0)
+                        } else {
+                            stringResource(R.string.sketchfab_streaming_from)
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )


### PR DESCRIPTION
## Summary

The Sketchfab download spinner was indeterminate for the entire ~20 s download — the user had no way to tell whether the network was working (screen-record QA 2026-05-26, frames f_017 → f_021).

Thomas at 1:30:
> « Pendant le streaming, typiquement, j'ai l'impression qu'avec le réseau, il ne l'a pas pris en compte. »

## Change

**Service layer** — `SketchfabService.downloadModel` accepted a progress callback since v1.0 but only ever fired it once with `1.0` at the end. Now:
- Signature widened to `onProgress: ((bytesRead: Long, totalBytes: Long) -> Unit)?`
- `downloadBinary` replaces `input.copyTo(out)` with a manual 16 KB chunked copy that fires `onProgress` after each chunk
- Final `(size, size)` event so the bar settles on 100 % even with chunked-transfer responses (`Content-Length = -1L`)
- Cache hits fire `(length, length)` immediately so the UI exits loading without flashing 0 %

**UI layer** (`DownloadingContent`):
- `progress: Float?` — `null` ⇒ indeterminate spinner (Content-Length unknown), `0..1` ⇒ determinate `LinearProgressIndicator`
- Bytes line: `"12.3 / 28.0 MB · 44 %"` when total known, `"12.3 MB"` when streaming, "Streaming from Sketchfab" only on the very first frame
- State keyed on `model.uid` so swapping models doesn't show stale progress

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator — open any Trending model → "Open in SceneView" → confirm LinearProgressIndicator + "X.X / Y.Y MB · Z %" updates smoothly during download
- [ ] Cache hit (re-open same model) — should land directly in Rendering stage, no flash
- [ ] CI green

Closes #2232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)