### PR TITLE
fix(android-demo): Feedback — persistent Snackbar confirmation after Sent (closes #2230)

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -33,7 +33,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -234,6 +239,15 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
     // and the NavHost were sibling root composables — the demo screens' own
     // TopAppBar then drew over the banner, clipping the "Update ready / Restart"
     // chrome. Drawing the banner last in the Box guarantees it stays visible.
+    // Host for the post-Sent feedback snackbar (#2230). Hoisted at this level
+    // (same scope as `feedbackOpen` below) so it can be triggered by the
+    // FeedbackFlow `onSent` callback and stays alive after the Dialog
+    // dismisses. CoroutineScope is rememberCoroutineScope'd here for the
+    // same reason — the snackbar.showSnackbar(...) launch must outlive the
+    // Dialog's own composition scope.
+    val feedbackSnackbarHost = remember { SnackbarHostState() }
+    val feedbackSentScope = rememberCoroutineScope()
+
     Box(modifier = Modifier.fillMaxSize()) {
         NavHost(
             navController = navController,
@@ -393,8 +407,40 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                 micPermanentlyDenied = micPermanentlyDenied,
                 notificationControlAvailable = notificationControlAvailable,
                 recordingAvailable = recordingAvailable,
+                onSent = { issueNumber ->
+                    // Persistent confirmation outside the dialog (#2230). The
+                    // dialog's Sent screen is dismissable in one tap; without
+                    // this snackbar the user lands back on Explore with no
+                    // visible trace that the feedback was sent. Lifecycle is
+                    // tied to the activity scope so the snackbar survives
+                    // tab switches.
+                    feedbackSentScope.launch {
+                        val msg = if (issueNumber != null) {
+                            context.getString(R.string.feedback_sent_snackbar, issueNumber)
+                        } else {
+                            context.getString(R.string.feedback_sent_snackbar_generic)
+                        }
+                        feedbackSnackbarHost.showSnackbar(
+                            message = msg,
+                            duration = SnackbarDuration.Long,
+                        )
+                    }
+                },
             )
         }
+
+        // Host for the post-Sent confirmation snackbar (#2230). Positioned at
+        // the bottom of the Box, above the navigation bar, so it sits below
+        // the FeedbackButton FAB instead of overlapping it. Padding matches
+        // the FAB's bottom offset so the snackbar appears just above the FAB
+        // while still respecting the system navigation bar.
+        SnackbarHost(
+            hostState = feedbackSnackbarHost,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .padding(bottom = FEEDBACK_FAB_BOTTOM_OFFSET + 72.dp),
+        )
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackFlow.kt
@@ -124,6 +124,15 @@ fun FeedbackFlow(
     micPermanentlyDenied: Boolean = false,
     notificationControlAvailable: Boolean = true,
     recordingAvailable: Boolean = true,
+    /**
+     * Fired ONCE the moment the upload reaches [UploadUiState.Sent] — the host
+     * uses it to show a persistent confirmation Snackbar (#2230) that survives
+     * the dialog dismissal, so users who tap "Done" don't end up wondering
+     * whether their feedback actually went through. `issueNumber` is the
+     * GitHub Issue number when the worker returned one, or `null` for the
+     * "Thank you" generic-confirmation path (text-only / queued submissions).
+     */
+    onSent: ((issueNumber: Int?) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -211,6 +220,11 @@ fun FeedbackFlow(
                     UploadUiState.Failed(result.errorKind)
                 }
                 if (result.ok) {
+                    // Notify the host (#2230) — the dialog's Sent screen is
+                    // dismissable in one tap, so the host snackbar is the
+                    // confirmation that survives "Done" and reassures the
+                    // user the upload actually went through.
+                    onSent?.invoke(result.issueNumber)
                     // Index the new ticket locally so "My feedback" can track
                     // it. Skipped when the worker stored the feedback but
                     // opened no issue (e.g. its hourly issue quota was hit) —

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -344,6 +344,11 @@
     <string name="feedback_sent_issue">Tracked as issue #%1$d. The team will take a look.</string>
     <string name="feedback_sent_generic">Your feedback was received by the SceneView team.</string>
     <string name="feedback_sent_done">Done</string>
+    <!-- Snackbar shown by the host after the dialog dismisses on a successful
+         send — persistent confirmation Thomas asked for at 0:58 of the
+         screen-record QA 2026-05-26 (#2230). %1$d is the GitHub issue number. -->
+    <string name="feedback_sent_snackbar">Feedback sent · Issue #%1$d</string>
+    <string name="feedback_sent_snackbar_generic">Feedback sent · Thank you</string>
     <string name="feedback_send_failed_title">Couldn\'t send</string>
     <string name="feedback_send_failed_body">Your feedback couldn\'t be sent. Check your connection and try again.</string>
     <string name="feedback_send_retry">Try again</string>


### PR DESCRIPTION
## Summary

Resolves the **second half of #2230** — the "silent submit result" complaint from screen-record QA 2026-05-26 (audio 0:58, frame f_012 → f_013: spinner flashes, dialog dismisses, user lands back on Explore with no visible trace that the feedback was sent).

The copy half (misleading "your note will be sent on its own" when Send was disabled) already shipped in #2243.

## Change

Host the confirmation OUTSIDE the dialog so it survives "Done":

- `FeedbackFlow` gains `onSent: ((issueNumber: Int?) -> Unit)?`, invoked the moment `uploadState` flips to `UploadUiState.Sent`.
- `MainActivity.SceneViewDemoApp` hoists a `SnackbarHostState` + `rememberCoroutineScope` at the same scope as `feedbackOpen`. Both outlive the Dialog → snackbar persists.
- New `SnackbarHost` at BottomCenter, above navbar + FAB.
- 2 strings: `feedback_sent_snackbar` ("Feedback sent · Issue #%1$d") and `feedback_sent_snackbar_generic` ("Feedback sent · Thank you" fallback when no issue number).
- `SnackbarDuration.Long` (~10 s).

Both halves of #2230 now ship.

## Test plan

- [x] `./gradlew :samples:android-demo:compileDebugKotlin` ✅
- [ ] Visual emulator: tap Feedback → pick a category → type a note → Send → tap Done → confirm snackbar appears at bottom + persists ~10 s
- [ ] CI green

Closes #2230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)