### PR TITLE
perf(arsceneview): PoseNode.pose direct TRS write — bypass per-frame matrix round-trip (#2266)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/Pose.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/Pose.kt
@@ -26,6 +26,24 @@ val Pose.transform: Transform
     get() = FloatArray(16).apply { toMatrix(this, 0) }.toTransform()
 //    get() = translation(position) * rotation(quaternion)
 
+/**
+ * Converts this [Pose] to a 4x4 [Transform] matrix, writing the column-major floats into the
+ * caller-supplied [out] scratch array instead of allocating a fresh `FloatArray(16)`.
+ *
+ * Hot-path callers that refresh the matrix every frame (e.g. [ARCameraNode]) should keep a single
+ * reusable `FloatArray(16)` field and pass it here to avoid per-frame allocation churn (#2266 /
+ * umbrella #2263).
+ *
+ * @param out a `FloatArray(16)` scratch buffer the matrix is written into; reused across calls.
+ * @return [out] wrapped as a [Transform] (`Mat4`). The returned matrix shares the backing floats
+ * with [out], so callers must not retain it past the next reuse of [out].
+ */
+fun Pose.toTransform(out: FloatArray): Transform {
+    require(out.size == 16) { "Pose.toTransform out array must have size 16, was ${out.size}" }
+    toMatrix(out, 0)
+    return out.toTransform()
+}
+
 /** The rotation component of this [Pose] as Euler angles (pitch, yaw, roll) in degrees. */
 val Pose.rotation: Rotation
     get() = quaternion.toEulerAngles()

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/ARCameraNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/ARCameraNode.kt
@@ -7,7 +7,8 @@ import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.arcore.getProjectionTransform
-import io.github.sceneview.ar.arcore.transform
+import io.github.sceneview.ar.arcore.position
+import io.github.sceneview.ar.arcore.quaternion
 import io.github.sceneview.node.CameraNode
 
 /**
@@ -44,7 +45,13 @@ open class ARCameraNode(engine: Engine) : CameraNode(engine) {
             if (field != value) {
                 field = value
                 value?.let {
-                    worldTransform = it.transform
+                    // Write the world translation + rotation directly from the ARCore Pose
+                    // components instead of `worldTransform = it.transform`, which allocated a
+                    // FloatArray(16) + Transform every frame only to decompose it straight back
+                    // into TRS. The camera pose refreshes on every tracked frame (#2266 /
+                    // umbrella #2263).
+                    worldPosition = it.position
+                    worldQuaternion = it.quaternion
                 }
             }
         }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
@@ -13,7 +13,7 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.arcore.createAnchor
 import io.github.sceneview.ar.arcore.isTracking
 import io.github.sceneview.ar.arcore.position
-import io.github.sceneview.ar.arcore.transform
+import io.github.sceneview.ar.arcore.quaternion
 import io.github.sceneview.gesture.MoveGestureDetector
 import io.github.sceneview.node.Node
 
@@ -57,7 +57,17 @@ open class PoseNode(
         set(value) {
             if (field != value) {
                 field = value
-                worldTransform(pose.transform)
+                // Write the world translation + rotation directly from the ARCore Pose
+                // components instead of routing through `worldTransform(pose.transform)`,
+                // which allocated a fresh FloatArray(16) + a Transform wrap and then
+                // immediately decomposed that matrix back into position/quaternion/scale.
+                // An ARCore Pose is a rigid transform (no scale), so the prior path also
+                // reset any user-set scale to identity every frame — writing only the
+                // translation and rotation preserves the node's scale. Fires for every
+                // AnchorNode / PlaneNode / AugmentedFaceNode / AugmentedImageNode /
+                // StreetscapeGeometryNode on every frame (#2266 / umbrella #2263).
+                worldPosition = value.position
+                worldQuaternion = value.quaternion
                 onPoseChanged(value)
             }
         }
@@ -98,7 +108,10 @@ open class PoseNode(
         }
 
     init {
-        worldTransform = pose.transform
+        // Seed the initial world transform from the Pose components directly, matching the
+        // allocation-free setter path above (#2266).
+        worldPosition = pose.position
+        worldQuaternion = pose.quaternion
 
         updateVisibility()
     }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
@@ -57,17 +57,26 @@ open class PoseNode(
         set(value) {
             if (field != value) {
                 field = value
-                // Write the world translation + rotation directly from the ARCore Pose
-                // components instead of routing through `worldTransform(pose.transform)`,
-                // which allocated a fresh FloatArray(16) + a Transform wrap and then
-                // immediately decomposed that matrix back into position/quaternion/scale.
-                // An ARCore Pose is a rigid transform (no scale), so the prior path also
-                // reset any user-set scale to identity every frame — writing only the
-                // translation and rotation preserves the node's scale. Fires for every
-                // AnchorNode / PlaneNode / AugmentedFaceNode / AugmentedImageNode /
-                // StreetscapeGeometryNode on every frame (#2266 / umbrella #2263).
-                worldPosition = value.position
-                worldQuaternion = value.quaternion
+                // Write the world translation + rotation from the ARCore Pose components
+                // instead of routing through `worldTransform(pose.transform)`, which
+                // allocated a fresh FloatArray(16) + a Transform wrap and then decomposed
+                // that matrix back into position/quaternion/scale. An ARCore Pose is a
+                // rigid transform (no scale), so the prior path also reset any user-set
+                // scale to identity every frame — passing only translation + rotation
+                // preserves the node's scale. Fires for every AnchorNode / PlaneNode /
+                // AugmentedFaceNode / AugmentedImageNode / StreetscapeGeometryNode on every
+                // frame (#2266 / umbrella #2263).
+                if (isSmoothTransformEnabled) {
+                    // HitResultNode / DepthHitResultNode set isSmoothTransformEnabled = true
+                    // and reassign `pose` every frame; the old `worldTransform(pose.transform)`
+                    // path fed the smooth slerp. Keep that smooth-follow (the component
+                    // overload still avoids Pose.transform's FloatArray(16)) (#2296 review).
+                    worldTransform(position = value.position, quaternion = value.quaternion)
+                } else {
+                    // High-frequency non-smooth nodes: fully alloc-free direct TRS write.
+                    worldPosition = value.position
+                    worldQuaternion = value.quaternion
+                }
                 onPoseChanged(value)
             }
         }

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/PoseNodeWriteTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/PoseNodeWriteTest.kt
@@ -1,0 +1,87 @@
+package io.github.sceneview.ar.node
+
+import dev.romainguy.kotlin.math.Quaternion
+import dev.romainguy.kotlin.math.normalize
+import dev.romainguy.kotlin.math.rotation
+import dev.romainguy.kotlin.math.translation
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Transform
+import io.github.sceneview.math.toQuaternion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * Pins the math equivalence behind the [PoseNode.pose] / [ARCameraNode.pose] hot-path fix (#2266,
+ * umbrella #2263).
+ *
+ * The previous setter routed through `worldTransform(pose.transform)`, where `Pose.transform`
+ * allocated a fresh `FloatArray(16)`, ran ARCore's `toMatrix`, wrapped it in a [Transform], and the
+ * world-transform setter then **decomposed that matrix straight back** into position + quaternion +
+ * scale. The fix writes the translation + rotation components directly
+ * (`worldPosition = pose.position; worldQuaternion = pose.quaternion`), skipping the matrix
+ * round-trip entirely.
+ *
+ * A real ARCore [com.google.ar.core.Pose] is JNI-backed and cannot be instantiated in a JVM unit
+ * runner (see [io.github.sceneview.ar.arcore.ArCoreExtensionsTest]). So this test pins the pure-math
+ * invariants the fix relies on, using the same `translation(p) * rotation(q)` composition ARCore's
+ * `toMatrix` produces for a rigid pose:
+ *
+ * - Decomposing the matrix yields the **same** translation + rotation the fix writes directly
+ *   (so the two paths are visually equivalent — no anchor moves).
+ * - A rigid pose carries **unit scale**, so the old matrix path forced node scale back to identity
+ *   every frame, whereas the direct-write path leaves the node's scale untouched. This documents
+ *   the intentional behaviour change.
+ */
+class PoseNodeWriteTest {
+
+    /** Builds the rigid TRS matrix ARCore's `Pose.toMatrix` produces for translation [t] + rotation [q]. */
+    private fun rigidPoseMatrix(t: Position, q: Quaternion): Transform =
+        translation(t) * rotation(normalize(q))
+
+    @Test
+    fun `direct translation matches the w-column of the decomposed pose matrix`() {
+        val t = Position(1.5f, -2.25f, 0.75f)
+        val q = normalize(Quaternion(0.1f, 0.2f, 0.3f, 0.9f))
+
+        val matrix = rigidPoseMatrix(t, q)
+
+        // Old path read translation from the matrix w-column; the fix writes `t` directly.
+        val decomposed = matrix.position
+        assertEquals(t.x, decomposed.x, 1e-5f)
+        assertEquals(t.y, decomposed.y, 1e-5f)
+        assertEquals(t.z, decomposed.z, 1e-5f)
+    }
+
+    @Test
+    fun `direct quaternion matches the rotation decomposed from the pose matrix`() {
+        val t = Position(3f, 4f, 5f)
+        val q = normalize(Quaternion(0.25f, -0.5f, 0.1f, 0.8f))
+
+        val matrix = rigidPoseMatrix(t, q)
+
+        // Old path: matrix.toQuaternion(). Fix: writes `q` directly. Quaternions q and -q represent
+        // the same rotation, so compare via the absolute dot product (|q . decomposed| ~= 1).
+        val decomposed = normalize(matrix.toQuaternion())
+        val dot = q.x * decomposed.x + q.y * decomposed.y + q.z * decomposed.z + q.w * decomposed.w
+        assertTrue(
+            "Decomposed rotation must equal the directly-written quaternion (|dot|=${abs(dot)})",
+            abs(abs(dot) - 1f) < 1e-4f,
+        )
+    }
+
+    @Test
+    fun `a rigid pose matrix carries unit scale`() {
+        // The old `worldTransform(pose.transform)` set the full matrix, so its unit scale reset any
+        // user-set node scale to identity every frame. The direct-write path leaves scale untouched.
+        val matrix = rigidPoseMatrix(
+            Position(10f, -3f, 7f),
+            normalize(Quaternion(0.4f, 0.1f, -0.2f, 0.88f)),
+        )
+        val scale = matrix.scale
+        assertEquals(1f, scale.x, 1e-4f)
+        assertEquals(1f, scale.y, 1e-4f)
+        assertEquals(1f, scale.z, 1e-4f)
+    }
+}

--- a/changelog.d/2266-ar-posenode-setter.md
+++ b/changelog.d/2266-ar-posenode-setter.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+- **Perf:** `PoseNode.pose` (and `ARCameraNode.pose`) now write the world translation + rotation
+  directly from the ARCore `Pose` components instead of routing through
+  `worldTransform(pose.transform)`, which allocated a fresh `FloatArray(16)` + `Transform` and ran
+  a matrix decompose/recompose on every anchor / plane / face / image / camera pose update, every
+  frame. Added an allocation-free `Pose.toTransform(out: FloatArray)` scratch variant for callers
+  that still need the matrix form. ([#2266](https://github.com/sceneview/sceneview/issues/2266),
+  umbrella [#2263](https://github.com/sceneview/sceneview/issues/2263))


### PR DESCRIPTION
## Summary

Fixes [#2266](https://github.com/sceneview/sceneview/issues/2266) — the AR-side cousin of #2187, part of hot-path audit umbrella [#2263](https://github.com/sceneview/sceneview/issues/2263).

**The bug.** `PoseNode.pose` (and `ARCameraNode.pose`) routed through `worldTransform(pose.transform)`, where `Pose.transform` allocated a fresh `FloatArray(16)` + `Transform` wrap and ran ARCore's `toMatrix`, only for the world-transform setter to immediately **decompose that matrix straight back** into position/quaternion/scale. This fired for every `AnchorNode` / `PlaneNode` / `AugmentedFaceNode` (centerNode + 3 regions) / `AugmentedImageNode` / `StreetscapeGeometryNode` / `ARCameraNode` on **every frame**.

**The fix.** Write the world translation + rotation directly from the rigid ARCore `Pose` components, bypassing the matrix round-trip and its allocation:

```kotlin
worldPosition = value.position      // tx()/ty()/tz()
worldQuaternion = value.quaternion  // qx()/qy()/qz()/qw()
```

- Semantics verified: the old `worldTransform(...)` single-arg path set the **world** transform, so the direct writes target `worldPosition`/`worldQuaternion` (not local). No subclass overrides `pose`.
- Side benefit: a rigid `Pose` carries unit scale, so the old path reset any user-set node scale to identity every frame — the direct-write path preserves it.
- Added an allocation-free `Pose.toTransform(out: FloatArray)` scratch variant for callers that still need the matrix form.
- `DepthMeshNode` is intentionally left on the allocating `pose.transform` path: it is **throttled** (not per-frame) and **retains** the matrix in a `DepthMeshSnapshot`, so a reused scratch buffer would alias the snapshot.

## Test plan

- [x] `./gradlew :arsceneview:compileReleaseKotlin :sceneview:compileReleaseKotlin` — green
- [x] `./gradlew :arsceneview:testDebugUnitTest :sceneview:testDebugUnitTest` — green
- [x] New `PoseNodeWriteTest` (3 cases, all pass) pins the pure-math equivalence: decomposing a rigid `translation(t) * rotation(q)` matrix yields the same translation + rotation the fix writes directly, and a rigid pose carries unit scale. (A real ARCore `Pose` is JNI-backed and can't be instantiated in a JVM unit runner — same constraint documented in `ArCoreExtensionsTest`.)
- [x] Changelog fragment `changelog.d/2266-ar-posenode-setter.md` (category `Fixed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)