### PR TITLE
fix(demo): register double-pendulum/spatial-audio/placement-scene in DemoHostActivity

### DIFF
--- a/changelog.d/demohost-missing-3-demos.md
+++ b/changelog.d/demohost-missing-3-demos.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Fixed `DemoHostActivity` (debug deep-link test harness) crashing with `Unknown demo id` when launched for `double-pendulum`, `spatial-audio`, or `placement-scene` — these three demos are registered in the catalog but were missing from the host's `when()` routing. They now route to their composables. Real users were unaffected (the normal `MainActivity` deep-link channel always handled them); the crash only hit the instrumentation/manual-QA `--es demo_id` path. Found during the #2239 interactive QA sweep.

--- a/samples/android-demo/src/debug/java/io/github/sceneview/demo/DemoHostActivity.kt
+++ b/samples/android-demo/src/debug/java/io/github/sceneview/demo/DemoHostActivity.kt
@@ -22,6 +22,7 @@ import io.github.sceneview.demo.demos.AnimationPhysicsDemo
 import io.github.sceneview.demo.demos.CameraAndGesturesDemo
 import io.github.sceneview.demo.demos.CustomGeometryDemo
 import io.github.sceneview.demo.demos.DebugOverlayDemo
+import io.github.sceneview.demo.demos.DoublePendulumDemo
 import io.github.sceneview.demo.demos.FogDemo
 import io.github.sceneview.demo.demos.GeometryDemo
 import io.github.sceneview.demo.demos.LightingDemo
@@ -30,8 +31,10 @@ import io.github.sceneview.demo.demos.LinesPathsDemo
 import io.github.sceneview.demo.demos.MaterialsDemo
 import io.github.sceneview.demo.demos.ModelViewerDemo
 import io.github.sceneview.demo.demos.PickingAndCollisionDemo
+import io.github.sceneview.demo.demos.PlacementSceneDemo
 import io.github.sceneview.demo.demos.PlaneGridPreviewDemo
 import io.github.sceneview.demo.demos.SecondaryCameraDemo
+import io.github.sceneview.demo.demos.SpatialAudioDemo
 import io.github.sceneview.demo.demos.TwoDInThreeDDemo
 import io.github.sceneview.demo.theme.SceneViewDemoTheme
 
@@ -120,6 +123,13 @@ class DemoHostActivity : ComponentActivity() {
             "custom-geometry", "custom-mesh", "shape" -> CustomGeometryDemo(onBack = back)
             "secondary-camera" -> SecondaryCameraDemo(onBack = back)
             "debug-overlay" -> DebugOverlayDemo(onBack = back)
+            // These 3 were registered in the catalog (GeneratedDemos / fragments) but
+            // missing from this debug deep-link host's when() — launching them via
+            // DemoHostActivity (--es demo_id) crashed with "Unknown demo id" while they
+            // worked fine through MainActivity navigation. Found during #2239 interactive QA.
+            "double-pendulum" -> DoublePendulumDemo(onBack = back)
+            "spatial-audio" -> SpatialAudioDemo(onBack = back)
+            "placement-scene" -> PlacementSceneDemo(onBack = back)
             // #2224 — non-AR static preview of the ARCore plane grid material for shader QA.
             "plane-grid-preview" -> PlaneGridPreviewDemo(onBack = back)
             // Augmented Reality


### PR DESCRIPTION
## What

`DemoHostActivity` (the debug-only deep-link test harness) crashed with `IllegalStateException: Unknown demo id` (DemoHostActivity.kt:~140 `else -> error(...)`) when launched for **`double-pendulum`**, **`spatial-audio`**, or **`placement-scene`**. These three demos are registered in the catalog (`GeneratedDemos.kt` / their `*Fragment`s) but were never added to `DemoHostActivity`'s `DemoById` `when()`.

- **Real users: unaffected** — the production `MainActivity` deep-link channel (`--es demo` → `DeepLinkRouter.validate` → `GeneratedDemos`) always handled them, and normal catalog navigation works.
- **Crash hit only the `DemoHostActivity --es demo_id` path** — used by instrumentation tests and manual QA. Maestro flows (`.maestro/android/advanced.yaml`, `ar.yaml`) reference these ids but launch via the `MainActivity` channel, so they were green; anyone using the `DemoHostActivity` host hit the crash.

Found during the #2239 interactive QA sweep (launching every demo via `DemoHostActivity`).

## Fix
Add the 3 imports + `when()` routes to `DemoHostActivity`.

## Verified
On a native arm64 emulator, all 3 now route + render with **no crash**:
- `double-pendulum` → chaotic double-pendulum trail ✅
- `spatial-audio` → audio-source sphere over ground, AudioTrack playing ✅
- `placement-scene` → placement UI ("0 models placed" + reticle + camera) ✅

## Follow-up (suggested)
Add a guard test asserting **every `ALL_DEMOS` id is routable by `DemoHostActivity`** so a catalog demo can't again be added without a host entry. (Could file as a separate issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)