### PR TITLE
docs: clarify the rememberMaterialInstance note (precise, not contradictory)

### DIFF
--- a/changelog.d/doc-remembermaterialinstance-note.md
+++ b/changelog.d/doc-remembermaterialinstance-note.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Clarified the `rememberMaterialInstance` note in `llms.txt`, `gpt/knowledge-api.md` and the website `.well-known/llms.txt`: the flat "there is NO `rememberMaterialInstance` function" was imprecise (and contradicted the demos, which use a sample-only helper of that name in `samples/common`). Reworded to say there is none in the *published SDK* and to copy the `materialLoader.createColorInstance(...)` pattern — so an AI reading both the docs and the demos isn't confused.

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -371,7 +371,7 @@ materialLoader.createColorInstance(
 ): MaterialInstance
 ```
 
-There is NO `rememberMaterialInstance`. Create materials inside `remember`:
+There is no `rememberMaterialInstance` in the published SDK (only a `samples/common` helper). Create materials inside `remember`:
 
 ```kotlin
 val mat = remember(materialLoader) {

--- a/llms.txt
+++ b/llms.txt
@@ -2719,7 +2719,7 @@ Most are default parameter values in `SceneView`/`ARSceneView` — call them exp
 | `rememberARCameraStream(materialLoader)` | `ARCameraStream` | Camera feed background texture |
 | `rememberAREnvironment(engine)` | `Environment` | No-skybox environment for AR |
 
-**NOTE:** There is NO `rememberMaterialInstance` function. Create materials with `materialLoader.createColorInstance(...)` inside a `remember` block:
+**NOTE:** There is no `rememberMaterialInstance` in the published SceneView SDK — create materials with `materialLoader.createColorInstance(...)` inside a `remember` block. (The demos use a sample-only helper of that name from `samples/common`; in your own code copy this pattern, not the helper.)
 ```kotlin
 val mat = remember(materialLoader) {
     materialLoader.createColorInstance(Color.Red, metallic = 0f, roughness = 0.4f)

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -1039,7 +1039,7 @@ Most are default parameter values in `SceneView`/`ARSceneView` — call them exp
 | `rememberARCameraStream(materialLoader)` | `ARCameraStream` | Camera feed background texture |
 | `rememberAREnvironment(engine)` | `Environment` | No-skybox environment for AR |
 
-**NOTE:** There is NO `rememberMaterialInstance` function. Create materials with `materialLoader.createColorInstance(...)` inside a `remember` block:
+**NOTE:** There is no `rememberMaterialInstance` in the published SceneView SDK — create materials with `materialLoader.createColorInstance(...)` inside a `remember` block. (The demos use a sample-only helper of that name from `samples/common`; in your own code copy this pattern, not the helper.)
 ```kotlin
 val mat = remember(materialLoader) {
     materialLoader.createColorInstance(Color.Red, metallic = 0f, roughness = 0.4f)


### PR DESCRIPTION
Follow-up to the independent review of #2336. The flat "there is NO `rememberMaterialInstance` function" in `llms.txt`, `gpt/knowledge-api.md` and the website `.well-known/llms.txt` was imprecise — the helper exists in `samples/common` (15+ demos, unit-tested), it just isn't in the published SDK. Reworded to scope it to the published SDK and keep the `createColorInstance`-inside-`remember` guidance, so an AI reading both docs and demos isn't confused.

Prose-only; structural llms-drift + sync-versions checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)