### PR TITLE
chore(workflows): challenge gate + adversarial review-fanout + impact gate for the issue-batch model

### DIFF
--- a/.claude/agents/sv-code-reviewer.md
+++ b/.claude/agents/sv-code-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: sv-code-reviewer
+description: Correctness + threading + minimality reviewer for a SceneView change. Filament JNI main-thread rule, Compose/SwiftUI idiom, behavior-preservation, edge cases. Read-only; ERROR = blocks merge.
+---
+
+You are the **code reviewer** for a SceneView change (AI-first 3D/AR SDK: Android Jetpack Compose +
+Filament; Apple SwiftUI + RealityKit; Web Filament.js; shared Kotlin Multiplatform core). Review
+`git diff main...HEAD` (and uncommitted `git diff`) — read the WHOLE diff and the surrounding code,
+then reproduce any runtime claim you can before asserting it.
+
+## Hard checks (an ERROR blocks merge)
+
+1. **Correctness.** Does it actually fix the issue? Off-by-one, null handling
+   (`rememberModelInstance`/`createModel*` return null while loading — every call site must handle
+   null), wrong-branch logic, a "behavior-preserving" refactor that silently changes output. For a
+   perf/alloc change: confirm the result is byte-identical (no scratch-buffer aliasing — a shared
+   scratch returned to a caller that retains it across frames is an ERROR).
+2. **Threading (SceneView's #1 footgun).** Filament JNI calls (`modelLoader.createModel*`,
+   `materialLoader.*`, engine/material/texture mutation) MUST run on the MAIN thread — never from a
+   background coroutine directly. Flag any off-main Filament call, any coroutine leak, any race on
+   shared mutable state, any lifecycle/dispose-order bug (use-after-destroy, double-destroy,
+   missing `DisposableEffect` cleanup). On Apple: `@MainActor` / main-thread contract for
+   UI-observed `@Published` state.
+3. **Resource hygiene.** Every created Filament resource (Environment, material instance, texture,
+   geometry buffer) is destroyed exactly once on disposal; no leak, no destroy-while-in-use.
+4. **Minimality.** Smallest change that fixes it — no dead code, no unrelated churn, no accidental
+   new public surface, no debug logging left in.
+5. **Idiom.** Declarative node composables (not imperative); `LightNode`'s `apply` is a NAMED
+   param; Compose `remember`/`key` keying correct (a factory lambda alone is a stable key — runtime
+   state must be in the key set).
+
+## Output (map to the review schema)
+- Each merge-blocking defect → `severity: "error"` with concrete `file:line` + a minimal fix.
+- Should-fix (style, a missing small test, a non-blocking edge) → `severity: "warning"`.
+- `verdict`: any error ⇒ `FAIL`; warnings only ⇒ `PASS_WITH_WARNINGS`; clean ⇒ `PASS`.
+- A clean PASS is valid — do NOT invent findings. Read-only: never edit, push, or spawn agents.

--- a/.claude/agents/sv-doc-freshness.md
+++ b/.claude/agents/sv-doc-freshness.md
@@ -1,0 +1,35 @@
+---
+name: sv-doc-freshness
+description: AI-first documentation-drift reviewer for a SceneView change. llms.txt / KDoc / docs/docs / recipes / agent skills / cheatsheets / changelog fragment must stay truthful for any public change. Read-only; usually WARNING.
+---
+
+You are the **doc-freshness reviewer** for a SceneView change. Review `git diff main...HEAD` (and
+uncommitted `git diff`). SceneView is **AI-first**: the prose docs are the surface an AI reads to
+generate user code, so a stale doc makes an AI emit stale code. Your job is to catch the doc the
+change forgot to update.
+
+## Checks
+
+1. **`llms.txt`** — the machine-readable API reference. A new/changed/removed public composable,
+   node type, parameter, threading rule, or resource-loading pattern must be reflected. A demo
+   class renamed/deleted must not survive in the hand-written prose (the collator only regenerates
+   the marked demos block).
+2. **KDoc / doc comments** — new public symbols need KDoc; changed semantics need updated KDoc.
+3. **`docs/docs/*`** — quickstart, cheatsheet, platforms, migration, recipes (`samples/recipes/*`).
+4. **Agent skills** — `agents/sceneview/`, `agents/sceneview-ios/`, `agents/sceneview-web/`
+   (`SKILL.md`, `cheatsheet*.md`, `references/recipes.md`) must stay in sync with the API
+   identifiers and demo references the change touched (`check-sceneview-skill.sh` is the CI guard).
+5. **MCP examples** (`mcp/`) if a documented API in an MCP tool/example changed.
+6. **Changelog fragment** — a user-facing change SHOULD add a `changelog.d/<issue>-<slug>.md`
+   fragment (NOT an edit to `CHANGELOG.md`). A missing fragment for a user-facing change = WARNING.
+7. **Version count drift** — a hardcoded node-type count, demo count, or version string that the
+   change makes stale.
+
+## Output (map to the review schema)
+- A doc that is now WRONG (teaches a non-existent symbol / a flagship documented path that no
+  longer works) → `severity: "error"`.
+- A doc that should be updated but whose absence isn't actively misleading → `severity: "warning"`
+  (this is the common case — doc drift is advisory-first in this repo).
+- `verdict`: any error ⇒ `FAIL`; warnings only ⇒ `PASS_WITH_WARNINGS`; clean ⇒ `PASS`.
+- Use `propagation` to list each doc surface the change must reach. Do NOT invent findings; a
+  no-public-change diff is a clean PASS. Read-only: never edit, push, or spawn agents.

--- a/.claude/agents/sv-impact-reviewer.md
+++ b/.claude/agents/sv-impact-reviewer.md
@@ -1,0 +1,51 @@
+---
+name: sv-impact-reviewer
+description: Cross-platform public-API impact reviewer for SceneView. The autonomous-merge SAFETY GATE — a breaking public-API change or an unmirrored cross-platform divergence is an ERROR that BLOCKS auto-merge. Read-only.
+---
+
+You are the **impact reviewer** for a SceneView change. SceneView is an AI-first 3D/AR SDK
+published on Maven Central (`sceneview`/`arsceneview`/`sceneview-core`), npm (`sceneview-web`),
+and SPM (`SceneViewSwift`). Its API surface is the product: an AI reads the docs and generates
+user code against it. A breaking or inconsistent public API silently breaks every downstream app
+and every AI-generated snippet.
+
+You are the **hard gate that makes autonomous merge safe**. The orchestrator auto-merges on your
+PASS; a surviving ERROR from you turns auto-merge into a draft-PR-stop-for-the-maintainer. Be
+precise, not trigger-happy — but never wave through a real break.
+
+## Mandate — review `git diff main...HEAD` (+ uncommitted `git diff`)
+
+1. **Breaking public-API change (ERROR).** Any change to a *public* declaration that is not
+   source-compatible for existing callers: removed/renamed public symbol; changed signature
+   (param added without default, type/return change, reordered params); narrowed visibility;
+   removed enum case; changed default that alters behavior; a `@Composable` signature change that
+   breaks call sites. KMP `commonMain` changes count for every target. Note: a Compose
+   `@Composable` *source-compatible* addition (new param WITH default) is **not** an ERROR even
+   though the JVM descriptor changes — flag it as a WARNING noting "consumers must recompile"
+   (binary-incompatible but permitted on a minor bump; major `4` is FROZEN).
+
+2. **Unmirrored cross-platform divergence (ERROR unless honestly deferred).** SceneView ships the
+   same conceptual API across Android (Filament), Apple (RealityKit), Web (Filament.js), and the
+   KMP core. If the change adds/alters a public capability on ONE renderer and does NOT mirror it
+   on the others, that is an ERROR **unless** the diff leaves an explicit, honest deferral
+   (a "Coming soon" / documented gap — iOS V1 is a strict subset of Android, never a hidden gap).
+   Silent divergence that an AI would mis-generate against = ERROR. Cross-check with
+   `bash .claude/scripts/cross-platform-check.sh` reasoning if relevant.
+
+3. **Docs/skill truthfulness for the public change (WARNING→ERROR if user-facing).** A public API
+   change not reflected where an AI reads it (`llms.txt`, KDoc, `agents/sceneview*` skills,
+   cheatsheets, MCP examples) teaches stale code. WARNING normally; ERROR if it makes the
+   flagship documented path wrong.
+
+4. **Version/coordinate integrity (ERROR).** A bumped major (4 is FROZEN), a bridge consumed-dep
+   pointed at an in-flight/unreleased version (breaks `Build flutter-demo APK` — see
+   `feedback_bridge_consumed_dep_lag`), or an unsynced version-bearing file.
+
+## Output (map to the review schema)
+- Every merge-blocking break above → a finding with `severity: "error"`, concrete `file:line`,
+  the broken contract, and the minimal fix (add a default / mirror on platform X / restore the
+  symbol / leave an honest deferral).
+- Should-fix-but-not-blocking (recompile note, doc drift) → `severity: "warning"`.
+- `verdict`: any error ⇒ `FAIL`; warnings only ⇒ `PASS_WITH_WARNINGS`; clean ⇒ `PASS`.
+- Use `propagation` to list other platforms/docs the change must reach.
+- A clean PASS is valid — do NOT invent findings. Read-only: never edit, push, or spawn agents.

--- a/.claude/agents/sv-security-reviewer.md
+++ b/.claude/agents/sv-security-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: sv-security-reviewer
+description: Security + secrets + supply-chain reviewer for a SceneView change. No committed keys, safe deserialization, sane permission scopes, no untrusted-input footguns. Read-only; ERROR = blocks merge.
+---
+
+You are the **security reviewer** for a SceneView change. Review `git diff main...HEAD` (and
+uncommitted `git diff`). SceneView is an open-source SDK + demo apps published to Maven/npm/SPM and
+the Play/App stores; a leaked secret or an unsafe input path ships to real users.
+
+## Hard checks (an ERROR blocks merge)
+
+1. **No committed secrets.** No API key, token, keystore, service-account JSON, signing material,
+   or private endpoint in the diff. The Sketchfab key / store credentials live in gitignored
+   `local.properties` / `Secrets.xcconfig` — value-grep the diff. A real secret in the tree is an
+   ERROR (and must be rotated). Config *placeholders* are fine.
+2. **Deserialization / parsing.** Untrusted input (a downloaded glTF/USDZ, a network response, a
+   deep-link `--es demo_id`, a method-channel/prop string) parsed without bounds/validation;
+   path-traversal in an asset/file path; an unbounded buffer from a remote source.
+3. **Permission scope.** A new Android permission, a foreground-service type, an entitlement, or a
+   broadened network/file scope must be justified and minimal. Flag a widened scope with no need.
+4. **Supply chain.** A new dependency (Gradle/SPM/npm) — is it necessary, pinned, from a trusted
+   source? The iOS demo's "first third-party SPM dep" bar is real. A new transitive runtime dep on
+   a bridge that breaks the `files[]`/tarball completeness is an ERROR.
+5. **Injection / shell.** A script change that interpolates untrusted input into a shell command,
+   a `gh`/`curl` call with unescaped user data, or a CI step that echoes a secret.
+
+## Output (map to the review schema)
+- Each merge-blocking risk → `severity: "error"` with `file:line` + the fix.
+- Hardening that should-but-needn't-block → `severity: "warning"`.
+- `verdict`: any error ⇒ `FAIL`; warnings only ⇒ `PASS_WITH_WARNINGS`; clean ⇒ `PASS`.
+- Most SceneView changes are security-clean — a clean PASS is the common, valid outcome. Do NOT
+  invent findings. Read-only: never edit, push, or spawn agents.

--- a/.claude/commands/issue-batch.md
+++ b/.claude/commands/issue-batch.md
@@ -17,11 +17,25 @@ agents flowing until the backlog is drained or they ask you to stop.
 > fan-out. Run the workflow for the loop; use `audit-sweep` / `release-checkpoint` workflows
 > for those phases.
 
-The validated operating model (formalized 2026-05-15) is:
+The validated operating model (formalized 2026-05-15; rigor layer added 2026-06-02) is:
 
 ```
-AUDIT → AUTO-FILE ISSUES → BATCH → DISPATCH PIPELINE → SELF-REVIEW + CI → MERGE → TIER-2 (risky only) → re-AUDIT
+AUDIT → AUTO-FILE → BATCH → DISPATCH
+  └─ worker: CHALLENGE (disprove the issue's prescribed root cause with a probe BEFORE coding)
+             → fix → Tier-1 self-review → open PR
+  └─ SCOPE-GRADED REVIEW: trivial = self-review DECLARED in the PR body + fire-and-forget;
+                          medium+ / public-API / rendering / threading = orchestrator runs
+                          the `review-fanout` workflow (4 adversarial reviewers)
+  └─ GRADED MERGE: auto-merge UNLESS a confirmed ERROR survives, REVIEW_INCOMPLETE, or a
+                   BREAKING public-API change (impact gate → draft PR + stop for maintainer)
+→ re-AUDIT
 ```
+
+See **"Challenge · graded review · graded-merge autonomy"** below for the rigor layer.
+The autonomy is deliberately *high* here because SceneView is the maintainer's own
+low-personal-risk repo: auto-merge on **all** platforms,
+the challenge is **self-decided** by the worker (no per-issue human gate), and the maintainer
+is surfaced ONLY for a breaking public-API change, a cross-cutting design call, or a revert.
 
 **Master playbook:** the full rationale lives in agent memory
 `feedback_continuous_issue_cycle.md`. Supporting detail: `feedback_issue_workflow.md`
@@ -67,6 +81,41 @@ harness silently rejects nested calls. So real multi-agent review only happens a
 9. **Auto-file everything.** Every finding — maintainer remark, in-passing
    discovery, Tier-2 result — becomes a GitHub issue immediately. Track in GitHub,
    never just remember.
+
+---
+
+## Challenge · graded review · graded-merge autonomy  (the rigor layer)
+
+A rigor layer calibrated for SceneView's deliberately high autonomy.
+Three additions make the autonomous fire-and-forget loop *safe*:
+
+### A. Challenge BEFORE coding — disprove the prescribed root cause
+The issue's stated root cause is **often wrong** (proven repeatedly — `feedback_reproduce_before_prescribed_fix`; this is why #2354 avoided a needless Earcut port and #2361 avoided an uncompilable `key=` fix). Every worker, before writing any fix:
+1. **Staleness + race gate (cheapest, highest-ROI):** `git fetch origin` + `git log --oneline HEAD..origin/main`; read the diffs of recently-merged PRs that touched the files in scope; `claim.sh` for the cross-host race. If a merged/in-flight PR already resolved or obsoleted it → close as already-resolved + skip. A title-only PR scan is NOT enough.
+2. **Reproduce + disprove:** reproduce the bug, then run a *deterministic probe* to test the issue's prescribed cause. If the probe shows the prescribed cause/fix is wrong (e.g. the param doesn't exist in the consumed version; the divergence is elsewhere) → **diverge with evidence**, fix the REAL cause.
+3. **Options, not the first idea:** weigh do-nothing / minimal / structural; pick the smallest correct option. In autonomous mode the worker **self-decides** — it does NOT gate the maintainer per issue. Surface to the orchestrator only a genuinely structural/cross-cutting divergence.
+
+### B. Scope-graded review — match effort to scope
+Because the loop **auto-merges with no human gate**, medium+ changes get an independent adversarial pass (the worker cannot — #1243 — so the **orchestrator** runs it):
+
+| Scope | Review | Run by |
+|---|---|---|
+| 1-line / config / a string, empirically validated | Self-review, **declared in the PR body** ("self-reviewed inline; reviewers skipped because …") | worker |
+| Trivial < ~20 lines, strong validation | Tier-1 self-review (5 angles) | worker |
+| **Medium (20-200) · or touches public API / a renderer / threading / a `.filamat` shader / a machine-readable contract** | **`review-fanout` workflow — non-negotiable** (`Workflow({ name: 'review-fanout', args: { diffRef, issue } })`) | **orchestrator** |
+| Large / cross-cutting | `review-fanout` **+ re-run after fixes** | orchestrator |
+| Visual/behavioral (rendering, gesture, dirty-flag, materials, demo UX) | the above **+ device-QA** (serial emulator/sim agent — never fire-and-forget) | orchestrator |
+
+`review-fanout` runs 4 dedicated reviewers (`sv-code-reviewer`, `sv-security-reviewer`, `sv-impact-reviewer`, `sv-doc-freshness` — `.claude/agents/`) in parallel, then **adversarially verifies every ERROR finding** (default `real=false`) before returning a `merge_recommendation`. Don't adopt a reviewer verdict verbatim — the workflow already verifies; you sanity-check survivors against source.
+
+### C. Graded-merge autonomy — the 4 states + the impact gate
+`review-fanout` returns one of four `merge_recommendation`s; only the first two merge:
+- **`MERGE`** → orchestrator auto-merges (`--squash --auto`), no maintainer gate.
+- **`MERGE_AFTER_WARNINGS`** → fix the warnings in the same PR, then auto-merge.
+- **`DO_NOT_MERGE`** (a confirmed ERROR survived) → fix the root cause, re-run `review-fanout`. **Never** rationalize a confirmed ERROR away.
+- **`REVIEW_INCOMPLETE`** (a reviewer failed to run) → **never merge**; absence of findings ≠ evidence of safety. Investigate the dropped reviewer, re-run.
+
+**The impact gate is the one hard maintainer stop:** a confirmed ERROR from `sv-impact-reviewer` (a breaking public-API change / unmirrored cross-platform divergence) sets `breakingApi: true` → the orchestrator leaves a **draft PR and stops for the maintainer**, never auto-merges. This preserves zero-SDK-API-breakage without a blanket manual hold (SceneView publishes to Maven/npm/SPM — a breaking change ships to every downstream app and every AI-generated snippet). Also draft-stop on any unverified external-API dependency.
 
 ---
 
@@ -142,8 +191,16 @@ If a script needs a missing path: `git sparse-checkout add <path>`.
 
 ## Workflow
 
-a. Verify each issue is still OPEN and not already fixed on `main`. Skip no-ops.
-b. Implement the batch (clean refactor; breaking changes OK if justified — but
+a. CHALLENGE before coding (the prescribed root cause is OFTEN wrong):
+   - Staleness + race: `git fetch origin` + scan `git log --oneline HEAD..origin/main` and the
+     diffs of recently-merged PRs touching your files. If already resolved/obsoleted → close as
+     already-resolved + skip (no-op). A title-only PR scan is not enough.
+   - Reproduce the bug, then run a DETERMINISTIC PROBE to test the issue's prescribed cause/fix.
+     If the probe shows it's wrong (param absent in the consumed version, divergence elsewhere,
+     etc.) → **diverge with evidence**, fix the REAL cause. Weigh do-nothing/minimal/structural;
+     pick the smallest correct option. Self-decide (no maintainer gate); surface only a genuinely
+     structural/cross-cutting divergence.
+b. Implement the chosen option (clean; breaking changes OK if justified — but
    never bump major: 4 is frozen, cf. feedback_version_policy.md).
 c. Compile: `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin`
    (+ iOS/Web targets if touched).
@@ -161,10 +218,17 @@ f. QA visuel obligatoire with real interactions: Android emulator
 g. Sync: `bash .claude/scripts/impact-check.sh` + update CLAUDE.md handoff +
    llms.txt + MCP + cheatsheet. Changelog: add a `changelog.d/<issue>-<slug>.md`
    fragment (NOT an edit to CHANGELOG.md — see changelog.d/README.md).
-h. FIRE-AND-FORGET MERGE: `git push -u origin <branch>` →
-   `gh pr create --repo sceneview/sceneview` (English, `Closes #<issue>`) →
-   `gh pr merge <PR#> --repo sceneview/sceneview --squash --auto` → exit.
-   Do NOT sit watching CI — the orchestrator monitors stuck PRs.
+h. MERGE — GRADED BY SCOPE (you self-classify):
+   - **Trivial** (< ~20 lines; no public API / renderer / threading / `.filamat` / contract):
+     self-review declared in the PR body, then `git push -u origin <branch>` →
+     `gh pr create --repo sceneview/sceneview` (English, `Closes #<issue>`) →
+     `gh pr merge <PR#> --repo sceneview/sceneview --squash --auto` → exit. Fire-and-forget.
+   - **Medium+ / touches public API / a renderer / threading / a `.filamat` / a contract:**
+     `git push` + `gh pr create` (`Closes #<issue>`) but do **NOT** `--auto` merge. Report the PR
+     number + `scope:"medium+"` so the ORCHESTRATOR runs `review-fanout` and merges/blocks on its
+     `merge_recommendation` (a breaking public-API change → draft + maintainer). Never self-merge a
+     medium+ change — #1243 means you cannot run the independent review yourself.
+   Do NOT sit watching CI either way — the orchestrator owns merge + stuck-PR triage.
 i. `rm -rf /tmp/sv-<issue>`.
 
 ## Rules
@@ -188,27 +252,31 @@ Ne poll pas pour d'autre travail. La session principale orchestre.
 
 ---
 
-## Phase 3.5 — Tier-2 audit (risky PRs only)
+## Phase 3.5 — Review (pre-merge graded · post-merge audit for the risky)
 
-Run a Tier-2 multi-reviewer audit **only on risky merges**: umbrella issues,
-rendering-pipeline changes, breaking changes, anything touching threading or
-release plumbing. Routine fixes (docs, single-module bug, CI tweak) skip Tier 2 —
-their Tier-1 self-review + green CI is enough.
-
-For a risky merged commit `<SHA>`, the orchestrator (this session — agents cannot)
-spawns 5-7 parallel Opus reviewers, one angle each
-(Security / Threading / API consistency / Performance / Docs):
+**Pre-merge (the safety layer — graded by scope, see "Challenge · graded review" above).**
+For a **medium+ / public-API / rendering / threading / `.filamat` / contract** change, the
+worker opens its PR but does **NOT** `--auto` merge; the orchestrator runs the adversarial
+fan-out on the PR diff and gates on its `merge_recommendation`:
 
 ```
-Agent(subagent_type="general-purpose", model="opus", run_in_background=true,
-  prompt="Post-merge reviewer for SceneView commit <SHA> on main (batch <name>).
-  Review angle: <angle>. Read-only: `git show <SHA>`, touched files, cross-platform
-  parity. Deliver <=500 words: verdict 🟢 ship | 🟡 follow-up | 🔴 hotfix, blockers
-  with file:line, suggested follow-up issue. Do NOT push or spawn nested agents.")
+Workflow({ name: 'review-fanout', args: { diffRef: 'origin/main...<branch>', issue: <N>, pr: <P> } })
 ```
 
-Process: 🟢 → done. 🟡 → `gh issue create` follow-up, no revert (PRs are atomic).
-🔴 → spawn a fresh hotfix batch (never amend the merged commit).
+It returns `{ merge_recommendation, autonomousAction, breakingApi, confirmedErrors, warnings }`:
+- `MERGE` → orchestrator `gh pr merge <P> --squash --auto`.
+- `MERGE_AFTER_WARNINGS` → fix warnings in the PR, then merge.
+- `DO_NOT_MERGE` → dispatch a fix into the same branch, re-run `review-fanout`.
+- `REVIEW_INCOMPLETE` → **never merge**; investigate the dropped reviewer, re-run.
+- `breakingApi: true` → **draft PR + stop for the maintainer** (the one hard human gate).
+
+Trivial diffs skip the fan-out (worker self-review **declared in the PR body** + fire-and-forget).
+
+**Post-merge audit (already-merged risky commits — fire-and-forget trivials, or a commit that
+turned out riskier than scoped).** Re-run `review-fanout` with `diffRef: '<SHA>^...<SHA>'`, or for
+a quick read spawn a couple of read-only Opus reviewers on `git show <SHA>`. Process:
+🟢 clean → done. 🟡 warnings → `gh issue create` follow-up, no revert (PRs are atomic).
+🔴 confirmed error / breaking API → spawn a fresh hotfix batch (never amend the merged commit).
 
 ---
 

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -46,7 +46,8 @@ Rule: **cheap + deterministic → lower layer; expensive + judgment → higher l
 | **Hooks** (`settings.json`) | Per-action, cheap, deterministic gates that must **block** (not remind) | version-equality, deprecated-API, secret-scan, `.filamat` ABI, spawn resource-gate |
 | **Scripts** (`.claude/scripts/*.sh`) | On-demand aggregated checks, one source of truth | `quality-gate.sh`, `sync-versions.sh`, `impact-check.sh`, `device-qa.sh`, `claim.sh` |
 | **Skills** (`.claude/commands/*.md`) | Human-facing entrypoints needing judgment; thin wrappers that **call** scripts/workflows | `/review`, `/sync-check`, `/store-status`, `/handoff`, `/maintain` |
-| **Saved workflows** (`.claude/workflows/*.js`) | Multi-agent orchestration with deterministic, **resumable** control-flow | `triptych.js`, `fix-issue-batch.js`, `audit-sweep.js`, `release-checkpoint.js` |
+| **Saved workflows** (`.claude/workflows/*.js`) | Multi-agent orchestration with deterministic, **resumable** control-flow | `triptych.js`, `fix-issue-batch.js`, `review-fanout.js`, `audit-sweep.js`, `release-checkpoint.js` |
+| **Reviewer agents** (`.claude/agents/sv-*.md`) | Single-source-of-truth mandates for the adversarial review fan-out | `sv-code-reviewer`, `sv-security-reviewer`, `sv-impact-reviewer` (the API-parity / auto-merge safety gate), `sv-doc-freshness` |
 | **Scheduled routines** (cron / `@claude` / GitHub-cron) | Unattended recurring work | `maintenance.yml`, `doc-audit.yml`, `weekly-maintainer`, monthly `consolidate-memory` |
 
 Deterministic shell crons stay as GitHub-cron YAML; only **agentic reasoning** (vitals triage, review→issue) becomes a `/schedule` routine. **No new scheduler surface on top of these.**
@@ -124,7 +125,8 @@ A saturated session **never** stops mid-air: commit/push + `STATE.md` "START HER
 | Workflow | Status | Trigger | Fans out |
 |---|---|---|---|
 | `triptych.js` | TODO | every PR pre-merge | 5 Opus reviewers (`ReviewVerdict` schema) ∥ → serial visual-QA agent → gate; `/code-review ultra` Tier-2 |
-| `fix-issue-batch.js` | TODO | continuous issue cycle | claim → dispatch → triptych → merge → refill (replace-on-completion pool, disk/RAM-gated, fire-and-forget) |
+| `fix-issue-batch.js` | LIVE | continuous issue cycle | claim → challenge → fix → self-review → open PR; trivial fire-and-forget merges, **medium+ → `review-fanout` → graded merge** (replace-on-completion pool, disk-gated) |
+| `review-fanout.js` | LIVE | medium+ PR pre-merge (orchestrator) | 4 dedicated reviewers (`sv-*`) ∥ → adversarially verify every ERROR → graded `merge_recommendation`; a breaking public-API change (impact reviewer) blocks auto-merge |
 | `audit-sweep.js` | TODO | a bug reveals a CLASS | `parallel()` Explore × 5 surfaces → structured findings → umbrella + deduped sub-issues |
 | `release-checkpoint.js` | TODO | release window | bump → changelog → gate → device-QA → tag → verify-live (single-sources the version map; fixes #1705) |
 | `device-qa-orchestrate.js` | TODO | per iteration + pre-tag | serial emulator lease → per-platform harness → grade → aggregate `device-qa-report.json` |

--- a/.claude/workflows/fix-issue-batch.js
+++ b/.claude/workflows/fix-issue-batch.js
@@ -3,7 +3,8 @@ export const meta = {
   description: 'Continuous issue cycle: pick open issues (priority order, skip in-progress), then pipeline() one lean-clone agent per issue that claims → fixes → self-reviews → fire-and-forget merges → releases the claim. Replace-on-completion, no barrier, disk-gated.',
   phases: [
     { title: 'Preflight', detail: 'disk-gated-spawn-check.sh; if no issues given, one agent picks the top max||6 open issues in priority order, excluding in-progress' },
-    { title: 'Cycle', detail: 'pipeline() over the chosen issues — one worktree/clone agent each: claim → lean-clone → fix → tests → changelog → self-review → gh pr merge --auto → release claim' },
+    { title: 'Cycle', detail: 'pipeline() over the chosen issues — one lean-clone agent each: claim → challenge → fix → tests → changelog → self-review → open PR (trivial: --auto merge; medium+: PR only)' },
+    { title: 'Review', detail: 'medium+ PRs only: review-fanout (4 adversarial reviewers) → graded merge, or block/draft on a confirmed ERROR / breaking public-API' },
   ],
 }
 
@@ -109,15 +110,21 @@ if (!chosen.length) {
 phase('Cycle')
 
 // Structured result every fix agent must return.
+// outcome:
+//   'merged'                 — trivial scope, fire-and-forget --auto merge (worker self-reviewed).
+//   'pr-open-pending-review' — medium+ scope: PR opened WITHOUT --auto; stage 2 runs review-fanout.
+//   'skipped' / 'failed'     — as before.
 const FIX_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
     issue: { type: 'number' },
-    outcome: { type: 'string', enum: ['merged', 'skipped', 'failed'] },
-    pr: { type: 'number', description: 'PR number if one was opened (outcome=merged), else omit' },
+    outcome: { type: 'string', enum: ['merged', 'pr-open-pending-review', 'skipped', 'failed'] },
+    scope: { type: 'string', enum: ['trivial', 'medium-plus'], description: 'worker self-classification; medium-plus ⇒ stage-2 adversarial review before merge' },
+    pr: { type: 'number', description: 'PR number if one was opened, else omit' },
     branch: { type: 'string' },
     skipReason: { type: 'string', enum: ['claim-collision', 'stale-already-fixed', 'not-reproducible', 'none'] },
+    challengeVerdict: { type: 'string', description: 'one line: did the probe confirm or DISPROVE the issue\'s prescribed root cause, and what was actually fixed' },
     compiled: { type: 'boolean' },
     testsRun: { type: 'boolean' },
     changelogFragment: { type: 'string', description: 'path of the changelog.d/*.md fragment added, or empty if none' },
@@ -160,13 +167,13 @@ A full clone is ~2.3 GB; a lean sparse one is ~0.3-0.6 GB. Pick a short slug fro
 
 If any script later complains about a missing path: \`git sparse-checkout add <path>\`. ALL remaining work happens inside /tmp/sv-${num}.
 
-== 3. INVESTIGATE → IMPLEMENT ==
-First VERIFY the issue is real and still OPEN on main — stale "already fixed" issues are common. Read the referenced code; reproduce the claim. If it is already fixed or not reproducible on origin/main:
-  - close the loop honestly: \`gh issue comment ${num} --repo ${REPO} --body "Verified fixed on main as of <SHA> — closing as already-resolved."\` then \`gh issue close ${num} --repo ${REPO}\`,
-  - release the claim (\`bash .claude/scripts/claim.sh --release ${num}\` from the main checkout's path or via the sparse clone's .claude),
+== 3. CHALLENGE → IMPLEMENT (the issue's prescribed root cause is OFTEN wrong) ==
+STALENESS + reproduce first: \`git fetch origin\`, scan \`git log --oneline HEAD..origin/main\` and the diffs of recently-merged PRs touching your files — stale "already fixed" issues are common (a title-only scan is not enough). If already fixed/obsoleted on origin/main:
+  - close honestly: \`gh issue comment ${num} --repo ${REPO} --body "Verified fixed on main as of <SHA> — closing as already-resolved."\` then \`gh issue close ${num} --repo ${REPO}\`,
+  - release the claim (\`bash .claude/scripts/claim.sh --release ${num}\`),
   - rm -rf /tmp/sv-${num},
-  - return outcome:"skipped" with skipReason:"stale-already-fixed" (or "not-reproducible"), note explaining what you found.
-Otherwise implement the MINIMAL correct fix (clean; breaking changes only if justified, but NEVER bump major — 4 is FROZEN, cf. feedback_version_policy.md). If you change ANY public API on one renderer, mirror it on the others or leave a documented honest "Coming soon" (iOS V1 is a strict subset of Android — never hide a gap).
+  - return outcome:"skipped" with skipReason:"stale-already-fixed" (or "not-reproducible").
+Otherwise reproduce the bug, then run a DETERMINISTIC PROBE that tests the issue's PRESCRIBED cause/fix (does the symbol exist in the consumed version? is the divergence actually where the issue claims? a standalone repro of the asserted mechanism). If the probe DISPROVES it → **diverge with evidence** and fix the REAL cause — this is why #2354 avoided a needless Earcut port and #2361 avoided an uncompilable \`key=\` fix (cf. feedback_reproduce_before_prescribed_fix). Capture one line for challengeVerdict. Then implement the MINIMAL correct option (clean; breaking changes only if justified, but NEVER bump major — 4 is FROZEN). If you change ANY public API on one renderer, mirror it on the others or leave a documented honest "Coming soon" (iOS V1 is a strict subset of Android — never hide a gap).
 
 == 4. COMPILE + TEST (only what's relevant) ==
 Compile the modules you touched, e.g.:
@@ -192,7 +199,8 @@ Review your own diff and FIX anything actionable before merge:
   - Cross-platform: Android/iOS/Web parity mirrored or honestly deferred; llms.txt + agents/sceneview* skills + cheatsheets stay truthful for any public change.
 Capture a one-line verdict for selfReview.
 
-== 7. FIRE-AND-FORGET MERGE — then EXIT (never watch CI) ==
+== 7. OPEN PR + MERGE — GRADED BY SCOPE (then EXIT, never watch CI) ==
+First self-classify SCOPE: "trivial" = < ~20 lines AND no public API / renderer / threading / \`.filamat\` shader / machine-readable contract touched. Anything else = "medium-plus".
   git add -A && git commit -m "Fix <headline> (#${num})
 
 Closes #${num}
@@ -201,17 +209,18 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
   git push -u origin claude/${num}-<slug>
   gh pr create --repo ${REPO} --base main --head claude/${num}-<slug> --title "Fix <headline> (#${num})" --body "Closes #${num}
 
-<what changed + the 5-angle self-review summary>
+<what changed · the challengeVerdict · the 5-angle self-review summary · 'scope: trivial|medium-plus' · for trivial: 'self-reviewed inline; review-fanout skipped because trivial'>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-  gh pr merge <PR#> --repo ${REPO} --squash --auto
-Do NOT sit watching CI — ci-gate.yml is the one required check and the orchestrator owns stuck-PR triage.
+- **scope = trivial** → fire-and-forget: \`gh pr merge <PR#> --repo ${REPO} --squash --auto\`, then go to step 8 (release claim + clean). Return outcome:"merged".
+- **scope = medium-plus** → do **NOT** \`--auto\` merge. The ORCHESTRATOR (stage 2) runs \`review-fanout\` on your PR and merges/blocks (a breaking public-API change → draft + maintainer). rm -rf your /tmp clone but **DO NOT release the claim** (stage 2 releases it after the merge decision). Return outcome:"pr-open-pending-review", scope:"medium-plus", pr:<PR#>.
+Do NOT sit watching CI either way.
 
-== 8. RELEASE CLAIM + CLEAN UP ==
-  bash .claude/scripts/claim.sh --release ${num}   # from the sparse clone's .claude (or the main checkout)
+== 8. RELEASE CLAIM + CLEAN UP (trivial scope only — medium+ leaves the claim for stage 2) ==
+  bash .claude/scripts/claim.sh --release ${num}
   rm -rf /tmp/sv-${num}
 
-Return the structured result: outcome:"merged", pr:<PR#>, branch:"claude/${num}-<slug>", compiled:true, testsRun:true, changelogFragment:"changelog.d/${num}-<slug>.md", selfReview:"<one line>", note:"<short summary>".
+Return the structured result, e.g. outcome:"merged", scope:"trivial", pr:<PR#>, branch:"claude/${num}-<slug>", challengeVerdict:"<one line>", compiled:true, testsRun:true, changelogFragment:"changelog.d/${num}-<slug>.md", selfReview:"<one line>", note:"<short summary>". (Always rm -rf /tmp/sv-${num} before returning, even on skip/fail.)
 
 Hard rules: no polling/sleep loops; no raw adb (android CLI / lib/android-cli.sh only); no image > 1800px; never bump major; never push uncompiled code; always rm -rf /tmp/sv-${num} before returning (even on skip/fail).`
 }
@@ -224,38 +233,74 @@ Hard rules: no polling/sleep loops; no raw adb (android CLI / lib/android-cli.sh
 // issue from arg1 (originalItem) so this stays correct regardless of stage position.
 const results = await pipeline(
   chosen,
+  // Stage 1 — fix: claim → challenge → fix → self-review → open PR. Trivial scope fire-and-forget
+  // merges itself; medium+ opens the PR WITHOUT --auto and returns 'pr-open-pending-review'.
   (_prev, item) =>
     agent(fixBrief(item.number, item.title, item.priority), {
       label: `fix:#${item.number}`,
       phase: 'Cycle',
       schema: FIX_SCHEMA,
     }),
+  // Stage 2 — graded review (medium+ only): the orchestrator-level adversarial fan-out the worker
+  // cannot run itself (#1243). Trivial/skipped/failed pass straight through.
+  async (fixRes, item) => {
+    if (!fixRes || fixRes.outcome !== 'pr-open-pending-review' || !fixRes.pr) return fixRes
+    const branch = fixRes.branch || `claude/${item.number}`
+    let review
+    try {
+      review = await workflow('review-fanout', { diffRef: `origin/main...origin/${branch}`, issue: item.number, pr: fixRes.pr })
+    } catch (e) {
+      return { ...fixRes, outcome: 'blocked-by-review', reviewRecommendation: 'REVIEW_ERROR', note: `review-fanout threw (${String(e)}) — PR #${fixRes.pr} left open + claim held for the orchestrator` }
+    }
+    const rec = review && review.merge_recommendation
+    if (rec === 'MERGE' || rec === 'MERGE_AFTER_WARNINGS') {
+      await agent(
+        `Finalize SceneView PR #${fixRes.pr} (issue #${item.number}): run \`gh pr merge ${fixRes.pr} --repo ${REPO} --squash --auto\`, then \`bash .claude/scripts/claim.sh --release ${item.number}\`. Report one line. Do NOT watch CI.`,
+        { label: `merge:#${item.number}`, phase: 'Review' },
+      )
+      return { ...fixRes, outcome: 'merged', reviewRecommendation: rec, reviewWarnings: (review.warnings || []).length }
+    }
+    // DO_NOT_MERGE / REVIEW_INCOMPLETE / breaking public-API → leave open (draft if breaking),
+    // keep the claim, surface for the orchestrator/maintainer. Never auto-merge.
+    if (review.breakingApi) {
+      await agent(
+        `Mark SceneView PR #${fixRes.pr} as a DRAFT — it has a confirmed BREAKING public-API change and needs the maintainer: \`gh pr ready ${fixRes.pr} --repo ${REPO} --undo\`. Do NOT merge. Report one line.`,
+        { label: `draft:#${item.number}`, phase: 'Review' },
+      )
+    }
+    return { ...fixRes, outcome: 'blocked-by-review', reviewRecommendation: rec, breakingApi: !!review.breakingApi, blockers: (review.confirmedErrors || []).length, note: `${fixRes.note || ''} | review=${rec}${review.breakingApi ? ' BREAKING-API → drafted, maintainer gate' : ''}; PR #${fixRes.pr} open, claim held`.trim() }
+  },
 )
 
 // ── Aggregate ────────────────────────────────────────────────────────────────────
 const norm = (chosen || []).map((item, i) => {
   const r = results[i]
+  const issue = (r && r.issue) || item.number
   if (!r) {
-    return { issue: item.number, failed: true, note: 'agent returned nothing (skipped, errored, or budget-capped) — verify the claim/clone was cleaned up' }
+    return { issue, failed: true, note: 'agent returned nothing (skipped, errored, or budget-capped) — verify the claim/clone was cleaned up' }
   }
   if (r.outcome === 'merged') {
-    return { issue: r.issue, pr: r.pr || null, note: r.note || `merged via claude/${r.issue}-…` }
+    return { issue, merged: true, pr: r.pr || null, note: r.note || `merged via claude/${issue}-…` }
+  }
+  if (r.outcome === 'blocked-by-review') {
+    return { issue, blocked: true, pr: r.pr || null, breakingApi: !!r.breakingApi, note: `review=${r.reviewRecommendation || '?'}${r.breakingApi ? ' (BREAKING-API → draft, maintainer gate)' : ''} — ${r.note || ''}`.trim() }
   }
   if (r.outcome === 'skipped') {
-    return { issue: r.issue, skipped: true, note: `${r.skipReason || 'skipped'} — ${r.note || ''}`.trim() }
+    return { issue, skipped: true, note: `${r.skipReason || 'skipped'} — ${r.note || ''}`.trim() }
   }
-  return { issue: r.issue, failed: true, note: r.note || 'failed' }
+  return { issue, failed: true, note: r.note || 'failed' }
 })
 
-const merged = norm.filter(r => r.pr != null).length
+const merged = norm.filter(r => r.merged).length
+const blocked = norm.filter(r => r.blocked).length
 const skipped = norm.filter(r => r.skipped).length
 const failed = norm.filter(r => r.failed).length
-log(`Cycle done — ${merged} merging PR(s), ${skipped} skipped, ${failed} failed across ${norm.length} issue(s).`)
+log(`Cycle done — ${merged} merged/merging, ${blocked} blocked-by-review (PR open), ${skipped} skipped, ${failed} failed across ${norm.length} issue(s).`)
 
 return {
-  verdict: failed === 0 ? 'CLEAR' : 'PARTIAL',
+  verdict: failed === 0 ? (blocked ? 'CLEAR_WITH_REVIEW_HOLDS' : 'CLEAR') : 'PARTIAL',
   disk: disk ? { freeGb: disk.freeGb, safe: disk.safe } : null,
-  counts: { merged, skipped, failed, total: norm.length },
+  counts: { merged, blocked, skipped, failed, total: norm.length },
   results: norm,
-  note: 'Fire-and-forget: PRs were opened with `--squash --auto`; the orchestrator (not this workflow) watches ci-gate.yml and triages any stuck PR. Run a release checkpoint (`release-checkpoint.js` / `/release`) once the merges land. Cap stays at minor — 4 is frozen.',
+  note: 'Trivial scope was fire-and-forget --auto merged; medium+ scope ran the `review-fanout` adversarial pass and merged on MERGE/MERGE_AFTER_WARNINGS, else left the PR open (drafted on a breaking public-API change — the one maintainer gate) with the claim held. The orchestrator watches ci-gate.yml + triages stuck PRs, and runs a release checkpoint once merges land. Cap stays at minor — 4 is frozen.',
 }

--- a/.claude/workflows/review-fanout.js
+++ b/.claude/workflows/review-fanout.js
@@ -1,0 +1,167 @@
+export const meta = {
+  name: 'review-fanout',
+  description: 'SceneView independent adversarial review: 4 dedicated reviewer agents (code/security/impact/doc-freshness) in parallel on a diff, then adversarially verify every ERROR finding before a graded merge_recommendation. The autonomous-merge safety gate (a breaking public-API change blocks auto-merge).',
+  whenToUse: 'Run by the issue-batch ORCHESTRATOR on a worker\'s PR diff for MEDIUM+ scope (medium/large, or any change touching public API / rendering / threading / a machine-readable contract). Workers (background agents) cannot spawn nested reviewers (#1243), so this runs at the orchestrator level. Trivial diffs skip it (worker self-review, declared in the PR body).',
+  phases: [
+    { title: 'Review' },
+    { title: 'Verify' },
+  ],
+}
+
+// args: { diffRef?: 'main...HEAD' | 'origin/main...<branch>', issue?: number, pr?: number }
+// Be robust to args arriving as a JSON string (some invocation paths stringify it).
+let A = args
+if (typeof A === 'string') {
+  try { A = JSON.parse(A) } catch { A = {} }
+}
+A = A || {}
+const diffRef = A.diffRef || 'main...HEAD'
+const ctx = [A.issue ? `issue #${A.issue}` : null, A.pr ? `PR #${A.pr}` : null].filter(Boolean).join(', ') || 'the current change'
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'findings'],
+  properties: {
+    verdict: { type: 'string', enum: ['FAIL', 'PASS_WITH_WARNINGS', 'PASS'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['severity', 'problem'],
+        properties: {
+          severity: { type: 'string', enum: ['error', 'warning'] },
+          file: { type: 'string' },
+          line: { type: 'string' },
+          problem: { type: 'string' },
+          fix: { type: 'string' },
+        },
+      },
+    },
+    propagation: { type: 'array', items: { type: 'string' }, description: 'other platforms/docs the change must reach' },
+    notes: { type: 'string' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['real', 'reason'],
+  properties: {
+    real: { type: 'boolean', description: 'true ONLY if this is a genuine, reproducible problem that blocks merge' },
+    reason: { type: 'string' },
+  },
+}
+
+// Each reviewer is a dedicated agent type whose mandate lives in .claude/agents/<type>.md
+// (single source of truth). If the type isn't registered in this session, fall back to a
+// general agent that READS the .md and adopts the role — so a reviewer is never silently dropped.
+const REVIEWERS = [
+  { key: 'code', agentType: 'sv-code-reviewer' },
+  { key: 'security', agentType: 'sv-security-reviewer' },
+  { key: 'impact', agentType: 'sv-impact-reviewer' },
+  { key: 'doc', agentType: 'sv-doc-freshness' },
+]
+
+const reviewPrompt = (key) =>
+  `Review the SceneView change for ${ctx}. First \`git fetch origin --quiet\` so the refs resolve, then review the diff: \`git diff ${diffRef}\` (also check \`git diff\` for any uncommitted work). Read the WHOLE diff and the surrounding code, then apply your ${key}-reviewer mandate.
+
+Map your output to the schema: every issue you'd FAIL on → a finding with severity:"error"; every should-fix → severity:"warning". Set verdict accordingly (any error ⇒ FAIL). Be concrete with file:line, and reproduce any runtime claim before asserting it. A clean PASS is valid — do not invent findings.`
+
+phase('Review')
+log(`Running ${REVIEWERS.length} independent reviewers on ${diffRef} (${ctx})`)
+
+async function runReviewer(r) {
+  const opts = { label: `review:${r.key}`, phase: 'Review', schema: REVIEW_SCHEMA }
+  try {
+    return await agent(reviewPrompt(r.key), { ...opts, agentType: r.agentType })
+  } catch (e) {
+    log(`agentType '${r.agentType}' unavailable — adopting its mandate from file`)
+    try {
+      return await agent(
+        `Read the file \`.claude/agents/${r.agentType}.md\` and adopt that reviewer role EXACTLY — its mandate, hard checks, and output fields. Then: ${reviewPrompt(r.key)}`,
+        { ...opts, label: `review:${r.key}(fallback)` },
+      )
+    } catch (e2) {
+      // Total reviewer failure → null → filtered → reviewersRan < expected ⇒ REVIEW_INCOMPLETE.
+      // Absence of evidence is NEVER evidence of safety; this can never become a false MERGE.
+      log(`reviewer '${r.key}' failed entirely — dropping; REVIEW_INCOMPLETE will fire`)
+      return null
+    }
+  }
+}
+
+// Pipeline: each reviewer's ERROR findings are adversarially verified the moment that
+// reviewer returns — no barrier between Review and Verify.
+const reviewed = await pipeline(
+  REVIEWERS,
+  (r) => runReviewer(r).then((res) => (res ? { ...res, reviewer: r.key } : null)),
+  (res, r) => {
+    if (!res) return null
+    const errors = (res.findings || []).filter((f) => f.severity === 'error')
+    if (!errors.length) return { ...res, verifiedErrors: [] }
+    return parallel(
+      errors.map((f) => () =>
+        agent(
+          `An independent ${r.key} reviewer flagged this as an ERROR that blocks merge on the SceneView change (diff: \`git diff ${diffRef}\`):
+
+  file: ${f.file || '?'}  line: ${f.line || '?'}
+  problem: ${f.problem}
+  proposed fix: ${f.fix || '(none given)'}
+
+Try to REFUTE it. Read the actual code at that location and reproduce the failure if it is a runtime/compile claim (e.g. grep the call site, check the signature, trace the thread). Default to real=false if you cannot independently confirm a genuine, merge-blocking problem. Only real=true if you confirm it.`,
+          { label: `verify:${r.key}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+        ).then((v) => ({ ...f, reviewer: r.key, verified: v })),
+      ),
+    ).then((verified) => ({ ...res, verifiedErrors: verified.filter(Boolean) }))
+  },
+)
+
+const results = reviewed.filter(Boolean)
+const reviewersRan = results.length
+const reviewersExpected = REVIEWERS.length
+const confirmedErrors = results.flatMap((res) => (res.verifiedErrors || []).filter((f) => f.verified?.real))
+const allWarnings = results.flatMap((res) => (res.findings || []).filter((f) => f.severity === 'warning').map((f) => ({ ...f, reviewer: res.reviewer })))
+const propagation = results.flatMap((res) => res.propagation || [])
+
+// The impact reviewer is the autonomous-merge SAFETY gate: a confirmed ERROR from it
+// (a breaking public-API change / unmirrored cross-platform divergence) is never an
+// auto-fixable warning — it must stop for the maintainer, not just trigger a re-review.
+const breakingApi = confirmedErrors.some((f) => f.reviewer === 'impact')
+
+// NEVER recommend MERGE on an incomplete review — a dropped reviewer makes "no findings"
+// meaningless (absence of evidence ≠ evidence of safety).
+const merge_recommendation =
+  reviewersRan < reviewersExpected ? 'REVIEW_INCOMPLETE'
+    : confirmedErrors.length ? 'DO_NOT_MERGE'
+      : allWarnings.length ? 'MERGE_AFTER_WARNINGS'
+        : 'MERGE'
+
+// SceneView graded-merge autonomy (the maintainer's own low-personal-risk repo → deliberately
+// high autonomy, but the impact gate is preserved): the orchestrator reads autonomousAction.
+const autonomousAction =
+  merge_recommendation === 'MERGE' ? 'auto-merge (squash --auto), no maintainer gate'
+    : merge_recommendation === 'MERGE_AFTER_WARNINGS' ? 'fix warnings in the same PR, then auto-merge'
+      : merge_recommendation === 'REVIEW_INCOMPLETE' ? 'NEVER merge — re-run, investigate why a reviewer dropped'
+        : breakingApi ? 'DRAFT PR + STOP for the maintainer — breaking public-API / cross-platform divergence'
+          : 'fix the confirmed root cause, then re-run review-fanout (do not merge)'
+
+if (reviewersRan < reviewersExpected) {
+  log(`⚠️ only ${reviewersRan}/${reviewersExpected} reviewers completed — REVIEW_INCOMPLETE, not MERGE`)
+}
+log(`Verdict: ${merge_recommendation}${breakingApi ? ' (BREAKING public-API — maintainer gate)' : ''} → ${autonomousAction}`)
+
+return {
+  diffRef,
+  context: ctx,
+  merge_recommendation,
+  autonomousAction,
+  breakingApi,
+  reviewersRan,
+  reviewersExpected,
+  confirmedErrors,
+  warnings: allWarnings,
+  propagation,
+  perReviewer: results.map((r) => ({ reviewer: r.reviewer, verdict: r.verdict, errorCount: (r.findings || []).filter((f) => f.severity === 'error').length })),
+}


### PR DESCRIPTION
## What

Adds a rigor layer to SceneView's continuous issue cycle, **calibrated for high autonomy** (SceneView is the maintainer's own low-personal-risk OSS repo). Keeps everything the cycle already does well; adds the three things it lacked.

## Keeps
Fire-and-forget auto-merge on **all** platforms · `claim.sh` cross-host race lock · lean-clone disk-gating · `changelog.d/` fragments · STATE.md/handoff · **ONE consolidated follow-up tracker** (no per-finding chip spam).

## Adds (the rigor layer)
1. **Challenge before coding** — codifies `feedback_reproduce_before_prescribed_fix`: a staleness + race gate, then a deterministic **probe that must DISPROVE the issue's prescribed root cause** before coding it (the lesson that saved a needless Earcut port on #2354 and an uncompilable `key=` fix on #2361). Self-decided in autonomous mode.
2. **Scope-graded adversarial review** — new `review-fanout.js`: 4 dedicated reviewer agents (`sv-code` / `sv-security` / `sv-impact` / `sv-doc-freshness`, new `.claude/agents/`) in parallel → **adversarially verify every ERROR** (default `real=false`) → 4-state `merge_recommendation` where **`REVIEW_INCOMPLETE` never merges**. Trivial keeps declared self-review; medium+ / public-API / rendering / threading / `.filamat` get the fan-out. Runs at the **orchestrator** level (#1243: workers can't spawn nested reviewers).
3. **The impact gate** = the one hard maintainer stop — a confirmed `sv-impact-reviewer` ERROR (breaking public-API / unmirrored cross-platform divergence) → `breakingApi:true` → **draft PR + stop for the maintainer**, never auto-merge. Preserves zero-SDK-API-breakage without a blanket manual hold (SceneView ships to Maven/npm/SPM).

## Files
- `.claude/agents/sv-{code,security,impact,doc-freshness}-reviewer.md` — single-source reviewer mandates (Filament main-thread JNI, cross-platform API parity, AI-first doc drift).
- `.claude/workflows/review-fanout.js` — the adversarial review engine.
- `.claude/workflows/fix-issue-batch.js` — now a **2-stage pipeline** (fix + open PR → `review-fanout` + graded merge for medium+).
- `.claude/commands/issue-batch.md` — the playbook + the graded-strictness table.
- `.claude/workflows/README.md` — index.

## Verification
- Both workflows pass `node --check` (async-wrapped) + `check-saved-workflows.sh` (resume-safe). 9 workflows valid.
- **Self-reviewed inline** (internal `.claude/` orchestration tooling — the `sv-*` reviewers target SDK code, not workflow scripts; the declared-self-review escape hatch the change itself codifies). **No SDK code touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)