### PR TITLE
Surface doc-audit weekly cron failures (#2340)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -118,3 +118,30 @@ jobs:
 
             Be rigorous and conservative. A small, correct patch beats a large,
             speculative one.
+
+      # Surface a failed weekly run so a silently-expired CLAUDE_CODE_OAUTH_TOKEN
+      # (or any other failure) doesn't stop the doc audit unnoticed for weeks
+      # (#2340 — we hit exactly this: run 26721287555 died on a 401 expired
+      # token). De-duplicated: ONE open tracking issue, refreshed with a comment
+      # per failure, so a multi-week outage never spams. gh CLI (repo style, no
+      # new action dep); GITHUB_TOKEN is least-privilege (issues: write is
+      # already granted above).
+      - name: Surface failure as a tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE='ci(doc-audit): weekly run failed'
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          # shellcheck disable=SC2016  # backticks are intentional Markdown code spans, not shell; dynamic values come via printf %s args.
+          BODY="$(printf 'The weekly **doc-audit** run failed: %s\n\nA common cause is an expired `CLAUDE_CODE_OAUTH_TOKEN` — the tier-2 agent needs it, and a `401 Invalid bearer token` means rotate it (`claude setup-token`, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`). The OIDC / checkout wiring is unaffected, and tier-1 (`check-doc-drift.sh`) is token-free so the per-PR advisory keeps working.\n\nTriggered by run %s. This issue is de-duplicated — repeat failures are appended as comments.' "$RUN_URL" "$GITHUB_RUN_ID")"
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label ci --limit 100 \
+            --json number,title --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+            echo "::notice::Refreshed doc-audit failure tracking issue #$existing"
+          else
+            url="$(gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --label ci --body "$BODY")"
+            echo "::notice::Opened doc-audit failure tracking issue $url"
+          fi

--- a/changelog.d/2340-docaudit-cron-surface.md
+++ b/changelog.d/2340-docaudit-cron-surface.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **The weekly `doc-audit` cron now surfaces failures as a de-duplicated tracking issue instead of failing silently ([#2340](https://github.com/sceneview/sceneview/issues/2340)).** An expired `CLAUDE_CODE_OAUTH_TOKEN` (or any failure) previously only showed in the Actions tab, so the audit could silently stop for weeks; an `if: failure()` step now opens or refreshes one tracking issue per outage.


### PR DESCRIPTION
Closes #2340

## What
The weekly `doc-audit` cron's tier-2 agent needs `CLAUDE_CODE_OAUTH_TOKEN`, which can expire silently — run `26721287555` died on a `401 Invalid bearer token` and nobody watches a weekly cron. A failed run was only visible in the Actions tab, so the audit could silently stop for weeks.

## Change
An `if: failure()` step on the `doc-audit` job opens — or refreshes via a comment — **one de-duplicated** tracking issue `ci(doc-audit): weekly run failed` (so a multi-week outage never spams). Uses the repo-standard `gh` CLI (no new action dependency); `GITHUB_TOKEN` is least-privilege (`issues: write` was already granted on the job).

## Self-review (5 angles)
- **Correctness**: `if: failure()` fires only on job failure; de-dup is an exact-title match over open `ci`-labelled issues → refresh-or-create. Tier-1 `check-doc-drift.sh` is token-free and untouched.
- **Security**: no new secret/permission; `GITHUB_TOKEN` least-priv; body built via `printf %s` (no `${{ }}` interpolation of untrusted data → no injection).
- **Minimality**: one additive step; zero change to the audit logic.
- **CI-hygiene**: `actionlint` CLEAN (YAML + Actions schema + shellcheck); the step never runs on a green run.
- **Consistency**: mirrors the repo's `gh`-CLI style + the existing de-duplicated-tracking-issue convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)