### PR TITLE
docs(llms.txt): document HitResultNode.refreshIntervalMs throttle (#2328)

### DIFF
--- a/changelog.d/2328-hitresult-refreshinterval-docs.md
+++ b/changelog.d/2328-hitresult-refreshinterval-docs.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- **Documented the new `HitResultNode.refreshIntervalMs` hit-test throttle in `llms.txt` ([#2328](https://github.com/sceneview/sceneview/issues/2328)).** #2328 added an opt-in `refreshIntervalMs` rate-limit to `HitResultNode` (mirroring `PointCloudNode`/`DepthMeshNode`); the AI-first reference now documents it so an assistant can generate code that uses the throttle, closing the doc-coverage gap a review-fanout flagged.

--- a/llms.txt
+++ b/llms.txt
@@ -1022,6 +1022,17 @@ ARSceneView(modifier = Modifier.fillMaxSize()) {
 }
 ```
 
+**Rate-limit the ARCore hit test (perf, [#2328](https://github.com/sceneview/sceneview/issues/2328)).**
+`HitResultNode.refreshIntervalMs` (default `0` = `Frame.hitTest` every frame) throttles the
+raycast the same way `PointCloudNode` / `DepthMeshNode` rate-limit their rebuilds: a positive
+value (e.g. `100` = 10 Hz) keeps the node's last pose between hit tests, cutting hit-test load
+on scenes with several cursors. Set it in the `apply` block:
+```kotlin
+HitResultNode(xPx = viewWidth / 2f, yPx = viewHeight / 2f, apply = { refreshIntervalMs = 100 }) {
+    CubeNode(size = Size(0.05f))
+}
+```
+
 ### ReticleNode — placement reticle with auto-hide
 
 `ReticleNode` is a **thin wrapper** over `HitResultNode` for "tap to place" UX. It is a


### PR DESCRIPTION
Documents the new `HitResultNode.refreshIntervalMs` opt-in hit-test throttle added by #2328, in the AI-first `llms.txt` reference (mirroring the `PointCloudNode`/`DepthMeshNode` rate-limit docs). Surfaced by review-fanout on #2328 (PR #2423): the new public knob was undocumented, so an AI reading llms.txt couldn't generate code using it. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)