### PR TITLE
refactor(sceneview): key the #2400 per-frame clear on (renderer, isOpaque) — supersedes #2428

### DIFF
--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -308,27 +308,6 @@ fun SceneView(
         // even when the swap chain is CONFIG_TRANSPARENT — nothing under the
         // SceneView shows through.
         view.blendMode = if (isOpaque) BlendMode.OPAQUE else BlendMode.TRANSLUCENT
-
-        // Force a per-frame color-buffer clear so stale renderable pixels never
-        // survive a scene change (#2400). Filament defaults to
-        // `ClearOptions.clear = false` and relies on the skybox to repaint the
-        // background every frame. A SceneView whose environment has NO skybox
-        // (the model-viewer / gallery demos use `createSkybox = false` so the
-        // model floats on the surface background) then never clears the swap
-        // chain: when the rendered footprint SHRINKS — swapping a large model
-        // for a smaller one in a single slot — the previously-rendered pixels
-        // the new model does not cover are left on screen, so the old model
-        // appears "stacked" behind the new one even though its renderable
-        // entities were correctly removed from the Scene (verified on device:
-        // `Scene.getRenderableCount()` drops to the new model's count, yet the
-        // old pixels linger). Clearing every frame fixes it for both opaque
-        // (clear to opaque black) and translucent (clear to transparent so the
-        // surface background shows through) views; when a skybox IS present it
-        // simply overdraws the clear, so this is a no-op for skybox scenes.
-        renderer.clearOptions = Renderer.ClearOptions().apply {
-            clear = true
-            clearColor = doubleArrayOf(0.0, 0.0, 0.0, if (isOpaque) 1.0 else 0.0)
-        }
     }
     // Keyed `LaunchedEffect` so the preset is reapplied ONLY when `renderQuality`
     // actually changes (#1078). The previous unkeyed `SideEffect` ran on every
@@ -338,6 +317,32 @@ fun SceneView(
     // they will not be undone".
     LaunchedEffect(view, renderQuality) {
         view.applyRenderQuality(renderQuality)
+    }
+
+    // Force a per-frame color-buffer clear so stale renderable pixels never survive
+    // a scene change (#2400). Filament defaults to `Renderer.ClearOptions.clear =
+    // false` and relies on the skybox to repaint the background every frame. A
+    // SceneView whose environment has NO skybox (the model-viewer / gallery demos
+    // use `createSkybox = false` so the model floats on the surface background) then
+    // never clears the swap chain: when the rendered footprint SHRINKS — swapping a
+    // large model for a smaller one in a single slot — the previously-rendered
+    // pixels the new model does not cover are left on screen, so the old model
+    // appears "stacked" behind the new one even though its renderable entities were
+    // correctly removed from the Scene (verified on device: `Scene.getRenderableCount()`
+    // drops to the new model's count, yet the old pixels linger). Clearing every
+    // frame fixes it for both opaque (clear to opaque black) and translucent (clear
+    // to transparent so the surface background shows through) views; when a skybox
+    // IS present it simply overdraws the clear, so this is a no-op for skybox scenes.
+    //
+    // Keyed on (renderer, isOpaque) — the only inputs the clear depends on — so it
+    // applies once per change instead of allocating a `ClearOptions` + issuing a JNI
+    // `setClearOptions` on every recomposition (mirrors the `renderQuality` effect
+    // above rather than the per-recomposition `view.*` SideEffect).
+    LaunchedEffect(renderer, isOpaque) {
+        renderer.clearOptions = Renderer.ClearOptions().apply {
+            clear = true
+            clearColor = doubleArrayOf(0.0, 0.0, 0.0, if (isOpaque) 1.0 else 0.0)
+        }
     }
 
     // ── Camera node — registered so children (HUD nodes) are tracked by the scene manager ─────────


### PR DESCRIPTION
**Supersedes #2428** (re-authored onto current `main`).

## What
Pure perf-hygiene refactor of the #2400 fix (which shipped in **v4.18.0**): move the per-frame Filament color-buffer clear out of the per-recomposition `SideEffect` into a `LaunchedEffect(renderer, isOpaque)`.

The clear depends only on `isOpaque`, so the `SideEffect` placement re-allocated a `ClearOptions` + a `double[4]` and issued a JNI `setClearOptions` on **every recomposition** (e.g. while a slider drives a reactive scene). The keyed effect applies it once per change — mirroring the adjacent `LaunchedEffect(view, renderQuality)`. **Behavior is identical** (device-verified: the Gallery model swap still clears, no first-frame garbage); only the redundant per-recomposition work is removed.

## Why a new PR instead of #2428
#2428 was based on pre-squash #2400 history and edited `Scene.kt`. Since then `main` got: (1) **#2431** renamed `Scene.kt` → `SceneView.kt` so #2428's diff stopped applying; (2) **v4.18.0** collated the `#2400` changelog fragment into the released section, so #2428's changelog-scope correction is moot (I won't rewrite a shipped release's history). So #2428 reduces to its code refinement, re-authored cleanly on `SceneView.kt` here — byte-identical to the change #2428 received a **4/4 `review-fanout` approval** on (only the host file differs).

## Scope / verification
`sceneview/SceneView.kt`, one block moved. No public API / behavior change; no changelog fragment (pure internal refactor — the user-facing fix already shipped). ✅ `:sceneview:compileReleaseKotlin`.

No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
