### PR TITLE
ci: dispatchable mcp-publish workflow (independent MCP npm republish)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -108,9 +108,9 @@ echo "npm=$NPM_VER  local=$PKG_VER"
 
 If `mcp/` changed since `npm=$NPM_VER` (refreshed SDK doc refs, tooling fix,
 etc.) and `local` is not ahead, bump `mcp/package.json` + `mcp/package-lock.json`
-+ the generated `mcp/src/version.ts` by a **patch** (e.g. 4.0.12 → 4.0.13 —
-never sync to `VERSION_NAME`), land it on `main`, then republish via the
-dispatchable workflow (no tag needed):
+by a **patch** (e.g. 4.0.12 → 4.0.13 — never sync to `VERSION_NAME`; the
+generated `mcp/src/generated/version.ts` is refreshed by `npm run prepare`),
+land it on `main`, then republish via the dispatchable workflow (no tag needed):
 
 ```bash
 gh workflow run mcp-publish.yml -R sceneview/sceneview --ref main

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -93,6 +93,35 @@ cd mcp && npm run prepare && npm test
 
 Verify dist/ files are updated and tests pass.
 
+### Step 3.5: Republish sceneview-mcp if `mcp/` changed (independent track, #1705)
+
+`sceneview-mcp` is on its OWN npm cadence — `release.yml` only republishes it
+on a `v*` tag, so a tag-less period of `mcp/` changes leaves npm stale (this is
+how it rotted a month behind at 4.0.12). After cutting the SDK release, check
+whether the MCP needs a republish:
+
+```bash
+NPM_VER=$(npm view sceneview-mcp version)
+PKG_VER=$(node -p "require('./mcp/package.json').version")
+echo "npm=$NPM_VER  local=$PKG_VER"
+```
+
+If `mcp/` changed since `npm=$NPM_VER` (refreshed SDK doc refs, tooling fix,
+etc.) and `local` is not ahead, bump `mcp/package.json` + `mcp/package-lock.json`
++ the generated `mcp/src/version.ts` by a **patch** (e.g. 4.0.12 → 4.0.13 —
+never sync to `VERSION_NAME`), land it on `main`, then republish via the
+dispatchable workflow (no tag needed):
+
+```bash
+gh workflow run mcp-publish.yml -R sceneview/sceneview --ref main
+# verify (bounded — no infinite loop):
+gh run watch "$(gh run list --workflow=mcp-publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')" -R sceneview/sceneview --exit-status
+npm view sceneview-mcp version   # must equal the new mcp/package.json version
+```
+
+`mcp-publish.yml` is idempotent — if the version is already on npm it logs a
+notice and succeeds, so a re-dispatch never errors.
+
 ## Step 4: Update CLAUDE.md session state
 
 Update the "Current state" section with:
@@ -226,7 +255,7 @@ auto-generated list.
 | sceneview | Maven Central | release.yml | git tag v* |
 | arsceneview | Maven Central | release.yml | git tag v* |
 | sceneview-core | Maven Central | release.yml | git tag v* |
-| sceneview-mcp | npm | release.yml | git tag v* |
+| sceneview-mcp | npm | release.yml **or** mcp-publish.yml | git tag v* / `workflow_dispatch` |
 | sceneview-web | npm | release.yml | git tag v* |
 | SceneViewSwift | SPM (git tag) | git tag | Manual |
 | GitHub Release | GitHub | release.yml | git tag v* |

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -581,3 +581,61 @@ jobs:
               echo "_No review data produced this run._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── 9. sceneview-mcp npm freshness ─────────────────────────────────────────
+  # sceneview-mcp is on an INDEPENDENT npm track (#1705) — it does NOT ship on
+  # every SDK release, so it silently rots when mcp/ changes without a tag (it
+  # fell a month behind at 4.0.12). WARN-only: if the local mcp/package.json
+  # version is ahead of npm, remind a maintainer to dispatch mcp-publish.yml.
+  mcp-npm-freshness:
+    name: MCP npm freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Compare local mcp/package.json against published npm
+        id: check
+        run: |
+          set -euo pipefail
+          LOCAL=$(node -p "require('./mcp/package.json').version")
+          NPM=$(npm view sceneview-mcp version 2>/dev/null || echo "unknown")
+          echo "local=$LOCAL  npm=$NPM"
+          echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+          echo "npm=$NPM" >> "$GITHUB_OUTPUT"
+          # `sort -V` puts the lower semver first. A lag means npm < local, i.e.
+          # local is NOT the first line. Equal versions = in sync (no lag).
+          if [ "$NPM" = "unknown" ] || [ "$LOCAL" = "$NPM" ]; then
+            echo "lag=false" >> "$GITHUB_OUTPUT"
+          elif [ "$(printf '%s\n%s\n' "$LOCAL" "$NPM" | sort -V | head -1)" = "$NPM" ]; then
+            echo "::warning::sceneview-mcp npm ($NPM) lags local mcp/package.json ($LOCAL) — dispatch mcp-publish.yml to republish."
+            echo "lag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "lag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.check.outputs.lag == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          LOCAL='${{ steps.check.outputs.local }}'
+          NPM='${{ steps.check.outputs.npm }}'
+          TITLE="sceneview-mcp npm is stale ($NPM < $LOCAL)"
+          BODY=$'Daily maintenance found `sceneview-mcp` on npm is **'"$NPM"$'**, behind the local `mcp/package.json` (**'"$LOCAL"$'**).\n\nThe MCP is on an independent npm track (#1705) and does not ship on every SDK tag. Republish it on demand (no tag needed):\n\n```\ngh workflow run mcp-publish.yml -R sceneview/sceneview --ref main\n```\n\nThe dispatch is idempotent — if the version is already on npm it logs a notice and succeeds.'
+          EXISTING=$(gh issue list --state open --search "sceneview-mcp npm is stale in:title" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$EXISTING" ]; then
+            gh issue create --title "$TITLE" --body "$BODY" --label "maintenance" \
+              || echo "::warning::Could not create MCP npm freshness issue"
+          else
+            gh issue comment "$EXISTING" --body "$BODY" \
+              || echo "::warning::Could not comment on existing MCP npm freshness issue #$EXISTING"
+          fi

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,83 @@
+# Dispatchable npm republish for `sceneview-mcp`.
+#
+# `sceneview-mcp` is on an INDEPENDENT version track (#1705) — its npm cadence
+# is decoupled from the SDK `VERSION_NAME`. `release.yml` already publishes it
+# on a `v*` tag, but the MCP often needs a republish *without* cutting a full
+# SDK release (e.g. refreshed SDK doc refs, a tooling fix). Cutting a tag just
+# to ship the MCP is wrong, so the package rotted a month behind npm.
+#
+# This workflow lets a maintainer republish the MCP on demand. It mirrors the
+# exact `publish-mcp` job in `release.yml` (same `setup-mcp` action, same
+# `secrets.NPM_TOKEN`, same build/test/publish sequence) and is fully
+# idempotent: if `mcp/package.json`'s version is already on npm it logs a
+# notice and succeeds without publishing, so a re-dispatch never errors.
+name: Publish MCP to npm (dispatch)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-publish
+  cancel-in-progress: false
+
+jobs:
+  publish-mcp:
+    name: Publish MCP to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-mcp
+        with:
+          registry-url: https://registry.npmjs.org
+
+      - name: Check if version already published
+        id: check-mcp
+        working-directory: mcp
+        run: |
+          # MCP has its own version cycle — always use package.json version.
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # npm view <pkg>@<ver> version returns the version string if it
+          # exists, or empty if it has never been published. Re-dispatch on an
+          # already-published version is a clean no-op success (idempotent).
+          PUBLISHED=$(npm view "sceneview-mcp@$VERSION" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$VERSION" ]; then
+            echo "::notice::sceneview-mcp@$VERSION already published — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing sceneview-mcp@$VERSION (not yet on npm)"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.check-mcp.outputs.skip != 'true'
+        working-directory: mcp
+        run: npm run prepare
+
+      - name: Test
+        if: steps.check-mcp.outputs.skip != 'true'
+        working-directory: mcp
+        run: npm test
+
+      - name: Publish
+        if: steps.check-mcp.outputs.skip != 'true'
+        working-directory: mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ steps.check-mcp.outputs.skip }}" = "true" ]; then
+            echo "✅ sceneview-mcp@${{ steps.check-mcp.outputs.version }} already on npm — nothing to do." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "📦 Published sceneview-mcp@${{ steps.check-mcp.outputs.version }} to npm." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,17 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 > where the sync agent downgraded `mcp/package.json` behind the published npm
 > `@next` tag. When releasing `sceneview-mcp`, bump these two files to the
 > next *MCP* version, never to the SDK `VERSION_NAME` (issue #1705).
+>
+> **Republishing the MCP without a full SDK release.** Because the MCP is not
+> tied to a `v*` tag, `mcp/` changes between releases leave npm stale (it once
+> rotted a month behind at 4.0.12). To ship the MCP on demand, bump
+> `mcp/package.json` + `mcp/package-lock.json` + `mcp/src/version.ts` by a patch,
+> land it on `main`, then dispatch the **`mcp-publish.yml`** workflow
+> (`gh workflow run mcp-publish.yml -R sceneview/sceneview --ref main`). It
+> mirrors `release.yml`'s `publish-mcp` job (same `NPM_TOKEN`, build/test/publish)
+> and is idempotent — re-dispatch on an already-published version is a clean
+> no-op. `maintenance.yml`'s `mcp-npm-freshness` job WARNs daily if npm lags the
+> local `mcp/package.json`. `/release` Step 3.5 covers this in the release flow.
 
 **Automation:**
 - `bash .claude/scripts/sync-versions.sh` — checks all 30+ locations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,7 +561,8 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 > **Republishing the MCP without a full SDK release.** Because the MCP is not
 > tied to a `v*` tag, `mcp/` changes between releases leave npm stale (it once
 > rotted a month behind at 4.0.12). To ship the MCP on demand, bump
-> `mcp/package.json` + `mcp/package-lock.json` + `mcp/src/version.ts` by a patch,
+> `mcp/package.json` + `mcp/package-lock.json` by a patch (the generated
+> `mcp/src/generated/version.ts` is refreshed automatically by `npm run prepare`),
 > land it on `main`, then dispatch the **`mcp-publish.yml`** workflow
 > (`gh workflow run mcp-publish.yml -R sceneview/sceneview --ref main`). It
 > mirrors `release.yml`'s `publish-mcp` job (same `NPM_TOKEN`, build/test/publish)


### PR DESCRIPTION
## Problem

`sceneview-mcp` is on an **independent npm version track** (#1705) and only republishes on a `v*` tag via `release.yml`'s `publish-mcp` job. There is no way to ship an MCP-only change without cutting a full SDK release — so when `mcp/` changes tag-lessly, npm silently rots. It fell a month behind at **4.0.12**.

## Fix

A dispatchable republish path, modeled precisely on the proven `release.yml` `publish-mcp` job:

- **`.github/workflows/mcp-publish.yml`** — `workflow_dispatch`-only workflow. Reuses the same `./.github/actions/setup-mcp` action, the same `secrets.NPM_TOKEN` (`NODE_AUTH_TOKEN`), and the same `npm run prepare → npm test → npm publish --access public` sequence. **Idempotent**: a guard step reads `mcp/package.json`'s version and skips publish with a `::notice::` (clean success) if `npm view sceneview-mcp@<ver>` already shows it, so a re-dispatch never errors on an existing version.
- **`maintenance.yml` → `mcp-npm-freshness`** — daily WARN (+ de-duplicated tracking issue) when the local `mcp/package.json` is ahead of the published npm version.
- **`.claude/commands/release.md` Step 3.5 + artifact matrix** — documents the on-demand republish in the release flow.
- **`CLAUDE.md`** — notes the republish path + freshness check.

No new auth scheme: same secret, same registry config, same steps as the existing tag-triggered MCP publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)