### PR TITLE
fix(ios-demo): resolve canonical `ar-record-playback` deep link (#2370)

### DIFF
--- a/changelog.d/2370-ios-deeplink-record-playback.md
+++ b/changelog.d/2370-ios-deeplink-record-playback.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- iOS demo: the published AR-recording deep link (`sceneview://demo/ar-record-playback`) now resolves to the recorder demo instead of the "Open in app" placeholder. The iOS `DemoDeepLinkRegistry` only wired the unpublished `ar-recording` id; the canonical `ar-record-playback` (used by the website QR landing page, `llms.txt`, and the Android catalog) fell through to the placeholder. Both ids now route to `ARRecorderDemo` (#2370).

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -147,7 +147,11 @@ enum DemoDeepLinkRegistry {
             #else
             DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
             #endif
-        case "ar-recording":
+        // `ar-record-playback` is the canonical, published deep-link id
+        // (website-static/open/index.html + llms.txt + Android catalog);
+        // `ar-recording` is kept as a legacy alias so older QR codes still
+        // resolve. Both route to the recorder demo.
+        case "ar-record-playback", "ar-recording":
             #if os(iOS)
             ARRecorderDemo()
             #else


### PR DESCRIPTION
## What
The iOS demo's published AR-recording QR — `sceneview://demo/ar-record-playback` — showed the *"Open in app"* placeholder instead of the recorder demo.

## Root cause (verified)
`ar-record-playback` is the **canonical, published** deep-link id:
- `website-static/open/index.html:297` → `'ar-record-playback': 'Record & Playback'`
- `llms.txt:4062` → `ar-record-playback — AR Recording`
- Android catalog id (`ArViewTab.kt`)

But `DemoDeepLinkRegistry.swift` only had `case "ar-recording":` (an id that exists **nowhere** in the published surface or Android). `ar-record-playback` *was* in `allowedIds` (line 57) — so it validated — but had **no switch case**, so it fell through to `default:` → `DeepLinkPlaceholder`. Net effect: the real published QR was broken on iOS; only the unpublished `ar-recording` worked.

## Fix
Route **both** ids to `ARRecorderDemo()` via a combined case (`ar-record-playback` = canonical; `ar-recording` retained as a legacy alias). Additive + behavior-preserving — no published QR can regress.

## How it was found
The **#2370 part-2 iOS/Web demo-router drift audit**. Methodology + full findings: I diffed the iOS `DemoDeepLinkRegistry` id set (63) against Android's full recognized set (catalog ids ∪ `DEMO_ID_ALIASES` = 101). Only **2** iOS ids resolve nowhere on Android: `ar-recording` (this fix) and `ar-lighting` (iOS-only `ARLightingDemo`, **no** published cross-platform QR → not a broken-QR bug; left as a parity note).

### Audit conclusions for #2370 (not in this PR)
- **Part 1 (impact-check lean-clone false-fail + stale gradle task)** — already resolved on `main` (impact-check now SKIPs on `! -d 3D || ! -d AR`; no `:sceneview-core:testDebugUnitTest` refs remain).
- **Part 2 (iOS/Web router drift)** — iOS uses a **hand-maintained** `DemoDeepLinkRegistry` with **no CI guard** asserting its id set ⊆ Android canonical. Web (`samples/web-demo`) is a single static viewer, no per-demo deep-link table → no drift hazard. Recommend a small `check-ios-deeplink-ids.sh` guard as a follow-up (not built here — would need full-repo CI validation).

## Self-review (5 angles)
- **Correctness** ✓ canonical id proven across 3 surfaces; was placeholder-falling, now routes.
- **Threading** ✓ SwiftUI routing only, no Filament JNI / coroutine.
- **Parity** ✓ aligns iOS with the published cross-platform id; `ar-lighting` parity gap noted.
- **Minimality** ✓ +5/−1, additive, no `allowedIds` churn.
- **Docs** ✓ changelog fragment; canonical id already documented.

No iOS test pins these ids. iOS CI compile is the only required gate (no visual/rendering aspect).