### PR TITLE
perf(sceneview): document Node.rotation Euler getter as deliberately un-cached (N2, #2328)

### DIFF
--- a/changelog.d/2328-phase2-hotpath.md
+++ b/changelog.d/2328-phase2-hotpath.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Documented `Node.rotation` (Euler getter) as deliberately un-cached — no per-frame render/animation path reads it (they read `quaternion`), so caching would only add invalidation cost to the hot `quaternion` write path. Closes the last open item (N2) of the Phase-2 hot-path tracker (#2328); the transform/parent JNI and gesture/light/animation allocation items landed earlier in #2366, #2417, and #2423.

--- a/sceneview/src/main/java/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/Node.kt
@@ -352,6 +352,12 @@ open class Node(
      * Note that modifying the individual components of the returned rotation doesn't have any
      * effect.
      *
+     * The getter derives the Euler angles from [quaternion] on every read and deliberately does
+     * **not** cache the result. Euler `rotation` is not read by any per-frame render or animation
+     * path (those read [quaternion] / [worldQuaternion] directly), so a cache would only add
+     * invalidation cost to every — hot — [quaternion] write for no hot-loop benefit. The only
+     * internal callers are one-shot (animator setup, debug inspection). See #2328 (N2).
+     *
      * @see transform
      */
     open var rotation: Rotation


### PR DESCRIPTION
Closes #2328 — the last open item (**N2**) of the Phase-2 hot-path tracker.

## Triage of #2328 (what's already done on `main`)
The tracker's other items all landed before this PR:
- **SV7 / SV8 / SV9 / SV10** — `ModelNode.applyAnimations`, `LightComponent.color`, gesture-event allocations → #2366 (merged).
- **N3 + SV17** (`parentEntity`/`parentInstance` JNI) and **N4** (`Node.transform` getter JNI) → implemented on `main` by #2417 (merged, audit umbrella #2402: #2403/#2404 = N3+SV17, #2405 = N4). Verified present in `Node.kt` (`_parentEntityValid`/`_parentInstanceValid` flag-caches, `_transform` local-matrix cache).
- Remaining JNI/alloc MED items → #2423 (merged).

The earlier N2/N3/N4 PR #2388 was closed as an unreviewed orphan; #2417 re-did N3/N4 the right way in the normal cycle, leaving **only N2** open.

## N2 — `Node.rotation` Euler getter
The item offered: *"Cache `_rotation` invalidated on quaternion change, **or document non-hot**."* The documented-non-hot branch is the correct resolution here:

- No per-frame render or animation path reads the Euler `rotation` getter — they read `quaternion` / `worldQuaternion` directly (verified by grepping every internal `.rotation` read in `sceneview`/`arsceneview`).
- The only internal callers are **one-shot**: `NodeAnimator.ofRotation` (reads once at animator-build time; the per-frame update listener writes `quaternion`), and `SceneInspector.snapshotNode` (debug inspection utility).
- A `_rotation` cache would add invalidation cost to every — *hot* — `quaternion` write for zero hot-loop benefit: a net pessimization.

## What changed
KDoc-only. The getter body (`get() = quaternion.toEulerAngles()`) is **byte-for-byte unchanged**; only prose is added explaining why it is deliberately not cached. No runtime behavior change, no public-API change.

## Verification
- `:sceneview:compileReleaseKotlin` — BUILD SUCCESSFUL
- `:sceneview:testDebugUnitTest` — BUILD SUCCESSFUL

scope: trivial (doc-only; getter body unchanged — no hot-path runtime change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)