### PR TITLE
fix(sceneview): dispose previous Environment on key change in HDR/KTX preset factories (#2458)

### DIFF
--- a/changelog.d/2458-env-preset-leak.md
+++ b/changelog.d/2458-env-preset-leak.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `rememberHDREnvironment` / `rememberKTXEnvironment` no longer leak the previously loaded `Environment` (its `IndirectLight` + `Skybox` GPU textures) when the asset path changes. The factories now dispose the prior environment on a key swap via a `DisposableEffect`, matching the sibling `rememberEnvironment(key = …)` — previously `produceState` only cancelled the loader coroutine and the old IBL/skybox stayed GPU-resident until the whole `SceneView` left composition (e.g. a time-of-day HDR slider leaked one set per swap). (#2458)

--- a/sceneview/src/main/java/io/github/sceneview/environment/EnvironmentPresets.kt
+++ b/sceneview/src/main/java/io/github/sceneview/environment/EnvironmentPresets.kt
@@ -1,12 +1,11 @@
 package io.github.sceneview.environment
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.produceState
 import io.github.sceneview.ExperimentalSceneViewApi
 import io.github.sceneview.loaders.EnvironmentLoader
 import io.github.sceneview.rememberEnvironment
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
  * Pre-defined HDR environment asset locations bundled with SceneView.
@@ -58,7 +57,7 @@ fun rememberHDREnvironment(
     assetFileLocation: String,
     createSkybox: Boolean = true
 ): Environment? {
-    return produceState<Environment?>(
+    val environment = produceState<Environment?>(
         initialValue = null,
         key1 = environmentLoader,
         key2 = assetFileLocation
@@ -72,6 +71,15 @@ fun rememberHDREnvironment(
             )
         }.getOrNull()
     }.value
+    // `produceState` only cancels the producer coroutine on a key change — it never destroys the
+    // previously produced [Environment]. Keying a [DisposableEffect] on the produced value fires
+    // `onDispose` for the *previous* environment whenever a new one is produced (key swap) and on
+    // leave-composition, matching the sibling `rememberEnvironment(key = …)`. `onDispose` runs on
+    // the composition (main) thread, satisfying the Filament JNI threading contract.
+    DisposableEffect(environment) {
+        onDispose { environment?.let { environmentLoader.destroyEnvironment(it) } }
+    }
+    return environment
 }
 
 /**
@@ -94,7 +102,7 @@ fun rememberKTXEnvironment(
     iblAssetFile: String? = null,
     skyboxAssetFile: String? = null
 ): Environment? {
-    return produceState<Environment?>(
+    val environment = produceState<Environment?>(
         initialValue = null,
         key1 = environmentLoader,
         key2 = iblAssetFile,
@@ -107,4 +115,11 @@ fun rememberKTXEnvironment(
             )
         }.getOrNull()
     }.value
+    // See [rememberHDREnvironment]: `produceState` skips per-key disposal, so destroy the previous
+    // [Environment] when the produced value changes (key swap) and on leave-composition. `onDispose`
+    // runs on the composition (main) thread, satisfying the Filament JNI threading contract.
+    DisposableEffect(environment) {
+        onDispose { environment?.let { environmentLoader.destroyEnvironment(it) } }
+    }
+    return environment
 }

--- a/sceneview/src/test/java/io/github/sceneview/environment/EnvironmentPresetDisposeContractTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/environment/EnvironmentPresetDisposeContractTest.kt
@@ -1,0 +1,126 @@
+package io.github.sceneview.environment
+
+import androidx.compose.runtime.DisposableEffectResult
+import androidx.compose.runtime.DisposableEffectScope
+import io.github.sceneview.loaders.EnvironmentLoader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+
+/**
+ * Regression contract for issue [#2458](https://github.com/sceneview/sceneview/issues/2458)
+ * — "rememberHDREnvironment/rememberKTXEnvironment leak the previous Environment on key change".
+ *
+ * Both factories build a Filament [Environment] (IndirectLight + Skybox, GPU-resident) via
+ * `produceState`. `produceState` only cancels the producer coroutine on a key (asset-path) change —
+ * it **never destroys the previously produced value**. So before the fix a key swap left the old
+ * [Environment] in `EnvironmentLoader.environments`, GPU-resident until the whole loader was torn
+ * down. The sibling `rememberEnvironment(loader, key = …)` on the *same* loader already disposes on
+ * key change via `DisposableEffect { onDispose { loader.destroyEnvironment(it) } }` — the bug was a
+ * clean asymmetry, not a missing-destroy-at-teardown.
+ *
+ * The fix keys a `DisposableEffect` on the produced [Environment] in each factory, so a new value
+ * (key swap) and leave-composition both fire `onDispose` for the previous environment. `onDispose`
+ * runs on the composition (main) thread, satisfying the Filament JNI threading contract.
+ *
+ * Exercising the live path needs a real Filament `Engine` + GPU (the loader constructor eagerly
+ * builds an `IBLPrefilter`) and a Compose runtime, so — matching the existing
+ * `EnvironmentLoaderIndirectLightApplyContractTest` / `LoaderCoroutineScopeContractTest`
+ * convention — this pins the **compiled shape** of the fix instead: each factory must emit the
+ * synthetic `DisposableEffect` disposal lambda that closes over the [Environment] and the
+ * [EnvironmentLoader], and the loader must expose the `destroyEnvironment` call that lambda targets.
+ * A revert to a bare `produceState` (no per-key dispose) deletes the synthetic lambda and fails.
+ */
+class EnvironmentPresetDisposeContractTest {
+
+    private val presetsClass: Class<*> by lazy {
+        Class.forName("io.github.sceneview.environment.EnvironmentPresetsKt")
+    }
+
+    @Test
+    fun `rememberHDREnvironment emits a per-key Environment disposal effect`() {
+        assertHasDisposalLambda("rememberHDREnvironment")
+    }
+
+    @Test
+    fun `rememberKTXEnvironment emits a per-key Environment disposal effect`() {
+        assertHasDisposalLambda("rememberKTXEnvironment")
+    }
+
+    @Test
+    fun `EnvironmentLoader exposes the destroyEnvironment call the disposal effect targets`() {
+        // The disposal lambda calls `environmentLoader.destroyEnvironment(env)` — the exact call
+        // the sibling `rememberEnvironment(key = …)` already uses on the same loader. Pin its
+        // single-Environment signature so a rename/removal can't silently strand the factory fix.
+        val destroy = EnvironmentLoader::class.java.declaredMethods.firstOrNull {
+            it.name == "destroyEnvironment" &&
+                it.parameterCount == 1 &&
+                it.parameterTypes[0] == Environment::class.java
+        }
+        assertNotNull(
+            "EnvironmentLoader must expose `destroyEnvironment(Environment)` — the call the " +
+                "rememberHDREnvironment/rememberKTXEnvironment disposal effect targets (#2458).",
+            destroy
+        )
+    }
+
+    @Test
+    fun `both factories are still public Composable producers`() {
+        // Sanity: the fix must not change the public surface — both factories stay public and keep
+        // their Composer parameter (i.e. they remain @Composable).
+        listOf("rememberHDREnvironment", "rememberKTXEnvironment").forEach { name ->
+            val factory = presetsClass.declaredMethods.firstOrNull { it.name == name }
+            assertNotNull("Missing public factory $name (#2458)", factory)
+            assertTrue(
+                "$name must remain a @Composable producer (Composer parameter present)",
+                factory!!.parameterTypes.any { it.name == "androidx.compose.runtime.Composer" }
+            )
+        }
+    }
+
+    /**
+     * Asserts [factoryName] emits the synthetic `DisposableEffect` disposal lambda the fix adds:
+     * a `private static` method returning [DisposableEffectResult] that closes over an
+     * [Environment] and an [EnvironmentLoader] (and receives a [DisposableEffectScope]). Matched
+     * structurally — by return + parameter types, not by the `$lambda$…` mangled name — so it
+     * stays robust across Kotlin compiler versions.
+     */
+    private fun assertHasDisposalLambda(factoryName: String) {
+        val candidates = presetsClass.declaredMethods.filter { it.name.startsWith(factoryName) }
+        val disposalLambda = candidates.firstOrNull { it.isEnvironmentDisposalLambda() }
+        assertNotNull(
+            "$factoryName must emit a DisposableEffect disposal lambda that destroys the " +
+                "previously produced Environment on key change (#2458). `produceState` alone " +
+                "never disposes the prior value — match the sibling rememberEnvironment(key = …). " +
+                "Synthetic methods seen: ${candidates.joinToString { it.signature() }}",
+            disposalLambda
+        )
+    }
+
+    private fun Method.isEnvironmentDisposalLambda(): Boolean {
+        if (returnType != DisposableEffectResult::class.java) return false
+        val params = parameterTypes.toList()
+        return Environment::class.java in params &&
+            EnvironmentLoader::class.java in params &&
+            DisposableEffectScope::class.java in params
+    }
+
+    private fun Method.signature(): String =
+        "$name(${parameterTypes.joinToString { it.simpleName }}): ${returnType.simpleName}"
+
+    @Test
+    fun `the asymmetry is closed - both produceState factories now dispose like the remember sibling`() {
+        // Umbrella assertion tying the two factories together: BOTH (not just one) must carry the
+        // disposal lambda. The original bug shipped two leaking factories; a partial fix that wires
+        // only one would still leak the other.
+        val disposers = presetsClass.declaredMethods.count { it.isEnvironmentDisposalLambda() }
+        assertEquals(
+            "Exactly the two produceState factories (rememberHDREnvironment + " +
+                "rememberKTXEnvironment) must each emit an Environment disposal effect (#2458).",
+            2,
+            disposers
+        )
+    }
+}


### PR DESCRIPTION
Fixes #2458. Part of #2457 (Filament resource lifecycle/disposal audit).

## Problem

`rememberHDREnvironment` / `rememberKTXEnvironment` (`sceneview/.../environment/EnvironmentPresets.kt`) build a Filament `Environment` (an `IndirectLight` + optional `Skybox` — prefiltered IBL + skybox cubemap, GPU-resident) via `produceState`. `produceState` only **cancels the producer coroutine** on a key (asset-path) change — it **never destroys the previously produced value**. The old IBL/Skybox stayed in `EnvironmentLoader.environments`, GPU-resident, until the whole loader was torn down (the entire `SceneView` leaving composition). The documented time-of-day HDR-slider use case leaked one IBL + Skybox set per swap for the life of the `SceneView`.

## Confirmed asymmetry (the root cause)

This is a clean asymmetry, not a missing-destroy-at-teardown. The directly-adjacent sibling `rememberEnvironment(loader, key = …)` on the **same loader** already disposes the old environment on key change (`SceneView.kt:1193`):

```kotlin
) = remember(environmentLoader, isOpaque, key, environment).also {
    DisposableEffect(it) { onDispose { environmentLoader.destroyEnvironment(it) } }
}
```

`produceState` provides no equivalent. `EnvironmentLoader.destroyEnvironment(Environment)` (`EnvironmentLoader.kt:418`) destroys the IBL + Skybox and drains the tracking list — the call target already exists.

## Fix

Key a `DisposableEffect` on the produced `Environment` in both factories:

```kotlin
val environment = produceState<Environment?>(...) { ... }.value
DisposableEffect(environment) {
    onDispose { environment?.let { environmentLoader.destroyEnvironment(it) } }
}
return environment
```

`DisposableEffect(environment)` fires `onDispose` for the **previous** environment whenever a new one is produced (key swap) and at leave-composition — mirroring the sibling. Correctness: `produceState`'s `MutableState` is `remember`-ed without keys, so on a swap the old value stays the returned/live value until the new producer assigns it; the dispose therefore fires precisely when the old env stops being live → no use-after-free. Threading: `DisposableEffect.onDispose` runs on the composition (main) thread, so the Filament JNI destroys run on main, satisfying the threading contract. Double-destroy is harmless (`safeDestroy*` wrap in `runCatching`; list `-=` is a no-op if absent). The async load path, null-while-loading return, and first composition are unchanged — only the leak is removed. Also drops two genuinely-unused imports (`Dispatchers`, `withContext`).

## Behavior-preservation

The swap still loads and shows the new environment exactly as before; only the previous one is now reclaimed. No public-API change (signatures, return types, `@Composable`/`@ExperimentalSceneViewApi` annotations all unchanged — pinned by a test).

## Tests

Adds `EnvironmentPresetDisposeContractTest` (5 tests, all green). Following the existing reflection-contract convention (`EnvironmentLoaderIndirectLightApplyContractTest`, `LoaderCoroutineScopeContractTest`) — the live path needs a real Filament `Engine` + GPU and a Compose runtime, so the test pins the **compiled shape** of the fix: both factories must emit the synthetic `DisposableEffect` disposal lambda closing over the `Environment` + `EnvironmentLoader`, the loader must keep `destroyEnvironment(Environment)`, and the public surface stays `@Composable`. A revert to a bare `produceState` (no per-key dispose) deletes the synthetic lambda and fails.

- `:sceneview:compileReleaseKotlin` — BUILD SUCCESSFUL
- `:sceneview:testDebugUnitTest` — BUILD SUCCESSFUL (full suite; new test 5/5)

## Scope

Android-only by design — `rememberHDREnvironment`/`rememberKTXEnvironment` are the Android Compose `produceState` factories the umbrella #2457 scoped to `sceneview/`. The sibling `rememberModelInstance` ×2 is tracked separately in #2459. No cross-platform mirror needed for this exact bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)