### PR TITLE
fix(core): correct scale conversions and honour LatheGeometry.closed (#2489, #2490)

### DIFF
--- a/changelog.d/2489-core-correctness.md
+++ b/changelog.d/2489-core-correctness.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- `sceneview-core`: `worldToLocalScale` / `localToWorldScale` no longer transform a scale through the `Mat4 * Float3` point operator, which leaked the parent transform's translation (and rotation) into the result. Scale conversions now compose the transform's basis-vector lengths, so a translated parent no longer corrupts the converted scale (#2489).
+- `sceneview-core`: `LatheGeometry`'s documented `closed` parameter now has an effect. Previously `closed = false` produced byte-for-byte the same fully-closed surface as `closed = true`; it now leaves the final angular seam unstitched, producing the open lathe the parameter promises (#2490).

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/geometries/LatheGeometry.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/geometries/LatheGeometry.kt
@@ -19,7 +19,10 @@ import kotlin.math.sin
  *                Points should be ordered from bottom to top (increasing Y).
  * @param center Offset applied to every vertex position.
  * @param segments Number of radial subdivisions around the Y axis. Default 24.
- * @param closed Whether to close the mesh by connecting the last slice back to the first. Default true.
+ * @param closed Whether to close the mesh by connecting the last slice back to the first.
+ *               When `true` (default) the surface wraps a full 2π revolution. When `false`
+ *               the final angular gap is left unstitched, producing an open lathe (a
+ *               non-wrapping ribbon). Default true.
  */
 fun generateLathe(
     profile: List<Float2>,
@@ -32,8 +35,9 @@ fun generateLathe(
     val vertices = mutableListOf<Vertex>()
     val indices = mutableListOf<Int>()
 
-    val sliceCount = if (closed) segments else segments + 1
-
+    // The vertex grid always carries `segments + 1` rings: slice 0 (θ=0) and slice
+    // `segments` (θ=2π) are geometrically coincident but kept distinct so the seam UVs
+    // are correct. `closed` controls only whether the final wrap strip is stitched.
     for (slice in 0..segments) {
         val theta = TWO_PI * slice.toFloat() / segments
         val cosT = cos(theta)
@@ -75,9 +79,12 @@ fun generateLathe(
         }
     }
 
-    // Generate indices
+    // Generate indices. A closed lathe stitches all `segments` angular strips (the last
+    // bridges slice segments-1 → segments, closing the seam). An open lathe omits that
+    // final wrap strip, leaving the seam unstitched — `segments - 1` strips.
     val rowSize = profile.size
-    for (slice in 0 until segments) {
+    val strips = if (closed) segments else segments - 1
+    for (slice in 0 until strips) {
         for (row in 0 until profile.size - 1) {
             val a = slice * rowSize + row
             val b = a + rowSize

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/TransformConversions.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/TransformConversions.kt
@@ -2,6 +2,7 @@ package io.github.sceneview.math
 
 import dev.romainguy.kotlin.math.Quaternion
 import dev.romainguy.kotlin.math.inverse
+import dev.romainguy.kotlin.math.scale
 
 /**
  * Platform-independent local↔world coordinate conversions.
@@ -177,20 +178,30 @@ fun localToWorldRotation(localRotation: Rotation, worldTransform: Transform): Ro
 /**
  * Convert a world-space scale to this node's local space.
  *
+ * A scale is a magnitude triple, not a homogeneous point: it must compose with the
+ * transform's **basis-vector lengths** (`Mat4.scale`), never via the `Mat4 * Float3`
+ * point operator (which folds in the matrix translation and rotation — wrong for a
+ * scale). Because `worldToLocal.scale == 1 / parentWorldScale`, multiplying the world
+ * scale by it divides out the parent's world scale.
+ *
  * @param worldScale Scale in world space.
  * @param worldToLocal Inverse of the node's world transform.
  */
 fun worldToLocalScale(worldScale: Scale, worldToLocal: Transform): Scale =
-    worldToLocal * worldScale
+    worldScale * worldToLocal.scale
 
 /**
  * Convert a local-space scale to world space.
+ *
+ * Composes the local scale with the world transform's **basis-vector lengths**
+ * (`Mat4.scale`), never via the `Mat4 * Float3` point operator (which would leak the
+ * matrix translation and rotation into the result — wrong for a scale).
  *
  * @param localScale Scale in this node's local space.
  * @param worldTransform The node's world transform matrix.
  */
 fun localToWorldScale(localScale: Scale, worldTransform: Transform): Scale =
-    worldTransform * localScale
+    worldTransform.scale * localScale
 
 // --- Full Transform ---
 

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/geometries/ExtendedGeometryTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/geometries/ExtendedGeometryTest.kt
@@ -161,6 +161,34 @@ class ExtendedGeometryTest {
         assertEquals((segments + 1) * profile.size, lathe.vertices.size)
     }
 
+    @Test
+    fun latheOpenProducesDifferentTopologyThanClosed() {
+        // #2490: closed=false must omit the final wrap strip, yielding an OPEN lathe
+        // with fewer indices than the closed surface. Pre-fix both were byte-for-byte
+        // identical (the `closed` flag was dead).
+        val profile = listOf(Float2(1f, 0f), Float2(0.5f, 1f), Float2(0.8f, 2f))
+        val segments = 4
+
+        val closed = generateLathe(profile, segments = segments, closed = true)
+        val open = generateLathe(profile, segments = segments, closed = false)
+
+        // Closed stitches `segments` strips, open stitches `segments - 1`.
+        // Each strip = (profileSize - 1) quads * 6 indices.
+        val indicesPerStrip = (profile.size - 1) * 6
+        assertEquals(segments * indicesPerStrip, closed.indices.size, "Closed index count")
+        assertEquals((segments - 1) * indicesPerStrip, open.indices.size, "Open index count")
+        assertTrue(
+            open.indices.size < closed.indices.size,
+            "Open lathe must have fewer indices than closed (${open.indices.size} vs ${closed.indices.size})"
+        )
+        // The vertex grid is unchanged (seam rings kept for UVs in both cases).
+        assertEquals(closed.vertices.size, open.vertices.size, "Vertex count unchanged by closed flag")
+        // All open indices must still be in bounds.
+        for (idx in open.indices) {
+            assertTrue(idx in 0 until open.vertices.size, "Open index $idx out of bounds")
+        }
+    }
+
     // ----- Extrude -----
 
     @Test

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/math/TransformConversionsTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/math/TransformConversionsTest.kt
@@ -64,6 +64,45 @@ class TransformConversionsTest {
     }
 
     @Test
+    fun localToWorldScaleIgnoresParentTranslation() {
+        // Parent: world translation (10, 0, 0), uniform world scale 2.
+        // worldTransform = Translate(10,0,0) · Scale(2,2,2).
+        // A scale conversion must NOT pick up the translation — #2489.
+        // Pre-fix (Mat4 * Float3 point multiply) this returned (12, 2, 2).
+        val worldTransform = translation(Float3(10f, 0f, 0f)) * scale(Float3(2f, 2f, 2f))
+
+        val worldScale = localToWorldScale(Scale(1f, 1f, 1f), worldTransform)
+        assertFloat3Near(Scale(2f, 2f, 2f), worldScale, "localToWorldScale must not leak translation")
+    }
+
+    @Test
+    fun worldToLocalScaleIgnoresParentTranslation() {
+        // Inverse direction of #2489. Pre-fix this returned (-4, 1, 1).
+        val worldTransform = translation(Float3(10f, 0f, 0f)) * scale(Float3(2f, 2f, 2f))
+        val worldToLocal = inverse(worldTransform)
+
+        val localScale = worldToLocalScale(Scale(2f, 2f, 2f), worldToLocal)
+        assertFloat3Near(Scale(1f, 1f, 1f), localScale, "worldToLocalScale must not leak translation")
+    }
+
+    @Test
+    fun scaleRoundTripUnderTranslatingTransform() {
+        // Parent with translation on all three axes + non-unit scale: pre-fix the
+        // point-multiply corrupts every component; the round-trip must recover the input.
+        val worldTransform = translation(Float3(10f, 20f, 30f)) * scale(Float3(2f, 3f, 4f))
+        val worldToLocal = inverse(worldTransform)
+
+        // localToWorldScale(unit) must equal the parent's world scale (2, 3, 4).
+        val parentWorldScale = localToWorldScale(Scale(1f, 1f, 1f), worldTransform)
+        assertFloat3Near(Scale(2f, 3f, 4f), parentWorldScale, "Parent world scale")
+
+        val original = Scale(0.5f, 1.5f, 2f)
+        val world = localToWorldScale(original, worldTransform)
+        val roundTrip = worldToLocalScale(world, worldToLocal)
+        assertFloat3Near(original, roundTrip, "Scale round-trip should preserve scale")
+    }
+
+    @Test
     fun localToWorldPositionWithTranslation() {
         val worldTransform = translation(Float3(10f, 20f, 30f))
         val localPos = Position(1f, 2f, 3f)


### PR DESCRIPTION
Closes #2489, #2490

Two deterministic-test-proven `sceneview-core` (KMP `commonMain`) public-API correctness fixes — sub-issues of the math/geometry audit #2464. No rendering / threading / device surface. Same class as the merged #2465.

## #2489 — scale conversions leak translation

`worldToLocalScale` / `localToWorldScale` transformed a **scale** through the `Mat4 * Float3` operator (`Math.kt:134`), which is a **w=1 homogeneous-point** multiply (`(this * Float4(v, 1f)).xyz`) — so the matrix's translation column (and rotation) leaked into the result. A scale is a magnitude triple, not a point.

**Fix:** compose with the transform's **basis-vector lengths** via kotlin-math's `Mat4.scale` accessor (already imported & used by `SmoothTransform` in `Math.kt:230/233`), not `M * v`:

```kotlin
fun localToWorldScale(localScale, worldTransform) = worldTransform.scale * localScale
fun worldToLocalScale(worldScale, worldToLocal)   = worldScale * worldToLocal.scale   // == 1/parentWorldScale
```

Numeric proof (parent `Translate(10,0,0)·Scale(2)`):

| call | before | after | expected |
|---|---|---|---|
| `localToWorldScale((1,1,1))` | `(12,2,2)` | `(2,2,2)` | `(2,2,2)` |
| `worldToLocalScale((2,2,2))` | `(-4,1,1)` | `(1,1,1)` | `(1,1,1)` |

The **position** siblings (`worldToLocalPosition` / `localToWorldPosition`) are deliberately **left untouched** — points correctly carry translation. Zero in-tree call sites (latent public-API bug), so no ripple.

## #2490 — `LatheGeometry.closed` was dead

`sliceCount` was assigned and never read; neither loop branched on `closed`, so `closed=false` produced **byte-for-byte the same fully-closed** mesh as `closed=true`.

**Fix:** honour the flag (preferred over removing the param — removal is a breaking public-API change). The vertex grid is unchanged (`segments+1` rings; the duplicate θ=0/θ=2π seam ring is kept for correct UVs in both cases). `closed` now controls only the index strip count:

```kotlin
val strips = if (closed) segments else segments - 1   // open lathe omits the final wrap strip
for (slice in 0 until strips) { ... }
```

- `closed=true` (default) → `segments` strips → **byte-for-byte unchanged** (existing `latheVertexCount` stays green).
- `closed=false` → `segments-1` strips → open seam, fewer indices. For `segments=4`, profile-3: 48 → 36 indices, vertices unchanged at 15.

## Tests (red-before-green verified)

Added 4 tests; with both fixes reverted, **exactly these 4 fail** (`774 tests completed, 4 failed`), and all pass with the fixes:

- `localToWorldScaleIgnoresParentTranslation`, `worldToLocalScaleIgnoresParentTranslation`, `scaleRoundTripUnderTranslatingTransform` (#2489 — the numeric proofs + round-trip under a translating+scaling parent)
- `latheOpenProducesDifferentTopologyThanClosed` (#2490 — open yields fewer indices than closed, vertices unchanged, all indices in bounds)

The pre-existing `scaleConvertsCorrectly` (actually a position test) and `latheVertexCount` stay green — no other test moved.

## Verification

- `./gradlew :sceneview-core:compileKotlinAndroid` — BUILD SUCCESSFUL
- `./gradlew :sceneview-core:androidTest` — BUILD SUCCESSFUL (TransformConversionsTest 10/10, ExtendedGeometryTest 39/39, 0 failures)

## Self-review

- ✅ **Correctness:** scale uses basis lengths not point-multiply; positions untouched; Lathe honours `closed`; default Lathe unchanged byte-for-byte.
- ✅ **Safety:** no rendering/threading/device; KMP `commonMain` only.
- ✅ **API consistency / non-breaking:** flag honoured (no param removal); no signature change.
- ✅ **Minimality:** two buggy expressions + KDoc + 4 tests + 1 changelog fragment. No drift.
- ✅ **No ripple:** #2489 has zero in-tree callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)