### PR TITLE
fix(ci): CI Gate ignores superseded concurrency-cancels (latest-run-per-name) — fixes rapid-merge false-FAIL (#2492)

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -236,9 +236,11 @@ jobs:
 
           while :; do
             # All check runs for the head commit (handles >100 via paging).
+            # `id` is carried so we can pick the LATEST run per name below
+            # (check-run ids increase monotonically with creation).
             runs=$(gh api --paginate \
               "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-              --jq '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion}')
+              --jq '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion, id: .id}')
 
             # Drop this gate's own check run from consideration, plus every
             # `Device QA — *` run: Device QA is deliberately NOT a per-PR gate
@@ -246,6 +248,34 @@ jobs:
             # Device QA run on a branch SHA must never count here (#1588).
             others=$(echo "$runs" | jq -c --arg self "$SELF_CHECK" \
               'select((.name != $self) and (.name | startswith("Device QA") | not))')
+
+            # LATEST-RUN-PER-NAME COLLAPSE (#2492)
+            # ------------------------------------
+            # `ci.yml`'s concurrency group is keyed on the PR HEAD SHA
+            # (`ci-<head.sha>`, ci.yml#L84). Merging a sibling PR to `main`
+            # makes GitHub recompute THIS PR's merge ref and re-fire its
+            # `pull_request` event — at the SAME head SHA, so `ci.yml`'s
+            # `cancel-in-progress` CANCELS the in-flight run and immediately
+            # starts a FRESH one for that same SHA. The check-runs API then
+            # returns BOTH the superseded `cancelled` run AND the fresh run
+            # under the same name (e.g. two `Detect changed paths`). The
+            # superseded `cancelled` conclusion is pure concurrency noise —
+            # exactly like `stale` — yet without this collapse it lands in
+            # the `failed` set and red-lights `CI Gate`, skipping every
+            # downstream job and blocking `--auto` until a manual re-run
+            # (#2492; this ping-ponged PR #2467 three times in one session).
+            #
+            # Fix: keep only the LATEST run (max id) for each name before the
+            # pending/fail decisions, so a name's verdict is its newest run.
+            # A genuinely-cancelled check with NO newer run stays the latest
+            # and STILL fails the gate (the #1984 advisory exclusion and the
+            # `blocking CANCELLED still fails` contract in
+            # test-ci-gate-aggregation.sh are untouched — the standalone
+            # aggregate script still receives one `<conclusion>\t<name>` line
+            # per name). Concurrency is unchanged, so the CI-minutes saving of
+            # `cancel-in-progress` is preserved.
+            others=$(echo "$others" \
+              | jq -s -c 'group_by(.name) | map(max_by(.id))[]')
 
             if [ -z "$others" ]; then
               # DOCS-ONLY BYPASS (#2117): if the short grace period has


### PR DESCRIPTION
Closes #2492.

## Symptom
Under rapid PR/merge activity, ci.yml's first job **`Detect changed paths`** gets **CANCELLED** by the workflow concurrency group → every downstream build/test job is **SKIPPED** → the aggregator **`CI Gate` reports FAILURE** (a pure infra false-FAIL — the tests never ran and never failed). With `--auto` armed the PR sits **BLOCKED** until a manual `gh run rerun`, and a second concurrent merge can re-cancel the rerun (ping-pong). This bit PR #2467 three times in one session.

## Root cause (challenge-probed — the prescribed fix would be a regression)
The issue suggested **Option 1: per-ref concurrency** (`group: ci-${{ github.ref }}`). But ci.yml's concurrency group is **already keyed on the PR HEAD SHA**, *stronger* than per-ref:

```yaml
# ci.yml (current)
concurrency:
  group: ci-${{ github.event.pull_request.head.sha || github.ref }}
  cancel-in-progress: true
```

It was deliberately moved **off** `github.ref` by #2089/#2062/#1818 precisely because `github.ref` (= `refs/pull/N/merge`) caused the cross-PR cancellation Option 1 is meant to prevent. Re-applying literal Option 1 would **re-introduce** that bug. So the cancellation comes from elsewhere:

Merging a sibling PR to `main` makes GitHub **recompute THIS PR's merge ref** and **re-fire its `pull_request` event at the SAME head SHA**. The head-sha concurrency group therefore `cancel-in-progress`-cancels the in-flight run **and immediately starts a fresh one for the same SHA**. The `check-runs` API then returns **both** the superseded `cancelled` run **and** the fresh run under the same name (e.g. two `Detect changed paths`). `ci-gate-aggregate.sh` treats `failure|cancelled|timed_out` as failures, so the stale `cancelled` red-lights the gate even though a fresh successful run exists.

## Fix — Option 2, surgical (latest-run-per-name collapse)
In **`ci-gate.yml`** only, collapse `others` to the **latest run (max check-run `id`) per name** before the pending/fail decisions, so a name's verdict is its **newest** run:

```diff
-  --jq '... {name, status, conclusion}'
+  --jq '... {name, status, conclusion, id}'
   ...
+  others=$(echo "$others" | jq -s -c 'group_by(.name) | map(max_by(.id))[]')
```

- A superseded `cancelled` that has a fresh re-run is dropped as concurrency noise (the same treatment `stale` already gets).
- A **genuinely-cancelled** check with **no newer run** stays the latest → **still FAILS** the gate.
- A real `failure` that is the latest run → **still FAILS**.
- `concurrency` is **unchanged** → the `cancel-in-progress` CI-minutes saving is preserved (a PR's new push still cancels that PR's old run).
- The standalone `ci-gate-aggregate.sh` and its regression suite `test-ci-gate-aggregation.sh` (incl. **"blocking CANCELLED still fails the gate"**) are **untouched** — the helper still receives one `<conclusion>\t<name>` line per name.

## Before / after
| Scenario | Before | After |
|---|---|---|
| superseded `cancelled` `Detect changed paths` + fresh `success` (same SHA) | gate **FAIL** (false-FAIL, the bug) | gate **PASS** |
| genuinely-cancelled blocking check, no newer run | gate FAIL | gate **FAIL** (unchanged) |
| real `failure` (latest run) | gate FAIL | gate **FAIL** (unchanged) |

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` — `ci-gate.yml` + `ci.yml` parse clean.
- `bash .github/scripts/test-ci-gate-aggregation.sh` — all 9 pinned cases pass, including case 5 (blocking CANCELLED still fails).
- Simulated the #2492 scenario + both controls through the dedup → aggregate pipeline; verdicts match the table above.

Internal CI infra — no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)