### PR TITLE
fix(sceneview-core): outward-wind TorusGeometry triangles (#2475)

### DIFF
--- a/changelog.d/2475-core-torus-winding.md
+++ b/changelog.d/2475-core-torus-winding.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Fixed the shared `sceneview-core` `TorusGeometry` generator winding every triangle inward (clockwise), which rendered the torus inside-out under a single-sided material on the web (Filament.js) and the iOS reference path. The triangle index order is now counter-clockwise (outward-facing), mirroring the Android `Torus` fix (#2469) and matching the convention of the core Sphere/Cylinder/Cone generators. Vertices are unchanged — index/winding only. ([#2475](https://github.com/sceneview/sceneview/issues/2475))

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/geometries/TorusGeometry.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/geometries/TorusGeometry.kt
@@ -66,8 +66,11 @@ fun generateTorus(
                 val c = a + 1
                 val d = b + 1
 
-                add(a); add(b); add(d)
-                add(a); add(d); add(c)
+                // Counter-clockwise (outward-facing) winding so the front face matches the
+                // outward shading normal under the default single-sided material (Filament /
+                // Filament.js back-face-cull clockwise triangles). See issues #2469 / #2475.
+                add(a); add(d); add(b)
+                add(a); add(c); add(d)
             }
         }
     }

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/geometries/ExtendedGeometryTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/geometries/ExtendedGeometryTest.kt
@@ -2,11 +2,53 @@ package io.github.sceneview.geometries
 
 import dev.romainguy.kotlin.math.Float2
 import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.cross
+import dev.romainguy.kotlin.math.dot
 import dev.romainguy.kotlin.math.length
+import dev.romainguy.kotlin.math.normalize
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
+/**
+ * Asserts every triangle of [geometry] is wound counter-clockwise / outward-facing: its
+ * geometric face normal (right-hand rule over the index order) points the same way as the
+ * mean of its three vertices' outward shading normals (`dot > 0`). A clockwise/inward
+ * winding flips the face normal, making `dot < 0`, which renders the surface inside-out
+ * under a single-sided material (Filament / Filament.js back-face-cull clockwise triangles).
+ */
+private fun assertOutwardWinding(geometry: GeometryData, label: String) {
+    val vertices = geometry.vertices
+    val indices = geometry.indices
+    var inverted = 0
+    var checked = 0
+    var i = 0
+    while (i + 2 < indices.size) {
+        val ia = indices[i]
+        val ib = indices[i + 1]
+        val ic = indices[i + 2]
+        val pa = vertices[ia].position
+        val pb = vertices[ib].position
+        val pc = vertices[ic].position
+        val faceNormal = cross(pb - pa, pc - pa)
+        // Skip degenerate triangles (zero-area) — their normal is undefined.
+        if (length(faceNormal) > 1e-6f) {
+            val na = vertices[ia].normal!!
+            val nb = vertices[ib].normal!!
+            val nc = vertices[ic].normal!!
+            val meanNormal = normalize(na + nb + nc)
+            if (dot(normalize(faceNormal), meanNormal) <= 0f) inverted++
+            checked++
+        }
+        i += 3
+    }
+    assertTrue(checked > 0, "$label: no non-degenerate triangles checked")
+    assertEquals(
+        0, inverted,
+        "$label: $inverted/$checked triangles are wound inward (inside-out)"
+    )
+}
 
 class ExtendedGeometryTest {
 
@@ -57,6 +99,22 @@ class ExtendedGeometryTest {
         for (idx in torus.indices) {
             assertTrue(idx in 0 until torus.vertices.size, "Index $idx out of bounds")
         }
+    }
+
+    @Test
+    fun torusWindingIsOutwardDefault() {
+        // Regression for #2475: the core Torus generator must wind triangles
+        // counter-clockwise (outward) so the donut is not rendered inside-out.
+        assertOutwardWinding(generateTorus(), "Torus(default)")
+    }
+
+    @Test
+    fun torusWindingIsOutwardNonDefault() {
+        // A non-default tessellation must be outward-wound too.
+        assertOutwardWinding(
+            generateTorus(majorRadius = 1.5f, minorRadius = 0.5f, majorSegments = 16, minorSegments = 10),
+            "Torus(non-default)"
+        )
     }
 
     // ----- Capsule Geometry -----


### PR DESCRIPTION
Closes #2475

## Problem

`sceneview-core`'s shared `TorusGeometry` generator (`generateTorus`) emitted every triangle with **clockwise/inward** winding (`(a,b,d)`, `(a,d,c)`), so the torus renders **inside-out** under a single-sided material — on the **web** (Filament.js, the live consumer of the core generator) and the **iOS** reference path. This is the same bug class fixed for the Android `Torus` in #2469 / PR #2472, just in the KMP-shared core.

## Fix

Reorder the index emission to **counter-clockwise/outward** (`(a,d,b)`, `(a,c,d)`) — byte-for-byte the Android `listOf(a, d, b, a, c, d)` correction from #2472, and the convention the already-correct core `Sphere`/`Cylinder`/`Cone` generators use.

- **Vertices unchanged** — positions, normals, UVs are identical. **Index/winding order only.**
- **Only `TorusGeometry` changed.** Sphere/Cylinder/Cone/Plane/Cube/Capsule untouched (verified — diff is 3 files: the generator, the test, the changelog).
- **No public-API signature change** — `generateTorus(...)` signature is identical.

## Test (deterministic, red-before-green proven)

Added an outward-winding regression to `ExtendedGeometryTest` (`commonTest`): for every non-degenerate triangle it compares the geometric face normal (`cross` over the index order) against the mean of the three vertices' outward shading normals (`dot > 0`), for the **default** and a **non-default** tessellation.

Verified by reverting only the generator fix (keeping the test):

| State | `torusWindingIsOutwardDefault` | `torusWindingIsOutwardNonDefault` |
|---|---|---|
| pre-fix (inward) | **FAIL** — 576/576 inverted | **FAIL** — 320/320 inverted |
| post-fix (outward) | **PASS** | **PASS** |

100% of triangles inverted pre-fix — exactly the analytic invariant the issue and the Android `WindingConsistencyTest` describe.

## Verification

`./gradlew :sceneview-core:compileKotlinAndroid :sceneview-core:androidTest` → **BUILD SUCCESSFUL** (772 tests, all green with the fix; the 2 new tests are the only delta).

## Self-review

- Torus now outward, matching Sphere/Cylinder/Cone and the merged Android #2469.
- Only Torus changed; other generators not touched.
- Test fails pre-fix / passes post-fix (proven by reverting).
- Minimal: index order only, vertex array unchanged.
- No public-API signature change.

Cross-platform mirror of #2469; sub-issue of the core correctness audit #2464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)