### PR TITLE
fix(demo/ar): lower AR Depth of Field default blur 2.0× → 1.0× (#2480)

### DIFF
--- a/changelog.d/2480-dof-default-blur.md
+++ b/changelog.d/2480-dof-default-blur.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **AR Depth of Field demo**: lowered the default blur strength from `2.0×` to `1.0×` (Filament's stock cinematic strength). The old `2.0×` over-scaled the circle-of-confusion and crushed out-of-focus regions to black bands and colour smears, making the demo look broken; `1.0×` shows a legible shallow depth-of-field instead. The blur slider still ranges up to `6×` for a stronger bokeh. ([#2480](https://github.com/sceneview/sceneview/issues/2480))

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOfFieldDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOfFieldDemo.kt
@@ -93,7 +93,11 @@ fun ARDepthOfFieldDemo(onBack: () -> Unit) {
     // ── User-facing knobs ────────────────────────────────────────────────────────────────────
     var dofEnabled by remember { mutableStateOf(true) }
     var focusDepth by remember { mutableStateOf(1.0f) }     // meters
-    var blurStrength by remember { mutableStateOf(2.0f) }   // identity ≈ 1.0
+    // Filament's stock cinematic strength (cocScale identity). 2.0× doubled the circle-of-
+    // confusion and crushed out-of-focus regions to black bands / colour smears (#2480) — it read
+    // as a glitch, not bokeh. 1.0× gives a pleasant, legible shallow-DoF; the slider still goes to
+    // 6× for anyone who wants a stronger blur.
+    var blurStrength by remember { mutableStateOf(1.0f) }
     var depthSupported by remember { mutableStateOf<Boolean?>(null) }
 
     // Latest Frame for tap-to-focus. The depth API requires the Frame from the same update tick.
@@ -206,7 +210,7 @@ fun ARDepthOfFieldDemo(onBack: () -> Unit) {
             OutlinedButton(
                 onClick = {
                     focusDepth = 1.0f
-                    blurStrength = 2.0f
+                    blurStrength = 1.0f
                 },
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
Closes #2480 (part of the Pixel 9 device review #2466).

## Problem
The **AR Depth of Field** demo opened with `blurStrength = 2.0×`. That knob maps **directly** to Filament's `cocScale` (circle-of-confusion scale), whose identity is `1.0` — so `2.0×` is **double Filament's stock cinematic strength**. The result over-scaled the CoC and crushed out-of-focus regions to **black horizontal bands** and red/green **colour smears** (frames `f_0326–0332`), reading as a rendering glitch rather than photographic bokeh.

## Fix
Lower the default blur from `2.0×` to **`1.0×`** — Filament's stock cinematic shallow-DoF, which also matches the library's own `ARDepthOfFieldOptions(blurStrength = 1.0f)` default. Changed in two places:
- the initial `blurStrength` state (`:96`)
- the **Reset** button (`:213`), so reset restores the same sensible default

**The blur slider keeps its full `0f..6f` range** — a user can still crank a stronger bokeh; only the *default* changes. No library API change, no slider-range change, demo-only.

## Old vs new
| | Old | New |
|---|---|---|
| Default blur strength | `2.0×` | `1.0×` |
| Reset → blur | `2.0×` | `1.0×` |
| Slider range | `0..6` | `0..6` (unchanged) |

## ⚠️ Device-QA flag
The visual claim — *"the scene is no longer crushed to black bands at the default; the bokeh now reads as a pleasant shallow-DoF"* — needs **on-device confirmation** (ARCore Depth API + real depth buffer). The change itself is a one-value default with no behavioural/threading risk, but the *look* should be eyeballed against the #2466 frames on a Pixel-class device before this is considered visually closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)