### PR TITLE
fix(demo/ar): place the picked AR model, not always the Damaged Helmet (#2476)

### DIFF
--- a/changelog.d/2476-ar-camera-placement.md
+++ b/changelog.d/2476-ar-camera-placement.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **android-demo:** Fix the AR View "Start AR Camera" experience always placing the default Damaged Helmet regardless of the model picked. The remembered tap-gesture lambda captured the derived `selectedModel` val from first composition, so picking Fox/Soldier/etc. updated the pill but never the placement. The tap handler now reads `arModels[selectedModelIndex]` through state at tap time (mirroring `ARPlacementDemo`), so each placement uses the currently-selected model. (#2476)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/ArViewTab.kt
@@ -407,12 +407,25 @@ fun ArViewTabContent(
                                 result.distance <= 5.0f
                         }
                         if (hit != null) {
+                            // Resolve the model from the CURRENT picker state at
+                            // tap time. Reading `arModels[selectedModelIndex]`
+                            // here — instead of closing over the derived
+                            // `selectedModel` val computed in composition —
+                            // avoids the stale-closure bug where every placement
+                            // kept the first model (Damaged Helmet) regardless of
+                            // the picker (#2476). The remembered gesture lambda is
+                            // built once, so anything it captures by value freezes
+                            // at first composition; `selectedModelIndex` is read
+                            // through state, so it stays live. This mirrors
+                            // ARPlacementDemo, which reads its selection inside the
+                            // tap body for the same reason.
+                            val model = arModels[selectedModelIndex]
                             placedAnchors.add(
                                 PlacedAr(
                                     id = nextId++,
                                     anchor = hit.createAnchor(),
-                                    assetPath = selectedModel.assetPath,
-                                    scale = selectedModel.scale,
+                                    assetPath = model.assetPath,
+                                    scale = model.scale,
                                 ),
                             )
                         }


### PR DESCRIPTION
Closes #2476 (part of #2466 — Pixel 9 device review).

## Problem
In **AR View → "Start AR Camera"**, choosing a different model in the "Pick a model" sheet had no effect: every tap kept placing the default **Damaged Helmet**. The status pill updated to the picked model (Fox/Soldier/…), but the actual placement never changed — all 7 placements in the device-review session were the helmet regardless of picker state.

## Root cause (confirmed in source)
`samples/android-demo/.../ui/ArViewTab.kt`:
- The tap handler is built once via `rememberOnGestureListener(onSingleTapConfirmed = { … })` — and `rememberOnGestureListener` ends with `remember(creator)`, so the listener is created at first composition.
- That lambda used the derived `val selectedModel = arModels[selectedModelIndex]` (computed in composition, captured **by value** at first composition = index 0 = Damaged Helmet). Picking a new model updates `selectedModelIndex` state and recomposes, but the already-remembered gesture lambda keeps its original captured `selectedModel`.

This is exactly why `ARPlacementDemo.kt` (the other tap-to-place) is not affected: its tap lambda reads its selection state (`selectedSlug`/`selectedBundledIndex`) **inside** the lambda body, i.e. at tap time.

## Fix
Read the model from the current picker state at tap time inside the lambda, instead of closing over the derived `val`:

```kotlin
val model = arModels[selectedModelIndex]   // reads current state
… assetPath = model.assetPath, scale = model.scale …
```

Robust regardless of any Compose lambda-memoization subtlety, and consistent with `ARPlacementDemo`. The placement UX is otherwise unchanged — it still requires a deliberate tap that hit-tests a tracked plane (`isPoseInPolygon`, distance ≤ 5 m); only *which* model is placed is fixed. The `selectedModel` val is retained — it still backs the status pill / label.

## Scope
- **Demo-only** (`samples/android-demo` + a changelog fragment). No library or public-API change. Major 4 unaffected.

## Verification
- Static-verified: type-correct (`ArModel.assetPath: String`, `.scale: Float` → `PlacedAr`), brace/paren-balanced, no dead code (`selectedModel` still used by the pill at L509/L571). No full Gradle build (lean clone) — CI builds.

## ⚠️ device-QA flag
Needs an **on-device / emulator** confirmation of the placement UX: open AR View → Start AR Camera → pick **Fox** (then **Soldier**) in the sheet → tap a tracked plane → assert the placed model is the **picked** one, not the Damaged Helmet. The bug was only visible at runtime on a Pixel 9; unit tests don't exercise the remembered-lambda capture. A UI test asserting the placed asset path follows the picker would be a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)