### PR TITLE
docs: June doc-audit — non-compiling rememberEnvironment snippets, stale web versions, ownership contracts, WebP triage, iOS CloudAnchor (local doc-audit.yml replacement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,18 @@ claude mcp add sceneview -- npx sceneview-mcp
 `SceneView` is a Composable that renders a Filament 3D viewport. Nodes are composables inside it.
 
 ```kotlin
+val engine = rememberEngine()
+val modelLoader = rememberModelLoader(engine)
+val environmentLoader = rememberEnvironmentLoader(engine)
+
 SceneView(
     modifier = Modifier.fillMaxSize(),
-    engine = rememberEngine(),
-    modelLoader = rememberModelLoader(engine),
-    environment = rememberEnvironment(engine, "envs/studio.hdr"),
+    engine = engine,
+    modelLoader = modelLoader,
+    environment = rememberEnvironment(environmentLoader) {
+        environmentLoader.createHDREnvironment("envs/studio.hdr")
+            ?: createEnvironment(environmentLoader)
+    },
     cameraManipulator = rememberCameraManipulator()
 ) {
     // Model — async loaded, appears when ready

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -83,6 +83,7 @@ ARSceneView(
 | `AnchorNode.world(position:)` | anchor at a world coordinate |
 | `AnchorNode.plane(alignment:minimumBounds:)` | anchor on a detected plane |
 | `AugmentedImageNode` | overlay content on a detected reference image |
+| `CloudAnchorNode.host(ttlDays:completion:operation:)` / `.resolve(cloudAnchorId:completion:operation:)` | cross-device persistent anchors — both return a cancellable `CloudAnchorFuture`; call `future.cancel()` from `.onDisappear`. The app supplies the `GARSession` round-trip (Google's `arcore-ios-sdk`) through the `operation` closure |
 
 ## Environment presets
 

--- a/docs/docs/android-xr-emulator.md
+++ b/docs/docs/android-xr-emulator.md
@@ -173,8 +173,10 @@ import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.height
 import androidx.xr.compose.subspace.layout.width
 import io.github.sceneview.SceneView
+import io.github.sceneview.createEnvironment
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
@@ -203,9 +205,11 @@ class XRDemoActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         engine = engine,
                         modelLoader = modelLoader,
-                        environment = environmentLoader.createHDREnvironment(
-                            "environments/studio_small.hdr"
-                        )!!,
+                        environment = rememberEnvironment(environmentLoader) {
+                            environmentLoader.createHDREnvironment(
+                                "environments/studio_small.hdr"
+                            ) ?: createEnvironment(environmentLoader)
+                        },
                     ) {
                         modelInstance?.let { instance ->
                             ModelNode(modelInstance = instance)

--- a/docs/docs/nodes.md
+++ b/docs/docs/nodes.md
@@ -93,7 +93,10 @@ SceneView(
         position = Position(0f, 0f, 4f)
     },
     mainLightNode = rememberMainLightNode(engine),
-    environment = rememberEnvironment(environmentLoader, "environments/studio_small.hdr")
+    environment = rememberEnvironment(environmentLoader) {
+        environmentLoader.createHDREnvironment("environments/studio_small.hdr")
+            ?: createEnvironment(environmentLoader)
+    }
 ) {
     // ─ nodes go here ─
     rememberModelInstance(modelLoader, "models/helmet.glb")?.let { instance ->

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -63,6 +63,19 @@ rememberModelInstance(modelLoader, "models/helmet.glb")?.let { instance ->
 
 4. **Check Logcat.** Filter by `Filament` or `SceneView` — load failures are logged there.
 
+### Model loads but renders untextured (WebP textures)
+
+If a glTF/GLB model loads and animates but every surface is flat black/grey, and Logcat shows
+`Missing texture provider for image/webp`, the model's textures are WebP-encoded
+(`EXT_texture_webp`). **WebP glTF textures are not supported on Android**: Filament's Android
+prebuilt ships `gltfio` with WebP support compiled out, so the textures silently fail to decode
+([#2305](https://github.com/sceneview/sceneview/issues/2305)).
+
+**Fix:** re-encode the model's textures to PNG, JPEG, or KTX2 before bundling it (e.g. re-export
+from Blender with PNG/JPEG textures, or convert with a glTF texture tool). PNG, JPEG, and KTX2
+decode natively. The same limitation applies to the web build (Filament.js registers no
+`image/webp` provider either).
+
 ### Black screen / no rendering
 
 A completely black or empty viewport usually means the scene is set up but nothing is visible to

--- a/llms.txt
+++ b/llms.txt
@@ -2588,6 +2588,8 @@ fun rememberModelInstance(
 ```
 Returns `null` while loading, recomposes when ready. **Always handle the null case.**
 
+**Lifecycle & ownership:** the composable owns the produced `ModelInstance` and its backing glTF `Model`. When the path key changes, the previous `Model` is destroyed (after any consuming `ModelNode` has detached its renderables) and the new asset is loaded; the `Model` is also destroyed on leave-composition. `ModelLoader` does NOT dedupe by path — each call is a fresh GPU allocation, not a cache hit. Never hold a swapped-out instance; for manual lifetime control use `ModelLoader.loadModelInstanceAsync` + `ModelLoader.destroyModel`.
+
 The `fileLocation` overload auto-detects URLs (http/https) and routes through Fuel HTTP client for download. Use it for remote model loading:
 ```kotlin
 val model = rememberModelInstance(modelLoader, "https://example.com/model.glb")
@@ -2700,6 +2702,8 @@ class EnvironmentLoader(engine: Engine, context: Context) {
 All `remember*` helpers create and memoize Filament objects, destroying them on disposal.
 Most are default parameter values in `SceneView`/`ARSceneView` — call them explicitly only when sharing resources or customizing.
 
+**Ownership on key change:** the keyed async loaders (`rememberModelInstance`, `rememberEnvironment(key = …)`, `rememberHDREnvironment`, `rememberKTXEnvironment`) also destroy the **previously produced** object when their key/path changes — a path swap (e.g. a gallery or HDR slider) frees the old GPU resources automatically. Never keep a reference to a swapped-out `ModelInstance`/`Environment`; re-read the helper's return value instead. For objects you manage yourself, use the imperative loaders (`loadModelInstanceAsync`, `createHDREnvironment`) and call `destroyModel`/`destroyEnvironment` when done.
+
 | Helper | Returns | Purpose |
 |--------|---------|---------|
 | `rememberEngine()` | `Engine` | Root Filament object — one per process |
@@ -2710,6 +2714,8 @@ Most are default parameter values in `SceneView`/`ARSceneView` — call them exp
 | `rememberEnvironment(environmentLoader, isOpaque)` | `Environment` | IBL + skybox environment |
 | `rememberEnvironment(environmentLoader) { ... }` | `Environment` | Custom environment from lambda |
 | `rememberEnvironment(environmentLoader, key = hdrPath) { ... }` | `Environment` | Pass `key` when the factory depends on a changing value (e.g. an HDR path from a slider) — the lambda is otherwise memoised once and the skybox never swaps |
+| `rememberHDREnvironment(environmentLoader, "env.hdr")` | `Environment?` | `@ExperimentalSceneViewApi` — async HDR load from assets, `null` while loading; previous environment destroyed when the path changes |
+| `rememberKTXEnvironment(environmentLoader, iblAssetFile, skyboxAssetFile)` | `Environment?` | `@ExperimentalSceneViewApi` — async pre-filtered KTX1 IBL/skybox load, `null` while loading; previous environment destroyed when the paths change |
 | `rememberCameraNode(engine) { ... }` | `CameraNode` | Custom camera with apply block |
 | `rememberMainLightNode(engine) { ... }` | `LightNode` | Primary directional light (key) with apply block — shadows ON by default; apply block is reactive (re-runs on recomposition, so Compose-state-driven intensity/direction/color update live) |
 | `rememberFillLightNode(engine) { ... }` | `LightNode` | Soft fill light opposite the main light — lifts shadows so models don't look flat; apply block is reactive (same as `rememberMainLightNode`) |
@@ -4883,7 +4889,7 @@ ferrari_f40.glb
 
 ## SceneView Web (Kotlin/JS + Filament.js)
 
-Package: `sceneview-web` v4.1.2 — npm `sceneview-web`
+Package: `sceneview-web` v4.18.0 — npm `sceneview-web`
 Renderer: **Filament.js (WebGL2/WASM)** — same Filament engine as SceneView Android, compiled to WebAssembly.
 Requires: Chrome 79+, Edge 79+, Firefox 78+ (WebGL2). Safari 15+ (WebGL2).
 
@@ -4895,7 +4901,7 @@ npm install sceneview-web filament
 Script-tag usage (no bundler):
 ```html
 <script src="https://sceneview.github.io/js/filament/filament.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.3.1/sceneview-web.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sceneview-web@4.18.0/sceneview-web.js"></script>
 ```
 
 After loading, the library registers itself on `window.sceneview`.

--- a/samples/recipes/editable-model.md
+++ b/samples/recipes/editable-model.md
@@ -9,13 +9,17 @@
 fun EditableModelViewer() {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
     val model = rememberModelInstance(modelLoader, "models/chair.glb")
 
     SceneView(
         modifier = Modifier.fillMaxSize(),
         engine = engine,
         modelLoader = modelLoader,
-        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
+        environment = rememberEnvironment(environmentLoader) {
+            environmentLoader.createHDREnvironment("environments/studio_2k.hdr")
+                ?: createEnvironment(environmentLoader)
+        },
         cameraManipulator = rememberCameraManipulator()
     ) {
         model?.let {

--- a/samples/recipes/environment-lighting.md
+++ b/samples/recipes/environment-lighting.md
@@ -9,6 +9,7 @@
 fun ModelWithEnvironment() {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
     val model = rememberModelInstance(modelLoader, "models/helmet.glb")
 
     SceneView(
@@ -16,7 +17,10 @@ fun ModelWithEnvironment() {
         engine = engine,
         modelLoader = modelLoader,
         // HDR environment provides both indirect lighting (IBL) and skybox
-        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
+        environment = rememberEnvironment(environmentLoader) {
+            environmentLoader.createHDREnvironment("environments/studio_2k.hdr")
+                ?: createEnvironment(environmentLoader)
+        },
         cameraManipulator = rememberCameraManipulator()
     ) {
         model?.let {
@@ -92,9 +96,9 @@ These are the HDR files bundled with `android-demo` under
 
 ## Key Points
 
-- `rememberEnvironment(engine, "environments/studio_2k.hdr")` loads the HDR file from assets
+- `rememberEnvironment(environmentLoader) { environmentLoader.createHDREnvironment("environments/studio_2k.hdr") ?: createEnvironment(environmentLoader) }` loads the HDR file from assets (falling back to the neutral default environment if the load fails)
 - HDR environments provide **Image-Based Lighting** (IBL) for realistic reflections
-- They also set the skybox (background) — set `skybox = false` to keep a solid background
+- They also set the skybox (background) — pass `createSkybox = false` to `createHDREnvironment` to keep a solid background
 - Combine IBL with `LightNode` for direct light sources (sun, lamps)
 - `LightNode`'s `apply` is a **named parameter**, not a trailing lambda: `apply = { ... }`
 - All HDR files should be in `src/main/assets/environments/` for Android

--- a/samples/recipes/multi-model.md
+++ b/samples/recipes/multi-model.md
@@ -9,6 +9,7 @@
 fun MultiModelScene() {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
+    val environmentLoader = rememberEnvironmentLoader(engine)
 
     val chair = rememberModelInstance(modelLoader, "models/chair.glb")
     val table = rememberModelInstance(modelLoader, "models/table.glb")
@@ -18,7 +19,10 @@ fun MultiModelScene() {
         modifier = Modifier.fillMaxSize(),
         engine = engine,
         modelLoader = modelLoader,
-        environment = rememberEnvironment(engine, "environments/studio_2k.hdr"),
+        environment = rememberEnvironment(environmentLoader) {
+            environmentLoader.createHDREnvironment("environments/studio_2k.hdr")
+                ?: createEnvironment(environmentLoader)
+        },
         cameraManipulator = rememberCameraManipulator()
     ) {
         chair?.let {


### PR DESCRIPTION
**DRAFT by design — human-gated.** Local replacement for the weekly `doc-audit.yml` agent run, which has been broken for weeks (expired `CLAUDE_CODE_OAUTH_TOKEN`, #2341/#2450) while ~25 API-changing PRs merged. Every patch below was verified against the current source before editing; surfaces that are still accurate were deliberately left untouched.

## Patches

| Surface | What drifted | Fix | Source evidence |
|---|---|---|---|
| `README.md` (front-page snippet) | `rememberEnvironment(engine, "envs/studio.hdr")` — **does not compile**: no String overload exists, the String lands on `isOpaque: Boolean`; snippet also referenced `engine`/`modelLoader` without declaring them | Hoist `val engine/modelLoader/environmentLoader`, use the canonical `rememberEnvironment(environmentLoader) { createHDREnvironment(...) ?: createEnvironment(...) }` pattern | `sceneview/src/main/java/io/github/sceneview/SceneView.kt:1226,1256` (only `() -> Environment` factory overloads); `SceneFactories.kt:214` |
| `samples/recipes/environment-lighting.md`, `multi-model.md`, `editable-model.md` | Same non-compiling `rememberEnvironment(engine, "….hdr")` call in 3 recipes (4 call sites incl. prose) | Same canonical pattern; added `rememberEnvironmentLoader(engine)` | same as above |
| `samples/recipes/environment-lighting.md` Key Points | `skybox = false` — parameter does not exist | `createSkybox = false` on `createHDREnvironment` | `loaders/EnvironmentLoader.kt:83` |
| `docs/docs/nodes.md` | `rememberEnvironment(environmentLoader, "environments/studio_small.hdr")` — String onto `isOpaque: Boolean`, does not compile | canonical factory-lambda pattern | `SceneView.kt:1226` |
| `docs/docs/android-xr-emulator.md` | Un-remembered `environmentLoader.createHDREnvironment(...)!!` inline in composition — re-creates the environment every recomposition (leak) | wrap in `rememberEnvironment(environmentLoader) { … }`, add the 2 imports | `SceneView.kt:1226` KDoc (disposal contract) |
| `llms.txt` web section | Stale versions: `sceneview-web v4.1.2` (l.4886) and CDN `sceneview-web@4.3.1` (l.4898) vs npm latest **4.18.0** | bump both to 4.18.0 | `npm view sceneview-web version` → 4.18.0; root `gradle.properties` `VERSION_NAME=4.18.0` |
| `llms.txt` remember-helpers | Missing the new dispose-on-key-change ownership contract (#2460/#2462) — an AI holding a swapped-out `ModelInstance`/`Environment` would emit use-after-free code | "Ownership on key change" note + "Lifecycle & ownership" paragraph under `rememberModelInstance` (mirrors the new KDoc) | `SceneView.kt:695-744` (`destroyModel` on key swap), `EnvironmentPresets.kt:75-84` |
| `llms.txt` remember-helpers table | `rememberHDREnvironment` / `rememberKTXEnvironment` (public `@ExperimentalSceneViewApi`, used by 6+ demos) absent | 2 table rows | `environment/EnvironmentPresets.kt:55,100` |
| `docs/docs/troubleshooting.md` | No entry for the "model loads but renders untextured" WebP symptom (`Missing texture provider for image/webp`) | New Runtime-errors subsection: limitation + re-encode workaround only — **no in-flight feature documented** (#2305 is still open) | `llms.txt:2922` (existing limitation note); commit `c2718cf` (demo assets re-encoded) |
| `agents/sceneview-ios/references/cheatsheet.md` | AR node-factory table omitted the new `CloudAnchorNode.host/.resolve` cancellable-Future API (#2430/#1859) — an AI could infer Cloud Anchors are unavailable on iOS | Added the table row with exact labels | `SceneViewSwift/Sources/SceneViewSwift/AR/CloudAnchorNode.swift:124-128,149-153` |

## NOT patched (still accurate / needs maintainer judgment)

- **`setMorphWeights` default offset 2.0→0 (#2472/#2471)** — no doc surface ever documented the old (wrong) default; source KDoc is current (`RenderableComponent.kt:104`, `ModelInstance.kt:137`, `ModelNode.kt:438` all `offset: Int = 0`). Nothing to fix.
- **Torus/Capsule winding fixes (#2494/#2472)** — no doc mentions a culling/double-sided workaround; `TorusNode`/`CapsuleNode` signatures + defaults in `llms.txt:517-546` still match source. No change.
- **`HitResultNode.refreshIntervalMs` (#2426)** — already documented at `llms.txt:1026` and matches source (`HitResultNode.kt:46`, default `0L`). No change.
- **Web `model { scale(); autoAnimate() }` builder (#2441/#2432)** — `llms.txt:5019-5024`, `agents/sceneview-web` all already match `ModelConfig.kt:16-31`. No change.
- **iOS CloudAnchor in `llms.txt` + `cheatsheet-ios.md`** — already covered by the #2430 PR itself (`llms.txt:1965`, `cheatsheet-ios.md:493`). Only the agents/ skill lagged (patched above).
- **AR camera-init scrim (#2502)** — PR is still **OPEN**; deliberately not documented (no pre-documenting unmerged work).
- **SDK-level WebP support (#2305)** — open; only the *current limitation* is documented, not the fix.
- **`Scene.kt`→`SceneView.kt` rename (#2431)** — repo-wide grep found zero stale file-path references in docs. No change.
- **`ModelNode(centerOrigin)` (#2416)** — `llms.txt:379` already describes the now-honoured additive contract. No change.
- **`llms.txt:5224` "sceneview-web ≥ 4.10.0"** — a since-version annotation, not a stale ref. Left alone.
- **Maintainer judgment:** `rememberHDREnvironment`/`rememberKTXEnvironment` are `@ExperimentalSceneViewApi` — if experimental APIs should stay out of `llms.txt`, drop those 2 table rows (the ownership-contract note stands on its own).

## Verification

- `bash .claude/scripts/check-sceneview-skill.sh` → **PASS** (all 24 API identifiers + demo refs resolve after the agents/ edit)
- Every symbol cited in touched snippets grepped against current source (`rememberEnvironmentLoader`, `createHDREnvironment`, `createEnvironment`, `destroyModel`, `loadModelInstanceAsync`, `host(ttlDays:completion:operation:)`, `resolve(cloudAnchorId:completion:operation:)`)
- Docs-only — **no changelog fragment**, per the weekly doc-audit convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
