### PR TITLE
fix(demo/ar): AR Body Tracker — camera-init scrim + in-viewport hint pill (#2485)

### DIFF
--- a/changelog.d/2485-body-tracker-empty-state.md
+++ b/changelog.d/2485-body-tracker-empty-state.md
@@ -1,0 +1,6 @@
+<!-- category: Fixed -->
+- **AR Body Tracker**: replaced silent black screen with a camera-init scrim (spinner while
+  ARCore starts) and a persistent in-viewport hint pill ("Point camera at a person — full body
+  visible") that fades out once a skeleton is detected. Error states (model missing, ARCore
+  tracking failure) now surface as a red pill directly in the viewport, matching the
+  `ARFaceDemo` UX pattern. The live skeleton detection path is device-gated and unchanged.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
@@ -5,11 +5,16 @@ import android.graphics.ImageFormat
 import android.graphics.Rect
 import android.graphics.YuvImage
 import android.media.Image
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -20,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -41,6 +47,7 @@ import io.github.sceneview.ar.arcore.cameraImage
 import io.github.sceneview.ar.body.BodyPose
 import io.github.sceneview.ar.body.Joint
 import io.github.sceneview.ar.body.SKELETON_BONES
+import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.common.trackingFailureMessage
@@ -116,6 +123,8 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
         onDispose { landmarker?.close() }
     }
 
+    // True after the first ARCore camera frame — used to dismiss ARCameraInitScrim (#2485).
+    var cameraReady by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var bodyPose by remember { mutableStateOf(BodyPose(emptyMap())) }
 
@@ -169,6 +178,8 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
                     config.planeFindingMode = Config.PlaneFindingMode.DISABLED
                 },
                 onSessionUpdated = { _, frame: Frame ->
+                    // First callback = camera is delivering frames; dismiss the init scrim.
+                    if (!cameraReady) cameraReady = true
                     if (landmarker == null) return@ARSceneView
                     if (frame.camera.trackingState != TrackingState.TRACKING) return@ARSceneView
 
@@ -208,6 +219,55 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
                 pose = bodyPose,
                 modifier = Modifier.fillMaxSize(),
             )
+
+            // Persistent hint pill — always visible in the viewport so the user knows what
+            // to do regardless of whether the controls panel is open. Hidden once the first
+            // body is tracked so it never fights the skeleton overlay (#2485).
+            //
+            // State priority:
+            //   model missing  → "Pose model unavailable" (error, red)
+            //   tracking failed → ARCore's standard tracking-failure reason
+            //   body tracked    → hidden (skeleton overlay is the feedback)
+            //   else            → "Point the camera at a person — full body visible"
+            val trackingFailureHint = trackingFailureMessage(trackingFailureReason)
+            val (hintText, hintColor) = when {
+                landmarker == null ->
+                    stringResource(R.string.demo_ar_body_tracker_status_no_model) to
+                        MaterialTheme.colorScheme.error
+                trackingFailureHint != null ->
+                    trackingFailureHint to MaterialTheme.colorScheme.error
+                bodyPose.isTracked -> null to MaterialTheme.colorScheme.primary
+                else ->
+                    stringResource(R.string.demo_ar_body_tracker_hint_aim) to
+                        MaterialTheme.colorScheme.primary
+            }
+            AnimatedVisibility(
+                visible = hintText != null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 32.dp),
+            ) {
+                if (hintText != null) {
+                    Text(
+                        text = hintText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .background(
+                                color = hintColor.copy(alpha = 0.82f),
+                                shape = RoundedCornerShape(24.dp),
+                            )
+                            .padding(horizontal = 24.dp, vertical = 12.dp),
+                    )
+                }
+            }
+
+            // Cover the still-black ARSceneView surface until ARCore delivers its first
+            // camera frame — on a cold start this can take several seconds and the
+            // silent black screen reads as a crash (#2485, #1473).
+            ARCameraInitScrim(initializing = !cameraReady)
         }
     }
 }

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_body_tracker.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_body_tracker.xml
@@ -11,4 +11,7 @@
     <string name="demo_ar_body_tracker_status_aim">Aim the camera at a person</string>
     <string name="demo_ar_body_tracker_status_tracked">Body tracked — %1$d joints</string>
     <string name="demo_ar_body_tracker_status_no_model">Pose model unavailable — add pose_landmarker_lite.task to assets/mediapipe/</string>
+    <!-- Persistent in-viewport hint pill: shown when the camera feed is live but no body is
+         detected yet. Kept brief so it fits on one line at bodyMedium size (#2485). -->
+    <string name="demo_ar_body_tracker_hint_aim">Point camera at a person — full body visible</string>
 </resources>


### PR DESCRIPTION
## Summary

Fixes the silent black screen in the AR Body Tracker demo (#2485, part of Pixel 9 device review #2466).

**Root causes:**
1. **Cold-start black screen** (f_0294): `ARSceneView` paints its surface black until ARCore opens the camera. The demo had no `ARCameraInitScrim`, so users saw several seconds of unexplained black with no loading indicator.
2. **No in-viewport guidance**: The "Point the camera at a person" hint existed only in the `DemoScaffold` controls panel (collapsed bottom sheet), invisible when the user hasn't opened it. The viewport showed the live camera feed with zero overlay when no body was detected.

**Fix (UX layer only — detection is device-gated and unchanged):**
- Wire `ARCameraInitScrim` off the first `onSessionUpdated` callback so the cold-start black screen shows a spinner + "Starting camera…" label.
- Add a persistent `BottomCenter` hint pill (`AnimatedVisibility`) covering all four viewport states: model unavailable (red), ARCore tracking failure (red), no body detected (blue "Point camera at a person — full body visible"), body tracked (pill hidden — skeleton overlay is the feedback).
- Follows the `ARFaceDemo` pattern exactly; no new helpers introduced.
- New string resource `demo_ar_body_tracker_hint_aim` for the no-body hint.

**Files changed:** `samples/android-demo` only — no SDK/library files touched.

## Test plan

- [ ] Launch AR Body Tracker cold: verify spinner + "Starting camera…" label covers the black surface during startup, disappears when camera feed appears
- [ ] Camera feed live, no person visible: verify blue "Point camera at a person — full body visible" pill at bottom
- [ ] Point camera at a person (full body): verify pill fades out and skeleton overlay appears
- [ ] Remove `.task` model asset: verify red "Pose model unavailable" pill (needs local build modification)
- [ ] Simulate ARCore tracking failure (cover camera): verify standard tracking-failure reason appears in red pill

> ⚠️ **Device-QA flag:** the live skeleton detection path (body actually tracked → skeleton overlay + pill hidden) requires a physical device with a person in frame. The AR replay harness can exercise the camera-init scrim and the no-body hint but cannot verify the tracked state without a recorded ARCore session that includes a person. Manual device verification recommended before tagging.

Closes #2485

🤖 Generated with [Claude Code](https://claude.com/claude-code)