### PR TITLE
docs(privacy): Face Data (TrueDepth) section — unblocks iOS App Review (Guideline 2.1)

### DIFF
--- a/.github/PRIVACY_POLICY.md
+++ b/.github/PRIVACY_POLICY.md
@@ -117,3 +117,10 @@ If you have questions about this Privacy Policy, please contact:
 - **Email:** thomas.gorisse@gmail.com
 - **Website:** https://sceneview.github.io
 - **GitHub:** https://github.com/sceneview/sceneview
+
+## Face Data (TrueDepth API / ARKit Face Tracking)
+
+- **What is collected:** when you open an AR face demo on iOS, the app uses Apple's ARKit face tracking (which relies on the TrueDepth camera) to obtain a real-time facial mesh — face geometry and expression coefficients. On Android, the equivalent demo uses Google ARCore Augmented Faces. No photographs of your face are taken by the app.
+- **Purpose:** face data is used **solely** to render real-time 3D effects anchored to your face inside the demo, on screen, while the demo is open. It is not used for identification, authentication, profiling, or any other purpose.
+- **Storage & retention:** face data is processed **in memory, on your device only**. It is never recorded, stored, written to disk, or retained — it is discarded as each camera frame is rendered, and entirely released when you leave the demo.
+- **Sharing:** face data **never leaves your device**. It is not transmitted to us or to any third party, and the app contains no analytics or tracking SDKs.

--- a/docs/docs/privacy.md
+++ b/docs/docs/privacy.md
@@ -15,6 +15,14 @@ The SceneView Demo app ("the App") is an open-source demonstration application d
 
 The App **collects no personal data during normal use**. It has no accounts, no analytics, and no tracking. The **one exception** is the **optional in-app feedback** feature: if you choose to report a bug or share an idea, it records your screen and microphone audio and uploads them — together with basic device/app context — to the SceneView feedback service. Nothing is recorded or sent unless you explicitly start a feedback report and agree.
 
+
+## Face Data (TrueDepth API / ARKit Face Tracking)
+
+- **What is collected:** when you open an AR face demo on iOS, the app uses Apple's ARKit face tracking (which relies on the TrueDepth camera) to obtain a real-time facial mesh — face geometry and expression coefficients. On Android, the equivalent demo uses Google ARCore Augmented Faces. No photographs of your face are taken by the app.
+- **Purpose:** face data is used **solely** to render real-time 3D effects anchored to your face inside the demo, on screen, while the demo is open. It is not used for identification, authentication, profiling, or any other purpose.
+- **Storage & retention:** face data is processed **in memory, on your device only**. It is never recorded, stored, written to disk, or retained — it is discarded as each camera frame is rendered, and entirely released when you leave the demo.
+- **Sharing:** face data **never leaves your device**. It is not transmitted to us or to any third party, and the app contains no analytics or tracking SDKs.
+
 ## Data Collection (normal use)
 
 Outside the feedback feature, the App does **not** collect, store, or transmit any personal data. Specifically:

--- a/website-static/privacy.html
+++ b/website-static/privacy.html
@@ -266,7 +266,7 @@
     <section class="privacy-hero">
       <div class="privacy-hero__container">
         <h1 class="privacy-hero__title reveal">Privacy Policy</h1>
-        <p class="privacy-hero__updated reveal"><strong>SceneView Demo</strong> &mdash; Last updated: May 21, 2026</p>
+        <p class="privacy-hero__updated reveal"><strong>SceneView Demo</strong> &mdash; Last updated: June 12, 2026</p>
       </div>
     </section>
 
@@ -291,6 +291,14 @@
         <li>Camera data for AR is processed <strong>locally on-device</strong> in real time for plane detection and object placement.</li>
         <li><strong>No camera images or AR video are stored, recorded, or transmitted</strong> to any server.</li>
         <li>Camera access is only requested when the user navigates to the AR tab. A feedback screen recording may capture the AR viewfinder if an AR demo is open &mdash; only while you are actively recording feedback.</li>
+      </ul>
+
+      <h2>Face Data (TrueDepth API / ARKit Face Tracking)</h2>
+      <ul>
+        <li><strong>What is collected:</strong> when you open an AR face demo on iOS, the app uses Apple&rsquo;s ARKit face tracking (which relies on the TrueDepth camera) to obtain a real-time facial mesh &mdash; face geometry and expression coefficients. On Android, the equivalent demo uses Google ARCore Augmented Faces. No photographs of your face are taken by the app.</li>
+        <li><strong>Purpose:</strong> face data is used <strong>solely</strong> to render real-time 3D effects anchored to your face inside the demo, on screen, while the demo is open. It is not used for identification, authentication, profiling, or any other purpose.</li>
+        <li><strong>Storage &amp; retention:</strong> face data is processed <strong>in memory, on your device only</strong>. It is never recorded, stored, written to disk, or retained &mdash; it is discarded as each camera frame is rendered, and entirely released when you leave the demo.</li>
+        <li><strong>Sharing:</strong> face data <strong>never leaves your device</strong>. It is not transmitted to us or to any third party, and the app contains no analytics or tracking SDKs.</li>
       </ul>
 
       <h2>In-App Feedback (Opt-In)</h2>


### PR DESCRIPTION
Apple rejected iOS 4.17.0 (submission `741d5f86`, **Guideline 2.1 — Information Needed**) asking where the privacy policy explains the collection, use, sharing and retention of **TrueDepth face data** (the AR Faces demo). The published policy had **zero face-data coverage** — root cause of the iOS publish blockage since May 26.

Adds a **Face Data (TrueDepth API / ARKit Face Tracking)** section to the 3 privacy surfaces (`website-static/privacy.html` = the App Store privacy URL, `.github/PRIVACY_POLICY.md`, `docs/docs/privacy.md`): real-time facial mesh, render-only purpose, in-memory on-device only, zero storage/retention, zero transmission/third-party sharing — consistent with the app's zero-analytics promise and the actual ARFace implementation.

Next step (browser flow in progress): resubmit iOS as 4.18.0 (build 1291) with App Review notes answering Apple's 5 questions, quoting this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)