### PR TITLE
fix(ios-demo): remove Sponsor/donation card from About tab (App Store 3.1.1)

### DIFF
--- a/changelog.d/2534-ios-remove-donation-link.md
+++ b/changelog.d/2534-ios-remove-donation-link.md
@@ -1,0 +1,4 @@
+<!-- category: Fixed -->
+- **iOS demo**: removed the "Sponsor" / GitHub Sponsors card from the About tab to comply with
+  App Store Guideline 3.1.1 (no external payment or donation links). The Android demo's
+  equivalent Sponsor card is intentionally unchanged — Google Play allows donation links.

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// About tab — Liquid Glass card layout (iOS 26+ Stitch spec).
 ///
 /// Hero logo + version pill, then a series of `.regularMaterial` glass cards
-/// (Open Source, Docs, GitHub, Sponsor, Credits), a tinted "Star on GitHub"
+/// (Open Source, Docs, GitHub, 3D Playground, Credits), a tinted "Star on GitHub"
 /// CTA, and a footer with attribution.
 struct AboutTab: View {
     private static let version: String = {
@@ -123,15 +123,6 @@ struct AboutTab: View {
                 subtitle: "Try every feature in the browser",
                 trailing: .link,
                 url: URL(string: "https://sceneview.github.io/playground.html")
-            )
-
-            AboutCard(
-                icon: "heart.fill",
-                iconColor: .red,
-                title: "Sponsor",
-                subtitle: "Help keep the project free & active",
-                trailing: .link,
-                url: URL(string: "https://github.com/sponsors/sceneview")
             )
 
             AboutCard(


### PR DESCRIPTION
## Context

Apple rejected iOS 4.18.0 under **Guideline 3.1.1 (Business — Payments / In-App Purchase)** because the About tab contained a "Sponsor" card linking to `github.com/sponsors/sceneview` — an external payment/donation mechanism. We replied to Apple committing to remove the link in the next update.

## What was removed

**File:** `samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift`

The `AboutCard` block for "Sponsor" (lines 128-135 pre-patch):
```swift
AboutCard(
    icon: "heart.fill",
    iconColor: .red,
    title: "Sponsor",
    subtitle: "Help keep the project free & active",
    trailing: .link,
    url: URL(string: "https://github.com/sponsors/sceneview")
)
```

Only this card was removed. All other About tab links remain:
- Open Source (static, no link)
- Documentation → sceneview.github.io
- GitHub → github.com/sceneview/sceneview
- 3D Playground → sceneview.github.io/playground.html
- Credits (sheet, no external URL)
- Star on GitHub CTA → github.com/sceneview/sceneview

## Android is intentionally untouched

Google Play **allows** donation/sponsor links. The Android demo's equivalent Sponsor card in `samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt` is preserved as-is.

## Verification

- Brace balance confirmed (33 opens, 33 closes)
- `github.com/sponsors` absent from all iOS Swift sources post-patch
- Android Sponsor card + strings confirmed present and unchanged
- No public SDK API touched — demo-app only change

## Device QA flag

The iOS About tab should be visually verified: the Sponsor row is gone, the Credits row immediately follows 3D Playground, the "Star on GitHub" CTA and footer are intact.

Fixes #2534