### PR TITLE
test(android-demo): Maestro flow for the live AR View session — PR 4/4 of #2482

### DIFF
--- a/.maestro/android/ar.yaml
+++ b/.maestro/android/ar.yaml
@@ -14,6 +14,11 @@
 # mirror ALL_DEMOS in samples/android-demo .../DemoRegistry.kt.
 appId: io.github.sceneview.demo
 ---
+# The AR View tab's LIVE session (consumer entry, not a deep-linked demo) —
+# launcher → Start AR Camera → unified tap-to-place overlay → back-arrow exit.
+# Closes the QA gap that let #2476 ship (#2482 PR 4/4).
+- runFlow:
+    file: flows/ar-view-live.yaml
 - runFlow:
     file: flows/demo.yaml
     env:

--- a/.maestro/android/flows/ar-view-live.yaml
+++ b/.maestro/android/flows/ar-view-live.yaml
@@ -1,0 +1,58 @@
+# Maestro flow — the AR View tab's LIVE session (NOT a deep-linked demo).
+#
+# Drives the consumer entry point like a real user: open the "AR View" tab,
+# start the live `ARSceneView` from the launcher CTA, assert the unified
+# tap-to-place status overlay renders (the shared `TapToPlaceArSession`
+# engine — #2482), exit via the top-START back arrow that replaced the old
+# X close, and assert the launcher is restored.
+#
+# WHY THIS EXISTS: until #2482 PR 4/4 (§3.7 of
+# `.claude/plans/tap-to-place-unification.md`) NO Maestro flow drove the AR
+# View tab's live session — only deep-linked demos via `flows/demo.yaml`.
+# That blind spot let #2476 (a stale-closure tap regression on this exact
+# surface) ship. This closes the gap.
+#
+# REQUIRES the ARCore-friendly emulator from
+# `.claude/scripts/setup-ar-emulator.sh` (virtualscene back camera, host GPU,
+# Google Play Services for AR installed): the "Start AR Camera" CTA only
+# enables when ARCore is SUPPORTED_INSTALLED. The android/ar device-QA legs
+# are advisory (continue-on-error, #1651), so a slow emulator AR frame never
+# blocks a release.
+#
+# Run standalone:  maestro test .maestro/android/flows/ar-view-live.yaml
+# Also invoked once at the head of `.maestro/android/ar.yaml`.
+appId: io.github.sceneview.demo
+---
+# Cold start with the camera permission pre-granted so the launcher CTA goes
+# straight to the live session instead of the system permission dialog.
+- launchApp:
+    clearState: true
+    permissions:
+      camera: allow
+
+# Land on the AR View tab (bottom NavigationBar label `tab_ar_view`).
+- tapOn: "AR View"
+
+# The launcher gate is shown first (opt-in live session — never auto-starts).
+- assertVisible: "AR Experiences"
+- assertVisible: "Start AR Camera"
+
+# Start the live ARSceneView.
+- tapOn: "Start AR Camera"
+
+# The unified tap-to-place status overlay renders (shared
+# `TapToPlaceArSession` → default `TapToPlaceStatusOverlays`). The pill shows
+# the scanning vocabulary immediately — it draws above the camera-init scrim
+# and is NOT gated on AR tracking, so it is deterministic. Give ARCore a
+# generous window to construct the session on the emulator.
+- extendedWaitUntil:
+    visible: "Scanning for surfaces"
+    timeout: 20000
+
+# The top-START back arrow replaced the X close (#2482) — `cd_back_button`
+# content description "Navigate back".
+- assertVisible: "Navigate back"
+- tapOn: "Navigate back"
+
+# Back on the launcher — the session tore down cleanly, no crash.
+- assertVisible: "Start AR Camera"

--- a/changelog.d/2482-tap-to-place-pr4-maestro.md
+++ b/changelog.d/2482-tap-to-place-pr4-maestro.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- Added a Maestro flow (`.maestro/android/flows/ar-view-live.yaml`) that drives the AR View tab's **live** session end-to-end — launcher → Start AR Camera → unified tap-to-place status overlay → top-start back-arrow exit → launcher restored — and wired it into `ar.yaml`. Until now no flow exercised the live AR View session (only deep-linked demos), the blind spot that let #2476 ship. Final piece of the #2482 tap-to-place unification (PR 4/4).


### PR DESCRIPTION
## What

PR **4 of 4** (final) of the tap-to-place unification (#2482), per design §3.7 of `.claude/plans/tap-to-place-unification.md`.

Adds a Maestro flow that drives the **AR View tab's live session** like a real user — the consumer entry, not a deep-linked demo:

`.maestro/android/flows/ar-view-live.yaml`:
1. cold launch with camera pre-granted (`clearState: true` + `permissions: camera: allow`)
2. tap the **AR View** tab (`tab_ar_view`)
3. assert the launcher gate (`AR Experiences` + `Start AR Camera`)
4. tap **Start AR Camera** → assert the unified tap-to-place status pill (`Scanning for surfaces…`, drawn by the shared `TapToPlaceStatusOverlays`, above the camera-init scrim, not gated on AR tracking) via `extendedWaitUntil` (20 s for ARCore session construction)
5. assert + tap the **top-start back arrow** (`Navigate back` / `cd_back_button`) that replaced the X close in PR 3
6. assert the launcher is restored (clean teardown, no crash)

Wired into `.maestro/android/ar.yaml` at the head of the AR category sweep.

## Why

Until this PR, **no Maestro flow exercised the live AR View session** — only deep-linked demos via `flows/demo.yaml`. That blind spot is exactly what let **#2476** (a stale-closure tap regression on this surface) ship. This closes the gap and locks in the PR 1–3 behaviour (unified engine + back-arrow + status vocabulary).

## Notes
- Requires the ARCore-friendly emulator (`.claude/scripts/setup-ar-emulator.sh`) — the `Start AR Camera` CTA only enables when ARCore is `SUPPORTED_INSTALLED`.
- The `android`/`ar` device-QA legs are **advisory** (continue-on-error, #1651), so a slow emulator AR frame never blocks a release.
- The `Navigate back` selector matches the established convention already used by `flows/demo.yaml` (lines 111/141/159).
- YAML validated (both docs parse). No source/compilation change — purely a test artifact + changelog fragment.

⚠️ **Device-QA flag**: a Pixel 9 / emulator pass should run this flow plus the #2466 tap-to-place scenarios, and confirm the reticle shows on the AR View entry + the helmet lands upright + back-arrow exits cleanly.

Part 4/4 of #2482.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>