### PR TITLE
fix(flutter): dedupe AR planes by reference identity, not identityHashCode (#2488)

### DIFF
--- a/changelog.d/2488-flutter-plane-identity-set.md
+++ b/changelog.d/2488-flutter-plane-identity-set.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Flutter (Android): the AR plane-discovery bridge now dedupes detected planes by reference identity (`IdentityHashMap`-backed set) instead of `System.identityHashCode`, which is not collision-free — a new plane whose hash collided with an already-reported one could silently drop its `onPlaneDetected` callback (#2488).

--- a/flutter/sceneview_flutter/android/src/main/kotlin/io/github/sceneview/flutter/SceneViewPlugin.kt
+++ b/flutter/sceneview_flutter/android/src/main/kotlin/io/github/sceneview/flutter/SceneViewPlugin.kt
@@ -425,7 +425,12 @@ class ARSceneViewPlatformView(
     private val lightNodes = mutableStateListOf<FlutterLightNode>()
 
     // Track which planes have already been reported to avoid duplicate callbacks.
-    private val reportedPlaneIds = mutableSetOf<String>()
+    // Keyed on the ARCore Plane reference itself via an IdentityHashMap-backed set:
+    // System.identityHashCode is NOT collision-free, so a distinct plane whose hash
+    // collided with an already-reported one would be silently dropped (#2488). Reference
+    // identity is genuinely unique for the lifetime of the session.
+    private val reportedPlanes: MutableSet<com.google.ar.core.Plane> =
+        java.util.Collections.newSetFromMap(java.util.IdentityHashMap())
 
     private val composeView = ComposeView(context).apply {
         setContent {
@@ -443,8 +448,7 @@ class ARSceneViewPlatformView(
                 onSessionUpdated = { _, frame ->
                     val updatedPlanes = frame.getUpdatedPlanes()
                     for (plane in updatedPlanes) {
-                        val planeId = System.identityHashCode(plane).toString()
-                        if (reportedPlaneIds.add(planeId)) {
+                        if (reportedPlanes.add(plane)) {
                             val planeType = when (plane.type) {
                                 com.google.ar.core.Plane.Type.HORIZONTAL_UPWARD_FACING -> "horizontal_upward"
                                 com.google.ar.core.Plane.Type.HORIZONTAL_DOWNWARD_FACING -> "horizontal_downward"
@@ -553,7 +557,7 @@ class ARSceneViewPlatformView(
         modelNodes.clear()
         geometryNodes.clear()
         lightNodes.clear()
-        reportedPlaneIds.clear()
+        reportedPlanes.clear()
         // Detach the ComposeView from any parent and dispose its composition
         // so that Filament/ARCore resources are released.
         composeView.disposeComposition()
@@ -599,7 +603,7 @@ class ARSceneViewPlatformView(
                 modelNodes.clear()
                 geometryNodes.clear()
                 lightNodes.clear()
-                reportedPlaneIds.clear()
+                reportedPlanes.clear()
                 result.success(null)
             }
             "setEnvironment" -> {


### PR DESCRIPTION
Closes #2488.

## Problem
`flutter/.../ARSceneViewPlatformView` keyed its `reportedPlaneIds` dedup set on `System.identityHashCode(plane).toString()`. `identityHashCode` is **not** unique — two distinct ARCore `Plane` objects can share a hash, so a new plane whose hash collided with an already-reported one was silently treated as already-reported and its `onPlaneDetected` callback was dropped.

## Fix
Key the dedup set on the ARCore `Plane` **reference itself** via `Collections.newSetFromMap(IdentityHashMap())`, which uses reference identity (genuinely unique for the session lifetime) rather than `hashCode`.

## Safety
- The plane id was only ever used as the dedup-set key — it is **never** sent over the `MethodChannel` (only `planeType` crosses the wire). So this is behavior-preserving apart from the bug fix.
- Runs inside the existing `onSessionUpdated` callback — no threading change.
- Self-review: all 4 references (declaration, `.add`, two `.clear()` sites) updated; no leftover `identityHashCode`.

## Verification
Static-verified (Kotlin types: `MutableSet<Plane>` + `.add(plane): Boolean` + `.clear()`). Full Flutter-Android Gradle build not run (bridge-only, no API surface change, disk-constrained worker).

Scope: trivial bridge correctness fix → worker self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)