### PR TITLE
fix(docs): sweep non-existent Frame.createAnchorOrNull to real Trackable form (#2525)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -130,7 +130,7 @@ import java.util.concurrent.atomic.AtomicReference
  *         if (anchor == null) {
  *             anchor = frame.getUpdatedPlanes()
  *                 .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
- *                 ?.let { frame.createAnchorOrNull(it.centerPose) }
+ *                 ?.let { it.createAnchorOrNull(it.centerPose) }
  *         }
  *     }
  * ) {

--- a/arsceneview/src/main/java/io/github/sceneview/ar/arcore/Trackable.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/arcore/Trackable.kt
@@ -17,6 +17,15 @@ val Trackable.isTracking get() = trackingState == TrackingState.TRACKING
  * between the pose of multiple anchors attached to a trackable may adjust slightly over time as
  * ARCore updates its model of the world.
  *
+ * This is the canonical entry point for the plane tap-to-place pattern — anchor a plane at its
+ * own center pose:
+ * ```
+ * anchor = frame.getUpdatedPlanes()
+ *     .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
+ *     ?.let { it.createAnchorOrNull(it.centerPose) }
+ * ```
+ * (`Frame` has no `createAnchorOrNull` — the receiver is the [Trackable], here a `Plane`.)
+ *
  * @return `null` if an exception was thrown during anchor creation.
  */
 fun Trackable.createAnchorOrNull(pose: Pose): Anchor? =

--- a/changelog.d/2525-frame-createanchor-doc-sweep.md
+++ b/changelog.d/2525-frame-createanchor-doc-sweep.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- AR docs & KDoc: the canonical plane tap-to-place snippet called `frame.createAnchorOrNull(plane.centerPose)`, but no `Frame.createAnchorOrNull` extension exists (ARCore's `Frame.session` field is package-private, so the extension is infeasible). Swept all occurrences to the real `Trackable.createAnchorOrNull(pose)` form (`plane.createAnchorOrNull(plane.centerPose)`) across `ARSceneView` KDoc, the AR codelab, migration/showcase docs, and `samples/README.md`, so AI-reproduced code compiles (#2525, #2519).

--- a/docs/docs/codelabs/codelab-ar-compose.md
+++ b/docs/docs/codelabs/codelab-ar-compose.md
@@ -97,7 +97,7 @@ ARSceneView(
         if (anchor == null) {
             anchor = frame.getUpdatedPlanes()
                 .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-                ?.let { frame.createAnchorOrNull(it.centerPose) }
+                ?.let { it.createAnchorOrNull(it.centerPose) }
         }
     }
 )
@@ -131,7 +131,7 @@ ARSceneView(
         if (anchor == null) {
             anchor = frame.getUpdatedPlanes()
                 .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-                ?.let { frame.createAnchorOrNull(it.centerPose) }
+                ?.let { it.createAnchorOrNull(it.centerPose) }
         }
     }
 ) {
@@ -266,7 +266,7 @@ fun ARViewerScreen() {
                 if (anchor == null) {
                     anchor = frame.getUpdatedPlanes()
                         .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-                        ?.let { frame.createAnchorOrNull(it.centerPose) }
+                        ?.let { it.createAnchorOrNull(it.centerPose) }
                 }
             },
             onGestureListener = rememberOnGestureListener(

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -632,7 +632,7 @@ ARSceneView(
         if (anchor == null) {
             anchor = frame.getUpdatedPlanes()
                 .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-                ?.let { frame.createAnchorOrNull(it.centerPose) }
+                ?.let { it.createAnchorOrNull(it.centerPose) }
         }
     }
 ) {

--- a/docs/docs/showcase.md
+++ b/docs/docs/showcase.md
@@ -165,7 +165,7 @@ ARSceneView(
     onSessionUpdated = { _, frame ->
         anchor = frame.getUpdatedPlanes()
             .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-            ?.let { frame.createAnchorOrNull(it.centerPose) }
+            ?.let { it.createAnchorOrNull(it.centerPose) }
     }
 ) {
     anchor?.let { a ->

--- a/samples/README.md
+++ b/samples/README.md
@@ -91,7 +91,7 @@ fun ARTapToPlace() {
             if (anchor == null) {
                 anchor = frame.getUpdatedPlanes()
                     .firstOrNull { it.type == Plane.Type.HORIZONTAL_UPWARD_FACING }
-                    ?.let { frame.createAnchorOrNull(it.centerPose) }
+                    ?.let { it.createAnchorOrNull(it.centerPose) }
             }
         }
     ) {


### PR DESCRIPTION
Closes #2525.

## Problem
The flagship plane tap-to-place snippet — repeated across doc surfaces and `ARSceneView`'s own KDoc — was:
```kotlin
?.let { frame.createAnchorOrNull(it.centerPose) }
```
But **no `Frame.createAnchorOrNull` extension exists**, so an AI reproducing it (the explicit AI-first contract goal) generates non-compiling code at the most common AR entry point.

## Why Option B, not the issue's "preferred" Option A
The issue suggested adding `fun Frame.createAnchorOrNull(pose) = frame.session.createAnchor(pose)`. I challenge-probed that against the pinned ARCore binding:

```
$ javap com.google.ar.core.Frame   # core-1.54.0.aar
  final com.google.ar.core.Session session;   // package-private, NO getSession()
```

`Frame.session` is a **package-private field with no public accessor** — Option A can't reach the session without fragile reflection, which is the wrong tradeoff for a public API. So I took **Option B**: sweep every broken occurrence to the existing, real `Trackable.createAnchorOrNull(pose)` extension.

## Changes (all doc markdown or in-source KDoc comments — no code/API change)
- `arsceneview/.../ARSceneView.kt` KDoc snippet → `it.createAnchorOrNull(it.centerPose)`
- `docs/docs/codelabs/codelab-ar-compose.md` (×3), `migration.md`, `showcase.md`, `samples/README.md` → same
- `arsceneview/.../arcore/Trackable.kt` — added a KDoc note: this is the canonical plane-anchor entry point, and `Frame` has no such extension (the receiver is the `Trackable`).

`llms.txt` and `samples/recipes/ar-tap-to-place.md` already used the correct form (#2523) — verified, untouched. `recipes.md` uses the valid no-arg `HitResult.createAnchorOrNull()` — left as-is.

## Verification
`grep` confirms zero `frame.createAnchorOrNull` remain repo-wide; 7 occurrences now use the compiling `Trackable` form. Both source edits are inside `*`-prefixed KDoc blocks → no Kotlin compilation impact.

Scope: doc-correctness sweep (no public-API change) → worker self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)