### PR TITLE
fix(website): hero grid collapse, corrupted SVG icon paths, stale version strings

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -418,6 +418,49 @@ if [ -f "$WEBSITE_INDEX" ]; then
     add_check "website-static/index.html (softwareVersion)" "$V"
 fi
 
+# Guard (#2562): a version string must NEVER appear inside SVG path data.
+# The historical unescaped-dot regex sweep injected versions into arc
+# commands (`a4 4 0` -> `a4.16.2 0`), and once corrupted, every later
+# escaped literal replace faithfully re-bumped the corruption
+# (4.16.2 -> 4.17.0 -> 4.18.0). Checking for the CURRENT version inside any
+# `d="..."` attribute is deterministic (legit path data never contains it)
+# and catches the whole class the moment it reappears.
+SVG_CORRUPTED=$(grep -rlE "d=\"[^\"]*${SOURCE_VERSION//./\\.}" "$REPO_ROOT/website-static" --include="*.html" 2>/dev/null || true)
+if [ -n "$SVG_CORRUPTED" ]; then
+    add_check "website-static SVG path data (version inside d= in: $(echo "$SVG_CORRUPTED" | tr '\n' ' '))" "CORRUPTED"
+else
+    add_check "website-static SVG path data (no version inside d=)" "$SOURCE_VERSION"
+fi
+
+# Website surfaces that drifted in #2564 — now pinned so they can't rot again.
+# iOS install-snippet comment on the homepage (`// Version: X.Y.Z`).
+if [ -f "$WEBSITE_INDEX" ]; then
+    V=$(grep -oE '// Version: [0-9]+\.[0-9]+\.[0-9]+' "$WEBSITE_INDEX" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "NOT FOUND")
+    add_check "website-static/index.html (iOS snippet // Version:)" "$V"
+fi
+# web.html JSON-LD softwareVersion (SEO structured data).
+WEBSITE_WEB="$REPO_ROOT/website-static/web.html"
+if [ -f "$WEBSITE_WEB" ]; then
+    V=$(grep 'softwareVersion' "$WEBSITE_WEB" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "NOT FOUND")
+    add_check "website-static/web.html (softwareVersion)" "$V"
+fi
+# Playground AI-prompt coordinates (arsceneview + sceneview-web@).
+WEBSITE_PLAYGROUND="$REPO_ROOT/website-static/playground.html"
+if [ -f "$WEBSITE_PLAYGROUND" ]; then
+    V=$(grep -oE 'arsceneview:[0-9]+\.[0-9]+\.[0-9]+' "$WEBSITE_PLAYGROUND" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "NOT FOUND")
+    add_check "website-static/playground.html (prompt arsceneview:)" "$V"
+    V=$(grep -oE 'sceneview-web@[0-9]+\.[0-9]+\.[0-9]+' "$WEBSITE_PLAYGROUND" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "NOT FOUND")
+    add_check "website-static/playground.html (prompt sceneview-web@)" "$V"
+fi
+# `js/sceneview.js?v=X.Y.Z` cache-busters — a stale ?v= keeps serving the
+# previous script from the HTTP cache after a deploy.
+STALE_BUSTERS=$(grep -rhoE 'sceneview\.js\?v=[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/website-static" --include="*.html" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u | grep -v "^${SOURCE_VERSION}$" || true)
+if [ -n "$STALE_BUSTERS" ]; then
+    add_check "website-static *.html (sceneview.js?v= cache-busters)" "$(echo "$STALE_BUSTERS" | head -1)"
+else
+    add_check "website-static *.html (sceneview.js?v= cache-busters)" "$SOURCE_VERSION"
+fi
+
 # ─── 9b. Auto-update artefacts (per-sample version polled at runtime) ────
 # `website-static/version.json` is fetched by `samples/web-demo` on every
 # `visibilitychange` to decide whether to surface the "Reload to update"

--- a/changelog.d/2560-website-visual-content-fixes.md
+++ b/changelog.d/2560-website-visual-content-fixes.md
@@ -1,0 +1,4 @@
+<!-- category: Fixed -->
+- **Website**: hero layout no longer collapses at ≥769px — `minmax(0,1fr)` grid tracks + `min-width:0` children, and the fallback visual's conflicting fixed `height:500px` (which imposed an ~889px intrinsic width via `aspect-ratio:16/9`) now derives from the aspect ratio (#2560).
+- **Website**: repaired 5 SVG icon paths in `index.html` corrupted by a historical version find-replace (`4.18.0` injected into arc commands), and added a `sync-versions.sh` guard that fails when a version string appears inside any `d="…"` path data (#2562).
+- **Website**: aligned stale version strings on 4.18.0 (iOS snippet 4.3.4, web JSON-LD 4.4.0, playground prompt 4.3.1, `?v=3.6.2`/`4.4.0` cache-busters) and pinned each surface in `sync-versions.sh` so they can't drift again (#2564).

--- a/website-static/claude-3d.html
+++ b/website-static/claude-3d.html
@@ -43,12 +43,12 @@
 
   <link rel="preload" href="styles.css" as="style">
   <link rel="preload" href="js/filament/filament.js" as="script">
-  <link rel="preload" href="js/sceneview.js?v=3.6.2" as="script">
+  <link rel="preload" href="js/sceneview.js?v=4.18.0" as="script">
 
   <!-- Filament.js v1.70.2 WASM engine (required by SceneView Web) -->
   <script src="js/filament/filament.js"></script>
   <!-- SceneView Web library -->
-  <script src="js/sceneview.js?v=3.6.2"></script>
+  <script src="js/sceneview.js?v=4.18.0"></script>
 
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/website-static/embed/index.html
+++ b/website-static/embed/index.html
@@ -10,7 +10,7 @@
 
   <!-- SceneView.js — Filament PBR renderer -->
   <script src="../js/filament/filament.js"></script>
-  <script src="../js/sceneview.js?v=4.4.0"></script>
+  <script src="../js/sceneview.js?v=4.18.0"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -352,7 +352,7 @@
           <div id="hero-drag-hint" class="hero__drag-hint" aria-hidden="true">
             <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M15 3l3 3-3 3M9 21l-3-3 3-3"/>
-              <path d="M18 6H9a4.18.0 0 0-4 4v1M6 18h9a4.18.0 0 0 4-4v-1"/>
+              <path d="M18 6H9a4 4 0 0 0-4 4v1M6 18h9a4 4 0 0 0 4-4v-1"/>
             </svg>
             <span>Drag to rotate</span>
           </div>
@@ -476,7 +476,7 @@
 <span class="syn-green">// Add in Xcode: File &rarr; Add Package Dependencies</span>
 
 <span class="syn-green-light">"https://github.com/sceneview/sceneview"</span>
-<span class="syn-green">// Version: 4.3.4</span>
+<span class="syn-green">// Version: 4.18.0</span>
 
 <span class="syn-purple">import</span> SceneViewSwift</code></pre>
           </div>
@@ -1103,21 +1103,21 @@
         </a>
         <a href="https://github.com/sceneview/sceneview/network/members" class="metric-card reveal" target="_blank" rel="noopener" aria-label="GitHub forks on sceneview/sceneview">
           <div class="metric-card__icon-wrap metric-card__icon-wrap--forks">
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M7 3a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm10 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-5 10a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 9a4.18.0 0 0 3 3.874V13a2 2 0 0 0 2 2 2 2 0 0 0 2-2v-.126A4.18.0 0 0 17 9h-2a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2H7z"/></svg>
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M7 3a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm10 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-5 10a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 9a4 4 0 0 0 3 3.874V13a2 2 0 0 0 2 2 2 2 0 0 0 2-2v-.126A4 4 0 0 0 17 9h-2a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2H7z"/></svg>
           </div>
           <div class="metric-card__value" data-metric="forks">223</div>
           <div class="metric-card__label">GitHub forks</div>
         </a>
         <a href="https://www.npmjs.com/package/sceneview-mcp" class="metric-card reveal" target="_blank" rel="noopener" aria-label="sceneview-mcp package on npm">
           <div class="metric-card__icon-wrap metric-card__icon-wrap--npm">
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M1.763 0C.786 0 0 .786 0 1.763v20.4.18.0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323h13.74v13.354h-3.328V8.665h-3.564.18.012H5.13z"/></svg>
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323h13.74v13.354h-3.328V8.665h-3.564v4.012H5.13z"/></svg>
           </div>
           <div class="metric-card__value" data-metric="mcp-downloads">768</div>
           <div class="metric-card__label">npm downloads (MCP, 30&nbsp;d)</div>
         </a>
         <a href="https://www.npmjs.com/package/sceneview-web" class="metric-card reveal" target="_blank" rel="noopener" aria-label="sceneview-web package on npm">
           <div class="metric-card__icon-wrap metric-card__icon-wrap--npm2">
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M1.763 0C.786 0 0 .786 0 1.763v20.4.18.0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323h13.74v13.354h-3.328V8.665h-3.564.18.012H5.13z"/></svg>
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true"><path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323h13.74v13.354h-3.328V8.665h-3.564v4.012H5.13z"/></svg>
           </div>
           <div class="metric-card__value" data-metric="web-downloads">4.7K</div>
           <div class="metric-card__label">npm downloads (Web, 30&nbsp;d)</div>
@@ -1277,7 +1277,7 @@
               Docs
             </a>
             <a href="https://discord.gg/sceneview" class="cta__btn cta__btn--glass" target="_blank" rel="noopener">
-              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" style="flex-shrink:0"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.4.18.0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674.18.049-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.4.18.0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.4.18.0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true" style="flex-shrink:0"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               Discord
             </a>
           </div>
@@ -1298,7 +1298,7 @@
                 <span class="cta__terminal-cmd">npm install sceneview-mcp</span>
               </div>
               <div class="cta__terminal-output">
-                + sceneview-mcp@4.0.12<br>
+                + sceneview-mcp@4.0.13<br>
                 added 12 packages from 8 contributors and audited 42 packages in 1.2s<br>
                 <br>
                 <span class="cta__terminal-success">Success!</span> Ready to use SceneView in your project.

--- a/website-static/platforms-showcase.html
+++ b/website-static/platforms-showcase.html
@@ -40,7 +40,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="styles.css">
     <script src="js/filament/filament.js"></script>
-    <script src="js/sceneview.js?v=3.6.2"></script>
+    <script src="js/sceneview.js?v=4.18.0"></script>
     <style>
         /* ===== PAGE LAYOUT ===== */
         .platforms-page {

--- a/website-static/playground.html
+++ b/website-static/playground.html
@@ -59,12 +59,12 @@
   <!-- Preconnect -->
   <!-- Preload -->
   <link rel="preload" href="js/filament/filament.js" as="script">
-  <link rel="preload" href="js/sceneview.js?v=3.6.2" as="script">
+  <link rel="preload" href="js/sceneview.js?v=4.18.0" as="script">
 
   <!-- Fonts -->
   <!-- SceneView engine -->
   <script src="js/filament/filament.js"></script>
-  <script src="js/sceneview.js?v=3.6.2"></script>
+  <script src="js/sceneview.js?v=4.18.0"></script>
 
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
@@ -3498,9 +3498,9 @@
 
         var prompt = 'Build me a SceneView ' + platLabel + ' app:\n\n' + userDesc + '\n\n';
         prompt += '--- SceneView Quick Reference ---\n';
-        prompt += 'SDK: io.github.sceneview:sceneview:4.18.0 (3D) / arsceneview:4.3.1 (AR)\n';
+        prompt += 'SDK: io.github.sceneview:sceneview:4.18.0 (3D) / arsceneview:4.18.0 (AR)\n';
         prompt += 'iOS: SPM https://github.com/sceneview/sceneview.git (from: "4.18.0")\n';
-        prompt += 'Web: npm install sceneview-web@4.3.1\n\n';
+        prompt += 'Web: npm install sceneview-web@4.18.0\n\n';
 
         if (plat === 'android' || plat === 'flutter' || plat === 'reactnative' || plat === 'desktop') {
           prompt += 'Key composables: SceneView { }, ARSceneView { }\n';

--- a/website-static/preview/embed.html
+++ b/website-static/preview/embed.html
@@ -8,7 +8,7 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <script src="../js/filament/filament.js"></script>
-  <script src="../js/sceneview.js?v=4.4.0"></script>
+  <script src="../js/sceneview.js?v=4.18.0"></script>
   <style>
     * { margin: 0; padding: 0; }
     body { background: transparent; overflow: hidden; }

--- a/website-static/preview/index.html
+++ b/website-static/preview/index.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
   <script src="../js/filament/filament.js"></script>
-  <script src="../js/sceneview.js?v=4.4.0"></script>
+  <script src="../js/sceneview.js?v=4.18.0"></script>
 
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/website-static/styles.css
+++ b/website-static/styles.css
@@ -346,9 +346,18 @@ ul { list-style: none; }
   margin: 0 auto;
   padding: 96px var(--container-padding);
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* minmax(0, 1fr): a plain 1fr track has an automatic min-content minimum, so
+     a child with a large intrinsic width (the aspect-ratio'd hero visual) can
+     steal the row and collapse the title column (#2560). */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 64px;
   align-items: center;
+}
+
+/* Let the grid children shrink below their intrinsic width (#2560). */
+.hero__content,
+.hero__visual {
+  min-width: 0;
 }
 
 .hero__title {
@@ -464,7 +473,11 @@ ul { list-style: none; }
 .hero__fallback-img {
   border-radius: 16px;
   width: 100%;
-  height: 500px;
+  /* height:auto — the inline aspect-ratio:16/9 drives the box. A fixed
+     height:500px combined with that aspect-ratio gave the element a definite
+     ~889px intrinsic width, blowing out the 1fr/1fr hero grid (#2560). */
+  height: auto;
+  aspect-ratio: 16/9;
   object-fit: cover;
   transition: opacity 0.8s ease;
 }

--- a/website-static/web.html
+++ b/website-static/web.html
@@ -766,7 +766,7 @@
     "url": "https://sceneview.github.io/web.html",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Web",
-    "softwareVersion": "4.4.0",
+    "softwareVersion": "4.18.0",
     "license": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": {


### PR DESCRIPTION
## Summary

Visual/content fixes from the website QA sweep (#2559):

- **Fixes #2560** — hero layout collapse at ≥769px. `.hero__container` tracks are now `minmax(0,1fr)` and the grid children get `min-width:0`; `.hero__fallback-img` drops the fixed `height:500px` that — combined with the inline `aspect-ratio:16/9` — gave it an ~889px definite intrinsic width and collapsed the title column (classic grid blowout).
- **Fixes #2562** — 5 SVG icon paths in `index.html` corrupted by a historical **unescaped-dot version sed** (`a4 4 0` matched `/4.4.0/` → `a4.16.2 0`), then faithfully re-bumped by every later escaped release replace (4.16.2 → 4.17.0 → 4.18.0 — the corruption predates the file's available git history). Discord was restored from the intact copy in `go/discord/index.html`; the others (share badge, sitemap, 2× npm logo) reconstructed from the unique valid SVG completion of each corrupted 5-char window. **Regression guard**: `sync-versions.sh` now fails when the current version literal appears inside any `d="…"` attribute (deterministic — legit path data never contains a semver; the issue's proposed loose regex false-positives on compact decimals like `.074.074`).
- **Fixes #2564** — stale versions aligned on 4.18.0: iOS snippet comment (4.3.4), `web.html` JSON-LD `softwareVersion` (4.4.0), playground prompt `arsceneview`/`sceneview-web` coords (4.3.1), all `sceneview.js?v=` cache-busters (3.6.2/4.4.0). Each occurrence changed **individually** with context verified — no blanket find-replace (that's what caused #2562). The MCP terminal mock was bumped to the live npm `4.0.13` (independent track). `sync-versions.sh` now pins every one of these surfaces (all report OK).

## Not done / honest notes
- `index.html:58` GA4 comment `Stream ID: 14.18.002837` was hit by the same historical corruption; the original digits are unrecoverable from history and it's a non-functional comment — left as-is.
- The 5 reconstructed non-Discord paths have no surviving canonical source (corrupted in the oldest available history); reconstruction is the unique syntactically valid completion, and all 5 render coherently (verified below).

## Verification
- In-browser against a local serve: hero `gridTemplateColumns` = `576px 576px` at 1280px (was `145.7px 920.9px`), title 3 lines (was 11); all 5 repaired paths have finite `getTotalLength()` and bboxes inside their 24×24 viewBox; footer/metrics icons render correctly on screenshot.
- `bash .claude/scripts/sync-versions.sh` → all website checks OK, exit 0; the new SVG guard tested in both directions (clean → OK, seeded corruption → MISMATCH).
- `grep`: zero `sceneview.js?v=` ≠ 4.18.0; zero semver inside `d=` in `index.html`.
- All modified pages serve 200 locally; `bash -n sync-versions.sh` clean.

Part of #2559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)