### PR TITLE
fix(website): Pricing nav on all pages, :focus-visible keyboard a11y, code hygiene

### DIFF
--- a/changelog.d/2565-website-nav-a11y-hygiene.md
+++ b/changelog.d/2565-website-nav-a11y-hygiene.md
@@ -1,0 +1,4 @@
+<!-- category: Fixed -->
+- **Website**: "Pricing" nav item now appears on every page (was only on the homepage), same position and markup, desktop and mobile menus (#2565).
+- **Website**: added `:focus-visible` styles — keyboard users get a visible, token-themed focus ring on links, buttons and form controls in both themes (WCAG 2.4.7) (#2566).
+- **Website**: hygiene — routine `SceneView:` info logs gated behind `window.SCENEVIEW_DEBUG`, dead CSS grids removed, the permanently-hidden duplicate `#hamburger` button removed from all 9 pages, scroll-reveal consolidated into `script.js` (single implementation, now honoring `prefers-reduced-motion` everywhere) (#2568).

--- a/website-static/404.html
+++ b/website-static/404.html
@@ -138,10 +138,6 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>

--- a/website-static/claude-3d.html
+++ b/website-static/claude-3d.html
@@ -863,15 +863,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
         <a href="/playground.html" class="nav__link">Playground</a>
         <a href="/docs.html" class="nav__link" target="_blank" rel="noopener">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>

--- a/website-static/docs.html
+++ b/website-static/docs.html
@@ -283,15 +283,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
         <a href="/playground.html" class="nav__link">Playground</a>
         <a href="/docs.html" class="nav__link nav__link--active">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -199,10 +199,6 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
@@ -1446,34 +1442,6 @@
   })();
   </script>
 
-  <!-- Scroll reveal animations -->
-  <script>
-  // Scroll reveal
-  (function() {
-    var reveals = document.querySelectorAll('.reveal');
-    if (!reveals.length) return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      reveals.forEach(function(el) { el.classList.add('revealed'); });
-      return;
-    }
-    function revealVisible() {
-      reveals.forEach(function(el) {
-        if (el.getBoundingClientRect().top < window.innerHeight + 100) el.classList.add('revealed');
-      });
-    }
-    revealVisible();
-    if ('IntersectionObserver' in window) {
-      var obs = new IntersectionObserver(function(entries) {
-        entries.forEach(function(e) {
-          if (e.isIntersecting) { e.target.classList.add('revealed'); obs.unobserve(e.target); }
-        });
-      }, { threshold: 0.01, rootMargin: '0px 0px 200px 0px' });
-      reveals.forEach(function(el) { if (!el.classList.contains('revealed')) obs.observe(el); });
-    }
-    var t; window.addEventListener('scroll', function() { clearTimeout(t); t = setTimeout(revealVisible, 50); }, { passive: true });
-    setTimeout(function() { reveals.forEach(function(el) { el.classList.add('revealed'); }); }, 3000);
-  })();
-  </script>
 </body>
 </html>
 <!-- deployed 2026-04-02T08:55:56Z -->

--- a/website-static/js/sceneview.js
+++ b/website-static/js/sceneview.js
@@ -28,6 +28,17 @@
   // This avoids dynamic script injection issues with WASM resolution.
 
   /**
+   * Info-level logging, silent in production (#2568). Opt in from the console
+   * with `window.SCENEVIEW_DEBUG = true`. Warnings/errors are NOT gated —
+   * real degradations must stay visible.
+   */
+  function _log() {
+    if (typeof global !== 'undefined' && global.SCENEVIEW_DEBUG && typeof console !== 'undefined') {
+      console.log.apply(console, arguments);
+    }
+  }
+
+  /**
    * Wait for Filament to be available (loaded by the script tag).
    */
   function _ensureFilament() {
@@ -700,7 +711,7 @@
             var ibl = self._engine.createIblFromKtx1(buffer);
             ibl.setIntensity(intensity || 40000);
             self._scene.setIndirectLight(ibl);
-            console.log('SceneView: Environment loaded (' + Math.round(buffer.length / 1024) + 'KB)');
+            _log('SceneView: Environment loaded (' + Math.round(buffer.length / 1024) + 'KB)');
           } catch (e) {
             console.warn('SceneView: loadEnvironment failed', e);
           }
@@ -2315,7 +2326,7 @@
           var ibl = engine.createIblFromKtx1(buffer);
           ibl.setIntensity(options.iblIntensity || 40000);
           scene.setIndirectLight(ibl);
-          console.log('SceneView: KTX IBL loaded (' + Math.round(buffer.length / 1024) + 'KB)');
+          _log('SceneView: KTX IBL loaded (' + Math.round(buffer.length / 1024) + 'KB)');
         } catch (e) {
           console.warn('SceneView: createIblFromKtx1 failed, using SH fallback', e);
           _applySyntheticIBL(engine, scene);
@@ -2355,7 +2366,7 @@
         .intensity(45000)
         .build(engine);
       scene.setIndirectLight(ibl);
-      console.log('SceneView: Using synthetic SH IBL');
+      _log('SceneView: Using synthetic SH IBL');
     } catch (e) { /* skip */ }
   }
 

--- a/website-static/platforms-showcase.html
+++ b/website-static/platforms-showcase.html
@@ -723,15 +723,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
         <a href="/playground.html" class="nav__link">Playground</a>
         <a href="/docs.html" class="nav__link" target="_blank" rel="noopener">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>

--- a/website-static/playground.html
+++ b/website-static/playground.html
@@ -1729,15 +1729,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
         <a href="/playground.html" class="nav__link nav__link--active">Playground</a>
         <a href="/docs.html" class="nav__link" target="_blank" rel="noopener">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>

--- a/website-static/privacy.html
+++ b/website-static/privacy.html
@@ -228,10 +228,6 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>

--- a/website-static/script.js
+++ b/website-static/script.js
@@ -85,6 +85,12 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
   var reveals = document.querySelectorAll('.reveal');
   if (!reveals.length) return;
 
+  // Respect prefers-reduced-motion: reveal everything immediately (#2568).
+  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    reveals.forEach(function(el) { el.classList.add('revealed'); });
+    return;
+  }
+
   // Immediately reveal elements already in or above the viewport
   function revealVisible() {
     reveals.forEach(function(el) {

--- a/website-static/showcase.html
+++ b/website-static/showcase.html
@@ -447,15 +447,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link nav__link--active">Showcase</a>
         <a href="/playground.html" class="nav__link">Playground</a>
         <a href="/docs.html" class="nav__link" target="_blank" rel="noopener">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>

--- a/website-static/styles.css
+++ b/website-static/styles.css
@@ -1914,11 +1914,6 @@ ul { list-style: none; }
   margin-bottom: 48px;
 }
 
-.testimonials__grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 24px;
-}
 
 .testimonial-card {
   background: var(--color-surface-container-lowest);
@@ -2002,11 +1997,6 @@ ul { list-style: none; }
   margin-bottom: 48px;
 }
 
-.demos__grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 24px;
-}
 
 .demo-card {
   display: flex;
@@ -2103,11 +2093,6 @@ ul { list-style: none; }
   margin-bottom: 48px;
 }
 
-.samples__grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 24px;
-}
 
 .sample-card {
   display: flex;
@@ -3226,4 +3211,27 @@ ul { list-style: none; }
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* ===== Keyboard focus visibility (WCAG 2.4.7, #2566) =====
+   :focus-visible only — mouse/touch interaction never shows the ring.
+   Token-driven so it themes automatically in light and dark modes. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* On the blue hero / gradient CTA surfaces the primary ring has too little
+   contrast — use the on-primary (light) ring there. */
+.hero a:focus-visible,
+.hero button:focus-visible,
+.cta a:focus-visible,
+.cta button:focus-visible {
+  outline-color: var(--color-on-primary);
 }

--- a/website-static/web.html
+++ b/website-static/web.html
@@ -803,15 +803,12 @@
         <span>SceneView SDK</span>
       </a>
 
-      <button class="nav__hamburger" id="hamburger" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-
       <div class="nav__links" id="navLinks">
         <a href="/#features" class="nav__link">Features</a>
         <a href="/showcase.html" class="nav__link">Showcase</a>
         <a href="/playground.html" class="nav__link">Playground</a>
         <a href="/docs.html" class="nav__link" target="_blank" rel="noopener">Docs</a>
+        <a href="https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing" class="nav__link" target="_blank" rel="noopener">Pricing</a>
         <button class="nav__theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
           <svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
@@ -1342,33 +1339,5 @@
     })();
   </script>
 
-  <!-- Scroll reveal -->
-  <script>
-  // Scroll reveal
-  (function() {
-    var reveals = document.querySelectorAll('.reveal');
-    if (!reveals.length) return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      reveals.forEach(function(el) { el.classList.add('revealed'); });
-      return;
-    }
-    function revealVisible() {
-      reveals.forEach(function(el) {
-        if (el.getBoundingClientRect().top < window.innerHeight + 100) el.classList.add('revealed');
-      });
-    }
-    revealVisible();
-    if ('IntersectionObserver' in window) {
-      var obs = new IntersectionObserver(function(entries) {
-        entries.forEach(function(e) {
-          if (e.isIntersecting) { e.target.classList.add('revealed'); obs.unobserve(e.target); }
-        });
-      }, { threshold: 0.01, rootMargin: '0px 0px 200px 0px' });
-      reveals.forEach(function(el) { if (!el.classList.contains('revealed')) obs.observe(el); });
-    }
-    var t; window.addEventListener('scroll', function() { clearTimeout(t); t = setTimeout(revealVisible, 50); }, { passive: true });
-    setTimeout(function() { reveals.forEach(function(el) { el.classList.add('revealed'); }); }, 3000);
-  })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Nav/a11y/hygiene batch from the website QA sweep (#2559):

- **Fixes #2565** — "Pricing" nav link added to every page (`showcase`, `web`, `docs`, `playground`, `platforms-showcase`, `claude-3d`), same markup/position as `index.html`. The `nav__links` block doubles as the mobile slide-in menu, so desktop + mobile are covered by one insertion per page. The external pricing target verified live (200). Decision: kept Pricing (target is up) rather than removing it from index; extracting a shared header partial is a larger refactor left out of this sweep.
- **Fixes #2566** — `:focus-visible` styles (WCAG 2.4.7): 2px `var(--color-primary)` outline, offset 2px, on links/buttons/inputs/`[tabindex]`; `var(--color-on-primary)` ring on the blue hero/CTA surfaces for contrast. Token-driven (no hardcoded values), themes automatically; deliberately no `border-radius` in the focus rules so styled buttons keep their shape (outlines follow the element's own radius). Verified no competing `outline` resets exist.
- **Fixes #2568** — hygiene items 1–3 and 5:
  1. Routine `SceneView:` `console.log` info lines gated behind `window.SCENEVIEW_DEBUG` (`_log()` helper); `console.warn` kept — real degradations must stay visible. *Out of scope:* Filament's own vendored shader-compilation logs (would require patching the Emscripten build).
  2. Dead CSS removed: `.testimonials__grid` / `.demos__grid` / `.samples__grid` (zero HTML/JS references, verified).
  3. Permanently-hidden duplicate `#hamburger` removed from all 9 pages (base `.nav__hamburger` is `display:none` at every breakpoint; `script.js` prefers `#hamburgerMobile`, present on all 9; its fallback lookup stays harmless).
  5. Scroll-reveal consolidated into `script.js`'s single implementation; the `prefers-reduced-motion` guard (previously only in the inline copies) moved in; duplicated inline blocks removed from `index.html` and `web.html`.
  - Item 4 (`geometry-demo` `lang`) was **already fixed on main** in v4.16.2 — stale finding. Items 6–7 are the issue's declared stretch goals — left open (noted on the issue via the umbrella).

## Not a code change: #2567
`/llms.txt` is **not** 404 — `docs.yml` copies the canonical root `llms.txt` to the site root at deploy and deliberately deletes any `website-static/llms.txt` copy (it once drifted 12 versions behind). Live `curl` returns 200 with canonical content. Re-adding a copy under `website-static/` would recreate the exact drift hazard the pipeline guards against — #2567 will be closed with evidence instead.

## Verification
- In-browser on the merged tree (this branch is rebased on main with #2575/#2576 in): 3D renders (Filament engine up, hero canvas visible), mobile menu opens/closes with Pricing present at 375px, scroll-reveal 61/61 elements revealed, zero `SceneView:` console noise, `:focus-visible` rule loaded with no resets outcompeting it.
- `node -c` clean on `script.js` and `js/sceneview.js`; all 9 modified pages serve 200 locally.

Part of #2559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)