### PR TITLE
chore(security): bump js-yaml to 3.15.0 in react-native lockfile (Dependabot 269)

### DIFF
--- a/react-native/react-native-sceneview/package-lock.json
+++ b/react-native/react-native-sceneview/package-lock.json
@@ -7218,9 +7218,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/react-native/react-native-sceneview/package.json
+++ b/react-native/react-native-sceneview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneview-sdk/react-native",
   "version": "4.18.0",
-  "description": "React Native bindings for SceneView \u2014 3D and AR scenes powered by Filament (Android) and RealityKit (iOS)",
+  "description": "React Native bindings for SceneView — 3D and AR scenes powered by Filament (Android) and RealityKit (iOS)",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/src/index.d.ts",
@@ -72,7 +72,8 @@
   "overrides": {
     "fast-xml-parser": "^5.7.0",
     "@babel/core": "^7.29.6",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "js-yaml": "^3.15.0"
   },
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
Clears Dependabot alert 269 (js-yaml < 3.15.0, moderate, dev-only transitive in `react-native/react-native-sceneview/package-lock.json`). npm `overrides` + `npm install --package-lock-only`; verified the lock now resolves js-yaml 3.15.0. Same pattern as #2570/#2558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)