### PR TITLE
docs: AI-first coverage for the #2241 Sprint-1 placement UX kit (PR 6/6)

### DIFF
--- a/agents/sceneview/references/cheatsheet.md
+++ b/agents/sceneview/references/cheatsheet.md
@@ -56,6 +56,25 @@ ARSceneView(
 There is **no `rememberARSession`** helper — configure via the
 `sessionConfiguration` lambda.
 
+## AR placement UX kit (#2241, v4.19+)
+
+Prefer these built-ins over hand-rolled banners/reticles/shadows:
+
+```kotlin
+Box {
+    ARSceneView(...) {
+        PlacementReticle(xPx = viewWidth/2f, yPx = viewHeight/2f,
+            onHitResultChanged = { reticleHit = it })      // smoothed cursor (slerp 0.75)
+        detectedPlanes.forEach { key(it) { ShadowReceiverPlane(plane = it) } }  // grounded shadows
+    }
+    PlaneDiscoveryGuide(cameraReady, isTracking, anyPlaneTracked, failure)  // onboarding overlay
+}
+```
+
+`PlaneDiscoveryGuide` = timed hand-hint/help onboarding (replaces static "Scanning…" banners).
+`snapToPlane=false` on the reticle = free placement (points accepted, planes in-polygon).
+iOS: coaching overlay = `ARSceneView(showCoachingOverlay: true)` (native); shadows/reticle → #894.
+
 ## Remember helpers (always use these)
 
 | Helper | Returns | Notes |

--- a/agents/sceneview/references/recipes.md
+++ b/agents/sceneview/references/recipes.md
@@ -60,3 +60,39 @@ are:
 - iOS: [`docs/docs/cheatsheet-ios.md`](https://github.com/sceneview/sceneview/blob/main/docs/docs/cheatsheet-ios.md)
 - Web: [`sceneview-web README`](https://www.npmjs.com/package/sceneview-web)
 - Flutter / RN: bridge packages; both render via the native SceneView underneath.
+
+## Recipe: complete tap-to-place UX (onboarding + reticle + grounded shadow) — #2241
+
+```kotlin
+var cameraReady by remember { mutableStateOf(false) }
+var isTracking by remember { mutableStateOf(false) }
+var anyPlaneTracked by remember { mutableStateOf(false) }
+var failure by remember { mutableStateOf<TrackingFailureReason?>(null) }
+var reticleHit by remember { mutableStateOf<HitResult?>(null) }
+val planes = remember { mutableStateListOf<Plane>() }
+
+Box {
+    ARSceneView(
+        onSessionUpdated = { session, frame ->
+            cameraReady = true
+            isTracking = frame.camera.trackingState == TrackingState.TRACKING
+            val tracked = session.getAllTrackables(Plane::class.java)
+                .filter { it.trackingState == TrackingState.TRACKING }
+            anyPlaneTracked = tracked.isNotEmpty()
+            if (planes.toList() != tracked) { planes.clear(); planes.addAll(tracked) }
+        },
+        onTrackingFailureChanged = { failure = it },
+        onGestureListener = rememberOnGestureListener(
+            onSingleTapConfirmed = { _, _ -> reticleHit?.createAnchor()?.let { /* AnchorNode + ModelNode */ } }
+        ),
+    ) {
+        PlacementReticle(xPx = viewWidth / 2f, yPx = viewHeight / 2f,
+            onHitResultChanged = { reticleHit = it })
+        planes.forEach { key(it) { ShadowReceiverPlane(plane = it) } }
+    }
+    PlaneDiscoveryGuide(cameraReady, isTracking, anyPlaneTracked, failure)
+}
+```
+
+The demo-app reference implementation is `samples/android-demo/.../common/placement/TapToPlaceArSession.kt`.
+

--- a/changelog.d/2241-pr6-docs.md
+++ b/changelog.d/2241-pr6-docs.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- llms.txt, agent skill (cheatsheet + recipes) and llms-full.txt now document the #2241 Sprint-1 placement UX kit — `PlaneDiscoveryGuide`, `PlacementReticle`, `ShadowReceiverPlane` — with the honest platform matrix (iOS: native coaching overlay ships today, grounded shadows/continuous reticle tracked under #894; Web: coming soon).

--- a/docs/docs/llms-full.txt
+++ b/docs/docs/llms-full.txt
@@ -183,6 +183,9 @@ PhysicsNode(node = modelNode, restitution = 0.6f, floorY = 0f, radius = 0.1f)
 AnchorNode(anchor = hitResult.createAnchor()) { ModelNode(...) }
 HitResultNode(xPx = screenCenterX, yPx = screenCenterY) { SphereNode(radius = 0.02f) }
 ReticleNode(xPx = screenCenterX, yPx = screenCenterY, onHitResultChanged = { hit -> }) { /* marker */ }
+PlaneDiscoveryGuide(cameraReady, isTracking, anyPlaneTracked, trackingFailureReason) — ARCore-Elements onboarding overlay: hand hint at 3 s, help at 8 s, 750 ms fade-out on first plane, contextual lost copy (#2241)
+PlacementReticle(xPx, yPx, snapToPlane=true, depthPoint=false, orientationSmoothing=0.75f, predicate=null, onHitResultChanged) — slerp-smoothed placement cursor, built-in cyan disc; snapToPlane=false = free placement (#2241)
+ShadowReceiverPlane(plane, shadowIntensity=0.6f) — invisible shadow catcher on a detected plane (shadowMultiplier material), placed models ground with a contact shadow (#2241)
 DepthHitResultNode(xPx = screenCenterX, yPx = screenCenterY) { /* rides any real surface */ }
 AugmentedImageNode(augmentedImage = image) { ModelNode(...) }
 AugmentedFaceNode(augmentedFace = face, meshMaterialInstance = faceMaterial)

--- a/llms.txt
+++ b/llms.txt
@@ -238,6 +238,55 @@ Text(hint ?: "Point your camera at a flat surface")
 
 Ported from arcore-android-sdk's `common/helpers/TrackingStateHelper.java`.
 
+### PlaneDiscoveryGuide — plane-discovery onboarding overlay (#2241, v4.19+)
+
+The built-in, user-tested onboarding for the "move your phone until a plane is found" phase —
+a port of ARCore Elements' `PlaneDiscoveryGuide` state machine. Prefer it over hand-rolling
+banners from `onTrackingFailureChanged`: it layers the timed hand-hint, help affordance and
+contextual failure copy for you, and auto-dismisses on the first tracked plane.
+
+Timeline (defaults, all tunable via `PlaneDiscoveryGuideDurations`): 0–3 s silent → animated
+hand hint + "Move your phone to find a surface" pill → "Need help?" button at 8 s (built-in tip
+card, or your `onHelp`) → 750 ms fade-out latched on the first tracked plane (never re-onboards
+within the session). While tracking is lost with an actionable reason it shows the contextual
+copy from the table above instead.
+
+`PlaneDiscoveryGuide` is a `BoxScope` composable — declare it as a SIBLING of `ARSceneView`
+inside a `Box`, feeding it plain booleans (no ARCore objects → previewable without a session):
+
+```kotlin
+var cameraReady by remember { mutableStateOf(false) }
+var isTracking by remember { mutableStateOf(false) }
+var anyPlaneTracked by remember { mutableStateOf(false) }
+var failure by remember { mutableStateOf<TrackingFailureReason?>(null) }
+
+Box {
+    ARSceneView(
+        onSessionUpdated = { session, frame ->
+            cameraReady = true
+            isTracking = frame.camera.trackingState == TrackingState.TRACKING
+            anyPlaneTracked = session.getAllTrackables(Plane::class.java)
+                .any { it.trackingState == TrackingState.TRACKING }
+        },
+        onTrackingFailureChanged = { failure = it },
+    ) { /* nodes */ }
+
+    PlaneDiscoveryGuide(
+        cameraReady = cameraReady,
+        isTracking = isTracking,
+        anyPlaneTracked = anyPlaneTracked,
+        trackingFailureReason = failure,
+    )
+}
+```
+
+Hoisted-state escape hatch: drive `rememberPlaneDiscoveryGuideState()` yourself and render
+`PlaneDiscoveryGuideOverlay(phase = state.phase, durations = state.durations, …)` — pass the
+STATE's durations, not a fresh copy, or the visual fade desynchronizes from the state machine.
+
+Platform matrix: **iOS** — use `ARSceneView(showCoachingOverlay: true)` (Apple's first-party
+`ARCoachingOverlayView` IS the onboarding; no port needed). **Web** — coming soon.
+
 ### Scene Understanding — grouped AR rendering flags
 
 `SceneUnderstanding` (`io.github.sceneview.ar.scene.SceneUnderstanding`, v4.10.0+, #1767) groups four scattered AR rendering flags into a single discoverable knob — mirrors RealityKit's `ARView.environment.sceneUnderstanding.options`. Pass it via `ARSceneView(sceneUnderstanding = ...)`; null (default) keeps every individual flag at its current default.
@@ -1101,6 +1150,62 @@ ARSceneView(
     }
 }
 ```
+
+### PlacementReticle — smoothed placement cursor (#2241, v4.19+)
+
+`ReticleNode`'s Sprint-1 upper layer — a port of ARCore Depth Lab's `OrientedReticle`. Same
+auto-hide + change-callback contract, plus: **orientation smoothing** (per-frame slerp toward
+the hit's surface normal, default `0.75` — kills the disc jitter as ARCore refines the normal;
+`1.0f` = raw) and **depth-capable acceptance** (`depthPoint = true` lands on arbitrary geometry;
+needs depth mode enabled, default off). Ships a built-in thin cyan disc when `content` is null.
+
+```kotlin
+var reticleHit by remember { mutableStateOf<HitResult?>(null) }
+ARSceneView(
+    onGestureListener = rememberOnGestureListener(
+        onSingleTapConfirmed = { _, _ -> reticleHit?.createAnchor()?.let { /* place */ } }
+    )
+) {
+    PlacementReticle(
+        xPx = viewWidth / 2f,
+        yPx = viewHeight / 2f,
+        onHitResultChanged = { reticleHit = it },
+    )
+}
+```
+
+Semantics: `snapToPlane = true` (default) is plane-only (#1891 contract);
+`snapToPlane = false` is FREE PLACEMENT — feature-point hits accepted, plane hits still
+in-polygon. Project acceptance policies (max distance, custom rules) go through `predicate`
+(construction-time). The smoothing knob and callback are live-updatable on recomposition.
+
+Platform matrix: **iOS** — continuous `ARView.raycast` reticle planned under the parity epic
+(#894); tap-to-place itself ships today. **Web** — coming soon.
+
+### ShadowReceiverPlane — invisible AR shadow catcher (#2241, v4.19+)
+
+An invisible surface bound to a detected `Plane` that renders NOTHING except the darkening of
+shadows cast onto it — placed models read as grounded on the real floor instead of floating.
+Filament `shadowMultiplier` material (the AR shadow-catcher feature; port of Depth Lab's
+`ShadowReceiverMeshShader`). Follows the plane's center pose and refined extents; receives
+shadows, never casts; `shadowIntensity` in `0..1` (default 0.6 = Depth Lab) tunable live.
+
+```kotlin
+ARSceneView(onSessionCreated = { arSession = it }) {
+    detectedPlanes.forEach { plane ->
+        key(plane) { ShadowReceiverPlane(plane = plane) }
+    }
+    // Placed ModelNodes cast the shadow (castShadows defaults on).
+}
+```
+
+Shadows require a shadow-casting directional light — `ARSceneView`'s default
+`ENVIRONMENTAL_HDR` light estimation provides one; diagnose the estimated main light's
+`isShadowCaster` before suspecting the catcher. This is NOT a plane visualisation (no grid,
+no fill — that is `PlaneNode`); declare both on the same plane if you want both.
+
+Platform matrix: **iOS** — `GroundingShadowComponent` equivalent planned under #894. **Web** —
+coming soon.
 
 ### Depth hit test — place on any real surface
 


### PR DESCRIPTION
Final PR of the #2241 stack — the doc batch deliberately deferred from #2578/#2580/#2582/#2584.

- **llms.txt**: `### PlaneDiscoveryGuide` (right after the tracking-failure strings it supersedes for onboarding, as the #2578 review recommended), `### PlacementReticle` + `### ShadowReceiverPlane` next to ReticleNode — each with the sibling-of-ARSceneView wiring, timings, contracts (free-placement semantics, hoisted-state durations trap, lighting dependency) and an honest per-platform line.
- **Agent skill** (`agents/sceneview/references/`): cheatsheet "AR placement UX kit" block + a complete tap-to-place recipe; `check-sceneview-skill.sh` green.
- **docs/docs/llms-full.txt**: 3 condensed lines.
- Changelog fragment (Docs).

Docs-only — no code. `check-sceneview-skill.sh` + `check-llms-drift.sh` pass locally.

Refs #2241, #2578, #2580, #2582, #2584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)