### PR TITLE
chore(deps): bump lifecycleRuntimeCompose 2.10.0 → 2.11.0 (supersedes #2543)

### DIFF
--- a/changelog.d/2543-lifecycle-2-11-0.md
+++ b/changelog.d/2543-lifecycle-2-11-0.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Bump `androidx.lifecycle:lifecycle-runtime-compose` / `-testing` 2.10.0 → 2.11.0.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ composeBom = "2026.05.01"
 composeMaterial3Expressive = "1.5.0-alpha18"
 activityCompose = "1.13.0"
 navigationCompose = "2.9.8"
-lifecycleRuntimeCompose = "2.10.0"
+lifecycleRuntimeCompose = "2.11.0"
 
 # Kotlin Libraries
 coroutines = "1.11.0"


### PR DESCRIPTION
Dependabot's #2543 went stale (its CI ran in June and the `@dependabot rebase` command was ignored). Same version bump on a fresh branch: `lifecycle-runtime-compose` + `lifecycle-runtime-testing` 2.10.0 → 2.11.0. `:sceneview:`/`:arsceneview:compileReleaseKotlin` + `:sceneview:testDebugUnitTest` green locally. Closes #2543's intent — will close the PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)