### PR TITLE
fix(qa): device-qa.sh web leg false-FAILs on macOS bash 3.2 (empty array under set -u)

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -449,7 +449,10 @@ run_web() {
   $FAST && spec_args=(tests/render.spec.ts)
 
   local rc=0
-  ( cd "$webdir" && npx playwright test "${spec_args[@]}" ) \
+  # ${arr[@]+…} idiom: bash 3.2 (macOS default) + `set -u` errors on expanding
+  # an EMPTY array — which made the BLOCKING web leg false-FAIL in 25 s on any
+  # Mac host (unbound variable, rc=1, zero tests run).
+  ( cd "$webdir" && npx playwright test ${spec_args[@]+"${spec_args[@]}"} ) \
     > "$ARTIFACTS/web-output.txt" 2>&1 || rc=$?
   cat "$ARTIFACTS/web-output.txt"
 


### PR DESCRIPTION
Found while running the 4.19.0 release checkpoint: the BLOCKING web leg failed in 25 s with `spec_args[@]: unbound variable` — bash 3.2 (macOS default) errors on expanding an empty array under `set -u`, so `device-qa.sh --platform=web` (non-fast) never ran a single Playwright test on a Mac host and the gate said `blocked` against a green suite (35/35 pass when run directly). Same false-FAIL class as #2433. Fix is the standard `${arr[@]+"${arr[@]}"}` idiom. Verified: web leg now passes through the harness, gate verdict `warn` (advisory web-perf CLS only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)