### PR TITLE
feat(ios): grounding shadows + placement reticle on ARSceneView (#894)

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
@@ -597,9 +597,10 @@ public struct ARSceneView: UIViewRepresentable {
         /// `PlacementReticleNode.DEFAULT_ORIENTATION_SMOOTHING`.
         static let reticleSmoothing: Float = 0.75
 
-        /// Reticle disc footprint (metres) — matches the 4 cm radius of the
-        /// built-in disc on Android's `ReticleNode`.
-        static let reticleDiameter: Float = 0.08
+        /// Reticle disc footprint (metres) — visual parity with the built-in
+        /// disc of Android's `PlacementReticle` (`PlacementScene.RETICLE_RADIUS`
+        /// = 0.07 m radius → 14 cm diameter).
+        static let reticleDiameter: Float = 0.14
 
         // Light-slot reactive plumbing — same pattern as ``SceneView`` (#1017)
         // adapted for AR. The anchor refs let the diff in `refreshARLightSlot`
@@ -817,9 +818,11 @@ public struct ARSceneView: UIViewRepresentable {
             )
         }
 
-        /// Builds the reticle — a thin translucent cyan disc (the same look as
-        /// the built-in disc on Android's `ReticleNode`), hosted on a world
-        /// anchor whose transform tracks the smoothed raycast pose.
+        /// Builds the reticle — a thin translucent disc in the design-system
+        /// cyan, matching Android `PlacementReticle`'s built-in disc
+        /// (`PlacementScene.DEFAULT_RETICLE_COLOR` = #44E7FF at ~60 % alpha),
+        /// hosted on a world anchor whose transform tracks the smoothed
+        /// raycast pose.
         private func makeReticleAnchor(in arView: ARView) -> AnchorEntity {
             let anchor = AnchorEntity(world: .zero)
             let mesh = MeshResource.generatePlane(
@@ -827,10 +830,13 @@ public struct ARSceneView: UIViewRepresentable {
                 depth: Self.reticleDiameter,
                 cornerRadius: Self.reticleDiameter / 2
             )
+            // Alpha rides the blending opacity, not the tint: RealityKit is
+            // known to drop the base-color alpha on some material paths, which
+            // would render the disc fully opaque.
             var material = UnlitMaterial(
-                color: .init(red: 0, green: 1, blue: 1, alpha: 0.85)
+                color: .init(red: 0x44 / 255.0, green: 0xE7 / 255.0, blue: 1.0, alpha: 1.0)
             )
-            material.blending = .transparent(opacity: .init(floatLiteral: 1.0))
+            material.blending = .transparent(opacity: .init(floatLiteral: 0.6))
             let disc = ModelEntity(mesh: mesh, materials: [material])
             // Nudge off the surface along the plane normal so the disc never
             // z-fights the detected-plane overlay fill (a 1 mm box).

--- a/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/ARSceneView.swift
@@ -29,6 +29,8 @@ public struct ARSceneView: UIViewRepresentable {
     private var planeDetection: PlaneDetectionMode
     private var showPlaneOverlay: Bool
     private var showCoachingOverlay: Bool
+    private var showPlacementReticle: Bool
+    private var groundingShadows: Bool
     private var cameraExposure: Float?
     private var onTapOnPlane: ((SIMD3<Float>, ARView) -> Void)?
     private var onSessionStarted: ((ARView) -> Void)?
@@ -75,6 +77,22 @@ public struct ARSceneView: UIViewRepresentable {
     ///   - planeDetection: Which plane orientations to detect. Default horizontal.
     ///   - showPlaneOverlay: Whether to visualize detected planes. Default true.
     ///   - showCoachingOverlay: Whether to show coaching when tracking limited. Default true.
+    ///   - showPlacementReticle: Whether to show a placement reticle — a small disc,
+    ///     snapped to the real surface at the screen centre, that previews exactly where
+    ///     a tap-to-place tap will land. Runs the same
+    ///     `raycast(from:allowing:.estimatedPlane, alignment:.any)` query as `onTapOnPlane`,
+    ///     once per AR frame; the reticle hides whenever the ray misses every surface.
+    ///     Orientation is smoothed with a per-frame slerp factor of `0.75` (ARCore Depth
+    ///     Lab's `OrientedReticle` value — Android `PlacementReticle` parity, #2241/#894)
+    ///     so the disc doesn't jitter while ARKit refines the surface estimate. Default false.
+    ///   - groundingShadows: Whether entities placed via `onTapOnPlane` automatically get
+    ///     RealityKit's `GroundingShadowComponent(castsShadow: true)`, so placed models
+    ///     project a contact shadow onto the detected surface and read as grounded instead
+    ///     of floating — the RealityKit analogue of Android's `ShadowReceiverPlane`
+    ///     (#2241/#894). Applied to every model entity of anchors added to
+    ///     `arView.scene` *synchronously inside* the `onTapOnPlane` callback (the
+    ///     documented placement flow); content anchored later (e.g. after an async model
+    ///     load) must set the component itself. Default true.
     ///   - imageTrackingDatabase: Set of reference images to detect. Use
     ///     `AugmentedImageNode.createImageDatabase()` or
     ///     `AugmentedImageNode.referenceImages(inGroupNamed:)` to create.
@@ -101,6 +119,8 @@ public struct ARSceneView: UIViewRepresentable {
         planeDetection: PlaneDetectionMode = .horizontal,
         showPlaneOverlay: Bool = true,
         showCoachingOverlay: Bool = true,
+        showPlacementReticle: Bool = false,
+        groundingShadows: Bool = true,
         cameraExposure: Float? = nil,
         imageTrackingDatabase: Set<ARReferenceImage>? = nil,
         faceTracking: Bool = false,
@@ -111,6 +131,8 @@ public struct ARSceneView: UIViewRepresentable {
         self.planeDetection = planeDetection
         self.showPlaneOverlay = showPlaneOverlay
         self.showCoachingOverlay = showCoachingOverlay
+        self.showPlacementReticle = showPlacementReticle
+        self.groundingShadows = groundingShadows
         self.cameraExposure = cameraExposure
         self.imageTrackingDatabase = imageTrackingDatabase
         self.faceTracking = faceTracking
@@ -264,6 +286,12 @@ public struct ARSceneView: UIViewRepresentable {
         // translucent overlay entity per plane — see `PlaneVisualizer`.
         context.coordinator.showPlaneOverlay = showPlaneOverlay && planeDetection != .none
 
+        // Placement reticle + grounding shadows (#894 — iOS half of #2241 Sprint-1).
+        // The reticle is driven per frame from `session(_:didUpdate:)`; grounding
+        // shadows are applied in `handleTap` to the anchors the callback places.
+        context.coordinator.showPlacementReticle = showPlacementReticle
+        context.coordinator.groundingShadows = groundingShadows
+
         // Coaching overlay
         if showCoachingOverlay {
             let coaching = ARCoachingOverlayView()
@@ -305,6 +333,11 @@ public struct ARSceneView: UIViewRepresentable {
         context.coordinator.onTapOnPlane = onTapOnPlane
         context.coordinator.onImageDetected = onImageDetected
         context.coordinator.onFrame = onFrame
+        // Reactive like the light slots: toggling the flags on a later render
+        // takes effect immediately — the per-frame reticle update tears the
+        // reticle entity down when the flag turns false.
+        context.coordinator.showPlacementReticle = showPlacementReticle
+        context.coordinator.groundingShadows = groundingShadows
 
         // Apply camera exposure override via post-processing (iOS 15.0+).
         // Converts the EV value to a CIColorControls brightness offset and installs
@@ -536,6 +569,38 @@ public struct ARSceneView: UIViewRepresentable {
         /// `session(_:didAdd:)` path cannot be exercised headlessly.
         var planeOverlays: [UUID: PlaneVisualizer] = [:]
 
+        /// Whether the centre-screen placement reticle is active. Set from
+        /// `makeUIView` / `updateUIView`; consumed once per AR frame in
+        /// ``session(_:didUpdate:)`` (#894 — Android `PlacementReticle` parity).
+        var showPlacementReticle: Bool = false
+
+        /// Whether anchors placed via `onTapOnPlane` automatically receive
+        /// `GroundingShadowComponent(castsShadow: true)` on their model
+        /// entities (#894 — Android `ShadowReceiverPlane` analogue).
+        var groundingShadows: Bool = true
+
+        /// World anchor hosting the reticle disc. Created lazily on the first
+        /// successful raycast, hidden (`isEnabled = false`) while the ray
+        /// misses, removed on teardown (#2407/#2408 pattern) or when
+        /// `showPlacementReticle` turns false. `internal` so the teardown leak
+        /// test can provision it headlessly (a headless raycast never hits).
+        var reticleAnchor: AnchorEntity?
+
+        /// Smoothing state for the reticle pose. `nil` after a miss so the next
+        /// surface is re-acquired verbatim — the same reset contract as
+        /// Android's `ReticleOrientationSmoother` (#2582).
+        private var reticleOrientation: simd_quatf?
+        private var reticlePosition: SIMD3<Float>?
+
+        /// Per-frame slerp/lerp fraction toward the raycast pose — ARCore Depth
+        /// Lab's `OrientedReticle` damping value, shared with Android's
+        /// `PlacementReticleNode.DEFAULT_ORIENTATION_SMOOTHING`.
+        static let reticleSmoothing: Float = 0.75
+
+        /// Reticle disc footprint (metres) — matches the 4 cm radius of the
+        /// built-in disc on Android's `ReticleNode`.
+        static let reticleDiameter: Float = 0.08
+
         // Light-slot reactive plumbing — same pattern as ``SceneView`` (#1017)
         // adapted for AR. The anchor refs let the diff in `refreshARLightSlot`
         // tear down the previous light's `AnchorEntity` before adding a new one.
@@ -593,6 +658,11 @@ public struct ARSceneView: UIViewRepresentable {
             mainLightAnchor = nil
             fillLightAnchor = nil
 
+            // Placement reticle (#894) — same coordinator-owned-anchor rule as
+            // the overlays and lights above.
+            if let reticle = reticleAnchor { arView.scene.removeAnchor(reticle) }
+            reticleAnchor = nil
+
             // Stop the AR session so the camera + sensor pipeline goes idle and
             // ARKit drops its hold; detach the delegate so no late frame
             // callback fires into a torn-down coordinator.
@@ -616,16 +686,20 @@ public struct ARSceneView: UIViewRepresentable {
             let overlayAnchors = planeOverlays.values.map(\.anchor)
             let main = mainLightAnchor
             let fill = fillLightAnchor
+            let reticle = reticleAnchor
             planeOverlays.removeAll()
             mainLightAnchor = nil
             fillLightAnchor = nil
+            reticleAnchor = nil
             guard let arView = arView,
-                  !overlayAnchors.isEmpty || main != nil || fill != nil else { return }
+                  !overlayAnchors.isEmpty || main != nil || fill != nil
+                    || reticle != nil else { return }
             let detach = {
                 MainActor.assumeIsolated {
                     for anchor in overlayAnchors { arView.scene.removeAnchor(anchor) }
                     if let main = main { arView.scene.removeAnchor(main) }
                     if let fill = fill { arView.scene.removeAnchor(fill) }
+                    if let reticle = reticle { arView.scene.removeAnchor(reticle) }
                 }
             }
             if Thread.isMainThread {
@@ -645,18 +719,134 @@ public struct ARSceneView: UIViewRepresentable {
                 allowing: .estimatedPlane,
                 alignment: .any
             )
-            if let firstResult = results.first {
-                let column = firstResult.worldTransform.columns.3
-                let position = SIMD3<Float>(column.x, column.y, column.z)
-                onTapOnPlane?(position, arView)
+            guard let firstResult = results.first,
+                  let onTapOnPlane = onTapOnPlane else { return }
+            let column = firstResult.worldTransform.columns.3
+            let position = SIMD3<Float>(column.x, column.y, column.z)
+
+            // Grounding shadows (#894): snapshot the scene's anchors, let the
+            // callback place its content, then give every model entity the
+            // callback anchored a RealityKit contact shadow. Covers the
+            // documented synchronous placement flow; asynchronously anchored
+            // content must set `GroundingShadowComponent` itself.
+            let anchorsBefore = groundingShadows
+                ? Set(arView.scene.anchors.map(\.id)) : []
+            onTapOnPlane(position, arView)
+            if groundingShadows {
+                applyGroundingShadows(in: arView, addedSince: anchorsBefore)
             }
+        }
+
+        /// Applies `GroundingShadowComponent(castsShadow: true)` to every model
+        /// entity under anchors that joined `arView.scene` after the snapshot —
+        /// the RealityKit analogue of Android's invisible `ShadowReceiverPlane`
+        /// (#2241/#894): RealityKit itself renders the contact shadow onto the
+        /// detected real-world surface, no shadow-catcher geometry needed.
+        func applyGroundingShadows(in arView: ARView, addedSince existing: Set<Entity.ID>) {
+            for anchor in arView.scene.anchors where !existing.contains(anchor.id) {
+                Self.applyGroundingShadow(to: anchor)
+            }
+        }
+
+        /// Recursively sets the grounding-shadow component on `entity` and its
+        /// descendants that render a model. Idempotent — re-setting the
+        /// component on an entity that already has one is a no-op overwrite.
+        static func applyGroundingShadow(to entity: Entity) {
+            if entity.components.has(ModelComponent.self) {
+                entity.components.set(GroundingShadowComponent(castsShadow: true))
+            }
+            for child in entity.children {
+                applyGroundingShadow(to: child)
+            }
+        }
+
+        // MARK: - Placement reticle (#894)
+
+        /// Per-frame reticle update, driven from ``session(_:didUpdate:)`` —
+        /// ARKit delivers session callbacks on the main thread for
+        /// `ARSceneView` (no `delegateQueue` override), so touching RealityKit
+        /// and `arView.bounds` here is safe. `internal` so tests can drive the
+        /// disabled/teardown paths headlessly.
+        func updatePlacementReticle(in arView: ARView) {
+            guard showPlacementReticle else {
+                // Flag turned off (or never on): tear the reticle down.
+                if let anchor = reticleAnchor {
+                    arView.scene.removeAnchor(anchor)
+                    reticleAnchor = nil
+                }
+                reticleOrientation = nil
+                reticlePosition = nil
+                return
+            }
+
+            // The same query the tap-to-place path uses, cast from the screen
+            // centre — what the reticle shows is exactly where a tap lands.
+            let center = CGPoint(x: arView.bounds.midX, y: arView.bounds.midY)
+            guard let result = arView.raycast(
+                from: center,
+                allowing: .estimatedPlane,
+                alignment: .any
+            ).first else {
+                // Ray misses every surface: hide, and forget the damping state
+                // so the next surface is re-acquired verbatim (Android
+                // `ReticleOrientationSmoother.reset()` contract).
+                reticleAnchor?.isEnabled = false
+                reticleOrientation = nil
+                reticlePosition = nil
+                return
+            }
+
+            let anchor = reticleAnchor ?? makeReticleAnchor(in: arView)
+            anchor.isEnabled = true
+
+            let target = Transform(matrix: result.worldTransform)
+            // Exponential per-frame damping toward the hit pose (factor 0.75,
+            // Depth Lab / Android PlacementReticle parity) — kills the jitter
+            // of ARKit's frame-to-frame surface refinement. The first sample
+            // after a miss applies verbatim, so the reticle never "rolls in".
+            let rotation = reticleOrientation.map {
+                simd_slerp($0, target.rotation, Self.reticleSmoothing)
+            } ?? target.rotation
+            let position = reticlePosition.map {
+                simd_mix($0, target.translation, SIMD3<Float>(repeating: Self.reticleSmoothing))
+            } ?? target.translation
+            reticleOrientation = rotation
+            reticlePosition = position
+            anchor.transform = Transform(
+                scale: .one, rotation: rotation, translation: position
+            )
+        }
+
+        /// Builds the reticle — a thin translucent cyan disc (the same look as
+        /// the built-in disc on Android's `ReticleNode`), hosted on a world
+        /// anchor whose transform tracks the smoothed raycast pose.
+        private func makeReticleAnchor(in arView: ARView) -> AnchorEntity {
+            let anchor = AnchorEntity(world: .zero)
+            let mesh = MeshResource.generatePlane(
+                width: Self.reticleDiameter,
+                depth: Self.reticleDiameter,
+                cornerRadius: Self.reticleDiameter / 2
+            )
+            var material = UnlitMaterial(
+                color: .init(red: 0, green: 1, blue: 1, alpha: 0.85)
+            )
+            material.blending = .transparent(opacity: .init(floatLiteral: 1.0))
+            let disc = ModelEntity(mesh: mesh, materials: [material])
+            // Nudge off the surface along the plane normal so the disc never
+            // z-fights the detected-plane overlay fill (a 1 mm box).
+            disc.position.y = 0.002
+            anchor.addChild(disc)
+            arView.scene.addAnchor(anchor)
+            reticleAnchor = anchor
+            return anchor
         }
 
         // MARK: - ARSessionDelegate
 
         public func session(_ session: ARSession, didUpdate frame: ARFrame) {
-            guard let arView = arView, let onFrame = onFrame else { return }
-            onFrame(frame, arView)
+            guard let arView = arView else { return }
+            updatePlacementReticle(in: arView)
+            onFrame?(frame, arView)
         }
 
         public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ARSceneViewPlacementTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ARSceneViewPlacementTests.swift
@@ -1,0 +1,152 @@
+#if os(iOS)
+import XCTest
+import ARKit
+import RealityKit
+@testable import SceneViewSwift
+
+/// Regression guard for the #894 iOS placement quick-wins (the iOS half of the
+/// #2241 Sprint-1 design, §3.A):
+/// - grounding shadows — anchors placed via `onTapOnPlane` get
+///   `GroundingShadowComponent(castsShadow: true)` on their model entities
+///   (Android `ShadowReceiverPlane` analogue),
+/// - placement reticle — the coordinator-owned reticle anchor must obey the
+///   same lifecycle rules as the plane overlays (#2407) and light anchors
+///   (#2408): removed when the flag turns off and on `dismantleUIView`.
+///
+/// A headless `ARView` never produces a raycast hit, so the reticle's
+/// hit-driven path (entity creation, pose smoothing) is not testable here —
+/// these tests provision the anchor directly, exactly like
+/// `ARSceneViewTeardownTests` provisions overlays and lights.
+@MainActor
+final class ARSceneViewPlacementTests: XCTestCase {
+
+    /// Builds a coordinator wired to a fresh `ARView`, exactly as `makeUIView`
+    /// does (session delegate + `arView` back-reference).
+    private func makeWiredCoordinator() -> (ARView, ARSceneView.Coordinator) {
+        let arView = ARView(frame: .zero)
+        let coordinator = ARSceneView.Coordinator(
+            onTapOnPlane: nil,
+            planeDetection: .horizontal
+        )
+        coordinator.arView = arView
+        arView.session.delegate = coordinator
+        return (arView, coordinator)
+    }
+
+    // MARK: - Grounding shadows (#894)
+
+    /// Anchors added after the snapshot get the component on every descendant
+    /// with a model; pre-existing anchors are left untouched.
+    func testGroundingShadowAppliedOnlyToNewlyPlacedAnchors() {
+        let (arView, coordinator) = makeWiredCoordinator()
+
+        // Pre-existing content (e.g. a light anchor) — must NOT be touched.
+        let existingAnchor = AnchorEntity(world: .zero)
+        let existingModel = ModelEntity(
+            mesh: .generateBox(size: 0.1), materials: [SimpleMaterial()]
+        )
+        existingAnchor.addChild(existingModel)
+        arView.scene.addAnchor(existingAnchor)
+
+        let before = Set(arView.scene.anchors.map(\.id))
+
+        // "Placed" content — a nested hierarchy, model entity one level down,
+        // mirroring the documented AnchorNode.world + add(child) flow.
+        let placedAnchor = AnchorEntity(world: .zero)
+        let group = Entity()
+        let placedModel = ModelEntity(
+            mesh: .generateBox(size: 0.1), materials: [SimpleMaterial()]
+        )
+        group.addChild(placedModel)
+        placedAnchor.addChild(group)
+        arView.scene.addAnchor(placedAnchor)
+
+        coordinator.applyGroundingShadows(in: arView, addedSince: before)
+
+        XCTAssertTrue(
+            placedModel.components.has(GroundingShadowComponent.self),
+            "placed model entities must receive the grounding shadow (#894)"
+        )
+        XCTAssertFalse(
+            group.components.has(GroundingShadowComponent.self),
+            "entities without a ModelComponent must not get the component"
+        )
+        XCTAssertFalse(
+            existingModel.components.has(GroundingShadowComponent.self),
+            "pre-existing anchors must not be mutated by a later placement"
+        )
+    }
+
+    /// The recursive helper sets `castsShadow` — the value RealityKit needs to
+    /// project a contact shadow onto detected surfaces.
+    func testGroundingShadowCastsShadow() {
+        let model = ModelEntity(
+            mesh: .generateBox(size: 0.1), materials: [SimpleMaterial()]
+        )
+        ARSceneView.Coordinator.applyGroundingShadow(to: model)
+        let component = model.components[GroundingShadowComponent.self]
+        XCTAssertEqual(component?.castsShadow, true)
+    }
+
+    // MARK: - Placement reticle lifecycle (#894)
+
+    /// Turning the flag off must remove the coordinator-owned reticle anchor
+    /// from the scene on the next per-frame update.
+    func testReticleRemovedWhenFlagTurnsOff() {
+        let (arView, coordinator) = makeWiredCoordinator()
+        let anchor = AnchorEntity(world: .zero)
+        arView.scene.addAnchor(anchor)
+        coordinator.reticleAnchor = anchor
+        coordinator.showPlacementReticle = false
+
+        coordinator.updatePlacementReticle(in: arView)
+
+        XCTAssertNil(coordinator.reticleAnchor)
+        XCTAssertTrue(
+            arView.scene.anchors.isEmpty,
+            "reticle anchor must leave the scene when the flag turns off (#894)"
+        )
+    }
+
+    /// With the flag on but no raycast hit (always the case headlessly), the
+    /// reticle must stay hidden and no anchor may be created.
+    func testReticleHiddenOnRaycastMiss() {
+        let (arView, coordinator) = makeWiredCoordinator()
+        coordinator.showPlacementReticle = true
+
+        coordinator.updatePlacementReticle(in: arView)
+
+        XCTAssertNil(
+            coordinator.reticleAnchor,
+            "no reticle entity may be provisioned while the ray misses (#894)"
+        )
+        XCTAssertTrue(arView.scene.anchors.isEmpty)
+    }
+
+    /// `dismantleUIView` must release the reticle anchor like every other
+    /// coordinator-owned anchor (#2407/#2408 teardown contract).
+    func testDismantleReleasesReticleAnchor() {
+        weak var weakReticle: AnchorEntity?
+        let (arView, coordinator) = makeWiredCoordinator()
+
+        autoreleasepool {
+            let reticle = AnchorEntity(world: .zero)
+            weakReticle = reticle
+            arView.scene.addAnchor(reticle)
+            coordinator.reticleAnchor = reticle
+            coordinator.showPlacementReticle = true
+            XCTAssertEqual(arView.scene.anchors.count, 1)
+
+            ARSceneView.dismantleUIView(arView, coordinator: coordinator)
+
+            XCTAssertNil(coordinator.reticleAnchor)
+            XCTAssertTrue(
+                arView.scene.anchors.isEmpty,
+                "reticle anchor must be removed from the AR scene on teardown (#894)"
+            )
+        }
+
+        XCTAssertNil(weakReticle, "reticle anchor leaked past teardown (#894)")
+    }
+}
+#endif // os(iOS)

--- a/agents/sceneview-ios/SKILL.md
+++ b/agents/sceneview-ios/SKILL.md
@@ -138,6 +138,9 @@ ARSceneView(
     planeDetection: .horizontal,        // .horizontal | .vertical | .both | .none
     showPlaneOverlay: true,
     showCoachingOverlay: true,
+    showPlacementReticle: true,   // built-in smoothed placement cursor (#894)
+    // groundingShadows: true is the default — tap-placed models get a
+    // RealityKit contact shadow automatically (opt out with false).
     onTapOnPlane: { position, arView in
         let anchor = AnchorNode.world(position: position)
         let cube = GeometryNode.cube(size: 0.1, color: .blue)

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -50,6 +50,8 @@ ARSceneView(
     planeDetection: .horizontal,   // .horizontal | .vertical | .both | .none
     showPlaneOverlay: true,
     showCoachingOverlay: true,
+    showPlacementReticle: true,   // continuous smoothed placement cursor (#894, opt-in)
+    groundingShadows: true,       // contact shadows on tap-placed models (#894, DEFAULT ON — opt out with false; sync placement flow only)
     onTapOnPlane: { position, arView in /* place content */ }
 )
     .onSessionStarted { arView in }

--- a/agents/sceneview/references/cheatsheet.md
+++ b/agents/sceneview/references/cheatsheet.md
@@ -73,7 +73,7 @@ Box {
 
 `PlaneDiscoveryGuide` = timed hand-hint/help onboarding (replaces static "Scanning…" banners).
 `snapToPlane=false` on the reticle = free placement (points accepted, planes in-polygon).
-iOS: coaching overlay = `ARSceneView(showCoachingOverlay: true)` (native); shadows/reticle → #894.
+iOS: coaching overlay = `ARSceneView(showCoachingOverlay: true)` (native); reticle = `showPlacementReticle: true`, contact shadows = `groundingShadows` (default on) — #894 shipped.
 
 ## Remember helpers (always use these)
 

--- a/changelog.d/894-ios-grounding-reticle.md
+++ b/changelog.d/894-ios-grounding-reticle.md
@@ -1,0 +1,9 @@
+<!-- category: Added -->
+- **iOS `ARSceneView(showPlacementReticle:)`** — opt-in placement reticle: the tap-to-place
+  raycast now runs every AR frame and drives a surface-snapped translucent disc at the screen
+  centre (orientation slerp `0.75`, Depth Lab / Android `PlacementReticle` parity; hidden while
+  the ray misses). Android's `PlacementReticle` iOS counterpart from the Sprint-1 design (#894).
+- **iOS `ARSceneView(groundingShadows:)`** — entities placed synchronously in `onTapOnPlane` now
+  automatically get RealityKit's `GroundingShadowComponent(castsShadow: true)`, projecting a
+  contact shadow onto the detected surface — the RealityKit analogue of Android's
+  `ShadowReceiverPlane` (#2580). Opt out with `groundingShadows: false` (#894).

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -62,6 +62,8 @@ ARSceneView(
     planeDetection: .horizontal,       // .horizontal, .vertical, .both, .none
     showPlaneOverlay: true,            // visualize detected planes
     showCoachingOverlay: true,         // ARKit coaching UI
+    showPlacementReticle: true,        // smoothed placement cursor (#894, opt-in)
+    groundingShadows: true,            // contact shadows on placed models (default on)
     onTapOnPlane: { position, arView in
         let anchor = AnchorNode.world(position: position)
         anchor.add(model.entity)

--- a/llms.txt
+++ b/llms.txt
@@ -4670,6 +4670,8 @@ ARSceneView(
     planeDetection: .horizontal,
     showPlaneOverlay: true,
     showCoachingOverlay: true,
+    showPlacementReticle: Bool = false,      // continuous smoothed placement cursor (#894)
+    groundingShadows: Bool = true,           // contact shadows on tap-placed models (#894)
     onTapOnPlane: { position in /* SIMD3<Float> world-space */ }
 )
 .content { arView in /* add content */ }
@@ -4682,6 +4684,8 @@ public struct ARSceneView: UIViewRepresentable {
         planeDetection: PlaneDetectionMode = .horizontal,
         showPlaneOverlay: Bool = true,
         showCoachingOverlay: Bool = true,
+        showPlacementReticle: Bool = false,      // continuous smoothed placement cursor (#894)
+        groundingShadows: Bool = true,           // contact shadows on tap-placed models (#894)
         cameraExposure: Float? = nil,
         imageTrackingDatabase: Set<ARReferenceImage>? = nil,
         faceTracking: Bool = false,

--- a/llms.txt
+++ b/llms.txt
@@ -1179,8 +1179,9 @@ Semantics: `snapToPlane = true` (default) is plane-only (#1891 contract);
 in-polygon. Project acceptance policies (max distance, custom rules) go through `predicate`
 (construction-time). The smoothing knob and callback are live-updatable on recomposition.
 
-Platform matrix: **iOS** — continuous `ARView.raycast` reticle planned under the parity epic
-(#894); tap-to-place itself ships today. **Web** — coming soon.
+Platform matrix: **iOS** — ships (v4.20+, #894): `ARSceneView(showPlacementReticle: true)` runs
+the tap-to-place raycast every frame and drives a surface-snapped disc (orientation slerp `0.75`,
+hidden while the ray misses); tap-to-place itself already ships. **Web** — coming soon.
 
 ### ShadowReceiverPlane — invisible AR shadow catcher (#2241, v4.19+)
 
@@ -1204,8 +1205,10 @@ Shadows require a shadow-casting directional light — `ARSceneView`'s default
 `isShadowCaster` before suspecting the catcher. This is NOT a plane visualisation (no grid,
 no fill — that is `PlaneNode`); declare both on the same plane if you want both.
 
-Platform matrix: **iOS** — `GroundingShadowComponent` equivalent planned under #894. **Web** —
-coming soon.
+Platform matrix: **iOS** — ships (v4.20+, #894): entities placed synchronously in `onTapOnPlane`
+get `GroundingShadowComponent(castsShadow: true)` automatically (RealityKit renders the contact
+shadow itself — no catcher geometry; opt out with `ARSceneView(groundingShadows: false)`;
+async-anchored content sets the component itself). **Web** — coming soon.
 
 ### Depth hit test — place on any real surface
 


### PR DESCRIPTION
Implements the two **§3.A quick-wins** of the committed Sprint-1 design (`.claude/plans/ar-v2-sprint1-design.md`) for the iOS parity epic #894 — the iOS half of #2241.

## Design → code mapping

| Design (§3.A) | Code |
|---|---|
| "add `GroundingShadowComponent(castsShadow: true)` to placed entities" (handleTap :643-653) | `ARSceneView(groundingShadows: Bool = true)` (opt-out, consistent with `showCoachingOverlay` :102). `Coordinator.handleTap` snapshots `scene.anchors` before the `onTapOnPlane` callback and applies the component recursively to every `ModelComponent` entity of newly added anchors — RealityKit renders the contact shadow onto detected surfaces itself, no catcher geometry (the RealityKit-idiomatic analogue of Android `ShadowReceiverPlane` #2580). Min deployment is iOS 18, so no availability guard needed. |
| "run the same raycast each frame in `session(_:didUpdate:)` (:657-660), place a reticle entity at the result's `worldTransform`, hide it when the raycast is empty" | `ARSceneView(showPlacementReticle: Bool = false)` (opt-in). `Coordinator.updatePlacementReticle(in:)` runs the identical `.estimatedPlane`/`.any` query from the screen centre once per frame, drives a thin translucent cyan disc (same look as Android `ReticleNode`'s built-in disc), `isEnabled = false` on miss. |
| slerp smoothing, factor 0.75 (Android `PlacementReticle` #2582 parity) | Per-frame `simd_slerp` (orientation) + `simd_mix` (position) at `0.75` (Depth Lab `OrientedReticle` value); damping state resets on miss so the next surface is re-acquired verbatim — same contract as Android's `ReticleOrientationSmoother.reset()`. |
| Reticle/shadow lifecycle | Reticle anchor follows the #2407/#2408 coordinator-owned-anchor teardown contract: removed in `dismantleUIView` → `tearDownScene`, in the `deinit` safety net, and reactively when the flag turns off (flags are live-updatable from `updateUIView`, like the light slots). |
| `ARCoachingOverlayView` onboarding (PlaneDiscoveryGuide parity) | **Already shipped** — wired at ARSceneView.swift `makeUIView` with the goal mapping; the design marks it FREE. Nothing to do; noted for completeness. |

## Compile & test proof (local, Xcode 26 toolchain)

- `xcodebuild build -scheme SceneViewSwift -destination 'generic/platform=iOS Simulator' -skipMacroValidation` → **BUILD SUCCEEDED**, 0 errors (remaining warnings are the pre-existing Swift-6 concurrency warnings in `NodeBuilder.swift`, untouched).
- `xcodebuild test … -only-testing:…/ARSceneViewPlacementTests -only-testing:…/ARSceneViewTeardownTests` on iPhone 17 Pro sim → **TEST SUCCEEDED**, 8/8 (5 new + the 3 existing teardown guards).

## Docs

- `llms.txt`: only the two platform-matrix lines (PlacementReticle / ShadowReceiverPlane sections) — iOS "planned under #894" → "ships (v4.20+, #894)" with the exact API + honest caveat.
- `changelog.d/894-ios-grounding-reticle.md` (`<!-- category: Added -->`).
- No other doc surface mentions these (grep over `agents/sceneview-ios/`, `cheatsheet-ios.md` — clean).

## Honest gaps

- **No simulator visual proof**: ARKit world tracking doesn't run on the iOS simulator, so the reticle's hit-driven path (entity creation, pose smoothing) can't be observed there. Tests cover the lifecycle paths that ARE headlessly reachable (flag-off teardown, miss path, dismantle leak, shadow diff/recursion); the raycast-hit branch is exercised only by compile + review. A physical-device pass would be the real confirmation.
- **Grounding shadows cover the synchronous placement flow only** (the documented `onTapOnPlane` pattern). Content anchored later — e.g. after an async model load — must set `GroundingShadowComponent` itself; documented in the param doc + llms.txt.
- iOS stays a strict subset of Android: no `depthPoint`/`predicate`/`shadowIntensity` knobs — those remain Android-only and their llms.txt sections still say so.

**No auto-merge** — cross-platform public API; orchestrator review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
