### PR TITLE
docs: node-count claims 42+ → 44+ across all doc surfaces (#2594)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -87,7 +87,7 @@ struct ContentView: View {
 }
 ```
 
-## 42+ node types
+## 44+ node types
 ModelNode, CubeNode, SphereNode, CylinderNode, PlaneNode, MeshNode,
 ImageNode, VideoNode, ViewNode, LightNode, DynamicSkyNode, FogNode,
 ReflectionProbeNode, LineNode, PathNode, BillboardNode, TextNode,

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ You get:
 - **Only** Compose-native 3D/AR SDK for Android — no alternative exists
 - **Compose-native successor** to Google Sceneform (archived 2021) — see [above](#the-compose-native-successor-to-sceneform)
 - **~5MB** footprint vs 50-100MB+ for Unity/Unreal
-- **42+ node types** as declarative composables
+- **44+ node types** as declarative composables
 - **MCP server** with 28+ tools — no other 3D SDK has this
 
 Listed on the [MCP Registry](https://registry.modelcontextprotocol.io). See the [MCP README](./mcp/README.md) for full setup and tool reference.

--- a/changelog.d/2594-node-count-44.md
+++ b/changelog.d/2594-node-count-44.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Node-count claims aligned to reality: "42+ node types" → "44+" across README, website, MCP docs and doc site (PlacementReticleNode + ShadowReceiverPlaneNode joined the inventory in #2241) — impact-check.sh runs clean again (#2594).

--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -1,6 +1,6 @@
 ---
 title: API Cheatsheet — SceneView Android
-description: "Complete API reference for SceneView's 42+ node types, composables, resource loading, camera controls, gestures, and AR features on Android."
+description: "Complete API reference for SceneView's 44+ node types, composables, resource loading, camera controls, gestures, and AR features on Android."
 ---
 
 # API Cheatsheet

--- a/docs/docs/manifest.json
+++ b/docs/docs/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SceneView — 3D & AR SDK for Android and iOS",
   "short_name": "SceneView",
-  "description": "The #1 open-source 3D & AR SDK for Android and iOS. Compose-native on Android, SwiftUI-native on iOS, shared core via Kotlin Multiplatform. 42+ node types, physics, AR, and AI-assisted development.",
+  "description": "The #1 open-source 3D & AR SDK for Android and iOS. Compose-native on Android, SwiftUI-native on iOS, shared core via Kotlin Multiplatform. 44+ node types, physics, AR, and AI-assisted development.",
   "start_url": "/",
   "scope": "/",
   "id": "/",

--- a/docs/docs/platforms.md
+++ b/docs/docs/platforms.md
@@ -29,7 +29,7 @@ SceneView uses **native renderers per platform** for the best performance and to
 
 The primary platform. SceneView wraps Google Filament (PBR rendering) and ARCore (augmented reality) in Jetpack Compose composables.
 
-- **3D**: `SceneView { }` composable with 42+ node types
+- **3D**: `SceneView { }` composable with 44+ node types
 - **AR**: `ARSceneView { }` with plane detection, image tracking, face mesh, cloud anchors, geospatial
 - **Min SDK**: 24 (Android 7.0)
 - **Install**: `implementation("io.github.sceneview:sceneview:4.20.0")`

--- a/docs/docs/structured-data.json
+++ b/docs/docs/structured-data.json
@@ -537,7 +537,7 @@
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "@id": "https://sceneview.github.io/cheatsheet/#techarticle",
-    "headline": "SceneView API Cheatsheet — Complete Reference for 42+ Node Types",
+    "headline": "SceneView API Cheatsheet — Complete Reference for 44+ Node Types",
     "description": "Complete API reference for SceneView SDK covering all node types, composables, resource loading, camera controls, gestures, and AR features.",
     "url": "https://sceneview.github.io/cheatsheet/",
     "author": {

--- a/docs/docs/try.md
+++ b/docs/docs/try.md
@@ -41,7 +41,7 @@ Run `./tools/try-demo.sh --help` for the full list.
 
 <div class="try-download-card">
 <h3>Android Demo</h3>
-<p>Full showcase: 4 tabs, 47 interactive demos, 42+ node types, animations, physics, post-processing.</p>
+<p>Full showcase: 4 tabs, 47 interactive demos, 44+ node types, animations, physics, post-processing.</p>
 <a href="https://github.com/sceneview/sceneview/releases/latest/download/sceneview-android-demo.apk" class="md-button md-button--primary">
 Download APK
 </a>
@@ -116,7 +116,7 @@ Night, studio, warm, sunset, outdoor, autumn
 </div>
 
 <div class="try-feature">
-<strong>42+ node types</strong><br>
+<strong>44+ node types</strong><br>
 Model, Light, Cube, Sphere, Text, Path, Video, View...
 </div>
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -111,7 +111,7 @@ Every developer tool is **free**: setup guides for every platform, code samples,
 
 | Tool | What it does |
 |---|---|
-| `get_node_reference` | Full API reference for any of 42+ node types — exact signatures, defaults, examples |
+| `get_node_reference` | Full API reference for any of 44+ node types — exact signatures, defaults, examples |
 | `list_platforms` | Supported platforms with their status, renderer, and framework |
 | `get_platform_roadmap` | Multi-platform status and timeline |
 
@@ -208,7 +208,7 @@ The assistant calls `validate_code` with the generated snippet and checks it aga
 - Always use the current SceneView 4.0.x API surface
 - Generate correct **Compose-native** 3D/AR code for Android
 - Generate correct **SwiftUI-native** code for iOS/macOS/visionOS
-- Know about all 42+ node types and their exact parameters
+- Know about all 44+ node types and their exact parameters
 - Validate code against 15+ rules before presenting it
 - Provide working, tested sample code for 33 scenarios
 

--- a/mcp/src/guides.ts
+++ b/mcp/src/guides.ts
@@ -36,7 +36,7 @@ KMP shares **logic**, not **rendering**. Each platform uses its native renderer.
 - **3D rendering** via Google Filament: PBR materials, HDR environments, glTF/GLB models, post-processing.
 - **AR** via ARCore: plane detection, hit testing, anchors, cloud anchors, augmented images, depth, light estimation, point cloud.
 - **Compose-native DSL**: all nodes are \`@Composable\` functions inside \`SceneView { }\` or \`ARSceneView { }\`.
-- **42+ node types**: ModelNode, LightNode, AnchorNode, CameraNode, TextNode, PathNode, ViewNode, PlaneNode, SphereNode, CylinderNode, CubeNode, DynamicSkyNode, FogNode, ReflectionProbeNode, PhysicsNode, BillboardNode, LineNode, and more.
+- **44+ node types**: ModelNode, LightNode, AnchorNode, CameraNode, TextNode, PathNode, ViewNode, PlaneNode, SphereNode, CylinderNode, CubeNode, DynamicSkyNode, FogNode, ReflectionProbeNode, PhysicsNode, BillboardNode, LineNode, and more.
 
 ## Apple — Alpha (SceneViewSwift)
 

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -136,7 +136,7 @@
         "name": "How do I add 3D to my Android Jetpack Compose app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.20.0\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 42+ node types, and adds only ~5MB to your APK."
+          "text": "Use SceneView SDK — the only Compose-native 3D library for Android. Add implementation(\"io.github.sceneview:sceneview:4.20.0\") to your build.gradle, then use SceneView { ModelNode(...) } composable. SceneView wraps Google Filament with a declarative API, supports 44+ node types, and adds only ~5MB to your APK."
         }
       },
       {
@@ -811,12 +811,12 @@
   <section class="features" id="features">
     <div class="features__container">
       <h2 class="features__title reveal">What you can build</h2>
-      <p class="features__subtitle reveal">42+ node types, full ARCore + ARKit coverage, physics, post-processing, and Compose UI inside a 3D scene.</p>
+      <p class="features__subtitle reveal">44+ node types, full ARCore + ARKit coverage, physics, post-processing, and Compose UI inside a 3D scene.</p>
 
       <div class="features__grid">
         <div class="feature-card reveal">
           <span class="feature-card__icon material-symbols-outlined">view_in_ar</span>
-          <h3 class="feature-card__title">42+ Node Types</h3>
+          <h3 class="feature-card__title">44+ Node Types</h3>
           <p class="feature-card__text">Models, primitives (cube, sphere, cone, torus, capsule), curves, shapes, text, video, billboard sprites, lights, reflection probes, dynamic sky, fog, physics, and more &mdash; every one a Composable / SwiftUI view.</p>
           <div class="feature-card__chips">
             <span class="feature-card__chip">Android</span>


### PR DESCRIPTION
The #2241 Sprint-1 nodes (`PlacementReticleNode`, `ShadowReceiverPlaneNode`) grew the real inventory to **44**; 10 doc surfaces still claimed "42+" and `impact-check.sh` FAILed on main. All claims updated (README, website index/JSON-LD, mcp README+guides, docs platforms/cheatsheet/try/manifest/structured-data, .cursorrules); the checker's own example strings left alone. `impact-check.sh` → 0 FAIL, `test-impact-check.sh` 4/4.

Fixes #2594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)