### PR TITLE
feat(tooling): codify model/effort routing across agents and saved workflows

### DIFF
--- a/.claude/agents/sv-code-reviewer.md
+++ b/.claude/agents/sv-code-reviewer.md
@@ -1,6 +1,8 @@
 ---
 name: sv-code-reviewer
 description: Correctness + threading + minimality reviewer for a SceneView change. Filament JNI main-thread rule, Compose/SwiftUI idiom, behavior-preservation, edge cases. Read-only; ERROR = blocks merge.
+model: opus
+effort: high
 ---
 
 You are the **code reviewer** for a SceneView change (AI-first 3D/AR SDK: Android Jetpack Compose +

--- a/.claude/agents/sv-doc-freshness.md
+++ b/.claude/agents/sv-doc-freshness.md
@@ -1,6 +1,8 @@
 ---
 name: sv-doc-freshness
 description: AI-first documentation-drift reviewer for a SceneView change. llms.txt / KDoc / docs/docs / recipes / agent skills / cheatsheets / changelog fragment must stay truthful for any public change. Read-only; usually WARNING.
+model: sonnet
+effort: medium
 ---
 
 You are the **doc-freshness reviewer** for a SceneView change. Review `git diff main...HEAD` (and

--- a/.claude/agents/sv-impact-reviewer.md
+++ b/.claude/agents/sv-impact-reviewer.md
@@ -1,6 +1,8 @@
 ---
 name: sv-impact-reviewer
 description: Cross-platform public-API impact reviewer for SceneView. The autonomous-merge SAFETY GATE — a breaking public-API change or an unmirrored cross-platform divergence is an ERROR that BLOCKS auto-merge. Read-only.
+model: opus
+effort: xhigh
 ---
 
 You are the **impact reviewer** for a SceneView change. SceneView is an AI-first 3D/AR SDK

--- a/.claude/agents/sv-security-reviewer.md
+++ b/.claude/agents/sv-security-reviewer.md
@@ -1,6 +1,8 @@
 ---
 name: sv-security-reviewer
 description: Security + secrets + supply-chain reviewer for a SceneView change. No committed keys, safe deserialization, sane permission scopes, no untrusted-input footguns. Read-only; ERROR = blocks merge.
+model: opus
+effort: high
 ---
 
 You are the **security reviewer** for a SceneView change. Review `git diff main...HEAD` (and

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -147,6 +147,27 @@ Every `*.js` in this directory MUST:
 6. **`isolation:'worktree'`** only for agents that mutate files in parallel; lean-clone in the agent prompt otherwise. `budget`-gate deep loops (`while (budget.total && budget.remaining() > 50_000)`).
 7. **Report incrementally** (`log()` at phase boundaries) so a budget/session cap never loses everything.
 8. **Be resumable** — pure of `Date.now()`/`Math.random()`; stamp timestamps after return or pass via `args`.
+9. **Codify `{model, effort}` on every `agent()` call** per the routing matrix below — never
+   leave a background agent on session-inherit (an inherited Fable default dies on the monthly
+   Fable quota mid-fan-out; that killed reviews twice, see STATE history). Where a call uses
+   `agentType: 'sv-*'`, the model/effort live in that agent's frontmatter
+   (`.claude/agents/sv-*.md`) — do not duplicate them in the opts.
+
+### Model & effort routing matrix (single source of truth)
+
+Cheap + mechanical → small model, low effort; judgment + gate → big model, high effort.
+`fable` is **never** hard-pinned in workflows/agents (monthly-quota SPOF for background work);
+it stays the interactive orchestrator's session model. `haiku` has no `xhigh`/`max`.
+
+| Classe de tâche | model | effort | Exemples |
+|---|---|---|---|
+| Probe mécanique / script-driven (curl, gh, gradle, parse) | `haiku` | `low` | store-status probes, disk check |
+| Discovery / sweep read-only (Explore) | `sonnet` | `medium` | audit-sweep, phase2 scan, doc-drift audit, parity audit |
+| Synthèse / rapport / PR body / triage | `sonnet` | `medium` (`low` si trivial) | reconcile trackers, draft-PR open, STATE bullet |
+| Patch de code / fix d'issue / doc patch | `opus` | `high` | fix-issue-batch workers, doc-drift patches |
+| Review indépendante (gate merge) | `opus` | `high` | sv-code/sv-security reviewers, triptych lenses |
+| Safety gate final / vérif adversariale d'ERROR | `opus` | `xhigh` | sv-impact-reviewer, review-fanout verify |
+| Device-QA serial driver / étape release state-changing | `opus` | `medium` | device-qa-orchestrate run, release tag+push |
 
 Validate every script before committing: `bash .claude/scripts/check-saved-workflows.sh`
 (static: ESM `node --check` + meta-block + resume-safety; never executes the workflow).

--- a/.claude/workflows/audit-sweep.js
+++ b/.claude/workflows/audit-sweep.js
@@ -92,7 +92,7 @@ ${DEPTH}
 Be concrete: EVERY finding needs a repo-relative file path, a best-known line number, the issue, a fix sketch, and the impact. If the class genuinely does NOT appear on this surface, return an empty findings array and say so in the summary — never invent findings to look productive (honesty rule). Use raw \`adb\` for nothing; you are read-only anyway.
 
 Return your structured findings for the ${s} surface.`,
-    { label: `audit:${s}`, phase: 'Audit', agentType: 'Explore', schema: FINDINGS })
+    { label: `audit:${s}`, phase: 'Audit', agentType: 'Explore', schema: FINDINGS, model: 'sonnet', effort: 'medium' })
 })
 
 const results = (await parallel(auditTasks)).filter(Boolean)
@@ -202,7 +202,7 @@ C) Create ONE sub-issue PER HIGH finding:
 D) Use \`--repo sceneview/sceneview\` on every \`gh\` call. Capture each created issue NUMBER (parse it from the URL gh prints). If a \`gh\` call fails (auth, rate-limit), do NOT fake a number — report the failure in \`note\` and set the number to 0.
 
 Return the umbrella number + URL, the list of sub-issue numbers/titles, and a note.`,
-  { label: 'frame-issues', phase: 'Frame', schema: FRAME_SCHEMA })
+  { label: 'frame-issues', phase: 'Frame', schema: FRAME_SCHEMA, model: 'opus', effort: 'medium' })
 
 const subIssues = (framed && Array.isArray(framed.subIssues)) ? framed.subIssues : []
 log(`Frame done — umbrella #${(framed && framed.umbrella) || '?'}, ${subIssues.length} sub-issue(s) for ${highs.length} HIGH finding(s)`)

--- a/.claude/workflows/device-qa-orchestrate.js
+++ b/.claude/workflows/device-qa-orchestrate.js
@@ -88,7 +88,7 @@ GATE POLICY you must reflect honestly (do NOT re-grade — just surface the repo
 - If the disk gate trips (exit 2) or the report was never written, say so plainly: ran=false, reportVerdict='missing'.
 
 Return your structured verdict. Be precise; the orchestrator's gate reads your fields directly.`,
-  { label: `device-qa:${PLATFORM}`, phase: 'Run', schema: RUN_VERDICT })
+  { label: `device-qa:${PLATFORM}`, phase: 'Run', schema: RUN_VERDICT, model: 'opus', effort: 'medium' })
 
 phase('Grade')
 

--- a/.claude/workflows/doc-drift-fix.js
+++ b/.claude/workflows/doc-drift-fix.js
@@ -64,7 +64,7 @@ TASK — build the candidate-drift worklist (do NOT patch anything yet):
 3. Distil into a DEDUPED list of concrete candidates. Each candidate names exactly one doc surface, the symbol at issue, the doc file to inspect/patch, and why it's suspect. Drop noise (the script's known false positives: a local val/var inside a refactored body, an internal-only symbol). Prefer high-signal candidates an Opus agent can actually act on. Cap at the ~20 most worthwhile; the long tail is fine to omit (the script's truncation is intentional).
 
 Return the structured worklist.`,
-  { label: 'doc-drift:audit', phase: 'Audit', schema: WORKLIST })
+  { label: 'doc-drift:audit', phase: 'Audit', schema: WORKLIST, model: 'sonnet', effort: 'medium' })
 
 const candidates = (audit && Array.isArray(audit.candidates)) ? audit.candidates : []
 log(`Audit: ${candidates.length} candidate(s) — ${audit ? audit.note : 'no worklist returned'}`)
@@ -120,7 +120,7 @@ PROCEDURE:
 3. You touch ONLY doc/prose files for THIS candidate. Never edit library logic. Never edit another candidate's file. Do NOT git add/commit/push — the PR phase bundles everything.
 
 Return your structured result: action='patched' (with the file you edited + the source file:line that proves the API) or action='deferred' (with the precise reason).`,
-  { label: `doc-drift:patch:${c.surface}:${(c.symbol || '').slice(0, 24)}`, phase: 'Patch', schema: PATCH })
+  { label: `doc-drift:patch:${c.surface}:${(c.symbol || '').slice(0, 24)}`, phase: 'Patch', schema: PATCH, model: 'opus', effort: 'high' })
 
 const results = (await pipeline(candidates, patchStage)).filter(Boolean)
 
@@ -172,7 +172,7 @@ TASK:
 4. Report: the PR URL (or the issue URL, or "no action — docs in sync"), the branch name, and the exact files committed.
 
 End the PR body with: 🤖 Generated with [Claude Code](https://claude.com/claude-code)`,
-    { label: 'doc-drift:pr', phase: 'PR' })
+    { label: 'doc-drift:pr', phase: 'PR', model: 'sonnet', effort: 'low' })
 
   log(`PR phase: ${prResult ? String(prResult).slice(0, 160) : 'no result'}`)
 }

--- a/.claude/workflows/fix-issue-batch.js
+++ b/.claude/workflows/fix-issue-batch.js
@@ -40,7 +40,7 @@ const disk = await agent(
   bash .claude/scripts/disk-gated-spawn-check.sh; echo "EXIT=$?"
 
 The script prints a machine-readable \`DISK_FREE_GB=<n>\` line and exits 0 when free space clears its threshold (default 15 GB), 1 below it. Do NOT run any cleanup, do NOT spawn anything, do NOT clone — just report. Parse DISK_FREE_GB into freeGb, set safe=true iff EXIT=0, and put the verbatim output in raw.`,
-  { label: 'preflight:disk', phase: 'Preflight', schema: DISK_SCHEMA })
+  { label: 'preflight:disk', phase: 'Preflight', schema: DISK_SCHEMA, model: 'haiku', effort: 'low' })
 
 if (disk) {
   log(`Disk preflight: ${disk.freeGb} GB free — ${disk.safe ? 'SAFE to spawn' : 'BELOW threshold (cleanup advised; build-heavy fan-out risky)'}. Hard cap ~2 build-heavy agents (runtime also caps concurrency).`)
@@ -90,7 +90,7 @@ From the result:
 - Pick the TOP ${MAX}, ordered highest-priority first (ties broken by ascending number).
 
 Return the chosen issues with each one's number, title, and resolved priority bucket. Do NOT claim, clone, or modify anything — selection only.`,
-    { label: 'preflight:select-issues', phase: 'Preflight', schema: PICK_SCHEMA })
+    { label: 'preflight:select-issues', phase: 'Preflight', schema: PICK_SCHEMA, model: 'sonnet', effort: 'medium' })
   chosen = (pick && Array.isArray(pick.issues) ? pick.issues : []).slice(0, MAX)
   log(`Auto-selected ${chosen.length} issue(s): ${chosen.map(i => `#${i.number}[${i.priority}]`).join(', ') || '(none open / all in-progress)'}`)
 }
@@ -240,6 +240,8 @@ const results = await pipeline(
       label: `fix:#${item.number}`,
       phase: 'Cycle',
       schema: FIX_SCHEMA,
+      model: 'opus',
+      effort: 'high',
     }),
   // Stage 2 — graded review (medium+ only): the orchestrator-level adversarial fan-out the worker
   // cannot run itself (#1243). Trivial/skipped/failed pass straight through.
@@ -256,7 +258,7 @@ const results = await pipeline(
     if (rec === 'MERGE' || rec === 'MERGE_AFTER_WARNINGS') {
       await agent(
         `Finalize SceneView PR #${fixRes.pr} (issue #${item.number}): run \`gh pr merge ${fixRes.pr} --repo ${REPO} --squash --auto\`, then \`bash .claude/scripts/claim.sh --release ${item.number}\`. Report one line. Do NOT watch CI.`,
-        { label: `merge:#${item.number}`, phase: 'Review' },
+        { label: `merge:#${item.number}`, phase: 'Review', model: 'haiku', effort: 'low' },
       )
       return { ...fixRes, outcome: 'merged', reviewRecommendation: rec, reviewWarnings: (review.warnings || []).length }
     }
@@ -265,7 +267,7 @@ const results = await pipeline(
     if (review.breakingApi) {
       await agent(
         `Mark SceneView PR #${fixRes.pr} as a DRAFT — it has a confirmed BREAKING public-API change and needs the maintainer: \`gh pr ready ${fixRes.pr} --repo ${REPO} --undo\`. Do NOT merge. Report one line.`,
-        { label: `draft:#${item.number}`, phase: 'Review' },
+        { label: `draft:#${item.number}`, phase: 'Review', model: 'haiku', effort: 'low' },
       )
     }
     return { ...fixRes, outcome: 'blocked-by-review', reviewRecommendation: rec, breakingApi: !!review.breakingApi, blockers: (review.confirmedErrors || []).length, note: `${fixRes.note || ''} | review=${rec}${review.breakingApi ? ' BREAKING-API → drafted, maintainer gate' : ''}; PR #${fixRes.pr} open, claim held`.trim() }

--- a/.claude/workflows/parity-audit.js
+++ b/.claude/workflows/parity-audit.js
@@ -78,7 +78,7 @@ CRITICAL: iOS V1 is a deliberate STRICT SUBSET of Android — an **honestly docu
 // Pipeline: each platform's gaps are adversarially verified the moment that platform audit returns.
 const audited = await pipeline(
   TARGETS,
-  (t) => agent(auditPrompt(t), { label: `audit:${t}`, phase: 'Audit', schema: GAPS_SCHEMA }).then((r) => (r ? { ...r, platform: t } : null)),
+  (t) => agent(auditPrompt(t), { label: `audit:${t}`, phase: 'Audit', schema: GAPS_SCHEMA, model: 'sonnet', effort: 'medium' }).then((r) => (r ? { ...r, platform: t } : null)),
   (r, t) => {
     if (!r) return null
     const gaps = r.gaps || []
@@ -94,7 +94,7 @@ const audited = await pipeline(
   target status: ${g.targetStatus || '?'}
 
 Try to REFUTE it. Open the actual source on BOTH platforms: does the reference \`refLocation\` resolve to that public symbol? Is it genuinely missing/divergent on the target, or is it actually mirrored under a different name, or left as an HONEST documented deferral ("Coming soon")? Default realGap=false unless you independently confirm a genuine, silent parity break. Set deferredHonestly=true if the target documents the gap.`,
-          { label: `verify:${t}:${(g.symbol || '').slice(0, 24)}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+          { label: `verify:${t}:${(g.symbol || '').slice(0, 24)}`, phase: 'Verify', schema: VERDICT_SCHEMA, model: 'opus', effort: 'high' },
         ).then((v) => ({ ...g, platform: t, verified: v })),
       ),
     ).then((verified) => ({ ...r, verifiedGaps: verified.filter(Boolean) }))

--- a/.claude/workflows/phase2-reconcile.js
+++ b/.claude/workflows/phase2-reconcile.js
@@ -119,7 +119,7 @@ This surface's standing tracker issue (read it for the already-known MED backlog
 Be concrete: EVERY item needs a short imperative title, a repo-relative file path, a best-known line number, and a rationale that states the concrete MED cost plus a fix sketch. If this surface genuinely has NO standing MED backlog beyond what its tracker already lists, return an empty items array and say so in the summary — never invent items to look productive (honesty rule). You are read-only; use raw \`adb\` for nothing.
 
 Return your structured MED backlog for the ${s} surface.`,
-    { label: `triage:${s}`, phase: 'Triage', agentType: 'Explore', schema: FINDINGS })
+    { label: `triage:${s}`, phase: 'Triage', agentType: 'Explore', schema: FINDINGS, model: 'sonnet', effort: 'medium' })
 })
 
 const results = (await parallel(triageTasks)).filter(Boolean)
@@ -224,7 +224,7 @@ C) For a surface with NO new MED items, do nothing and report action "unchanged"
 D) Capture each tracker's NUMBER (parse it from the URL gh prints on create, or echo it on update). If a \`gh\` call fails (auth, rate-limit), do NOT fake a number — set number 0, action "failed", and explain in \`note\`.
 
 Return one entry per surface (number + action + url) and a note.`,
-  { label: 'reconcile-trackers', phase: 'Reconcile', schema: RECONCILE_SCHEMA })
+  { label: 'reconcile-trackers', phase: 'Reconcile', schema: RECONCILE_SCHEMA, model: 'sonnet', effort: 'medium' })
 
 const trackers = (reconciled && Array.isArray(reconciled.trackers)) ? reconciled.trackers : []
 const created = trackers.filter((t) => t.action === 'created').length

--- a/.claude/workflows/release-checkpoint.js
+++ b/.claude/workflows/release-checkpoint.js
@@ -63,7 +63,7 @@ Run these, from the repo root, and reason over their output:
    nextVersion must keep major=${FROZEN_MAJOR} (e.g. 4.17.0 + minor → 4.18.0; + patch → 4.17.1).
 
 clean = (syncMismatch==0) AND qualityGatePass AND ciGreen AND bumpKind in {patch,minor} AND NOT needsHuman. Put every failing reason in blockers. Be honest — a half-green CI or a single real MISMATCH means clean=false.`,
-  { label: 'preflight', phase: 'Preflight', schema: PREFLIGHT })
+  { label: 'preflight', phase: 'Preflight', schema: PREFLIGHT, model: 'sonnet', effort: 'medium' })
 
 if (!preflight) {
   log('Preflight agent returned null — BLOCKED')
@@ -174,7 +174,7 @@ This is a SINGLE \`/release\` actor — never run a second release agent concurr
 6. \`git tag v${nextVersion}\` then \`git push origin HEAD --tags\` (push the current main HEAD + the new tag — this triggers release.yml: Maven Central / npm sceneview-web / GitHub Release, plus the store workflows). Set pushedTag="v${nextVersion}", tagged=true.
 
 If ANY step fails (dirty mcp diff, non-zero MISMATCH after --fix, push rejected), STOP, set tagged=false, leave pushedTag empty, and explain in blockers. Do NOT force-push, do NOT bump a major.`,
-  { label: 'tag', phase: 'Tag', schema: TAG })
+  { label: 'tag', phase: 'Tag', schema: TAG, model: 'opus', effort: 'medium' })
 
 if (!tag || !tag.tagged) {
   const tb = (tag && tag.blockers && tag.blockers.length) ? tag.blockers : ['tag step did not complete (agent returned null or tagged=false)']

--- a/.claude/workflows/review-fanout.js
+++ b/.claude/workflows/review-fanout.js
@@ -65,10 +65,10 @@ const VERDICT_SCHEMA = {
 // (single source of truth). If the type isn't registered in this session, fall back to a
 // general agent that READS the .md and adopts the role — so a reviewer is never silently dropped.
 const REVIEWERS = [
-  { key: 'code', agentType: 'sv-code-reviewer' },
-  { key: 'security', agentType: 'sv-security-reviewer' },
-  { key: 'impact', agentType: 'sv-impact-reviewer' },
-  { key: 'doc', agentType: 'sv-doc-freshness' },
+  { key: 'code', agentType: 'sv-code-reviewer', model: 'opus', effort: 'high' },
+  { key: 'security', agentType: 'sv-security-reviewer', model: 'opus', effort: 'high' },
+  { key: 'impact', agentType: 'sv-impact-reviewer', model: 'opus', effort: 'xhigh' },
+  { key: 'doc', agentType: 'sv-doc-freshness', model: 'sonnet', effort: 'medium' },
 ]
 
 const reviewPrompt = (key) =>
@@ -84,13 +84,14 @@ log(`Running ${REVIEWERS.length} independent reviewers on ${diffRef} (${ctx})`)
 async function runReviewer(r) {
   const opts = { label: `review:${r.key}`, phase: 'Review', schema: REVIEW_SCHEMA }
   try {
+    // model/effort come from the sv-* agent frontmatter (.claude/agents/*.md)
     return await agent(reviewPrompt(r.key), { ...opts, agentType: r.agentType })
   } catch (e) {
     log(`agentType '${r.agentType}' unavailable — adopting its mandate from file`)
     try {
       return await agent(
         `Read the file \`.claude/agents/${r.agentType}.md\` and adopt that reviewer role EXACTLY — its mandate, hard checks, and output fields. Then: ${reviewPrompt(r.key)}`,
-        { ...opts, label: `review:${r.key}(fallback)` },
+        { ...opts, label: `review:${r.key}(fallback)`, model: r.model, effort: r.effort },
       )
     } catch (e2) {
       // Total reviewer failure → null → filtered → reviewersRan < expected ⇒ REVIEW_INCOMPLETE.
@@ -120,7 +121,7 @@ const reviewed = await pipeline(
   proposed fix: ${f.fix || '(none given)'}
 
 Try to REFUTE it. Read the actual code at that location and reproduce the failure if it is a runtime/compile claim (e.g. grep the call site, check the signature, trace the thread). Default to real=false if you cannot independently confirm a genuine, merge-blocking problem. Only real=true if you confirm it.`,
-          { label: `verify:${r.key}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+          { label: `verify:${r.key}`, phase: 'Verify', schema: VERDICT_SCHEMA, model: 'opus', effort: 'xhigh' },
         ).then((v) => ({ ...f, reviewer: r.key, verified: v })),
       ),
     ).then((verified) => ({ ...res, verifiedErrors: verified.filter(Boolean) }))

--- a/.claude/workflows/store-status.js
+++ b/.claude/workflows/store-status.js
@@ -29,7 +29,7 @@ Run exactly:
   ${RESOLVE_MAIN}
   grep -E '^VERSION_NAME=' "$MAIN/gradle.properties" | head -1 | cut -d= -f2 | tr -d '[:space:]'
 Return that value verbatim as your entire output.`,
-    { label: 'probe:expected-version', phase: 'Probe' })
+    { label: 'probe:expected-version', phase: 'Probe', model: 'haiku', effort: 'low' })
   expected = String(vRaw || '').trim().replace(/^["']|["']$/g, '')
 }
 if (!expected || !/^\d+\.\d+\.\d+/.test(expected)) {
@@ -84,7 +84,7 @@ Run exactly:
 Parse the JSON: read \`resultCount\`, and from \`results[0]\` read \`version\`, \`currentVersionReleaseDate\`, \`trackName\`.
 If resultCount is 0 (app not found / not yet live) return version=null, currentVersionReleaseDate=null, and say so in \`raw\`.
 Do NOT guess or infer a version from anywhere else — report only what the live lookup returns. Return your structured verdict.`,
-  { label: 'probe:ios-itunes', phase: 'Probe', schema: IOS_SCHEMA })
+  { label: 'probe:ios-itunes', phase: 'Probe', schema: IOS_SCHEMA, model: 'haiku', effort: 'low' })
 
 const POM_URL = `https://repo1.maven.org/maven2/io/github/sceneview/sceneview/${V}/sceneview-${V}.pom`
 const mavenProbe = () => agent(
@@ -92,14 +92,14 @@ const mavenProbe = () => agent(
 Run exactly:
   curl -sI -o /dev/null -w "%{http_code}" "${POM_URL}"
 Report the integer HTTP status as \`httpCode\` (200 = the artifact's .pom is live on repo1; 404 = not present / still propagating) and echo the URL. Do not follow up with other endpoints. Return your structured verdict.`,
-  { label: 'probe:maven-repo1', phase: 'Probe', schema: MAVEN_SCHEMA })
+  { label: 'probe:maven-repo1', phase: 'Probe', schema: MAVEN_SCHEMA, model: 'haiku', effort: 'low' })
 
 const npmProbe = () => agent(
   `You verify that the EXACT npm version sceneview-web@${V} is published (the published web CDN artifact is sceneview-web).
 Run exactly:
   npm view sceneview-web@${V} version
 If that exact version is published, npm echoes "${V}" — set version to that. If the exact version is NOT published, npm prints nothing / an error to stderr — set version=null and capture the message in \`raw\`. Do not fall back to the dist-tag latest. Return your structured verdict.`,
-  { label: 'probe:npm-sceneview-web', phase: 'Probe', schema: NPM_SCHEMA })
+  { label: 'probe:npm-sceneview-web', phase: 'Probe', schema: NPM_SCHEMA, model: 'haiku', effort: 'low' })
 
 const [ios, maven, npmRes] = await parallel([iosProbe, mavenProbe, npmProbe])
 
@@ -222,7 +222,7 @@ PY
 This file is gitignored runtime evidence (\`.claude/data/\`), never committed. Its \`verdict\` is "${verdict}"; claim-gate.sh blocks an "all-live ✅" STATE.md claim unless verdict=ALL_LIVE and the record is fresh.
 
 After editing, print a 3-line confirmation: (1) the absolute STATE.md path you edited, (2) the new bullet text verbatim, (3) the absolute probe path written + its verdict. Do NOT git add / commit / push. Do NOT modify any file other than STATE.md and .claude/data/last-store-probe.json.`,
-  { label: 'report:update-state', phase: 'Report' })
+  { label: 'report:update-state', phase: 'Report', model: 'sonnet', effort: 'low' })
 
 const reportConfirm = await reportTask()
 

--- a/.claude/workflows/triptych.js
+++ b/.claude/workflows/triptych.js
@@ -62,12 +62,12 @@ phase('Verify')
 
 const tasks = LENSES.map(L => () =>
   agent(`${COMMON}\n\nYOUR LENS — ${L.key}: ${L.brief}\n\nReturn your structured verdict.`,
-    { label: `review:${L.key}`, phase: 'Verify', schema: VERDICT }))
+    { label: `review:${L.key}`, phase: 'Verify', schema: VERDICT, model: 'opus', effort: 'high' }))
 
 // Updated-everywhere leg — runs impact-check + the all-platforms surface audit.
 const impactTask = () => agent(
   `${COMMON}\n\nYOUR LENS — updated-everywhere: run \`bash .claude/scripts/impact-check.sh\` and reason over its output for the diff. Verify EVERY impacted surface is in sync: llms.txt, KDoc, docs/docs/*, samples/recipes, README, CLAUDE.md, the agents/sceneview* skills, the version map (sync-versions.sh), changelog.d fragment present, MCP generated artefacts. A missing doc/changelog/parity update for a public change is a blocker. List exactly which surfaces are stale.`,
-  { label: 'review:updated-everywhere', phase: 'Verify', schema: VERDICT })
+  { label: 'review:updated-everywhere', phase: 'Verify', schema: VERDICT, model: 'sonnet', effort: 'medium' })
 
 // Visual device-QA leg — ONE serial agent (single emulator/sim lease). It is the
 // only QA agent in this batch, so it never contends for the device.
@@ -91,7 +91,7 @@ If the diff touches a demo/sample/UI on a platform you can drive locally:
 - iOS → simulator via XcodeBuildMCP, drive the demo, screenshot.
 - Web → Playwright (\`samples/web-demo/tests/\`).
 Assert: no crash, the change renders as intended, no rendering corruption (drift/skew/black viewport/frozen billboard). If the platform can't be driven locally (e.g. true ARCore tracking on arm64), say so HONESTLY and mark applicable=false — never fake a pass. If a demo path is KEY-GATED (Sketchfab Explore, ARCore Cloud) and the build has no API key (SKETCHFAB_API_KEY / ARCORE_API_KEY), mark applicable=false with notes 'key missing — path NOT tested', and alert that QA could not be complete — NEVER report a key-gated path as passing on a keyless build (#2343). Return your structured verdict.`,
-  { label: 'visual-qa', phase: 'Verify', schema: VQ })
+  { label: 'visual-qa', phase: 'Verify', schema: VQ, model: 'opus', effort: 'medium' })
 
 const all = await parallel([...tasks, impactTask, visualTask])
 


### PR DESCRIPTION
## What

Codifies the model/effort routing policy that until now only existed as prose ("Opus reviewers") and manual `model:opus` forcing:

- **`.claude/agents/sv-*.md`** — frontmatter now pins `model` + `effort` (code/security = opus/high, impact = opus/**xhigh** as the auto-merge safety gate, doc-freshness = sonnet/medium).
- **All 10 saved workflows** — every `agent()` call passes explicit `{model, effort}` (mechanical probes = haiku/low, discovery/synthesis = sonnet/medium, patches + gate reviews = opus/high, adversarial-verify safety gates = opus/xhigh, device-QA driver + release tag = opus/medium). Where `agentType: 'sv-*'` is used, model/effort come from the agent frontmatter (not duplicated).
- **`.claude/workflows/README.md`** — new authoring convention 9 + the routing matrix as single source of truth.

## Why

Background agents inherited the session model; when the session runs Fable, fan-out agents die on the monthly Fable quota mid-review (happened twice, see STATE history) and required manual `model:opus` forcing. Explicit pins make the workflows quota-robust AND cost-right (haiku for curl/gh probes instead of a frontier model).

Rule codified: `fable` is never hard-pinned for background work; `haiku` has no xhigh/max.

## Verification

- `bash .claude/scripts/check-saved-workflows.sh` → OK, 10 workflows valid.
- `.claude/` tooling only — no SDK/library/source change, no changelog fragment needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)