### PR TITLE
feat(tooling): route skills by model/effort + codify token-economy rules

### DIFF
--- a/.claude/commands/caught.md
+++ b/.claude/commands/caught.md
@@ -1,5 +1,7 @@
 ---
 description: Log a caught false claim / recurring miss to the claim-ledger; on the 3rd occurrence of a class, promote it to a feedback_*.md memory rule. Part of the Evidence-Stamped Claim Gate (#2346).
+model: haiku
+effort: low
 ---
 
 # /caught — record a caught miss, promote a 3×-recurring class to a rule

--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -1,5 +1,7 @@
 ---
 description: Daily SceneView maintenance sweep — CI status, open issues, dependencies, quality gate.
+model: sonnet
+effort: medium
 ---
 
 # /maintain — SceneView daily maintenance sweep

--- a/.claude/commands/quality-gate.md
+++ b/.claude/commands/quality-gate.md
@@ -1,5 +1,7 @@
 ---
 description: Comprehensive pre-push quality gate — compile, unit tests, bundle build, website JS validation.
+model: sonnet
+effort: low
 ---
 
 # /quality-gate — Comprehensive pre-push quality gate

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,5 +1,7 @@
 ---
 description: Review current changes at an effort level — checklist (low) → adversarial multi-agent triptych (high) → weighted scorecard (--score) → coverage (--coverage). Generator ≠ evaluator.
+model: opus
+effort: high
 ---
 
 # /review — one review skill, four depths

--- a/.claude/commands/store-status.md
+++ b/.claude/commands/store-status.md
@@ -1,5 +1,7 @@
 ---
 description: Verify the REAL live state of published artifacts (iOS App Store, Maven Central, npm) vs the expected version — CI-green is never proof of live. Runs the store-status workflow.
+model: sonnet
+effort: low
 ---
 
 # /store-status — is what's LIVE actually our version?

--- a/.claude/commands/sync-check.md
+++ b/.claude/commands/sync-check.md
@@ -1,5 +1,7 @@
 ---
 description: Verify SceneView repo synchronization — versions across 30+ files and published artifacts.
+model: sonnet
+effort: low
 ---
 
 # /sync-check — Verify SceneView repo synchronization

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -169,6 +169,32 @@ it stays the interactive orchestrator's session model. `haiku` has no `xhigh`/`m
 | Safety gate final / vérif adversariale d'ERROR | `opus` | `xhigh` | sv-impact-reviewer, review-fanout verify |
 | Device-QA serial driver / étape release state-changing | `opus` | `medium` | device-qa-orchestrate run, release tag+push |
 
+### Token economy (quota discipline)
+
+Measured on 30 days of this repo's sessions (125 sessions, 5.3B tokens, 2026-07-09,
+details in the local `.claude/plans/qa-efficiency-2026-07.md`): **95.2% of all tokens
+are `cache_read`** — the conversation history re-transmitted on every turn. Visual QA
+is 6–23% depending on attribution; screenshot pixels are <0.05%. The quota killer is
+**session length × loop turns**, not images. Hence:
+
+1. **One chantier = one session; reset, don't linger.** Never leave a session open
+   across days — every resume re-pays the whole history (one 4-day device-QA session
+   alone cost 117M tokens). Close with `/handoff` + a relay issue instead.
+2. **Close the device-QA session when the run ends.** QA runs get a dedicated session
+   that dies with its verdict; don't reuse it as a work session.
+3. **Cap fix→re-verify loops at 3 attempts**, then stop and file/escalate with a
+   summary (observed 23–28-turn screenshot loops are the single worst pattern).
+4. **Text-first verification**: exit codes, report JSON, `android layout` UI tree,
+   logs BEFORE any screenshot; a screenshot only confirms visuals no text can prove
+   (size/count rule in §9.5 — don't bother compressing further, it's <0.05%).
+5. **Read discipline**: big files once, by slices (`limit`/`offset`); never re-Read
+   STATE.md / MEMORY.md / llms.txt every turn — `Read` is the #1 text-volume tool,
+   ahead of ALL QA commands combined.
+6. **Fan-out must earn its overhead**: each subagent costs a fixed ~60–90k tokens of
+   context setup before any work. Delegate broad searches to ONE Explore agent that
+   returns a conclusion; reserve parallel fan-out for genuinely independent, long
+   tasks (reviews, per-surface audits).
+
 Validate every script before committing: `bash .claude/scripts/check-saved-workflows.sh`
 (static: ESM `node --check` + meta-block + resume-safety; never executes the workflow).
 That is distinct from `check-workflow-scripts.sh`, which validates the CI YAML in `.github/workflows/`.


### PR DESCRIPTION
## What

Second half of the qa-efficiency chantier (first half: #2628 routed the sv-* agents and all 10 saved workflows):

- **Skills frontmatter**: 6 repo skills now pin `model` + `effort` per the routing matrix — `/review` = opus/high (the evaluator gate), `/quality-gate` `/sync-check` `/store-status` = sonnet/low (script drivers), `/maintain` = sonnet/medium, `/caught` = haiku/low. Interactive/critical skills (contribute, release, issue-batch, version-bump, handoff, document) deliberately stay on session-inherit.
- **Token economy section** (workflows/README.md §9): codifies the measured findings of the 30-day transcript analysis — 95.2% of tokens are `cache_read` (history re-transmission), visual QA is 6-23%, screenshot pixels <0.05%. Rules: one chantier = one session (reset > lingering), close the device-QA session with its run, cap fix→re-verify loops at 3 attempts, text-first verification before screenshots, Read big files once by slices, fan-out must earn its ~60-90k fixed per-subagent overhead.

## Why

The quota killer is session length × loop turns, not images. These rules were prose/intuition; now they live in the canonical methodology doc every session reads.

## Verification

`check-saved-workflows.sh` OK. Markdown/tooling only — no code paths, no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)