### PR TITLE
feat(ci): weekly GitHub Actions job for site community-metrics refresh

### DIFF
--- a/.claude/scripts/update-site-metrics.sh
+++ b/.claude/scripts/update-site-metrics.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Updates the community-metrics values embedded in website-static/index.html
+# (the `data-metric="…"` anchors under the "Community & Metrics" section).
+#
+# Used by .github/workflows/site-metrics.yml (weekly cron) — this replaces
+# the retired Claude scheduled routine that used to refresh these numbers by
+# hand, at zero AI quota cost.
+#
+# In scope: stars, contributors, releases, web-downloads (sceneview-web npm
+# package). `forks` and `mcp-downloads` (sceneview-mcp npm package) are
+# deliberately NOT touched here — out of scope for this automation.
+#
+# Formatting rule mirrors the existing hand-authored values: a value >= 1000
+# renders as "X.YK" (one decimal), anything below renders as a plain integer
+# (e.g. current file has stars=1.2K, web-downloads=4.7K, contributors=43,
+# releases=123).
+#
+# Usage:
+#   update-site-metrics.sh --stars N --contributors N --releases N --web-downloads N [--file PATH]
+#
+# Exits 0 whether or not the file actually changed — the caller (the
+# workflow) checks `git diff` to decide whether a commit is needed. Exits
+# non-zero only on bad input or a missing/changed anchor.
+
+set -euo pipefail
+
+FILE="website-static/index.html"
+STARS=""
+CONTRIBUTORS=""
+RELEASES=""
+WEB_DOWNLOADS=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --stars) STARS="$2"; shift 2 ;;
+    --contributors) CONTRIBUTORS="$2"; shift 2 ;;
+    --releases) RELEASES="$2"; shift 2 ;;
+    --web-downloads) WEB_DOWNLOADS="$2"; shift 2 ;;
+    --file) FILE="$2"; shift 2 ;;
+    *) echo "::error::unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+for name_val in "stars:$STARS" "contributors:$CONTRIBUTORS" "releases:$RELEASES" "web-downloads:$WEB_DOWNLOADS"; do
+  name="${name_val%%:*}"
+  val="${name_val#*:}"
+  if [ -z "$val" ]; then
+    echo "::error::missing required value for --$name" >&2
+    exit 1
+  fi
+  case "$val" in
+    ''|*[!0-9]*) echo "::error::--$name must be a plain non-negative integer, got '$val'" >&2; exit 1 ;;
+  esac
+done
+
+if [ ! -f "$FILE" ]; then
+  echo "::error::$FILE not found" >&2
+  exit 1
+fi
+
+format_metric() {
+  awk -v n="$1" 'BEGIN {
+    if (n >= 1000) { printf "%.1fK", n / 1000 }
+    else { printf "%d", n }
+  }'
+}
+
+STARS_FMT="$(format_metric "$STARS")"
+CONTRIBUTORS_FMT="$(format_metric "$CONTRIBUTORS")"
+RELEASES_FMT="$(format_metric "$RELEASES")"
+WEB_DOWNLOADS_FMT="$(format_metric "$WEB_DOWNLOADS")"
+
+set_metric() {
+  key="$1"
+  value="$2"
+  # Each data-metric="<key>" anchor appears exactly once in the file; anchor
+  # the replacement on that exact attribute so unrelated markup can never
+  # match, and fail loudly if the anchor has moved/been renamed.
+  if ! grep -q "data-metric=\"$key\">" "$FILE"; then
+    echo "::error::anchor data-metric=\"$key\" not found in $FILE — website markup changed, update this script" >&2
+    exit 1
+  fi
+  sed -i.bak -E "s|(data-metric=\"$key\">)[^<]*(<)|\\1${value}\\2|" "$FILE"
+  rm -f "$FILE.bak"
+}
+
+set_metric "stars" "$STARS_FMT"
+set_metric "contributors" "$CONTRIBUTORS_FMT"
+set_metric "releases" "$RELEASES_FMT"
+set_metric "web-downloads" "$WEB_DOWNLOADS_FMT"
+
+echo "Updated $FILE: stars=$STARS_FMT contributors=$CONTRIBUTORS_FMT releases=$RELEASES_FMT web-downloads=$WEB_DOWNLOADS_FMT"

--- a/.github/workflows/site-metrics.yml
+++ b/.github/workflows/site-metrics.yml
@@ -1,0 +1,118 @@
+name: Site Metrics Refresh
+
+# Weekly refresh of the "Community & Metrics" numbers on the public website
+# (website-static/index.html — data-metric="stars"/"contributors"/"releases"/
+# "web-downloads" anchors). Replaces a retired Claude scheduled routine that
+# used to update these by hand — this job spends zero AI quota.
+#
+# In scope (mirrors what the retired routine covered): GitHub stars,
+# contributors, releases (sceneview/sceneview), and npm downloads for the
+# sceneview-web package. `forks` and `mcp-downloads` (sceneview-mcp package)
+# are separate metric cards on the same page that this job deliberately does
+# NOT touch — out of scope here.
+#
+# WHY A PR INSTEAD OF A LITERAL DIRECT PUSH: `main` requires the "CI Gate"
+# status check (branch protection) and GitHub only allows a direct push once
+# a commit SHA already carries a passing required check — a brand-new commit
+# never does. That's why every other automated main-commit in this repo
+# (release-fast.yml, tag-release.yml) goes through `gh pr create` +
+# `gh pr merge --squash --auto` rather than `git push origin main`; this
+# workflow follows the same proven pattern. It resolves fast here because
+# ci.yml has `paths-ignore: website-static/**` — a metrics-only diff
+# registers no other check runs, so CI Gate's documented "docs-only bypass"
+# (ci-gate.yml) goes green after its ~2 min grace period instead of waiting
+# on a build.
+on:
+  schedule:
+    # Monday 07:00 UTC, weekly.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: site-metrics
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-metrics:
+    name: Refresh community metrics
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch GitHub + npm metrics
+        id: metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          API="https://api.github.com/repos/sceneview/sceneview"
+
+          # Stars: a direct field on the repo object.
+          STARS=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$API" | jq -r '.stargazers_count')
+
+          # Contributors / releases: the API has no total-count field, so ask
+          # for 1-per-page and read the last-page number out of the
+          # pagination Link header (the standard cheap-total-count trick).
+          # If there's no Link header at all, everything fit on one page —
+          # fall back to fetching up to 100 and counting the array.
+          count_via_link_header() {
+            endpoint="$1"
+            link=$(curl -sf -D - -o /dev/null -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$endpoint?per_page=1")
+            last=$(printf '%s' "$link" | grep -i '^link:' | grep -oE 'page=[0-9]+>; rel="last"' | grep -oE '[0-9]+' || true)
+            if [ -n "$last" ]; then
+              echo "$last"
+            else
+              curl -sf -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$endpoint?per_page=100" | jq 'length'
+            fi
+          }
+
+          CONTRIBUTORS=$(count_via_link_header "$API/contributors")
+          RELEASES=$(count_via_link_header "$API/releases")
+
+          WEB_DOWNLOADS=$(curl -sf "https://api.npmjs.org/downloads/point/last-month/sceneview-web" | jq -r '.downloads')
+
+          echo "stars=$STARS" >> "$GITHUB_OUTPUT"
+          echo "contributors=$CONTRIBUTORS" >> "$GITHUB_OUTPUT"
+          echo "releases=$RELEASES" >> "$GITHUB_OUTPUT"
+          echo "web_downloads=$WEB_DOWNLOADS" >> "$GITHUB_OUTPUT"
+          echo "Fetched: stars=$STARS contributors=$CONTRIBUTORS releases=$RELEASES web_downloads=$WEB_DOWNLOADS"
+
+      - name: Update website-static/index.html
+        run: |
+          bash .claude/scripts/update-site-metrics.sh \
+            --stars "${{ steps.metrics.outputs.stars }}" \
+            --contributors "${{ steps.metrics.outputs.contributors }}" \
+            --releases "${{ steps.metrics.outputs.releases }}" \
+            --web-downloads "${{ steps.metrics.outputs.web_downloads }}"
+
+      - name: Commit and open auto-merge PR if metrics changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- website-static/index.html; then
+            echo "No metric change this week — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="chore/site-metrics-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git add website-static/index.html
+          git commit -m "chore(site): refresh community metrics [skip ci]" \
+            -m "Automated weekly refresh (site-metrics.yml) — stars/contributors/releases from the GitHub API, web downloads from api.npmjs.org. Replaces the retired Claude scheduled routine; zero AI quota spent."
+          git push origin "$BRANCH"
+
+          gh pr create --title "chore(site): refresh community metrics [skip ci]" \
+            --body "Automated weekly community-metrics refresh (site-metrics.yml). Docs-only diff (website-static/index.html) — merges itself once CI Gate reports green." \
+            --base main --head "$BRANCH"
+          gh pr merge "$BRANCH" --squash --auto


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/site-metrics.yml`: a weekly (Monday 07:00 UTC) + `workflow_dispatch` job that fetches GitHub stars/contributors/releases (`sceneview/sceneview`) and npm downloads (`sceneview-web`) from public APIs and refreshes the corresponding `data-metric="..."` values in `website-static/index.html`.
- Adds `.claude/scripts/update-site-metrics.sh`: the targeted, idempotent updater used by the workflow (anchor-drift and bad-input guarded, tested locally on a copy of index.html — see test plan).
- Replaces a retired Claude scheduled routine that used to refresh these numbers by hand. Zero AI quota spent going forward.

Deliberately out of scope (untouched by this job): the `forks` and `mcp-downloads` (sceneview-mcp) metric cards on the same page — only stars/contributors/releases/web-downloads were requested.

## Why a PR instead of a literal direct push
`main` requires the `CI Gate` status check (branch protection), and GitHub only allows a direct push once a commit SHA already carries a passing required check — a brand-new commit never does. That's why `release-fast.yml`/`tag-release.yml` already use `gh pr create` + `gh pr merge --squash --auto` instead of `git push origin main`, and this job follows the same proven pattern for its own weekly commit. It resolves fast: `ci.yml` has `paths-ignore: website-static/**`, so a metrics-only diff registers no other check runs, and `ci-gate.yml`'s documented "docs-only bypass" goes green after its ~2 min grace period.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/site-metrics.yml'))"` — parses cleanly.
- [x] `bash .claude/scripts/check-workflow-scripts.sh` — passes (exit 0), zero new warnings/errors attributable to this file.
- [x] `update-site-metrics.sh` dry-run tested locally against a copy of `website-static/index.html`: correct targeted diff (only the 4 in-scope anchors changed), non-numeric input rejected, renamed/missing anchor detected and fails loudly, re-running with unchanged values produces a byte-identical file (the idempotency the `git diff --quiet` gate in the workflow relies on).
- [ ] Post-merge: `gh workflow run site-metrics.yml` dispatched to confirm a real end-to-end run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)