### PR TITLE
fix(qa): AR device-QA leg diagnoses mid-sweep crashes instead of dying silently (#2620)

### DIFF
--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -35,14 +35,22 @@
 #
 # Options:
 #   --no-install   Skip the build+install step (APK already on device).
-#   --out <dir>    Directory to copy ar-qa-summary.json into. Default: a temp
-#                  dir; the resolved path is printed on the last line.
+#   --out <dir>    Directory to copy ar-qa-summary.json into. Also receives
+#                  ar-logcat.txt (streamed for the whole run) and
+#                  ar-instrumentation.txt (teed `am instrument` output) so a
+#                  crash is diagnosable from the artifact bundle (#2620).
+#                  Default: a temp dir; the resolved path is printed last.
 #   -h | --help    Show this help.
 #
 # Exit status:
 #   0  every AR demo survived recorded-session replay AND the recorded ARCore
-#      dataset genuinely replayed frames (verdict `replayed`)
-#   1  one or more demos crashed, or the harness could not run
+#      dataset genuinely replayed frames (verdict `replayed`); OR the harness
+#      assumeTrue-skipped because the bundled recording is absent (sparse
+#      checkout / release build) — a no-op that stays green (#1565)
+#   1  one or more demos crashed, OR the instrumentation host process died
+#      mid-sweep (a demo took down the shared MainActivity process, or lmkd
+#      OOM-killed it). The recovered partial summary names the culprit and the
+#      captured logcat holds the crash signature (#2620)
 #   2  no device / emulator connected
 #   3  SKIPPED — no demo crashed, but `ar-record-playback` advanced 0 frames:
 #      ARCore dataset playback is unsupported on this emulator. An environment
@@ -69,7 +77,7 @@ while [[ $# -gt 0 ]]; do
     --no-install) INSTALL=0; shift ;;
     --out) OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
     -h|--help)
-      sed -n '2,49p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,57p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "[ar-replay-qa] unknown option: $1" >&2; exit 1 ;;
@@ -98,25 +106,58 @@ else
   echo "[ar-replay-qa] --no-install: skipping build+install."
 fi
 
-# ── Clean logcat so a crash this run is not masked by an older one ──────────
-adb -s "$SERIAL" logcat -c || true
-
-# ── Run the replay harness ─────────────────────────────────────────────────
-echo "[ar-replay-qa] running ARReplayHarnessTest (headless AR replay over all AR demos)…"
-HARNESS_STATUS=0
-adb -s "$SERIAL" shell am instrument -w \
-  -e class io.github.sceneview.demo.ar.ARReplayHarnessTest \
-  io.github.sceneview.demo.test/androidx.test.runner.AndroidJUnitRunner \
-  || HARNESS_STATUS=$?
-
-# ── Pull the machine-readable verdict ──────────────────────────────────────
-DEVICE_SUMMARY="/sdcard/Download/SceneView/ar-qa-summary.json"
+# ── Resolve the output dir up-front ────────────────────────────────────────
+# Needed BEFORE the run so the streamed logcat and the teed instrumentation
+# output land in the artifact dir device-qa.sh uploads (device-qa-artifacts/).
 if [[ -z "$OUT_DIR" ]]; then
   OUT_DIR="$(mktemp -d)"
 fi
 mkdir -p "$OUT_DIR"
 LOCAL_SUMMARY="$OUT_DIR/ar-qa-summary.json"
+LOGCAT_FILE="$OUT_DIR/ar-logcat.txt"
+INSTR_FILE="$OUT_DIR/ar-instrumentation.txt"
 
+# ── Clean logcat so a crash this run is not masked by an older one ──────────
+adb -s "$SERIAL" logcat -c || true
+
+# ── Stream logcat for the whole run ────────────────────────────────────────
+# The AR demos are deep-linked into MainActivity's process, which is ALSO the
+# instrumentation host (the demo manifest declares no `android:process`). A
+# native crash (Filament/GL on the software-GPU swiftshader CI emulator) or an
+# lmkd OOM-kill of that RAM-heavy process tears the instrumentation down
+# mid-sweep: `am instrument` then exits non-zero with NO JUnit output and the
+# harness never finishes writing its summary (#2620). A streamed logcat is the
+# only place the real crash signature (tombstone / SIGSEGV / lowmemorykiller)
+# survives — a post-hoc `logcat -d` can miss it once the ring buffer rolls over
+# on a chatty multi-minute Filament run, so stream live into the artifact dir.
+LOGCAT_PID=""
+stop_logcat() { [[ -n "$LOGCAT_PID" ]] && kill "$LOGCAT_PID" >/dev/null 2>&1 || true; }
+trap stop_logcat EXIT
+adb -s "$SERIAL" logcat -v threadtime > "$LOGCAT_FILE" 2>&1 &
+LOGCAT_PID=$!
+
+# ── Run the replay harness ─────────────────────────────────────────────────
+echo "[ar-replay-qa] running ARReplayHarnessTest (headless AR replay over all AR demos)…"
+HARNESS_STATUS=0
+# `tee` the instrumentation stream to a file for the artifact bundle. errexit is
+# toggled off around the pipe so PIPESTATUS[0] captures `am instrument`'s own
+# status (not tee's) — a crashed instrumentation host exits non-zero, whereas a
+# plain JUnit assertion failure would still exit 0 and write its summary.
+set +e
+adb -s "$SERIAL" shell am instrument -w \
+  -e class io.github.sceneview.demo.ar.ARReplayHarnessTest \
+  io.github.sceneview.demo.test/androidx.test.runner.AndroidJUnitRunner \
+  2>&1 | tee "$INSTR_FILE"
+HARNESS_STATUS=${PIPESTATUS[0]}
+set -e
+
+# Stop the logcat stream now the run is over so the file is complete before we
+# inspect it below.
+stop_logcat
+trap - EXIT
+
+# ── Pull the machine-readable verdict ──────────────────────────────────────
+DEVICE_SUMMARY="/sdcard/Download/SceneView/ar-qa-summary.json"
 SUMMARY_PULLED=0
 if adb -s "$SERIAL" pull "$DEVICE_SUMMARY" "$LOCAL_SUMMARY" >/dev/null 2>&1; then
   SUMMARY_PULLED=1
@@ -124,21 +165,69 @@ if adb -s "$SERIAL" pull "$DEVICE_SUMMARY" "$LOCAL_SUMMARY" >/dev/null 2>&1; the
   cat "$LOCAL_SUMMARY"
   echo
   echo "[ar-replay-qa] summary written to: $LOCAL_SUMMARY"
-else
-  echo "[ar-replay-qa] WARNING: no ar-qa-summary.json on device — the harness" >&2
-  echo "[ar-replay-qa] was likely assumeTrue-skipped (bundled recording absent," >&2
-  echo "[ar-replay-qa] or Google Play Services for AR missing). See test output." >&2
 fi
 
 # ── Verdict ────────────────────────────────────────────────────────────────
-# A non-zero instrumentation status means a demo crashed (the harness asserts
-# no crash) -> hard FAIL. Note the harness also ends the test with assumeTrue
-# when the replay demo advanced 0 frames; an assumeTrue-skip is NOT an
-# instrumentation failure, so HARNESS_STATUS stays 0 in that case and we fall
-# through to the summary-based skip detection below.
+# A non-zero instrumentation status is NOT a normal JUnit assertion failure
+# (that prints `FAILURES!!!` + a stack trace and still writes the summary). It
+# means the instrumentation host process DIED — a demo crashed the shared
+# MainActivity process, or lmkd OOM-killed it — before the sweep finished. The
+# harness now writes its summary incrementally with an `inProgress` marker, so a
+# recovered partial summary names the exact culprit; the streamed logcat holds
+# the native crash tombstone the instrumentation stdout does not (#2620).
 if [[ "$HARNESS_STATUS" -ne 0 ]]; then
-  echo "[ar-replay-qa] FAIL — one or more AR demos crashed during replay." >&2
+  echo "[ar-replay-qa] FAIL — AR replay harness exited non-zero ($HARNESS_STATUS)." >&2
+  if [[ "$SUMMARY_PULLED" -eq 1 ]]; then
+    CRASHER=""
+    if command -v python3 >/dev/null 2>&1; then
+      CRASHER="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+v = d.get("inProgress")
+if v:
+    print(v)
+' "$LOCAL_SUMMARY" 2>/dev/null || true)"
+    fi
+    if [[ -n "$CRASHER" ]]; then
+      echo "[ar-replay-qa] the app process died while replaying demo '$CRASHER'" >&2
+      echo "[ar-replay-qa] — it runs in MainActivity's process, which is also the" >&2
+      echo "[ar-replay-qa] instrumentation host, so a native crash / OOM-kill took" >&2
+      echo "[ar-replay-qa] both down and no per-demo verdict is possible for it." >&2
+    else
+      echo "[ar-replay-qa] a partial summary was recovered but names no in-flight" >&2
+      echo "[ar-replay-qa] demo — see the summary + logcat for the crash point." >&2
+    fi
+  else
+    echo "[ar-replay-qa] no summary on device: the harness died before the demo" >&2
+    echo "[ar-replay-qa] sweep began (a setUp / asset-deploy crash), or it" >&2
+    echo "[ar-replay-qa] assumeTrue-skipped because the bundled recording is absent." >&2
+  fi
+  echo "[ar-replay-qa] captured logcat:        $LOGCAT_FILE" >&2
+  echo "[ar-replay-qa] instrumentation output: $INSTR_FILE" >&2
+  # Echo the most telling native-crash lines inline so the CI job log is
+  # self-diagnosing without downloading the artifact.
+  echo "[ar-replay-qa] --- logcat crash signature (grep) -------------------------" >&2
+  grep -aiE 'FATAL|signal [0-9]|SIGSEGV|SIGABRT|tombstone|lowmemorykiller|lmkd|Process io.github.sceneview.demo.*(died|killed)|libfilament|JNI DETECTED' \
+    "$LOGCAT_FILE" 2>/dev/null | tail -40 >&2 || true
+  echo "[ar-replay-qa] -----------------------------------------------------------" >&2
   exit 1
+fi
+
+# HARNESS_STATUS==0 but no summary → the test assumeTrue-skipped before writing
+# one: the bundled recording is absent (a release build, or a sparse checkout
+# that excluded the MP4). That is intentionally green — a sparse checkout must
+# not fail the leg (see ARReplayHarnessTest KDoc, #1565). Nothing was replayed,
+# so do NOT fall through to the PASS line (which would falsely claim frames
+# replayed); exit 0 with an honest note.
+if [[ "$SUMMARY_PULLED" -eq 0 ]]; then
+  echo "[ar-replay-qa] no ar-qa-summary.json and instrumentation exited cleanly —" >&2
+  echo "[ar-replay-qa] the harness assumeTrue-skipped before the sweep (bundled" >&2
+  echo "[ar-replay-qa] recording absent: release build or sparse checkout). Nothing" >&2
+  echo "[ar-replay-qa] to replay; leaving the leg green (#1565)." >&2
+  exit 0
 fi
 
 # Honesty gate (#1645): inspect the machine-readable summary. If the replay

--- a/changelog.d/2620-ar-replay-harness-crash-diagnostics.md
+++ b/changelog.d/2620-ar-replay-harness-crash-diagnostics.md
@@ -1,0 +1,9 @@
+<!-- category: Tests -->
+- AR device-QA leg (`ar-replay-qa.sh` + `ARReplayHarnessTest`): the harness now writes its
+  machine-readable summary **incrementally** with an `inProgress` marker, and the script
+  streams `logcat` + tees the instrumentation output into the artifact bundle. When the
+  instrumentation host process dies mid-sweep — a demo crashing the shared `MainActivity`
+  process, or an lmkd OOM-kill, as happened silently on the CI x86_64/swiftshader emulator
+  for over a week — the leg now leaves an honest partial verdict that **names the crashing
+  demo** and captures the crash signature, instead of a bare `rc=1` with no summary at all
+  ([#2620](https://github.com/sceneview/sceneview/issues/2620)).

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/ar/ARReplayHarnessTest.kt
@@ -31,8 +31,7 @@ import java.io.FileOutputStream
  *
  * ## What it does
  *
- * For each demo in [DemoCategory.AUGMENTED_REALITY] (13 demos, see
- * [ALL_DEMOS]) it:
+ * For each demo in [DemoCategory.AUGMENTED_REALITY] (see [ALL_DEMOS]) it:
  *
  * 1. Deploys the bundled ARCore recording into the app's external files dir.
  * 2. Deep-links the demo with `--es ar_playback_file <path>` so any demo that
@@ -85,7 +84,7 @@ import java.io.FileOutputStream
  * ## Why most demos get a crash-survival check, not a golden
  *
  * Only `ar-record-playback` reads [DemoSettings.arPendingPlaybackFile] and
- * mounts `ARSceneView(playbackDataset = file)`. The other 12 AR demos build a
+ * mounts `ARSceneView(playbackDataset = file)`. The other AR demos build a
  * **live** `ARSceneView`. Driving them through a recorded session still has
  * real value — ARCore session creation, demo composition, the Filament
  * engine, model loading and the AR overlay all execute on the emulator, which
@@ -143,9 +142,25 @@ class ARReplayHarnessTest {
             arDemos.isNotEmpty(),
         )
 
+        // Persist the verdict INCREMENTALLY, not just once after the loop. Every
+        // AR demo is deep-linked into MainActivity's process — which is ALSO the
+        // instrumentation host (the manifest declares no `android:process`) — so a
+        // native crash (Filament/GL on a software-GPU emulator) or an lmkd
+        // OOM-kill of that RAM-heavy process takes THIS test process down with it.
+        // When that happens `am instrument` exits non-zero with no JUnit output,
+        // and a trailing-only `writeSummary` would never run: the whole sweep
+        // vanishes with no machine-readable verdict at all
+        // ([#2620](https://github.com/sceneview/sceneview/issues/2620) — the CI
+        // x86_64 / swiftshader AR leg failed exactly this way, rc=1 and no summary,
+        // silently for over a week). Writing the summary before each launch and
+        // tagging the about-to-run demo in `inProgress` guarantees a mid-sweep
+        // process death still leaves an honest PARTIAL verdict on disk that names
+        // the culprit. On a healthy host the final write below clears `inProgress`
+        // and the summary is identical to the old behaviour.
         val results = ArrayList<DemoResult>(arDemos.size)
         try {
             for (demo in arDemos) {
+                writeSummary(results, inProgress = demo.id)
                 results += replayDemo(demo.id, deployed)
                 // Land on the demo list between demos so onNewIntent fires cleanly
                 // for the next deep-link.
@@ -155,7 +170,7 @@ class ARReplayHarnessTest {
             deployed.delete()
         }
 
-        val summaryPath = writeSummary(results)
+        val summaryPath = writeSummary(results, inProgress = null)
 
         // The harness fails if ANY demo crashed during replay. Demos that the
         // recording could not advance (live-only demos that ignore the playback
@@ -258,13 +273,21 @@ class ARReplayHarnessTest {
      * `{ harness, passed, total, <items> }` skeleton so the slice-5
      * orchestrator can merge platform reports without special-casing each.
      *
+     * Called after **every** demo (not just once at the end) so a mid-sweep
+     * process death still leaves a partial verdict on disk — see the call site.
+     * [inProgress], when non-null, records the demo currently being replayed as a
+     * top-level `inProgress` field: if the shared MainActivity/instrumentation
+     * process dies replaying it, that field names the exact culprit for
+     * `ar-replay-qa.sh` to surface ([#2620](https://github.com/sceneview/sceneview/issues/2620)).
+     * The final post-loop write passes `null`, clearing it.
+     *
      * `passed` counts only genuine passes — `replayed` and live-only `alive`.
      * A `skipped` demo (#1645: replay demo that advanced 0 frames because the
      * emulator cannot do ARCore dataset playback) is reported in its own
      * `skipped` count and is NOT folded into `passed`, so a green AR leg
      * genuinely means the recorded session replayed.
      */
-    private fun writeSummary(results: List<DemoResult>): File {
+    private fun writeSummary(results: List<DemoResult>, inProgress: String?): File {
         val demos = JSONArray()
         for (r in results) {
             val obj = JSONObject()
@@ -284,7 +307,11 @@ class ARReplayHarnessTest {
             .put("skipped", skipped)
             .put("failed", failed)
             .put("total", results.size)
-            .put("demos", demos)
+        // Non-null only between launching a demo and its verdict landing in
+        // `results`. If the shared process dies in that window this is the last
+        // thing written, so it pinpoints the crashing demo (#2620).
+        if (inProgress != null) root.put("inProgress", inProgress)
+        root.put("demos", demos)
 
         device.executeShellCommand("mkdir -p /sdcard/Download/SceneView")
         val file = File("/sdcard/Download/SceneView/ar-qa-summary.json")
@@ -378,12 +405,15 @@ class ARReplayHarnessTest {
         const val REPLAY_DEMO_ID = "ar-record-playback"
 
         /**
-         * Reason surfaced for a [VERDICT_SKIPPED] replay demo: ARCore dataset
-         * playback (`Session.setPlaybackDataset`) needs camera-stream support
-         * the x86 software-GPU CI emulator does not provide.
+         * Reason surfaced for a [VERDICT_SKIPPED] replay demo: the recorded
+         * ARCore dataset (`Session.setPlaybackDataset`) advanced 0 frames. This
+         * reproduces on BOTH the software-GPU CI emulator (no replayable camera
+         * stream) AND host-GPU local emulators, so the message must not
+         * over-specify "software-GPU CI emulator" ([#2620](https://github.com/sceneview/sceneview/issues/2620)).
          */
         const val REASON_PLAYBACK_UNSUPPORTED =
-            "ARCore dataset playback not supported on this emulator " +
-                "(software-GPU CI emulator has no replayable camera stream)"
+            "ARCore dataset playback not supported on this emulator configuration " +
+                "(0 replayable frames — reproduces on both software-GPU CI and " +
+                "host-GPU local emulators)"
     }
 }


### PR DESCRIPTION
Fixes #2620.

## Problem

The `ar` leg of `device-qa.yml` produced
`{"status":"failed","reason":"ar-replay-qa.sh rc=1","summary":null}` on **every**
CI run for over a week — no summary, no stack trace. Materially worse than the
documented graceful skip (#1645), and silent because the leg is advisory
(#1651/#1670).

## Root cause

Every AR demo is deep-linked into the **single** `MainActivity` (the demo
manifest declares no `android:process`), so demos run in the **same process** as
the instrumentation host. On the CI `x86_64` + `swiftshader_indirect` emulator a
demo crashes that process — native Filament/GL on software-GPU, or an lmkd
OOM-kill — which takes the instrumentation down mid-sweep. `am instrument` then
exits non-zero with **no JUnit output**, and `writeSummary()` (called only after
the demo loop) never runs. Environmental: the identical harness passes on a
host-GPU arm64 emulator (`passed:31, skipped:1`). The exact trigger (native GL
crash vs OOM-kill) is not yet confirmed — no CI run captured a logcat.

## Fix — honest + diagnosable, NOT a papered-over skip

- **`ARReplayHarnessTest`**: write the summary **incrementally** with an
  `inProgress` marker, so a mid-sweep process death still leaves a partial
  verdict on disk that **names the crashing demo**. Healthy-host behaviour is
  byte-identical.
- **`ar-replay-qa.sh`**: stream `logcat` for the whole run + `tee` the
  instrumentation output into `device-qa-artifacts/` (uploaded by CI); on a
  non-zero instrumentation exit, read `inProgress`, name the crasher, and echo
  the crash signature inline. Capture `PIPESTATUS` behind the `tee` so a crashed
  host is still detected. Replace the misleading "assumeTrue-skipped" message.
- Generalise `REASON_PLAYBACK_UNSUPPORTED` (the 0-frames symptom reproduces on
  host-GPU too, not only the software-GPU CI emulator).
- Fix stale KDoc demo counts ("13 demos" / "other 12" → ~34).

The verdict stays `failed` (advisory WARN) for a genuine crash — **not** silently
converted to a skip, which could hide a real product crash — but becomes a named,
logcat-backed failure. **The `device-qa.yml` run this merge triggers on `main`
will produce the first `ar-logcat.txt`, confirming the exact trigger** (then: real
bug → fix it; purely environmental → downgrade to an honest `skipped`).

## Verification

- `:samples:android-demo:compileDebugAndroidTestKotlin` → **BUILD SUCCESSFUL**.
- `ar-replay-qa.sh` → `bash -n` + `shellcheck` clean; `--help` renders in full.
- New bash mechanics unit-tested under bash: `inProgress` extraction
  (partial→name / complete→empty), `PIPESTATUS[0]` behind `tee` (captures `am
  instrument`'s status, not `tee`'s), crash-signature grep (matches
  SIGSEGV/lmkd/died, ignores noise).

Scope: QA harness + `androidTest` only — no public API, no rendering, no
threading change. Advisory leg; cannot block a release either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
