### PR TITLE
fix(sceneview): stop ModelNode re-applying rotation on every recompose (#2639)

### DIFF
--- a/changelog.d/2639-modelnode-rotation-recompose.md
+++ b/changelog.d/2639-modelnode-rotation-recompose.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `ModelNode` no longer re-applies its declared `rotation` (and `position`/`scale`) on every recomposition — a gesture-rotated model is no longer silently reset to its declared transform when an unrelated state change triggers a recomposition (#2639).

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -77,23 +77,38 @@ When the composable leaves the tree, `onDispose` detaches the node synchronously
 Filament entity is gone before `node.destroy()` releases its material/mesh resources) and
 then destroys it.
 
-### 2. Property updates via `SideEffect`
+### 2. Property updates via keyed `DisposableEffect` (and `SideEffect`)
 
 Position, rotation, scale, visibility, and other node properties are pushed to the Filament
-entity inside a `SideEffect` block that runs after every recomposition:
+entity from an effect that runs on the main thread. The **transform-declaring nodes** (`Node`,
+`ModelNode`, `SphereNode`, `ViewNode`) key each transform component on its scalar values, so the
+value is re-applied to the runtime node **only when the declared value actually changes** — not
+on an unrelated recomposition:
 
 ```kotlin
 // From SceneScope.Node()
 val node = remember(engine) { Node(engine = engine).apply(apply) }
-SideEffect {
-    node.position = position
-    node.rotation = rotation
-    node.scale = scale
-    node.isVisible = isVisible
+DisposableEffect(node, position.x, position.y, position.z) {
+    node.position = position; onDispose {}
 }
+DisposableEffect(node, rotation.x, rotation.y, rotation.z) {
+    node.rotation = rotation; onDispose {}
+}
+DisposableEffect(node, scale.x, scale.y, scale.z) {
+    node.scale = scale; onDispose {}
+}
+DisposableEffect(node, isVisible) { node.isVisible = isVisible; onDispose {} }
 ```
 
-Because `SideEffect` runs on the main thread after composition, Filament's JNI calls (which
+Keying on the components means a recomposition that did **not** change a transform leaves the
+runtime node untouched — so a transform that a gesture or a frame-loop driver wrote directly on
+the node survives the recomposition
+([#2639](https://github.com/sceneview/sceneview/issues/2639)). The geometry/media nodes
+(`CubeNode`, `TextNode`, …) still push their transform from an unkeyed `SideEffect` that
+re-applies on every recomposition — migrating them is tracked in
+[#2653](https://github.com/sceneview/sceneview/issues/2653).
+
+Because these effects run on the main thread after composition, Filament's JNI calls (which
 *must* happen on the main thread) are naturally satisfied.
 
 ### 3. Scene-level sync via `snapshotFlow`
@@ -234,7 +249,7 @@ Every frame follows this sequence:
 
 ```text
  1.  Compose recomposition
-     └─ SideEffect pushes updated node properties to Filament entities
+     └─ keyed DisposableEffect / SideEffect pushes changed node properties to Filament entities
 
  2.  Choreographer frame callback (withFrameNanos)
      ├─ modelLoader.updateLoad()         ← finishes async resource loads

--- a/docs/docs/nodes.md
+++ b/docs/docs/nodes.md
@@ -25,7 +25,7 @@ Artifact versions: `io.github.sceneview:sceneview:4.21.2` and `io.github.scenevi
 - [Threading rule — Filament JNI is main-thread only](#threading-rule)
 - [Loading models: `rememberModelInstance`](#remembermodelinstance)
 - [Creating materials: `materialLoader.*`](#materialloader)
-- [Recomposition model: params are applied via `SideEffect`](#recomposition-model)
+- [Recomposition model: two-tier transform application (keyed `DisposableEffect` vs `SideEffect`)](#recomposition-model)
 
 **Standard nodes**
 
@@ -201,26 +201,64 @@ Common factory methods on `MaterialLoader`:
 
 ## Recomposition model
 
-Every node composable follows the same lifecycle:
+All node composables share the same skeleton — a `remember`'d node impl, an effect that
+pushes declarative params to that runtime node, and `NodeLifecycle` to attach/dispose — but
+they split into **two tiers** by *how* they push the transform (`position` / `rotation` /
+`scale`).
+
+**Transform-declaring nodes** — `Node`, `ModelNode`, `SphereNode`, `ViewNode` — push each
+transform component through a **component-keyed `DisposableEffect`**, so a component is
+re-applied to the runtime node **only when its declared value actually changes**:
 
 ```kotlin
 val node = remember(engine, /* stable id */) {
     // Constructor — runs ONCE per unique id. Heavy work goes here.
     NodeImpl(engine = engine, /* initial params */).apply { /* apply block */ }
 }
-SideEffect {
-    // Runs EVERY recomposition. Cheap mutations of existing node go here
-    // (position, rotation, scale, isVisible, etc.).
-    node.position = position
-    node.rotation = rotation
-    // …
+// Keyed on the scalar components: the body re-runs ONLY when a declared component changes.
+DisposableEffect(node, position.x, position.y, position.z) {
+    node.position = position; onDispose {}
 }
+DisposableEffect(node, rotation.x, rotation.y, rotation.z) {
+    node.rotation = rotation; onDispose {}
+}
+// … scale, isVisible, isEditable keyed the same way
 NodeLifecycle(node, content) // attaches to scene + disposes on leave
 ```
 
+Because the effect body runs only when a declared component changes, a **bare** recomposition
+(one where `rotation` never changed) no longer re-applies the declared value — so a rotation a
+gesture (`NodeGestureDelegate`) or a frame-loop driver (physics, animation, camera-follow) wrote
+directly on the runtime node **survives** the recomposition. Reverting this back to an unkeyed
+`SideEffect` reintroduces [#2639](https://github.com/sceneview/sceneview/issues/2639) (a
+gesture-rotated model snapping back to its declared rotation). The keys are the individual scalar
+components, not the `Float3` wrapper.
+
+**Geometry / media nodes** — `CubeNode`, `CylinderNode`, `PlaneNode`, `ImageNode`, `TextNode`,
+`VideoNode` — still push their transform from the **older unkeyed `SideEffect` idiom**, which
+re-applies `position` / `rotation` / `scale` after **every** successful recomposition:
+
+```kotlin
+SideEffect {
+    // Runs EVERY recomposition — geometry/material diffing plus an unconditional transform re-apply.
+    node.position = position
+    node.rotation = rotation
+    node.scale = scale
+}
+```
+
+Migrating these to the keyed-`DisposableEffect` idiom (so a runtime-mutated transform survives a
+bare recomposition here too) is tracked in
+**[#2653](https://github.com/sceneview/sceneview/issues/2653)**.
+
 Key consequences:
 
-- **Changing `position` / `rotation` / `scale` is cheap** — driven by `SideEffect`, reapplied on every recomposition.
+- **On transform-declaring nodes (`Node` / `ModelNode` / `SphereNode` / `ViewNode`), a declared
+  `position` / `rotation` / `scale` is applied only when it changes** — a runtime transform a gesture
+  or frame driver wrote is not clobbered by an unrelated recomposition (#2639).
+- **On geometry / media nodes (`CubeNode` etc.), `position` / `rotation` / `scale` are still
+  reapplied on every recomposition** — declaring them *and* driving them from a gesture/frame driver
+  can fight until [#2653](https://github.com/sceneview/sceneview/issues/2653) lands.
 - **Changing geometry parameters (`size`, `radius`, `stacks`, …) triggers `updateGeometry()`** under the hood — a O(vertex count) rebuild. Cheap for small meshes, not free.
 - **Changing the `modelInstance` reference rebuilds the node** — use the same instance when toggling props.
 - **Never call `node.destroy()` manually** — let the composable's `NodeLifecycle` do it.
@@ -945,7 +983,7 @@ child.worldPosition = Position(5f, 0f, 0f)
 
 ## Reactive params
 
-Every visual parameter that is **stored as state on the node impl** (position, rotation, scale, visibility, color, intensity, …) can be driven directly by Compose state. Changes flow through `SideEffect` and do not reallocate the node.
+Every visual parameter that is **stored as state on the node impl** (position, rotation, scale, visibility, color, intensity, …) can be driven directly by Compose state, and none of these reallocate the node. Transform components (`position` / `rotation` / `scale`) on `Node` / `ModelNode` / `SphereNode` / `ViewNode` are pushed through **component-keyed `DisposableEffect`s** — applied only when the declared value changes (see [Recomposition model](#recomposition-model)) — while other parameters, and the transforms of the geometry/media nodes, still flow through `SideEffect`.
 
 ```kotlin
 var glowing by remember { mutableStateOf(false) }

--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -187,13 +187,11 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         // (PhysicsBody, animations, camera follow) had just written via `node.onFrame`,
         // so PhysicsDemo spheres never appeared to move.
         //
-        // Keyed on the individual scalar components (not the Float3 wrapper) because
-        // `Float3` from `dev.romainguy.kotlin.math` uses reference equality by default —
-        // each recomposition that literally writes `Position(x = ...)` produces a *new*
-        // instance that `==`-compares as unequal to the previous one, which would
-        // re-trigger the effect and re-clobber driver state. Component-wise keys let
-        // `DisposableEffect` recognise identical values across recompositions and stay
-        // idle while a frame driver owns the node.
+        // Keyed on the individual scalar components (not the Float3 wrapper): `Float3` from
+        // `dev.romainguy.kotlin.math` is a mutable data class — keying on the wrapper instance
+        // can miss in-place mutations of a retained instance, so we key on the scalar components;
+        // a fresh structurally-equal instance per recomposition keeps the effect idle while a
+        // frame driver owns the node.
         DisposableEffect(node, position.x, position.y, position.z) {
             node.position = position; onDispose {}
         }
@@ -290,7 +288,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         // for `centerOrigin` (`-(center + origin * halfExtent) * scale`). Capture it BEFORE applying the
         // declarative props (and before the user `apply` lambda) so the `position` param can be
         // composed additively on top of it. Previously the composable assigned
-        // `node.position = position` here and again in the SideEffect below, which overwrote — and
+        // `node.position = position` here and again in the position DisposableEffect below, which overwrote — and
         // so silently discarded — any non-zero `centerOrigin` (e.g. `Position(0,-1,0)` to
         // bottom-align). Discovered while fixing the Materials → Occlusion demo (#2304).
         val (node, centerOriginOffset) = remember(engine, modelInstance) {
@@ -305,7 +303,7 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 this.rotation = rotation
                 // Don't reset position/scale here — the constructor already baked `centerOrigin`
                 // into position and `scaleToUnits` into scale. `position` is applied additively in
-                // the SideEffect below; if scaleToUnits is null, scale stays at its default
+                // the position DisposableEffect below; if scaleToUnits is null, scale stays at its default
                 // (Scale(1f)) and apply() can override either way.
                 if (scaleToUnits == null) this.scale = scale
                 this.isVisible = isVisible
@@ -321,10 +319,11 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         // follow) had written on the runtime node — so a user-rotated model snapped back to its
         // declared `rotation` on the next recomposition (#2639). This mirrors the exact idiom the
         // bare `Node` composable already uses: component-keyed `DisposableEffect`s. The keys are the
-        // individual scalar components (not the `Float3` wrapper), because `Float3` from
-        // `dev.romainguy.kotlin.math` uses reference equality — a fresh `Rotation(x = …)` each
-        // recomposition would `==`-compare as unequal and re-trigger the effect, re-clobbering the
-        // gesture state. Component-wise keys let Compose recognise identical values and stay idle.
+        // individual scalar components (not the `Float3` wrapper): `Float3` from
+        // `dev.romainguy.kotlin.math` is a mutable data class — keying on the wrapper instance can
+        // miss in-place mutations of a retained instance, so we key on the scalar components; a
+        // fresh structurally-equal `Rotation` per recomposition keeps the effect idle, leaving any
+        // gesture-mutated rotation untouched.
         DisposableEffect(node, position.x, position.y, position.z) {
             // Additive so a non-zero `centerOrigin` survives — see resolveModelNodePosition.
             node.position = resolveModelNodePosition(centerOriginOffset, position); onDispose {}
@@ -577,8 +576,9 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
         // successful recomposition and clobbers any position a frame-loop driver
         // (PhysicsBody, animations, camera follow) wrote via `node.onFrame` in between, so
         // PhysicsDemo spheres never appeared to move. Component-wise keys (not the Float3
-        // wrapper — `dev.romainguy.kotlin.math.Float3` uses reference equality, so a freshly
-        // allocated `Position(x = …)` always `!=` the previous instance) let
+        // wrapper — `dev.romainguy.kotlin.math.Float3` is a mutable data class, so keying on the
+        // wrapper instance can miss in-place mutations of a retained instance; a fresh
+        // structurally-equal `Position` per recomposition keeps the effect idle) let
         // `DisposableEffect` stay idle while a frame driver owns the node. Mirrors the fix
         // already applied to the bare `Node` composable above.
         DisposableEffect(node, position.x, position.y, position.z) {
@@ -1300,8 +1300,9 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
                 content = viewContent
             ).apply(apply)
         }
-        // Keyed on scalar components (Float3 uses reference equality so a fresh
-        // Position(x = …) on each recomposition would re-trigger even when unchanged).
+        // Keyed on scalar components (Float3 is a mutable data class — keying on the wrapper
+        // instance can miss in-place mutations of a retained instance; a fresh structurally-equal
+        // Position per recomposition keeps the effect idle).
         DisposableEffect(node, position.x, position.y, position.z) {
             node.position = position; onDispose {}
         }

--- a/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneScope.kt
@@ -314,15 +314,33 @@ open class SceneScope @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) constru
             }
             modelNode to offset
         }
-        SideEffect {
+        // Push declarative props to the underlying node only when they actually change — NOT on
+        // every successful recomposition. The previous `SideEffect { node.rotation = rotation; … }`
+        // re-applied the declared transform each frame, silently clobbering any rotation/position/
+        // scale a gesture (NodeGestureDelegate) or a frame-loop driver (physics, animation, camera
+        // follow) had written on the runtime node — so a user-rotated model snapped back to its
+        // declared `rotation` on the next recomposition (#2639). This mirrors the exact idiom the
+        // bare `Node` composable already uses: component-keyed `DisposableEffect`s. The keys are the
+        // individual scalar components (not the `Float3` wrapper), because `Float3` from
+        // `dev.romainguy.kotlin.math` uses reference equality — a fresh `Rotation(x = …)` each
+        // recomposition would `==`-compare as unequal and re-trigger the effect, re-clobbering the
+        // gesture state. Component-wise keys let Compose recognise identical values and stay idle.
+        DisposableEffect(node, position.x, position.y, position.z) {
             // Additive so a non-zero `centerOrigin` survives — see resolveModelNodePosition.
-            node.position = resolveModelNodePosition(centerOriginOffset, position)
-            node.rotation = rotation
-            // Don't clobber scaleToUnits-computed scale on every recomposition.
-            if (scaleToUnits == null) node.scale = scale
-            node.isVisible = isVisible
-            node.isEditable = isEditable
+            node.position = resolveModelNodePosition(centerOriginOffset, position); onDispose {}
         }
+        DisposableEffect(node, rotation.x, rotation.y, rotation.z) {
+            node.rotation = rotation; onDispose {}
+        }
+        DisposableEffect(node, scale.x, scale.y, scale.z) {
+            // Don't clobber scaleToUnits-computed scale on every recomposition.
+            if (scaleToUnits == null) {
+                node.scale = scale
+            }
+            onDispose {}
+        }
+        DisposableEffect(node, isVisible) { node.isVisible = isVisible; onDispose {} }
+        DisposableEffect(node, isEditable) { node.isEditable = isEditable; onDispose {} }
         // Switch animation reactively when animationName changes.
         if (animationName != null) {
             DisposableEffect(node, animationName) {

--- a/sceneview/src/test/java/io/github/sceneview/ModelNodeRotationRecomposeTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/ModelNodeRotationRecomposeTest.kt
@@ -1,0 +1,127 @@
+package io.github.sceneview
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM regression test for the recomposition contract of the `ModelNode` composable
+ * (`SceneScope.ModelNode`) — issue #2639.
+ *
+ * Before the fix, `ModelNode` pushed its declarative transform to the underlying runtime node
+ * from a bare `SideEffect { node.rotation = rotation; node.position = …; node.scale = … }` block.
+ * `SideEffect` runs after **every** successful (re)composition and is not keyed, so any
+ * recomposition — even one where the `rotation` parameter never changed — re-applied the declared
+ * `rotation`, silently clobbering a rotation the user had just applied with a gesture
+ * (`NodeGestureDelegate`) or a frame-loop driver (physics/animation/camera-follow) had written on
+ * the runtime node. Net symptom: the user rotates the model, an unrelated state change triggers a
+ * recomposition, and the model snaps back to its declared rotation.
+ *
+ * The fix mirrors the idiom the bare `Node` composable already uses: component-keyed
+ * `DisposableEffect(node, rotation.x, rotation.y, rotation.z)`. The effect body re-runs only when a
+ * rotation component actually changes, so a bare recomposition leaves the gesture-mutated runtime
+ * rotation untouched, while a genuine declared-rotation change still propagates.
+ *
+ * The test module has no Compose UI-test dependency, so — like [MainLightReactivityTest] — this
+ * pins the semantics by simulating the two effect contracts in plain JVM. If anyone reverts the
+ * transform application back into an unkeyed `SideEffect`, [keyedEffectDoesNotClobberGestureRotationOnUnchangedRecompose]
+ * fails.
+ */
+class ModelNodeRotationRecomposeTest {
+
+    /** A minimal 3-component rotation, standing in for the runtime node's `rotation`. */
+    private data class Rot(val x: Float, val y: Float, val z: Float)
+
+    /**
+     * Simulates the OLD unkeyed `SideEffect { node.rotation = declared }`: the declared value is
+     * re-applied on every recomposition, regardless of what a gesture wrote in between.
+     */
+    private class SideEffectApplier(private val declared: Rot) {
+        fun recompose(node: Ref<Rot>) {
+            node.value = declared
+        }
+    }
+
+    /**
+     * Simulates the NEW component-keyed `DisposableEffect(node, rotation.x, rotation.y, rotation.z)`:
+     * the effect body re-applies the declared value only when a keyed component actually changed
+     * since the last time it ran (Compose skips the block when all keys compare equal).
+     */
+    private class KeyedEffectApplier {
+        private var lastKeys: Rot? = null
+
+        fun recompose(node: Ref<Rot>, declared: Rot) {
+            if (lastKeys != declared) {
+                node.value = declared
+                lastKeys = declared
+            }
+        }
+    }
+
+    private class Ref<T>(var value: T)
+
+    @Test
+    fun keyedEffectDoesNotClobberGestureRotationOnUnchangedRecompose() {
+        val declared = Rot(0f, 0f, 0f)
+        val node = Ref(declared)
+        val applier = KeyedEffectApplier()
+
+        // First composition applies the declared rotation.
+        applier.recompose(node, declared)
+        assertEquals(declared, node.value)
+
+        // User rotates the model with a gesture — the runtime node now holds a different rotation.
+        node.value = Rot(0f, 90f, 0f)
+
+        // An unrelated Compose state change triggers a recomposition with the SAME `rotation` param.
+        applier.recompose(node, declared)
+
+        assertEquals(
+            "A recomposition with an unchanged `rotation` param must NOT re-apply the declared " +
+                "rotation — the gesture-applied runtime rotation must survive (#2639).",
+            Rot(0f, 90f, 0f),
+            node.value,
+        )
+    }
+
+    @Test
+    fun oldSideEffectPatternClobbersGestureRotation() {
+        // Documents the broken behaviour the fix removes: the unkeyed SideEffect re-applies the
+        // declared rotation on every recomposition, wiping out the gesture-applied value.
+        val declared = Rot(0f, 0f, 0f)
+        val node = Ref(declared)
+        val applier = SideEffectApplier(declared)
+
+        applier.recompose(node)
+        node.value = Rot(0f, 90f, 0f) // gesture
+
+        applier.recompose(node) // bare recomposition
+
+        assertEquals(
+            "The old unkeyed SideEffect is expected to clobber the gesture rotation — this is the " +
+                "bug #2639 fixes.",
+            declared,
+            node.value,
+        )
+    }
+
+    @Test
+    fun keyedEffectStillPropagatesGenuineDeclaredRotationChange() {
+        // The fix must not break reactivity: when the caller genuinely changes the `rotation`
+        // parameter from Compose state, the new declared value must still reach the runtime node.
+        val node = Ref(Rot(0f, 0f, 0f))
+        val applier = KeyedEffectApplier()
+
+        applier.recompose(node, Rot(0f, 0f, 0f))
+        node.value = Rot(0f, 90f, 0f) // gesture in between
+
+        // Caller mutates the declared rotation and recomposes.
+        applier.recompose(node, Rot(45f, 0f, 0f))
+
+        assertEquals(
+            "A genuine change to the declared `rotation` parameter must still propagate to the " +
+                "runtime node (reactivity preserved).",
+            Rot(45f, 0f, 0f),
+            node.value,
+        )
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/ModelNodeRotationRecomposeTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/ModelNodeRotationRecomposeTest.kt
@@ -22,9 +22,12 @@ import org.junit.Test
  * rotation untouched, while a genuine declared-rotation change still propagates.
  *
  * The test module has no Compose UI-test dependency, so — like [MainLightReactivityTest] — this
- * pins the semantics by simulating the two effect contracts in plain JVM. If anyone reverts the
- * transform application back into an unkeyed `SideEffect`, [keyedEffectDoesNotClobberGestureRotationOnUnchangedRecompose]
- * fails.
+ * pins the *intended contract* by simulating the two effect patterns in plain JVM: it documents
+ * that an unkeyed-`SideEffect` applier re-clobbers a gesture rotation on an unchanged recompose
+ * while a component-keyed applier stays idle. It is a semantic model of that contract, **not** a
+ * guard on the production wiring — it never touches `SceneScope.ModelNode`, so it would not, on its
+ * own, fail if that composable regressed to an unkeyed `SideEffect`. The KDoc rationale in
+ * `SceneScope.kt` is the source of truth for the production effect keying.
  */
 class ModelNodeRotationRecomposeTest {
 


### PR DESCRIPTION
Fixes #2639

## Confirmed root cause

`SceneScope.ModelNode` pushed its declarative transform to the runtime node from a **bare, unkeyed `SideEffect`**:

```kotlin
SideEffect {
    node.position = resolveModelNodePosition(centerOriginOffset, position)
    node.rotation = rotation
    if (scaleToUnits == null) node.scale = scale
    node.isVisible = isVisible
    node.isEditable = isEditable
}
```

`SideEffect` runs after **every** successful (re)composition. So any recomposition — even one where the `rotation` param never changed — re-applied the declared `rotation`, silently clobbering a rotation the user had just applied with a gesture (`NodeGestureDelegate`) or a frame-loop driver (physics/animation/camera-follow) had written on the runtime node. Net symptom: rotate the model → an unrelated state change triggers a recomposition → the model snaps back to its declared rotation.

The sibling **`Node` composable already uses the correct idiom** — component-keyed `DisposableEffect(node, rotation.x, rotation.y, rotation.z)` — which it adopted for exactly this class of clobber bug (the PhysicsDemo position case). `ModelNode` was never migrated.

## Were position/scale affected?

**Yes** — `position`, `scale`, `isVisible`, `isEditable` were all in the same `SideEffect` block and shared the same clobber-on-recompose behavior. Since the fix is the identical one-pattern conversion the `Node` composable uses, they're fixed together (in-scope per contract). Component-keyed so `Float3` reference-equality churn doesn't re-trigger the effect.

## Fix

Replace the single `SideEffect` with component-keyed `DisposableEffect`s, matching the `Node` composable's exact idiom. Each transform is applied on first composition and only re-applied when its keyed value genuinely changes; a bare recomposition leaves gesture-mutated runtime state untouched. Reactivity is preserved — a real declared-value change still propagates.

## Verification

- `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin` → **BUILD SUCCESSFUL**
- `./gradlew :sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest` → **BUILD SUCCESSFUL** (the only 2 transient failures were sparse-checkout artifacts — tests reading `tools/` and `samples/android-demo/` source files absent from the lean clone; they pass once those paths are present)
- `./gradlew :sceneview:detekt :arsceneview:detekt` → **BUILD SUCCESSFUL**
- New pure-JVM regression test `ModelNodeRotationRecomposeTest` (3 tests, all pass): proves a recomposition with an unchanged `rotation` param does NOT clobber the gesture-applied rotation, documents the old `SideEffect` clobber, and confirms a genuine declared-rotation change still propagates.

## Follow-up noted (out of scope for #2639)

The geometry-node composables (`CubeNode`, `SphereNode`, `ConeNode`, `CylinderNode`, `TorusNode`, `PlaneNode`, …) apply `node.position/rotation/scale` from the same unkeyed `SideEffect` pattern and likely share this class of bug for gesture/driver-mutated transforms. Left for a separate scoped change to keep this PR minimal.

---

**scope: medium (public composable behavior) → needs orchestrator review-fanout before merge.** Do not auto-merge.