### PR TITLE
fix(web): Node.parent setter isDestroyed guard + probe sentinel invariant (#2613)

### DIFF
--- a/changelog.d/2613-web-parent-setter-guard.md
+++ b/changelog.d/2613-web-parent-setter-guard.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **sceneview-web**: `Node.parent` setter now guards the engine write after `destroy()` — re-parenting a retained, destroyed node no longer reaches `TransformManager.setParent` on a freed instance (a WASM use-after-free abort), closing the last unguarded hierarchy-write path (#2611 review, symmetric to the existing transform-write guard). The `#2024` P1 browser probe also asserts the detach-sentinel invariant: the sentinel entity never gains a transform component, so `nullParentInstance()` stays native instance 0.

--- a/samples/web-demo/tests/kotlin-bundle.spec.ts
+++ b/samples/web-demo/tests/kotlin-bundle.spec.ts
@@ -193,7 +193,15 @@ test.describe('SceneView Kotlin/JS bundle — browser init', () => {
         step = 'getWorldTransform(detached)';
         const detachedWorldX = tm.getWorldTransform(tm.getInstance(child))[12];
 
-        return { worldX, detachedWorldX };
+        // The invariant `nullParentInstance()` depends on: the sentinel entity
+        // must NEVER be granted a transform component, or `getInstance(sentinel)`
+        // stops being native instance 0 and the detach silently re-parents to a
+        // real node instead. Using it as a null parent above must not have
+        // materialised a component on it. (#2613)
+        step = 'hasComponent(detachSentinel)';
+        const sentinelHasComponent = tm.hasComponent(detachSentinel);
+
+        return { worldX, detachedWorldX, sentinelHasComponent };
       } catch (e: any) {
         return { error: `${step}: ${e?.name ?? ''} ${e?.message ?? String(e)}` };
       }
@@ -204,6 +212,12 @@ test.describe('SceneView Kotlin/JS bundle — browser init', () => {
     expect((result as any).worldX).toBeCloseTo(5, 3);
     // detached → world = local → x = 3
     expect((result as any).detachedWorldX).toBeCloseTo(3, 3);
+    // The detach sentinel must stay component-less — the invariant that keeps
+    // its instance native-0 (the null parent). (#2613)
+    expect(
+      (result as any).sentinelHasComponent,
+      'detach sentinel gained a transform component — nullParentInstance() invariant broken',
+    ).toBe(false);
   });
 
   /**

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
@@ -230,7 +230,16 @@ open class Node internal constructor(
             field = value
             oldParent?.let { it._childNodes = it._childNodes - this }
             (value as Node?)?.let { it._childNodes = it._childNodes + this }
-            backend.setParent((value as Node?)?.backend)
+            // Guard ONLY the engine write — never a top-level `return`. destroy()
+            // runs its internal `parent = null` detach AFTER [isDestroyed] is set
+            // and still needs the Kotlin-side child-list cleanup above; a naive
+            // early-return would break it. After destroy() the entity + transform
+            // component are freed, so a late setParent on a RETAINED destroyed node
+            // would hit a freed instance — a WASM use-after-free abort, not a
+            // catchable exception. Symmetric to the [applyLocalTransform] guard.
+            if (!isDestroyed) {
+                backend.setParent((value as Node?)?.backend)
+            }
         }
 
     private var _childNodes = setOf<SceneNode>()

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeTest.kt
@@ -376,6 +376,27 @@ class NodeTest {
     }
 
     @Test
+    fun parentSetterAfterDestroyDoesNotReachBackend() {
+        val parent = node("parent")
+        val child = node("child")
+
+        child.destroy()
+        val callsBeforeReparent = child.fake.setParentCalls
+
+        // A caller retains a destroyed node and re-parents it. The Filament
+        // entity + transform component are already freed, so the engine write
+        // (TransformManager.setParent on a freed instance) would be a WASM
+        // use-after-free abort — uncatchable. The guard must skip it, exactly
+        // like the transform-write guard skips setLocalTransform after destroy.
+        child.parent = parent
+
+        assertEquals(
+            callsBeforeReparent, child.fake.setParentCalls,
+            "no engine setParent may run on a destroyed node"
+        )
+    }
+
+    @Test
     fun destroyDetachesFromLivingParent() {
         val parent = node("parent")
         val child = node("child")


### PR DESCRIPTION
Closes #2613 — the two non-blocking follow-ups from the #2611 independent code review, tracked separately to keep the generator≠evaluator boundary clean.

## What & why

### 1. `Node.parent` setter was missing the `isDestroyed` guard (latent WASM abort)
`sceneview-web/.../nodes/Node.kt` — the `isDestroyed` guard added in #2611 covered only the transform-write path (`applyLocalTransform`), not the hierarchy-write path. A caller who **retains a destroyed node** and then assigns `node.parent = …` reached `backend.setParent(...)` on a freed instance → **WASM abort** (uncatchable), the same failure class the transform guard was added to prevent.

**Ordering trap handled (per the issue):** `destroy()` sets `isDestroyed = true` **then** runs its own internal `parent = null` detach *before* `backend.destroy()`. A naive `if (isDestroyed) return` at the top of the setter would block that internal detach (and the Kotlin-side child-list cleanup it performs) and break `destroy()`. So the guard wraps **only the engine write** (`if (!isDestroyed) backend.setParent(...)`), leaving the Kotlin-side hierarchy bookkeeping intact — **exactly symmetric to the existing `applyLocalTransform` guard** (Kotlin caches update, only the engine call is skipped). During `destroy()` the skipped engine detach is redundant anyway: `backend.destroy()` (next line) frees the transform component, which Filament removes from its parent on the engine side.

### 2. Probe: assert the sentinel never receives a transform component
`samples/web-demo/tests/kotlin-bundle.spec.ts` (#2024 P1 probe) proved `setParent` composition + sentinel-detach but not the invariant `nullParentInstance()` depends on — that the detach-sentinel entity is never granted a transform component, so `getInstance(sentinel)` stays native instance 0. Added `expect(tm.hasComponent(detachSentinel)).toBe(false)` (`hasComponent` is a real Filament.js `TransformManager` method, already used by production `FilamentNodeBackend`).

## Verification (all local, `ANDROID_HOME` set)
| Task | Result |
|---|---|
| `:sceneview-web:compileKotlinJs` | ✅ PASS |
| `:sceneview-web:jsTest` | ✅ PASS — `NodeTest` **21/21** (0 failures/errors/skipped), incl. the new `parentSetterAfterDestroyDoesNotReachBackend` guard test (asserts `setParent` is NOT invoked on a destroyed node; would fail against the pre-fix unguarded code) |

`sceneview-core` untouched → its test suite not required. The probe (`.ts`) change runs in the **web device-QA Playwright leg** (the blocking release leg), not gradle `jsTest`; it uses a `TransformManager` method already exercised in production, and the spec transpiles under Playwright's runner.

## Scope
scope: small — one wrapping `if` on the engine write (behaviour-preserving for live nodes, symmetric with the existing transform guard), one focused unit test, one probe assertion + one changelog fragment. No public/`@JsExport` API change, no version bump (major 4 frozen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)