### PR TITLE
fix(ci): release-fast bump step no longer aborts on sync-versions --fix exit-1 (#2619)

### DIFF
--- a/.github/workflows/release-fast.yml
+++ b/.github/workflows/release-fast.yml
@@ -87,8 +87,15 @@ jobs:
         run: |
           V="$RELEASE_VERSION"
           sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$V/" gradle.properties
-          bash .claude/scripts/sync-versions.sh --fix
-          # M7b made --fix complete; verify it stayed that way.
+          # `|| true` is load-bearing: sync-versions.sh --fix EXITS 1 by contract
+          # whenever it had mismatches to fix ("1 = mismatches found (or fixed if
+          # --fix)"), because $ERRORS is the pre-fix count and is never recomputed
+          # after fixing. This step's shell is `bash -e`, so an unguarded --fix
+          # aborted the whole step the instant it returned 1 — BEFORE the verify
+          # pass below ever ran (issue #2619). The writes did persist; only the
+          # premature set -e exit made CI look like a coverage regression.
+          bash .claude/scripts/sync-versions.sh --fix || true
+          # M7b made --fix complete; the verify pass below is the real gate.
           OUT=$(bash .claude/scripts/sync-versions.sh || true)
           echo "$OUT" | tail -5
           echo "$OUT" | grep -q "Errors (MISMATCH): 0" \


### PR DESCRIPTION
## Root cause (with evidence)

Failing run: [release-fast #28867212767](https://github.com/sceneview/sceneview/actions/runs/28867212767) (dispatch 4.21.0, head `2bea1c2`). The **"Bump + verify 0 mismatch"** step failed.

The reported hypothesis — *"`--fix` does not persist its writes"* / *"BSD-vs-GNU `sed -i` prime suspect"* — is **disproven by the run's own log**:

1. The `--fix` invocation printed `Fixed: …` for **every** file (incl. `Fixed: sceneview/gradle.properties (4.20.0 -> 4.21.0)`), so the writes were applied.
2. The log ends immediately after the `--fix` invocation's own summary:
   ```
   Fixes applied. Re-run without --fix to verify.
   === Summary ===
     Checks: 108
     Errors (MISMATCH): 98
   98 version mismatch(es) found.
   ##[error]Process completed with exit code 1.
   ```
   The **verify pass never appears** — no second report table, no `tail -5`, no `::error::residual version mismatches`. The step died at the `--fix` line, not at the intended guard.

Why: `sync-versions.sh` **exits 1 by contract** whenever `$ERRORS > 0` ([`sync-versions.sh:1587-1592`](https://github.com/sceneview/sceneview/blob/main/.claude/scripts/sync-versions.sh#L1587-L1592)) — `$ERRORS` is the **pre-fix** check count and is **never recomputed after fixing** (header: *"1 = mismatches found (or fixed if --fix)"*). So `--fix` returns **1 even when it successfully fixed everything**. The step shell is GitHub's default `/usr/bin/bash -e {0}`, and the `--fix` line had **no `|| true` guard**, so `set -e` aborted the whole step the instant `--fix` returned 1 — **before** the verify pass (lines 92-95) ran.

That is also exactly why it *"works locally"*: an interactive dev shell has no `set -e`, so the exit-1 is harmless and re-running the verify shows ~0 residuals. The stale-SHA theory is also wrong: `2bea1c2` was the tip of `main` (committed 6 min before the run) and already contained M7b's completed `--fix`.

## Reproduction

Ran the step body verbatim with a throwaway `VERSION_NAME` bump:

- Under `bash -e` (CI's shell): step exits **1**, the post-`--fix` `### REACHED_VERIFY` marker **never prints** → matches CI (verify never ran). Writes confirmed persisted on disk (`sceneview/gradle.properties`, `sceneview-web/package.json`, … all bumped).
- Without `-e` (local): verify runs → `Errors (MISMATCH): 0` → exit **0**. Matches "works locally".

## The fix

Guard the `--fix` invocation with `|| true` (release-fast.yml line 90), mirroring the verify line which already does the same. The **re-run verify pass (lines 92-95) remains the real 0-mismatch gate**, so a genuine coverage regression still fails the step. One-line behavior change + an explanatory comment.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-fast.yml'))"` → VALID.
- `bash .claude/scripts/check-workflow-scripts.sh` → `OK` (172 run: blocks; the only 2 shellcheck warnings are pre-existing in unrelated app-store deploy scripts).
- Fixed step body re-run under `bash -e`: `### REACHED_VERIFY` prints, verify reports 0 mismatch, exit 0.
- No version bump left in the tree (`VERSION_NAME=4.21.2`, unchanged); `sync-versions.sh` untouched so its contract and all interactive callers are unaffected. release-fast.yml is the only `bash -e` CI caller of `--fix`.

No changelog fragment: this is internal release-pipeline CI tooling, not a user-visible surface (no `changelog.d` enforcement in `ci.yml`).

**scope: medium** — release-pipeline tooling; behavior is a single guarded exit code, but it gates tagging/publishing, so it warrants review-fanout before merge.