### PR TITLE
fix(demo): re-canonicalize cancellation in SketchfabService.executeCancellably — Fixes #2665

### DIFF
--- a/changelog.d/2665-sketchfab-cancellation-flake.md
+++ b/changelog.d/2665-sketchfab-cancellation-flake.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Explore/Sketchfab: a search cancelled mid-body-read now reliably surfaces `CancellationException` instead of the socket-abort `SocketException`, so a query superseded by fast typing can no longer flash the "Sketchfab unavailable" error banner. Fixes the flaky `SketchfabServiceTest` cancellation test. (#2665)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabService.kt
@@ -349,10 +349,21 @@ class SketchfabService @VisibleForTesting internal constructor(
      *  - On normal completion the watcher is cancelled; its `finally` still
      *    runs [okhttp3.Call.cancel], which is a documented no-op on a
      *    finished call.
-     *  - [coroutineScope] re-canonises the outcome: when the caller IS
-     *    cancelled, the function completes with the caller's
-     *    CancellationException — the socket-abort IOException can never
-     *    masquerade as a network failure to `catch` blocks upstream.
+     *  - When the caller IS cancelled, the function completes with the
+     *    caller's CancellationException — the socket-abort IOException can
+     *    never masquerade as a network failure to `catch` blocks upstream.
+     *    [coroutineScope] alone does NOT guarantee this: the socket close the
+     *    watcher triggers aborts an in-flight blocking body read with an
+     *    IOException (`SocketException: Socket closed`), and when the block
+     *    completes with that non-cancellation exception `coroutineScope`
+     *    surfaces IT, not the cancellation (kotlinx prefers the first
+     *    non-cancellation exception when finalising a cancelling scope). The
+     *    [ensureActive] below closes that race: an IOException thrown while the
+     *    scope is already cancelled is re-canonised into the caller's
+     *    CancellationException; a genuine network IOException on a still-active
+     *    scope is rethrown unchanged. Without it the Explore search's
+     *    `catch (CancellationException)` fast-path is bypassed under load and a
+     *    superseded query flashes its error/empty state (#2665 CI flake, #2644).
      */
     private suspend fun <T> executeCancellably(
         call: okhttp3.Call,
@@ -367,6 +378,14 @@ class SketchfabService @VisibleForTesting internal constructor(
         }
         try {
             block()
+        } catch (e: IOException) {
+            // If the caller cancelled us, the closed-socket IOException is just
+            // the shape the abort took — surface the cancellation instead.
+            // ensureActive() throws the scope's CancellationException when the
+            // scope is cancelling; otherwise it is a no-op and we rethrow the
+            // real network failure below.
+            coroutineContext.ensureActive()
+            throw e
         } finally {
             tie.cancel()
         }


### PR DESCRIPTION
## Root cause

`SketchfabService.executeCancellably` runs the request `block()` inside a
`coroutineScope` guarded by a watcher coroutine that calls `Call.cancel()` on
cancellation. Closing the socket aborts an **in-flight blocking body read** with
a non-cancellation `IOException` (`SocketException: Socket closed`). When
`coroutineScope` finalises a scope that is *already cancelling* it surfaces the
**first non-cancellation exception**, so the `SocketException` propagated to the
caller instead of the caller's `CancellationException`.

This is a race, so it flaked `SketchfabServiceTest`'s
*"in-flight search is cooperatively cancelled instead of running to completion"*
test (CI job `86375643943` in run
[29096889590](https://github.com/sceneview/sceneview/actions/runs/29096889590/job/86375643943),
on PR #2655): `expected CancellationException from a cancelled search, got java.net.SocketException: Socket closed`.

The same race is user-facing: `ExploreTabScreen` distinguishes
`catch (CancellationException) { throw }` (superseded search, silent) from
`catch (Throwable) { error banner }`, so a search merely superseded by fast
typing could flash the "Sketchfab unavailable" banner — a regression of the
#2644 fix.

## Fix

`executeCancellably` now catches `IOException`, calls
`coroutineContext.ensureActive()` — which throws the scope's
`CancellationException` when the scope is cancelling and is a no-op otherwise —
then rethrows the genuine network `IOException`. The closed-socket abort can no
longer masquerade as a network failure upstream.

## Deterministic reproduction

Stress test with a 150 ms park injected inside the body read, cancelling the
search mid-read, 200 iterations:

| | without fix | with fix |
|---|---|---|
| outcome | `SocketException` 200/200 | `JobCancellationException` 200/200 |

## Gate

`./gradlew :samples:android-demo:testDebugUnitTest` → **BUILD SUCCESSFUL**;
`SketchfabServiceTest` = 8 tests, 0 failures, 0 errors, 0 skipped.

Fixes #2665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
