### PR TITLE
fix(demo): reword demo_chip_bundled to plain-language "Offline model"

### DIFF
--- a/changelog.d/2482-bundled-chip-reword.md
+++ b/changelog.d/2482-bundled-chip-reword.md
@@ -1,0 +1,2 @@
+<!-- category: Changed -->
+- Reworded the `AssetSourceChip` "Bundled fallback" label to plain-language "Offline model" (demo apps only — tap-to-place unification plan item 4, #2482).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -101,7 +101,7 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
  * - `controls != null` → a `Tune` FAB pinned to the bottom-end opens the controls
  *   sheet. While the sheet is closed, a small peek chip ("Settings") sits above
  *   the FAB to advertise the gesture (see [#951] discoverability lesson).
- * - `assetSource != null` → an "Streamed / Streaming / Bundled fallback" chip
+ * - `assetSource != null` → an "Streamed / Streaming / Offline model" chip
  *   pinned to the top-end of the scene area, advertising the offline origin
  *   of the currently visible asset (#1152 Stage 3). The chip auto-hides when
  *   `null` so legacy demos stay untouched.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -153,7 +153,7 @@ fun ARPlacementDemo(onBack: () -> Unit) {
 
     // Per-demo offline indicator chip (#1152 Stage 3). The chip reflects the
     // selected slug's resolve state — `null` means no slug picked yet (cycle
-    // mode), so we surface "Bundled fallback" (the cycle is 100% bundled).
+    // mode), so we surface "Offline model" (the cycle is 100% bundled).
     val assetSource = when {
         selectedSlug == null -> AssetSourceState.Bundled
         SketchfabConfig.apiKey == null -> AssetSourceState.Bundled

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
@@ -406,7 +406,7 @@ fun OrbitalARDemo(onBack: () -> Unit) {
     // are still null, we're "Streaming…". If `SketchfabConfig.apiKey` is
     // absent up-front, the resolver short-circuits to the bundled fallback
     // and every slot resolves quickly to its fallback file — chip says
-    // "Bundled fallback" instead.
+    // "Offline model" instead.
     val streamedSlugs = ORBITAL_PLANETS.mapNotNull { it.streamedSlug }
     val assetSource: AssetSourceState? = if (streamedSlugs.isEmpty()) {
         null

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -230,7 +230,7 @@
     <!-- Stage 3 per-demo offline indicator chip (DemoScaffold v2) -->
     <string name="demo_chip_streamed">Streamed (cached)</string>
     <string name="demo_chip_streaming">Streaming…</string>
-    <string name="demo_chip_bundled">Bundled fallback</string>
+    <string name="demo_chip_bundled">Offline model</string>
 
     <!-- DemoScaffold v2 bottom-sheet settings (#1154) -->
     <string name="demo_settings_title">Settings</string>


### PR DESCRIPTION
## Summary
- Rewords the `AssetSourceChip`'s user-facing "Bundled fallback" label (internal jargon) to plain language, **"Offline model"** — the exact wording prescribed by `.claude/plans/tap-to-place-unification.md` §3.5 (:540-542).
- Updates the three code comments (`DemoScaffold.kt`, `ARPlacementDemo.kt`, `OrbitalARDemo.kt`) that quote the old chip text, so they stay accurate.
- `changelog.d/2482-bundled-chip-reword.md` fragment added.

Delivers plan item 4 of #2482 (device pass still pending — not closing #2482).

## Scope check
- Only one locale exists in this repo today (`values/strings.xml`; no `values-fr` present, contrary to a stale historical CHANGELOG entry) — no other locale file needed updating.
- Grepped `.maestro/` and all `*test*` sources for `Bundled fallback` / `demo_chip_bundled` — no flow or test asserts on the old text, so nothing else needed updating.
- Diff is 4 files / 4 lines: one resource string value + three comment-only edits. No `R.string` identifier changed, no Kotlin structural change — cannot alter compilation behavior.

## Self-review (trivial scope, no dedicated reviewer per workflow policy)
- [x] `xmllint --noout` on `strings.xml` — well-formed.
- [x] `git diff` reviewed line-by-line — confirmed comment/string-value-only, zero API/type/behavior change.
- [x] Repo-wide grep for the old string text and key — no other file references it (Maestro/tests/other locales clean).
- [ ] `./gradlew :samples:android-demo:compileDebugKotlin` — **could not run**: the shared build host is at 0 GB free disk (ENOSPC, confirmed via `df` and a failed write) at the time of this PR, unrelated to this change. Given the diff cannot affect compilation (no identifier renamed, comments/string-value only), this is a low-risk gap, but flagging honestly rather than claiming a check that didn't run. Happy to re-run once the host has headroom.

## Test plan
- [x] `xmllint --noout samples/android-demo/src/main/res/values/strings.xml`
- [ ] `./gradlew :samples:android-demo:compileDebugKotlin` — blocked by host disk exhaustion, see above; CI should confirm this on a clean runner.