### PR TITLE
fix(sceneview): EnvironmentLoader suspend loaders run Filament JNI on Main thread (#2669/#2670/#2671)

### DIFF
--- a/changelog.d/2669-env-loader-jni-thread.md
+++ b/changelog.d/2669-env-loader-jni-thread.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `EnvironmentLoader`: the three suspend loaders (`loadHDREnvironment`, both `loadKTX1Environment` overloads) now build the environment inside `withContext(Dispatchers.Main)` instead of on the loader's IO scope — Filament asserts (native abort) on JNI thread mismatch. Buffer loading (network/disk) stays off the main thread; only the `create*Environment` builder call moves, mirroring `MaterialLoader.loadMaterial` / `ModelLoader.loadModel` (#2669, #2670, #2671, part of #2668).

--- a/sceneview/src/main/java/io/github/sceneview/loaders/EnvironmentLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/EnvironmentLoader.kt
@@ -19,6 +19,7 @@ import io.github.sceneview.utils.readBuffer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.nio.Buffer
 
@@ -242,13 +243,17 @@ class EnvironmentLoader(
         textureOptions: HDRLoader.Options = HDRLoader.Options(),
         createSkybox: Boolean = true,
     ): Environment? = context.loadFileBuffer(url)?.let { buffer ->
-        createHDREnvironment(
-            buffer = buffer,
-            indirectLightSpecularFilter = indirectLightSpecularFilter,
-            indirectLightApply = indirectLightApply,
-            textureOptions = textureOptions,
-            createSkybox = createSkybox
-        )
+        // Filament asserts on JNI thread mismatch — build on Main, mirroring
+        // MaterialLoader.loadMaterial / ModelLoader.loadModel.
+        withContext(Dispatchers.Main) {
+            createHDREnvironment(
+                buffer = buffer,
+                indirectLightSpecularFilter = indirectLightSpecularFilter,
+                indirectLightApply = indirectLightApply,
+                textureOptions = textureOptions,
+                createSkybox = createSkybox
+            )
+        }
     }
 
     /**
@@ -378,10 +383,18 @@ class EnvironmentLoader(
     suspend fun loadKTX1Environment(
         iblUrl: String? = null,
         skyboxUrl: String? = null
-    ): Environment = createKTX1Environment(
-        iblBuffer = iblUrl?.let { context.loadFileBuffer(iblUrl) },
-        skyboxBuffer = skyboxUrl?.let { context.loadFileBuffer(skyboxUrl) }
-    )
+    ): Environment {
+        // Load both buffers on the caller's (IO) dispatcher first, then build on Main —
+        // Filament asserts on JNI thread mismatch (same pattern as MaterialLoader.loadMaterial).
+        val iblBuffer = iblUrl?.let { context.loadFileBuffer(iblUrl) }
+        val skyboxBuffer = skyboxUrl?.let { context.loadFileBuffer(skyboxUrl) }
+        return withContext(Dispatchers.Main) {
+            createKTX1Environment(
+                iblBuffer = iblBuffer,
+                skyboxBuffer = skyboxBuffer
+            )
+        }
+    }
 
     /**
      * Utility for decoding and producing environment resources from an HDR file.
@@ -406,13 +419,17 @@ class EnvironmentLoader(
         textureOptions: HDRLoader.Options = HDRLoader.Options(),
         createSkybox: Boolean = true,
     ): Environment? = context.loadFileBuffer(url)?.let { buffer ->
-        createHDREnvironment(
-            buffer = buffer,
-            indirectLightSpecularFilter = indirectLightSpecularFilter,
-            indirectLightApply = indirectLightApply,
-            textureOptions = textureOptions,
-            createSkybox = createSkybox
-        )
+        // Filament asserts on JNI thread mismatch — build on Main, mirroring
+        // MaterialLoader.loadMaterial / ModelLoader.loadModel.
+        withContext(Dispatchers.Main) {
+            createHDREnvironment(
+                buffer = buffer,
+                indirectLightSpecularFilter = indirectLightSpecularFilter,
+                indirectLightApply = indirectLightApply,
+                textureOptions = textureOptions,
+                createSkybox = createSkybox
+            )
+        }
     }
 
     fun destroyEnvironment(environment: Environment) {


### PR DESCRIPTION
## What / Why

`EnvironmentLoader`'s three suspend loaders called Filament-JNI-touching `create*Environment` builders directly, while the loader's own `coroutineScope` defaults to `Dispatchers.IO`. Filament asserts on JNI thread mismatch — a native abort, not a catchable exception. This mirrors the fix pattern already established in `MaterialLoader.loadMaterial` (~line 194) and `ModelLoader.loadModel` (`withContext(Dispatchers.Main)` around the builder only).

## Call sites changed (sceneview/src/main/java/io/github/sceneview/loaders/EnvironmentLoader.kt)

1. **`loadHDREnvironment(url, ...)`** — `context.loadFileBuffer(url)?.let { buffer -> withContext(Dispatchers.Main) { createHDREnvironment(buffer, ...) } }`
2. **`loadKTX1Environment(iblUrl, skyboxUrl)`** — both buffers are loaded first on the caller's (IO) dispatcher, THEN `withContext(Dispatchers.Main) { createKTX1Environment(iblBuffer = ..., skyboxBuffer = ...) }`
3. **`loadKTX1Environment(url, indirectLightSpecularFilter, ...)`** — same as (1): only the `createHDREnvironment(...)` call is wrapped.

`context.loadFileBuffer(...)` (network/disk IO) deliberately stays OFF the main thread — only the Filament builder call moves. Added `import kotlinx.coroutines.withContext` (Dispatchers was already imported). Changelog fragment: `changelog.d/2669-env-loader-jni-thread.md`.

Fixes #2669, #2670, #2671
Part of #2668

## Verification

- Gradle `:sceneview:compileReleaseKotlin` + `:sceneview:testDebugUnitTest` → **BUILD SUCCESSFUL** (all unit tests pass; only pre-existing warnings about `*` in test method names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
