### PR TITLE
fix(sceneview-web): loadEnvironment .then use-after-free when destroy() runs first (#2673)

### DIFF
--- a/changelog.d/2673-web-loadenv-uaf.md
+++ b/changelog.d/2673-web-loadenv-uaf.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **sceneview-web**: `loadEnvironment` / `loadDefaultEnvironment` no longer use-after-free a destroyed engine when `destroy()` runs while a KTX fetch is in flight — both the IBL and skybox `.then` callbacks now bail out on a new `destroyed` flag (set first in `destroy()`), still settling `pendingLoads` so the render-gate counter never leaks. Same #1597 Tier-2 guard as `loadModel`'s `superseded` flag (#2673, part of #2668).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -73,6 +73,15 @@ class SceneView private constructor(
     private var pendingLoads = 0
 
     /**
+     * #1597 (Tier-2): set as the FIRST statement of [destroy] so any in-flight
+     * async callback that lands after teardown — e.g. a [loadEnvironment] KTX
+     * fetch resolving after the WASM Engine is freed — can bail out instead of
+     * calling into a destroyed engine/scene (use-after-free). Callbacks that
+     * bail MUST still run their settle helper so [pendingLoads] never leaks.
+     */
+    private var destroyed = false
+
+    /**
      * Stored bound reference to [renderLoop] so the per-frame
      * `requestAnimationFrame` reschedule reuses one function object instead of
      * allocating a fresh member-reference wrapper every tick (#2332).
@@ -657,6 +666,18 @@ class SceneView private constructor(
 
         // Fetch and create IBL (indirect lighting) from a KTX1 file
         window.fetch(iblUrl).then { it.arrayBuffer() }.then { buffer ->
+            // #1597 (Tier-2): if destroy() ran while the fetch was in flight,
+            // the engine/scene are freed WASM handles — bail out before
+            // touching them, but still settle so pendingLoads never leaks.
+            // Same pattern as loadModel's `superseded` guard.
+            if (destroyed) {
+                console.log(
+                    "SceneView: dropped stale IBL load for $iblUrl " +
+                        "(SceneView destroyed before fetch resolved)",
+                )
+                settleIbl()
+                return@then
+            }
             // Uint8Array view, not the raw ArrayBuffer — see loadModel (embind
             // BindingError otherwise).
             val ibl = engine.createIblFromKtx1(Uint8Array(buffer.unsafeCast<ArrayBuffer>()))
@@ -680,6 +701,16 @@ class SceneView private constructor(
                 if (!skySettled) { skySettled = true; pendingLoads--; requestRender() }
             }
             window.fetch(url).then { it.arrayBuffer() }.then { buffer ->
+                // #1597 (Tier-2): same destroy() guard as the IBL above — never
+                // touch a freed engine/scene, but always settle the counter.
+                if (destroyed) {
+                    console.log(
+                        "SceneView: dropped stale skybox load for $url " +
+                            "(SceneView destroyed before fetch resolved)",
+                    )
+                    settleSky()
+                    return@then
+                }
                 // Uint8Array view, not the raw ArrayBuffer — see loadModel.
                 val sky = engine.createSkyFromKtx1(Uint8Array(buffer.unsafeCast<ArrayBuffer>()))
                 // Same leak-free swap as the IBL above (issue #1496).
@@ -1162,6 +1193,10 @@ class SceneView private constructor(
 
     /** Clean up all Filament resources. */
     fun destroy() {
+        // #1597 (Tier-2): flag FIRST so any async callback still in flight
+        // (loadEnvironment's KTX fetches) bails out instead of calling into
+        // the freed engine/scene below.
+        destroyed = true
         stopRendering()
         cameraController?.dispose()
 


### PR DESCRIPTION
## What / Why

`sceneview-web` `SceneView.loadEnvironment` / `loadDefaultEnvironment` fire `window.fetch(iblUrl)` (plus a second fetch when `skyboxUrl` is given) with **no guard against `destroy()` completing before the promise resolves**. When teardown won the race, the `.then` bodies called `engine.createIblFromKtx1(...)` / `scene.setIndirectLight(...)` (and `engine.createSkyFromKtx1(...)` / `scene.setSkybox(...)`) on a freed WASM Engine/Scene — a use-after-free (crash or silent heap corruption).

This is the #1597 Tier-2 stale-async pattern that `loadModel`/`addGeometry` already guard via `LoadedModel.superseded`; this PR mirrors that guard for the environment path.

## Fix

- New `private var destroyed = false` on `SceneView` (`sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt`).
- `destroy()` sets `destroyed = true` as its **first** statement, before any resource is released.
- Both `loadEnvironment` `.then` callbacks bail out when `destroyed`:
  - the IBL callback (before `engine.createIblFromKtx1` / `indirectLight.replaceWith` / `scene.setIndirectLight`)
  - the skybox callback (before `engine.createSkyFromKtx1` / `skybox.replaceWith` / `scene.setSkybox`)
- The bail-out paths **still call `settleIbl()` / `settleSky()`**, so `pendingLoads` is decremented exactly once and never leaks — same settle discipline as `loadModel`'s superseded bail-out.

No engine/scene/indirectLight/skybox access happens after `destroyed` is set.

## Call sites changed

- `SceneView.loadEnvironment` — IBL `window.fetch(iblUrl).then { ... }` body: `destroyed` guard added at the top.
- `SceneView.loadEnvironment` — skybox `window.fetch(url).then { ... }` body: same guard.
- `SceneView.destroy()` — sets `destroyed = true` first.
- Changelog fragment: `changelog.d/2673-web-loadenv-uaf.md`.

## Verification

- `./gradlew :sceneview-web:compileKotlinJs` — BUILD SUCCESSFUL
- `./gradlew :sceneview-web:jsTest` — BUILD SUCCESSFUL (all tests pass)

Fixes #2673
Part of #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)