### PR TITLE
docs(mcp): fix mcpize.yaml Pro-tool count 35 → 27 (#2675 follow-up)

### DIFF
--- a/changelog.d/2675-mcpize-pro-tool-count.md
+++ b/changelog.d/2675-mcpize-pro-tool-count.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Fixed stale Pro-tool count in `mcp/mcpize.yaml`: the manifest claimed "35 Pro tools" in two places, but `PRO_TOOLS` in `mcp/src/tiers.ts` has 27 entries (counted programmatically by importing the module). Also dropped "multi-platform setup" from the Pro description — setup guides moved to Free in MCP 4.0.5 (follow-up to the "26 free tools" sibling drift fixed in #2675).

--- a/mcp/mcpize.yaml
+++ b/mcp/mcpize.yaml
@@ -17,8 +17,8 @@ name: sceneview-mcp
 description: >-
   Cross-platform 3D & AR MCP for Android (Compose + Filament), iOS / macOS /
   visionOS (SwiftUI + RealityKit), and Web (Filament.js + WebXR). 30 free
-  tools (samples, guides, validator, analyze) + 35 Pro tools (scene
-  generation, multi-platform setup, Automotive / Gaming / Healthcare /
+  tools (samples, guides, validator, analyze) + 27 Pro tools (3D preview /
+  artifact / scene generation, Automotive / Gaming / Healthcare /
   Interior packages).
 
 runtime: typescript
@@ -40,7 +40,7 @@ credentials:
   - name: SCENEVIEW_API_KEY
     required: false
     description: >-
-      Optional. SceneView Pro subscription key (sv_live_...) — unlocks the 35
+      Optional. SceneView Pro subscription key (sv_live_...) — unlocks the 27
       Pro tools through the hosted gateway. Leave empty to use only the 30
       free tools.
     docs_url: https://sceneview-mcp.mcp-tools-lab.workers.dev/pricing


### PR DESCRIPTION
## What

Fixes a pre-existing doc drift on the MCPize deployment manifest — a credential/tier surface read by MCP subscribers. `mcp/mcpize.yaml` claimed **"35 Pro tools"** in two places (the marketplace `description` and the `SCENEVIEW_API_KEY` credential help). The actual `PRO_TOOLS` array in `mcp/src/tiers.ts` has **27** entries.

## How the count was measured (not regex-guessed)

`tiers.ts` is import-clean, so the module was imported directly and the exported helpers were called:

```
node --experimental-strip-types -e "import('mcp/src/tiers.ts').then(m => ...)"
→ getProToolNames().length = 27, getFreeToolNames().length = 30
```

Re-verified against `dist/` after `npm ci && npm run build` on today's `main` (9dc0240): 27 = 3 generation tools + 4 vertical packages × 6.

## Also in this diff (same lines)

- The Pro parenthetical listed **"multi-platform setup"** as a Pro feature — setup guides moved to **Free** in MCP 4.0.5 (see the `FREE_TOOLS` header comment in `tiers.ts`). Replaced with the actual Pro surface: 3D preview / artifact / scene generation.
- The "30 free tools" wording (fixed by #2675) is confirmed still correct.

## Sweep results (`mcp/` + `docs/` for other hard-coded counts)

- `docs/docs/ai-context.md` "31 tools" — **correct**, verified: `getAllTools()` from the built package returns exactly 31 locally-exposed tools (28 free + the 3 Pro generation tools; the 24 vertical-package tools are gateway-only).
- "63 tools total" in `mcp/packages/{gaming,interior,rerun}/README.md` — gateway-aggregate claim, needs a gateway-side count; deliberately out of scope for this doc-only PR (flagged as follow-up).
- Noted in passing: `get_started` and `view_3d_model` are declared in `FREE_TOOLS` but absent from `TOOL_DEFINITIONS` (phantom tier entries) — follow-up candidate, not touched here.

## Scope

Doc-only: `mcp/mcpize.yaml` (6 lines) + changelog fragment. No version bump — `sceneview-mcp` stays on its independent track (#1705). Trivial diff → worker self-review per the triptych policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)