### PR TITLE
ci(demo): name the hanging unit test — started-event logging + 25 min task timeout (#2692)

### DIFF
--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -191,6 +191,16 @@ android {
             includeAndroidResources = true
             all {
                 systemProperty 'robolectric.logging.enabled', 'true'
+                // #2692: the CI Unit-tests job intermittently hangs in THIS task and
+                // gets force-cancelled at the job's 30 min timeout with zero output —
+                // no attribution possible. Name every test as it starts so the log's
+                // last line identifies the hanging test, and fail the task at 25 min
+                // (before the job kill) so partial reports survive as artifacts.
+                testLogging {
+                    events 'started', 'failed'
+                    displayGranularity = 2
+                }
+                timeout = java.time.Duration.ofMinutes(25)
             }
         }
     }


### PR DESCRIPTION
Diagnostic tooling for #2692 (release-blocking: main CI Unit-tests job hangs intermittently, 2 consecutive 30-min force-cancels, zero attribution possible today).

- `testLogging events 'started','failed'` on android-demo unit tests → the log's **last started line names the hanging test** at the next occurrence.
- Task `timeout = 25 min` → the task fails **before** the job's 30-min kill, so partial JUnit XML reports survive as artifacts.

Test-config-only diff (no test behavior change). Self-reviewed; sanity-verified locally — started events stream per test, single-class run green in 12 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)