### PR TITLE
fix(sceneview-web): loadModel initial GLB-fetch continuation use-after-free on destroy() (#2691)

### DIFF
--- a/changelog.d/2691-web-loadmodel-uaf.md
+++ b/changelog.d/2691-web-loadmodel-uaf.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **sceneview-web**: `loadModel` no longer use-after-frees a destroyed engine when `destroy()` runs while the initial GLB fetch is in flight — the fetch `.then` continuation now bails on the `destroyed` flag before `createAsset`/`addEntities` touch the freed WASM engine/scene, still settling `pendingLoads` so the render-gate counter never leaks. The existing `superseded` guard only covered the late `loadResources`/`onDone` step, not this initial continuation; this mirrors the `loadEnvironment` KTX guard (#2691, sibling of #2673, part of #2668).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -542,6 +542,22 @@ class SceneView private constructor(
         window.fetch(url).then { response ->
             response.arrayBuffer()
         }.then { buffer ->
+            // #1597 (Tier-2): if destroy() ran while this initial GLB fetch was
+            // in flight, the loader/engine/scene are freed WASM handles — bail
+            // out before createAsset/addEntities touch them (use-after-free),
+            // but still settle so pendingLoads never leaks. The `superseded`
+            // guard below only covers the late loadResources/onDone step, NOT
+            // this initial continuation. Mirrors loadEnvironment's KTX guard
+            // (#2687) — same `destroyed` flag, checked before the first engine
+            // call.
+            if (destroyed) {
+                console.log(
+                    "SceneView: dropped stale model load for $url " +
+                        "(SceneView destroyed before fetch resolved)",
+                )
+                settleLoad()
+                return@then
+            }
             // Filament.js gltfio `createAsset` expects a typed-array VIEW
             // (Uint8Array), NOT a raw ArrayBuffer — passing the ArrayBuffer
             // throws an embind BindingError. Mirrors the conversion the


### PR DESCRIPTION
Fixes #2691. Sibling of #2687 (#2673) on the **model** load path. Part of #2668.

## The gap

`sceneview-web` `SceneView.loadModel` issues `window.fetch(url).then { … }` and, in the second `.then`, calls `loader.createAsset(...)` and `scene.addEntities(...)` **unconditionally**. If `SceneView.destroy()` completes while that GLB fetch is still in flight, the continuation resolves afterward and touches a **freed WASM engine/scene/loader** → use-after-free (crash or silent heap corruption).

The existing `superseded` guard (#1597 Tier-2) only protects the **late** `loadResources`/`onDone` step — it does **not** cover this **initial** fetch continuation, which runs before any `LoadedModel` is even added to `models`.

## The fix (mirrors #2687)

`#2687` added a `private var destroyed` flag, set as the **first** statement of `destroy()`, and had `loadEnvironment`s KTX `.then` callbacks bail on it. This PR applies the **same** guard, same flag, same check-point, to `loadModel`s initial GLB-fetch `.then`:

```kotlin
}.then { buffer ->
    if (destroyed) {
        console.log("SceneView: dropped stale model load for $url …")
        settleLoad()          // settle so pendingLoads never leaks
        return@then
    }
    val asset = loader.createAsset(…)   // freed handle, now unreachable after destroy()
    …
}
```

The guard bails **before** the first `loader`/`engine`/`scene` call and still calls `settleLoad()` (idempotent via `loadSettled`), so the `pendingLoads` render-gate counter never leaks.

## Symmetry / completeness

- `destroyed` is declared once, set once (first in `destroy()`), and now guards **all three** async fetch continuations: `loadModel` (new), `loadEnvironment` IBL + skybox (#2687).
- The two `loadResources`/`onDone` callbacks remain `superseded`-guarded.
- `addGeometry`s initial `createAsset`/`addEntities` is **synchronous** — it cannot race `destroy()`; its only async callback (`loadResources` onDone) is already `superseded`-guarded. No change needed there, matching the issue's acceptance note.

## Verification

- `./gradlew :sceneview-web:compileKotlinJs` → **BUILD SUCCESSFUL** (only pre-existing WebXR unchecked-cast warnings).
- Changelog fragment added: `changelog.d/2691-web-loadmodel-uaf.md` (`category: Fixed`).

No auto-merge — leaving review/merge to the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)