### PR TITLE
Fix CI unit-test hangs: name culprit + fail fast (#2692)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,4 +84,33 @@ subprojects {
             }
         }
     }
+
+    // ── CI hang diagnostics + fail-fast for JVM unit tests (#2692) ────────────
+    // The `Unit tests` CI job intermittently hung >30 min with ZERO output and
+    // was force-cancelled at its job timeout, naming NO culprit test — the log
+    // went silent the moment `testDebugUnitTest` started, so every hang was
+    // unattributable. Two safeguards convert that silent 30-min kill into a
+    // named, thread-dumped failure:
+    //
+    //   1. `testLogging` emits a `started` event per test method, so the CI log
+    //      always names the test currently running. The NEXT hang points at the
+    //      exact test instead of going dark. (`passed` is deliberately omitted —
+    //      `started` already names the culprit and a line-per-pass is noise.)
+    //   2. A per-task `timeout` fires at 15 min — comfortably above the whole
+    //      suite's normal <20-min wall time yet well under the job's 30-min
+    //      ceiling — so a genuinely hung test task self-cancels with a Gradle
+    //      thread dump (stack trace of the stuck thread) instead of silently
+    //      eating the job. `--stacktrace` on the CI step then attributes it.
+    //
+    // Scoped to JVM `Test` tasks only: KMP `jsTest` / native test tasks are a
+    // different task type and are unaffected, and instrumented
+    // `connectedAndroidTest` tasks are `DeviceProviderInstrumentTestTask`, not
+    // `Test`, so they are never timeout-killed by this convention.
+    tasks.withType(Test).configureEach {
+        testLogging {
+            events "started", "skipped", "failed"
+            exceptionFormat = "full"
+        }
+        timeout.set(java.time.Duration.ofMinutes(15))
+    }
 }

--- a/changelog.d/2692-ci-unit-tests-hang.md
+++ b/changelog.d/2692-ci-unit-tests-hang.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **CI unit-test hangs now name the culprit and fail fast instead of silently eating the 30-min job ([#2692](https://github.com/sceneview/sceneview/issues/2692)).** Every JVM `Test` task now emits a `started` event per test method (so an intermittent hang points at the exact running test instead of going dark) and self-cancels with a Gradle thread dump at a 15-min per-task timeout — well under the `Unit tests` job's 30-min ceiling. Converts an unattributable force-cancel into a named, stack-traced failure.


### PR DESCRIPTION
Closes #2692

## What changed
Adds a global JVM `Test` task convention in root `build.gradle` (`subprojects {}`):
- `testLogging` emits a **`started`** event per test method → the CI log always names the test currently running, so the next intermittent hang points at the exact culprit instead of going dark at task start.
- A per-task **`timeout` of 15 min** (above the whole suite's normal <20-min wall time, well under the `Unit tests` job's 30-min ceiling) → a genuinely hung test task self-cancels with a Gradle thread dump instead of silently eating the job. `--stacktrace` on the CI step then attributes it.

Scoped to JVM `Test` tasks only: KMP `jsTest`/native test tasks are a different task type, and instrumented `connectedAndroidTest` tasks are `DeviceProviderInstrumentTestTask` (never timeout-killed).

## Challenge verdict
The prescribed 'single culprit Robolectric/MockWebServer test' cause is **not confirmable** — the reporter's local repro passes and mine does too (`:sceneview:`/`:arsceneview:`/`:samples:common:testDebugUnitTest` all green well under timeout), confirming the hang is intermittent/CI-environmental, not deterministic. So this ships the issue's own high-value quick wins (#2 per-task timeout + #3 test-logging) that convert the unattributable 30-min silent kill into a named, stack-traced failure — the right scope for a non-reproducible deadlock.

## Self-review (5 angles)
- **Correctness**: delivers exactly the diagnostics/fail-fast the issue calls for; 15-min timeout verified above real suite runtime (no false-positive kills). Does not claim to fix the nondeterministic hang itself.
- **Threading**: no Filament JNI / coroutines touched — pure build config.
- **API consistency**: no public API change; build convention only.
- **Minimality**: single `tasks.withType(Test).configureEach {}` block, ~7 lines of code; no workflow edit needed (applies to CI automatically). `passed` events omitted to avoid line-per-test noise.
- **Cross-platform**: KMP/native/instrumented tasks unaffected and documented; no llms.txt/skills impact.

scope: trivial — self-reviewed inline; review-fanout skipped because trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)