### PR TITLE
fix(demo): externalize tap-to-place gesture pill + aiming hint to string resources (#2482 §3.5)

### DIFF
--- a/changelog.d/2482-gesture-pill-l10n.md
+++ b/changelog.d/2482-gesture-pill-l10n.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Externalized the last hard-coded English strings in the unified tap-to-place engine (`TapToPlaceArSession.kt`) to string resources — the gesture pill labels ("Moving" / "Rotating" / "Scaling" → `ar_gesture_*`) and the "Aim at a surface…" aiming hint (`ar_aim_at_surface`), completing #2482 plan §3.5. Shared by both AR entries; no visual or behavioural change in the default locale.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceArSession.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceArSession.kt
@@ -433,7 +433,7 @@ fun BoxScope.TapToPlaceStatusOverlays(
             shape = MaterialTheme.shapes.small
         ) {
             Text(
-                text = gestureLabel(state.activeGesture),
+                text = state.activeGesture?.let { stringResource(gestureLabelRes(it)) } ?: "",
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 style = MaterialTheme.typography.labelLarge
             )
@@ -457,7 +457,7 @@ fun BoxScope.TapToPlaceStatusOverlays(
             shape = MaterialTheme.shapes.small,
         ) {
             Text(
-                text = "Aim at a surface…",
+                text = stringResource(R.string.ar_aim_at_surface),
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 style = MaterialTheme.typography.labelLarge,
             )
@@ -465,9 +465,8 @@ fun BoxScope.TapToPlaceStatusOverlays(
     }
 }
 
-private fun gestureLabel(gesture: PlacementGesture?): String = when (gesture) {
-    PlacementGesture.MOVING -> "Moving"
-    PlacementGesture.ROTATING -> "Rotating"
-    PlacementGesture.SCALING -> "Scaling"
-    null -> ""
+private fun gestureLabelRes(gesture: PlacementGesture): Int = when (gesture) {
+    PlacementGesture.MOVING -> R.string.ar_gesture_moving
+    PlacementGesture.ROTATING -> R.string.ar_gesture_rotating
+    PlacementGesture.SCALING -> R.string.ar_gesture_scaling
 }

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -111,6 +111,11 @@
     <string name="ar_status_tap_to_place">Tap a surface to place %s</string>
     <string name="ar_status_one_placed">1 placed · tap to add</string>
     <string name="ar_status_n_placed">%d placed · tap to add</string>
+    <!-- Gesture pill + aiming hint (TapToPlaceArSession.kt) — #2482 plan §3.5 -->
+    <string name="ar_gesture_moving">Moving</string>
+    <string name="ar_gesture_rotating">Rotating</string>
+    <string name="ar_gesture_scaling">Scaling</string>
+    <string name="ar_aim_at_surface">Aim at a surface…</string>
     <string name="ar_starting_session">Starting AR session…</string>
     <string name="ar_starting_session_subtitle">Hold up — initializing ARCore.</string>
     <string name="ar_permission_required_title">Camera permission is required to run AR</string>


### PR DESCRIPTION
Part of #2482 — closes plan item 3 of the 2026-07-11 completion audit (does NOT close the issue: item 1, the 5-point Pixel 9 checklist, remains and is device-gated).

## What

The last hard-coded English UI strings in the unified `TapToPlaceArSession` engine move to string resources, per the design doc §3.5 (`.claude/plans/tap-to-place-unification.md`):

- Gesture pill labels → `ar_gesture_moving` / `ar_gesture_rotating` / `ar_gesture_scaling`
- "Aim at a surface…" (#1882 hint) → `ar_aim_at_surface`

`gestureLabel(g?): String` becomes an exhaustive `gestureLabelRes(g): Int` resource resolver; the `null → ""` fade-out behaviour is preserved at the call site (`state.activeGesture?.let { stringResource(…) } ?: ""`). Shared by both AR entries (AR View tab + ar-placement) — zero visual or behavioural change in the default locale, no new translations added (repo has `values` + `values-night` only).

## Audit-state recap (for #2482 close-out)

- Item 2 (reword "Bundled fallback") — **already delivered on main** (`strings.xml:242` reads "Offline model"); verified before writing this PR.
- Item 3 (this PR) — done.
- Item 1 — the 5-point Pixel 9 recorded checklist stays the only closing condition. ~3 min on device.

## Verification

`./gradlew :samples:android-demo:compileDebugKotlin` — BUILD SUCCESSFUL (resource linking + Kotlin compile validate the R references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)