### PR TITLE
fix(qa): launchability gate in qa-android-demos.sh — stale-install residue remediation (#2725)

### DIFF
--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -154,6 +154,39 @@ if $INSTALL; then
   fi
 fi
 
+# --- Launchability gate (#2725) ---------------------------------------------
+# A stale/partial prior install can leave the package listed by `pm list
+# packages` while its launcher activity is NOT resolvable. `adb install -r`
+# over that residue "succeeds", and Maestro then fails every flow with
+# "Unable to launch app" — proven 2026-07-14: the whole catalog leg died in
+# 34 s and was graded a genuine FAIL. Probe the actual launch component; if
+# unresolvable, do ONE clean uninstall + reinstall (needs the APK), re-probe,
+# and otherwise fail fast with a clear diagnostic instead of letting 49 demos
+# fail one by one.
+qa_launchable() {
+  adb shell cmd package resolve-activity --brief "${PACKAGE}/${ACTIVITY}" 2>/dev/null \
+    | tr -d '\r' | grep -q "^${PACKAGE}/"
+}
+if ! qa_launchable; then
+  echo "[qa] WARNING: ${PACKAGE}/${ACTIVITY} is not resolvable — stale/partial install residue (#2725)." >&2
+  if [[ -f "$APK" ]]; then
+    echo "[qa] remediation: clean uninstall + reinstall from $APK"
+    adb uninstall "$PACKAGE" >/dev/null 2>&1 || true
+    adb install -r -g "$APK" || {
+      echo "[qa] ERROR: clean reinstall failed." >&2
+      exit 1
+    }
+    if ! qa_launchable; then
+      echo "[qa] ERROR: ${PACKAGE}/${ACTIVITY} still not resolvable after a clean reinstall — aborting before the flow burns the whole catalog." >&2
+      exit 1
+    fi
+    echo "[qa] remediation OK — launch activity resolvable."
+  else
+    echo "[qa] ERROR: no APK at $APK to reinstall from — rerun with --install (or build the demo APK first)." >&2
+    exit 1
+  fi
+fi
+
 # --- Crash gate: clear logcat so the post-run FATAL/ANR sweep is scoped -----
 adb logcat -c 2>/dev/null || true
 

--- a/changelog.d/2725-qa-launchability-gate.md
+++ b/changelog.d/2725-qa-launchability-gate.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- device-QA android: launchability gate in `qa-android-demos.sh` — a stale/partial install residue (package listed but launcher activity unresolvable) is now detected before the Maestro flow, remediated by one clean uninstall+reinstall, and otherwise fails fast with a diagnostic instead of burning the whole 49-demo catalog (#2725).


### PR DESCRIPTION
Fixes #2725

## What
Adds a **launchability gate** between the install section and the Maestro flow in `.claude/scripts/qa-android-demos.sh`:
1. Probes `cmd package resolve-activity --brief ${PACKAGE}/${ACTIVITY}` (CR-stripped, component-anchored grep).
2. If unresolvable and the APK exists → one clean `adb uninstall` + `adb install -r -g` + re-probe.
3. Still unresolvable, reinstall failed, or no APK to reinstall from → `exit 1` with a clear diagnostic.

## Why
Proven 2026-07-14: a stale/partial prior install left the package listed by `pm list packages` while `.MainActivity` was NOT resolvable. `install -r` over the residue "succeeded", then Maestro failed every demo with `Unable to launch app` — the whole catalog leg died in 34 s and was graded a genuine FAIL. The clean uninstall+reinstall workaround was verified on the same emulator/APK (all subsequent QA runs launched fine). Same stale-install class as the documented asset-QA rule (#2305/#2411).

## Verification
- `bash -n` syntax check green.
- Fail-fast semantics: the gate runs after the optional `--install` block, so it covers both invocation modes (with and without `--install`); `adb` calls honour the pinned `ANDROID_SERIAL` like every other adb call in the script (global env pin).
- Scope: QA harness script only — no library/demo code touched; `Tests` changelog fragment included.

scope: small (harness-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)