### PR TITLE
fix(workflows): guard all saved workflows against JSON-stringified args

### DIFF
--- a/.claude/workflows/audit-sweep.js
+++ b/.claude/workflows/audit-sweep.js
@@ -12,7 +12,14 @@ export const meta = {
 //   surfaces — module surfaces to audit; each maps 1:1 to a top-level module dir.
 // Depth scales with budget: if budget.total is set, agents go DEEPER (more findings,
 // LOW micro-issues included); otherwise default depth (HIGH/MED focus).
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('audit-sweep: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const DEFAULT_SURFACES = ['sceneview', 'arsceneview', 'sceneview-core', 'SceneViewSwift', 'sceneview-web']
 const SURFACES = (Array.isArray(a.surfaces) && a.surfaces.length) ? a.surfaces : DEFAULT_SURFACES
 const TRIGGER = (a.trigger && String(a.trigger).trim())

--- a/.claude/workflows/device-qa-orchestrate.js
+++ b/.claude/workflows/device-qa-orchestrate.js
@@ -14,7 +14,14 @@ export const meta = {
 //   surfaces the leg's failure loudly as WARN — never a silent pass.
 //   platform — which device-QA leg(s) to run (default 'all').
 //   fast     — pass --fast for a per-category subset rather than the full catalog.
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('device-qa-orchestrate: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const VALID = ['android', 'ios', 'web', 'ar', 'all']
 const PLATFORM = VALID.includes(a.platform) ? a.platform : 'all'
 const FAST = a.fast === true

--- a/.claude/workflows/doc-drift-fix.js
+++ b/.claude/workflows/doc-drift-fix.js
@@ -10,7 +10,14 @@ export const meta = {
 
 // args: { dry?: boolean }
 //   dry — skip the PR/issue phase (audit + patch only; nothing pushed to GitHub).
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('doc-drift-fix: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const DRY = a.dry === true
 
 // AI-first invariant repeated into every agent: prose docs are the surface an AI

--- a/.claude/workflows/fix-issue-batch.js
+++ b/.claude/workflows/fix-issue-batch.js
@@ -12,7 +12,14 @@ export const meta = {
 //   issues — explicit issue numbers to drive. If empty/omitted, the preflight
 //            agent queries open issues and selects the top `max` in priority order.
 //   max    — cap on auto-selected issues (default 6).
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('fix-issue-batch: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const MAX = Number(a.max) > 0 ? Number(a.max) : 6
 const GIVEN = Array.isArray(a.issues) ? a.issues.map(Number).filter(n => Number.isFinite(n) && n > 0) : []
 

--- a/.claude/workflows/phase2-reconcile.js
+++ b/.claude/workflows/phase2-reconcile.js
@@ -13,7 +13,14 @@ export const meta = {
 // We collect the standing MED-severity debt per surface and fold it into the
 // per-surface tracker issues (#2328 sceneview / #2329 arsceneview / #2330 core /
 // #2331 SceneViewSwift / #2332 web), creating one where it doesn't yet exist.
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('phase2-reconcile: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const DEFAULT_SURFACES = ['sceneview', 'arsceneview', 'sceneview-core', 'SceneViewSwift', 'sceneview-web']
 const SURFACES = (Array.isArray(a.surfaces) && a.surfaces.length) ? a.surfaces : DEFAULT_SURFACES
 

--- a/.claude/workflows/release-checkpoint.js
+++ b/.claude/workflows/release-checkpoint.js
@@ -11,7 +11,14 @@ export const meta = {
 
 // args: { dry?: boolean }
 //   dry — preflight + device-QA + verify-live only; NEVER commits/pushes a tag.
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('release-checkpoint: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const DRY = a.dry === true
 
 const REPO = 'sceneview/sceneview'

--- a/.claude/workflows/store-status.js
+++ b/.claude/workflows/store-status.js
@@ -9,7 +9,14 @@ export const meta = {
 
 // args: { version?: string } — expected version to verify live. If absent, the
 // Probe phase reads it from the root gradle.properties VERSION_NAME.
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('store-status: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const APP_ID = '6761329763'
 
 // Resolve the canonical (non-worktree) main repo root from the AGENT'S OWN CWD — never a

--- a/.claude/workflows/triptych.js
+++ b/.claude/workflows/triptych.js
@@ -11,7 +11,14 @@ export const meta = {
 //   pr       — review a GitHub PR by number (reviewers run `gh pr diff <pr>`)
 //   branch   — else review this local branch vs base (default origin/main)
 //   platforms— hint for the visual-QA leg: "android" | "ios" | "web" | "none"
-const a = args || {}
+// Be robust to args arriving as a JSON string (some invocation paths stringify it — same guard as review-fanout.js).
+let a = args
+if (typeof a === 'string') {
+  try { a = JSON.parse(a) } catch {
+    throw new Error('triptych: args must be JSON — got a non-JSON string: ' + a.slice(0, 120))
+  }
+}
+a = a || {}
 const BASE = a.base || 'origin/main'
 const TARGET = a.pr
   ? `GitHub PR #${a.pr} — get the diff with: gh pr diff ${a.pr} --repo sceneview/sceneview`

--- a/changelog.d/2734-workflow-args-string-guard.md
+++ b/changelog.d/2734-workflow-args-string-guard.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **Saved workflows: guard against JSON-stringified `args`.** All 8 remaining `.claude/workflows/*.js` scripts now parse a stringified `args` (or fail loudly on non-JSON) instead of silently ignoring it — a stringified `{"issues":[…]}` made `fix-issue-batch` fall back to auto-selecting issues, twice on 2026-07-16, picking maintainer-gated work. Same guard `review-fanout.js` and `parity-audit.js` already had.


### PR DESCRIPTION
Stringified `args` (an invocation-path quirk) silently no-ops caller parameters: `Array.isArray` on a string is false, so `fix-issue-batch` fell back to auto-selecting issues instead of the caller-curated list — twice on 2026-07-16, picking maintainer-gated work (#2482 design-gated, #2241 claimed) that had to be claim-released and cleaned up.

`review-fanout.js` and `parity-audit.js` already parse-or-fail-loudly (added after the 2026-07-03 empty-diff PASS incident). This applies the identical guard to the 8 remaining scripts: fix-issue-batch, doc-drift-fix, device-qa-orchestrate, audit-sweep, release-checkpoint, phase2-reconcile, triptych, store-status.

`bash .claude/scripts/check-saved-workflows.sh` → OK, 10 workflows valid.

scope: trivial — internal .claude tooling only, no library/public API/renderer/shader touched; self-reviewed inline; review-fanout skipped because trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)