### PR TITLE
fix(qa): pin Maestro to the leased emulator (--device $ANDROID_SERIAL) (#2741)

### DIFF
--- a/.claude/scripts/lib/maestro.sh
+++ b/.claude/scripts/lib/maestro.sh
@@ -125,16 +125,24 @@ maestro_run() {
     return 2
   fi
   maestro_ensure || return 1
+  # Pin Maestro to the leased device: maestro does NOT honor ANDROID_SERIAL,
+  # and with several adb devices connected (e.g. a personal phone on wireless
+  # debugging next to the QA emulator) it silently drives the wrong one — the
+  # emulator-first rule must hold even on multi-device hosts.
+  local -a device_args=()
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    device_args=(--device "$ANDROID_SERIAL")
+  fi
   # Bound the run: a flow that hangs (e.g. waiting on an element that never
   # appears) must fail fast instead of silently eating the CI job budget
   # (#1560). `timeout` exit 124 propagates as a normal non-zero failure.
   # On macOS, `timeout` is not available by default — use `gtimeout` (from
   # homebrew coreutils) if present, otherwise run unbounded (#2184).
   if command -v timeout >/dev/null 2>&1; then
-    timeout "${MAESTRO_TEST_TIMEOUT:-900}" "$MAESTRO_BIN" test "$flow" "$@"
+    timeout "${MAESTRO_TEST_TIMEOUT:-900}" "$MAESTRO_BIN" "${device_args[@]}" test "$flow" "$@"
   elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "${MAESTRO_TEST_TIMEOUT:-900}" "$MAESTRO_BIN" test "$flow" "$@"
+    gtimeout "${MAESTRO_TEST_TIMEOUT:-900}" "$MAESTRO_BIN" "${device_args[@]}" test "$flow" "$@"
   else
-    "$MAESTRO_BIN" test "$flow" "$@"
+    "$MAESTRO_BIN" "${device_args[@]}" test "$flow" "$@"
   fi
 }

--- a/changelog.d/2741-maestro-device-pin.md
+++ b/changelog.d/2741-maestro-device-pin.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- **Device-QA: Maestro runs are now pinned to the leased QA emulator (`--device "$ANDROID_SERIAL"`).** Maestro does not honor `ANDROID_SERIAL`; on a host with several adb devices connected (e.g. a personal phone on wireless debugging next to the pool emulator) it silently drove the wrong device, producing an invalid QA verdict against whatever app was on that device. `maestro_run` now forwards the leased serial explicitly, keeping the emulator-first rule true on multi-device hosts.


### PR DESCRIPTION
Closes #2741

## What changed
- `lib/maestro.sh` → `maestro_run()`: forward `--device "$ANDROID_SERIAL"` to `maestro` when the harness leased a device. Maestro does not honor `ANDROID_SERIAL`; with several adb devices attached it silently picked its own (during the #2718 gate: a personal phone on wireless debugging instead of the leased `emulator-5554` — invalid verdict + emulator-first rule violation).
- `changelog.d/2741-maestro-device-pin.md` fragment (Tests).

## Verification
- `bash -n` clean; `--device`/`--udid` global flag verified against the pinned Maestro 2.6.1 (`maestro --help`).
- Field-verified on the #2718 gate run 3: flow targeted `emulator-5554` with the fix in place.
- No behavior change when `ANDROID_SERIAL` is unset (single-device CI runners).

## Self-review (trivial scope: 1 shell function, no product code)
Correctness: array-based arg forwarding, safe under `set -u`, empty when unset. Minimality: one guard + three call-sites of the same line. Cross-platform: Android QA path only; iOS harness unaffected. No public API, no docs surface beyond the changelog fragment.

scope: small

🤖 Generated with [Claude Code](https://claude.com/claude-code)