### PR TITLE
ci(nightly): report cancelled runs and all legs — start-of-run health check (#2732)

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -117,9 +117,14 @@ jobs:
             echo "Previous night still terminating (attempt $attempt/4) — waiting 30s..."
             sleep 30
           done
+          # `|| echo "[]"` (a valid empty array, NOT ""): under `set -e` an
+          # unguarded transient API blip would red this job, flip the run
+          # conclusion, and feed a manufactured "bad night" back into the
+          # very signal this job grades (review finding, PR #2743). An empty
+          # array degrades to the honest "nothing to grade" branch instead.
           RUNS=$(gh run list --repo "$REPO" --workflow=nightly-ci.yml \
             --event schedule --status completed --limit 2 \
-            --json databaseId,conclusion,createdAt,url)
+            --json databaseId,conclusion,url 2>/dev/null || echo "[]")
           COUNT=$(jq 'length' <<<"$RUNS")
           if [ "$COUNT" -lt 2 ]; then
             echo "Fewer than 2 completed scheduled nights on record — nothing to grade."

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -70,52 +70,103 @@ jobs:
     uses: ./.github/workflows/device-qa.yml
     secrets: inherit
 
-  # ── Failure surfacing ─────────────────────────────────────────────────────
-  # If any of the reused workflows fail, open (or update) a tracking issue so
-  # the regression is visible without anyone watching the Actions tab.
-  # `render-tests` jobs are `continue-on-error` internally, so a reused
-  # render-test failure does not by itself flip this job — that is intended:
-  # SwiftShader render flake should not spam issues. A genuine compile/test
-  # regression in `full-ci` (which since #1370 also runs the quality gate)
-  # does flip it.
-  report-failure:
-    name: Report nightly failure
-    needs: [full-ci, render-tests]
-    if: always() && needs.full-ci.result == 'failure'
+  # ── Nightly health surfacing (#2732) ──────────────────────────────────────
+  # v1 reported from the END of the run (`needs: [full-ci, render-tests]`,
+  # `if: needs.full-ci.result == 'failure'`) and was blind three ways:
+  #   - a CANCELLED run kills its own report job — the 2026-07-09→07-16 week
+  #     of nightly `cancelled` runs (hang → next night's concurrency cancel)
+  #     produced zero reports;
+  #   - `cancelled` never matched `== 'failure'` anyway;
+  #   - `render-tests` result was ignored and `device-qa` wasn't in `needs`.
+  # v2 therefore grades from the START of the run, where nothing can be
+  # cancelled yet: it looks at the last TWO completed *scheduled* nights
+  # (run-level conclusion covers every leg — any non-success of full-ci /
+  # render-tests / device-qa flips the run) and opens/updates the tracking
+  # issue only when BOTH were bad — the 2-consecutive-nights anti-noise rule,
+  # which absorbs one-off SwiftShader or runner flakes. Leg-level detail is
+  # pulled from the most recent bad run's job list; `skipped` sub-jobs are
+  # NOT named (path-gated skips inside the reused workflows are legitimate),
+  # a leg-level `cancelled` or `failure` is. Manual workflow_dispatch runs
+  # are excluded from the streak (`--event schedule`) so a manual green run
+  # cannot mask a sick schedule.
+  nightly-health:
+    name: Nightly health check (last 2 nights)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       contents: read
       issues: write
+      actions: read
     steps:
-      - name: Open or update tracking issue
+      - name: Grade the last two completed nights
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          FULL_CI_RESULT: ${{ needs.full-ci.result }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
+          # Our concurrency group cancels a still-running previous night when
+          # this run starts; give that dying run a bounded window to reach a
+          # terminal state so the streak is graded on fresh data (otherwise
+          # the grading is off by one night — still correct, just staler).
+          for attempt in 1 2 3 4; do
+            NEWEST_OTHER=$(gh run list --repo "$REPO" --workflow=nightly-ci.yml \
+              --event schedule --limit 3 --json databaseId,status \
+              --jq "[.[] | select(.databaseId != ${CURRENT_RUN_ID})][0].status" 2>/dev/null || echo "")
+            [ "$NEWEST_OTHER" = "in_progress" ] || [ "$NEWEST_OTHER" = "queued" ] || break
+            echo "Previous night still terminating (attempt $attempt/4) — waiting 30s..."
+            sleep 30
+          done
+          RUNS=$(gh run list --repo "$REPO" --workflow=nightly-ci.yml \
+            --event schedule --status completed --limit 2 \
+            --json databaseId,conclusion,createdAt,url)
+          COUNT=$(jq 'length' <<<"$RUNS")
+          if [ "$COUNT" -lt 2 ]; then
+            echo "Fewer than 2 completed scheduled nights on record — nothing to grade."
+            exit 0
+          fi
+          C1=$(jq -r '.[0].conclusion' <<<"$RUNS")   # most recent completed night
+          C2=$(jq -r '.[1].conclusion' <<<"$RUNS")   # the night before it
+          echo "Last two scheduled nights: $C1 (newest), $C2"
+          if [ "$C1" = "success" ]; then
+            echo "Most recent night is green — healthy."
+            exit 0
+          fi
+          if [ "$C2" = "success" ]; then
+            echo "One bad night ($C1) — holding fire (anti-noise #2732: reports need 2 consecutive bad nights)."
+            exit 0
+          fi
+          ID1=$(jq -r '.[0].databaseId' <<<"$RUNS")
+          URL1=$(jq -r '.[0].url' <<<"$RUNS")
+          URL2=$(jq -r '.[1].url' <<<"$RUNS")
+          LEGS=$(gh run view "$ID1" --repo "$REPO" --json jobs \
+            --jq '[.jobs[] | select(.conclusion != null and .conclusion != "success" and .conclusion != "skipped") | "- \(.name): **\(.conclusion)**"] | join("\n")' \
+            2>/dev/null || echo "_job details unavailable_")
+          [ -n "$LEGS" ] || LEGS="_no per-job detail (run-level: $C1)_"
           BODY=$(printf '%s\n' \
-            "The nightly full-CI safety-net run failed against \`main\` HEAD." \
+            "The nightly safety net has been unhealthy for **2+ consecutive scheduled nights** (#2732)." \
             "" \
-            "| Reused workflow | Result |" \
+            "| Night | Conclusion |" \
             "|---|---|" \
-            "| Full CI (forced, incl. quality gate) | $FULL_CI_RESULT |" \
+            "| $URL1 | $C1 |" \
+            "| $URL2 | $C2 |" \
             "" \
-            "Run: $RUN_URL" \
+            "Non-success legs of the most recent bad night:" \
+            "$LEGS" \
             "" \
-            "A path-gated-out regression may have reached \`main\` between per-push CI runs. Investigate the failing job above.")
+            "If the full-ci leg hung, the unit-test job uploads a thread-dump artifact since #2716 — check the run's artifacts for the culprit test." \
+            "" \
+            "A cancelled night usually means the run hung until the next night's concurrency group killed it — treat it as a failure, not noise.")
           EXISTING=$(gh issue list --repo "$REPO" --state open \
-            --search "Nightly full CI failed in:title" \
+            --search "\"Nightly CI unhealthy\" in:title" \
             --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -z "$EXISTING" ]; then
             gh issue create --repo "$REPO" \
-              --title "Nightly full CI failed — $(date -u +%Y-%m-%d)" \
+              --title "Nightly CI unhealthy — 2+ consecutive bad nights" \
               --body "$BODY" \
               --label "ci" \
-              || echo "::warning::Could not create nightly-failure issue"
+              || echo "::warning::Could not create nightly-health issue"
           else
             gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY" \
-              || echo "::warning::Could not comment on existing nightly-failure issue #$EXISTING"
+              || echo "::warning::Could not comment on existing nightly-health issue #$EXISTING"
           fi

--- a/changelog.d/2732-nightly-reporter-blind.md
+++ b/changelog.d/2732-nightly-reporter-blind.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- Fixed the nightly-CI failure reporter that was blind to `cancelled` runs and to the render-tests/device-qa legs (a week of silently-dying nightly runs produced zero reports): the reporter now grades the last two completed scheduled nights at the START of each run — immune to its own run being cancelled — and opens/updates a single deduplicated tracking issue only after 2 consecutive bad nights (#2732).


### PR DESCRIPTION
Fixes #2732.

## Why a start-of-run design (not just widening `needs`)

The issue's observed pathology — **every night from 07-09 to 07-16 ended `cancelled`, zero reports** — cannot be fixed by an end-of-run reporter at all: a run that hangs until the next night's `concurrency: cancel-in-progress` kills it **loses its own report job with it**. Widening `needs`/`if` (the issue's action 1 as literally written) would still report nothing in exactly the scenario that motivated the issue.

So the reporter moved to the **start** of the run, where nothing can be cancelled yet:

- `nightly-health` (no `needs`) grades the **last two completed scheduled nights** by run-level conclusion — which covers all three legs, since any non-success of `full-ci` / `render-tests` / `device-qa` flips the run conclusion (none are `continue-on-error` at this level).
- **Anti-noise (action 2)**: the tracking issue is only opened/updated when BOTH nights were bad — 2 consecutive bad nights, exactly as specified; a single flaky night logs "holding fire" and stays silent. Dedup via the stable title key `Nightly CI unhealthy` (the old title embedded a date, which the search tolerated but made titles inconsistent).
- **Leg detail**: the report body names the non-success jobs of the most recent bad run (`skipped` excluded — path-gated skips inside the reused workflows are legitimate; `cancelled`/`failure` are named). It also points at the #2716 thread-dump artifact for hang triage (action 3) and explains that a `cancelled` night = a hung run, not noise.
- **Streak integrity**: `--event schedule` filtering, so a manual `workflow_dispatch` green run can't mask a sick schedule. A bounded 4×30 s wait lets the previous night's dying run reach a terminal state before grading (otherwise grading is one night staler — still correct).

The timing trade-off is honest: with the mandated 2-consecutive rule, the earliest possible report was always night N+1 — the start-of-run design hits that same bound while being immune to cancellation.

## Validation

- `yaml.safe_load` OK (jobs: full-ci, render-tests, device-qa, nightly-health).
- Extracted `run:` script → `bash -n` OK.
- No untrusted input interpolated (only API-sourced conclusions/URLs via env).

## Self-review declared

Single-file YAML change + changelog fragment; no library code, no gradle. The orchestrator session reviews before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)