### PR TITLE
feat(release): automated pub.dev publishing for sceneview_flutter — OIDC job + PR dry-run preflight (#2735)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,13 @@ jobs:
         working-directory: samples/flutter-demo
         run: flutter pub get
 
+      # pub.dev publish preflight (#2735): catches archive/pubspec problems
+      # (missing files, invalid metadata, size limits) on the PR that
+      # introduces them instead of at release time in the `pub-publish` job.
+      - name: pub.dev publish preflight (--dry-run)
+        working-directory: flutter/sceneview_flutter
+        run: flutter pub publish --dry-run
+
       - name: flutter analyze
         working-directory: samples/flutter-demo
         run: flutter analyze --no-fatal-infos --no-fatal-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,9 +482,84 @@ jobs:
           done
           echo "::notice::Both SPM manifests present and well-formed at tag ${GITHUB_REF_NAME}"
 
-  # NOTE: pub.dev / Flutter publish is not yet automated. Requires a
-  # `PUB_TOKEN` org-level secret + `dart pub publish --force`. Tracked
-  # separately in #962 follow-up.
+  # ── 4d. Publish sceneview_flutter to pub.dev (OIDC) ───────────────────────
+  # Automated pub.dev publishing via GitHub OIDC (no long-lived token — the
+  # pub client exchanges the Actions id-token when `id-token: write` is set
+  # and pub.dev has "Automated publishing" enabled for this repo + tag
+  # pattern). #2735 replaced the old "not yet automated" note (#962 follow-up).
+  #
+  # DELIBERATELY NOT in `create-release`'s needs-gate yet: until the pub.dev
+  # side is configured (package admin action, ~10 min), this job fails on
+  # auth — an HONEST red (never a swallowed error: that's the #2731 failure
+  # mode), but it must not block the user-visible GitHub Release. Promote it
+  # into the create-release gate after the first successful publish.
+  pub-publish:
+    name: Publish sceneview_flutter to pub.dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # OIDC token exchange for pub.dev automated publishing
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check if version already published
+        id: check-pub
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION=$(grep -E '^version:' flutter/sceneview_flutter/pubspec.yaml | awk '{print $2}')
+          else
+            VERSION=${GITHUB_REF_NAME#v}
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # pub.dev versions are immutable — mirror the npm publishers'
+          # skip-if-published so a workflow_dispatch retry after a partial
+          # failure stays idempotent.
+          PUBLISHED=$(curl -sf "https://pub.dev/api/packages/sceneview_flutter" \
+            | python3 -c "import json,sys; print(any(v['version'] == '$VERSION' for v in json.load(sys.stdin)['versions']))" \
+            2>/dev/null || echo "False")
+          if [ "$PUBLISHED" = "True" ]; then
+            echo "::notice::sceneview_flutter $VERSION already on pub.dev — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing sceneview_flutter $VERSION (not yet on pub.dev)"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: subosito/flutter-action@v2
+        if: steps.check-pub.outputs.skip != 'true'
+        with:
+          # Keep pinned in lockstep with ci.yml's flutter-demo job.
+          flutter-version: "3.41.6"
+          channel: stable
+          cache: true
+
+      - name: Sync pubspec version from tag
+        if: steps.check-pub.outputs.skip != 'true'
+        run: |
+          # Belt-and-suspenders (mirrors publish-rn): the version-bump skill
+          # already updates pubspec.yaml in the bump commit, but a
+          # workflow_dispatch run against a stale tree would otherwise
+          # publish whatever pubspec.yaml currently says.
+          VERSION="${{ steps.check-pub.outputs.version }}"
+          sed -i -E "s/^version: .*/version: $VERSION/" flutter/sceneview_flutter/pubspec.yaml
+
+      - name: Validate package archive (--dry-run)
+        if: steps.check-pub.outputs.skip != 'true'
+        working-directory: flutter/sceneview_flutter
+        # Runs BEFORE the real publish so an archive/pubspec problem is
+        # distinguishable from the auth failure you get while pub.dev-side
+        # OIDC activation (#2735) is still pending.
+        run: flutter pub publish --dry-run
+
+      - name: Publish to pub.dev (OIDC)
+        if: steps.check-pub.outputs.skip != 'true'
+        working-directory: flutter/sceneview_flutter
+        run: |
+          if ! flutter pub publish --force; then
+            echo "::warning::pub.dev publish failed. If this is an auth error, enable 'Automated publishing' (GitHub Actions, repo sceneview/sceneview, tag pattern v{{version}}) on pub.dev — see #2735. Failing honestly rather than masking (#2731 lesson)."
+            exit 1
+          fi
 
   # ── 5. Create GitHub Release with auto-generated notes ────────────────────
   create-release:

--- a/changelog.d/2735-pubdev-publish.md
+++ b/changelog.d/2735-pubdev-publish.md
@@ -1,0 +1,2 @@
+<!-- category: Added -->
+- Automated pub.dev publishing for `sceneview_flutter`: OIDC `pub-publish` job in the release workflow (idempotent, honest-red until pub.dev-side activation) + PR-time `flutter pub publish --dry-run` preflight in CI (#2735)

--- a/flutter/sceneview_flutter/CHANGELOG.md
+++ b/flutter/sceneview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.22.0
+
+- Version alignment with SceneView v4.22.0 (first version published to pub.dev via the automated OIDC `pub-publish` release job, #2735 — the registry previously served an unrelated 0.0.1 placeholder). Cumulative since 4.17.0: DisplayHelper NPE fix on screen close, Sketchfab viewer ground-shadow hardening, Explore multi-source (Sketchfab | Icosa Gallery | Poly Haven), SplatNode P1 (3D Gaussian Splatting, Android), centerOrigin normalized-origin parity. No breaking Flutter API change.
+
 ## 4.17.0
 
 - Version alignment with SceneView v4.17.0. Performance & correctness release: hot-path audit cutting per-frame allocations / matrix decompositions / JNI across Android 3D, AR, KMP core, Apple and Web; the #2187 transform-drift is now fully fixed (component setters no longer re-decompose). No breaking Flutter API change.

--- a/flutter/sceneview_flutter/CHANGELOG.md
+++ b/flutter/sceneview_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.22.0
 
-- Version alignment with SceneView v4.22.0 (first version published to pub.dev via the automated OIDC `pub-publish` release job, #2735 — the registry previously served an unrelated 0.0.1 placeholder). Cumulative since 4.17.0: DisplayHelper NPE fix on screen close, Sketchfab viewer ground-shadow hardening, Explore multi-source (Sketchfab | Icosa Gallery | Poly Haven), SplatNode P1 (3D Gaussian Splatting, Android), centerOrigin normalized-origin parity. No breaking Flutter API change.
+- Version alignment with SceneView v4.22.0 (2026-07-12). First version published to pub.dev via the automated OIDC `pub-publish` release job (#2735) — the registry previously served an unrelated 0.0.1 placeholder; entries 4.18.x–4.21.x were never published there. Native-side highlights per the [v4.22.0 release notes](https://github.com/sceneview/sceneview/releases/tag/v4.22.0): public `SurfaceMirrorer` in-app video recording (#2626), normalized-origin `centerOrigin` parity (#2632), store-preflight release tooling. No breaking Flutter API change.
 
 ## 4.17.0
 


### PR DESCRIPTION
Part of #2735 (wave 1 of the #2642 SDK ideation triage). Does **not** close the issue — the pub.dev-side OIDC activation and the first publish remain.

## What

- **`release.yml`**: new `pub-publish` job (§4d) replacing the l.485 "pub.dev publish is not yet automated" note (#962 follow-up):
  - GitHub **OIDC** (`id-token: write`) — no long-lived `PUB_TOKEN` secret.
  - **Idempotent**: skips when the version is already on pub.dev (mirrors the `publish-rn`/`publish-web` npm pattern), so dispatch retries after partial failures stay clean.
  - `flutter pub publish --dry-run` runs **before** the real publish, so an archive/pubspec problem is distinguishable from the auth error expected until activation.
  - **Deliberately not in `create-release`'s needs-gate** until the first successful publish: it fails honest-red (never a swallowed error — the #2731 vert-menteur lesson), without blocking the user-visible GitHub Release. Promotion criterion documented in the job comment.
- **`ci.yml`** (`flutter-demo` job): `flutter pub publish --dry-run` preflight, so a broken package archive is caught on the PR that introduces it instead of at release time.
- Changelog fragment `changelog.d/2735-pubdev-publish.md` (Added).

## Deliberately out of scope (tracked on #2735)

- **Thomas (~10 min, pub.dev admin)**: enable *Automated publishing* for `sceneview_flutter` → GitHub Actions, repository `sceneview/sceneview`, tag pattern `v{{version}}`.
- `docs/docs/quickstart-flutter.md` still shows the git pin **on purpose** — flipping it to a hosted `^4.x` before the first successful publish would document an install that 404s (AI-first: docs must generate working code). Flip lands right after the first publish.
- Consumed-dep coordinates in `flutter/.../android/build.gradle` untouched (#1494 rule).

## Verification

- `yaml.safe_load` + `actionlint` green on both workflows.
- No Kotlin/JS/product code touched — CI-config + changelog only. Self-review declared (small scope, no public API); release-job behavior is exercised at the next tag.