### PR TITLE
ci(web): deterministic sceneview-web.d.ts drift gate + type the missing sceneview.haptic surface (#2736)

### DIFF
--- a/.claude/scripts/check-web-dts.sh
+++ b/.claude/scripts/check-web-dts.sh
@@ -78,12 +78,17 @@ api_keys() {
 }
 
 # Member names of a d.ts interface block: `^export interface <Name> {` … `}`.
+# A member START is `name(`, `name:` or `name?:` at 2-space indent — requiring
+# the `(`/`:` right after the name keeps continuation lines of a future
+# multi-line member signature from being captured as phantom members
+# (review W2 on #2736's PR).
 dts_iface_members() { # $1 = interface name
     awk -v name="$1" '
         $0 ~ ("^export interface " name " \\{") { f = 1; next }
         f && /^\}/ { exit }
         f
-    ' "$DTS" | grep -oE '^  (readonly )?[A-Za-z0-9_]+' | awk '{print $NF}' | sort -u
+    ' "$DTS" | grep -oE '^  (readonly )?[A-Za-z0-9_]+\??[(:]' \
+             | sed -E 's/\??[(:]$//' | awk '{print $NF}' | sort -u
 }
 
 # Public member JS-names of ONE Kotlin class: 4-space-indented public
@@ -103,7 +108,12 @@ kt_members() { # $1 = kotlin file, $2 = class name
             next
         }
         /^    (override )?(public )?(fun|val|var) [A-Za-z0-9_]+/ {
-            if ($0 ~ /private|internal/) { pending = ""; next }
+            # No private/internal filter needed: a private/internal member
+            # declaration STARTS with its modifier, so it never matches the
+            # leading (override)?(public)?(fun|val|var) pattern above. A
+            # whole-line substring test here would wrongly drop a public
+            # member whose body merely mentions an internal identifier
+            # (review W1 on #2736 PR).
             if (pending != "") { print pending; pending = ""; next }
             line = $0
             sub(/^    (override )?(public )?(fun|val|var) /, "", line)

--- a/.claude/scripts/check-web-dts.sh
+++ b/.claude/scripts/check-web-dts.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# check-web-dts.sh — deterministic drift gate between the hand-written npm
+# TypeScript declarations (`sceneview-web/sceneview-web.d.ts`) and the actual
+# Kotlin/JS surface. Closes #2736.
+#
+# WHY THIS EXISTS
+# ---------------
+# The `sceneview-web` npm package ships hand-written typings guarded, until
+# this script, by nothing but a "Keep this file in sync" comment (#946). An
+# export added to the Kotlin sources without a `.d.ts` update ships wrong
+# types to real npm consumers (~780 dl/month) and skews every AI assistant
+# that reads the typings to generate user code. First run of this guard
+# found a live instance: `sceneview.haptic` was registered on the namespace
+# but absent from the `.d.ts`.
+#
+# Why not generate the `.d.ts` (Kotlin `generateTypeScriptDefinitions()`)?
+# The published surface is NOT the `@JsExport` surface: `Main.kt#main()`
+# builds the `sceneview` global namespace dynamically
+# (`api["createViewer"] = ::jsCreateViewer` … `window["sceneview"] = api`),
+# which is invisible to the compiler, and the typings use
+# `export as namespace sceneview` + hand-shaped Promise signatures that the
+# generated ES-module d.ts cannot express. Generation would document the
+# wrong surface; this deterministic guard keeps the manual file honest.
+#
+# WHAT IT CHECKS (all bidirectional, all hard-fail)
+# -------------------------------------------------
+#   1. Namespace registry: every `api["X"]` key in Main.kt appears as a
+#      top-level `export function X` / `export const X` in the d.ts — and
+#      every such export maps back to a registered key.
+#   2. Interface members: for each (Kotlin class ↔ d.ts interface) pair
+#        SceneViewJS.kt      ↔ interface SceneViewer
+#        NodeHandle.kt       ↔ interface NodeHandle
+#        SceneViewHaptic.kt  ↔ interface SceneViewHaptic
+#      the public member names (honouring `@JsName` overrides) must match
+#      the interface's member names exactly, both directions.
+#
+# Deliberately NOT checked (precision over recall — a false positive teaches
+# humans to ignore the gate): parameter lists / types (prose-level, covered
+# by review + the in-browser smoke test), `@JsExport` classes that are not
+# reachable from the `sceneview` namespace registry (e.g. SpatialAudioNode —
+# module-import-only surface), and jsTest sources.
+#
+# Usage:  bash .claude/scripts/check-web-dts.sh
+#         CHECK_WEB_DTS_ROOT=<dir> …   # fixture root (used by the self-test)
+#
+# Exit: 0 in sync · 1 drift (each mismatch listed) · 2 missing input file.
+
+set -uo pipefail
+
+ROOT="${CHECK_WEB_DTS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+DTS="$ROOT/sceneview-web/sceneview-web.d.ts"
+JSMAIN="$ROOT/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web"
+MAIN_KT="$JSMAIN/Main.kt"
+
+for f in "$DTS" "$MAIN_KT"; do
+    if [ ! -f "$f" ]; then
+        echo "[ERROR] missing input: $f" >&2
+        exit 2
+    fi
+done
+
+FAIL=0
+report() { echo "[FAIL] $1"; FAIL=1; }
+
+# ─── Extractors ─────────────────────────────────────────────────────────
+
+# Top-level `export function X` / `export const X` names in the d.ts.
+dts_top_level() {
+    grep -oE '^export (declare )?(function|const) [A-Za-z0-9_]+' "$DTS" \
+        | awk '{print $NF}' | sort -u
+}
+
+# `api["X"]` keys registered on the namespace in Main.kt.
+api_keys() {
+    grep -oE 'api\["[A-Za-z0-9_]+"\]' "$MAIN_KT" \
+        | sed -E 's/.*\["([A-Za-z0-9_]+)"\].*/\1/' | sort -u
+}
+
+# Member names of a d.ts interface block: `^export interface <Name> {` … `}`.
+dts_iface_members() { # $1 = interface name
+    awk -v name="$1" '
+        $0 ~ ("^export interface " name " \\{") { f = 1; next }
+        f && /^\}/ { exit }
+        f
+    ' "$DTS" | grep -oE '^  (readonly )?[A-Za-z0-9_]+' | awk '{print $NF}' | sort -u
+}
+
+# Public member JS-names of ONE Kotlin class: 4-space-indented public
+# fun/val/var declarations between `class <Name>` and the next top-level `}`,
+# with a preceding `@JsName("x")` taking precedence over the Kotlin
+# identifier (that is what mangling-stable exports rely on). Members of any
+# OTHER type in the same file (e.g. NodeHandle.kt's `internal interface
+# NodeHost`) and private/internal members are skipped.
+kt_members() { # $1 = kotlin file, $2 = class name
+    awk -v cls="$2" '
+        !inclass && $0 ~ ("(^|[[:space:]])class " cls "([ ({]|$)") { inclass = 1; next }
+        !inclass { next }
+        /^\}/ { exit }   # first top-level closing brace ends the class
+        /^[[:space:]]*@JsName\("[A-Za-z0-9_]+"\)/ {
+            match($0, /"[A-Za-z0-9_]+"/)
+            pending = substr($0, RSTART + 1, RLENGTH - 2)
+            next
+        }
+        /^    (override )?(public )?(fun|val|var) [A-Za-z0-9_]+/ {
+            if ($0 ~ /private|internal/) { pending = ""; next }
+            if (pending != "") { print pending; pending = ""; next }
+            line = $0
+            sub(/^    (override )?(public )?(fun|val|var) /, "", line)
+            match(line, /^[A-Za-z0-9_]+/)
+            print substr(line, RSTART, RLENGTH)
+            next
+        }
+        /^[[:space:]]*$/ { next }   # blank lines keep a pending @JsName alive
+        { if ($0 !~ /^[[:space:]]*(\/\/|\/\*|\*)/) pending = "" }
+    ' "$1" | sort -u
+}
+
+diff_sets() { # $1 = expected-in label, $2 = list A, $3 = list B (A minus B reported)
+    local missing
+    missing=$(comm -23 <(echo "$2") <(echo "$3") | grep -v '^$' || true)
+    if [ -n "$missing" ]; then
+        while IFS= read -r sym; do
+            report "$1: \`$sym\`"
+        done <<< "$missing"
+    fi
+}
+
+# ─── 1. Namespace registry ↔ d.ts top-level exports ────────────────────
+KEYS=$(api_keys)
+TOP=$(dts_top_level)
+diff_sets "registered on the sceneview namespace (Main.kt) but missing from sceneview-web.d.ts" "$KEYS" "$TOP"
+diff_sets "declared top-level in sceneview-web.d.ts but not registered in Main.kt" "$TOP" "$KEYS"
+
+# ─── 2. Class ↔ interface member pairs ─────────────────────────────────
+check_pair() { # $1 = kotlin file (relative to JSMAIN), $2 = kotlin class, $3 = d.ts interface name
+    local kt="$JSMAIN/$1"
+    if [ ! -f "$kt" ]; then
+        report "expected Kotlin source missing: $kt (update this script if the class moved)"
+        return
+    fi
+    local kmembers dmembers
+    kmembers=$(kt_members "$kt" "$2")
+    dmembers=$(dts_iface_members "$3")
+    if [ -z "$dmembers" ]; then
+        report "interface \`$3\` not found in sceneview-web.d.ts"
+        return
+    fi
+    if [ -z "$kmembers" ]; then
+        report "no public members extracted from $1 class \`$2\` (extractor broken or class renamed?)"
+        return
+    fi
+    diff_sets "public in $1 but missing from d.ts interface \`$3\`" "$kmembers" "$dmembers"
+    diff_sets "in d.ts interface \`$3\` but not public in $1" "$dmembers" "$kmembers"
+}
+
+check_pair "SceneViewJS.kt" "SceneViewJS" "SceneViewer"
+check_pair "NodeHandle.kt" "NodeHandle" "NodeHandle"
+check_pair "haptic/SceneViewHaptic.kt" "SceneViewHaptic" "SceneViewHaptic"
+
+# ─── Verdict ────────────────────────────────────────────────────────────
+if [ "$FAIL" -ne 0 ]; then
+    echo ""
+    echo "sceneview-web.d.ts has drifted from the Kotlin/JS surface."
+    echo "Fix: update sceneview-web/sceneview-web.d.ts (or the registry/class)"
+    echo "so both sides agree. See #2736 for the contract."
+    exit 1
+fi
+echo "OK: sceneview-web.d.ts is in sync with the Kotlin/JS surface (namespace registry + 3 interface pairs)."
+exit 0

--- a/.claude/scripts/quality-gate.sh
+++ b/.claude/scripts/quality-gate.sh
@@ -282,6 +282,26 @@ fi
 
 echo ""
 
+# ─── 4c-bis. sceneview-web.d.ts ↔ Kotlin/JS surface drift (issue #2736) ─
+# The npm typings are hand-written (#946) and consumed by real users and by
+# AI codegen; check-web-dts.sh asserts the `sceneview` namespace registry
+# (Main.kt) and the SceneViewJS/NodeHandle/SceneViewHaptic member surfaces
+# match the d.ts in both directions. Deterministic (bash+awk, no toolchain)
+# → hard FAIL on drift.
+echo -e "${CYAN}--- sceneview-web.d.ts drift ---${NC}"
+if [ -x ".claude/scripts/check-web-dts.sh" ]; then
+    if bash .claude/scripts/check-web-dts.sh > /tmp/check-web-dts.log 2>&1; then
+        check "sceneview-web.d.ts in sync with JS surface" "PASS"
+    else
+        DRIFT_COUNT=$(grep -c '^\[FAIL\]' /tmp/check-web-dts.log 2>/dev/null || echo "?")
+        check "sceneview-web.d.ts in sync with JS surface" "FAIL" "$DRIFT_COUNT mismatch(es) — see /tmp/check-web-dts.log"
+    fi
+else
+    check "sceneview-web.d.ts drift check" "WARN" ".claude/scripts/check-web-dts.sh missing"
+fi
+
+echo ""
+
 # ─── 4d. Worktree-prune regression suite (advisory) ────────────────────
 # Pins the safety contract of `.claude/scripts/worktree-auto-prune.sh`
 # (locked-tree skip #1833, broad subprocess detect #1834, forensic log

--- a/.claude/scripts/quality-gate.sh
+++ b/.claude/scripts/quality-gate.sh
@@ -293,8 +293,11 @@ if [ -x ".claude/scripts/check-web-dts.sh" ]; then
     if bash .claude/scripts/check-web-dts.sh > /tmp/check-web-dts.log 2>&1; then
         check "sceneview-web.d.ts in sync with JS surface" "PASS"
     else
-        DRIFT_COUNT=$(grep -c '^\[FAIL\]' /tmp/check-web-dts.log 2>/dev/null || echo "?")
-        check "sceneview-web.d.ts in sync with JS surface" "FAIL" "$DRIFT_COUNT mismatch(es) — see /tmp/check-web-dts.log"
+        # grep -c prints "0" BEFORE exiting 1 on no-match, so `|| echo` would
+        # produce a two-line "0\n?" here; `|| true` + a default covers the
+        # only empty case (log unreadable, exit 2).
+        DRIFT_COUNT=$(grep -c '^\[FAIL\]' /tmp/check-web-dts.log 2>/dev/null || true)
+        check "sceneview-web.d.ts in sync with JS surface" "FAIL" "${DRIFT_COUNT:-?} mismatch(es) — see /tmp/check-web-dts.log"
     fi
 else
     check "sceneview-web.d.ts drift check" "WARN" ".claude/scripts/check-web-dts.sh missing"

--- a/.claude/scripts/test-check-web-dts.sh
+++ b/.claude/scripts/test-check-web-dts.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# test-check-web-dts.sh — self-test for check-web-dts.sh (#2736).
+#
+# A drift gate that silently PASSes is worse than none (same rationale as
+# test-check-doc-drift.sh), so this pins the guard's contract by mutation:
+# copy the real sceneview-web surface into a fixture, verify the guard
+# PASSes on it, then verify each class of injected drift turns the guard
+# red. Runs in repo-hygiene (ci.yml) and standalone; needs bash + awk only.
+#
+# Exit: 0 all scenarios hold · 1 a scenario failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CHECK="$REPO_ROOT/.claude/scripts/check-web-dts.sh"
+SRC_WEB="$REPO_ROOT/sceneview-web"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/check-web-dts-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+scenario() { # $1 = name, $2 = expected exit (0|1), then the guard runs on $TMP/fixture
+    local name="$1" expected="$2" actual out
+    out=$(CHECK_WEB_DTS_ROOT="$TMP/fixture" bash "$CHECK" 2>&1) && actual=0 || actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        echo "[PASS] $name"
+    else
+        echo "[FAIL] $name — expected exit $expected, got $actual"
+        while IFS= read -r line; do echo "       | $line"; done <<< "$out"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_fixture() {
+    rm -rf "$TMP/fixture"
+    mkdir -p "$TMP/fixture/sceneview-web"
+    cp "$SRC_WEB/sceneview-web.d.ts" "$TMP/fixture/sceneview-web/"
+    mkdir -p "$TMP/fixture/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/haptic"
+    for f in Main.kt SceneViewJS.kt NodeHandle.kt; do
+        cp "$SRC_WEB/src/jsMain/kotlin/io/github/sceneview/web/$f" \
+           "$TMP/fixture/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/"
+    done
+    cp "$SRC_WEB/src/jsMain/kotlin/io/github/sceneview/web/haptic/SceneViewHaptic.kt" \
+       "$TMP/fixture/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/haptic/"
+}
+FIX_WEB="$TMP/fixture/sceneview-web"
+FIX_JSMAIN="$FIX_WEB/src/jsMain/kotlin/io/github/sceneview/web"
+
+# ── 1. Baseline: the real tree must be in sync ─────────────────────────
+reset_fixture
+scenario "baseline (real surface) passes" 0
+
+# ── 2. New namespace registration without d.ts → red ───────────────────
+reset_fixture
+sed -i.bak 's/js("window")\["sceneview"\] = api/api["ghostFeature"] = ::jsCreateViewer\n    js("window")["sceneview"] = api/' \
+    "$FIX_JSMAIN/Main.kt"
+scenario "api[\"ghostFeature\"] without d.ts export fails" 1
+
+# ── 3. d.ts export without registry entry → red ────────────────────────
+reset_fixture
+printf '\nexport function ghostExport(): void;\n' >> "$FIX_WEB/sceneview-web.d.ts"
+scenario "d.ts export without api registration fails" 1
+
+# ── 4. New public SceneViewJS method without d.ts member → red ─────────
+reset_fixture
+# Inject right after the class opening line, 4-space indent like real members.
+awk '1; /^class SceneViewJS/ && !done { print "    fun ghostMethod() {}"; done = 1 }' \
+    "$FIX_JSMAIN/SceneViewJS.kt" > "$FIX_JSMAIN/SceneViewJS.kt.new"
+mv "$FIX_JSMAIN/SceneViewJS.kt.new" "$FIX_JSMAIN/SceneViewJS.kt"
+scenario "new public SceneViewJS method without d.ts member fails" 1
+
+# ── 5. Stale d.ts member (removed Kotlin-side) → red ───────────────────
+reset_fixture
+sed -i.bak 's/  fitToModels(): void;/  fitToModels(): void;\n  ghostMember(): void;/' \
+    "$FIX_WEB/sceneview-web.d.ts"
+scenario "stale d.ts SceneViewer member fails" 1
+
+# ── 6. @JsName rename without d.ts update → red ────────────────────────
+reset_fixture
+sed -i.bak 's/@JsName("setVisible")/@JsName("setShown")/' "$FIX_JSMAIN/NodeHandle.kt"
+scenario "@JsName rename without d.ts update fails" 1
+
+echo ""
+if [ "$FAILURES" -ne 0 ]; then
+    echo "check-web-dts.sh self-test: $FAILURES scenario(s) FAILED"
+    exit 1
+fi
+echo "check-web-dts.sh self-test: all 6 scenarios hold"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,20 @@ jobs:
         shell: bash
         run: bash .claude/scripts/test-check-doc-drift.sh
 
+      # sceneview-web.d.ts drift gate (#2736) — the npm typings are
+      # hand-written (#946); this asserts the `sceneview` namespace registry
+      # and the exported class surfaces match the d.ts bidirectionally.
+      # Self-test first, same rationale as the doc-drift pair above.
+      - name: Self-test check-web-dts.sh
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/test-check-web-dts.sh
+
+      - name: Check sceneview-web.d.ts drift
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/check-web-dts.sh
+
       # Store-preflight grader self-test — same rationale (#2612 P1). Exercises
       # the ASC blocker grading / gate / JSON offline via the FAKE seam and the
       # openssl ES256 JWT builder; needs no App Store Connect secret.

--- a/changelog.d/2736-dts-drift-gate.md
+++ b/changelog.d/2736-dts-drift-gate.md
@@ -1,0 +1,2 @@
+<!-- category: Tests -->
+- `sceneview-web.d.ts` is now machine-guarded: `check-web-dts.sh` (quality-gate + repo-hygiene CI) fails on any bidirectional drift between the npm typings and the actual Kotlin/JS surface, with a 6-scenario mutation self-test (#2736)

--- a/changelog.d/2736-haptic-dts.md
+++ b/changelog.d/2736-haptic-dts.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `sceneview.haptic` (light/medium/heavy taps, notification patterns, continuous, pattern) was live at runtime but missing from the npm TypeScript declarations — now typed in `sceneview-web.d.ts` (found by the new #2736 drift gate)

--- a/sceneview-web/build.gradle.kts
+++ b/sceneview-web/build.gradle.kts
@@ -3,6 +3,17 @@ plugins {
 }
 
 kotlin {
+    // TypeScript declarations: `sceneview-web.d.ts` stays HAND-WRITTEN,
+    // guarded by `.claude/scripts/check-web-dts.sh` (quality-gate +
+    // repo-hygiene CI, #2736). Kotlin's `generateTypeScriptDefinitions()`
+    // was evaluated and rejected: the published npm/browser surface is NOT
+    // the `@JsExport` surface — Main.kt#main() assembles the `sceneview`
+    // global namespace dynamically (`api["createViewer"] = ::jsCreateViewer`),
+    // which the compiler cannot see, and the typings rely on
+    // `export as namespace sceneview` + hand-shaped Promise signatures that
+    // a generated ES-module d.ts cannot express. Generation would therefore
+    // document the wrong surface; the deterministic guard keeps the manual
+    // file honest instead.
     js(IR) {
         outputModuleName.set("sceneview")
         browser {

--- a/sceneview-web/sceneview-web.d.ts
+++ b/sceneview-web/sceneview-web.d.ts
@@ -9,6 +9,11 @@
 // `src/jsMain/kotlin/io/github/sceneview/web/Main.kt` — they're a
 // small, stable surface so a hand-written declaration costs less than
 // wiring `kotlin.js.dtsGenerator`. See #946.
+//
+// Sync is MACHINE-CHECKED since #2736: `.claude/scripts/check-web-dts.sh`
+// (quality-gate + repo-hygiene CI) fails when the `api[...]` namespace
+// registry in Main.kt or the public members of SceneViewJS / NodeHandle /
+// SceneViewHaptic diverge from these declarations, in either direction.
 
 export as namespace sceneview;
 
@@ -178,6 +183,40 @@ export interface SceneViewer {
   /** Release Filament resources. The viewer is unusable after this. */
   dispose(): void;
 }
+
+/**
+ * Cross-platform haptic facade (mirrors Android `SceneViewHaptic` and iOS
+ * `SceneViewSwift.SceneViewHaptic`), backed by the Web Vibration API.
+ * Browsers without `navigator.vibrate` (Safari, all iOS browsers) no-op
+ * silently. Available as `sceneview.haptic.*`.
+ */
+export interface SceneViewHaptic {
+  /** Light tap (10 ms) — taps, button presses, selections. */
+  light(): void;
+  /** Medium tap (20 ms) — placing an anchor, mode-change confirmation. */
+  medium(): void;
+  /** Heavy tap (40 ms) — boundary hit, drag-lock engagement. */
+  heavy(): void;
+  /** Success notification pattern (`[10, 50, 20]`). */
+  success(): void;
+  /** Warning notification pattern (`[30, 30, 30]`). */
+  warning(): void;
+  /** Error notification pattern (`[50, 30, 50]`). */
+  error(): void;
+  /** Selection tick (5 ms) — drag tick, picker scroll. */
+  selection(): void;
+  /** Continuous vibration for `durationMs` milliseconds. `intensity` is
+   *  accepted for cross-platform API parity (Android/iOS) but **ignored** —
+   *  the Web Vibration API exposes durations only, no amplitude. */
+  continuous(intensity: number, durationMs: number): void;
+  /** Custom vibrate/pause pattern in milliseconds, alternating on/off
+   *  starting with on (e.g. `[100, 50, 100]`). Some browsers cap total
+   *  duration or require a user-gesture handler. */
+  pattern(durationsMs: number[] | Int32Array): void;
+}
+
+/** Shared haptic facade instance — `sceneview.haptic.light()` etc. */
+export const haptic: SceneViewHaptic;
 
 /** Create a viewer attached to the canvas with the given DOM id.
  *  Defaults: `autoRotate=true`, `cameraControls=true`. */


### PR DESCRIPTION
Closes #2736 (wave 1 of the #2642 SDK ideation triage).

## What

- **`.claude/scripts/check-web-dts.sh`** — deterministic, bidirectional, hard-fail drift gate between the hand-written npm typings and the actual Kotlin/JS surface:
  1. `api["X"]` namespace registry in `Main.kt` ↔ top-level `export function/const` set in the d.ts;
  2. public member surfaces of `SceneViewJS` ↔ `SceneViewer`, `NodeHandle` ↔ `NodeHandle`, `SceneViewHaptic` ↔ `SceneViewHaptic` — honouring `@JsName` overrides, scoped to the target class (internal seams like `NodeHost` correctly excluded).
- **`test-check-web-dts.sh`** — 6-scenario mutation self-test (baseline pass + 5 injected drift classes each turn the gate red). All 6 hold locally.
- Wired into **`quality-gate.sh`** (§4c-bis, FAIL blocks) and **`ci.yml` → repo-hygiene** (self-test first, then the check — same pattern as the doc-drift pair).
- **Real drift fixed on first run:** `sceneview.haptic` (registered on the namespace since the haptic facade landed) was absent from the d.ts — npm/TS consumers and AI codegen couldn't see it. Now fully typed, with durations (10/20/40 ms taps, notification patterns) and the parity-only **ignored** `intensity` parameter documented from the actual Kotlin source.
- **`generateTypeScriptDefinitions()` evaluated and rejected** (the issue asked for this first): the published surface is NOT the `@JsExport` surface — `main()` assembles the `sceneview` global namespace dynamically (`api["createViewer"] = ::jsCreateViewer`), invisible to the compiler, and the typings need `export as namespace` + hand-shaped Promise signatures a generated ES-module d.ts cannot express. Decision documented in `sceneview-web/build.gradle.kts`.

## Deliberately not checked (precision over recall)

Parameter lists/types (prose-level), `@JsExport` classes not reachable from the namespace registry (e.g. `SpatialAudioNode`, module-import surface), jsTest sources.

## Verification

- `check-web-dts.sh` green on the fixed tree; red with 3 named findings before the extractor was class-scoped (caught its own false positive on `NodeHost` during development).
- `test-check-web-dts.sh`: **6/6 scenarios hold** (output in the commit).
- `shellcheck` clean on both scripts; `yaml.safe_load` + `actionlint` green on ci.yml.
- No Kotlin behavior change — typings, scripts, CI config, docs only.