### PR TITLE
docs(ai-first): Point & Ask recipe — llms.txt + samples/recipes + agent skill (#2648 item 3)

### DIFF
--- a/agents/sceneview/references/recipes.md
+++ b/agents/sceneview/references/recipes.md
@@ -47,6 +47,9 @@ mirroring the same surface.
 ## 13. ViewNode (Compose UI inside 3D)
 [`PickingAndCollisionDemo.kt`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PickingAndCollisionDemo.kt) — the unified Picking & Collision demo bundles two modes: **Ray Hit-Test** with `CollisionSystem` + per-node tap highlights, **View Node** with `ViewNode { Card { Text("…") } }` (requires `viewNodeWindowManager` on `SceneView`).
 
+## 14. Point & Ask (on-device AI explains the camera view)
+[`PointAndAskDemo.kt`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt) — tap → `frame.cameraImage()` (in `onSessionUpdated`, current frame only) → `Image.toArgbBitmap(rotationDegrees)` off the main thread → **Gemini Nano** via ML Kit GenAI Prompt API: `Generation.getClient()`, gate on `checkStatus()`, then `generateContent(generateContentRequest(ImagePart(bitmap), TextPart(question)) {})`. Fully on-device (AICore, Pixel 8+); emulators are always `UNAVAILABLE` — swap in a canned engine under QA mode (see `AskEngine.kt`). Markdown recipe: `samples/recipes/point-and-ask.md`.
+
 ## AR recording / playback
 [`ARRecordPlaybackDemo.kt`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt) — `val recorder = rememberARRecorder(); recorder.start(file); recorder.stop()`. To replay, pass `playbackDataset = file` to `ARSceneView`.
 

--- a/changelog.d/2648-point-and-ask-recipe.md
+++ b/changelog.d/2648-point-and-ask-recipe.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- **AI-first docs**: new **Point & Ask** recipe — "build an AR app that explains what the camera sees" — across all three AI-facing surfaces: `samples/recipes/point-and-ask.md` (full pattern: AICore availability gating, current-frame CPU-image capture, off-main YUV→Bitmap, multimodal `generateContent`, emulator QA note), an `llms.txt` "Recipes" entry with the condensed working code and its gotchas, and agent-skill reference #14 pointing at the shipped `PointAndAskDemo.kt`. Completes item 3 of #2648 (P1 follow-up).

--- a/docs/docs/samples.md
+++ b/docs/docs/samples.md
@@ -145,6 +145,7 @@ Markdown recipes with side-by-side Kotlin and Swift code:
 | Model Viewer | `samples/recipes/model-viewer.md` | Load glTF, HDR environment, orbit camera |
 | Ground Shadow Catcher | `samples/recipes/ground-shadow-catcher.md` | Invisible contact-shadow floor, FL2+ flat-quad hardening |
 | AR Tap-to-Place | `samples/recipes/ar-tap-to-place.md` | Plane detection, anchor placement |
+| Point & Ask | `samples/recipes/point-and-ask.md` | AR frame capture, Gemini Nano on-device (ML Kit GenAI Prompt API), availability gating |
 | Physics | `samples/recipes/physics.md` | Rigid body, gravity, collision, bounce |
 | Procedural Geometry | `samples/recipes/procedural-geometry.md` | Cubes, spheres, custom shapes |
 | Text Labels | `samples/recipes/text-labels.md` | 3D text, billboards, tap interaction |

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -90,6 +90,56 @@ fun ARTapToPlace() {
 }
 ```
 
+### Point & Ask — AI explains what the camera sees (on-device, offline)
+
+Tap → capture the AR camera frame → **Gemini Nano on-device** (ML Kit GenAI
+Prompt API, `com.google.mlkit:genai-prompt:1.0.0-beta3`, minSdk 26) → answer.
+No cloud; frames never leave the device. AICore devices only (Pixel 8+,
+recent flagships) — gate with `checkStatus()` and degrade honestly.
+
+```kotlin
+val generativeModel = remember { Generation.getClient() }   // Gemini Nano via AICore
+var ready by remember { mutableStateOf(false) }
+LaunchedEffect(Unit) { ready = generativeModel.checkStatus() == FeatureStatus.AVAILABLE }
+// DOWNLOADABLE -> generativeModel.download() (Flow of progress); UNAVAILABLE -> explain, don't hide.
+
+var captureRequested by remember { mutableStateOf(false) }
+ARSceneView(
+    engine = engine, modelLoader = modelLoader,
+    onSessionUpdated = { _, frame ->
+        // Must use THIS frame's CPU image — acquiring from a stored older frame throws.
+        if (captureRequested && frame.camera.trackingState == TrackingState.TRACKING) {
+            frame.cameraImage()?.let { image ->            // null while warming up
+                captureRequested = false
+                scope.launch {
+                    val bitmap = withContext(Dispatchers.Default) {   // JPEG round-trip: off main
+                        image.use { it.toArgbBitmap(rotationDegrees = 90) }  // ALWAYS close the Image
+                    } ?: return@launch
+                    try {
+                        val response = generativeModel.generateContent(
+                            generateContentRequest(
+                                ImagePart(bitmap),
+                                TextPart("What am I looking at? Answer in one short sentence.")
+                            ) {}
+                        )
+                        answer = response.candidates.firstOrNull()?.text
+                    } finally { bitmap.recycle() }
+                }
+            }
+        }
+    },
+    onGestureListener = rememberOnGestureListener(
+        onSingleTapConfirmed = { _, _ -> if (ready) captureRequested = true }
+    ),
+)
+```
+
+Gotchas: a leaked CPU `Image` stalls ARCore within a few frames (`use { }` closes
+it); `toArgbBitmap` is main-thread-hostile; 90° is the portrait `ROTATION_0`
+rotation; emulators never have AICore — inject a canned engine under QA mode.
+Working demo: `point-and-ask` (`PointAndAskDemo.kt` + `AskEngine.kt`). Full
+recipe (with download CTA + capture timeout): `samples/recipes/point-and-ask.md`.
+
 ### Procedural geometry (no model files)
 
 ```kotlin

--- a/llms.txt
+++ b/llms.txt
@@ -4078,6 +4078,56 @@ fun ARTapToPlace() {
 }
 ```
 
+### Point & Ask — AI explains what the camera sees (on-device, offline)
+
+Tap → capture the AR camera frame → **Gemini Nano on-device** (ML Kit GenAI
+Prompt API, `com.google.mlkit:genai-prompt:1.0.0-beta3`, minSdk 26) → answer.
+No cloud; frames never leave the device. AICore devices only (Pixel 8+,
+recent flagships) — gate with `checkStatus()` and degrade honestly.
+
+```kotlin
+val generativeModel = remember { Generation.getClient() }   // Gemini Nano via AICore
+var ready by remember { mutableStateOf(false) }
+LaunchedEffect(Unit) { ready = generativeModel.checkStatus() == FeatureStatus.AVAILABLE }
+// DOWNLOADABLE -> generativeModel.download() (Flow of progress); UNAVAILABLE -> explain, don't hide.
+
+var captureRequested by remember { mutableStateOf(false) }
+ARSceneView(
+    engine = engine, modelLoader = modelLoader,
+    onSessionUpdated = { _, frame ->
+        // Must use THIS frame's CPU image — acquiring from a stored older frame throws.
+        if (captureRequested && frame.camera.trackingState == TrackingState.TRACKING) {
+            frame.cameraImage()?.let { image ->            // null while warming up
+                captureRequested = false
+                scope.launch {
+                    val bitmap = withContext(Dispatchers.Default) {   // JPEG round-trip: off main
+                        image.use { it.toArgbBitmap(rotationDegrees = 90) }  // ALWAYS close the Image
+                    } ?: return@launch
+                    try {
+                        val response = generativeModel.generateContent(
+                            generateContentRequest(
+                                ImagePart(bitmap),
+                                TextPart("What am I looking at? Answer in one short sentence.")
+                            ) {}
+                        )
+                        answer = response.candidates.firstOrNull()?.text
+                    } finally { bitmap.recycle() }
+                }
+            }
+        }
+    },
+    onGestureListener = rememberOnGestureListener(
+        onSingleTapConfirmed = { _, _ -> if (ready) captureRequested = true }
+    ),
+)
+```
+
+Gotchas: a leaked CPU `Image` stalls ARCore within a few frames (`use { }` closes
+it); `toArgbBitmap` is main-thread-hostile; 90° is the portrait `ROTATION_0`
+rotation; emulators never have AICore — inject a canned engine under QA mode.
+Working demo: `point-and-ask` (`PointAndAskDemo.kt` + `AskEngine.kt`). Full
+recipe (with download CTA + capture timeout): `samples/recipes/point-and-ask.md`.
+
 ### Procedural geometry (no model files)
 
 ```kotlin

--- a/samples/recipes/point-and-ask.md
+++ b/samples/recipes/point-and-ask.md
@@ -1,0 +1,110 @@
+# Recipe: Point & Ask — explain what the camera sees (on-device AI)
+
+**Intent:** "Build an AR app where the user taps and AI explains what the camera sees"
+
+Fully offline: the AR camera frame goes to **Gemini Nano on-device** (ML Kit GenAI
+Prompt API via AICore) — no cloud, frames never leave the device.
+
+## Android (Kotlin + Jetpack Compose)
+
+```gradle
+// minSdk 26+ (demo app uses 28). No model asset in the APK — Gemini Nano lives
+// in the system AICore app (Pixel 8+, recent flagships).
+implementation("com.google.mlkit:genai-prompt:1.0.0-beta3")
+```
+
+```kotlin
+@Composable
+fun PointAndAsk() {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val scope = rememberCoroutineScope()
+
+    // Gemini Nano client — gate on availability before letting the user ask.
+    val generativeModel = remember { Generation.getClient() }
+    var ready by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        ready = generativeModel.checkStatus() == FeatureStatus.AVAILABLE
+        // DOWNLOADABLE -> offer generativeModel.download() (a Flow of progress);
+        // UNAVAILABLE  -> unsupported device: show an explanation, don't hide the UI.
+    }
+    DisposableEffect(Unit) { onDispose { generativeModel.close() } }
+
+    var captureRequested by remember { mutableStateOf(false) }
+    var answer by remember { mutableStateOf<String?>(null) }
+
+    Box(Modifier.fillMaxSize()) {
+        ARSceneView(
+            modifier = Modifier.fillMaxSize(),
+            engine = engine,
+            modelLoader = modelLoader,
+            onSessionUpdated = { _, frame ->
+                // Serve the pending tap with THIS frame's CPU image — acquiring
+                // from a stored older frame throws once the session advances.
+                if (captureRequested &&
+                    frame.camera.trackingState == TrackingState.TRACKING
+                ) {
+                    frame.cameraImage()?.let { image ->   // null while warming up
+                        captureRequested = false
+                        scope.launch {
+                            // JPEG round-trip — keep it OFF the main thread, and
+                            // always close the Image (a leaked CPU image stalls
+                            // ARCore within a few frames).
+                            val bitmap = withContext(Dispatchers.Default) {
+                                image.use { it.toArgbBitmap(rotationDegrees = 90) }
+                            } ?: return@launch
+                            try {
+                                val response = generativeModel.generateContent(
+                                    generateContentRequest(
+                                        ImagePart(bitmap),
+                                        TextPart("What am I looking at? Answer in one short sentence.")
+                                    ) {}
+                                )
+                                answer = response.candidates.firstOrNull()?.text
+                            } finally {
+                                bitmap.recycle()
+                            }
+                        }
+                    }
+                }
+            },
+            onGestureListener = rememberOnGestureListener(
+                onSingleTapConfirmed = { _, _ -> if (ready) captureRequested = true }
+            ),
+        )
+
+        answer?.let {
+            Surface(
+                Modifier.align(Alignment.BottomCenter).padding(16.dp),
+                shape = MaterialTheme.shapes.large,
+            ) { Text(it, Modifier.padding(16.dp)) }
+        }
+    }
+}
+```
+
+Key imports: `io.github.sceneview.ar.arcore.cameraImage`,
+`io.github.sceneview.ar.arcore.toArgbBitmap`, `com.google.mlkit.genai.prompt.*`,
+`com.google.mlkit.genai.common.FeatureStatus`.
+
+## iOS (Swift + SwiftUI)
+
+Not available yet — SceneViewSwift has no on-device multimodal prompt API wired
+(an Apple Foundation Models / Apple Intelligence integration would be a separate
+feature). Tracked on [#2648](https://github.com/sceneview/sceneview/issues/2648).
+
+## Key concepts
+
+| Concept | Android |
+|---|---|
+| On-device model | Gemini Nano via AICore (`Generation.getClient()`) |
+| Availability gate | `checkStatus()` → `AVAILABLE` / `DOWNLOADABLE` / `UNAVAILABLE` |
+| Frame capture | `frame.cameraImage()` inside `onSessionUpdated` (current frame only) |
+| YUV → Bitmap | `Image.toArgbBitmap(rotationDegrees)` — off main thread, close the Image |
+| Multimodal ask | `generateContent(generateContentRequest(ImagePart, TextPart) {})` |
+| Rotation | 90° at portrait `ROTATION_0` (map from display rotation for other orientations) |
+| Emulator QA | AICore is never available on emulators — inject a canned engine under QA mode (see `PointAndAskDemo.kt` / `AskEngine.kt`) |
+
+Reference demo: [`PointAndAskDemo.kt`](../android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt)
+(demo id `point-and-ask`), with the production-grade extras: download CTA with
+progress, capture timeout, cancellation-safe Image close, deterministic QA engine.


### PR DESCRIPTION
## Summary

Completes **item 3 of #2648** ("llms.txt recipe + agent-skill reference — the pattern is exactly what AI agents will be asked to build"), following the P1 demo shipped in #2753:

- **`samples/recipes/point-and-ask.md`** — the full pattern: `genai-prompt:1.0.0-beta3` (minSdk 26, no bundled model), AICore availability gating, current-frame `cameraImage()` capture inside `onSessionUpdated`, off-main `toArgbBitmap` with guaranteed `Image` close, multimodal `generateContent(generateContentRequest(ImagePart, TextPart) {})`, honest iOS "not yet" note, and the emulator-QA guidance (AICore is never available on emulators → canned engine under QA mode).
- **`llms.txt`** — new "Point & Ask" entry in the *Recipes — "I want to…"* section with the condensed working code and its gotchas. Verified the hand-written section **survives `collate-demos.sh` regeneration**.
- **`agents/sceneview/references/recipes.md`** — entry #14 pointing at the shipped `PointAndAskDemo.kt`.
- **`docs/docs/samples.md`** — recipes-table row.
- **`gpt/knowledge-*.md`** regenerated from llms.txt (the CI blocking gate).

## Verification

- `bash .claude/scripts/check-sceneview-skill.sh` → ✓ Skill drift check passed
- `node tools/generate-gpt-knowledge.js` → in sync (committed)
- `collate-demos.sh` re-run → recipe entry survives, GeneratedDemos unchanged (51 fragments)
- Docs-only diff (no app/library code) — self-reviewed (trivial tier). Code snippets are condensed from the merged, emulator-QA'd `PointAndAskDemo.kt`, and the ML Kit API surface was verified against the actual beta3 AAR during #2753.

#2648 remains open for P2 (world-space anchoring, gated by #2754) and the remaining P3 UX items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)