### PR TITLE
feat(web): XRAnchorNode.drive(node) — anchor pose drives Node.worldTransform (#2024 P5a)

### DIFF
--- a/agents/sceneview-web/SKILL.md
+++ b/agents/sceneview-web/SKILL.md
@@ -213,6 +213,32 @@ ARSceneView.checkSupport { supported ->
 WebXR VR uses the same shape via `VRSceneView`; `WebXRSession` is the
 lower-level unified AR+VR API. See `llms.txt § WebXR`.
 
+### Anchoring content to the real world (`XRAnchorNode`)
+
+Verified against `xr/XRAnchorNode.kt`. For AR content that must stay pinned to
+a real-world spot across frames, create an anchor from a hit-test result and
+`drive(...)` a **root** scene-graph node with it — the node's `worldTransform`
+then follows the anchor's per-frame pose, and children parented under it
+compose for free (requires the `XRFeature.ANCHORS` session feature):
+
+```kotlin
+hit.createAnchor().then { anchor: XRAnchor ->
+    val anchorNode = XRAnchorNode(anchor)
+    anchorNode.drive(sceneView.addModelNode("models/chair.glb"))
+    anchors += anchorNode
+}
+// Per-frame — update() returns false once the anchor is lost:
+webXrSession.onFrame = { frame, _ ->
+    anchors.removeAll { !it.update(frame, webXrSession.referenceSpace) }
+}
+```
+
+Contract: `drive` throws on a parented or destroyed node (anchor poses are
+world-space — they must not compose through a parent) and on a detached
+anchor; a node re-parented later is skipped with a one-time console warning;
+a destroyed node is auto-released. `stopDriving()` releases the node and keeps
+its last pose; `detach()` releases the underlying anchor.
+
 ## Critical rules (verified — do not break)
 
 1. **Load filament.js BEFORE sceneview-web.js.** The library needs the WASM

--- a/changelog.d/2024-p5a-xr-anchor-drive.md
+++ b/changelog.d/2024-p5a-xr-anchor-drive.md
@@ -1,0 +1,9 @@
+<!-- category: Added -->
+- Web XR: `XRAnchorNode.drive(node)` bridges a tracked anchor to the retained
+  scene graph — the bound root `Node`'s `worldTransform` follows the anchor's
+  per-frame pose, so AR-placed content is real graph content with children
+  composing beneath it. `stopDriving()` releases the node; a destroyed node is
+  auto-released; parented nodes are rejected (world-space poses must not
+  double-compose). Proven with synthetic poses in `jsTest` — no new embind
+  binding (the write path is the #2024-P1-probed `TransformManager.setTransform`)
+  (#2024 P5a).

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3899,8 +3899,12 @@ Chrome on Android (ARCore) + Quest 3. Mirrors Android `arsceneview` `AnchorNode`
 val anchorPromise = session.xrSession.asDynamic().createAnchor(transform, session.referenceSpace)
 anchorPromise.then { anchor: XRAnchor ->
     val node = XRAnchorNode(anchor) { pose ->
-        // Apply pose.transform.matrix to a Filament entity each frame
+        // Optional per-frame pose callback (pose.transform.matrix, column-major)
     }
+    // Scene-graph bridge (#2024 P5a): bind a ROOT-level Node so its
+    // worldTransform follows the anchor pose each update() — children
+    // parented under it compose for free. stopDriving() releases it.
+    node.drive(sceneView.addModelNode("models/chair.glb"))
     node.onAttached = { firstPose -> }
     node.onLost     = { }
     anchors += node
@@ -3919,6 +3923,8 @@ session.onSessionEnd = { anchors.forEach { it.detach() }; anchors.clear() }
 ```
 
 `update(frame, referenceSpace)` returns `false` when the anchor is no longer in `frame.trackedAnchors` — drop the node from your list. `detach()` calls `XRAnchor.delete()` and is idempotent.
+
+`drive(node)` requires a parentless (root) `Node` — anchor poses are world-space, so a parented node would double-compose (the call throws; a node re-parented *after* `drive` is skipped with a one-time console warning). A destroyed node is auto-released. `drivenNode` exposes the currently bound node.
 
 XRFrame additions: `trackedAnchors` (anchor set), extension `frame.getDepthInformation(view)`, extension `frame.getImageTrackingResults()`.
 

--- a/llms.txt
+++ b/llms.txt
@@ -5934,8 +5934,12 @@ Chrome on Android (ARCore) + Quest 3. Mirrors Android `arsceneview` `AnchorNode`
 val anchorPromise = session.xrSession.asDynamic().createAnchor(transform, session.referenceSpace)
 anchorPromise.then { anchor: XRAnchor ->
     val node = XRAnchorNode(anchor) { pose ->
-        // Apply pose.transform.matrix to a Filament entity each frame
+        // Optional per-frame pose callback (pose.transform.matrix, column-major)
     }
+    // Scene-graph bridge (#2024 P5a): bind a ROOT-level Node so its
+    // worldTransform follows the anchor pose each update() — children
+    // parented under it compose for free. stopDriving() releases it.
+    node.drive(sceneView.addModelNode("models/chair.glb"))
     node.onAttached = { firstPose -> }
     node.onLost     = { }
     anchors += node
@@ -5954,6 +5958,8 @@ session.onSessionEnd = { anchors.forEach { it.detach() }; anchors.clear() }
 ```
 
 `update(frame, referenceSpace)` returns `false` when the anchor is no longer in `frame.trackedAnchors` — drop the node from your list. `detach()` calls `XRAnchor.delete()` and is idempotent.
+
+`drive(node)` requires a parentless (root) `Node` — anchor poses are world-space, so a parented node would double-compose (the call throws; a node re-parented *after* `drive` is skipped with a one-time console warning). A destroyed node is auto-released. `drivenNode` exposes the currently bound node.
 
 XRFrame additions: `trackedAnchors` (anchor set), extension `frame.getDepthInformation(view)`, extension `frame.getImageTrackingResults()`.
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/xr/XRAnchorNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/xr/XRAnchorNode.kt
@@ -1,5 +1,8 @@
 package io.github.sceneview.web.xr
 
+import io.github.sceneview.math.toTransform
+import io.github.sceneview.web.nodes.Node
+
 /**
  * High-level wrapper around an [XRAnchor] — mirrors Android `arsceneview`
  * `AnchorNode`.
@@ -10,16 +13,18 @@ package io.github.sceneview.web.xr
  *
  * Requires the [XRFeature.ANCHORS] session feature.
  *
- * Create one from a hit-test result:
+ * Create one from a hit-test result, and [drive] a scene-graph [Node] so
+ * AR-placed content is real graph content (children compose beneath it):
  *
  * ```kotlin
  * webXrSession.onHitTest = { pose -> /* show reticle */ }
  * webXrSession.onInputSelect = { _, _ ->
  *     val hit = lastHitResult ?: return@onInputSelect
  *     hit.createAnchor().then { anchor: XRAnchor ->
- *         val node = XRAnchorNode(anchor) { pose ->
- *             // Update Filament entity transform from pose.transform.matrix
- *         }
+ *         val node = XRAnchorNode(anchor)
+ *         // Anchor the model: its worldTransform now follows the anchor's
+ *         // per-frame pose, and children parented under it compose for free.
+ *         node.drive(sceneView.addModelNode("chair.glb"))
  *         anchors += node
  *     }
  * }
@@ -62,6 +67,55 @@ class XRAnchorNode(
     val isDetached: Boolean get() = detached
 
     /**
+     * The scene-graph [Node] whose `worldTransform` this anchor drives each
+     * [update], or `null` when the anchor only reports poses through
+     * [onUpdate]. Set via [drive], cleared via [stopDriving] (and
+     * automatically when the node is destroyed).
+     */
+    var drivenNode: Node? = null
+        private set
+
+    /** One-shot guard so a node re-parented after [drive] warns once, not per frame. */
+    private var warnedNonRoot = false
+
+    /**
+     * Binds [node] so its `worldTransform` follows this anchor's per-frame
+     * pose — AR-placed content becomes a real scene-graph node, with children
+     * composing beneath it (#2024 P5a).
+     *
+     * The node must be a **root** (no parent): anchor poses are world-space,
+     * so writing them into a parented node's world transform would compose
+     * them twice through the parent chain. If the node gains a parent after
+     * this call, per-frame writes are skipped (with a one-time console
+     * warning) until it is a root again.
+     *
+     * The write path is the node's plain `worldTransform` setter — the same
+     * `TransformManager.setTransform` route proven in-browser by the
+     * `kotlin-bundle.spec.ts` #2024-P1 probe; no new embind binding.
+     *
+     * Replaces any previously driven node. Call [stopDriving] to release
+     * the node while keeping the anchor alive.
+     */
+    fun drive(node: Node) {
+        require(!node.isDestroyed) { "Cannot drive a destroyed Node" }
+        require(node.parent == null) {
+            "XRAnchorNode can only drive a root node (anchor poses are " +
+                "world-space); detach '${node.name ?: node}' from its parent first"
+        }
+        drivenNode = node
+        warnedNonRoot = false
+    }
+
+    /**
+     * Releases the node bound by [drive] without touching the anchor. The
+     * node keeps its last driven transform. Safe to call when nothing is
+     * driven.
+     */
+    fun stopDriving() {
+        drivenNode = null
+    }
+
+    /**
      * Drive the node per-frame.
      *
      * @return `true` if the anchor is still tracked / present. `false` once it
@@ -82,12 +136,38 @@ class XRAnchorNode(
             }
         }
         val pose = frame.getPose(anchor.anchorSpace, referenceSpace) ?: return true
+        // Drive the bound node BEFORE the callbacks, so onAttached/onUpdate
+        // observe an up-to-date graph.
+        drivenNode?.let { driveNode(it, pose) }
         if (!attached) {
             attached = true
             onAttached?.invoke(pose)
         }
         onUpdate(pose)
         return true
+    }
+
+    private fun driveNode(node: Node, pose: XRPose) {
+        if (node.isDestroyed) {
+            // Auto-release: a late transform write on a destroyed node would be
+            // dropped by the node anyway; stop tracking it entirely.
+            drivenNode = null
+            return
+        }
+        if (node.parent != null) {
+            if (!warnedNonRoot) {
+                warnedNonRoot = true
+                console.warn(
+                    "XRAnchorNode: driven node '${node.name ?: node}' gained a " +
+                        "parent — skipping pose writes (anchor poses are " +
+                        "world-space and would double-compose). Detach it or " +
+                        "call stopDriving().",
+                )
+            }
+            return
+        }
+        warnedNonRoot = false
+        applyXRPoseMatrix(node, pose.transform.matrix)
     }
 
     /**
@@ -103,4 +183,24 @@ class XRAnchorNode(
             // delete() may throw if the anchor was already released by the runtime
         }
     }
+}
+
+/** Element count of a 4x4 pose matrix. */
+private const val POSE_MATRIX_SIZE = 16
+
+/**
+ * Writes a WebXR pose matrix — a column-major 16-element `Float32Array`
+ * ([XRRigidTransform.matrix]) — into [node]'s `worldTransform`.
+ *
+ * WebXR and Filament share the same right-handed, +y-up, -z-forward,
+ * column-major convention, so the matrix maps 1:1 onto the core
+ * `FloatArray.toTransform()` column layout — no axis or handedness fix-up.
+ * Kept as a top-level internal (not a method) so the synthetic-pose `jsTest`
+ * can prove the conversion without a live WebXR session.
+ */
+internal fun applyXRPoseMatrix(node: Node, matrix: dynamic) {
+    val columns = FloatArray(POSE_MATRIX_SIZE) { i ->
+        matrix[i].unsafeCast<Double>().toFloat()
+    }
+    node.worldTransform = columns.toTransform()
 }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/xr/XRAnchorNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/xr/XRAnchorNode.kt
@@ -94,9 +94,11 @@ class XRAnchorNode(
      * `kotlin-bundle.spec.ts` #2024-P1 probe; no new embind binding.
      *
      * Replaces any previously driven node. Call [stopDriving] to release
-     * the node while keeping the anchor alive.
+     * the node while keeping the anchor alive. Throws if this anchor node is
+     * already [detached][isDetached] — an inert anchor never drives anything.
      */
     fun drive(node: Node) {
+        require(!detached) { "Cannot drive from a detached XRAnchorNode" }
         require(!node.isDestroyed) { "Cannot drive a destroyed Node" }
         require(node.parent == null) {
             "XRAnchorNode can only drive a root node (anchor poses are " +

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/XRAnchorNodeDriveTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/XRAnchorNodeDriveTest.kt
@@ -2,6 +2,7 @@ package io.github.sceneview.web
 
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Transform
+import io.github.sceneview.math.copyColumnsInto
 import io.github.sceneview.web.nodes.Node
 import io.github.sceneview.web.nodes.NodeBackend
 import io.github.sceneview.web.xr.XRAnchor
@@ -30,10 +31,10 @@ import kotlin.test.assertTrue
 class XRAnchorNodeDriveTest {
 
     private class FakeBackend : NodeBackend {
-        override fun setLocalTransform(transform: Transform) {}
-        override fun setParent(parent: NodeBackend?) {}
-        override fun adoptChildEntity(child: io.github.sceneview.web.bindings.Entity) {}
-        override fun destroy() {}
+        override fun setLocalTransform(transform: Transform) = Unit
+        override fun setParent(parent: NodeBackend?) = Unit
+        override fun adoptChildEntity(child: io.github.sceneview.web.bindings.Entity) = Unit
+        override fun destroy() = Unit
     }
 
     private fun node(name: String? = null) = Node(FakeBackend()).also { it.name = name }
@@ -108,11 +109,19 @@ class XRAnchorNodeDriveTest {
     }
 
     @Test
-    fun poseMatrixRotationLandsInWorldRotation() {
+    fun poseMatrixRotationRoundTripsIntoWorldTransform() {
         val root = node("anchored")
-        applyXRPoseMatrix(root, yaw30Matrix(2f, 3f, 4f))
+        val pose = yaw30Matrix(2f, 3f, 4f)
+        applyXRPoseMatrix(root, pose)
         assertPosition(root, 2f, 3f, 4f)
-        assertClose(30f, root.worldRotation.y, "worldRotation.y")
+        // The node's world matrix must BE the pose matrix, element for element
+        // (column-major on both sides). The renderer consumes the matrix, so
+        // matrix equality — not any particular Euler-angle convention — is
+        // the bridge's contract.
+        val actual = root.worldTransform.copyColumnsInto(FloatArray(16))
+        for (i in 0 until 16) {
+            assertClose(pose[i].unsafeCast<Double>().toFloat(), actual[i], "worldTransform[$i]")
+        }
         // Scale must stay identity — pose matrices are rigid transforms.
         assertClose(1f, root.worldScale.x, "worldScale.x")
     }
@@ -171,6 +180,17 @@ class XRAnchorNodeDriveTest {
         parent.addChildNode(child)
         val anchorNode = XRAnchorNode(fakeAnchor())
         assertFails("world-space poses must not double-compose") { anchorNode.drive(child) }
+        assertNull(anchorNode.drivenNode)
+    }
+
+    @Test
+    fun driveRejectsADetachedAnchorNode() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.detach()
+        assertFails("a detached anchor is inert and must not bind a node") {
+            anchorNode.drive(root)
+        }
         assertNull(anchorNode.drivenNode)
     }
 

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/XRAnchorNodeDriveTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/XRAnchorNodeDriveTest.kt
@@ -1,0 +1,238 @@
+package io.github.sceneview.web
+
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Transform
+import io.github.sceneview.web.nodes.Node
+import io.github.sceneview.web.nodes.NodeBackend
+import io.github.sceneview.web.xr.XRAnchor
+import io.github.sceneview.web.xr.XRAnchorNode
+import io.github.sceneview.web.xr.XRFrame
+import io.github.sceneview.web.xr.XRReferenceSpace
+import io.github.sceneview.web.xr.applyXRPoseMatrix
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * #2024 P5a — the XR-anchor → scene-graph bridge, proven with SYNTHETIC poses.
+ *
+ * WebXR is not headlessly drivable (no XR device in Karma/CI), so these tests
+ * feed [XRAnchorNode.update] a fake [XRFrame] whose `getPose` returns a
+ * hand-built pose matrix — the exact per-frame input a live ARCore/Quest
+ * session produces — and assert the driven [Node]'s world transform tracks
+ * it. Nodes use a recording fake backend (the [NodeTest] pattern): the graph
+ * math under test is pure Kotlin; the engine write path
+ * (`TransformManager.setTransform`) is the #2024-P1 in-browser probe's job.
+ */
+class XRAnchorNodeDriveTest {
+
+    private class FakeBackend : NodeBackend {
+        override fun setLocalTransform(transform: Transform) {}
+        override fun setParent(parent: NodeBackend?) {}
+        override fun adoptChildEntity(child: io.github.sceneview.web.bindings.Entity) {}
+        override fun destroy() {}
+    }
+
+    private fun node(name: String? = null) = Node(FakeBackend()).also { it.name = name }
+
+    private val eps = 1e-4f
+
+    private fun assertClose(expected: Float, actual: Float, message: String) {
+        assertTrue(abs(expected - actual) < eps, "$message: expected $expected, was $actual")
+    }
+
+    private fun assertPosition(node: Node, x: Float, y: Float, z: Float) {
+        val p = node.worldPosition
+        assertClose(x, p.x, "worldPosition.x")
+        assertClose(y, p.y, "worldPosition.y")
+        assertClose(z, p.z, "worldPosition.z")
+    }
+
+    // --- Synthetic WebXR objects -------------------------------------------
+
+    private fun fakeAnchor(): XRAnchor {
+        val a: dynamic = js("{}")
+        a.anchorSpace = js("{}")
+        a.delete = {}
+        return a.unsafeCast<XRAnchor>()
+    }
+
+    private val referenceSpace = js("{}").unsafeCast<XRReferenceSpace>()
+
+    /**
+     * A frame whose `getPose` always resolves to [matrix] — the synthetic
+     * stand-in for a live tracked anchor. `trackedAnchors` is absent, which
+     * [XRAnchorNode.update] treats as "presence unknown, assume tracked".
+     */
+    private fun fakeFrame(matrix: dynamic): XRFrame {
+        val transform: dynamic = js("{}")
+        transform.matrix = matrix
+        val pose: dynamic = js("{}")
+        pose.transform = transform
+        val frame: dynamic = js("{}")
+        frame.getPose = { _: dynamic, _: dynamic -> pose }
+        return frame.unsafeCast<XRFrame>()
+    }
+
+    /** Column-major identity + translation — what `XRRigidTransform.matrix` yields. */
+    private fun translationMatrix(x: Float, y: Float, z: Float): dynamic {
+        val m: dynamic = js("new Float32Array(16)")
+        m[0] = 1f; m[5] = 1f; m[10] = 1f; m[15] = 1f
+        m[12] = x; m[13] = y; m[14] = z
+        return m
+    }
+
+    /** Column-major 30° yaw (rotation about +y) then translation. */
+    private fun yaw30Matrix(x: Float, y: Float, z: Float): dynamic {
+        val cos30 = 0.8660254f
+        val sin30 = 0.5f
+        val m: dynamic = js("new Float32Array(16)")
+        // x column = (cos, 0, -sin), z column = (sin, 0, cos)
+        m[0] = cos30; m[2] = -sin30
+        m[5] = 1f
+        m[8] = sin30; m[10] = cos30
+        m[12] = x; m[13] = y; m[14] = z; m[15] = 1f
+        return m
+    }
+
+    // --- applyXRPoseMatrix (the conversion itself) --------------------------
+
+    @Test
+    fun poseMatrixTranslationLandsInWorldPosition() {
+        val root = node("anchored")
+        applyXRPoseMatrix(root, translationMatrix(2f, 3f, 4f))
+        assertPosition(root, 2f, 3f, 4f)
+    }
+
+    @Test
+    fun poseMatrixRotationLandsInWorldRotation() {
+        val root = node("anchored")
+        applyXRPoseMatrix(root, yaw30Matrix(2f, 3f, 4f))
+        assertPosition(root, 2f, 3f, 4f)
+        assertClose(30f, root.worldRotation.y, "worldRotation.y")
+        // Scale must stay identity — pose matrices are rigid transforms.
+        assertClose(1f, root.worldScale.x, "worldScale.x")
+    }
+
+    // --- drive() through update() with synthetic frames ---------------------
+
+    @Test
+    fun driveWritesPoseIntoRootNodeEachUpdate() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(root)
+
+        assertTrue(anchorNode.update(fakeFrame(translationMatrix(1f, 0f, -2f)), referenceSpace))
+        assertPosition(root, 1f, 0f, -2f)
+
+        // The next frame's pose moves — the node tracks it.
+        assertTrue(anchorNode.update(fakeFrame(translationMatrix(5f, 1f, -3f)), referenceSpace))
+        assertPosition(root, 5f, 1f, -3f)
+    }
+
+    @Test
+    fun childrenComposeUnderTheDrivenRoot() {
+        val root = node("anchored")
+        val child = node("content")
+        root.addChildNode(child)
+        child.position = Position(1f, 0f, 0f)
+
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(root)
+        anchorNode.update(fakeFrame(translationMatrix(2f, 3f, 4f)), referenceSpace)
+
+        // world = anchorPose * local — the whole point of the bridge.
+        val p = child.worldPosition
+        assertClose(3f, p.x, "child.worldPosition.x")
+        assertClose(3f, p.y, "child.worldPosition.y")
+        assertClose(4f, p.z, "child.worldPosition.z")
+    }
+
+    @Test
+    fun callbacksObserveTheAlreadyDrivenNode() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        var observed: Position? = null
+        anchorNode.onAttached = { observed = root.worldPosition }
+        anchorNode.drive(root)
+        anchorNode.update(fakeFrame(translationMatrix(7f, 8f, 9f)), referenceSpace)
+        assertClose(7f, observed!!.x, "onAttached must see the driven transform")
+    }
+
+    // --- Guards -------------------------------------------------------------
+
+    @Test
+    fun driveRejectsAParentedNode() {
+        val parent = node("parent")
+        val child = node("child")
+        parent.addChildNode(child)
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        assertFails("world-space poses must not double-compose") { anchorNode.drive(child) }
+        assertNull(anchorNode.drivenNode)
+    }
+
+    @Test
+    fun driveRejectsADestroyedNode() {
+        val root = node("gone")
+        root.destroy()
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        assertFails { anchorNode.drive(root) }
+    }
+
+    @Test
+    fun updateSkipsANodeReparentedAfterDrive() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(root)
+        anchorNode.update(fakeFrame(translationMatrix(1f, 1f, 1f)), referenceSpace)
+
+        val newParent = node("group")
+        newParent.addChildNode(root)
+        // No write, no throw — the stale pose stays, the graph is untouched.
+        assertTrue(anchorNode.update(fakeFrame(translationMatrix(9f, 9f, 9f)), referenceSpace))
+        assertPosition(root, 1f, 1f, 1f)
+
+        // Back to root — driving resumes.
+        newParent.removeChildNode(root)
+        anchorNode.update(fakeFrame(translationMatrix(2f, 2f, 2f)), referenceSpace)
+        assertPosition(root, 2f, 2f, 2f)
+    }
+
+    @Test
+    fun updateAutoReleasesADestroyedNode() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(root)
+        root.destroy()
+        assertTrue(anchorNode.update(fakeFrame(translationMatrix(1f, 2f, 3f)), referenceSpace))
+        assertNull(anchorNode.drivenNode, "a destroyed node must be auto-released")
+    }
+
+    @Test
+    fun stopDrivingReleasesTheNodeAndKeepsItsLastPose() {
+        val root = node("anchored")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(root)
+        anchorNode.update(fakeFrame(translationMatrix(4f, 5f, 6f)), referenceSpace)
+        anchorNode.stopDriving()
+        assertNull(anchorNode.drivenNode)
+        anchorNode.update(fakeFrame(translationMatrix(0f, 0f, 0f)), referenceSpace)
+        assertPosition(root, 4f, 5f, 6f)
+    }
+
+    @Test
+    fun driveReplacesThePreviouslyDrivenNode() {
+        val first = node("first")
+        val second = node("second")
+        val anchorNode = XRAnchorNode(fakeAnchor())
+        anchorNode.drive(first)
+        anchorNode.drive(second)
+        assertEquals(second, anchorNode.drivenNode)
+        anchorNode.update(fakeFrame(translationMatrix(1f, 2f, 3f)), referenceSpace)
+        assertPosition(second, 1f, 2f, 3f)
+        assertPosition(first, 0f, 0f, 0f)
+    }
+}


### PR DESCRIPTION
## P5a — the XR-anchor → scene-graph bridge (first of the three P5 slices, #2024)

Per the maintainer decisions posted on #2024 (2026-07-17): full P5 ships as one wave — **P5a (this PR)** → P5b (SmoothTransform) → P5c (hitTest JS export). #2024 closes when all three are merged.

### What

- `XRAnchorNode.drive(node)` binds a **root-level** scene-graph `Node` so its `worldTransform` follows the anchor's per-frame pose — AR-placed content becomes real graph content, children compose beneath it (design: `.claude/plans/v5-p5-xr-compose.md` §P5a).
- `stopDriving()` releases the node (keeps its last pose); `drivenNode` exposes the binding.
- Guards: `drive()` **throws** on a parented or destroyed node (world-space poses must not double-compose); a node re-parented *after* `drive` is skipped with a **one-time** console warning and resumes when rooted again; a destroyed node is **auto-released** during `update()`.
- The node is written **before** `onAttached`/`onUpdate`, so callbacks observe an up-to-date graph.

### embind probe-first (⛔ rule) — no new binding

The write path is `Node.worldTransform` → `NodeBackend.setLocalTransform` → `TransformManager.setTransform`, **already proven in-browser** by the `kotlin-bundle.spec.ts` #2024-P1 probe. The pose conversion (`FloatArray.toTransform()`) is pure core math. WebXR and Filament share the same right-handed, +y-up, column-major convention — no axis fix-up.

### Verification (WebXR is not headlessly drivable → synthetic poses)

`XRAnchorNodeDriveTest` (jsTest, 11 tests) feeds `update()` a fake `XRFrame` whose `getPose` returns hand-built column-major `Float32Array` matrices: translation + yaw land in `worldPosition`/`worldRotation`, children compose (`world = anchorPose * local`), per-frame tracking, and every guard above.

- [ ] `:sceneview-web:compileKotlinJs :sceneview-web:jsTest :sceneview-web:detekt` (local run pending — host disk gate; CI covers meanwhile)
- [ ] `web-bundle-smoke.sh` + Playwright web-demo
- [ ] review-fanout before merge

### Docs

llms.txt Anchors section (example + root-only contract note), `gpt/knowledge-*.md` regenerated (never hand-edited), changelog fragment `2024-p5a-xr-anchor-drive.md`. The web agent skill defers XR API detail to `llms.txt § WebXR` — no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)