### PR TITLE
fix(ios-demo): canonicalize 4 drifted iOS scene ids to Android's canonical ids

### DIFF
--- a/changelog.d/2799-canonicalize-ios-scene-ids.md
+++ b/changelog.d/2799-canonicalize-ios-scene-ids.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+- iOS demo ids that diverged from Android's canonical `DemoRegistry` slugs are
+  now aligned: `ar-cloud-anchors` → `ar-cloud-anchor`, `ar-rooftop-anchors` →
+  `ar-rooftop`, `ar-terrain-anchors` → `ar-terrain`, `ar-recording` →
+  `ar-record-playback`. The 4 old ids are kept as documented deep-link
+  aliases in `DemoDeepLinkRegistry.allowedIds` so existing QR codes and
+  bookmarks keep resolving. First lot (#2799) of the iOS/Android catalog-ISO
+  effort (#2798) — required before the generated-registry union (#2800) can
+  land without silently duplicating ids.

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -60,6 +60,12 @@ enum DemoDeepLinkRegistry {
         "ar-plane-node", "ar-scene-mesh", "ar-scene-semantics", "ar-ml-object-label",
         "placement-scene", "ar-collaborative", "ar-body-tracker",
         "ar-hand-tracking", "ar-xr-face",
+        // Legacy aliases (#2799) — pre-canonicalization ids kept only so
+        // existing QR codes / bookmarks keep resolving. Canonical
+        // replacements ("ar-cloud-anchor", "ar-rooftop", "ar-terrain") are
+        // listed above; both old and new ids route to the same destination
+        // (today, the same coming-soon placeholder — see `destination(for:)`).
+        "ar-cloud-anchors", "ar-rooftop-anchors", "ar-terrain-anchors",
     ]
 
     /// Resolve a demo id to its presented `View`. Returns a fallback

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArCloudAnchorsScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArCloudAnchorsScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-cloud-anchors
+// @sceneId     ar-cloud-anchor
 // @title       Cloud Anchors
 // @subtitle    Persistent multi-user anchors
 // @category    ar

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRecordingScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRecordingScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-recording
+// @sceneId     ar-record-playback
 // @title       AR Recording
 // @subtitle    Capture the AR session as a screen video (record-only on iOS)
 // @category    ar

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRooftopAnchorsScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRooftopAnchorsScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-rooftop-anchors
+// @sceneId     ar-rooftop
 // @title       Rooftop Anchors
 // @subtitle    Anchor models on geospatial rooftops
 // @category    ar

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArTerrainAnchorsScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArTerrainAnchorsScene.swift
@@ -1,4 +1,4 @@
-// @sceneId     ar-terrain-anchors
+// @sceneId     ar-terrain
 // @title       Terrain Anchors
 // @subtitle    Anchor models on geospatial terrain
 // @category    ar

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
@@ -559,7 +559,10 @@ struct FeaturedARDemo: Identifiable {
             destination: AnyView(ARLightingDemo())
         ),
         FeaturedARDemo(
-            id: "ar-recording",
+            // Canonicalized to match Android's DemoRegistry id (#2799); the
+            // deep-link registry still accepts the old "ar-recording" id as
+            // a legacy alias (see `DemoDeepLinkRegistry.allowedIds`).
+            id: "ar-record-playback",
             title: "AR Recording",
             subtitle: "Capture the AR session as a screen video",
             icon: "record.circle",


### PR DESCRIPTION
## Summary

First lot (L0.1) of the iOS/Android catalog-ISO tracker (#2798). Canonicalizes 4 iOS `@sceneId` values that diverged from Android's canonical `DemoRegistry` slugs, keeping every old id as a documented deep-link alias so existing QR codes / bookmarks keep resolving:

| Scene file | Old `@sceneId` | New canonical id |
|---|---|---|
| `ArCloudAnchorsScene.swift` | `ar-cloud-anchors` | `ar-cloud-anchor` |
| `ArRooftopAnchorsScene.swift` | `ar-rooftop-anchors` | `ar-rooftop` |
| `ArTerrainAnchorsScene.swift` | `ar-terrain-anchors` | `ar-terrain` |
| `ArRecordingScene.swift` | `ar-recording` | `ar-record-playback` |

This is a required prerequisite for #2800 (generated-registry union) — without it, that union would silently duplicate ids.

## What changed

- The 4 Scene files: only the `// @sceneId` directive value changed (file name, enum type, title/subtitle/icon/category/available all untouched — this lot is ids only).
- `DemoDeepLinkRegistry.swift`: `allowedIds` already carried the 3 canonical anchor ids (`ar-cloud-anchor`, `ar-rooftop`, `ar-terrain`) and both `ar-record-playback`/`ar-recording` ids, apparently pre-staged for this rename. Only the 3 legacy `-anchors` ids were missing from the set — added as a documented alias block. `destination(for:)` needed no change: the anchor trio already falls through to the coming-soon placeholder identically for old and new ids (no real destination exists yet — all 3 Scenes are still `@available false`), and the record-playback pair already had an explicit dual-label case with its own alias comment — reused as-is per the issue's instruction to not invent a second mechanism.
- `ARTab.swift`: found one more literal `id: "ar-recording"` in the `FeaturedARDemo` launcher-grid list (not one of the 3 registry surfaces the issue names, and not in its "Files" list) while grepping for every occurrence of the old ids. Updated it to `ar-record-playback` too, since it's the exact same rename and the issue's own acceptance-criteria grep (`"ar-recording"`, quoted) would otherwise still flag it outside the alias table. Flagging this explicitly in case the extra file is unwanted scope.

## Verification

- `grep -rn "ar-cloud-anchors\|ar-rooftop-anchors\|ar-terrain-anchors\|\"ar-recording\"" samples/ios-demo` — every remaining match is inside `DemoDeepLinkRegistry.swift`'s alias table/switch, or a code comment documenting the alias. No `@sceneId` directive uses an old id anymore.
- `bash samples/ios-demo/scripts/collate-ios-demos.sh` — regenerates `GeneratedScenes.swift` clean, 51 scenes, no duplicate-id error (confirms none of the new canonical ids collide with an existing `@sceneId`).
- **`xcodebuild` could NOT be run locally** — host disk was at 5 Gi free (`df -g /`), under this repo's 6 Gi safety gate for local builds, so the build step was skipped per that constraint rather than risking a build on a near-full disk. `ios.yml` CI (triggers on `pull_request` with `paths: samples/ios-demo/**`) will build and test this PR — please treat CI as the real compile/test verification here, since I could not produce one locally.

## Test plan

- [ ] CI `ios.yml` build + test job goes green
- [ ] Reviewer confirms the `ARTab.swift` addition (outside the issue's named file list) is in scope, or asks for it to be reverted

Closes #2799
Part of #2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)