### PR TITLE
fix(ci): backfill sceneview_flutter CHANGELOG for 4.23.0/4.24.0 — un-red the pub.dev publish preflight (#2775)

### DIFF
--- a/changelog.d/2775-flutter-changelog-preflight.md
+++ b/changelog.d/2775-flutter-changelog-preflight.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- CI: backfilled the `sceneview_flutter` CHANGELOG entries for 4.23.0 and 4.24.0 — `pubspec.yaml` was bumped to 4.24.0 with no matching CHANGELOG entry, so the pub.dev publish preflight (`flutter pub publish --dry-run`, #2735) failed the `Build flutter-demo APK` job on every non-path-gated PR and nightly run (#2775).

--- a/flutter/sceneview_flutter/CHANGELOG.md
+++ b/flutter/sceneview_flutter/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.24.0
+
+- Version alignment with SceneView v4.24.0 (in-flight release — `VERSION_NAME` and this plugin's `pubspec.yaml` are already bumped on `main`). Native-side fixes landing in v4.24.0 include the web photometric camera exposure fix (#2784). No breaking Flutter API change. Entry added ahead of the tag so the PR-time `flutter pub publish --dry-run` preflight (#2735) validates — a bumped `pubspec.yaml` without a matching CHANGELOG entry turned the preflight red on every non-path-gated PR and nightly (#2775).
+
+## 4.23.0
+
+- Version alignment with SceneView v4.23.0 (2026-07-18). Native-side highlights per the [v4.23.0 release notes](https://github.com/sceneview/sceneview/releases/tag/v4.23.0): Gaussian Splatting (`SplatNode`) on Android & Web, on-device Point & Ask AR demo (Gemini Nano), Filament runtime 1.71.5 → 1.72.1, public-API surface tracking (`apiCheck`). No breaking Flutter API change.
+
 ## 4.22.0
 
 - Version alignment with SceneView v4.22.0 (2026-07-12). First version published to pub.dev via the automated OIDC `pub-publish` release job (#2735) — the registry previously served an unrelated 0.0.1 placeholder; entries 4.18.x–4.21.x were never published there. Native-side highlights per the [v4.22.0 release notes](https://github.com/sceneview/sceneview/releases/tag/v4.22.0): public `SurfaceMirrorer` in-app video recording (#2626), normalized-origin `centerOrigin` parity (#2632), store-preflight release tooling. No breaking Flutter API change.


### PR DESCRIPTION
## What / why

`flutter/sceneview_flutter/pubspec.yaml` is at **4.24.0** on `main`, but the plugin's `CHANGELOG.md` stopped at **4.22.0** (both the 4.23.0 and 4.24.0 entries were missing). `flutter pub publish --dry-run` — the pub.dev publish preflight added by #2735 (`ci.yml` → `Build flutter-demo APK`) — validates that the CHANGELOG mentions the current pubspec version, so the job failed **deterministically on every non-path-gated PR and nightly run**:

- nightly `main` runs 29722340208 and 29676409222 (tracked in #2775)
- PR #2797's runs 29774368557 / 29779720207 (unrelated diff — CI-workflow + a PNG golden)

Because branch protection's single required check (`CI Gate`) aggregates every non-advisory check on the head SHA, this pre-existing red also blocks auto-merge on any PR whose paths trigger the flutter job.

**Fix: backfill the two missing CHANGELOG entries** (4.23.0 in the repo's established "version alignment" style; 4.24.0 marked honestly as the in-flight release, ahead of the tag). No code change. The rename PR #2766 (`sceneview_flutter` → `flutter_sceneview`) is untouched — this only prepends two entries.

Refs #2775 (left open — it also tracks cancelled render-test nights, a separate cause).

**scope: trivial (docs/changelog only) — orchestrator self-review declared in body; proof = this PR's own `Build flutter-demo APK` job must go green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)