### PR TITLE
fix(scripts): sync-versions --fix auto-prepends the Flutter CHANGELOG stub entry (#2775)

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -1587,6 +1587,36 @@ if changed:
     echo -e "${GREEN}Fixes applied. Re-run without --fix to verify.${NC}"
 fi
 
+# ─── Flutter CHANGELOG stub (--fix; deliberately OUTSIDE the ERRORS gate) ──
+# The pub.dev publish preflight (`flutter pub publish --dry-run`, #2735 —
+# ci.yml → "Build flutter-demo APK") requires the plugin CHANGELOG to mention
+# the current pubspec version. A bump that updates the pubspec without adding
+# the entry therefore turns that job red on EVERY non-path-gated PR and
+# nightly until someone backfills it by hand — this bit twice, for 4.23.0 AND
+# 4.24.0 (#2775; backfilled by #2766). The CHANGELOG top-entry check above is
+# WARN-only (prose content can't be verified mechanically), so a lagging
+# CHANGELOG never raises ERRORS — which is exactly why this handler must NOT
+# live inside the `$ERRORS -gt 0` fix block: with every numeric version
+# already aligned, that block never runs. Prepends a stub in the file's
+# established "version alignment" style; enrich the bullet by hand when the
+# release notes are written. Idempotent: skips when `## $SOURCE_VERSION`
+# already exists anywhere in the file.
+if [ "$FIX_MODE" = "--fix" ]; then
+    FLUTTER_CL="$REPO_ROOT/flutter/sceneview_flutter/CHANGELOG.md"
+    if [ -f "$FLUTTER_CL" ] && ! grep -qE "^## ${SOURCE_VERSION}($| )" "$FLUTTER_CL"; then
+        TMP_CL=$(mktemp)
+        {
+            printf '## %s\n\n' "$SOURCE_VERSION"
+            printf -- '- Version alignment with SceneView v%s; see the [v%s release notes](https://github.com/sceneview/sceneview/releases/tag/v%s). No breaking Flutter API change.\n\n' \
+                "$SOURCE_VERSION" "$SOURCE_VERSION" "$SOURCE_VERSION"
+            cat "$FLUTTER_CL"
+        } > "$TMP_CL"
+        mv "$TMP_CL" "$FLUTTER_CL"
+        echo -e "  Fixed: flutter/.../CHANGELOG.md — prepended '## $SOURCE_VERSION' stub (pub.dev preflight requires it, #2775)"
+        echo ""
+    fi
+fi
+
 # ─── Summary ───────────────────────────────────────────────────────────
 echo -e "${CYAN}=== Summary ===${NC}"
 echo "  Checks: ${#LOCATIONS[@]}"

--- a/changelog.d/2775-sync-versions-flutter-changelog-stub.md
+++ b/changelog.d/2775-sync-versions-flutter-changelog-stub.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- `sync-versions.sh --fix` now auto-prepends the missing `## X.Y.Z` stub entry to the Flutter plugin's `CHANGELOG.md` when it lags `VERSION_NAME` — a bumped pubspec without a matching CHANGELOG entry made the pub.dev publish preflight (#2735) fail the `Build flutter-demo APK` job on every non-path-gated PR and nightly (bit twice, for 4.23.0 and 4.24.0 — #2775). The handler runs outside the MISMATCH-gated fix block on purpose: the CHANGELOG check is WARN-only, so it must fire even when every numeric version is already aligned.


### PR DESCRIPTION
## What / why

Closes the process gap behind the #2775 pub.dev-preflight reds: every version bump updates `flutter/sceneview_flutter/pubspec.yaml` (via `sync-versions.sh --fix`, which the release flow runs on every bump), but nothing added the matching `## X.Y.Z` entry to the plugin's `CHANGELOG.md`. `flutter pub publish --dry-run` (#2735, ci.yml → `Build flutter-demo APK`) requires that entry, so the job went deterministically red on every non-path-gated PR and nightly — it bit for **both 4.23.0 and 4.24.0** (backfilled by #2766; evidence in https://github.com/sceneview/sceneview/issues/2775#issuecomment-5027671966).

**Fix:** a `--fix` handler that prepends a stub entry in the file's established "version alignment" style when `## $VERSION_NAME` is absent. Design notes:

- **Outside the `$ERRORS -gt 0` fix block, on purpose** — the CHANGELOG top-entry check is WARN-only (prose can't be mechanically verified), so a lagging CHANGELOG alone never raises ERRORS and the main fix block would never run.
- **Idempotent** — skips when `## $VERSION_NAME` already exists anywhere in the file (second `--fix` run is a no-op).
- Check mode is unchanged (still WARN) — advisory-first, consistent with the repo stance.

## Proof (sandbox, run before opening this PR)

Fake repo root with `VERSION_NAME=9.9.9` and a CHANGELOG topped at `## 9.9.8`, all other version locations absent (→ 0 MISMATCH errors, the exact case the old code missed): run 1 of `--fix` prepends the `## 9.9.9` stub above `## 9.9.8`; run 2 changes nothing (grep count of prepend message = 0, exactly one `## 9.9.9` entry). `bash -n` clean.

**scope: trivial (one script + changelog fragment) — self-review declared in body.**

Refs #2775

🤖 Generated with [Claude Code](https://claude.com/claude-code)