### PR TITLE
fix(deps): bump brace-expansion in react-native lockfile (Dependabot #270 #271)

### DIFF
--- a/react-native/react-native-sceneview/package-lock.json
+++ b/react-native/react-native-sceneview/package-lock.json
@@ -4013,9 +4013,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7197,9 +7197,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9131,9 +9131,9 @@
       }
     },
     "node_modules/react-native-builder-bob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps `brace-expansion` in `react-native/react-native-sceneview/package-lock.json` (dev-scope only, no runtime impact) to close 2 Dependabot HIGH alerts.
- `node_modules/brace-expansion`: `1.1.14` → `1.1.16` (patched version per GHSA for alert #270, range `< 1.1.16`)
- `node_modules/react-native-builder-bob/node_modules/brace-expansion`: `2.1.0` → `2.1.2` (patched version per GHSA for alert #271, range `>= 2.0.0, < 2.1.2`)
- Regenerated via `npm update brace-expansion --package-lock-only` (no full `npm install`, no `package.json` changes). This also picked up a transitive `joi` patch bump (`17.13.3` → `17.13.4`, within its existing `^17.2.1` range) as a side effect of lockfile resolution — safe, dev-scope, unrelated advisory.
- Verified with `gh api repos/sceneview/sceneview/dependabot/alerts/270` and `.../271`: both list `first_patched_version.identifier` matching the versions above.

## Test plan
- [x] `node -e "JSON.parse(...)"` — lockfile is valid JSON
- [x] Confirmed both `brace-expansion` entries now resolve to versions ≥ the advisories' `first_patched_version`
- [x] Dev-scope dependency only — no runtime/library code touched, no changelog fragment needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)