### PR TITLE
feat(web): Node.smoothTransform — smooth transform animation on the frame loop (#2024 P5b)

### DIFF
--- a/changelog.d/2024-p5b-smooth-transform.md
+++ b/changelog.d/2024-p5b-smooth-transform.md
@@ -1,10 +1,14 @@
 <!-- category: Added -->
-- Web: `Node.smoothTransform` / `Node.smoothTransformSpeed` — Android-mirror
-  smooth transform animation on the retained web node tree. Setting a target
-  local `Transform` starts a per-frame speed-scaled slerp/lerp on the scene's
-  frame loop (the pre-decomposed TRS core path — zero matrix decompositions
-  per tick); on convergence the node snaps and the property resets to `null`;
-  setting `null` cancels in place. The repaint hook (`onInvalidate`) moved up
-  from `SplatNode` to `Node` and is wired subtree-wide by `addNode` (and
-  inherited on attach), so animations keep the on-demand render gate awake
-  from idle scenes (#2024 P5b).
+- Web: `Node.smoothTransform` / `Node.smoothTransformSpeed` — smooth
+  transform animation on the retained web node tree, with the Android core
+  semantics and the same `5f` default speed (no `isSmoothTransformEnabled`
+  gate, no `onSmoothEnd` on web). Setting a target local `Transform` starts a
+  per-frame speed-scaled slerp/lerp on the scene's frame loop (the
+  pre-decomposed TRS core path — zero matrix decompositions per tick); on
+  convergence the node snaps and the property resets to `null`; setting
+  `null` cancels in place. The repaint hook (`onInvalidate`) moved up from
+  `SplatNode` to `Node`, is wired subtree-wide by `addNode` (and inherited on
+  attach) and released by `removeNode`, so animations keep the on-demand
+  render gate awake from idle scenes. `CameraNode`/`SplatNode` `onFrame`
+  overrides call `super`, so camera and splat nodes smooth-animate too
+  (#2024 P5b).

--- a/changelog.d/2024-p5b-smooth-transform.md
+++ b/changelog.d/2024-p5b-smooth-transform.md
@@ -1,0 +1,10 @@
+<!-- category: Added -->
+- Web: `Node.smoothTransform` / `Node.smoothTransformSpeed` — Android-mirror
+  smooth transform animation on the retained web node tree. Setting a target
+  local `Transform` starts a per-frame speed-scaled slerp/lerp on the scene's
+  frame loop (the pre-decomposed TRS core path — zero matrix decompositions
+  per tick); on convergence the node snaps and the property resets to `null`;
+  setting `null` cancels in place. The repaint hook (`onInvalidate`) moved up
+  from `SplatNode` to `Node` and is wired subtree-wide by `addNode` (and
+  inherited on attach), so animations keep the on-demand render gate awake
+  from idle scenes (#2024 P5b).

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3706,13 +3706,14 @@ handle.destroy()                   // remove + free entity (idempotent)
 ```
 
 Kotlin/JS retained nodes additionally support smooth transform animation
-(#2024 P5b — mirrors Android `Node.smoothTransform`; not yet on the JS
-`NodeHandle` surface):
+(#2024 P5b — the Android `Node.smoothTransform` core semantics and the same
+`5f` default speed; web has no `isSmoothTransformEnabled` gate and no
+`onSmoothEnd` callback. Not yet on the JS `NodeHandle` surface):
 
 ```kotlin
 // Animate a node toward a target LOCAL transform — speed-scaled slerp/lerp
 // stepped on the scene's frame loop (zero per-tick matrix decompositions).
-node.smoothTransformSpeed = 5f     // higher = faster convergence (default 10f)
+node.smoothTransformSpeed = 10f    // higher = faster convergence (default 5f)
 node.smoothTransform = Transform(position = Position(0f, 1f, -2f))
 // On convergence the node snaps to the target and smoothTransform resets to
 // null. Setting null cancels in place (the node keeps its current transform).

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3705,6 +3705,21 @@ handle.getWorldPosition()          // → [x, y, z] composed through the parent 
 handle.destroy()                   // remove + free entity (idempotent)
 ```
 
+Kotlin/JS retained nodes additionally support smooth transform animation
+(#2024 P5b — mirrors Android `Node.smoothTransform`; not yet on the JS
+`NodeHandle` surface):
+
+```kotlin
+// Animate a node toward a target LOCAL transform — speed-scaled slerp/lerp
+// stepped on the scene's frame loop (zero per-tick matrix decompositions).
+node.smoothTransformSpeed = 5f     // higher = faster convergence (default 10f)
+node.smoothTransform = Transform(position = Position(0f, 1f, -2f))
+// On convergence the node snaps to the target and smoothTransform resets to
+// null. Setting null cancels in place (the node keeps its current transform).
+// Only animates while the node is attached to a SceneView — the scene's
+// frame dispatch drives it, and it keeps the on-demand render gate awake.
+```
+
 ---
 
 ### WebXR — ARSceneView (browser AR)

--- a/llms.txt
+++ b/llms.txt
@@ -5741,13 +5741,14 @@ handle.destroy()                   // remove + free entity (idempotent)
 ```
 
 Kotlin/JS retained nodes additionally support smooth transform animation
-(#2024 P5b — mirrors Android `Node.smoothTransform`; not yet on the JS
-`NodeHandle` surface):
+(#2024 P5b — the Android `Node.smoothTransform` core semantics and the same
+`5f` default speed; web has no `isSmoothTransformEnabled` gate and no
+`onSmoothEnd` callback. Not yet on the JS `NodeHandle` surface):
 
 ```kotlin
 // Animate a node toward a target LOCAL transform — speed-scaled slerp/lerp
 // stepped on the scene's frame loop (zero per-tick matrix decompositions).
-node.smoothTransformSpeed = 5f     // higher = faster convergence (default 10f)
+node.smoothTransformSpeed = 10f    // higher = faster convergence (default 5f)
 node.smoothTransform = Transform(position = Position(0f, 1f, -2f))
 // On convergence the node snaps to the target and smoothTransform resets to
 // null. Setting null cancels in place (the node keeps its current transform).

--- a/llms.txt
+++ b/llms.txt
@@ -5740,6 +5740,21 @@ handle.getWorldPosition()          // → [x, y, z] composed through the parent 
 handle.destroy()                   // remove + free entity (idempotent)
 ```
 
+Kotlin/JS retained nodes additionally support smooth transform animation
+(#2024 P5b — mirrors Android `Node.smoothTransform`; not yet on the JS
+`NodeHandle` surface):
+
+```kotlin
+// Animate a node toward a target LOCAL transform — speed-scaled slerp/lerp
+// stepped on the scene's frame loop (zero per-tick matrix decompositions).
+node.smoothTransformSpeed = 5f     // higher = faster convergence (default 10f)
+node.smoothTransform = Transform(position = Position(0f, 1f, -2f))
+// On convergence the node snaps to the target and smoothTransform resets to
+// null. Setting null cancels in place (the node keeps its current transform).
+// Only animates while the node is attached to a SceneView — the scene's
+// frame dispatch drives it, and it keeps the on-demand render gate awake.
+```
+
 ---
 
 ### WebXR — ARSceneView (browser AR)

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -834,6 +834,9 @@ class SceneView private constructor(
      */
     fun removeNode(node: Node) {
         sceneGraph.removeNode(node)
+        // Release the repaint hook on the whole subtree — a detached node must
+        // not fire spurious renders nor pin this view through the closure.
+        node.propagateInvalidate(null)
         requestRender()
     }
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -817,6 +817,10 @@ class SceneView private constructor(
      */
     fun addNode(node: Node, parent: Node? = null) {
         sceneGraph.addNode(node, parent)
+        // Wire the repaint hook on the whole subtree so per-frame animation
+        // (Node.smoothTransform, SplatNode re-sorts) keeps the on-demand
+        // render gate alive (#2024 P5b).
+        node.propagateInvalidate { requestRender() }
         requestRender()
     }
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewNodes.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewNodes.kt
@@ -163,7 +163,7 @@ fun SceneView.addSplatNode(
     parent: Node? = null,
 ): SplatNode {
     val node = SplatNode(engine, newEntity(), splatCloud)
-    node.onInvalidate = { requestRender() }
+    // Repaint is wired by addNode below (Node.propagateInvalidate, #2024 P5b).
     node.onDetach = { entities -> scene.removeEntities(entities) }
     node.cameraPositionProvider = {
         // Camera world position straight from Filament (a JS number[] float3).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/CameraNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/CameraNode.kt
@@ -55,14 +55,14 @@ class CameraNode internal constructor(
     private val matrixScratch = FloatArray(16)
 
     /**
-     * Pushes the current [worldTransform] to the camera. A no-op after
-     * [destroy] (the guard mirrors [Node.applyLocalTransform]) and when no
-     * controller is wired.
-     *
-     * @param deltaSeconds Unused — the camera follows the node's transform, not
-     *   a time-based animation; kept to satisfy the `SceneNode.onFrame` contract.
+     * Advances any active [smoothTransform] (the `super` call — #2024 P5b),
+     * then pushes the current [worldTransform] to the camera, so a smooth
+     * camera move lands the same frame it steps. A no-op after [destroy]
+     * (the guard mirrors [Node.applyLocalTransform]) and when no controller
+     * is wired.
      */
     override fun onFrame(deltaSeconds: Float) {
+        super.onFrame(deltaSeconds)
         if (isDestroyed) return
         val controller = controller ?: return
         writeModelMatrix(worldTransform)

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
@@ -3,6 +3,9 @@ package io.github.sceneview.web.nodes
 import dev.romainguy.kotlin.math.Quaternion
 import dev.romainguy.kotlin.math.lookAt
 import dev.romainguy.kotlin.math.lookTowards
+import io.github.sceneview.animation.SmoothTransformTRSState
+import io.github.sceneview.animation.SmoothTransformTRSTarget
+import io.github.sceneview.animation.updateSmoothTransform
 import io.github.sceneview.math.Direction
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -145,6 +148,47 @@ open class Node internal constructor(
             applyLocalTransform()
         }
 
+    // --- Smooth transform (#2024 P5b) ---------------------------------------
+
+    /**
+     * Pre-decomposed [smoothTransform] target — decomposed ONCE at set so the
+     * per-frame step pays zero `Mat4` decompositions (the #2187 hot-path
+     * pattern; see [SmoothTransformTRSState]).
+     */
+    private var smoothTarget: SmoothTransformTRSTarget? = null
+
+    /**
+     * The smooth position, rotation and scale interpolation speed used by
+     * [smoothTransform]. Higher converges faster. Mirrors Android
+     * `Node.smoothTransformSpeed`.
+     */
+    var smoothTransformSpeed: Float = 10f
+
+    /**
+     * Target **local** transform to smoothly interpolate toward, or `null`
+     * when idle — the Android `Node.smoothTransform` semantics: setting a
+     * value starts a per-frame speed-scaled slerp/lerp from the node's
+     * current TRS state toward the target; on convergence the node snaps to
+     * the target and this resets to `null`. Setting `null` cancels the
+     * animation in place (the node keeps its current, possibly intermediate,
+     * transform). Direct writes to [position]/[quaternion]/[scale] during an
+     * animation are picked up — each frame interpolates from the node's
+     * *current* state.
+     *
+     * Runs on the scene's frame loop, so it only animates while the node is
+     * attached to a `SceneView` (its graph dispatches `onFrame`).
+     */
+    var smoothTransform: Transform? = null
+        set(value) {
+            field = value
+            smoothTarget = value?.let {
+                SmoothTransformTRSTarget(it.position, it.quaternion, it.scale)
+            }
+            // Wake the on-demand render gate (#2332) so the animation's first
+            // step lands on the very next frame even from an idle scene.
+            onInvalidate?.invoke()
+        }
+
     // --- World transforms -------------------------------------------------
     //
     // Composed through the Kotlin parent chain with the shared core math —
@@ -230,6 +274,10 @@ open class Node internal constructor(
             field = value
             oldParent?.let { it._childNodes = it._childNodes - this }
             (value as Node?)?.let { it._childNodes = it._childNodes + this }
+            // Inherit the new parent's repaint hook so a node attached to an
+            // in-scene subtree animates ([smoothTransform]) without a manual
+            // re-wire; addNode covers roots and pre-attached descendants.
+            (value as Node?)?.onInvalidate?.let { propagateInvalidate(it) }
             // Guard ONLY the engine write — never a top-level `return`. destroy()
             // runs its internal `parent = null` detach AFTER [isDestroyed] is set
             // and still needs the Kotlin-side child-list cleanup above; a naive
@@ -283,6 +331,38 @@ open class Node internal constructor(
     // --- Lifecycle -------------------------------------------------------------
 
     /**
+     * Per-frame hook dispatched by the scene graph. Advances any active
+     * [smoothTransform] interpolation (#2024 P5b). Subclasses overriding this
+     * MUST call `super.onFrame(deltaTime)` to keep smooth transforms working.
+     */
+    override fun onFrame(deltaTime: Float) {
+        val target = smoothTarget ?: return
+        if (isDestroyed) {
+            smoothTransform = null
+            return
+        }
+        val result = updateSmoothTransform(
+            SmoothTransformTRSState(
+                position = _position,
+                quaternion = _quaternion,
+                scale = _scale,
+                target = target,
+                speed = smoothTransformSpeed
+            ),
+            deltaSeconds = deltaTime.toDouble()
+        )
+        _position = result.state.position
+        _quaternion = result.state.quaternion
+        _scale = result.state.scale
+        applyLocalTransform()
+        // Keep the on-demand render gate (#2332) alive for the whole
+        // animation — without this an idle scene would render one frame and
+        // freeze mid-interpolation.
+        onInvalidate?.invoke()
+        if (result.arrived) smoothTransform = null
+    }
+
+    /**
      * Destroys this node and its whole subtree, freeing each node's Filament
      * transform component + entity exactly once (idempotent via [isDestroyed]).
      *
@@ -300,6 +380,20 @@ open class Node internal constructor(
     }
 
     // --- Internals --------------------------------------------------------------
+
+    /**
+     * Repaint hook — wired by `SceneView.addNode` (and inherited from the
+     * parent on attach) so per-frame animation ([smoothTransform],
+     * `SplatNode` re-sorts) keeps the on-demand render gate (#2332) alive.
+     * `null` while the node is not part of a `SceneView`'s graph.
+     */
+    internal var onInvalidate: (() -> Unit)? = null
+
+    /** Wires [onInvalidate] on this node and its whole subtree. */
+    internal fun propagateInvalidate(hook: () -> Unit) {
+        onInvalidate = hook
+        _childNodes.forEach { (it as? Node)?.propagateInvalidate(hook) }
+    }
 
     private val parentNode: Node? get() = parent as Node?
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
@@ -159,10 +159,11 @@ open class Node internal constructor(
 
     /**
      * The smooth position, rotation and scale interpolation speed used by
-     * [smoothTransform]. Higher converges faster. Mirrors Android
-     * `Node.smoothTransformSpeed`.
+     * [smoothTransform]. Higher converges faster. Same `5f` default as
+     * Android `Node.smoothTransformSpeed`, so a ported animation converges
+     * at the same rate.
      */
-    var smoothTransformSpeed: Float = 10f
+    var smoothTransformSpeed: Float = 5f
 
     /**
      * Target **local** transform to smoothly interpolate toward, or `null`
@@ -177,6 +178,10 @@ open class Node internal constructor(
      *
      * Runs on the scene's frame loop, so it only animates while the node is
      * attached to a `SceneView` (its graph dispatches `onFrame`).
+     *
+     * Web mirrors the Android *core* semantics only: there is no
+     * `isSmoothTransformEnabled` gate (setting a target always animates) and
+     * no `onSmoothEnd` callback.
      */
     var smoothTransform: Transform? = null
         set(value) {
@@ -383,14 +388,15 @@ open class Node internal constructor(
 
     /**
      * Repaint hook — wired by `SceneView.addNode` (and inherited from the
-     * parent on attach) so per-frame animation ([smoothTransform],
-     * `SplatNode` re-sorts) keeps the on-demand render gate (#2332) alive.
-     * `null` while the node is not part of a `SceneView`'s graph.
+     * parent on attach), cleared by `SceneView.removeNode`, so per-frame
+     * animation ([smoothTransform], `SplatNode` re-sorts) keeps the
+     * on-demand render gate (#2332) alive. `null` while the node is not part
+     * of a `SceneView`'s graph.
      */
     internal var onInvalidate: (() -> Unit)? = null
 
-    /** Wires [onInvalidate] on this node and its whole subtree. */
-    internal fun propagateInvalidate(hook: () -> Unit) {
+    /** Wires (or, with `null`, clears) [onInvalidate] on this whole subtree. */
+    internal fun propagateInvalidate(hook: (() -> Unit)?) {
         onInvalidate = hook
         _childNodes.forEach { (it as? Node)?.propagateInvalidate(hook) }
     }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/SplatNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/SplatNode.kt
@@ -76,8 +76,8 @@ class SplatNode internal constructor(
      */
     var cameraPositionProvider: (() -> Position)? = null
 
-    /** Repaint hook (the render gate cannot infer a texture re-upload) — set by the factory. */
-    internal var onInvalidate: (() -> Unit)? = null
+    // Repaint hook: inherits Node.onInvalidate (#2024 P5b) — the render gate
+    // cannot infer a texture re-upload, so re-sorts invoke it explicitly.
 
     /** Scene-detach hook run first on [destroy] — set by the factory. */
     internal var onDetach: ((Array<Entity>) -> Unit)? = null
@@ -241,6 +241,7 @@ class SplatNode internal constructor(
      * synchronously on the frame tick (single-threaded JS).
      */
     override fun onFrame(deltaTime: Float) {
+        super.onFrame(deltaTime)
         val provider = cameraPositionProvider ?: return
         if (isDestroyed) return
         // Map the camera world position into this node's model space so

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeSmoothTransformTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeSmoothTransformTest.kt
@@ -1,0 +1,185 @@
+package io.github.sceneview.web.nodes
+
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Rotation
+import io.github.sceneview.math.Scale
+import io.github.sceneview.math.Transform
+import io.github.sceneview.math.toQuaternion
+import io.github.sceneview.web.bindings.Entity
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * #2024 P5b — `Node.smoothTransform` on the frame loop.
+ *
+ * The interpolation core (`updateSmoothTransform`, TRS variant) is already
+ * unit-tested in `sceneview-core`; these tests cover the WIRING — the
+ * decompose-once target cache, the per-frame step through [Node.onFrame],
+ * convergence + auto-reset, cancellation, the destroyed guard, and the
+ * render-gate invalidation hook (including inheritance on attach).
+ */
+class NodeSmoothTransformTest {
+
+    private class FakeBackend : NodeBackend {
+        override fun setLocalTransform(transform: Transform) = Unit
+        override fun setParent(parent: NodeBackend?) = Unit
+        override fun adoptChildEntity(child: Entity) = Unit
+        override fun destroy() = Unit
+    }
+
+    private fun node(name: String? = null) = Node(FakeBackend()).also { it.name = name }
+
+    private val eps = 1e-3f
+
+    private fun assertClose(expected: Float, actual: Float, message: String) {
+        assertTrue(abs(expected - actual) < eps, "$message: expected $expected, was $actual")
+    }
+
+    /** 60 fps tick. */
+    private val tick = 1f / 60f
+
+    private fun Node.runFrames(count: Int) = repeat(count) { onFrame(tick) }
+
+    // --- Stepping -----------------------------------------------------------
+
+    @Test
+    fun smoothStepMovesTowardTheTargetWithoutSnapping() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(10f, 0f, 0f))
+        node.onFrame(tick)
+        val x = node.position.x
+        assertTrue(x > 0f, "one tick must move toward the target (x=$x)")
+        assertTrue(x < 10f, "one tick must not snap to the target (x=$x)")
+        assertNotNull(node.smoothTransform, "still animating — target must persist")
+    }
+
+    @Test
+    fun smoothConvergesSnapsAndResetsToNull() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(2f, -1f, 3f))
+        node.runFrames(600)
+        assertClose(2f, node.position.x, "position.x")
+        assertClose(-1f, node.position.y, "position.y")
+        assertClose(3f, node.position.z, "position.z")
+        assertNull(node.smoothTransform, "arrived — smoothTransform must reset to null")
+    }
+
+    @Test
+    fun higherSpeedConvergesFaster() {
+        val slow = node().also { it.smoothTransformSpeed = 2f }
+        val fast = node().also { it.smoothTransformSpeed = 20f }
+        val target = Transform(position = Position(1f, 0f, 0f))
+        slow.smoothTransform = target
+        fast.smoothTransform = target
+        slow.runFrames(10)
+        fast.runFrames(10)
+        assertTrue(
+            abs(1f - fast.position.x) < abs(1f - slow.position.x),
+            "speed=20 (x=${fast.position.x}) must be closer than speed=2 (x=${slow.position.x})"
+        )
+    }
+
+    @Test
+    fun rotationSlerpsTowardTheTarget() {
+        val node = node()
+        val targetQuaternion = Rotation(0f, 90f, 0f).toQuaternion()
+        node.smoothTransform = Transform(
+            position = Position(),
+            quaternion = targetQuaternion,
+            scale = Scale(1f)
+        )
+        node.runFrames(600)
+        // Compare via |dot| ≈ 1 — tolerant of the q/-q double cover.
+        val q = node.quaternion
+        val dot = q.x * targetQuaternion.x + q.y * targetQuaternion.y +
+            q.z * targetQuaternion.z + q.w * targetQuaternion.w
+        assertTrue(abs(dot) > 1f - 1e-3f, "quaternion must converge (|dot|=${abs(dot)})")
+        assertNull(node.smoothTransform)
+    }
+
+    @Test
+    fun animationInterpolatesInLocalSpaceUnderAParent() {
+        val parent = node("group")
+        parent.position = Position(5f, 0f, 0f)
+        val child = node("content")
+        parent.addChildNode(child)
+        child.smoothTransform = Transform(position = Position(1f, 0f, 0f))
+        child.runFrames(600)
+        assertClose(1f, child.position.x, "child local x")
+        assertClose(6f, child.worldPosition.x, "child world x = parent + local target")
+    }
+
+    // --- Cancellation and lifecycle ----------------------------------------
+
+    @Test
+    fun settingNullCancelsInPlace() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(10f, 0f, 0f))
+        node.runFrames(3)
+        val midway = node.position.x
+        assertTrue(midway > 0f && midway < 10f, "must be mid-animation (x=$midway)")
+        node.smoothTransform = null
+        node.onFrame(tick)
+        assertClose(midway, node.position.x, "cancelled — the node must hold its transform")
+    }
+
+    @Test
+    fun destroyedNodeStopsAnimatingAndClearsTheTarget() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(10f, 0f, 0f))
+        node.runFrames(2)
+        node.destroy()
+        node.onFrame(tick)
+        assertNull(node.smoothTransform, "destroyed — the target must be released")
+    }
+
+    // --- Render-gate invalidation ------------------------------------------
+
+    @Test
+    fun onInvalidateFiresEachAnimatedFrameAndStopsAfterArrival() {
+        val node = node()
+        var invalidations = 0
+        node.propagateInvalidate { invalidations++ }
+        node.smoothTransform = Transform(position = Position(1f, 0f, 0f))
+        val afterSet = invalidations
+        assertTrue(afterSet >= 1, "setting a target must wake the render gate")
+        node.runFrames(600)
+        val duringAnimation = invalidations - afterSet
+        assertTrue(duringAnimation >= 2, "every animated frame must invalidate")
+        val settled = invalidations
+        node.runFrames(5)
+        assertEquals(settled, invalidations, "an idle node must not keep invalidating")
+    }
+
+    @Test
+    fun childAttachedToAWiredParentInheritsTheInvalidateHook() {
+        val parent = node("group")
+        var invalidations = 0
+        parent.propagateInvalidate { invalidations++ }
+        val child = node("content")
+        parent.addChildNode(child)
+        child.smoothTransform = Transform(position = Position(1f, 0f, 0f))
+        child.onFrame(tick)
+        assertTrue(
+            invalidations >= 1,
+            "a child attached to an in-scene subtree must reach the render gate"
+        )
+    }
+
+    @Test
+    fun propagateWiresTheWholeExistingSubtree() {
+        val root = node("root")
+        val child = node("child")
+        val grandChild = node("grandchild")
+        root.addChildNode(child)
+        child.addChildNode(grandChild)
+        var invalidations = 0
+        root.propagateInvalidate { invalidations++ }
+        grandChild.smoothTransform = Transform(position = Position(1f, 0f, 0f))
+        assertTrue(invalidations >= 1, "the set itself must wake the gate through the hook")
+    }
+}

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeSmoothTransformTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/NodeSmoothTransformTest.kt
@@ -113,6 +113,33 @@ class NodeSmoothTransformTest {
         assertClose(6f, child.worldPosition.x, "child world x = parent + local target")
     }
 
+    @Test
+    fun externalWritesMidAnimationAreAbsorbed() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(10f, 0f, 0f))
+        node.runFrames(3)
+        // An external jump mid-animation — the next step interpolates from
+        // HERE (the state is re-read each tick), not from the pre-jump path.
+        node.position = Position(9f, 0f, 0f)
+        node.onFrame(tick)
+        val x = node.position.x
+        assertTrue(x > 9f && x < 10f, "the step must depart from the external write (x=$x)")
+        node.runFrames(600)
+        assertClose(10f, node.position.x, "still converges to the target")
+    }
+
+    @Test
+    fun scaleInterpolatesTowardTheTarget() {
+        val node = node()
+        node.smoothTransform = Transform(position = Position(), scale = Scale(3f))
+        node.onFrame(tick)
+        val s = node.scale.x
+        assertTrue(s > 1f && s < 3f, "one tick must move the scale (s=$s)")
+        node.runFrames(600)
+        assertClose(3f, node.scale.x, "scale.x")
+        assertNull(node.smoothTransform)
+    }
+
     // --- Cancellation and lifecycle ----------------------------------------
 
     @Test


### PR DESCRIPTION
Part of #2024 — **P5b** of the maintainer-approved full-P5 wave (P5a #2809 ✅ → **P5b** → P5c).

## What

Android-mirror smooth transforms for the retained web node tree:

- **`Node.smoothTransform: Transform?`** — setting a target **local** transform starts a per-frame speed-scaled slerp/lerp from the node's *current* TRS state toward it. On convergence the node snaps to the target and the property resets to `null`. Setting `null` cancels in place. **`Node.smoothTransformSpeed`** (default `10f`) mirrors Android.
- **Zero per-tick decompositions** — the step runs in `Node.onFrame` through the pre-decomposed TRS core variant (`SmoothTransformTRSState`, #2187): the target is decomposed once at set, each tick writes the pristine caches + compose-only `applyLocalTransform()` (the #2335 invariant is preserved).
- **Render-gate wiring** — the repaint hook `onInvalidate` moves up from `SplatNode` to `Node`. `SceneView.addNode` wires it subtree-wide (`propagateInvalidate`) and the parent setter propagates it on attach, so an animation on any in-scene node — root or late-attached child — keeps the on-demand render gate (#2332) awake from an idle scene. `addSplatNode`'s manual wire was redundant and is removed; `SplatNode.onFrame` now calls `super` (required for smooth transforms on splat nodes).

No new embind binding — the write path is the #2024-P1-probed `TransformManager.setTransform` route via `applyLocalTransform()`.

## Tests

10 new jsTests (`NodeSmoothTransformTest`): stepping without snap, convergence + auto-reset, speed ordering, rotation slerp (double-cover-tolerant), local-space animation under a parent, in-place cancellation, destroyed guard, invalidation lifecycle (fires per animated frame, stops at rest) and hook inheritance on attach.

## Verification (local, all green)

- [x] `:sceneview-web:compileKotlinJs` + `:sceneview-web:jsTest` — **236/236**
- [x] `:sceneview-web:detektJsTestSourceSet` — 0 issue (jsMain has 2 pre-existing main-branch issues — `LongMethod`/`LoopWithTooManyJumpStatements` in `SceneView.kt`, untouched here, follow-up task filed)
- [x] `bash .claude/scripts/web-bundle-smoke.sh` — 5/5 (splat orbit-stability spec exercises the re-wired invalidation path in-browser)
- [x] `cd samples/web-demo && npx playwright test` — 51/51
- [x] `llms.txt` + `gpt/knowledge-*` regenerated in lockstep; changelog fragment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)