### PR TITLE
docs(claude): drop Stitch as the demo-app UI path — reference-driven native only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ with shared logic in Kotlin Multiplatform.
 See [`llms.txt`](./llms.txt) at the repo root for the complete, machine-readable API reference:
 composable signatures, node types, resource loading, threading rules, and common patterns.
 
-## Design System (Google Stitch)
+## Design System
 
 See [`DESIGN.md`](./DESIGN.md) for the complete design system: colors, typography, spacing,
 radius, shadows, motion, breakpoints, and component patterns.
@@ -173,8 +173,16 @@ radius, shadows, motion, breakpoints, and component patterns.
 - Support both light and dark modes
 - Follow Material 3 Expressive patterns
 
-**Google Stitch MCP:** when configured, enables direct UI generation from Stitch projects.
-To set up: `npm install @google/stitch-sdk`, then add the Stitch MCP server in Claude Code settings.
+**The demo-app UI is reference-driven, not tool-generated.** Do NOT use Stitch, v0, or
+Figma to author the demo app's Compose/SwiftUI chrome — that path shipped a poor UI in
+v4.1.0 (generic cards, flat hierarchy) because a web-oriented design tool does not know
+it is framing a 3D Filament viewport. Instead, design natively against `DESIGN.md` tokens,
+anchored on real reference apps (Sketchfab mobile, Polycam, Reality Composer, Apple Quick
+Look, Google Scene Viewer), then verify visually on device/emulator before every push.
+The "Spatial Studio"-style redesign that this method produced is the bar to clear.
+
+Design tools stay fine for **marketing** surfaces (store screenshots, website hero shots),
+where pixel precision has real ROI — never for the app chrome itself.
 
 ## When writing any SceneView code
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -353,5 +353,7 @@ This file is optimized for consumption by AI coding agents (Claude Code, Cursor,
 4. Follow the component patterns above
 5. Use responsive typography with `clamp()`
 
-**With Google Stitch MCP:**
-Import this file into a Stitch project to enforce consistent branding across all generated screens.
+**For marketing surfaces only** (store screenshots, website hero shots): you may import
+this file into a design tool (Stitch, Figma, …) to keep branding consistent. Do **not**
+generate the demo app's own Compose/SwiftUI screens this way — that chrome is
+reference-driven native, per the "Design System" rule in `CLAUDE.md`.


### PR DESCRIPTION
## What

`CLAUDE.md` still advertised **Google Stitch MCP** as a way to generate the demo
app's UI. This removes that and states the actual standing rule: the demo-app
chrome is **reference-driven native** (Compose/SwiftUI against `DESIGN.md` tokens),
never authored with Stitch / v0 / Figma.

## Why

The decision to drop Stitch for the app chrome was taken **2026-05-11** after the
v4.1.0 Play Store audit — the Stitch-generated UI shipped generic and flat because
a web-oriented design tool has no notion that it is framing a 3D Filament viewport.
The redesign the maintainer approved ("Spatial Studio"-style) came from the
reference-driven method instead. The guide now matches that reality, so an AI
reading `CLAUDE.md` won't be told to reach for a tool that produces the exact UI
we rejected.

## Changes

- Section header `Design System (Google Stitch)` → `Design System`
- Replaced the Stitch-MCP setup blurb with the reference-driven rule + the
  marketing-surfaces exception (store screenshots / website hero are still fine
  for design tools).

## Scope

Docs-only. No code, no public API, no version-location surface touched — nothing
to compile or test. Left **not** auto-merged: this edits the maintainer's own
guidance file, so it's yours to approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
