### PR TITLE
feat(ios-demo): generate deep-link registry (allowedIds + destination) from @sceneId (#2800)

### DIFF
--- a/changelog.d/2800-generated-ios-registry.md
+++ b/changelog.d/2800-generated-ios-registry.md
@@ -1,0 +1,12 @@
+<!-- category: Changed -->
+- iOS demo: the deep-link registry is now generated. `collate-ios-demos.sh`
+  emits `GeneratedScenes.allowedIds` and `GeneratedScenes.destination(for:)`
+  from the same `@sceneId` directives that already drive the Samples tab, so
+  the three deep-link surfaces (list, `allowedIds` gate, id→view resolver) can
+  no longer drift apart — the root cause that silently dropped 12 ids (#2769).
+  `DemoDeepLinkRegistry` shrinks from a hand-maintained 66-id `allowedIds` +
+  43-case `switch` to a generated union plus a ~15-id residual (AR ids without
+  a Scene file yet, and legacy aliases). Adding a demo is now one Scene file.
+  All 66 pre-existing deep-link ids still resolve identically. A well-formed
+  `sceneview://demo/<id>` whose id is unknown now surfaces a placeholder
+  instead of being silently dropped (#2800).

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -1,228 +1,121 @@
 import SwiftUI
 
-/// Maps a stable demo id (`ar-rerun`, `model-viewer`, …) to the
-/// corresponding SwiftUI destination, for the deep-link path.
+/// Maps a stable demo id (`ar-rerun`, `model-viewer`, …) to the corresponding
+/// SwiftUI destination for the deep-link path (`sceneview://demo/<id>`).
 ///
-/// Why this exists separately from `SamplesTab.allScenes()` and
-/// friends: the iOS demo's catalogue uses human titles (`"AR Debug
-/// (Rerun)"`) while the deep-link contract requires a stable, slug-style
-/// id matched **byte-for-byte** with the Android `DemoRegistry.kt` —
-/// otherwise the same `sceneview://demo/<id>` URL would route to
-/// different things on Android and iOS, defeating the cross-platform
-/// guarantee of the QR codes generated on the website.
+/// # Why the id set is (mostly) generated
 ///
-/// **Coverage policy** — we only need to map the ids that QR codes
-/// actually point at today. The set grows as we add QR codes on
-/// website / README / docs. Unknown ids fall through to a fallback
-/// "Open in app" placeholder (the parent `DeepLinkRouter` already
-/// validates ids against `allowedIds` so the placeholder is only ever
-/// reached for ids registered here without a destination).
+/// The deep-link contract requires a stable, slug-style id matched
+/// **byte-for-byte** with Android's `DemoRegistry` — otherwise the same
+/// `sceneview://demo/<id>` URL would route to different things on Android and
+/// iOS, defeating the cross-platform guarantee of the QR codes on the website.
+///
+/// Historically this file hand-maintained *two* copies of that id set — a
+/// `allowedIds` literal and a parallel `switch` — alongside the Samples tab's
+/// own generated list. Three surfaces, three hand edits, and they drifted:
+/// 12 ids silently diverged (#2769). They are now driven from **one** source
+/// of truth — the `@sceneId` header directives that the collator
+/// (`samples/ios-demo/scripts/collate-ios-demos.sh`) already parses:
+///
+///   - `GeneratedScenes.allowedIds` — every id that has a `*Scene.swift` file.
+///   - `GeneratedScenes.destination(for:)` — that id's view (or `nil` for a
+///     coming-soon / non-iOS AR scene).
+///
+/// Adding a demo = adding one Scene file; all three surfaces update on the
+/// next build with no edit here.
+///
+/// # What stays hand-maintained (the residual)
+///
+/// Only ids that have **no** `*Scene.swift` file yet:
+///   - `legacyAliases` — pre-canonicalization ids (#2799) kept so existing QR
+///     codes keep resolving. Each maps to a canonical id a Scene declares, so
+///     the alias inherits that scene's destination.
+///   - `residualIds` — AR demos present in Android's catalog whose iOS card is
+///     still to be ported (L0.6, #2804). They resolve to a placeholder until a
+///     Scene file lands; when one does, delete the id here and the generated
+///     union covers it automatically.
+///
+/// # Deep-link guarantee
+///
+/// An id is **never silently ignored**. Ids in `allowedIds` resolve to a real
+/// view or an honest placeholder; a well-formed `sceneview://demo/<id>` URL
+/// whose id is *not* in `allowedIds` is still surfaced as a placeholder by the
+/// caller (`SceneViewDemoApp.onOpenURL`), never dropped into a silent no-op.
 enum DemoDeepLinkRegistry {
 
-    /// Subset of `DemoRegistry.kt` ids that should be reachable via
-    /// `sceneview://demo/<id>` on iOS. Add ids here as new QR codes are
-    /// published; new ids should always be a *subset* of the canonical
-    /// list (see `DeepLinkRouter` Kotlin).
-    /// Full demo catalog — mirrors Android's `DemoRegistry.kt` id set so
-    /// every `sceneview://demo/<id>` QR code resolves on iOS.  Coming-soon
-    /// demos are included and route to a placeholder so the deep-link URL
-    /// is never silently ignored (closed-registry + placeholder  > silent
-    /// 404). Add new ids here whenever a new demo is published on any platform.
-    static let allowedIds: Set<String> = [
-        // ── 3D Basics ───────────────────────────────────────────────────
-        "model-viewer", "geometry", "animation", "multi-model", "scene-gallery",
-        // ── Lighting ────────────────────────────────────────────────────
-        "lighting", "movable-light", "fog", "dynamic-sky", "environment",
-        // ── Content ─────────────────────────────────────────────────────
-        "text", "lines-paths", "image", "billboard",
-        // Coming-soon Content (routed to placeholder)
-        "video", "texture-streaming",
-        // ── Interaction ─────────────────────────────────────────────────
-        "camera-controls", "collision",
-        // Coming-soon Interaction (routed to placeholder)
-        "gesture-editing", "view-node",
-        // ── Advanced ────────────────────────────────────────────────────
-        "physics", "double-pendulum", "custom-mesh", "materials", "spatial-audio",
-        "post-processing", "reflection-probes", "secondary-camera", "shape",
-        "occlusion-material", "debug-overlay",
-        // Coming-soon Advanced (routed to placeholder)
-        // ── AR (iOS-only on device) ──────────────────────────────────────
-        "ar-placement", "ar-instant-placement", "ar-orbital", "ar-lighting",
-        "ar-recording", "ar-rerun",
-        // Coming-soon AR (routed to placeholder)
-        "ar-image", "ar-face", "ar-cloud-anchor", "ar-depth-occlusion",
-        "ar-rooftop", "ar-streetscape",
-        "ar-terrain",
-        // Newer AR demos (Android-side additions, routed to placeholder on iOS)
-        "ar-pose", "ar-record-playback", "ar-image-stabilization",
-        "ar-depth-of-field", "ar-fog", "ar-depth-collider", "ar-depth-visualization",
-        "ar-people-occlusion", "ar-point-cloud", "ar-raw-depth-point-cloud",
-        "ar-plane-node", "ar-scene-mesh", "ar-scene-semantics", "ar-ml-object-label",
-        "placement-scene", "ar-collaborative", "ar-body-tracker",
-        "ar-hand-tracking", "ar-xr-face",
-        // Legacy aliases (#2799) — pre-canonicalization ids kept only so
-        // existing QR codes / bookmarks keep resolving. Canonical
-        // replacements ("ar-cloud-anchor", "ar-rooftop", "ar-terrain") are
-        // listed above; both old and new ids route to the same destination
-        // (today, the same coming-soon placeholder — see `destination(for:)`).
-        "ar-cloud-anchors", "ar-rooftop-anchors", "ar-terrain-anchors",
+    /// Legacy deep-link aliases → canonical scene id. Pre-canonicalization
+    /// ids (#2799) kept only so existing QR codes / bookmarks keep resolving.
+    /// The canonical target is declared by a `*Scene.swift` file, so the alias
+    /// resolves to exactly that scene's destination (or its placeholder, when
+    /// the canonical scene is `@available false`).
+    private static let legacyAliases: [String: String] = [
+        "ar-recording": "ar-record-playback",
+        "ar-cloud-anchors": "ar-cloud-anchor",
+        "ar-rooftop-anchors": "ar-rooftop",
+        "ar-terrain-anchors": "ar-terrain",
     ]
 
-    /// Resolve a demo id to its presented `View`. Returns a fallback
-    /// "Coming soon" view for ids that pass `allowedIds` but don't yet
-    /// have an iOS destination wired up — this keeps the QR / deep-link
-    /// path working as soon as a new id is published, even if the iOS
-    /// catalogue lags behind.
+    /// Deep-linkable ids with no `*Scene.swift` file yet — AR demos present in
+    /// Android's catalog whose iOS card is still to be ported (L0.6, #2804).
+    /// They pass `allowedIds` so the URL is accepted, and resolve to the
+    /// coming-soon placeholder. Remove an id from here the moment a matching
+    /// Scene file is added; the generated union then covers it with no hand edit.
+    private static let residualIds: Set<String> = [
+        "ar-collaborative",
+        "ar-depth-collider",
+        "ar-depth-of-field",
+        "ar-depth-visualization",
+        "ar-fog",
+        "ar-hand-tracking",
+        "ar-ml-object-label",
+        "ar-raw-depth-point-cloud",
+        "ar-scene-semantics",
+        "ar-xr-face",
+        "placement-scene",
+    ]
+
+    /// Full set of accepted deep-link ids: the generated scene ids
+    /// (`GeneratedScenes.allowedIds`) ∪ legacy aliases ∪ not-yet-ported
+    /// residual ids. Every `sceneview://demo/<id>` QR code for a real Android
+    /// demo resolves on iOS through this set — coming-soon ids included, routed
+    /// to a placeholder so the URL is never a silent 404.
+    static let allowedIds: Set<String> =
+        GeneratedScenes.allowedIds
+            .union(legacyAliases.keys)
+            .union(residualIds)
+
+    /// Resolve a demo id to its presented `View`.
     ///
-    /// `@MainActor`-isolated because it constructs SwiftUI `View` values,
-    /// which are themselves main-actor-isolated; the only call site
-    /// (`ContentView`'s `.fullScreenCover` / `.sheet`) already runs on the
-    /// main actor.
+    /// Resolution order: the generated id→view map, then the legacy-alias
+    /// indirection, then a coming-soon placeholder. The placeholder is returned
+    /// for any id without a live destination — a coming-soon scene, a residual
+    /// not-yet-ported AR id, an iOS-only AR scene on a non-iOS build, or an id
+    /// that isn't in `allowedIds` at all — so a deep link always lands on a
+    /// screen and is never silently dropped.
+    ///
+    /// `@MainActor`-isolated because it constructs SwiftUI `View` values, which
+    /// are main-actor-isolated; the only call site (`ContentView`'s
+    /// `.fullScreenCover` / `.sheet`) already runs on the main actor.
     @MainActor
-    @ViewBuilder
-    static func destination(for id: String) -> some View {
-        switch id {
-        // ── AR Rerun debug ───────────────────────────────────────────
-        case "ar-rerun":
-            #if os(iOS)
-            RerunDebugDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR Rerun is iOS-only on this build.")
-            #endif
-
-        // ── 3D Basics ────────────────────────────────────────────────
-        case "animation":     AnimationDemo()
-        case "geometry":      GeometryDemo()
-        case "model-viewer":  ModelViewerDemo()
-        case "multi-model":   MultiModelDemo()
-        case "scene-gallery": SceneGalleryDemo()
-
-        // ── Lighting ─────────────────────────────────────────────────
-        case "lighting":      LightingDemo()
-        case "movable-light": MovableLightDemo()
-        case "dynamic-sky":   DynamicSkyDemo()
-        case "environment":   EnvironmentDemo()
-        case "fog":           FogDemo()
-
-        // ── Content ──────────────────────────────────────────────────
-        case "billboard":         BillboardDemo()
-        case "image":             ImageDemo()
-        case "lines-paths":       LinesPathsDemo()
-        case "text":              TextDemo()
-        case "texture-streaming": TextureStreamingDemo()
-        case "video":             VideoTextureDemo()
-
-        // ── Interaction ──────────────────────────────────────────────
-        case "camera-controls":  CameraControlsDemo()
-        case "collision":        CollisionHitTestDemo()
-        case "gesture-editing":  GestureEditingDemo()
-
-        // ── Advanced ─────────────────────────────────────────────────
-        case "custom-mesh":     CustomMeshDemo()
-        case "double-pendulum": DoublePendulumDemo()
-        case "materials":       MaterialsDemo()
-        case "physics":         PhysicsDemo()
-        case "debug-overlay":     DebugOverlayDemo()
-        case "occlusion-material": OcclusionMaterialDemo()
-        case "shape":           ShapeExtrudeDemo()
-        case "reflection-probes": ReflectionProbesDemo()
-        case "spatial-audio":   SpatialAudioDemo()
-
-        // ── AR (iOS device-only) ──────────────────────────────────────
-        case "ar-instant-placement":
-            #if os(iOS)
-            ARInstantPlacementDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-lighting":
-            #if os(iOS)
-            ARLightingDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-orbital":
-            #if os(iOS)
-            OrbitalARDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-placement":
-            #if os(iOS)
-            ARPlacementDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        // `ar-record-playback` is the canonical, published deep-link id
-        // (website-static/open/index.html + llms.txt + Android catalog);
-        // `ar-recording` is kept as a legacy alias so older QR codes still
-        // resolve. Both route to the recorder demo.
-        case "ar-record-playback", "ar-recording":
-            #if os(iOS)
-            ARRecorderDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-image":
-            #if os(iOS)
-            ARImageTrackingDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-face":
-            #if os(iOS)
-            ARAugmentedFacesDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-depth-occlusion":
-            #if os(iOS)
-            ARDepthOcclusionDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-people-occlusion":
-            #if os(iOS)
-            ARPeopleOcclusionDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-body-tracker":
-            #if os(iOS)
-            ARBodyTrackerDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-scene-mesh":
-            #if os(iOS)
-            ARSceneMeshDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-plane-node":
-            #if os(iOS)
-            ARPlaneNodeDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-        case "ar-point-cloud":
-            #if os(iOS)
-            ARPointCloudDemo()
-            #else
-            DeepLinkPlaceholder(id: id, reason: "AR demos are iOS-only on this build.")
-            #endif
-
-        // ── Coming-soon — placeholder keeps URL live ──────────────────
-        default:
-            DeepLinkPlaceholder(id: id, reason: "This demo isn't available in the iOS app yet — open it on Android, or browse the Samples tab for the full iOS catalog.")
+    static func destination(for id: String) -> AnyView {
+        if let view = GeneratedScenes.destination(for: id) {
+            return view
         }
+        if let canonical = legacyAliases[id],
+           let view = GeneratedScenes.destination(for: canonical) {
+            return view
+        }
+        return AnyView(DeepLinkPlaceholder(
+            id: id,
+            reason: "This demo isn't available in the iOS app yet — open it on Android, or browse the Samples tab for the full iOS catalog."
+        ))
     }
 }
 
-/// Tiny placeholder shown when a deep-link id is recognised by the
-/// router but doesn't yet have a destination wired in
-/// `DemoDeepLinkRegistry`. Communicates the gap clearly and offers a
-/// way out (close + browse the Scenes tab).
+/// Tiny placeholder shown when a deep-link id resolves to no live iOS
+/// destination — a coming-soon scene, a not-yet-ported AR id, or an id that
+/// isn't registered at all. Communicates the gap clearly and offers a way out
+/// (close + browse the Samples tab).
 private struct DeepLinkPlaceholder: View {
     let id: String
     let reason: String

--- a/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
+++ b/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
@@ -65,6 +65,15 @@ struct SceneViewDemoApp: App {
                 .onOpenURL { url in
                     if let id = DeepLinkRouter.parse(url, allowedDemos: DemoDeepLinkRegistry.allowedIds) {
                         pendingDeepLinkDemo = id
+                    } else if let candidate = DeepLinkRouter.extractCandidate(url) {
+                        // A well-formed `sceneview://demo/<id>` (or the
+                        // Universal Link) whose id is not in the registry.
+                        // Surface it so `DemoDeepLinkRegistry.destination(for:)`
+                        // shows the "not available" placeholder — never a
+                        // silent no-op (the registry doc-comment's guarantee).
+                        // Malformed URLs (wrong scheme/host) yield `nil` here
+                        // and are correctly ignored.
+                        pendingDeepLinkDemo = candidate
                     }
                 }
                 .onChange(of: scenePhase) { _, phase in

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
@@ -7,8 +7,10 @@ import SwiftUI
 ///    conforming to `DemoScene`.
 /// 2. Run `bash samples/ios-demo/scripts/collate-ios-demos.sh` to regenerate
 ///    `GeneratedScenes.swift`.
-/// 3. The demo appears in `SamplesTab` automatically — **no other file
-///    needs to be edited**.
+/// 3. The demo appears in `SamplesTab` **and** becomes deep-linkable via
+///    `sceneview://demo/<sceneId>` automatically — the collator generates
+///    the Samples list, the `allowedIds` gate, and the id→view resolver from
+///    the same `@sceneId`, so **no other file needs to be edited**.
 ///
 /// # Rules
 ///

--- a/samples/ios-demo/scripts/collate-ios-demos.sh
+++ b/samples/ios-demo/scripts/collate-ios-demos.sh
@@ -14,8 +14,19 @@
 #
 # The script emits `GeneratedScenes.swift` which:
 #   - Provides `GeneratedScenes.all() -> [DemoItem]`  — consumed by SamplesTab
+#   - Provides `GeneratedScenes.allowedIds: Set<String>` — every scene id, the
+#     generated half of `DemoDeepLinkRegistry.allowedIds` (the deep-link gate)
+#   - Provides `GeneratedScenes.destination(for:) -> AnyView?` — resolves a
+#     scene id to its view (`nil` for coming-soon / non-iOS AR → placeholder)
 #   - Is .gitignore'd and regenerated before every Xcode build via a
 #     "Collate iOS demos" Run Script phase in SceneViewDemo.xcodeproj
+#
+# Because `allowedIds` and the id→view map are generated from the SAME
+# `@sceneId` directives that drive the Samples tab, the three deep-link
+# surfaces (list, gate, resolver) can no longer drift apart — the root cause
+# that silently dropped 12 ids before #2800. Adding a demo = adding one Scene
+# file; `DemoDeepLinkRegistry` only keeps a small hand-maintained residual for
+# AR ids that have no Scene file yet, plus legacy aliases.
 #
 # Usage:
 #   bash samples/ios-demo/scripts/collate-ios-demos.sh           # write
@@ -164,7 +175,13 @@ cat <<'HEADER'
 import SwiftUI
 
 /// Generated aggregate of every `DemoScene` declared under
-/// `Views/Demos/Scenes/`. Consumed by `SamplesTab.allScenes()`.
+/// `Views/Demos/Scenes/`. Drives three surfaces from one source of truth —
+/// the `@sceneId` directives — so they can never drift apart:
+///   - `all()` — the Samples-tab demo grid (`SamplesTab.allScenes()`).
+///   - `allowedIds` — the generated half of `DemoDeepLinkRegistry.allowedIds`
+///     (which deep-link ids are accepted).
+///   - `destination(for:)` — the generated id→view resolver behind
+///     `DemoDeepLinkRegistry.destination(for:)`.
 /// Regenerate with `samples/ios-demo/scripts/collate-ios-demos.sh`.
 enum GeneratedScenes {
     /// All demo items, sorted by scene id.
@@ -208,8 +225,61 @@ while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only
     fi
 done < "$TMP_FULL"
 
-cat <<'FOOTER'
+cat <<'ALL_END'
         return items
+    }
+
+    /// Every scene id declared under `Views/Demos/Scenes/`, regardless of
+    /// `@available`. This is the generated half of
+    /// `DemoDeepLinkRegistry.allowedIds`: a deep link to any of these ids is
+    /// accepted, and `destination(for:)` returns the scene's view when it is
+    /// `@available true`, or `nil` (→ caller shows a coming-soon placeholder)
+    /// when it is not. Adding a `*Scene.swift` file grows this set with no
+    /// hand edit — the root-cause fix for the registry drift behind #2769.
+    static let allowedIds: Set<String> = [
+ALL_END
+
+# `allowedIds`: every scene id (available true AND false), sorted by id so
+# the diff stays stable and two parallel PRs never collide.
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only type_name; do
+    printf '        "%s",\n' "$scene_id"
+done < "$TMP_FULL"
+
+cat <<'IDS_END'
+    ]
+
+    /// Resolve a scene id to its destination view, or `nil` when no
+    /// `@available true` scene backs the id on this platform — a coming-soon
+    /// scene, or an iOS-only AR scene on a non-iOS build. `nil` is the
+    /// caller's signal to present a placeholder; a deep-link id is never
+    /// silently dropped. The view mapping is generated from each scene's own
+    /// `destination`, so it can never disagree with the Samples tab.
+    @MainActor
+    static func destination(for id: String) -> AnyView? {
+        switch id {
+IDS_END
+
+# `destination(for:)`: one case per `@available true` scene. `@available false`
+# scenes fall through to `default: return nil` (→ placeholder), never their
+# own `EmptyView`. iOS-only scenes are guarded so a non-iOS build returns
+# `nil` (→ placeholder) rather than a blank view.
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only type_name; do
+    [ "$available" = "true" ] || continue
+    if [ "$ios_only" = "true" ]; then
+        printf '        case "%s":\n' "$scene_id"
+        printf '            #if os(iOS)\n'
+        printf '            return %s.destination\n' "$type_name"
+        printf '            #else\n'
+        printf '            return nil\n'
+        printf '            #endif\n'
+    else
+        printf '        case "%s": return %s.destination\n' "$scene_id" "$type_name"
+    fi
+done < "$TMP_FULL"
+
+cat <<'FOOTER'
+        default: return nil
+        }
     }
 }
 FOOTER


### PR DESCRIPTION
## What

Root-cause fix for the #2769-class iOS deep-link registry drift (L0.2 of #2798). The iOS demo's deep-link registry had **three surfaces synced by hand** with no compiled link between them:

1. `@sceneId` directives → `GeneratedScenes.swift` (already generated) — drove **only** the Samples tab
2. the hand-maintained `allowedIds: Set<String>` literal — the deep-link gate
3. the hand-maintained `destination(for:)` `switch` — the id→view map

They drifted: 12 ids diverged silently.

This PR makes `collate-ios-demos.sh` generate **`allowedIds`** and **`destination(for:)`** from the same `@sceneId` metadata it already parses, so the three surfaces can no longer disagree. Adding a demo is now **one Scene file**.

## Changes

- **`collate-ios-demos.sh`** — emits two new members into `GeneratedScenes.swift`:
  - `allowedIds: Set<String>` — every scene id (sorted, stable diff).
  - `destination(for:) -> AnyView?` — one `case` per `@available true` scene; iOS-only AR scenes are `#if os(iOS)`-guarded so a non-iOS build returns `nil` (→ placeholder), never a blank view. `@available false` scenes fall through to `default: return nil` (→ placeholder), never their own `EmptyView`.
- **`DemoDeepLinkRegistry.swift`** — shrinks from a 66-id `allowedIds` literal + 43-case `switch` to a **generated union** (`GeneratedScenes.allowedIds ∪ legacyAliases ∪ residualIds`) plus a **15-id residual** (4 legacy aliases + 11 AR ids with no Scene file yet). **Hand-maintained ids: 109 → 15.**
- **`SceneViewDemoApp.swift`** — adds the missing `else` in `onOpenURL`: a well-formed `sceneview://demo/<id>` with an unknown id now falls back to `DeepLinkRouter.extractCandidate` and surfaces a placeholder instead of a **silent no-op**. Malformed URLs still no-op correctly.
- **`DemoScene.swift`** — the "no other file needs editing" contract now also covers deep-linking.
- The registry's `"never silently ignored"` doc-comment was **false**; it is now true and reworded.

## Invariant — no deep link breaks

All **66** pre-existing deep-link ids still resolve, and the **43** that mapped to a real demo still map to the **identical** demo (the other 23 stay placeholders). Verified by:
- static analysis (`OLD allowedIds == NEW allowedIds`; every real-demo mapping preserved byte-for-byte);
- a clean simulator build (`BUILD SUCCEEDED`, 0 errors) + test target (`TEST SUCCEEDED`, 20 tests, 0 failures);
- live simulator QA — a valid id (`animation`) renders the real 3D demo through the new resolver; an unknown `sceneview://demo/<garbage>` renders the placeholder (not a silent drop).

`GeneratedScenes.swift` stays gitignored (regenerated by the existing Run Script phase; `--check` is idempotent).

## Scope

Generation only. Prepares **L0.3** (guard tests) — `GeneratedScenes.allowedIds` / `destination(for:)` are the testable surface those tests assert on. No demo porting, no IBL sweep.

Closes #2800
Part of #2798