### PR TITLE
docs(samples): drop Stitch from source provenance comments

### DIFF
--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoListScreen.kt
@@ -358,7 +358,7 @@ private fun StatusChip(status: DemoStatus, modifier: Modifier = Modifier) {
 
 /**
  * Per-category accent color. The light-mode palette mirrors the v4.1.0
- * Stitch design system; the dark-mode palette desaturates each hue and
+ * SceneView design system (see DESIGN.md); the dark-mode palette desaturates each hue and
  * lifts the lightness so the tinted gradients and icon tints don't
  * burn at >9:1 contrast against an M3 dark `surfaceContainer`.
  */

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Color.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Color.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.graphics.Color
 /**
  * SceneView M3 Expressive Color System
  *
- * Generated from Stitch design system with source color #005bc1.
+ * Generated from the SceneView design system (see DESIGN.md) with source color #005bc1.
  * Aligned with website tokens (styles.css) for brand consistency.
  *
  * Light: primary #005bc1, tertiary #6446cd

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Theme.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Theme.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 /**
  * SceneView Demo Theme — Material 3 Expressive
  *
- * Color system from Stitch design system (source: #005bc1).
+ * Color system from the SceneView design system (source: #005bc1).
  * Typography: M3 Expressive scale with Inter-weight equivalents.
  * Shapes: M3 Expressive with DESIGN.md radius tokens (8/12/16/28/32dp).
  * Motion: Expressive spring animations.

--- a/samples/android-demo/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/samples/android-demo/src/main/res/drawable/ic_launcher_foreground.xml
@@ -8,7 +8,7 @@
     <!--
         SceneView logo — isometric 3D cube with viewport brackets
         Brand blue: #005bc1 (light), #a4c1ff (dark)
-        Design: Material Design 3 Expressive (Stitch)
+        Design: Material Design 3 Expressive (SceneView design system, see DESIGN.md)
         Safe zone: 66dp centered (21dp inset on each side)
     -->
 

--- a/samples/android-demo/src/main/res/values-night/colors.xml
+++ b/samples/android-demo/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- SceneView M3 Expressive — Dark (GitHub-dark inspired, from Stitch design system) -->
+    <!-- SceneView M3 Expressive — Dark (GitHub-dark inspired — see DESIGN.md) -->
     <color name="md_theme_primary">#A4C1FF</color>
     <color name="md_theme_onPrimary">#002F64</color>
     <color name="md_theme_primaryContainer">#00448D</color>

--- a/samples/android-demo/src/main/res/values/colors.xml
+++ b/samples/android-demo/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- SceneView M3 Expressive — Light (from Stitch design system, source #005bc1) -->
+    <!-- SceneView M3 Expressive — Light (source #005bc1 — see DESIGN.md) -->
     <color name="md_theme_primary">#005BC1</color>
     <color name="md_theme_onPrimary">#FFFFFF</color>
     <color name="md_theme_primaryContainer">#D6E3FF</color>

--- a/samples/common/src/main/java/io/github/sceneview/sample/Theme.kt
+++ b/samples/common/src/main/java/io/github/sceneview/sample/Theme.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 object Colors {
-    // SceneView Stitch brand — seed #005BC1
+    // SceneView brand — seed #005BC1
     val Seed = Color(0xFF005BC1)
 
     // Light scheme
@@ -151,7 +151,7 @@ val Typography = Typography()
  * Material 3 theme shared by all SceneView sample apps.
  *
  * Uses dynamic colour (Material You) on Android 12+ and falls back to the
- * SceneView Stitch brand colour scheme (seed #005BC1) on older devices.
+ * SceneView brand colour scheme (seed #005BC1) on older devices.
  *
  * @param darkTheme Whether to use the dark colour scheme. Defaults to the system setting.
  * @param dynamicColor Whether to use Material You dynamic colours on Android 12+.

--- a/samples/desktop-demo/src/desktopMain/kotlin/io/github/sceneview/desktop/Main.kt
+++ b/samples/desktop-demo/src/desktopMain/kotlin/io/github/sceneview/desktop/Main.kt
@@ -41,7 +41,7 @@ import kotlin.math.sin
  * To run: ./gradlew :samples:desktop-demo:run
  */
 
-// SceneView brand colors (Stitch M3 design system)
+// SceneView brand colors (M3 design system — see DESIGN.md)
 private val SceneViewBlue = Color(0xFFA4C1FF)       // dark mode primary
 private val SceneViewDarkBlue = Color(0xFF005BC1)    // brand blue
 private val SceneViewSurface = Color(0xFF0D1117)

--- a/samples/ios-demo/SceneViewDemo/Theme.swift
+++ b/samples/ios-demo/SceneViewDemo/Theme.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// SceneView iOS Theme — Apple HIG + Liquid Glass
 ///
-/// Brand colors aligned with Stitch M3 design system (source: #005bc1).
+/// Brand colors from the SceneView M3 design system (see DESIGN.md, source: #005bc1).
 /// Uses SwiftUI native patterns — no Material Design concepts.
 /// Liquid Glass effects for floating surfaces (iOS 26+).
 enum SceneViewTheme {

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ARTab.swift
@@ -7,7 +7,7 @@ import SceneViewSwift
 
 /// AR tab — place 3D models in your real-world space.
 ///
-/// Liquid Glass overlay design (iOS 26+ Stitch spec):
+/// Liquid Glass overlay design (iOS 26+, per the SceneView design system — see DESIGN.md):
 /// - Full-bleed AR camera underneath
 /// - Top-center: floating glass status pill ("Tap to place" / "N placed")
 /// - Top-right: glass exit button to dismiss the tab

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// About tab — Liquid Glass card layout (iOS 26+ Stitch spec).
+/// About tab — Liquid Glass card layout (iOS 26+, per the SceneView design system — see DESIGN.md).
 ///
 /// Hero logo + version pill, then a series of `.regularMaterial` glass cards
 /// (Open Source, Docs, GitHub, 3D Playground, Credits), a tinted "Star on GitHub"

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
@@ -201,7 +201,7 @@ final class RecentSearches {
 
 /// The main Explore tab — Liquid Glass discovery hub for 3D models.
 ///
-/// Layout follows the Stitch mockup (iOS Liquid Glass design system):
+/// Layout follows the SceneView design system (iOS Liquid Glass — see DESIGN.md):
 /// - Featured carousel of curated models (currently from the bundled `ModelItem.all` set;
 ///   V1.1 will pull from `SketchfabService.featured()` when an API key is configured).
 /// - Categories chips that filter / search by topic.

--- a/website-static/playground.html
+++ b/website-static/playground.html
@@ -73,7 +73,7 @@
 
   <style>
     /* ===================================================================
-       PLAYGROUND — Stitch "Architectural Blueprint" Design System
+       PLAYGROUND — "Architectural Blueprint" Design System
        Tonal layering, no hard borders, ambient depth, editorial quality
        =================================================================== */
 

--- a/website-static/styles.css
+++ b/website-static/styles.css
@@ -1,12 +1,12 @@
 /* ===================================================================
-   SceneView Website — Stitch M3 Design Faithful Conversion
-   Colors: M3 Expressive from Stitch Tailwind config
-   Layout: Faithful to Stitch screen 2 (primary) + screen 1 (gallery/platforms)
+   SceneView Website — M3 Expressive Design System (see DESIGN.md)
+   Colors: M3 Expressive from the SceneView design system
+   Layout: primary section + gallery/platforms sections
    =================================================================== */
 
 /* ===== DESIGN TOKENS ===== */
 :root {
-  /* M3 Stitch Colors */
+  /* M3 Expressive colors */
   --color-primary: #005bc1;
   --color-primary-dim: #0050aa;
   --color-secondary: #005eb8;
@@ -42,7 +42,7 @@
   /* Gradients */
   --gradient-hero: linear-gradient(135deg, #005bc1 0%, #6446cd 100%);
 
-  /* Shadows — from Stitch */
+  /* Shadows */
   --shadow-card: 0px 12px 32px rgba(30, 50, 86, 0.06);
   --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
 
@@ -587,7 +587,7 @@ ul { list-style: none; }
   font-size: 24px;
 }
 
-/* Varied icon backgrounds — faithful to Stitch */
+/* Varied icon backgrounds */
 .feature-card__icon--primary-container {
   background: var(--color-primary-container);
   color: var(--color-primary);


### PR DESCRIPTION
Follow-up to the review of #2824 (which dropped Stitch as the demo-app UI path in `CLAUDE.md` / `DESIGN.md`).

## What

Comment-only cleanup: 14 sample / website source files still carried provenance
comments naming **Stitch** (e.g. *"from the Stitch design system"*, *"follows the
Stitch mockup"*, *"Stitch spec"*). Those designs **were** originally derived from
Stitch mockups, so the comments were historically accurate — but an AI agent
reading the source in isolation could wrongly infer that **Stitch is the UI
workflow**, which contradicts the reference-driven-native decision now recorded in
`CLAUDE.md` / `DESIGN.md`.

Each mention now points at the current source of truth (the SceneView design
system / `DESIGN.md`) instead of naming the tool. The seed colour that these
designs derive from is unchanged.

## Scope / safety

- **Comments only** — zero functional change, zero rendering change.
- No token / colour / seed value touched (`#005bc1`, `0xFF005BC1`, every CSS
  custom property … all unchanged).
- 14 files across `samples/**` + `website-static/**`, 20 insertions / 20 deletions.
- `git grep -in stitch -- 'samples/**' 'website-static/**'` now returns nothing
  (excluding the unrelated `sneaker_vibe.glb` binary, whose match is a mesh name).
- Verified: `./gradlew :samples:android-demo:compileReleaseKotlin` → **BUILD
  SUCCESSFUL**. iOS / website edits are comment-only (no compile needed).

## Out of scope (flagged, deliberately not touched)

A few non-sample surfaces still mention Stitch — either as the *DESIGN.md file
format* (`DESIGN.md`, `branding/README.md` "Google Stitch format", which #2824
left intact) or as the same provenance pattern (`docs/docs/stylesheets/extra.css`,
`branding/README.md` favicon line). Left for a possible separate follow-up to keep
this PR tightly scoped to `samples/**` + `website-static/**`.
