### PR TITLE
feat(web): sv.hitTest — screen-point picking with real per-node bounds (#2024 P5c)

### DIFF
--- a/agents/sceneview-web/SKILL.md
+++ b/agents/sceneview-web/SKILL.md
@@ -145,7 +145,9 @@ against your kept references works:
 
 ```js
 canvas.addEventListener('click', (e) => {
-  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  // Scale CSS event coords to backing-store pixels (devicePixelRatio canvases).
+  const px = canvas.width / canvas.clientWidth;
+  const hits = sv.hitTest(e.offsetX * px, e.offsetY * px);
   if (hits[0] === cube) cube.setScaleUniform(1.5);
 });
 ```

--- a/agents/sceneview-web/SKILL.md
+++ b/agents/sceneview-web/SKILL.md
@@ -136,6 +136,23 @@ const cube = sv.addCubeNode(0.2);
 cube.setPosition(0, 1, 0);
 ```
 
+Since #2024 P5c the viewer also picks nodes under a screen point:
+`sv.hitTest(x, y)` (canvas pixels, (0,0) = top-left) unprojects through the
+live camera and tests every node's real bounds (model/geometry: asset AABB;
+splat: cloud bounds) at their current world transform. It returns the **same**
+`NodeHandle` instances the factories returned, nearest-first — so `===`
+against your kept references works:
+
+```js
+canvas.addEventListener('click', (e) => {
+  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  if (hits[0] === cube) cube.setScaleUniform(1.5);
+});
+```
+
+Model nodes become pickable once loaded; geometry and splat nodes
+immediately; empty pivots, lights and cameras are never hit.
+
 Since #2646 P2 the viewer also renders **3D Gaussian Splatting** (radiance-field
 captures — Scaniverse / Polycam / Luma / INRIA): `addSplatNode(url)` fetches a
 `.ply` (INRIA) or `.spz` (Niantic) file, parses it through the shared KMP

--- a/agents/sceneview-web/references/cheatsheet.md
+++ b/agents/sceneview-web/references/cheatsheet.md
@@ -66,6 +66,8 @@ sv.addCubeNode(size)                    // → NodeHandle (content already in sc
 sv.addSphereNode(radius)                // → NodeHandle
 sv.addLightNode(type)                   // type: "directional" | "point" | "spot" — else throws
 sv.removeNode(handle)                   // detach + free the node's Filament entity
+sv.hitTest(x, y)                        // → NodeHandle[] nearest-first — canvas px, (0,0)=top-left;
+                                        //   SAME instances the factories returned (=== works)
 ```
 
 #### `NodeHandle` methods

--- a/changelog.d/2024-p5c-hittest.md
+++ b/changelog.d/2024-p5c-hittest.md
@@ -1,0 +1,14 @@
+<!-- category: Added -->
+- Web: `sv.hitTest(x, y)` — screen-point picking on the retained node tree
+  (#2024 P5c). The point is unprojected through the live camera (projection +
+  model matrix reads proven by a new in-browser embind probe) into a world
+  ray and tested against **real per-node bounds**: model/geometry nodes get
+  their asset AABB (analytic for primitives — pickable immediately), splat
+  nodes their cloud bounds, each transformed by the node's current world
+  transform at hit time. Returns the same `NodeHandle` instances the
+  `add*Node` factories handed out (`===`-comparable), nearest-first.
+  Kotlin/JS gains `SceneView.hitTest(x, y)` / `hitTest(ray)` (→
+  `List<HitResult>`) and the Android-mirror `Node.collisionShape` override.
+  The unprojection samples its second point mid-volume because Filament
+  renders with an infinite-far projection (NDC z = +1 is a point at
+  infinity).

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3702,7 +3702,9 @@ the `add*Node` factories returned (`===`-comparable), sorted nearest-first:
 ```js
 const cube = sv.addCubeNode(0.5);
 canvas.addEventListener('click', (e) => {
-  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  // Scale CSS event coords to backing-store pixels (devicePixelRatio canvases).
+  const px = canvas.width / canvas.clientWidth;
+  const hits = sv.hitTest(e.offsetX * px, e.offsetY * px);
   if (hits[0] === cube) cube.setScaleUniform(1.5);
 });
 ```

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3689,7 +3689,31 @@ sv.addCubeNode(size)               // → NodeHandle
 sv.addSphereNode(radius)           // → NodeHandle
 sv.addLightNode(type)              // type: "directional" | "point" | "spot" → NodeHandle
 sv.removeNode(handle)              // detach + free the node's entity
+sv.hitTest(x, y)                   // → NodeHandle[] nearest-first (#2024 P5c)
 ```
+
+Screen-point picking (`sv.hitTest(x, y)`, #2024 P5c): coordinates are canvas
+pixels ((0,0) = top-left). The point is unprojected through the live camera
+into a world ray and tested against every node's real bounds (models and
+geometry: their asset AABB; splats: the cloud bounds), transformed by each
+node's current world transform. Returns the **same** `NodeHandle` instances
+the `add*Node` factories returned (`===`-comparable), sorted nearest-first:
+
+```js
+const cube = sv.addCubeNode(0.5);
+canvas.addEventListener('click', (e) => {
+  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  if (hits[0] === cube) cube.setScaleUniform(1.5);
+});
+```
+
+Model nodes become pickable once loaded (their AABB is only readable then);
+geometry and splat nodes are pickable immediately. Empty pivots, lights and
+cameras have no bounds and are never hit. Kotlin/JS additionally exposes
+`SceneView.hitTest(x, y): List<HitResult>` (node + distance + world point),
+a world-`Ray` overload for XR controller poses, and `Node.collisionShape`
+(the Android mirror) to override a node's local picking bounds or set
+`null` to make it un-pickable; `Node.isHittable = false` skips a node.
 
 NodeHandle methods (opaque handle to a retained node; address it after create()):
 ```js

--- a/llms.txt
+++ b/llms.txt
@@ -5724,7 +5724,31 @@ sv.addCubeNode(size)               // → NodeHandle
 sv.addSphereNode(radius)           // → NodeHandle
 sv.addLightNode(type)              // type: "directional" | "point" | "spot" → NodeHandle
 sv.removeNode(handle)              // detach + free the node's entity
+sv.hitTest(x, y)                   // → NodeHandle[] nearest-first (#2024 P5c)
 ```
+
+Screen-point picking (`sv.hitTest(x, y)`, #2024 P5c): coordinates are canvas
+pixels ((0,0) = top-left). The point is unprojected through the live camera
+into a world ray and tested against every node's real bounds (models and
+geometry: their asset AABB; splats: the cloud bounds), transformed by each
+node's current world transform. Returns the **same** `NodeHandle` instances
+the `add*Node` factories returned (`===`-comparable), sorted nearest-first:
+
+```js
+const cube = sv.addCubeNode(0.5);
+canvas.addEventListener('click', (e) => {
+  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  if (hits[0] === cube) cube.setScaleUniform(1.5);
+});
+```
+
+Model nodes become pickable once loaded (their AABB is only readable then);
+geometry and splat nodes are pickable immediately. Empty pivots, lights and
+cameras have no bounds and are never hit. Kotlin/JS additionally exposes
+`SceneView.hitTest(x, y): List<HitResult>` (node + distance + world point),
+a world-`Ray` overload for XR controller poses, and `Node.collisionShape`
+(the Android mirror) to override a node's local picking bounds or set
+`null` to make it un-pickable; `Node.isHittable = false` skips a node.
 
 NodeHandle methods (opaque handle to a retained node; address it after create()):
 ```js

--- a/llms.txt
+++ b/llms.txt
@@ -5737,7 +5737,9 @@ the `add*Node` factories returned (`===`-comparable), sorted nearest-first:
 ```js
 const cube = sv.addCubeNode(0.5);
 canvas.addEventListener('click', (e) => {
-  const hits = sv.hitTest(e.offsetX, e.offsetY);
+  // Scale CSS event coords to backing-store pixels (devicePixelRatio canvases).
+  const px = canvas.width / canvas.clientWidth;
+  const hits = sv.hitTest(e.offsetX * px, e.offsetY * px);
   if (hits[0] === cube) cube.setScaleUniform(1.5);
 });
 ```

--- a/samples/web-demo/tests/kotlin-bundle.spec.ts
+++ b/samples/web-demo/tests/kotlin-bundle.spec.ts
@@ -391,7 +391,7 @@ test.describe('SceneView Kotlin/JS bundle — browser init', () => {
         const model = camera.getModelMatrix();
         return {
           projLen: proj?.length ?? -1,
-          p0: Number(proj[0]), p5: Number(proj[5]),
+          p0: Number(proj[0]), p5: Number(proj[5]), p10: Number(proj[10]),
           modelLen: model?.length ?? -1,
           m12: Number(model[12]), m13: Number(model[13]), m14: Number(model[14]),
         };
@@ -404,6 +404,13 @@ test.describe('SceneView Kotlin/JS bundle — browser init', () => {
     expect((result as any).projLen).toBe(16);
     expect((result as any).p0).toBeCloseTo(1, 3);
     expect((result as any).p5).toBeCloseTo(1, 3);
+    // getProjectionMatrix() returns the RENDERING projection, which uses an
+    // INFINITE far plane regardless of the finite far passed to
+    // setProjectionFov (the finite far only feeds the culling matrix):
+    // [2][2] is exactly -1 (infinite far), not -(f+n)/(f-n) = -1.002 for the
+    // finite far=100/near=0.1 set above. This is the premise ScreenRay.kt's
+    // mid-volume sampling relies on — NDC z = +1 is a point at infinity.
+    expect(Math.abs((result as any).p10 + 1)).toBeLessThan(1e-4);
     expect((result as any).modelLen).toBe(16);
     expect((result as any).m12).toBeCloseTo(2, 3);
     expect((result as any).m13).toBeCloseTo(3, 3);

--- a/samples/web-demo/tests/kotlin-bundle.spec.ts
+++ b/samples/web-demo/tests/kotlin-bundle.spec.ts
@@ -351,4 +351,98 @@ test.describe('SceneView Kotlin/JS bundle — browser init', () => {
     expect((result as any).py).toBeCloseTo(3, 3);
     expect((result as any).pz).toBeCloseTo(4, 3);
   });
+
+  test('Camera projection & model matrices are READABLE as mat4 (#2024 P5c probe)', async ({ page }) => {
+    // Screen-ray picking (sv.hitTest) unprojects through the INVERSE of
+    // getProjectionMatrix() and re-bases through getModelMatrix(). Both
+    // bindings exist in Filament.kt but had zero call sites before P5c —
+    // per the embind probe-first rule (#2611), prove them in-browser BEFORE
+    // node code depends on them.
+    await page.goto('/kotlin-bundle/index.html');
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__smoke?.status), { timeout: 30_000 })
+      .toBe('resolved');
+
+    const result = await page.evaluate(() => {
+      const F = (window as any).Filament;
+      if (!F?.Engine?.create) return { error: 'Filament global not initialised' };
+
+      const probeCanvas = document.createElement('canvas');
+      probeCanvas.width = 8;
+      probeCanvas.height = 8;
+      document.body.appendChild(probeCanvas);
+      let step = 'Engine.create';
+      try {
+        const engine = F.Engine.create(probeCanvas);
+        step = 'createCamera';
+        const cameraEntity = F.EntityManager.get().create();
+        const camera = engine.createCamera(cameraEntity);
+        if (typeof camera.getProjectionMatrix !== 'function') return { error: 'getProjectionMatrix missing' };
+        if (typeof camera.getModelMatrix !== 'function') return { error: 'getModelMatrix missing' };
+
+        // fov 90° vertical + aspect 1 → projection [0][0] = [1][1] = 1/tan(45°) = 1.
+        step = 'setProjectionFov';
+        camera.setProjectionFov(90.0, 1.0, 0.1, 100.0, F.Camera$Fov.VERTICAL);
+        step = 'getProjectionMatrix';
+        const proj = camera.getProjectionMatrix();
+        step = 'setModelMatrix';
+        camera.setModelMatrix([1,0,0,0, 0,1,0,0, 0,0,1,0, 2,3,4,1]);
+        step = 'getModelMatrix';
+        const model = camera.getModelMatrix();
+        return {
+          projLen: proj?.length ?? -1,
+          p0: Number(proj[0]), p5: Number(proj[5]),
+          modelLen: model?.length ?? -1,
+          m12: Number(model[12]), m13: Number(model[13]), m14: Number(model[14]),
+        };
+      } catch (e: any) {
+        return { error: `${step}: ${e?.name ?? ''} ${e?.message ?? String(e)}` };
+      }
+    });
+
+    expect((result as any).error, `matrix-read probe failed: ${(result as any).error}`).toBeUndefined();
+    expect((result as any).projLen).toBe(16);
+    expect((result as any).p0).toBeCloseTo(1, 3);
+    expect((result as any).p5).toBeCloseTo(1, 3);
+    expect((result as any).modelLen).toBe(16);
+    expect((result as any).m12).toBeCloseTo(2, 3);
+    expect((result as any).m13).toBeCloseTo(3, 3);
+    expect((result as any).m14).toBeCloseTo(4, 3);
+  });
+
+  test('sv.hitTest picks the cube under the screen centre (#2024 P5c)', async ({ page }) => {
+    // End-to-end screen-point picking through the REAL camera: unproject via
+    // getProjectionMatrix()/getModelMatrix() (probed above), analytic cube
+    // bounds (pickable immediately — no post-load gate), handle identity via
+    // the Node → NodeHandle registry.
+    await page.goto('/kotlin-bundle/index.html');
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__smoke?.status), { timeout: 30_000 })
+      .toBe('resolved');
+
+    const result = await page.evaluate(() => {
+      const sv = (window as any).__sv;
+      if (!sv) return { error: 'viewer not exposed on window.__sv' };
+      if (typeof sv.hitTest !== 'function') return { error: 'hitTest missing on the exported viewer' };
+      try {
+        // The default orbit camera targets the world origin — a cube at the
+        // default (0,0,0) sits dead under the canvas centre. The helmet the
+        // page loads has no collision shape (surface-A loadModel), so the
+        // cube is the only pickable node.
+        const cube = sv.addCubeNode(0.5);
+        const hits = sv.hitTest(320, 240);   // canvas centre (640x480 backing store)
+        const miss = sv.hitTest(2, 2);       // top-left corner — nothing there
+        const sameInstance = hits.length > 0 && hits[0] === cube;
+        sv.removeNode(cube);
+        return { hitCount: hits.length, missCount: miss.length, sameInstance };
+      } catch (e: any) {
+        return { error: `${e?.name ?? ''} ${e?.message ?? String(e)}` };
+      }
+    });
+
+    expect((result as any).error, `hitTest e2e failed: ${(result as any).error}`).toBeUndefined();
+    expect((result as any).hitCount).toBe(1);
+    expect((result as any).sameInstance, 'hitTest must return the SAME handle instance addCubeNode returned').toBe(true);
+    expect((result as any).missCount).toBe(0);
+  });
 });

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -1369,6 +1369,7 @@ public final class io/github/sceneview/scene/SceneGraph {
 	public final fun findNode (Lkotlin/jvm/functions/Function1;)Lio/github/sceneview/rendering/SceneNode;
 	public final fun getRootNodes ()Ljava/util/List;
 	public final fun hitTest (Lio/github/sceneview/collision/Ray;)Ljava/util/List;
+	public final fun removeCollisionShape (Lio/github/sceneview/rendering/SceneNode;)V
 	public final fun removeNode (Lio/github/sceneview/rendering/SceneNode;)V
 	public final fun setCollisionShape (Lio/github/sceneview/rendering/SceneNode;Lio/github/sceneview/collision/CollisionShape;)V
 }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/scene/SceneGraph.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/scene/SceneGraph.kt
@@ -93,6 +93,17 @@ class SceneGraph {
     }
 
     /**
+     * Removes [node]'s collision shape, making it invisible to [hitTest]
+     * until a new shape is set. A no-op when the node has no shape. The
+     * clearing counterpart of [setCollisionShape] — without it a caller that
+     * nulls a node's shape after a hit test would leave the last world-space
+     * shape lingering in the graph (#2024 P5c review).
+     */
+    fun removeCollisionShape(node: SceneNode) {
+        collisionShapes.remove(node)
+    }
+
+    /**
      * Returns the first node matching [predicate], searched depth-first from roots.
      */
     fun findNode(predicate: (SceneNode) -> Boolean): SceneNode? {

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/scene/SceneGraphTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/scene/SceneGraphTest.kt
@@ -217,6 +217,25 @@ class SceneGraphTest {
     }
 
     @Test
+    fun removeCollisionShapeMakesTheNodeInvisibleToHitTest() {
+        val graph = SceneGraph()
+        val node = TestNode("target")
+        graph.addNode(node)
+        graph.setCollisionShape(node, Sphere(1f, Vector3(0f, 0f, -2f)))
+
+        val ray = Ray(Vector3(0f, 0f, 0f), Vector3(0f, 0f, -1f))
+        assertEquals(1, graph.hitTest(ray).size, "Shape set — the node must be hit")
+
+        graph.removeCollisionShape(node)
+        assertTrue(
+            graph.hitTest(ray).isEmpty(),
+            "Shape removed — the node must no longer be hit"
+        )
+        // Idempotent on a node with no shape.
+        graph.removeCollisionShape(node)
+    }
+
+    @Test
     fun hitTestSkipsNonHittableNodes() {
         val graph = SceneGraph()
         val node = TestNode("hidden")

--- a/sceneview-web/sceneview-web.d.ts
+++ b/sceneview-web/sceneview-web.d.ts
@@ -186,6 +186,17 @@ export interface SceneViewer {
    *  equivalent to `handle.destroy()`. */
   removeNode(node: NodeHandle): void;
 
+  /**
+   * Screen-point picking on the retained node tree. Coordinates are canvas
+   * pixels ((0,0) = top-left; scale `event.offsetX/Y` by
+   * `canvas.width / canvas.clientWidth` on devicePixelRatio-scaled backing
+   * stores). Returns the hit nodes' handles nearest-first — the SAME
+   * instances the `add*Node` factories returned, so `===` works. Model
+   * nodes are pickable once loaded; geometry/splat nodes immediately;
+   * empty pivots, lights and cameras are never hit.
+   */
+  hitTest(x: number, y: number): NodeHandle[];
+
   /** Release Filament resources. The viewer is unusable after this. */
   dispose(): void;
 }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -900,11 +900,17 @@ class SceneView private constructor(
     private fun refreshCollisionShapes() {
         fun visit(sceneNode: SceneNode) {
             (sceneNode as? Node)?.let { node ->
-                node.collisionShape?.let { local ->
+                val local = node.collisionShape
+                if (local != null) {
                     sceneGraph.setCollisionShape(
                         node,
                         local.transform(TransformProvider { node.worldTransform.toMatrix() }),
                     )
+                } else {
+                    // Honors the documented opt-out: a nulled collisionShape
+                    // must also drop the previously derived world shape, or
+                    // the node would keep getting hit at its stale bounds.
+                    sceneGraph.removeCollisionShape(node)
                 }
             }
             sceneNode.childNodes.forEach { visit(it) }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -1,5 +1,11 @@
 package io.github.sceneview.web
 
+import io.github.sceneview.collision.Ray
+import io.github.sceneview.collision.TransformProvider
+import io.github.sceneview.math.toMatrix
+import io.github.sceneview.math.toTransform
+import io.github.sceneview.rendering.SceneNode
+import io.github.sceneview.scene.HitResult
 import io.github.sceneview.scene.SceneGraph
 import io.github.sceneview.web.bindings.*
 import io.github.sceneview.web.nodes.CameraConfig
@@ -838,6 +844,72 @@ class SceneView private constructor(
         // not fire spurious renders nor pin this view through the closure.
         node.propagateInvalidate(null)
         requestRender()
+    }
+
+    /**
+     * Picks the retained nodes under a screen point (#2024 P5c) — the web
+     * mirror of Android's screen-point node picking.
+     *
+     * The point is unprojected through the live camera (its projection and
+     * model matrices — the engine reads proven by the `kotlin-bundle.spec.ts`
+     * P5c probe) into a world ray, each node's **local** [Node.collisionShape]
+     * (real per-node bounds: asset AABB for models/geometry, cloud bounds for
+     * splats) is transformed by its current `worldTransform`, and the ray is
+     * tested against all of them.
+     *
+     * @param x Horizontal coordinate in **canvas pixels** (0 = left). For a
+     *   pointer event on the canvas use `event.offsetX * (canvas.width /
+     *   canvas.clientWidth)` when the backing store is scaled
+     *   (devicePixelRatio canvases).
+     * @param y Vertical coordinate in canvas pixels (0 = top).
+     * @return Hits sorted nearest-first; empty when nothing is under the
+     *   point. Invisible ([Node.isVisible]), non-hittable ([Node.isHittable])
+     *   and shape-less nodes are skipped.
+     */
+    fun hitTest(x: Float, y: Float): List<HitResult> {
+        // The engine reads (proven by the kotlin-bundle.spec.ts P5c probe,
+        // #2611 probe-first) — column-major mat4s converted to core math.
+        val ray = screenPointToRay(
+            x = x,
+            y = y,
+            viewportWidth = canvas.width.toFloat(),
+            viewportHeight = canvas.height.toFloat(),
+            projection = readMat4(camera.getProjectionMatrix()).toTransform(),
+            cameraModel = readMat4(camera.getModelMatrix()).toTransform(),
+        )
+        return hitTest(ray)
+    }
+
+    /**
+     * Picks the retained nodes intersected by a world-space [ray] — the
+     * lower-level twin of the screen-point [hitTest] overload (use it with an
+     * externally sourced ray, e.g. an XR controller pose).
+     */
+    fun hitTest(ray: Ray): List<HitResult> {
+        refreshCollisionShapes()
+        return sceneGraph.hitTest(ray)
+    }
+
+    /**
+     * Re-derives every in-graph node's **world-space** collision shape from
+     * its local [Node.collisionShape] and current `worldTransform`. Runs per
+     * hit test (event-frequency, not per-frame) — the Sceneform
+     * shape-transform pattern, so bounds always follow the node with no
+     * manual upkeep.
+     */
+    private fun refreshCollisionShapes() {
+        fun visit(sceneNode: SceneNode) {
+            (sceneNode as? Node)?.let { node ->
+                node.collisionShape?.let { local ->
+                    sceneGraph.setCollisionShape(
+                        node,
+                        local.transform(TransformProvider { node.worldTransform.toMatrix() }),
+                    )
+                }
+            }
+            sceneNode.childNodes.forEach { visit(it) }
+        }
+        sceneGraph.rootNodes.forEach { visit(it) }
     }
 
     fun addLight(config: LightConfig) {

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
@@ -39,9 +39,21 @@ class SceneViewJS {
         }
 
         override fun removeNodeInternal(node: io.github.sceneview.web.nodes.Node) {
+            nodeHandles.remove(node)
             _sceneView?.removeNode(node)
         }
     }
+
+    /**
+     * Node → handle registry so [hitTest] returns the **same** JS handle
+     * instances the `add*Node` factories handed out (`===`-comparable), and
+     * repeated hits on one node do not mint new wrappers (#2024 P5c).
+     * Entries are dropped when a node is removed/destroyed through its handle.
+     */
+    private val nodeHandles = mutableMapOf<io.github.sceneview.web.nodes.Node, NodeHandle>()
+
+    private fun handleFor(node: io.github.sceneview.web.nodes.Node): NodeHandle =
+        nodeHandles.getOrPut(node) { NodeHandle(node, nodeHost) }
 
     internal fun attach(sv: SceneView) {
         _sceneView = sv
@@ -219,7 +231,7 @@ class SceneViewJS {
         val sv = _sceneView ?: throw IllegalStateException("SceneViewer not initialized")
         val node = io.github.sceneview.web.nodes.Node(sv.engine, sv.newEntity())
         sv.addNode(node)
-        return NodeHandle(node, nodeHost)
+        return handleFor(node)
     }
 
     /**
@@ -247,7 +259,7 @@ class SceneViewJS {
                 // pivot; it is assigned synchronously (before any async load can
                 // complete), so `pivot` is always non-null when `onLoaded` runs.
                 var pivot: io.github.sceneview.web.nodes.ModelNode? = null
-                pivot = sv.addModelNode(url, onLoaded = { resolve(NodeHandle(pivot!!, nodeHost)) })
+                pivot = sv.addModelNode(url, onLoaded = { resolve(handleFor(pivot!!)) })
             } catch (e: Throwable) {
                 reject(e)
             }
@@ -268,7 +280,7 @@ class SceneViewJS {
             try {
                 sv.addSplatNode(
                     url,
-                    onLoaded = { splat -> resolve(NodeHandle(splat, nodeHost)) },
+                    onLoaded = { splat -> resolve(handleFor(splat)) },
                     onError = { reject(it) },
                 )
             } catch (e: Throwable) {
@@ -284,7 +296,7 @@ class SceneViewJS {
     @JsName("addCubeNode")
     fun addCubeNode(size: Double): NodeHandle {
         val sv = _sceneView ?: throw IllegalStateException("SceneViewer not initialized")
-        return NodeHandle(sv.addCubeNode(size), nodeHost)
+        return handleFor(sv.addCubeNode(size))
     }
 
     /**
@@ -294,7 +306,7 @@ class SceneViewJS {
     @JsName("addSphereNode")
     fun addSphereNode(radius: Double): NodeHandle {
         val sv = _sceneView ?: throw IllegalStateException("SceneViewer not initialized")
-        return NodeHandle(sv.addSphereNode(radius), nodeHost)
+        return handleFor(sv.addSphereNode(radius))
     }
 
     /**
@@ -315,7 +327,7 @@ class SceneViewJS {
                 )
             }
         }
-        return NodeHandle(sv.addLightNode(config), nodeHost)
+        return handleFor(sv.addLightNode(config))
     }
 
     /**
@@ -326,6 +338,43 @@ class SceneViewJS {
     @JsName("removeNode")
     fun removeNode(node: NodeHandle) {
         node.destroy()
+    }
+
+    /**
+     * Picks the retained nodes under a screen point (#2024 P5c) — the JS
+     * mirror of `SceneView.hitTest(x, y)`.
+     *
+     * Coordinates are **canvas pixels** ((0,0) = top-left). For a pointer
+     * event on the canvas: `sv.hitTest(event.offsetX * (canvas.width /
+     * canvas.clientWidth), event.offsetY * (canvas.height /
+     * canvas.clientHeight))` (the factor corrects devicePixelRatio-scaled
+     * backing stores).
+     *
+     * Returns the hit nodes' handles sorted nearest-first — the **same**
+     * handle instances the `add*Node` factories returned, so `===`
+     * comparison against your kept references works:
+     *
+     * ```js
+     * const cube = sv.addCubeNode(0.5);
+     * canvas.addEventListener('click', (e) => {
+     *   const hits = sv.hitTest(e.offsetX, e.offsetY);
+     *   if (hits[0] === cube) cube.setScaleUniform(1.5);
+     * });
+     * ```
+     *
+     * Nodes without bounds (empty pivots, lights, cameras), invisible nodes,
+     * and nodes with `isHittable == false` are skipped. Model nodes become
+     * pickable once loaded (their AABB is only readable then); geometry and
+     * splat nodes are pickable immediately.
+     */
+    @JsName("hitTest")
+    fun hitTest(x: Double, y: Double): Array<NodeHandle> {
+        val sv = _sceneView ?: return emptyArray()
+        return sv.hitTest(x.toFloat(), y.toFloat())
+            .mapNotNull { hit ->
+                (hit.node as? io.github.sceneview.web.nodes.Node)?.let { handleFor(it) }
+            }
+            .toTypedArray()
     }
 
     /**

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewJS.kt
@@ -39,8 +39,19 @@ class SceneViewJS {
         }
 
         override fun removeNodeInternal(node: io.github.sceneview.web.nodes.Node) {
-            nodeHandles.remove(node)
+            // Purge the WHOLE subtree from the handle registry — removal
+            // cascades to descendants, and factory-created children
+            // (addCubeNode(parent = …)) hold entries too. Walk before the
+            // graph detach mutates the child sets.
+            dropHandlesRecursive(node)
             _sceneView?.removeNode(node)
+        }
+    }
+
+    private fun dropHandlesRecursive(node: io.github.sceneview.web.nodes.Node) {
+        nodeHandles.remove(node)
+        node.childNodes.forEach { child ->
+            (child as? io.github.sceneview.web.nodes.Node)?.let { dropHandlesRecursive(it) }
         }
     }
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewNodes.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneViewNodes.kt
@@ -1,5 +1,7 @@
 package io.github.sceneview.web
 
+import io.github.sceneview.collision.Box as CollisionBox
+import io.github.sceneview.collision.Vector3
 import io.github.sceneview.web.bindings.FilamentAsset
 import io.github.sceneview.web.nodes.CameraNode
 import io.github.sceneview.web.nodes.CubeNode
@@ -8,6 +10,7 @@ import io.github.sceneview.web.nodes.FilamentCameraController
 import io.github.sceneview.web.nodes.FilamentLightController
 import io.github.sceneview.web.nodes.GeometryConfig
 import io.github.sceneview.web.nodes.GeometryNode
+import io.github.sceneview.web.nodes.localCollisionShape
 import io.github.sceneview.web.nodes.LightConfig
 import io.github.sceneview.web.nodes.LightNode
 import io.github.sceneview.web.nodes.ModelNode
@@ -52,7 +55,16 @@ fun SceneView.addModelNode(
     addNode(node, parent)
     loadModelInternal(
         url,
-        onLoaded = onLoaded,
+        onLoaded = { asset ->
+            // Real per-node picking bounds (#2024 P5c): the asset AABB is
+            // readable only now (post-loadResources, #1597). It is
+            // asset-space, and the asset root was scaled by [scale] at load
+            // (#2432) — scale the box so it matches the rendered extent.
+            if (!node.isDestroyed) {
+                node.collisionShape = assetCollisionBox(asset, scale)
+            }
+            onLoaded?.invoke(asset)
+        },
         autoAnimate = autoAnimate,
         scale = scale,
         // Node-owned: this content is framed via its ModelNode pivot, so the
@@ -140,6 +152,9 @@ fun SceneView.addPlaneNode(
  */
 private fun SceneView.attachGeometry(node: GeometryNode, config: GeometryConfig, parent: Node?) {
     addNode(node, parent)
+    // Real per-node picking bounds (#2024 P5c) — analytic from the config,
+    // so hit-testing works immediately (no post-load AABB gate).
+    node.collisionShape = config.localCollisionShape()
     // Node-owned geometry: framed via this GeometryNode pivot, so it is excluded
     // from the flat-content auto-centre pass (#2024 P4).
     addGeometry(config, nodeOwned = true)?.let { asset ->
@@ -289,4 +304,29 @@ fun SceneView.applyNodeVisibility(node: Node) {
     val entities = asset.getEntities()
     if (node.isVisible) scene.addEntities(entities) else scene.removeEntities(entities)
     requestRender()
+}
+
+/**
+ * The local-space picking [CollisionBox] of a loaded asset (#2024 P5c):
+ * its asset-space `getBoundingBox()` (readable post-load only, #1597)
+ * scaled by the root [scale] baked at load time (#2432), so the box matches
+ * the rendered extent in the owning node's space.
+ */
+private fun assetCollisionBox(asset: FilamentAsset, scale: Float): CollisionBox {
+    val aabb = asset.getBoundingBox()
+    val mn: dynamic = aabb.min
+    val mx: dynamic = aabb.max
+    fun c(v: dynamic, i: Int) = (v[i] as Number).toFloat()
+    return CollisionBox(
+        Vector3(
+            (c(mx, 0) - c(mn, 0)) * scale,
+            (c(mx, 1) - c(mn, 1)) * scale,
+            (c(mx, 2) - c(mn, 2)) * scale,
+        ),
+        Vector3(
+            (c(mx, 0) + c(mn, 0)) / 2f * scale,
+            (c(mx, 1) + c(mn, 1)) / 2f * scale,
+            (c(mx, 2) + c(mn, 2)) / 2f * scale,
+        ),
+    )
 }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/ScreenRay.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/ScreenRay.kt
@@ -38,9 +38,13 @@ internal fun screenPointToRay(
     val invProjection = inverse(projection)
     val near = unprojectNdc(invProjection, cameraModel, ndcX, ndcY, ndcZ = -1f)
     // The second point sits MID-volume (NDC z = 0), not on the far plane:
-    // Filament renders with an infinite-far projection, where NDC z = +1 maps
-    // to w = 0 — a point at infinity whose perspective divide is NaN. Any
-    // second finite depth on the same pixel yields the same ray direction.
+    // Filament's getProjectionMatrix() returns the RENDERING projection,
+    // which uses an INFINITE far plane regardless of the finite `far` passed
+    // to setProjectionFov (that value only feeds the culling matrix) — the
+    // kotlin-bundle.spec.ts P5c probe asserts proj[10] == -1 exactly. Under
+    // it, NDC z = +1 maps to w = 0 — a point at infinity whose perspective
+    // divide is NaN. Any second finite depth on the same pixel yields the
+    // same ray direction (and NDC z = 0 stays finite for an ortho too).
     val mid = unprojectNdc(invProjection, cameraModel, ndcX, ndcY, ndcZ = 0f)
     // Ray's constructor normalizes the direction.
     return Ray(

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/ScreenRay.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/ScreenRay.kt
@@ -1,0 +1,63 @@
+package io.github.sceneview.web
+
+import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.Float4
+import dev.romainguy.kotlin.math.inverse
+import io.github.sceneview.collision.Ray
+import io.github.sceneview.collision.Vector3
+import io.github.sceneview.math.Transform
+
+/**
+ * Unprojects a screen point into a world-space picking [Ray] (#2024 P5c).
+ *
+ * Pure math — kept free of any engine access so `jsTest` can prove the
+ * unprojection without the Filament WASM module. The two matrices come from
+ * the engine at the [SceneView.hitTest] call site.
+ *
+ * @param x Horizontal screen coordinate in canvas pixels (0 = left edge).
+ * @param y Vertical screen coordinate in canvas pixels (0 = top edge — DOM
+ *   convention; the NDC flip happens here).
+ * @param viewportWidth Canvas width in the same pixel unit as [x].
+ * @param viewportHeight Canvas height in the same pixel unit as [y].
+ * @param projection The camera's projection matrix (column-major).
+ * @param cameraModel The camera's model (camera-to-world) matrix — the
+ *   inverse view matrix.
+ * @return A [Ray] from the near plane through the screen point, in world
+ *   space, with a normalized direction.
+ */
+internal fun screenPointToRay(
+    x: Float,
+    y: Float,
+    viewportWidth: Float,
+    viewportHeight: Float,
+    projection: Transform,
+    cameraModel: Transform,
+): Ray {
+    val ndcX = 2f * x / viewportWidth - 1f
+    val ndcY = 1f - 2f * y / viewportHeight
+    val invProjection = inverse(projection)
+    val near = unprojectNdc(invProjection, cameraModel, ndcX, ndcY, ndcZ = -1f)
+    // The second point sits MID-volume (NDC z = 0), not on the far plane:
+    // Filament renders with an infinite-far projection, where NDC z = +1 maps
+    // to w = 0 — a point at infinity whose perspective divide is NaN. Any
+    // second finite depth on the same pixel yields the same ray direction.
+    val mid = unprojectNdc(invProjection, cameraModel, ndcX, ndcY, ndcZ = 0f)
+    // Ray's constructor normalizes the direction.
+    return Ray(
+        Vector3(near.x, near.y, near.z),
+        Vector3(mid.x - near.x, mid.y - near.y, mid.z - near.z),
+    )
+}
+
+/** NDC → view space (inverse projection + perspective divide) → world space. */
+private fun unprojectNdc(
+    invProjection: Transform,
+    cameraModel: Transform,
+    ndcX: Float,
+    ndcY: Float,
+    ndcZ: Float,
+): Float3 {
+    val view = invProjection * Float4(ndcX, ndcY, ndcZ, 1f)
+    val world = cameraModel * Float4(view.x / view.w, view.y / view.w, view.z / view.w, 1f)
+    return Float3(world.x, world.y, world.z)
+}

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/GeometryConfig.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/GeometryConfig.kt
@@ -1,5 +1,10 @@
 package io.github.sceneview.web.nodes
 
+import io.github.sceneview.collision.Box
+import io.github.sceneview.collision.CollisionShape
+import io.github.sceneview.collision.Sphere
+import io.github.sceneview.collision.Vector3
+
 /**
  * Geometry configuration for SceneView web.
  *
@@ -113,4 +118,36 @@ enum class GeometryType {
     SPHERE,
     CYLINDER,
     PLANE
+}
+
+/** Picking thickness of a flat plane's collision box (a zero-height box cannot be hit edge-on). */
+private const val PLANE_PICK_THICKNESS = 0.01
+
+/**
+ * The **local-space** collision shape matching this config's generated
+ * geometry (#2024 P5c) — analytic (dimensions are known at build time), so
+ * picking works immediately, with no post-load AABB gate.
+ *
+ * A baked `rotation(...)` in the config is NOT folded into the box (the box
+ * stays axis-aligned in node space) — for the rare rotated-bake config the
+ * bounds are approximate; assign `Node.collisionShape` manually for a tight
+ * fit.
+ */
+internal fun GeometryConfig.localCollisionShape(): CollisionShape {
+    if (geometryType == GeometryType.SPHERE) {
+        return Sphere(
+            (radius * maxOf(scaleX, scaleY, scaleZ)).toFloat(),
+            Vector3(positionX.toFloat(), positionY.toFloat(), positionZ.toFloat()),
+        )
+    }
+    val (sx, sy, sz) = when (geometryType) {
+        GeometryType.CUBE -> Triple(sizeX, sizeY, sizeZ)
+        GeometryType.CYLINDER -> Triple(radius * 2, height, radius * 2)
+        GeometryType.PLANE -> Triple(sizeX, PLANE_PICK_THICKNESS, sizeZ)
+        GeometryType.SPHERE -> error("handled above")
+    }
+    return Box(
+        Vector3((sx * scaleX).toFloat(), (sy * scaleY).toFloat(), (sz * scaleZ).toFloat()),
+        Vector3(positionX.toFloat(), positionY.toFloat(), positionZ.toFloat()),
+    )
 }

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/Node.kt
@@ -6,6 +6,7 @@ import dev.romainguy.kotlin.math.lookTowards
 import io.github.sceneview.animation.SmoothTransformTRSState
 import io.github.sceneview.animation.SmoothTransformTRSTarget
 import io.github.sceneview.animation.updateSmoothTransform
+import io.github.sceneview.collision.CollisionShape
 import io.github.sceneview.math.Direction
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
@@ -76,6 +77,19 @@ open class Node internal constructor(
     override var isVisible: Boolean = true
 
     override var isHittable: Boolean = true
+
+    /**
+     * **Local-space** collision shape used by `SceneView.hitTest` picking
+     * (#2024 P5c) — the Android `Node.collisionShape` mirror. Transformed
+     * into world space through this node's [worldTransform] at hit-test time,
+     * so it follows the node (and any animation) with no manual upkeep.
+     *
+     * Wired automatically with real per-node bounds: model/geometry nodes get
+     * their asset AABB once loaded, splat nodes their cloud bounds. Assign to
+     * override (e.g. a tighter core `Box`/`Sphere`), or `null` to make the
+     * node un-pickable (a node with no shape is skipped by hit tests).
+     */
+    var collisionShape: CollisionShape? = null
 
     /** `true` once [destroy] has run; every later [destroy] call is a no-op. */
     var isDestroyed: Boolean = false

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/SplatNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/SplatNode.kt
@@ -1,5 +1,7 @@
 package io.github.sceneview.web.nodes
 
+import io.github.sceneview.collision.Box as CollisionBox
+import io.github.sceneview.collision.Vector3
 import io.github.sceneview.core.splat.SplatCloud
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.computeWorldToLocal
@@ -93,6 +95,15 @@ class SplatNode internal constructor(
 
     /** Rough cloud radius — scales the camera-motion threshold that gates a re-sort. */
     private val boundingRadius: Float = max(boundingBox[3], max(boundingBox[4], boundingBox[5]))
+
+    init {
+        // Real per-node picking bounds (#2024 P5c): the cloud's model-space
+        // AABB, known at construction — no post-load gate like glTF assets.
+        collisionShape = CollisionBox(
+            Vector3(boundingBox[3] * 2f, boundingBox[4] * 2f, boundingBox[5] * 2f),
+            Vector3(boundingBox[0], boundingBox[1], boundingBox[2]),
+        )
+    }
 
     private val material: Material = createSplatMaterial(filamentEngine)
     private val positionScaleTexture = buildDataTexture()

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/NodeHitTestTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/NodeHitTestTest.kt
@@ -1,0 +1,124 @@
+package io.github.sceneview.web
+
+import io.github.sceneview.collision.Box
+import io.github.sceneview.collision.Ray
+import io.github.sceneview.collision.TransformProvider
+import io.github.sceneview.collision.Vector3
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Transform
+import io.github.sceneview.math.toMatrix
+import io.github.sceneview.scene.SceneGraph
+import io.github.sceneview.web.nodes.Node
+import io.github.sceneview.web.nodes.NodeBackend
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * #2024 P5c — ray-vs-node picking through the core [SceneGraph], with the
+ * exact world-shape derivation `SceneView.refreshCollisionShapes` performs
+ * (local [Node.collisionShape] transformed by the node's `worldTransform`).
+ * The screen-ray half is [ScreenRayTest]; the engine matrix reads are the
+ * `kotlin-bundle.spec.ts` P5c probe's job.
+ */
+class NodeHitTestTest {
+
+    private class FakeBackend : NodeBackend {
+        override fun setLocalTransform(transform: Transform) = Unit
+        override fun setParent(parent: NodeBackend?) = Unit
+        override fun adoptChildEntity(child: io.github.sceneview.web.bindings.Entity) = Unit
+        override fun destroy() = Unit
+    }
+
+    private fun node(name: String) = Node(FakeBackend()).also { it.name = name }
+
+    /** The refreshCollisionShapes derivation, applied to one node. */
+    private fun SceneGraph.refreshShape(node: Node) {
+        node.collisionShape?.let { local ->
+            setCollisionShape(
+                node,
+                local.transform(TransformProvider { node.worldTransform.toMatrix() }),
+            )
+        }
+    }
+
+    private val unitBox get() = Box(Vector3(1f, 1f, 1f))
+
+    private val rayAlongX = Ray(Vector3(0f, 0f, 0f), Vector3(1f, 0f, 0f))
+
+    @Test
+    fun rayHitsATranslatedNodeAtItsWorldBounds() {
+        val graph = SceneGraph()
+        val node = node("target")
+        node.collisionShape = unitBox
+        node.position = Position(5f, 0f, 0f)
+        graph.addNode(node)
+        graph.refreshShape(node)
+
+        val hits = graph.hitTest(rayAlongX)
+        assertEquals(1, hits.size, "one node under the ray")
+        assertEquals(node, hits[0].node)
+        // Unit box centred at x=5 → near face at 4.5.
+        assertTrue(abs(hits[0].distance - 4.5f) < 1e-3f, "distance was ${hits[0].distance}")
+    }
+
+    @Test
+    fun hitsAreSortedNearestFirst() {
+        val graph = SceneGraph()
+        val near = node("near").also { it.collisionShape = unitBox; it.position = Position(3f, 0f, 0f) }
+        val far = node("far").also { it.collisionShape = unitBox; it.position = Position(8f, 0f, 0f) }
+        graph.addNode(far)
+        graph.addNode(near)
+        graph.refreshShape(near)
+        graph.refreshShape(far)
+
+        val hits = graph.hitTest(rayAlongX)
+        assertEquals(listOf<Any>(near, far), hits.map { it.node }, "nearest first")
+    }
+
+    @Test
+    fun scaledParentGrowsTheChildBounds() {
+        val graph = SceneGraph()
+        val parent = node("group")
+        parent.scale = io.github.sceneview.math.Scale(3f)
+        val child = node("content")
+        child.collisionShape = unitBox
+        child.position = Position(2f, 0f, 0f) // world x = 6 under scale 3
+        graph.addNode(parent)
+        graph.addNode(child, parent)
+        graph.refreshShape(child)
+
+        val hits = graph.hitTest(rayAlongX)
+        assertEquals(1, hits.size)
+        // Unit box scaled ×3 centred at world x=6 → near face at 4.5.
+        assertTrue(abs(hits[0].distance - 4.5f) < 1e-3f, "distance was ${hits[0].distance}")
+    }
+
+    @Test
+    fun nonHittableAndShapelessNodesAreSkipped() {
+        val graph = SceneGraph()
+        val ghost = node("ghost").also {
+            it.collisionShape = unitBox
+            it.position = Position(3f, 0f, 0f)
+            it.isHittable = false
+        }
+        val shapeless = node("pivot").also { it.position = Position(5f, 0f, 0f) }
+        graph.addNode(ghost)
+        graph.addNode(shapeless)
+        graph.refreshShape(ghost)
+        graph.refreshShape(shapeless)
+
+        assertEquals(0, graph.hitTest(rayAlongX).size)
+    }
+
+    @Test
+    fun missedRayReturnsEmpty() {
+        val graph = SceneGraph()
+        val node = node("aside").also { it.collisionShape = unitBox; it.position = Position(0f, 5f, 0f) }
+        graph.addNode(node)
+        graph.refreshShape(node)
+
+        assertEquals(0, graph.hitTest(rayAlongX).size)
+    }
+}

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/NodeHitTestTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/NodeHitTestTest.kt
@@ -35,11 +35,14 @@ class NodeHitTestTest {
 
     /** The refreshCollisionShapes derivation, applied to one node. */
     private fun SceneGraph.refreshShape(node: Node) {
-        node.collisionShape?.let { local ->
+        val local = node.collisionShape
+        if (local != null) {
             setCollisionShape(
                 node,
                 local.transform(TransformProvider { node.worldTransform.toMatrix() }),
             )
+        } else {
+            removeCollisionShape(node)
         }
     }
 
@@ -110,6 +113,24 @@ class NodeHitTestTest {
         graph.refreshShape(shapeless)
 
         assertEquals(0, graph.hitTest(rayAlongX).size)
+    }
+
+    @Test
+    fun nullingTheShapeAfterAHitDropsTheStaleWorldShape() {
+        // The documented opt-out (#2024 P5c review): collisionShape = null
+        // AFTER a hit test must not leave the last derived world shape
+        // lingering in the graph.
+        val graph = SceneGraph()
+        val node = node("target")
+        node.collisionShape = unitBox
+        node.position = Position(5f, 0f, 0f)
+        graph.addNode(node)
+        graph.refreshShape(node)
+        assertEquals(1, graph.hitTest(rayAlongX).size, "shape set — hit expected")
+
+        node.collisionShape = null
+        graph.refreshShape(node)
+        assertEquals(0, graph.hitTest(rayAlongX).size, "nulled — the node must be un-pickable")
     }
 
     @Test

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/ScreenRayTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/ScreenRayTest.kt
@@ -1,0 +1,120 @@
+package io.github.sceneview.web
+
+import dev.romainguy.kotlin.math.Float4
+import dev.romainguy.kotlin.math.inverse
+import io.github.sceneview.collision.Vector3
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Transform
+import io.github.sceneview.math.toTransform
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.math.tan
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * #2024 P5c — screen-point → world-ray unprojection, proven without the
+ * engine. The matrices are hand-built with the standard OpenGL perspective
+ * layout — the exact layout Filament's `getProjectionMatrix()` returns
+ * (asserted in-browser by the `kotlin-bundle.spec.ts` P5c probe).
+ */
+class ScreenRayTest {
+
+    private val eps = 1e-3f
+
+    private fun assertClose(expected: Float, actual: Float, message: String) {
+        assertTrue(abs(expected - actual) < eps, "$message: expected $expected, was $actual")
+    }
+
+    /** Standard column-major OpenGL perspective — what Filament produces. */
+    private fun perspectiveProjection(
+        fovYDegrees: Float,
+        aspect: Float,
+        near: Float,
+        far: Float,
+    ): Transform {
+        val f = 1f / tan(fovYDegrees * PI.toFloat() / 360f)
+        val cols = FloatArray(16)
+        cols[0] = f / aspect
+        cols[5] = f
+        cols[10] = (far + near) / (near - far)
+        cols[11] = -1f
+        cols[14] = 2f * far * near / (near - far)
+        return cols.toTransform()
+    }
+
+    private val projection = perspectiveProjection(90f, 1f, 0.1f, 100f)
+
+    @Test
+    fun centerOfScreenLooksStraightDownMinusZ() {
+        val ray = screenPointToRay(
+            x = 300f, y = 300f, viewportWidth = 600f, viewportHeight = 600f,
+            projection = projection, cameraModel = Transform(),
+        )
+        val d = ray.getDirection()
+        assertClose(0f, d.x, "direction.x")
+        assertClose(0f, d.y, "direction.y")
+        assertClose(-1f, d.z, "direction.z")
+        val o = ray.getOrigin()
+        assertClose(0f, o.x, "origin.x")
+        assertClose(-0.1f, o.z, "origin.z is on the near plane")
+    }
+
+    @Test
+    fun translatedCameraShiftsTheRayOrigin() {
+        val ray = screenPointToRay(
+            x = 300f, y = 300f, viewportWidth = 600f, viewportHeight = 600f,
+            projection = projection,
+            cameraModel = Transform(position = Position(0f, 0f, 5f)),
+        )
+        val o = ray.getOrigin()
+        assertClose(0f, o.x, "origin.x")
+        assertClose(0f, o.y, "origin.y")
+        assertClose(4.9f, o.z, "origin.z = camera z minus near")
+        assertClose(-1f, ray.getDirection().z, "direction.z")
+    }
+
+    @Test
+    fun cornerRayDivergesDiagonally() {
+        // fov 90° + aspect 1 → the top-right corner (NDC 1,1) looks along
+        // normalize(1, 1, -1).
+        val ray = screenPointToRay(
+            x = 600f, y = 0f, viewportWidth = 600f, viewportHeight = 600f,
+            projection = projection, cameraModel = Transform(),
+        )
+        val d = ray.getDirection()
+        val c = 1f / sqrt(3f)
+        assertClose(c, d.x, "direction.x")
+        assertClose(c, d.y, "direction.y")
+        assertClose(-c, d.z, "direction.z")
+    }
+
+    @Test
+    fun roundTripThroughAProjectedWorldPoint() {
+        // Project a known world point with the same matrices, then unproject
+        // its screen position — the resulting ray must pass through the point.
+        val width = 800f
+        val height = 600f
+        val projection = perspectiveProjection(60f, width / height, 0.1f, 100f)
+        val cameraModel = Transform(position = Position(2f, 1f, 8f))
+        val world = Float4(1f, -0.5f, 3f, 1f)
+
+        val view = inverse(cameraModel) * world
+        val clip = projection * view
+        val ndcX = clip.x / clip.w
+        val ndcY = clip.y / clip.w
+        val screenX = (ndcX + 1f) / 2f * width
+        val screenY = (1f - ndcY) / 2f * height
+
+        val ray = screenPointToRay(screenX, screenY, width, height, projection, cameraModel)
+
+        // Distance from the point to the ray line: |d × (P - O)| with |d| = 1.
+        val toPoint = Vector3.subtract(
+            Vector3(world.x, world.y, world.z),
+            ray.getOrigin(),
+        )
+        val distance = Vector3.cross(ray.getDirection(), toPoint).length()
+        assertTrue(distance < eps, "ray must pass through the projected point (distance=$distance)")
+    }
+}

--- a/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/GeometryCollisionShapeTest.kt
+++ b/sceneview-web/src/jsTest/kotlin/io/github/sceneview/web/nodes/GeometryCollisionShapeTest.kt
@@ -1,0 +1,70 @@
+package io.github.sceneview.web.nodes
+
+import io.github.sceneview.collision.Box
+import io.github.sceneview.collision.Sphere
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * #2024 P5c — the analytic local picking bounds derived from a
+ * [GeometryConfig] (no engine, no post-load gate).
+ */
+class GeometryCollisionShapeTest {
+
+    private val eps = 1e-4f
+
+    private fun assertClose(expected: Float, actual: Float, message: String) {
+        assertTrue(abs(expected - actual) < eps, "$message: expected $expected, was $actual")
+    }
+
+    @Test
+    fun cubeBoundsMatchSizeAndBakedPosition() {
+        val config = GeometryConfig().apply {
+            cube(); size(2.0, 3.0, 4.0); position(1.0, 2.0, 3.0)
+        }
+        val box = config.localCollisionShape() as Box
+        assertClose(2f, box.getSize().x, "size.x")
+        assertClose(3f, box.getSize().y, "size.y")
+        assertClose(4f, box.getSize().z, "size.z")
+        assertClose(1f, box.getCenter().x, "center.x")
+        assertClose(3f, box.getCenter().z, "center.z")
+    }
+
+    @Test
+    fun bakedScaleGrowsTheBox() {
+        val config = GeometryConfig().apply { cube(); size(1.0); scale(2.0, 3.0, 4.0) }
+        val box = config.localCollisionShape() as Box
+        assertClose(2f, box.getSize().x, "size.x")
+        assertClose(3f, box.getSize().y, "size.y")
+        assertClose(4f, box.getSize().z, "size.z")
+    }
+
+    @Test
+    fun sphereBoundsAreASphereShape() {
+        val config = GeometryConfig().apply {
+            sphere(); radius(1.5); position(0.0, 1.0, 0.0); scale(2.0, 1.0, 1.0)
+        }
+        val sphere = config.localCollisionShape() as Sphere
+        assertClose(3f, sphere.getRadius(), "radius scaled by the max axis")
+        assertClose(1f, sphere.getCenter().y, "center.y")
+    }
+
+    @Test
+    fun cylinderBoundsSpanDiameterAndHeight() {
+        val config = GeometryConfig().apply { cylinder(); radius(0.5); height(2.0) }
+        val box = config.localCollisionShape() as Box
+        assertClose(1f, box.getSize().x, "size.x = diameter")
+        assertClose(2f, box.getSize().y, "size.y = height")
+        assertClose(1f, box.getSize().z, "size.z = diameter")
+    }
+
+    @Test
+    fun planeBoundsAreThinButHittable() {
+        val config = GeometryConfig().apply { plane(); size(4.0, 1.0, 6.0) }
+        val box = config.localCollisionShape() as Box
+        assertClose(4f, box.getSize().x, "size.x")
+        assertTrue(box.getSize().y in 1e-4f..0.1f, "plane thickness must be thin but non-zero")
+        assertClose(6f, box.getSize().z, "size.z")
+    }
+}


### PR DESCRIPTION
Part of #2024 — **P5c**, the final slice of the maintainer-approved full-P5 wave (P5a #2809 ✅ → P5b #2823 ✅ → **P5c**). Implements both maintainer decisions: **expose `sv.hitTest` in JS** and **real per-node bounds now**.

## What

- **Embind probe first (#2611)** — a new `kotlin-bundle.spec.ts` probe proves `Camera.getProjectionMatrix()` / `getModelMatrix()` are readable 16-element mat4s in-browser *before* any node code depends on them (both bindings existed with zero call sites).
- **`screenPointToRay`** (pure Kotlin, engine-free): NDC → inverse projection → perspective divide → camera model matrix → world `Ray`. The second sample sits **mid-volume** (NDC z = 0), not on the far plane — Filament renders with an infinite-far projection where NDC z = +1 is a point at infinity (`w = 0` → NaN direction). Caught live by the e2e spec, now documented in code.
- **Real per-node bounds** — `Node.collisionShape` (Android-mirror name, local-space):
  - geometry nodes: analytic shape from their config (`Sphere` for spheres, thin box for planes) — **pickable immediately**, no post-load gate;
  - model nodes: post-load asset AABB (#1597) scaled by the baked root scale (#2432);
  - splat nodes: cloud AABB at construction.
  Shapes are transformed through each node's **live `worldTransform` at hit time** (the Sceneform transform pattern) and tested via the core `SceneGraph.hitTest` (sorted nearest-first, `isVisible`/`isHittable` respected).
- **Surfaces** — Kotlin: `SceneView.hitTest(x, y)` + a world-`Ray` overload (XR controller poses). JS: `sv.hitTest(x, y) → NodeHandle[]`, returning the **same** handle instances the `add*Node` factories handed out via a new `Node → NodeHandle` registry (`===` works; entries dropped on removal).

## Tests

- 14 new jsTests: `ScreenRayTest` (incl. a project→unproject round-trip through a translated camera), `GeometryCollisionShapeTest` (5 shapes), `NodeHitTestTest` (through the real core graph: distance sort, scaled parent, non-hittable/shapeless skip, miss).
- 1 new e2e Playwright spec: cube picked under the canvas centre on the real bundle, **handle identity** (`hits[0] === cube`), corner miss.

## Verification (local, all green)

- [x] `:sceneview-web:compileKotlinJs` + `:sceneview-web:jsTest` — **252/252**
- [x] `:sceneview-web:detektJsTestSourceSet` — 0 issue (jsMain: 2 pre-existing main-branch issues, untouched, follow-up already filed)
- [x] `bash .claude/scripts/web-bundle-smoke.sh` — **7/7** (probe + e2e included)
- [x] `cd samples/web-demo && npx playwright test` — **53/53**
- [x] `llms.txt` + `gpt/knowledge-*` regenerated; `sceneview-web.d.ts`, web skill + cheatsheet updated; changelog fragment; `check-sceneview-skill.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)