### PR TITLE
fix(ios-demo): IBL sweep — 6 more PBR demo views gain .environment(.studio)

### DIFF
--- a/changelog.d/2805-ios-ibl-sweep.md
+++ b/changelog.d/2805-ios-ibl-sweep.md
@@ -1,0 +1,33 @@
+<!-- category: Fixed -->
+- **ios-demo**: 6 more demo views now render with an image-based light
+  (`.environment(.studio)`), same preset and pattern as the `ModelViewerDemo`
+  (#2114), `MaterialsDemo` and Scene Gallery/Multi-Model (#2805 predecessors):
+  `AnimationDemo` (bundled `cyberpunk_character.usdz` + streamed Sketchfab
+  characters), `GestureEditingDemo` (Ferrari F40), `AllShapesDemo`/`GeometryDemo`
+  (PBR cube + sphere — its own on-screen caption already claimed "PBR
+  materials"), `BillboardDemo` (the metallic "Treasure" sphere), `CameraControlsDemo`
+  (the central PBR cube), and `CustomMeshDemo` (the PBR pyramid + diamond built
+  from raw vertex data). Every one of these renders a metallic/rough PBR
+  surface that had nothing to reflect without an IBL. Re-measured from scratch
+  against the current repo rather than reusing an older estimate: 12 non-AR
+  demo views already carried `.environment()` before this PR, 6 more gain it
+  here, and a further set (`FogDemo`, `LightTypesDemo`, `MovableLightDemo`,
+  `TextDemo`, `ImagePlaneDemo`/`ImageDemo`, `LinesPathsDemo`) is left
+  deliberately untouched — either the neutral background is the demonstrated
+  effect itself, or the view has no PBR material to reflect anything with.
+  AR demo views are unaffected — `ARSceneView` already lights its content from
+  the real-world camera feed, so a synthetic IBL would not apply. Part of the
+  iOS/Android catalog-ISO effort (#2798). Two structural gaps were found but
+  deliberately not patched here because the one-line `.environment()` pattern
+  does not reach them (raw `RealityView` content, not the `SceneView` wrapper
+  that owns the modifier): `TextureStreamingDemo`'s visible PBR sphere lives in
+  a `RealityView` overlay entirely separate from its (empty) `SceneView`, and
+  `OcclusionMaterialDemo`'s metallic reference sphere is also built directly on
+  `RealityView`. Fixing either for real needs more than this mechanical sweep,
+  so both are left for a follow-up rather than shipping a `.environment()` call
+  that would silently do nothing. Verified: `xcodebuild` compiles clean;
+  visual QA on the iOS Simulator confirms every changed view still renders
+  without crashing, though — per the 2026-07-18 finding that RealityKit
+  degrades IBL/skybox rendering on the Simulator — the before/after captures
+  read as visually close on this host, so final visual confirmation on a
+  physical device remains an open follow-up.

--- a/changelog.d/2805-ios-ibl-sweep.md
+++ b/changelog.d/2805-ios-ibl-sweep.md
@@ -9,23 +9,28 @@
   (the central PBR cube), and `CustomMeshDemo` (the PBR pyramid + diamond built
   from raw vertex data). Every one of these renders a metallic/rough PBR
   surface that had nothing to reflect without an IBL. Re-measured from scratch
-  against the current repo rather than reusing an older estimate: 12 non-AR
-  demo views already carried `.environment()` before this PR, 6 more gain it
-  here, and a further set (`FogDemo`, `LightTypesDemo`, `MovableLightDemo`,
-  `TextDemo`, `ImagePlaneDemo`/`ImageDemo`, `LinesPathsDemo`) is left
-  deliberately untouched — either the neutral background is the demonstrated
-  effect itself, or the view has no PBR material to reflect anything with.
-  AR demo views are unaffected — `ARSceneView` already lights its content from
-  the real-world camera feed, so a synthetic IBL would not apply. Part of the
-  iOS/Android catalog-ISO effort (#2798). Two structural gaps were found but
-  deliberately not patched here because the one-line `.environment()` pattern
-  does not reach them (raw `RealityView` content, not the `SceneView` wrapper
-  that owns the modifier): `TextureStreamingDemo`'s visible PBR sphere lives in
-  a `RealityView` overlay entirely separate from its (empty) `SceneView`, and
-  `OcclusionMaterialDemo`'s metallic reference sphere is also built directly on
-  `RealityView`. Fixing either for real needs more than this mechanical sweep,
-  so both are left for a follow-up rather than shipping a `.environment()` call
-  that would silently do nothing. Verified: `xcodebuild` compiles clean;
+  against the current repo rather than reusing an older estimate — 42
+  non-registry views live under `Views/Demos/*.swift` (a 43rd file,
+  `GeneratedScenes.swift`, is an auto-generated registry, not a view): 12
+  already carried `.environment()` before this PR, 14 are AR views
+  (`ARSceneView` lights from the real camera feed, out of scope by design),
+  6 gain the fix here, 3 are confirmed carve-outs (`FogDemo`, `LightTypesDemo`,
+  `MovableLightDemo` — the neutral/single-light background is the demonstrated
+  effect itself), and 4 have no PBR material to reflect anything with
+  (`TextDemo`, `ImagePlaneDemo`/`ImageDemo`, `LinesPathsDemo`,
+  `VideoTextureDemo`) so are left deliberately untouched. The remaining 3 are
+  structural findings, not judgment calls: `.environment()` is only defined on
+  `SceneView`, so it cannot reach a raw `RealityView`. `TextureStreamingDemo`'s
+  visible PBR sphere (the demo's entire point — Gold/Silver/Copper/Ceramic/
+  Plastic/Rubber presets) lives in a `RealityView` overlay entirely separate
+  from its own (empty) `SceneView`; `OcclusionMaterialDemo`'s metallic
+  reference sphere is also built directly on `RealityView`; `DebugOverlayDemo`
+  has the same structural block but isn't a PBR showcase either way (its
+  spheres are non-metallic stress-test filler). Fixing the first two for real
+  needs more than this mechanical sweep, so all three are left for a
+  follow-up rather than shipping a `.environment()` call that would silently
+  do nothing. Part of the iOS/Android catalog-ISO effort (#2798).
+  Verified: `xcodebuild` compiles clean;
   visual QA on the iOS Simulator confirms every changed view still renders
   without crashing, though — per the 2026-07-18 finding that RealityKit
   degrades IBL/skybox rendering on the Simulator — the before/after captures

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AllShapesDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AllShapesDemo.swift
@@ -49,6 +49,12 @@ struct GeometryDemo: View {
                 }
             }
             .cameraControls(.orbit)
+            // The cube and sphere use `.pbr(metallic:roughness:)` — this
+            // demo's own caption below claims "PBR materials," but with no
+            // IBL those metallic/rough surfaces have nothing to reflect and
+            // render flat, undercutting the claim. Same `.studio` preset as
+            // ModelViewerDemo (#2114).
+            .environment(.studio)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
@@ -120,6 +120,13 @@ struct AnimationDemo: View {
                 }
                 .cameraControls(.orbit)
                 .autoRotate(speed: 0.3)
+                // Every subject here is a curated PBR model — the bundled
+                // cyberpunk_character.usdz or a streamed Sketchfab character —
+                // and a PBR surface is defined by what it reflects. With no
+                // IBL there is nothing to reflect and the carousel undersells
+                // its own subjects. Same `.studio` preset as ModelViewerDemo
+                // (#2114).
+                .environment(.studio)
                 .ignoresSafeArea()
                 .id("animation-\(selectedSubject.streamedSlug?.uid ?? selectedSubject.bundledAsset ?? "none")")
             } else {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/BillboardDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/BillboardDemo.swift
@@ -33,6 +33,11 @@ struct BillboardDemo: View {
                 root.addChild(title.entity)
             }
             .cameraControls(.orbit)
+            // The "Treasure" sphere uses a metallic/rough `.pbr()` material —
+            // meant to read as shiny and valuable — but with no IBL it has
+            // nothing to reflect and renders flat. Same `.studio` preset as
+            // ModelViewerDemo (#2114).
+            .environment(.studio)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/CameraControlsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/CameraControlsDemo.swift
@@ -69,6 +69,11 @@ struct CameraControlsDemo: View {
             }
             .cameraControls(mode)
             .recentersTargetOnOrbit(recenterOnOrbit)
+            // The central object is an explicit "orange PBR cube" (metallic
+            // 0.7, roughness 0.2) — without an IBL it has nothing to reflect
+            // and renders flat regardless of which camera mode is active.
+            // Same `.studio` preset as ModelViewerDemo (#2114).
+            .environment(.studio)
             .ignoresSafeArea()
         }
         .background(Color.black)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/CustomMeshDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/CustomMeshDemo.swift
@@ -88,6 +88,11 @@ struct CustomMeshDemo: View {
                 root.addChild(diamondLabel.entity)
             }
             .cameraControls(.orbit)
+            // Both the pyramid and the diamond use a metallic/rough `.pbr()`
+            // material — with no IBL they have nothing to reflect and render
+            // as flat silhouettes despite being built from raw PBR vertex
+            // data. Same `.studio` preset as ModelViewerDemo (#2114).
+            .environment(.studio)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
@@ -86,6 +86,11 @@ struct GestureEditingDemo: View {
         }
         // .cameraControls must precede .id — .id wraps to some View which loses the modifier.
         .cameraControls(isEditable ? .none : .orbit)
+        // The loaded subject is the bundled Ferrari F40 — a PBR USDZ with
+        // metallic paint — and with no IBL it has nothing to reflect while
+        // the user drags/pinches/rotates it. Same `.studio` preset as
+        // ModelViewerDemo (#2114); must also precede .id (see above).
+        .environment(.studio)
         // Don't include isEditable in the id — camera mode changes without scene rebuild.
         .id("gesture-\(loadedModel != nil)")
         .ignoresSafeArea()


### PR DESCRIPTION
## Summary

Closes #2805. Part of #2798.

Same defect class already fixed for `MaterialsDemo`/`ModelViewerDemo`/Scene
Gallery/Multi-Model (`c77404ea7`, `406095bea`): a PBR surface is defined by
what it reflects, and with no IBL a metallic/rough model has nothing to
reflect and looks flat.

## Re-measured from scratch (do not trust either prior figure)

Neither the original plan's "31/43 views without IBL" nor `406095bea`'s "12
of 26 non-AR demos" figure was reused — both are snapshots in time. I read
every file under `samples/ios-demo/SceneViewDemo/Views/Demos/*.swift`
directly: **43 files total, of which `GeneratedScenes.swift` is an
auto-generated registry (`DO NOT EDIT` header), not a view — 42 actual demo
views.** Full reconciliation:

| Bucket | Count | Views |
|---|---|---|
| Already had `.environment()` | 12 | `MaterialsDemo`, `ModelViewerDemo`, `SceneGalleryDemo`, `MultiModelDemo`, `PhysicsDemo`, `CollisionHitTestDemo`, `DoublePendulumDemo`, `ShapeExtrudeDemo`, `SpatialAudioDemo`, `DynamicSkyDemo`, `EnvironmentDemo`, `ReflectionProbesDemo` |
| AR views (out of scope — real camera lighting) | 14 | the 12 `AR*Demo` files + `OrbitalARDemo` + `RerunDebugDemo` |
| **Fixed in this PR** | **6** | see table below |
| Confirmed carve-outs | 3 | `FogDemo`, `LightTypesDemo`, `MovableLightDemo` |
| No PBR subject | 4 | `TextDemo`, `ImagePlaneDemo`/`ImageDemo`, `LinesPathsDemo`, `VideoTextureDemo` |
| Structural blocker (raw `RealityView`, not `SceneView`) | 3 | `TextureStreamingDemo`, `OcclusionMaterialDemo`, `DebugOverlayDemo` |
| **Total** | **42** | |

(An earlier revision of this PR description undercounted the last two
buckets by one each — `VideoTextureDemo` and `DebugOverlayDemo` were
findings I'd made but hadn't rolled into the stated totals. Fixed in a
follow-up commit; no code changed, only the reconciliation.)

### Changed (6) — `.environment(.studio)` added

| View | Why it qualifies |
|---|---|
| `AnimationDemo.swift` | Bundled `cyberpunk_character.usdz` + streamed Sketchfab characters — the issue's own flagged "clearest remaining case" |
| `GestureEditingDemo.swift` | Loads the Ferrari F40, commented in-file as "bundled PBR USDZ, looks great when scaled/rotated" |
| `AllShapesDemo.swift` (`struct GeometryDemo`) | Cube + sphere use `.pbr(metallic:roughness:)`; the demo's own on-screen caption already says *"5 built-in geometry types with **PBR materials**"* |
| `BillboardDemo.swift` | The "Treasure" sphere is `.pbr(metallic: 0.9, roughness: 0.1)` — meant to read as shiny/valuable |
| `CameraControlsDemo.swift` | Sole visual subject is an explicit "orange PBR cube" (metallic 0.7, roughness 0.2) |
| `CustomMeshDemo.swift` | Both the pyramid and diamond (raw vertex data) use high-metallic `.pbr()` materials |

Comment style and modifier placement follow `406095bea`/`c77404ea7` exactly —
`.environment(.studio)` inserted right after `.cameraControls()`/`.autoRotate()`
and *before* `.id()`/`.ignoresSafeArea()`, since those return `some View` and
lose the `SceneView`-specific modifier (an existing comment in
`GestureEditingDemo.swift` already documents this ordering constraint).

### Confirmed carve-outs (3) — deliberately untouched, same reasoning as `406095bea`

`FogDemo`, `LightTypesDemo`, `MovableLightDemo` — each isolates a specific
lighting effect (fog density/mode, one light type, one orbiting point light)
that an ambient IBL would compete with or wash out. Notably,
`MovableLightDemo` already loads the *same* `ferrari_f40` PBR model as
`GestureEditingDemo`, but its whole point is watching one specular highlight
track a dragged light — exactly the effect an IBL would blur. This
confirms "carve-out" is about pedagogical intent, not simply "does it load a
PBR model."

### No PBR subject (4) — left alone

`TextDemo` (3D text + plain-color primitives, no `.pbr()` anywhere),
`ImagePlaneDemo`/`struct ImageDemo` (flat solid-color image planes),
`LinesPathsDemo` (lines/paths/grid; the only `.pbr()`-tagged elements are
decorative ~1.2 cm helix dots, not a showcased surface), `VideoTextureDemo`
(plain-color floor/wall planes + a video texture plane, no `.pbr()` anywhere).

### Structural findings (3) — NOT patched here, flagged for follow-up

`.environment()` is defined only on `SceneView` (`SceneView.swift:168`,
returns `SceneView`) — it cannot be called on a raw `RealityView`.

- **`TextureStreamingDemo.swift`** — this demo's entire purpose is a PBR
  material showcase (Gold/Silver/Copper/Ceramic/Plastic/Rubber
  metallic/roughness presets), but the visible sphere is rendered inside a
  `RealityView` `.overlay()`, completely separate from the file's own
  (empty/decorative) `SceneView`. Calling `.environment(.studio)` on that
  `SceneView` would compile and change nothing visible — I chose not to ship
  a fix that looks real but is a no-op. A real fix needs either moving the
  sphere into the `SceneView` content closure or manually wiring
  `ImageBasedLightComponent`/`ImageBasedLightReceiverComponent` onto the
  `RealityView`'s entities — out of scope for a mechanical pattern sweep.
- **`OcclusionMaterialDemo.swift`** — its reference sphere is a genuine PBR
  material (metallic 0.8, roughness 0.3) but is also built directly on
  `RealityView`, same structural blocker.
- **`DebugOverlayDemo.swift`** — same structural blocker (raw `RealityView`),
  but its spheres are non-metallic `SimpleMaterial` stress-test filler, not a
  PBR showcase, so it isn't a real gap either way — listed here for
  completeness of the reconciliation, not as a missed fix.

I filed a follow-up task for the first two (the genuine PBR gaps blocked by
this structural issue) rather than leaving them only implicit in this PR
description.

## Build

`xcodebuild` (scheme `SceneViewDemo`, iOS Simulator) — **SUCCEEDED**, two
runs: initial 47.8s, final incremental re-verification after restoring from
a temporary stash 6.8s. Zero errors, one pre-existing unrelated warning
(`SketchfabService.swift:363`, Sendable mutability — not touched by this PR).

## Visual QA (iOS Simulator, before/after)

Captured before/after screenshots for the 5 most-affected views (Animation,
GestureEditing, AllShapes/Geometry, CustomMesh, CameraControls) by stashing
the fix, rebuilding, capturing, then popping the stash and rebuilding again.
Every view renders correctly with no crash in both states.

**Important caveat, stated honestly rather than glossed over:** per the
2026-07-18 cross-session finding, RealityKit degrades IBL/skybox rendering
specifically on the iOS **Simulator**. Consistent with that, the before/after
capture pairs read as visually close on this host — this does not mean the
fix is inert, it means the Simulator is known to undersell IBL. This PR
verifies the fix is *structurally* correct (compiles, `.environment()` is
actually applied, nothing crashes) — final fine-grained visual confirmation
on a physical device is an open follow-up, not something this PR claims to
have proven.

## Test plan

- [x] `xcodebuild build` (SceneViewDemo scheme, iOS Simulator) — compiles clean
- [x] Re-measured the real list of PBR-showcasing views without IBL from source, not from either prior estimate (42 views fully reconciled, see table above)
- [x] Applied `.environment(.studio)` to the 6 confirmed views, following the exact `406095bea`/`c77404ea7` pattern (placement + comment style)
- [x] Left carve-outs (Fog/LightTypes/MovableLight) and no-PBR views (Text/ImagePlane/LinesPaths/VideoTexture) untouched, with reasoning recorded here and in the changelog fragment
- [x] Flagged 3 structurally-blocked views (TextureStreamingDemo, OcclusionMaterialDemo, DebugOverlayDemo) instead of shipping a no-op `.environment()` call
- [x] Visual QA before/after on the 5 most-affected views — no crashes, simulator IBL-degradation caveat noted honestly
- [x] Changelog fragment `changelog.d/2805-ios-ibl-sweep.md` (`<!-- category: Fixed -->`)
- [ ] Physical-device visual confirmation (open follow-up, tracked in #2798)

🤖 Generated with [Claude Code](https://claude.com/claude-code)