### PR TITLE
test(ios-demo): registry/deep-link guard suite + parity-manifest.yml + register orphaned tests

### DIFF
--- a/.claude/scripts/check-demo-id-parity.sh
+++ b/.claude/scripts/check-demo-id-parity.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# check-demo-id-parity.sh — Android <-> iOS demo-catalog parity gate (#2801,
+# part of the iOS-parity tracker #2798).
+#
+# Compares three surfaces:
+#   1. Android's canonical demo ids — read directly from each
+#      `*Fragment.kt`'s `id = "..."` under
+#      `samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/`
+#      (the same field `collate-demos.sh` itself parses; `GeneratedDemos.kt`'s
+#      TEXT only lists Kotlin object names, not id strings, so it can't be
+#      grepped directly — this script also RUNS collate-demos.sh --kt-only
+#      first, purely so its own duplicate-id / missing-directive validation
+#      still gates this check even when it runs before the Android Gradle
+#      build does).
+#   2. iOS's registry — `GeneratedScenes.allowedIds` (regenerated fresh via
+#      `collate-ios-demos.sh`, the same collator the Xcode build phase runs)
+#      unioned with the hand-maintained `legacyAliases` / `residualIds` read
+#      directly from `DemoDeepLinkRegistry.swift`.
+#   3. `parity-manifest.yml` — the committed ledger of expected iOS status
+#      per Android id (working / stub / android-only).
+#
+# Exit non-zero when:
+#   - an Android id has NEITHER an iOS registry entry NOR a manifest row
+#     (the #2769 drift class: a demo silently invisible to iOS)
+#   - a manifest row's `id` is no longer a live Android id (stale entry)
+#   - a live Android id has no manifest row at all
+#   - a manifest row claims `iosStatus: working` but iOS does not actually
+#     resolve that id to a real (non-placeholder) destination
+#   - a manifest row claims `iosStatus: android-only` but the id IS actually
+#     present in iOS's `allowedIds` today (stale — promote it to `stub` or
+#     `working`)
+#   - a manifest row claims `iosStatus: stub` but the id isn't in iOS's
+#     `allowedIds` at all (demoted without updating the manifest)
+#
+# Usage:
+#   bash .claude/scripts/check-demo-id-parity.sh
+#
+# Testability seams (mirrors check-doc-drift.sh's DOC_DRIFT_FILES pattern) —
+# used by test-check-demo-id-parity.sh so the self-test never depends on the
+# real working tree:
+#   PARITY_ANDROID_FRAG_DIR   override the Android fragments directory
+#   PARITY_IOS_REGISTRY       override DemoDeepLinkRegistry.swift's path
+#   PARITY_IOS_GENERATED      override GeneratedScenes.swift's path (implies
+#                             skipping the real collate-ios-demos.sh run —
+#                             the fixture supplies pre-generated content)
+#   PARITY_MANIFEST           override parity-manifest.yml's path
+#   PARITY_SKIP_ANDROID_COLLATE=1   skip running collate-demos.sh
+#   PARITY_SKIP_IOS_COLLATE=1       skip running collate-ios-demos.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+ANDROID_FRAG_DIR="${PARITY_ANDROID_FRAG_DIR:-$REPO_ROOT/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments}"
+IOS_REGISTRY="${PARITY_IOS_REGISTRY:-$REPO_ROOT/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift}"
+IOS_GENERATED="${PARITY_IOS_GENERATED:-$REPO_ROOT/samples/ios-demo/SceneViewDemo/Views/Demos/GeneratedScenes.swift}"
+MANIFEST="${PARITY_MANIFEST:-$REPO_ROOT/parity-manifest.yml}"
+
+[ -d "$ANDROID_FRAG_DIR" ] || { echo "Error: Android fragments dir not found: $ANDROID_FRAG_DIR" >&2; exit 1; }
+[ -f "$IOS_REGISTRY" ] || { echo "Error: iOS registry not found: $IOS_REGISTRY" >&2; exit 1; }
+[ -f "$MANIFEST" ] || { echo "Error: manifest not found: $MANIFEST" >&2; exit 1; }
+
+# ─── 1. Regenerate + validate the Android collator (dup ids / missing
+#     directives fail loudly here too, independent of the Gradle build) ────
+if [ "${PARITY_SKIP_ANDROID_COLLATE:-0}" != "1" ]; then
+    bash "$REPO_ROOT/samples/android-demo/scripts/collate-demos.sh" --kt-only >/dev/null
+fi
+
+# NOTE on `grep` + `set -o pipefail`: `grep -oE PATTERN` exits 1 when it
+# finds no match — a perfectly legitimate outcome here (e.g. an empty
+# `residualIds` list once every residual id is ported). Under `pipefail`
+# that would abort the whole script via `set -e` even though "zero matches"
+# is a valid, expected result, not an error. Every extraction below that
+# could legitimately match nothing is wrapped `(grep ... || true)` so a
+# real "no match" only ever produces empty output, never a false crash.
+
+# ─── 2. Android canonical ids — same field collate-demos.sh parses ────────
+ANDROID_IDS_FILE="$(mktemp)"
+for f in "$ANDROID_FRAG_DIR"/*Fragment.kt; do
+    base="$(basename "$f")"
+    [ "$base" = "DemoFragment.kt" ] && continue
+    id=$( (grep -oE 'id[[:space:]]*=[[:space:]]*"[a-z0-9-]+"' "$f" || true) | head -n1 \
+        | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"')
+    if [ -z "$id" ]; then
+        echo "Error: $f has no 'id = \"<demo-id>\"' on its DemoEntry." >&2
+        exit 1
+    fi
+    printf '%s\n' "$id"
+done | sort -u > "$ANDROID_IDS_FILE"
+
+# ─── 3. Regenerate iOS's GeneratedScenes.swift (unless a fixture overrides it) ──
+if [ "${PARITY_SKIP_IOS_COLLATE:-0}" != "1" ] && [ -z "${PARITY_IOS_GENERATED:-}" ]; then
+    bash "$REPO_ROOT/samples/ios-demo/scripts/collate-ios-demos.sh" >/dev/null
+fi
+[ -f "$IOS_GENERATED" ] || { echo "Error: iOS generated registry not found: $IOS_GENERATED (build the iOS collator first)" >&2; exit 1; }
+
+# ─── 4. iOS generated ids + "real" (non-placeholder) ids ──────────────────
+IOS_GENERATED_IDS_FILE="$(mktemp)"
+awk '/static let allowedIds: Set<String> = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_GENERATED" \
+    | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"' | sort -u > "$IOS_GENERATED_IDS_FILE"
+
+IOS_REAL_IDS_FILE="$(mktemp)"
+awk '/static func destination\(for id: String\) -> AnyView\? \{/{f=1} f && /default: return nil/{f=0} f' "$IOS_GENERATED" \
+    | { grep -oE 'case "[a-z0-9-]+"' || true; } | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"' | sort -u > "$IOS_REAL_IDS_FILE"
+
+[ -s "$IOS_GENERATED_IDS_FILE" ] || { echo "Error: no ids parsed from $IOS_GENERATED — collator output shape changed?" >&2; exit 1; }
+
+# ─── 5. iOS hand-maintained legacyAliases (key\tvalue) + residualIds ──────
+# (legacyAliases is expected to be small but non-empty in practice; residualIds
+# is EXPECTED to shrink toward empty over time as L0.6 ports each id — so it
+# especially must not crash the script when it eventually reaches zero.)
+IOS_ALIASES_FILE="$(mktemp)"
+awk '/static let legacyAliases: \[String: String\] = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
+    > "$IOS_ALIASES_FILE.raw"
+: > "$IOS_ALIASES_FILE"
+while IFS= read -r line; do
+    key=$(printf '%s\n' "$line" | { grep -oE '"[a-z0-9-]+"' || true; } | sed -n '1p' | tr -d '"')
+    val=$(printf '%s\n' "$line" | { grep -oE '"[a-z0-9-]+"' || true; } | sed -n '2p' | tr -d '"')
+    [ -n "$key" ] && [ -n "$val" ] && printf '%s\t%s\n' "$key" "$val" >> "$IOS_ALIASES_FILE"
+done < "$IOS_ALIASES_FILE.raw"
+rm -f "$IOS_ALIASES_FILE.raw"
+
+IOS_RESIDUAL_FILE="$(mktemp)"
+awk '/static let residualIds: Set<String> = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
+    | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"' | sort -u > "$IOS_RESIDUAL_FILE"
+
+# ─── 6. Hand everything to Python for the structured comparison + YAML ────
+# (PyYAML is already asserted present in the repo-hygiene job before this
+# step runs — see ci.yml's "Install dash + shellcheck" step.)
+PYTHONPATH="" python3 - "$ANDROID_IDS_FILE" "$IOS_GENERATED_IDS_FILE" "$IOS_REAL_IDS_FILE" "$IOS_ALIASES_FILE" "$IOS_RESIDUAL_FILE" "$MANIFEST" <<'PYEOF'
+import sys
+import yaml
+
+android_ids_file, ios_gen_file, ios_real_file, ios_alias_file, ios_residual_file, manifest_file = sys.argv[1:7]
+
+def load_set(path):
+    with open(path) as f:
+        return set(l.strip() for l in f if l.strip())
+
+android_ids = load_set(android_ids_file)
+ios_generated = load_set(ios_gen_file)
+ios_real = load_set(ios_real_file)
+ios_residual = load_set(ios_residual_file)
+
+ios_aliases = {}
+with open(ios_alias_file) as f:
+    for line in f:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        k, v = line.split("\t")
+        ios_aliases[k] = v
+
+ios_allowed = ios_generated | set(ios_aliases.keys()) | ios_residual
+
+def ios_is_real(demo_id):
+    """True iff `demo_id` resolves to a real (non-placeholder) destination
+    through DemoDeepLinkRegistry's actual resolution order: generated id,
+    then legacy-alias indirection."""
+    if demo_id in ios_real:
+        return True
+    canonical = ios_aliases.get(demo_id)
+    if canonical is not None:
+        return canonical in ios_real
+    return False
+
+with open(manifest_file) as f:
+    manifest_data = yaml.safe_load(f) or {}
+manifest_rows = manifest_data.get("demos", [])
+
+errors = []
+warnings = []
+
+manifest_by_id = {}
+for row in manifest_rows:
+    row_id = row.get("id")
+    if not row_id:
+        errors.append("manifest has a row with no 'id'")
+        continue
+    if row_id in manifest_by_id:
+        errors.append(f"manifest has a duplicate row for id '{row_id}'")
+    manifest_by_id[row_id] = row
+
+VALID_STATUSES = {"working", "stub", "android-only"}
+for row_id, row in manifest_by_id.items():
+    status = row.get("iosStatus")
+    if status not in VALID_STATUSES:
+        errors.append(f"manifest row '{row_id}' has invalid iosStatus '{status}' "
+                       f"(must be one of {sorted(VALID_STATUSES)})")
+    if status and status != "working" and not str(row.get("reason", "")).strip():
+        errors.append(f"manifest row '{row_id}' has iosStatus '{status}' but no 'reason'")
+
+# ─── The core gate: every Android id is accounted for ─────────────────────
+for demo_id in sorted(android_ids):
+    in_ios = demo_id in ios_allowed
+    in_manifest = demo_id in manifest_by_id
+    if not in_ios and not in_manifest:
+        errors.append(
+            f"Android demo '{demo_id}' has NEITHER an iOS registry entry NOR a "
+            f"parity-manifest.yml row — this is the #2769 drift class (a demo "
+            f"silently invisible to iOS). Add a matching iOS Scene/residual id, "
+            f"or declare it in parity-manifest.yml as 'stub'/'android-only'."
+        )
+        continue
+    if not in_manifest:
+        errors.append(
+            f"Android demo '{demo_id}' is in iOS's allowedIds but has no "
+            f"parity-manifest.yml row. Every current Android id needs a row "
+            f"(#2801 done-criteria: one entry per Android canonical id)."
+        )
+        continue
+
+    row = manifest_by_id[demo_id]
+    declared = row.get("iosStatus")
+    if declared == "working":
+        if not in_ios or not ios_is_real(demo_id):
+            errors.append(
+                f"manifest declares '{demo_id}' as iosStatus: working, but iOS "
+                f"does not actually resolve it to a real destination today "
+                f"(it may still be a placeholder, or missing from allowedIds)."
+            )
+    elif declared == "stub":
+        if not in_ios:
+            errors.append(
+                f"manifest declares '{demo_id}' as iosStatus: stub, but the id "
+                f"is not in iOS's allowedIds at all — either it was removed "
+                f"(demote the manifest row to 'android-only') or the registry "
+                f"regressed."
+            )
+        elif ios_is_real(demo_id):
+            warnings.append(
+                f"manifest declares '{demo_id}' as iosStatus: stub, but iOS now "
+                f"resolves it to a REAL destination — promote the manifest row "
+                f"to 'working' (great news, a port landed)."
+            )
+    elif declared == "android-only":
+        if in_ios:
+            errors.append(
+                f"manifest declares '{demo_id}' as iosStatus: android-only, but "
+                f"the id IS present in iOS's allowedIds today — promote the "
+                f"manifest row to 'stub' or 'working'."
+            )
+
+# ─── Manifest rows that no longer correspond to a live Android id ─────────
+stale_rows = sorted(set(manifest_by_id.keys()) - android_ids)
+for row_id in stale_rows:
+    errors.append(
+        f"parity-manifest.yml row '{row_id}' is not a current Android canonical "
+        f"id (renamed, removed, or a typo) — remove or fix the row."
+    )
+
+# ─── Report ────────────────────────────────────────────────────────────────
+print(f"Android canonical ids: {len(android_ids)}")
+print(f"iOS allowedIds:        {len(ios_allowed)}  "
+      f"(generated={len(ios_generated)} aliases={len(ios_aliases)} residual={len(ios_residual)})")
+print(f"parity-manifest.yml:   {len(manifest_rows)} rows")
+
+if warnings:
+    print(f"\n{len(warnings)} warning(s) (non-blocking):")
+    for w in warnings:
+        print(f"  WARN: {w}")
+
+if errors:
+    print(f"\n{len(errors)} error(s):")
+    for e in errors:
+        print(f"  FAIL: {e}")
+    print("\ncheck-demo-id-parity.sh: FAILED")
+    sys.exit(1)
+
+print("\ncheck-demo-id-parity.sh: OK — every Android demo id is accounted for "
+      "(iOS registry or parity-manifest.yml), and every manifest row matches "
+      "iOS's live state.")
+PYEOF

--- a/.claude/scripts/check-demo-id-parity.sh
+++ b/.claude/scripts/check-demo-id-parity.sh
@@ -95,9 +95,26 @@ if [ "${PARITY_SKIP_IOS_COLLATE:-0}" != "1" ] && [ -z "${PARITY_IOS_GENERATED:-}
 fi
 [ -f "$IOS_GENERATED" ] || { echo "Error: iOS generated registry not found: $IOS_GENERATED (build the iOS collator first)" >&2; exit 1; }
 
+# Single-line-array guard on the block extractors below (reviewer catch on
+# PR #2830). Each `awk '/…= \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f'`
+# state machine has a latent bug: if the source array is written on ONE line
+# (`… = []` for a Set, `… = [:]` for a dictionary), the opening rule sets
+# `f=1; next` and skips the line, but the closing `]` was ON that skipped
+# line — so `f` never resets and the extractor slurps quoted ids from
+# UNRELATED arrays further down the file into this id set (a false positive
+# on this BLOCKING gate). It is harmless today only by luck; `residualIds`
+# shrinks toward `[]` as L0.6 (#2804) ports each residual id to a real
+# screen, which would trip it. The fix: in the opening rule, strip the line
+# up to and including the assignment `= [`, then if the remainder still holds
+# a `]` the whole literal is single-line → `print` it (so a non-empty
+# single-line array still yields its ids) and `next` WITHOUT entering
+# multi-line mode. Stripping up to `= [` first is what makes this correct for
+# `legacyAliases`, whose `[String: String]` TYPE annotation also contains a
+# `]` that a naive whole-line `~ /\]/` test would misread as a closing.
+
 # ─── 4. iOS generated ids + "real" (non-placeholder) ids ──────────────────
 IOS_GENERATED_IDS_FILE="$(mktemp)"
-awk '/static let allowedIds: Set<String> = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_GENERATED" \
+awk '/static let allowedIds: Set<String> = \[/{ rest=$0; sub(/^.*= \[/,"",rest); if (rest ~ /\]/) { print; next } f=1; next } f && /^[[:space:]]*\]/{f=0} f' "$IOS_GENERATED" \
     | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"' | sort -u > "$IOS_GENERATED_IDS_FILE"
 
 IOS_REAL_IDS_FILE="$(mktemp)"
@@ -111,7 +128,7 @@ awk '/static func destination\(for id: String\) -> AnyView\? \{/{f=1} f && /defa
 # is EXPECTED to shrink toward empty over time as L0.6 ports each id — so it
 # especially must not crash the script when it eventually reaches zero.)
 IOS_ALIASES_FILE="$(mktemp)"
-awk '/static let legacyAliases: \[String: String\] = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
+awk '/static let legacyAliases: \[String: String\] = \[/{ rest=$0; sub(/^.*= \[/,"",rest); if (rest ~ /\]/) { print; next } f=1; next } f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
     > "$IOS_ALIASES_FILE.raw"
 : > "$IOS_ALIASES_FILE"
 while IFS= read -r line; do
@@ -122,7 +139,7 @@ done < "$IOS_ALIASES_FILE.raw"
 rm -f "$IOS_ALIASES_FILE.raw"
 
 IOS_RESIDUAL_FILE="$(mktemp)"
-awk '/static let residualIds: Set<String> = \[/{f=1;next} f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
+awk '/static let residualIds: Set<String> = \[/{ rest=$0; sub(/^.*= \[/,"",rest); if (rest ~ /\]/) { print; next } f=1; next } f && /^[[:space:]]*\]/{f=0} f' "$IOS_REGISTRY" \
     | { grep -oE '"[a-z0-9-]+"' || true; } | tr -d '"' | sort -u > "$IOS_RESIDUAL_FILE"
 
 # ─── 6. Hand everything to Python for the structured comparison + YAML ────

--- a/.claude/scripts/test-check-demo-id-parity.sh
+++ b/.claude/scripts/test-check-demo-id-parity.sh
@@ -251,6 +251,87 @@ run
     && ok "id resolved as working (alias-target realness path exercised) → PASS" \
     || bad "alias-target realness path should still PASS (rc=$RC): $OUT"
 
+# ─── 10. Collapsed single-line residualIds (`= []`) must not leak ─────────
+# Regression for the awk block-extractor leak (reviewer catch on PR #2830):
+# a `residualIds` written on ONE line as `= []` used to leave the awk state
+# machine "open", slurping quoted ids from an UNRELATED array further down
+# the registry into the residual set — inflating allowedIds and
+# false-failing the BLOCKING gate. L0.6 (#2804) shrinks residualIds toward
+# [] as it ports each id, so this MUST be correct before then. The
+# write_ios_registry helper only ever emits multi-line arrays (the gap that
+# let the bug through), so this case writes the registry by hand: a collapsed
+# residualIds followed by a decoy array whose id (`future-demo`) leaks into
+# allowedIds WITHOUT the fix and there collides with its `android-only`
+# manifest row. Asserts PASS; without the fix this fixture FAILS.
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "future-demo" "Future"
+write_ios_generated "model-viewer" ""
+cat > "$SCRATCH/DemoDeepLinkRegistry.swift" <<'EOF'
+enum DemoDeepLinkRegistry {
+    static let legacyAliases: [String: String] = [
+    ]
+    static let residualIds: Set<String> = []
+    static let unrelatedIds: Set<String> = [
+        "future-demo",
+    ]
+}
+EOF
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: future-demo
+    androidStatus: Working
+    iosStatus: android-only
+    reason: "not yet ported"
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "collapsed single-line residualIds (= []) does not leak an unrelated id → PASS" \
+    || bad "collapsed single-line residualIds must not leak (rc=$RC): $OUT"
+
+# ─── 11. Collapsed single-line legacyAliases (`= [:]`) must not leak ──────
+# Same class as case 10, but for the DICTIONARY extractor — and it also pins
+# the trickiest part of the fix: `legacyAliases`'s `[String: String]` TYPE
+# annotation itself contains a `]`, so a naive "does the opening line contain
+# a `]`" guard would misclassify the NORMAL multi-line opening as single-line
+# and break every multi-line alias table (see case 9). The fix strips the
+# line up to the assignment `= [` first, so only a `]` AFTER the opener counts.
+# Here legacyAliases is collapsed to `= [:]`, followed by a decoy DICTIONARY
+# whose two-quotes-on-a-line entry would be slurped as a spurious alias key
+# (`spoof-key`) WITHOUT the fix, leaking it into allowedIds and colliding with
+# its `android-only` manifest row. Asserts PASS; without the fix this FAILS.
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "spoof-key" "Spoof"
+write_ios_generated "model-viewer" ""
+cat > "$SCRATCH/DemoDeepLinkRegistry.swift" <<'EOF'
+enum DemoDeepLinkRegistry {
+    static let legacyAliases: [String: String] = [:]
+    static let someOtherMap: [String: String] = [
+        "spoof-key": "spoof-target",
+    ]
+    static let residualIds: Set<String> = [
+    ]
+}
+EOF
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: spoof-key
+    androidStatus: Working
+    iosStatus: android-only
+    reason: "not yet ported"
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "collapsed single-line legacyAliases (= [:]) does not leak, multi-line still works → PASS" \
+    || bad "collapsed single-line legacyAliases must not leak (rc=$RC): $OUT"
+
 # ─── Summary ───────────────────────────────────────────────────────────────
 echo ""
 echo "test-check-demo-id-parity.sh: $PASS passed, $FAIL failed"

--- a/.claude/scripts/test-check-demo-id-parity.sh
+++ b/.claude/scripts/test-check-demo-id-parity.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+#
+# test-check-demo-id-parity.sh — self-test for check-demo-id-parity.sh (#2801).
+#
+# A regressed parity gate that silently PASSes is worse than none — it gives
+# a false sense of coverage on the exact drift class (#2769) it exists to
+# prevent. This pins the gate's contract in a fully isolated scratch
+# directory (never the real repo tree) via the PARITY_* env-var injection
+# seams, same self-test-first discipline as test-check-doc-drift.sh /
+# test-web-dts.sh / test-store-preflight.sh in `repo-hygiene`.
+
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$ROOT/.claude/scripts/check-demo-id-parity.sh"
+PASS=0; FAIL=0
+
+ok()  { printf '  ✓ %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+echo "test-check-demo-id-parity.sh"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FRAG_DIR="$SCRATCH/fragments"
+mkdir -p "$FRAG_DIR"
+
+# Minimal fixtures matching only the fields check-demo-id-parity.sh itself
+# greps for — not real, compilable Kotlin/Swift (PARITY_SKIP_*_COLLATE=1
+# means the real collate-*.sh scripts never run against these).
+write_fragment() { # id -> writes a *Fragment.kt with that id
+    local id="$1" name="$2"
+    cat > "$FRAG_DIR/${name}Fragment.kt" <<EOF
+object ${name}Fragment : DemoFragment {
+    override val entry: DemoEntry = DemoEntry(
+        id = "$id",
+        category = DemoCategory.BASICS_3D,
+    )
+}
+EOF
+}
+
+write_ios_generated() { # writes a GeneratedScenes.swift-shaped fixture
+    # $1 = space-separated "real" ids (in both allowedIds and the switch)
+    # $2 = space-separated "coming-soon" ids (in allowedIds, NOT in the switch)
+    local real_ids="$1" comingsoon_ids="$2"
+    {
+        echo "enum GeneratedScenes {"
+        echo "    static let allowedIds: Set<String> = ["
+        for id in $real_ids $comingsoon_ids; do echo "        \"$id\","; done
+        echo "    ]"
+        echo "    static func destination(for id: String) -> AnyView? {"
+        echo "        switch id {"
+        for id in $real_ids; do echo "        case \"$id\": return SomeScene.destination"; done
+        echo "        default: return nil"
+        echo "        }"
+        echo "    }"
+        echo "}"
+    } > "$SCRATCH/GeneratedScenes.swift"
+}
+
+write_ios_registry() { # writes a DemoDeepLinkRegistry.swift-shaped fixture
+    # $1 = space-separated "key=value" alias pairs (may be empty)
+    # $2 = space-separated residual ids (may be empty)
+    local aliases="$1" residual="$2"
+    {
+        echo "enum DemoDeepLinkRegistry {"
+        echo "    static let legacyAliases: [String: String] = ["
+        for pair in $aliases; do
+            key="${pair%%=*}"; val="${pair#*=}"
+            echo "        \"$key\": \"$val\","
+        done
+        echo "    ]"
+        echo "    static let residualIds: Set<String> = ["
+        for id in $residual; do echo "        \"$id\","; done
+        echo "    ]"
+        echo "}"
+    } > "$SCRATCH/DemoDeepLinkRegistry.swift"
+}
+
+write_manifest() { # writes parity-manifest.yml from stdin (heredoc body)
+    cat > "$SCRATCH/parity-manifest.yml"
+}
+
+run() { # -> sets OUT, RC
+    set +e
+    OUT="$(
+        PARITY_ANDROID_FRAG_DIR="$FRAG_DIR" \
+        PARITY_IOS_REGISTRY="$SCRATCH/DemoDeepLinkRegistry.swift" \
+        PARITY_IOS_GENERATED="$SCRATCH/GeneratedScenes.swift" \
+        PARITY_MANIFEST="$SCRATCH/parity-manifest.yml" \
+        PARITY_SKIP_ANDROID_COLLATE=1 \
+        PARITY_SKIP_IOS_COLLATE=1 \
+        bash "$SCRIPT" 2>&1
+    )"; RC=$?
+    set -e
+}
+
+# ─── 1. Happy path: one working id, correctly declared → PASS ────────────
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_ios_generated "model-viewer" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "matching working id → PASS" \
+    || bad "matching working id should PASS (rc=$RC): $OUT"
+
+# ─── 2. The #2769 drift class: new Android id, no iOS entry, no manifest row ──
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "brand-new-demo" "BrandNew"
+write_ios_generated "model-viewer" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "NEITHER an iOS registry entry NOR a parity-manifest.yml row" <<<"$OUT" \
+    && grep -q "brand-new-demo" <<<"$OUT"; } \
+    && ok "undeclared new Android id → FAIL (the #2769 drift class)" \
+    || bad "undeclared new Android id should FAIL (rc=$RC): $OUT"
+
+# ─── 3. Android id present in iOS registry, but manifest doesn't mention it ──
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "ported-demo" "Ported"
+write_ios_generated "model-viewer ported-demo" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "no parity-manifest.yml row" <<<"$OUT" && grep -q "ported-demo" <<<"$OUT"; } \
+    && ok "id in iOS registry but missing manifest row → FAIL" \
+    || bad "id in iOS registry but missing manifest row should FAIL (rc=$RC): $OUT"
+
+# ─── 4. Manifest overclaims 'working' for a coming-soon (non-real) id ────
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "stub-demo" "Stub"
+write_ios_generated "" "stub-demo"
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: stub-demo
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "does not actually resolve it to a real destination" <<<"$OUT"; } \
+    && ok "manifest overclaims 'working' for a placeholder id → FAIL" \
+    || bad "overclaimed 'working' should FAIL (rc=$RC): $OUT"
+
+# ─── 5. Manifest correctly declares 'stub' for a coming-soon id → PASS ───
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "stub-demo" "Stub"
+write_ios_generated "" "stub-demo"
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: stub-demo
+    androidStatus: Working
+    iosStatus: stub
+    reason: "not yet ported"
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "correctly-declared stub id → PASS" \
+    || bad "correctly-declared stub id should PASS (rc=$RC): $OUT"
+
+# ─── 6. Manifest says 'android-only' but the id IS in iOS's allowedIds (stale) ──
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "now-ported" "NowPorted"
+write_ios_generated "now-ported" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: now-ported
+    androidStatus: Working
+    iosStatus: android-only
+    reason: "not yet ported"
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "IS present in iOS's allowedIds today" <<<"$OUT"; } \
+    && ok "stale 'android-only' row (id now in iOS registry) → FAIL" \
+    || bad "stale 'android-only' row should FAIL (rc=$RC): $OUT"
+
+# ─── 7. Manifest row for an id that's no longer a live Android id ────────
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_ios_generated "model-viewer" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: renamed-away-demo
+    androidStatus: Working
+    iosStatus: android-only
+    reason: "stale"
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "is not a current Android canonical id" <<<"$OUT" \
+    && grep -q "renamed-away-demo" <<<"$OUT"; } \
+    && ok "stale manifest row (id no longer on Android) → FAIL" \
+    || bad "stale manifest row should FAIL (rc=$RC): $OUT"
+
+# ─── 8. Non-working row missing a 'reason' → FAIL ─────────────────────────
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "stub-demo" "Stub"
+write_ios_generated "" "stub-demo"
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  - id: stub-demo
+    androidStatus: Working
+    iosStatus: stub
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "no 'reason'" <<<"$OUT"; } \
+    && ok "non-working row without a reason → FAIL" \
+    || bad "non-working row without a reason should FAIL (rc=$RC): $OUT"
+
+# ─── 9. A legacy-alias id inherits its canonical target's realness → PASS ──
+# (exercises the alias-resolution branch of ios_is_real, not just direct ids)
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "canonical-demo" "Canonical"
+write_ios_generated "canonical-demo" ""
+write_ios_registry "retired-alias=canonical-demo" ""
+write_manifest <<'EOF'
+demos:
+  - id: canonical-demo
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "id resolved as working (alias-target realness path exercised) → PASS" \
+    || bad "alias-target realness path should still PASS (rc=$RC): $OUT"
+
+# ─── Summary ───────────────────────────────────────────────────────────────
+echo ""
+echo "test-check-demo-id-parity.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,27 @@ jobs:
         shell: bash
         run: bash .claude/scripts/test-impact-check.sh
 
+      # Android <-> iOS demo-catalog parity gate (BLOCKING, #2801, tracker
+      # #2798). Self-test first, same discipline as the pairs above. Diffs
+      # Android's 52 canonical ids (read from *Fragment.kt, the same field
+      # collate-demos.sh itself parses) against iOS's live registry
+      # (GeneratedScenes.allowedIds + DemoDeepLinkRegistry's legacyAliases /
+      # residualIds) and the committed parity-manifest.yml. Unlike the
+      # advisory doc-drift checks above, this is BLOCKING: it fails the
+      # moment a new Android demo ships without a matching iOS registry
+      # entry or manifest row — the exact silent-drift class behind #2769
+      # (12 ids that diverged unnoticed for months). Pure bash/awk/python
+      # against source text — no Xcode, no Gradle, zero macOS cost.
+      - name: Self-test check-demo-id-parity.sh
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/test-check-demo-id-parity.sh
+
+      - name: Check Android <-> iOS demo id parity
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/check-demo-id-parity.sh
+
   # ── Full quality gate ────────────────────────────────────────────────────
   # Runs the same .claude/scripts/quality-gate.sh that contributors run
   # locally before pushing. Includes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,7 +827,7 @@ jobs:
 
       # Android <-> iOS demo-catalog parity gate (BLOCKING, #2801, tracker
       # #2798). Self-test first, same discipline as the pairs above. Diffs
-      # Android's 52 canonical ids (read from *Fragment.kt, the same field
+      # Android's canonical demo ids (read from *Fragment.kt, the same field
       # collate-demos.sh itself parses) against iOS's live registry
       # (GeneratedScenes.allowedIds + DemoDeepLinkRegistry's legacyAliases /
       # residualIds) and the committed parity-manifest.yml. Unlike the

--- a/changelog.d/2801-ios-guard-tests.md
+++ b/changelog.d/2801-ios-guard-tests.md
@@ -9,7 +9,7 @@
   compiled) in the `SceneViewDemoTests` target. iOS test count: 20 -> 56
   (#2801, part of #2798).
 - Added `parity-manifest.yml` (repo root) — one row per Android canonical
-  demo id (52) declaring its current iOS status (working / stub /
+  demo id (53) declaring its current iOS status (working / stub /
   android-only) with a reason for every non-working entry — plus
   `.claude/scripts/check-demo-id-parity.sh`, wired into `ci.yml` ->
   `repo-hygiene` (ubuntu, blocking, zero macOS cost). Fails the moment a new

--- a/changelog.d/2801-ios-guard-tests.md
+++ b/changelog.d/2801-ios-guard-tests.md
@@ -1,0 +1,17 @@
+<!-- category: Tests -->
+- iOS: added a registry/deep-link guard suite (`DemoRegistryGuardTests`, 19
+  tests) asserting `GeneratedScenes`/`DemoDeepLinkRegistry` invariants — id
+  uniqueness across the three sources, kebab-case format, every legacy alias
+  resolving to a live scene id, and the central check a human used to verify
+  by hand: ids that should show a real demo do, everything else honestly
+  falls through to the placeholder. Also registered the orphaned
+  `SketchfabAssetResolver+Tests.swift` (17 tests, dead since May — never
+  compiled) in the `SceneViewDemoTests` target. iOS test count: 20 -> 56
+  (#2801, part of #2798).
+- Added `parity-manifest.yml` (repo root) — one row per Android canonical
+  demo id (52) declaring its current iOS status (working / stub /
+  android-only) with a reason for every non-working entry — plus
+  `.claude/scripts/check-demo-id-parity.sh`, wired into `ci.yml` ->
+  `repo-hygiene` (ubuntu, blocking, zero macOS cost). Fails the moment a new
+  Android demo ships without a matching iOS registry entry or manifest row —
+  the silent-drift class behind #2769 (#2801, part of #2798).

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -1,0 +1,301 @@
+# parity-manifest.yml
+#
+# Android <-> iOS demo-catalog parity ledger (#2801, part of the iOS-parity
+# tracker #2798). One row per Android canonical demo id — the 52 ids in
+# `GeneratedDemos.all` (collated by `samples/android-demo/scripts/collate-demos.sh`
+# from `samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/*Fragment.kt`,
+# NOT `DemoRegistry.kt`, which only declares the schema).
+#
+# Location: repo root (not `samples/ios-demo/`) because this ledger compares
+# TWO platforms — Android's canonical id set against iOS's registry — so it
+# is not an iOS-only artifact. It sits alongside other cross-cutting,
+# machine-readable root files (`llms.txt`, `smithery.yaml`).
+#
+# `iosStatus` is a mechanically-checked CURRENT-STATE fact, not an aspiration:
+#   - working:      the id is a member of iOS's `DemoDeepLinkRegistry.allowedIds`
+#                    AND resolves to a real (non-placeholder) destination.
+#   - stub:         the id is a member of `allowedIds` but currently falls
+#                    through to the honest placeholder (a `*Scene.swift` file
+#                    exists but is `@available false`, or the id is only a
+#                    residual entry with no Scene file yet).
+#   - android-only: the id is NOT a member of `allowedIds` at all today —
+#                    either a genuinely platform-exclusive capability (no
+#                    ARKit equivalent, never planned) or a demo iOS simply
+#                    hasn't reserved an id for yet.
+# `reason` is required for every non-`working` row (one line, honest, cites
+# the tracking issue). `androidStatus` mirrors Android's own `DemoStatus`
+# (Working/KnownIssue/ComingSoon/InReview) for context — the #2798 audit
+# found a strict correlation: every Android demo that is not itself `Working`
+# lands in iOS's `stub` or `android-only` bucket, with zero exceptions.
+#
+# Verified against source 2026-07-21 (post L0.1 #2799 + L0.2 #2800):
+#   - Android: 52 fragments, 44 Working / 5 KnownIssue / 2 ComingSoon / 1 InReview.
+#   - iOS: `DemoDeepLinkRegistry.allowedIds` = 66 (51 generated ∪ 4 legacy
+#     aliases ∪ 11 residual ids). Of the 52 Android ids: 22 working, 18 stub,
+#     12 android-only.
+#
+# Checked by `.claude/scripts/check-demo-id-parity.sh` (`ci.yml` ->
+# `repo-hygiene`, ubuntu, blocking): fails if a Android id has neither an iOS
+# registry entry nor a row here, if a row's `iosStatus` disagrees with the
+# live registry, or if a row here no longer corresponds to a live Android id.
+# Update this file (status + reason) in the SAME PR that changes either
+# platform's registry — that's what keeps it honest.
+
+demos:
+  # ─── working (22) — iOS has a real, non-placeholder destination ─────────
+  - id: ar-body-tracker
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-depth-occlusion
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-face
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-image
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-instant-placement
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-orbital
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-people-occlusion
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-placement
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-plane-node
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-point-cloud
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-record-playback
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-rerun
+    androidStatus: Working
+    iosStatus: working
+  - id: ar-scene-mesh
+    androidStatus: Working
+    iosStatus: working
+  - id: debug-overlay
+    androidStatus: Working
+    iosStatus: working
+  - id: double-pendulum
+    androidStatus: Working
+    iosStatus: working
+  - id: fog
+    androidStatus: Working
+    iosStatus: working
+  - id: geometry
+    androidStatus: Working
+    iosStatus: working
+  - id: lighting
+    androidStatus: Working
+    iosStatus: working
+  - id: lines-paths
+    androidStatus: Working
+    iosStatus: working
+  - id: materials
+    androidStatus: Working
+    iosStatus: working
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: spatial-audio
+    androidStatus: Working
+    iosStatus: working
+
+  # ─── stub (18) — iOS registry has the id, but it falls to the placeholder ──
+  - id: ar-cloud-anchor
+    androidStatus: KnownIssue
+    iosStatus: stub
+    reason: >-
+      Scene file exists (ArCloudAnchorScene, canonicalized from
+      ArCloudAnchorsScene in #2799) but @available false — Cloud Anchor
+      persistence not yet implemented on iOS. Android itself is KnownIssue too.
+  - id: ar-collaborative
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — a CollaborativeSession SDK + demo is
+      not yet ported (Phase 2 Wave B, #2798).
+  - id: ar-depth-collider
+    androidStatus: KnownIssue
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — depth-based collision not yet ported.
+      Android itself is KnownIssue too.
+  - id: ar-depth-of-field
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — depth-of-field post-process not yet
+      ported (Phase 2 Wave B, #2798).
+  - id: ar-depth-visualization
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — depth visualization + the SDK depth
+      API it needs are not yet ported (Phase 2 Wave B, #2798).
+  - id: ar-fog
+    androidStatus: Working
+    iosStatus: stub
+    reason: "Residual id, no Scene file yet — the AR-specific fog demo is not yet ported."
+  - id: ar-hand-tracking
+    androidStatus: ComingSoon
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — Android itself is ComingSoon
+      (visionOS hand-tracking SDK work).
+  - id: ar-image-stabilization
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Platform-locked: ARCore's Electronic Image Stabilization (EIS) toggle
+      has no public ARKit equivalent. Scene file exists but @available
+      false — a permanent honest placeholder, not a port target (#2798).
+  - id: ar-ml-object-label
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — Vision/CoreML object labeling not yet
+      ported (Phase 3, #2798).
+  - id: ar-pose
+    androidStatus: Working
+    iosStatus: stub
+    reason: "Scene file exists but @available false — free pose placement not yet implemented."
+  - id: ar-raw-depth-point-cloud
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — raw depth point cloud not yet ported
+      (Phase 2 Wave B, #2798).
+  - id: ar-rooftop
+    androidStatus: KnownIssue
+    iosStatus: stub
+    reason: >-
+      Platform-locked: ARCore Geospatial rooftop anchors are a Google-backend
+      service with no ARKit equivalent. Scene file exists (canonicalized from
+      ArRooftopAnchorsScene in #2799) but @available false — a permanent
+      honest placeholder, not a port target. Android itself is KnownIssue too.
+  - id: ar-scene-semantics
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — scene semantics not yet ported (Phase
+      3, honest-card candidate, #2798).
+  - id: ar-streetscape
+    androidStatus: KnownIssue
+    iosStatus: stub
+    reason: >-
+      Platform-locked: ARCore Streetscape Geometry (Geospatial/VPS) is a
+      Google-backend service with no ARKit equivalent. Scene file exists but
+      @available false — a permanent honest placeholder, not a port target.
+      Android itself is KnownIssue too.
+  - id: ar-terrain
+    androidStatus: KnownIssue
+    iosStatus: stub
+    reason: >-
+      Scene file exists (canonicalized from ArTerrainAnchorsScene in #2799)
+      but @available false — Geospatial terrain anchors not yet implemented.
+      Android itself is KnownIssue too.
+  - id: ar-xr-face
+    androidStatus: ComingSoon
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — Android itself is ComingSoon
+      (visionOS face-tracking SDK work).
+  - id: placement-scene
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Residual id, no Scene file yet — this placement scene is not yet
+      ported (Phase 2 Wave A, #2798).
+  - id: secondary-camera
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Scene file exists but @available false — picture-in-picture camera
+      view not yet implemented.
+
+  # ─── android-only (12) — no iOS registry entry at all yet ───────────────
+  - id: animation-physics
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from the #2239 catalog regroup — iOS still only
+      carries its pre-regroup sub-ids (animation, physics), not the umbrella
+      id itself. Tracked for L0.6 (#2804).
+  - id: ar-plane-renderer-v2
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog — no iOS id
+      reserved yet; needs LiDAR-backed plane rendering. Tracked for L0.6 (#2804).
+  - id: camera-gestures
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from #2239 — iOS still only carries pre-regroup
+      sub-ids (camera-controls, gesture-editing). Tracked for L0.6 (#2804).
+  - id: custom-geometry
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from #2239 — iOS still only carries pre-regroup
+      sub-ids (custom-mesh, shape). Tracked for L0.6 (#2804).
+  - id: lighting-lab
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from #2239 — iOS still only carries pre-regroup
+      sub-ids (dynamic-sky, environment, reflection-probes, post-processing).
+      Tracked for L0.6 (#2804).
+  - id: picking-collision
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from #2239 — iOS still only carries pre-regroup
+      sub-ids (collision, view-node). Tracked for L0.6 (#2804).
+  - id: placement-reticle-preview
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog — no iOS id
+      reserved yet. Tracked for L0.6 (#2804).
+  - id: point-and-ask
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog — no iOS id
+      reserved yet; a port would use Apple's Foundation Models (#2648).
+      Tracked for L0.6 (#2804).
+  - id: splat-preview
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog — no iOS id
+      reserved yet; blocked on an iOS SplatNode renderer (#2768).
+  - id: two-d-in-three-d
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Android umbrella id from #2239 — iOS still only carries pre-regroup
+      sub-ids (text, image, video, billboard). Tracked for L0.6 (#2804).
+  - id: video-recording
+    androidStatus: Working
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog — no iOS id
+      reserved yet. Tracked for L0.6 (#2804).
+  - id: wall-placement
+    androidStatus: InReview
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog (Android itself
+      is InReview, #2740) — no iOS id reserved yet. Tracked for L0.6 (#2804).

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -1,7 +1,7 @@
 # parity-manifest.yml
 #
 # Android <-> iOS demo-catalog parity ledger (#2801, part of the iOS-parity
-# tracker #2798). One row per Android canonical demo id — the 52 ids in
+# tracker #2798). One row per Android canonical demo id — the ids in
 # `GeneratedDemos.all` (collated by `samples/android-demo/scripts/collate-demos.sh`
 # from `samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/*Fragment.kt`,
 # NOT `DemoRegistry.kt`, which only declares the schema).
@@ -28,11 +28,14 @@
 # found a strict correlation: every Android demo that is not itself `Working`
 # lands in iOS's `stub` or `android-only` bucket, with zero exceptions.
 #
-# Verified against source 2026-07-21 (post L0.1 #2799 + L0.2 #2800):
-#   - Android: 52 fragments, 44 Working / 5 KnownIssue / 2 ComingSoon / 1 InReview.
+# Verified against source 2026-07-21 (post L0.1 #2799 + L0.2 #2800, and
+# after #2817 added `contact-shadow-preview` — rebased onto that commit
+# during this PR's own preparation, a live demonstration of exactly the
+# drift class this manifest + check-demo-id-parity.sh now catch):
+#   - Android: 53 fragments, 44 Working / 5 KnownIssue / 2 ComingSoon / 2 InReview.
 #   - iOS: `DemoDeepLinkRegistry.allowedIds` = 66 (51 generated ∪ 4 legacy
-#     aliases ∪ 11 residual ids). Of the 52 Android ids: 22 working, 18 stub,
-#     12 android-only.
+#     aliases ∪ 11 residual ids). Of the 53 Android ids: 22 working, 18 stub,
+#     13 android-only.
 #
 # Checked by `.claude/scripts/check-demo-id-parity.sh` (`ci.yml` ->
 # `repo-hygiene`, ubuntu, blocking): fails if a Android id has neither an iOS
@@ -243,6 +246,15 @@ demos:
     reason: >-
       Android umbrella id from #2239 — iOS still only carries pre-regroup
       sub-ids (camera-controls, gesture-editing). Tracked for L0.6 (#2804).
+  - id: contact-shadow-preview
+    androidStatus: InReview
+    iosStatus: android-only
+    reason: >-
+      Added to Android after iOS stopped tracking the catalog (#2817,
+      contact-shadow sub-task C of #2740; Android itself is InReview) — no
+      iOS id reserved yet. Tracked for L0.6 (#2804). Landed on main mid-PR;
+      this row is a live example of the drift class check-demo-id-parity.sh
+      now catches.
   - id: custom-geometry
     androidStatus: Working
     iosStatus: android-only

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -226,7 +226,7 @@ demos:
       Scene file exists but @available false — picture-in-picture camera
       view not yet implemented.
 
-  # ─── android-only (12) — no iOS registry entry at all yet ───────────────
+  # ─── android-only (13) — no iOS registry entry at all yet ───────────────
   - id: animation-physics
     androidStatus: Working
     iosStatus: android-only

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E3457CB732DF2AE71757CC /* MovableLightDemo.swift */; };
 		F00000000000000000000003 /* AppStoreUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000002 /* AppStoreUpdaterTests.swift */; };
 		F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000060 /* SketchfabService+Tests.swift */; };
+		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
+		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -197,6 +199,8 @@
 		F00000000000000000000001 /* SceneViewDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SceneViewDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F00000000000000000000002 /* AppStoreUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreUpdaterTests.swift; path = SceneViewDemoTests/AppStoreUpdaterTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000060 /* SketchfabService+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabService+Tests.swift"; path = "SceneViewDemo/Services/SketchfabService+Tests.swift"; sourceTree = SOURCE_ROOT; };
+		F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabAssetResolver+Tests.swift"; path = "SceneViewDemo/Services/SketchfabAssetResolver+Tests.swift"; sourceTree = SOURCE_ROOT; };
+		F00000000000000000000072 /* DemoRegistryGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoRegistryGuardTests.swift; path = SceneViewDemoTests/DemoRegistryGuardTests.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000002 /* DemoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoItem.swift; sourceTree = "<group>"; };
 		C20000000000000000000003 /* ExploreTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreTab.swift; sourceTree = "<group>"; };
 		C20000000000000000000004 /* ARTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARTab.swift; sourceTree = "<group>"; };
@@ -390,6 +394,8 @@
 			children = (
 				F00000000000000000000002 /* AppStoreUpdaterTests.swift */,
 				F00000000000000000000060 /* SketchfabService+Tests.swift */,
+				F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */,
+				F00000000000000000000072 /* DemoRegistryGuardTests.swift */,
 			);
 			path = SceneViewDemoTests;
 			sourceTree = "<group>";
@@ -902,6 +908,8 @@
 			files = (
 				F00000000000000000000003 /* AppStoreUpdaterTests.swift in Sources */,
 				F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */,
+				F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */,
+				F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -48,7 +48,13 @@ enum DemoDeepLinkRegistry {
     /// The canonical target is declared by a `*Scene.swift` file, so the alias
     /// resolves to exactly that scene's destination (or its placeholder, when
     /// the canonical scene is `@available false`).
-    private static let legacyAliases: [String: String] = [
+    ///
+    /// Internal (not `private`) so `DemoRegistryGuardTests` (#2801) can assert
+    /// the registry-integrity invariants directly against this table — e.g.
+    /// every value must be a live `GeneratedScenes.allowedIds` member, no key
+    /// may also be a live scene id — mirroring how Android's
+    /// `DeepLinkRouterTest` asserts directly against `DEMO_ID_ALIASES`.
+    static let legacyAliases: [String: String] = [
         "ar-recording": "ar-record-playback",
         "ar-cloud-anchors": "ar-cloud-anchor",
         "ar-rooftop-anchors": "ar-rooftop",
@@ -60,7 +66,11 @@ enum DemoDeepLinkRegistry {
     /// They pass `allowedIds` so the URL is accepted, and resolve to the
     /// coming-soon placeholder. Remove an id from here the moment a matching
     /// Scene file is added; the generated union then covers it with no hand edit.
-    private static let residualIds: Set<String> = [
+    ///
+    /// Internal (not `private`) for the same reason as `legacyAliases` above —
+    /// `DemoRegistryGuardTests` (#2801) asserts this list never collides with a
+    /// live generated scene id (a stale entry that should have been deleted).
+    static let residualIds: Set<String> = [
         "ar-collaborative",
         "ar-depth-collider",
         "ar-depth-of-field",

--- a/samples/ios-demo/SceneViewDemoTests/DemoRegistryGuardTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/DemoRegistryGuardTests.swift
@@ -1,0 +1,316 @@
+// DemoRegistryGuardTests.swift
+//
+// Registry / deep-link guard suite for `GeneratedScenes` + `DemoDeepLinkRegistry`
+// (#2801, part of the iOS-parity tracker #2798). This is the iOS mirror of
+// Android's `DemoRegistryIntegrityTest.kt` (registry shape: uniqueness,
+// kebab-case, routability) and the alias section of `DeepLinkRouterTest.kt`
+// (`every DEMO_ID_ALIASES target is a live registered demo`, `retired alias id
+// must not also be a registered demo`).
+//
+// Before this suite, iOS had ZERO registry/deep-link guard tests, against
+// Android's 284 `@Test`s covering the same surface. The specific gap this
+// closes: the #2769 regression (12 ids silently dropped because three
+// hand-maintained surfaces — a `Set` literal, a `switch`, and the Samples-tab
+// list — drifted apart) was fixed structurally in #2800 by generating all
+// three from the same `@sceneId` directives, but nothing YET asserted the
+// generator's output stays internally consistent, or that a human doesn't
+// have to re-verify "does this id show a real screen or the placeholder?" by
+// hand on every review — which is exactly what happened during the #2798
+// baseline audit. This suite automates that manual cross-check.
+//
+// Depends on L0.2 (#2800): it asserts against the GENERATED
+// `GeneratedScenes.allowedIds` / `.destination(for:)` surface, not the old
+// hand-maintained registry. It consumes that surface; it does not change
+// `collate-ios-demos.sh` (L0.4's territory, #2802).
+
+#if DEBUG
+
+import XCTest
+@testable import SceneViewDemo
+
+@MainActor
+final class DemoRegistryGuardTests: XCTestCase {
+
+    /// kebab-case: lowercase ASCII letters / digits, hyphen-separated —
+    /// mirrors Android's `DemoRegistryIntegrityTest.kebabCase`. The id is a
+    /// `sceneview://demo/<id>` path segment; anything else breaks routing.
+    /// Also the compensating control for the L0.2-review NIT: the collator
+    /// (`collate-ios-demos.sh`) validates `@available`/`@category` against a
+    /// closed enum but never validates `@sceneId`'s own format — this test
+    /// runs against the REAL generated output on every CI run instead.
+    private let kebabCase = try! NSRegularExpression(pattern: "^[a-z0-9]+(-[a-z0-9]+)*$")
+
+    private func isKebabCase(_ id: String) -> Bool {
+        let range = NSRange(id.startIndex..<id.endIndex, in: id)
+        return kebabCase.firstMatch(in: id, options: [], range: range) != nil
+    }
+
+    // MARK: - Registry shape (non-emptiness, format)
+
+    func testAllowedIdsIsNonEmpty() {
+        // A regression in the collator (or an empty Scenes dir) would
+        // silently ship a zero-demo deep-link gate.
+        XCTAssertFalse(DemoDeepLinkRegistry.allowedIds.isEmpty,
+                        "DemoDeepLinkRegistry.allowedIds must not be empty")
+    }
+
+    func testGeneratedAllowedIdsIsNonEmpty() {
+        XCTAssertFalse(GeneratedScenes.allowedIds.isEmpty,
+                        "GeneratedScenes.allowedIds must list at least one *Scene.swift")
+    }
+
+    func testEveryAllowedIdIsKebabCase() {
+        for id in DemoDeepLinkRegistry.allowedIds {
+            XCTAssertTrue(isKebabCase(id),
+                          "id '\(id)' must be kebab-case (lowercase, hyphen-separated) — " +
+                          "it is a sceneview://demo/<id> path segment")
+        }
+    }
+
+    func testUnknownIdIsNotInAllowedIds() {
+        // Negative-space guard, mirrors Android's `deep-link router rejects
+        // ids that are not in the registry`.
+        XCTAssertFalse(DemoDeepLinkRegistry.allowedIds.contains("definitely-not-a-real-demo"))
+    }
+
+    // MARK: - The three sources never collide (Swift's analogue of "unique ids")
+    //
+    // `allowedIds` is a `Set`, so a literal duplicate string can't survive as
+    // two entries — the real drift risk this repo has actually hit is the
+    // SAME id being claimed by two of the three sources: a new `*Scene.swift`
+    // reusing an id that's still a legacy alias key or a residual
+    // (not-yet-ported) id that was never deleted once its Scene shipped
+    // (`DemoDeepLinkRegistry`'s own doc comment: "Remove an id from here the
+    // moment a matching Scene file is added").
+
+    func testGeneratedIdsDoNotCollideWithLegacyAliasKeys() {
+        let collisions = GeneratedScenes.allowedIds.intersection(DemoDeepLinkRegistry.legacyAliases.keys)
+        XCTAssertTrue(collisions.isEmpty,
+                      "Scene id(s) \(collisions) are also legacy alias keys — a real Scene file " +
+                      "must not be shadowed by an alias entry")
+    }
+
+    func testGeneratedIdsDoNotCollideWithResidualIds() {
+        let collisions = GeneratedScenes.allowedIds.intersection(DemoDeepLinkRegistry.residualIds)
+        XCTAssertTrue(collisions.isEmpty,
+                      "Scene id(s) \(collisions) are still listed as residual (not-yet-ported) but " +
+                      "already have a real Scene file — delete from residualIds, the generated " +
+                      "union already covers them (see DemoDeepLinkRegistry's doc comment)")
+    }
+
+    func testLegacyAliasKeysDoNotCollideWithResidualIds() {
+        let collisions = Set(DemoDeepLinkRegistry.legacyAliases.keys).intersection(DemoDeepLinkRegistry.residualIds)
+        XCTAssertTrue(collisions.isEmpty,
+                      "id(s) \(collisions) are listed as both a legacy alias key and a residual id")
+    }
+
+    /// Pins the union arithmetic itself so a future refactor of `allowedIds`
+    /// can't silently drop one of the three sources without a test noticing.
+    func testAllowedIdsIsExactlyTheUnionOfAllThreeSources() {
+        let expected = GeneratedScenes.allowedIds
+            .union(DemoDeepLinkRegistry.legacyAliases.keys)
+            .union(DemoDeepLinkRegistry.residualIds)
+        XCTAssertEqual(DemoDeepLinkRegistry.allowedIds, expected,
+                       "allowedIds must be exactly generated ∪ legacyAliases.keys ∪ residualIds")
+    }
+
+    // MARK: - Legacy aliases resolve to a real, currently-registered scene id
+    //
+    // Mirrors Android's `DeepLinkRouterTest`: "every DEMO_ID_ALIASES target is
+    // a live registered demo" + "retired alias id must not also be a
+    // registered demo".
+
+    func testEveryLegacyAliasTargetIsARegisteredSceneId() {
+        // An alias VALUE that typos or outlives its target Scene file would
+        // silently fall through to the generic placeholder — this is the
+        // only thing standing between that typo and a shipped 404.
+        for (retired, canonical) in DemoDeepLinkRegistry.legacyAliases {
+            XCTAssertTrue(
+                GeneratedScenes.allowedIds.contains(canonical),
+                "legacy alias '\(retired)' -> '\(canonical)' but '\(canonical)' is not a " +
+                "registered Scene id"
+            )
+        }
+    }
+
+    func testNoLegacyAliasKeyIsItselfARegisteredSceneId() {
+        // An alias key that's ALSO a live scene id is dead code (the
+        // generated id already wins any `Set` union) and hides a stale entry
+        // that should have been deleted when the id was canonicalized.
+        for retired in DemoDeepLinkRegistry.legacyAliases.keys {
+            XCTAssertFalse(
+                GeneratedScenes.allowedIds.contains(retired),
+                "legacy alias key '\(retired)' is also a live Scene id — the alias is dead, delete it"
+            )
+        }
+    }
+
+    // MARK: - The central invariant: real demos resolve, everything else
+    // honestly falls through to the placeholder.
+    //
+    // This is the check that used to be done BY HAND during the #2798 /
+    // #2769 audits: grep every `*Scene.swift`'s `@available` value, cross-
+    // reference against `destination(for:)`'s switch, note any mismatch.
+    // Rather than hardcode all 66 ids (a list that would itself rot the
+    // moment a demo is added, ported, or its `@available` flag flips — churn
+    // this repo sees on nearly every samples PR), this pins:
+    //   (a) a handful of long-stable flagship ids that must never regress to
+    //       a placeholder, and
+    //   (b) the small, historically-significant set that's already caused a
+    //       real bug (the #2799 canonicalized ids + their #2769 aliases).
+    // Growth of the *un-pinned* middle (new demos, newly-ported residuals) is
+    // exactly what `parity-manifest.yml` + `check-demo-id-parity.sh` (#2801
+    // deliverable c) track going forward, so it isn't duplicated here.
+
+    /// Flagship, long-shipped ids — if any of these ever falls through to the
+    /// placeholder, something is badly broken (a deleted Scene file, an
+    /// `@available` flip, a switch typo). Deliberately chosen to be simple,
+    /// non-networked, non-AR demos so constructing the destination view has
+    /// no side effects beyond a plain SwiftUI initializer.
+    func testWellKnownWorkingDemosResolveToARealDestination() {
+        let mustBeReal = ["model-viewer", "geometry", "animation", "physics", "materials"]
+        for id in mustBeReal {
+            XCTAssertNotNil(GeneratedScenes.destination(for: id),
+                            "'\(id)' is expected to be a real, working demo but resolved to nil " +
+                            "(placeholder) — check its Scene file's @available directive")
+        }
+    }
+
+    /// Ids known today to be coming-soon or not-yet-ported — a regression pin
+    /// so a demo doesn't quietly start claiming to be "working" (a false
+    /// promise to users) without this test (and `parity-manifest.yml`, if the
+    /// id is Android-sourced) also being updated intentionally.
+    func testKnownComingSoonAndResidualIdsStillFallThroughToThePlaceholder() {
+        let mustBePlaceholder = [
+            "ar-cloud-anchor", "ar-rooftop", "ar-terrain",   // #2799 canonicalized ids, still @available false
+            "post-processing", "secondary-camera",           // long-standing coming-soon cards
+            "ar-collaborative", "placement-scene",           // residual — no Scene file yet (L0.6, #2804)
+        ]
+        for id in mustBePlaceholder {
+            XCTAssertNil(GeneratedScenes.destination(for: id),
+                        "'\(id)' was expected to still be coming-soon/residual. If it now has a " +
+                        "real, @available Scene, that's great — update this pin (and " +
+                        "residualIds / parity-manifest.yml if it's an Android-sourced id).")
+        }
+    }
+
+    /// The #2769 regression, pinned directly. Before #2800, `custom-geometry`
+    /// et al. (a different bug, still open — tracked by `parity-manifest.yml`
+    /// as `android-only`) and these 4 pre-#2799 ids silently 404'd because
+    /// `allowedIds` was a hand-copied literal that never got updated. Each of
+    /// these 4 must keep resolving — through its canonical target — to
+    /// exactly that target's current realness, whichever way the canonical
+    /// scene's own `@available` flag goes.
+    func testLegacyAliasesArePinnedAndInheritTheirCanonicalTargetsRealness() {
+        let aliases = DemoDeepLinkRegistry.legacyAliases
+        XCTAssertEqual(aliases, [
+            "ar-recording": "ar-record-playback",
+            "ar-cloud-anchors": "ar-cloud-anchor",
+            "ar-rooftop-anchors": "ar-rooftop",
+            "ar-terrain-anchors": "ar-terrain",
+        ], "legacyAliases changed — update this pin (and re-verify the new/changed alias " +
+           "resolves sanely through DemoDeepLinkRegistry.destination(for:))")
+
+        for (retired, canonical) in aliases {
+            let canonicalIsReal = GeneratedScenes.destination(for: canonical) != nil
+            // The alias key itself is never a generated id (pinned above), so
+            // its ONLY path to a real destination is through `canonical`.
+            let aliasReachesReal = GeneratedScenes.destination(for: retired) != nil || canonicalIsReal
+            XCTAssertEqual(
+                aliasReachesReal, canonicalIsReal,
+                "alias '\(retired)' must inherit exactly '\(canonical)'s realness (\(canonicalIsReal))"
+            )
+        }
+    }
+
+    // MARK: - Every allowed id is routable through the public entry point
+
+    /// Smoke-tests the PUBLIC surface (`DemoDeepLinkRegistry.destination(for:)`
+    /// — the one `SceneViewDemoApp` / `ContentView` actually call) end-to-end
+    /// for every id in `allowedIds`, not just the generated half. This is
+    /// what would have caught #2769: `custom-geometry` et al. were accepted
+    /// by nothing, so `destination(for:)` was never even exercised for them.
+    /// `destination(for:)` returns `AnyView` (non-optional) — reaching the
+    /// end of the loop without a crash/trap IS the assertion; every id
+    /// resolves to *some* view (real or the honest placeholder), never a
+    /// silent drop.
+    func testEveryAllowedIdIsRoutableThroughThePublicRegistry() {
+        for id in DemoDeepLinkRegistry.allowedIds {
+            _ = DemoDeepLinkRegistry.destination(for: id)
+        }
+    }
+
+    /// `destination(for:)` never special-cases its input against
+    /// `allowedIds` — it is a total function that resolves generated → alias
+    /// → placeholder for ANY string. Defense in depth beyond the `allowedIds`
+    /// gate `SceneViewDemoApp` applies before ever calling this: even a
+    /// completely unregistered id must resolve to the honest placeholder,
+    /// never crash.
+    func testDestinationNeverCrashesForAnUnregisteredId() {
+        _ = DemoDeepLinkRegistry.destination(for: "definitely-not-a-real-demo")
+        _ = DemoDeepLinkRegistry.destination(for: "")
+    }
+
+    // MARK: - Samples-tab list (`GeneratedScenes.all()`) stays in lockstep
+    // with the deep-link surface (`GeneratedScenes.allowedIds`)
+    //
+    // Both are emitted from the SAME collator pass over the SAME per-scene
+    // metadata, so they can't drift from typing a demo twice — but nothing
+    // previously asserted that guarantee at the Swift level. Mirrors the
+    // spirit of Android's `DemoRegistryIntegrityTest` checks on `ALL_DEMOS`
+    // (non-empty, unique titles, every category populated), adapted to
+    // iOS's plain-string `DemoItem` (no `@StringRes` indirection to check).
+
+    /// On iOS (this test always runs on an iOS simulator/device), every
+    /// `#if os(iOS)` AR item is included, so the Samples-tab list and the
+    /// deep-link id set must describe exactly the same number of scenes.
+    /// A mismatch means the two collator emissions (the `all()` list and the
+    /// `allowedIds` set) fell out of sync.
+    func testGeneratedAllCountMatchesAllowedIdsCountOnIOS() {
+        XCTAssertEqual(
+            GeneratedScenes.all().count, GeneratedScenes.allowedIds.count,
+            "GeneratedScenes.all() and .allowedIds must describe the same scenes on iOS"
+        )
+    }
+
+    /// Two demos sharing the same title would confuse users in the Samples
+    /// grid — almost always a copy-paste bug in a new `*Scene.swift`'s
+    /// `@title` directive. Mirrors Android's title/subtitle-resource
+    /// uniqueness check, translated to iOS's plain string titles.
+    func testNoDuplicateTitlesAmongGeneratedItems() {
+        let titles = GeneratedScenes.all().map(\.title)
+        let duplicates = Dictionary(grouping: titles, by: { $0 }).filter { $0.value.count > 1 }.keys
+        XCTAssertTrue(duplicates.isEmpty, "Duplicate demo titles: \(duplicates)")
+    }
+
+    /// The collator only guards its directives against being literally empty
+    /// (bash `-z`); a whitespace-only title/subtitle/icon would slip through
+    /// generation and still render as a blank card. Compensating control,
+    /// same rationale as the kebab-case check above.
+    func testEveryGeneratedItemHasNonBlankTitleIconAndSubtitle() {
+        for item in GeneratedScenes.all() {
+            XCTAssertFalse(item.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                           "A generated DemoItem has a blank title")
+            XCTAssertFalse(item.icon.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                           "'\(item.title)' has a blank icon")
+            XCTAssertFalse(item.subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                           "'\(item.title)' has a blank subtitle")
+        }
+    }
+
+    /// The Samples tab groups items by category and (per `SamplesTab`)
+    /// self-hides an empty section; a category with zero demos almost always
+    /// means a `*Scene.swift` file failed to collate. Mirrors Android's "at
+    /// least one demo exists per non-AR category" (iOS has no AR-specific
+    /// exemption here since AR scenes DO run in this suite, on an iOS sim).
+    func testAtLeastOneGeneratedItemExistsPerCategory() {
+        let populated = Set(GeneratedScenes.all().map(\.category))
+        for category in DemoCategory.allCases {
+            XCTAssertTrue(populated.contains(category),
+                          "Category '\(category.rawValue)' has no demos — a Scene file likely " +
+                          "failed to collate")
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

L0.3 of the iOS-parity chantier (tracker #2798), depends on L0.2 (#2800,
merged). Closes the 0-iOS-guard-test gap that let 12 ids silently diverge
before L0.2 generated the registry (#2769). Three deliverables:

**(a) Registered the orphaned test file.** `SketchfabAssetResolver+Tests.swift`
had zero references in `project.pbxproj` (`grep -c` confirmed 0, vs 4 for the
properly-wired sibling files) — 17 test methods across 2 `XCTestCase` classes
(`SampleAssetsTests`: 11, `SketchfabAssetResolverTests`: 6) never compiled or
ran since May. Added the standard 4 pbxproj entries (PBXBuildFile,
PBXFileReference, group membership, Sources build phase). **All 17 pass once
wired — no hidden regression.**

**(b) Guard-test suite** (`DemoRegistryGuardTests.swift`, 19 tests) — mirrors
the intent of Android's `DemoRegistryIntegrityTest.kt` + the alias section of
`DeepLinkRouterTest.kt`: id uniqueness across the three registry sources
(generated / legacy aliases / residual), kebab-case format (closes the L0.2-review
NIT — the collator validates `@available`/`@category` but never `@sceneId`'s
format), every legacy alias resolving to a live scene id, and the central
invariant a human used to verify by hand during the #2798 baseline audit: ids
that should show a real demo do, everything else honestly falls through to the
placeholder. `legacyAliases`/`residualIds` go from `private` to `internal` in
`DemoDeepLinkRegistry.swift` so the suite can assert against them directly —
mirroring how Android's tests assert directly against `DEMO_ID_ALIASES`.

**(c) `parity-manifest.yml`** (repo root — cross-platform ledger, not iOS-only,
so it sits alongside `llms.txt`) + **`check-demo-id-parity.sh`**, wired into
`ci.yml` → `repo-hygiene` (ubuntu, **blocking**, zero macOS cost). One row per
Android canonical id declaring its current iOS status
(`working`/`stub`/`android-only` + a reason for every non-working row).

## Test counts (verified, `xcodebuild test`)

| | Before | After |
|---|---|---|
| Total | 20 (19 passed, 1 skipped) | **56** (55 passed, 1 skipped) |

Before/after measured by stashing this PR's changes, running the full suite,
then popping the stash and running again — not estimated.

Note on the issue's "≥70" estimate: measured reality is 56 (17 previously-dead
+ 19 new guard tests). I added 5 tests beyond a minimal guard suite where they
covered genuinely new invariants (`GeneratedScenes.all()` ↔ `.allowedIds` count
parity, duplicate-title/blank-field checks, per-category coverage) rather than
padding the count — Android's own reference tests loop over the registry
instead of one-test-per-id, and I mirrored that spirit. Flagging the gap
explicitly rather than inflating it.

## Proof the guard suite actually guards

Injected a typo into `legacyAliases`' target locally (not committed), reran
`xcodebuild test`:

```
Test Failures (2):
  ✗ DemoRegistryGuardTests / testEveryLegacyAliasTargetIsARegisteredSceneId:
    XCTAssertTrue failed - legacy alias 'ar-recording' ->
    'ar-record-playback-TYPO-INJECTED-FOR-GUARD-PROOF' but
    'ar-record-playback-TYPO-INJECTED-FOR-GUARD-PROOF' is not a registered Scene id
  ✗ DemoRegistryGuardTests / testLegacyAliasesArePinnedAndInheritTheirCanonicalTargetsRealness:
    XCTAssertEqual failed: ... legacyAliases changed — update this pin ...
❌ 2 tests failed, 53 passed, 1 skipped
```

Reverted, reran — green again (55 passed, 1 skipped, 0 failed).

## `parity-manifest.yml` content

53 rows (Android's canonical count as of this PR's own rebase — see below):
**22 working / 18 stub / 13 android-only**, every non-working row carries a
one-line, source-cited reason (platform-locked vs not-yet-ported vs
umbrella-regroup gap vs brand-new Android demo).

## `check-demo-id-parity.sh` — verified both directions with live repros

- **Undeclared new Android id** (a throwaway well-formed fragment, not
  committed): script exits 1 with `... has NEITHER an iOS registry entry NOR
  a parity-manifest.yml row ...`. Removed the fixture, script goes green again.
- **Removed manifest row** (temporarily deleted `model-viewer`'s row from the
  real, committed manifest): script exits 1 with `... has no
  parity-manifest.yml row ...`. Restored, green again.
- 9-scenario self-test (`test-check-demo-id-parity.sh`, fully isolated via
  `PARITY_*` env-var injection seams, mirrors `check-doc-drift.sh`'s
  `DOC_DRIFT_FILES` pattern) — all 9 pass, covering both directions plus the
  alias-resolution and stale-manifest-row paths.
- Found and fixed a real robustness bug while building this: `grep` exits 1 on
  "no match", which under `set -e -o pipefail` would abort the whole script
  the moment any hand-maintained list (e.g. `residualIds`) legitimately
  reaches zero entries. Wrapped every such extraction `(grep ... || true)`.

## An unplanned live demonstration

Rebasing this branch onto a fresh `origin/main` pulled in #2817
(`contact-shadow-preview`, an in-review AR demo) — bumping Android's canonical
count from 52 to 53 mid-PR. `check-demo-id-parity.sh` correctly went red for
it on the first post-rebase run. Added its manifest row (`android-only`,
mirrors `wall-placement`'s InReview shape) rather than leave a freshly-merged,
unrelated feature failing CI. Left a note on that row — it's now a live,
in-repo example of the exact drift class this gate exists to catch, not a
contrived one.

## Deviations from the issue body

- Issue's status vocabulary was `working / stub / android-only`; the task
  brief said `working / coming-soon / android-only` — followed the issue
  body (authoritative per instructions). `stub` reads slightly more accurate
  anyway: some `stub` rows are genuinely `@available false` Scene files
  ("coming soon"), others are permanently platform-locked capabilities that
  will never become "coming soon" in the ordinary sense (ARCore Geospatial /
  EIS — no ARKit equivalent).
- `parity-manifest.yml` placed at the repo root (not `samples/ios-demo/`) —
  it's a cross-platform ledger, not an iOS-only artifact; documented the
  choice in the file's own header comment per the issue's explicit
  "implementer's call, document the choice."
- Test count landed at 56, short of the issue's "≥70" estimate — see the test
  counts section above for why, and the reasoning against padding.

## Out of scope (left alone per the task's constraints)

- `collate-ios-demos.sh` untouched — tests consume `GeneratedScenes`, they
  don't change the generator (L0.4's territory).
- No `.usdz` / resource changes in the pbxproj — stayed on the test target
  only, per the note that L1.2 (GLB→USDZ) is running in parallel and may
  touch the same file for asset bundling.

## Verification run locally

- `plutil -lint` on the modified `project.pbxproj`: OK
- `xcodebuild test` (via XcodeBuildMCP, dedicated simulator): 56 total, 0
  failed, 1 network-gated skip (unchanged, pre-existing)
- `bash .claude/scripts/check-demo-id-parity.sh`: OK
- `bash .claude/scripts/test-check-demo-id-parity.sh`: 9 passed, 0 failed
- `bash .claude/scripts/check-workflow-scripts.sh`: OK (no new warnings)
- Disk: purged this session's Xcode DerivedData/result-bundles/logs (~511 MB)
  after verification; host stayed above the 6 Gi hard floor throughout

Closes #2801. Part of #2798.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>