### PR TITLE
feat(ios-demo): 4-state DemoStatus (working/knownIssue/inReview/comingSoon)

### DIFF
--- a/changelog.d/2802-ios-demo-status.md
+++ b/changelog.d/2802-ios-demo-status.md
@@ -1,0 +1,16 @@
+<!-- category: Added -->
+- iOS demo: `DemoStatus` grows from 2 states to 4 — `.working` / `.knownIssue`
+  / `.inReview` / `.comingSoon` — mirroring Android's `DemoStatus`
+  (`Working`/`KnownIssue`/`ComingSoon`/`InReview`). Before this, iOS could not
+  express a known bug on an already-implemented demo or a newly-shipped demo
+  awaiting review sign-off, even though Android uses both states today (5
+  `KnownIssue` + 2 `InReview` demos, verified by grep). The collator
+  (`collate-ios-demos.sh`) gains an optional `@status` directive alongside
+  `@sceneId`/`@available`, defaulting sensibly when omitted (`working` for an
+  `@available true` scene, `comingSoon` for one that isn't) so none of the 51
+  existing `*Scene.swift` files needed an edit, and cross-validates `@status`
+  against `@available` so the two can't contradict each other. `SamplesTab`
+  renders a small `StatusBadge` capsule per status ("Preview" / "In review" /
+  "Soon"; `.working` shows no badge) — the iOS mirror of Android's
+  `DemoListScreen.kt` status chip. L0.4 of the iOS/Android catalog-ISO effort
+  (#2798); depends on the generated registry (#2800).

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
@@ -1,21 +1,70 @@
 import SwiftUI
 
-/// Availability status for a demo on iOS.
+/// Maturity status for a demo on iOS — mirrors Android's `DemoStatus`
+/// (`samples/android-demo/.../DemoRegistry.kt:13-29`) so both platforms can
+/// express the same four states about a demo's audit status:
 ///
-/// Demos that are present on Android but not yet ported to iOS appear in the list with a
-/// "Coming soon" badge and route to ``ComingSoonScreen`` instead of crashing or hiding.
+/// | iOS case      | Android case | Badge (`badgeLabel`) | Has a real destination? |
+/// |---------------|--------------|-----------------------|--------------------------|
+/// | `.working`    | `Working`    | none                  | yes                      |
+/// | `.knownIssue` | `KnownIssue` | "Preview"             | yes                      |
+/// | `.inReview`   | `InReview`   | "In review"           | yes                      |
+/// | `.comingSoon` | `ComingSoon` | "Soon"                | no                       |
+///
+/// **Documented asymmetry with Android:** Android's `ComingSoon` fragments
+/// still ship a real (if partial) `Screen()` — e.g. `ArHandTrackingFragment`
+/// renders a static reference skeleton because live hand tracking needs
+/// hardware the audit matrix doesn't have. iOS's `DemoScene` contract is
+/// binary instead (`@available true|false` gates whether a Scene provides a
+/// real `destination` at all — see `DemoScene.swift`), so on iOS
+/// `.comingSoon` always means "no destination yet", never "a partial one". A
+/// demo that IS implemented on iOS but has a known rendering/interaction bug
+/// is `.knownIssue`, not `.comingSoon` — see `collate-ios-demos.sh`'s
+/// `@status`/`@available` cross-validation.
+///
+/// Demos present on Android but not yet ported to iOS appear in the list with a
+/// "Soon" badge and route to ``ComingSoonScreen`` instead of crashing or hiding.
 enum DemoStatus: Equatable {
-    case available
+    /// Verified working — no badge (the common case shouldn't be visually flagged).
+    case working
+
+    /// Has a real destination but a known visual/interaction regression on the
+    /// audited device matrix — surfaced with a "Preview" badge so users have
+    /// honest expectations without the card reading as broken. Mirrors
+    /// Android's `KnownIssue`.
+    case knownIssue
+
+    /// Newly shipped, awaiting on-device review sign-off — surfaced with an
+    /// "In review" badge so testers know exactly which demos to exercise on
+    /// the next store build. Flip to `.working` once the review pass
+    /// validates it. Mirrors Android's `InReview`.
+    case inReview
+
+    /// Not yet implemented on iOS — no real destination; routes to
+    /// ``ComingSoonScreen`` instead. Mirrors Android's `ComingSoon` in
+    /// spirit (see the documented asymmetry above).
     case comingSoon
 
-    var isAvailable: Bool {
-        if case .available = self { return true }
-        return false
-    }
+    /// `true` for any status with a real, tappable destination
+    /// (`.working`, `.knownIssue`, `.inReview`) — only `.comingSoon` has none.
+    var isAvailable: Bool { self != .comingSoon }
 
-    var isComingSoon: Bool {
-        if case .comingSoon = self { return true }
-        return false
+    /// `true` only for `.comingSoon`. Kept as a named accessor (existing call
+    /// sites already read naturally as `scene.status.isComingSoon`).
+    var isComingSoon: Bool { self == .comingSoon }
+
+    /// Badge text shown on the demo card in `SamplesTab`, or `nil` for
+    /// `.working` (no badge rendered). Mirrors Android's `StatusChip` label
+    /// strings (`DemoListScreen.kt:322-328` / `strings.xml`'s
+    /// `samples_chip_*` entries) so the same four states read the same way
+    /// on both platforms.
+    var badgeLabel: String? {
+        switch self {
+        case .working: return nil
+        case .knownIssue: return "Preview"
+        case .inReview: return "In review"
+        case .comingSoon: return "Soon"
+        }
     }
 }
 
@@ -29,26 +78,37 @@ struct DemoItem: Identifiable {
     let status: DemoStatus
     let destination: AnyView
 
-    /// Available demo with a real destination view.
+    /// Demo with a real destination view. `status` must be one of the three
+    /// "available" cases (`.working`, `.knownIssue`, `.inReview`) — enforced
+    /// with a precondition since `.comingSoon` has no destination by
+    /// definition and must go through the `comingSoonTitle:` initializer
+    /// below instead.
     init<V: View>(
         title: String,
         icon: String,
         subtitle: String,
         category: DemoCategory,
+        status: DemoStatus = .working,
         @ViewBuilder destination: () -> V
     ) {
+        precondition(
+            status.isAvailable,
+            "DemoItem(title:...) requires an available status (.working/.knownIssue/.inReview) " +
+            "— use the comingSoonTitle: initializer for .comingSoon"
+        )
         self.title = title
         self.icon = icon
         self.subtitle = subtitle
         self.category = category
-        self.status = .available
+        self.status = status
         self.destination = AnyView(destination())
     }
 
     /// Coming-soon demo — tap routes to ``ComingSoonScreen`` instead of a real destination.
     ///
     /// Mirrors an Android demo that is not yet ported to iOS. The item stays visible in the list
-    /// (with a "Coming soon" badge) so users see the roadmap rather than discovering gaps.
+    /// (with a "Soon" badge) so users see the roadmap rather than discovering gaps. Status is
+    /// always `.comingSoon` — there is no destination to attach any other status to.
     init(
         comingSoonTitle title: String,
         icon: String,

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
@@ -24,16 +24,17 @@ import SwiftUI
 ///
 /// `samples/ios-demo/scripts/collate-ios-demos.sh` discovers every
 /// `*Scene.swift` file, reads the `// @sceneId`, `// @title`,
-/// `// @subtitle`, `// @category`, and `// @available` directives from
-/// each file's header comments, and regenerates `GeneratedScenes.swift`.
-/// That generated file is `.gitignore`d (like Android's `GeneratedDemos.kt`)
-/// and re-created before each Xcode build by a Run Script phase.
+/// `// @subtitle`, `// @category`, `// @available`, and `// @status`
+/// directives from each file's header comments, and regenerates
+/// `GeneratedScenes.swift`. That generated file is `.gitignore`d (like
+/// Android's `GeneratedDemos.kt`) and re-created before each Xcode build by a
+/// Run Script phase.
 ///
 /// Using structured header comments (instead of parsing Swift syntax)
 /// keeps the collator a simple line-grepping shell script that works
 /// without a Swift parser or SPM plugins.
 ///
-/// # Directives (all required in each `*Scene.swift` file)
+/// # Directives
 ///
 /// ```
 /// // @sceneId     model-viewer
@@ -41,7 +42,25 @@ import SwiftUI
 /// // @subtitle    Load and display 3D models
 /// // @category    basics3D          (one of: basics3D|lighting|content|interaction|advanced|ar)
 /// // @available   true              (true = shows destination view; false = "Coming soon")
+/// // @status      working           (optional — see below)
 /// ```
+///
+/// `@sceneId`, `@title`, `@subtitle`, `@category`, and `@available` are
+/// required. `@status` is **optional** and mirrors Android's `DemoStatus`
+/// (`Working`/`KnownIssue`/`ComingSoon`/`InReview`, see `DemoItem.swift`):
+///
+/// - One of `working` | `knownIssue` | `inReview` | `comingSoon`.
+/// - **Default when omitted** (so no pre-existing `*Scene.swift` file needs
+///   editing): `working` when `@available true`, `comingSoon` when
+///   `@available false`.
+/// - **Cross-validated against `@available`** — the collator errors out on a
+///   contradictory pair: `working`/`knownIssue`/`inReview` all require
+///   `@available true` (they claim a real destination exists); `comingSoon`
+///   requires `@available false` (it claims none does).
+/// - Drives the badge rendered on the Samples-tab card
+///   (`SamplesTab.swift`'s `StatusBadge` — "Preview" / "In review" / "Soon",
+///   `.working` renders no badge) — the iOS mirror of Android's
+///   `DemoListScreen.kt` `StatusChip`.
 ///
 /// The conforming type must also provide:
 /// - `static var destination: AnyView { get }` — SwiftUI view (ignored when

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -11,6 +11,10 @@ import SceneViewSwift
 /// (a plain scrollable info screen, no 3D surface) uses the `.sheet`.
 ///
 /// A `3D / AR` filter chip at the top filters the visible categories.
+///
+/// Cards with a non-``DemoStatus/working`` status surface a small
+/// ``StatusBadge`` ("Preview" / "In review" / "Soon") next to the title —
+/// the iOS mirror of Android's `DemoListScreen.kt` status chip (#2802).
 struct SamplesTab: View {
     // Lazy initialization on first access so the @MainActor constraint of
     // GeneratedScenes.all() is satisfied — View init runs on the main actor
@@ -189,7 +193,7 @@ struct SamplesTab: View {
     @ViewBuilder
     private func sheetDestination(for scene: DemoItem) -> some View {
         switch scene.status {
-        case .available:
+        case .working, .knownIssue, .inReview:
             scene.destination
                 .navigationTitle(scene.title)
                 .navigationBarTitleInline()
@@ -204,8 +208,12 @@ struct SamplesTab: View {
 
     private func accessibilityLabel(for scene: DemoItem) -> String {
         switch scene.status {
-        case .available:
+        case .working:
             return "\(scene.title): \(scene.subtitle)"
+        case .knownIssue:
+            return "\(scene.title): \(scene.subtitle). Known issue."
+        case .inReview:
+            return "\(scene.title): \(scene.subtitle). In review."
         case .comingSoon:
             return "\(scene.title): \(scene.subtitle). Coming soon."
         }
@@ -258,14 +266,7 @@ private struct SceneRow: View {
                         .foregroundStyle(scene.status.isAvailable ? Color.primary : Color.secondary)
                         .lineLimit(1)
 
-                    if scene.status.isComingSoon {
-                        Text("Soon")
-                            .font(.caption2.weight(.semibold))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.orange.opacity(0.18), in: Capsule())
-                            .foregroundStyle(.orange)
-                    }
+                    StatusBadge(status: scene.status)
                 }
 
                 Text(scene.subtitle)
@@ -288,5 +289,44 @@ private struct SceneRow: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .strokeBorder(Color.primary.opacity(0.06), lineWidth: 0.5)
         )
+    }
+}
+
+// MARK: - Status badge
+
+/// Small capsule badge communicating a demo's ``DemoStatus`` — the iOS
+/// mirror of Android's `StatusChip` (`DemoListScreen.kt:321-357`): an honest
+/// signal ("Preview" / "In review" / "Soon") rather than a red alarm, so
+/// users have accurate expectations without the card reading as broken.
+/// Renders nothing for `.working` (the common case shouldn't be flagged),
+/// matching Android's `StatusChip` early-return for `DemoStatus.Working`.
+///
+/// Unlike Android's single neutral chip style (same colors for all three
+/// non-Working statuses, varying only the label), each iOS badge keeps its
+/// own restrained tint — idiomatic for SwiftUI capsule badges and already
+/// the established pattern here pre-#2802 (`.comingSoon`'s "Soon" badge was
+/// already orange). None uses an alarm color (red); "Preview" reuses the
+/// yellow Android's own `DemoStatus.KnownIssue` doc-comment calls for.
+private struct StatusBadge: View {
+    let status: DemoStatus
+
+    private var tint: Color {
+        switch status {
+        case .working: return .clear // never rendered — see `body`
+        case .knownIssue: return .yellow
+        case .inReview: return .blue
+        case .comingSoon: return .orange
+        }
+    }
+
+    var body: some View {
+        if let label = status.badgeLabel {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(tint.opacity(0.18), in: Capsule())
+                .foregroundStyle(tint)
+        }
     }
 }

--- a/samples/ios-demo/scripts/collate-ios-demos.sh
+++ b/samples/ios-demo/scripts/collate-ios-demos.sh
@@ -11,6 +11,18 @@
 #   // @category    <category>     one of: basics3D|lighting|content|interaction|advanced|ar
 #   // @available   <true|false>   false → "Coming soon" card in SamplesTab
 #   // @iosOnly     <true|false>   (optional, default false) wraps item in #if os(iOS)
+#   // @status      <value>        (optional) one of: working|knownIssue|comingSoon|inReview
+#
+# `@status` (optional — mirrors Android's 4-state `DemoStatus`, #2802):
+#   - Default when omitted: `working` if @available true, `comingSoon` if @available false.
+#     No pre-existing *Scene.swift file needs an edit to keep working after this directive
+#     was added.
+#   - Cross-validated against @available so the two directives can't contradict each other:
+#     `working`/`knownIssue`/`inReview` all require @available true (they claim a real
+#     destination exists); `comingSoon` requires @available false (it claims none does).
+#   - Drives the badge rendered on the Samples-tab card (SamplesTab.swift's `StatusBadge`:
+#     "Preview" for knownIssue, "In review" for inReview, "Soon" for comingSoon; `working`
+#     renders no badge) — the iOS mirror of Android's `DemoListScreen.kt` `StatusChip`.
 #
 # The script emits `GeneratedScenes.swift` which:
 #   - Provides `GeneratedScenes.all() -> [DemoItem]`  — consumed by SamplesTab
@@ -71,6 +83,7 @@ for f in "$SCENES_DIR"/*Scene.swift; do
     category=$(grep -m1 '// @category' "$f" | sed -E 's|.*// @category[[:space:]]+||; s/[[:space:]]+$//')
     available=$(grep -m1 '// @available' "$f" | sed -E 's|.*// @available[[:space:]]+||; s/[[:space:]]+$//')
     ios_only=$(grep -m1 '// @iosOnly' "$f" 2>/dev/null | sed -E 's|.*// @iosOnly[[:space:]]+||; s/[[:space:]]+$//' || echo "false")
+    status=$(grep -m1 '// @status' "$f" 2>/dev/null | sed -E 's|.*// @status[[:space:]]+||; s/[[:space:]]+$//' || echo "")
 
     for field in scene_id title subtitle icon category available; do
         if [ -z "${!field}" ]; then
@@ -96,9 +109,48 @@ for f in "$SCENES_DIR"/*Scene.swift; do
         *) ios_only="false" ;;
     esac
 
-    # TAB-separated: sceneId title subtitle icon category available iosOnly
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" >> "$TMP_META"
+    # @status defaults from @available when omitted (#2802): `working` for an
+    # available scene, `comingSoon` for one that isn't — so none of the
+    # pre-#2802 *Scene.swift files need an edit to keep collating correctly.
+    if [ -z "$status" ]; then
+        if [ "$available" = "true" ]; then
+            status="working"
+        else
+            status="comingSoon"
+        fi
+    fi
+
+    case "$status" in
+        working|knownIssue|inReview|comingSoon) ;;
+        *) echo "Error: $base @status '$status' is not one of: working knownIssue comingSoon inReview." >&2; exit 1 ;;
+    esac
+
+    # Cross-validate @status against @available — a scene can't claim both a
+    # real destination and no destination at the same time. This is the
+    # invariant DemoItem's own precondition enforces at runtime (#2802); the
+    # collator catches it at build time instead, with a file name attached.
+    case "$status" in
+        working|knownIssue|inReview)
+            if [ "$available" != "true" ]; then
+                echo "Error: $base has @status '$status' but @available false — " \
+                     "'$status' requires a real destination (@available true). " \
+                     "Use @status comingSoon for a scene with no destination." >&2
+                exit 1
+            fi
+            ;;
+        comingSoon)
+            if [ "$available" != "false" ]; then
+                echo "Error: $base has @status comingSoon but @available true — " \
+                     "a scene with a real destination can't be comingSoon. " \
+                     "Use @status working, knownIssue, or inReview instead." >&2
+                exit 1
+            fi
+            ;;
+    esac
+
+    # TAB-separated: sceneId title subtitle icon category available iosOnly status
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" >> "$TMP_META"
     scene_count=$((scene_count + 1))
 done
 
@@ -120,7 +172,7 @@ SORTED_META="$(mktemp)"
 trap 'rm -f "$TMP_META" "$SORTED_META"' EXIT
 sort -k1,1 "$TMP_META" > "$SORTED_META"
 
-# ─── 2. Map category slug → DemoCategory enum value ─────────────────────
+# ─── 2. Map category/status slugs → Swift enum values ───────────────────
 category_enum() {
     case "$1" in
         basics3D)    printf '.basics3D' ;;
@@ -133,12 +185,24 @@ category_enum() {
     esac
 }
 
+# Maps to `DemoStatus` (`DemoItem.swift`, #2802). Only called for
+# @available true scenes — `comingSoon` never needs the mapping since the
+# `comingSoonTitle:` initializer hard-codes `.comingSoon` itself.
+status_enum() {
+    case "$1" in
+        working)    printf '.working' ;;
+        knownIssue) printf '.knownIssue' ;;
+        inReview)   printf '.inReview' ;;
+        *) echo "Error: unknown status '$1' for an available scene." >&2; exit 1 ;;
+    esac
+}
+
 # ─── 3. Augment sorted meta with Swift type names ───────────────────────
 # Extract the `enum <Name>Scene: DemoScene` declaration from each file.
 TMP_FULL="$(mktemp)"
 trap 'rm -f "$TMP_META" "$SORTED_META" "$TMP_FULL"' EXIT
 
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status; do
     # Find the *Scene.swift file whose @sceneId matches.
     type_name=""
     for f in "$SCENES_DIR"/*Scene.swift; do
@@ -152,9 +216,9 @@ while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only
         echo "Error: no 'enum <Name>Scene: DemoScene' declaration found for sceneId='$scene_id'." >&2
         exit 1
     fi
-    # 8 columns: sceneId title subtitle icon category available iosOnly typeName
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$type_name" >> "$TMP_FULL"
+    # 9 columns: sceneId title subtitle icon category available iosOnly status typeName
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" "$type_name" >> "$TMP_FULL"
 done < "$SORTED_META"
 
 # ─── 4. Emit GeneratedScenes.swift ───────────────────────────────────────
@@ -193,7 +257,7 @@ enum GeneratedScenes {
         var items: [DemoItem] = []
 HEADER
 
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
     cat_enum=$(category_enum "$category")
 
     # Escape title / subtitle for Swift string literals.
@@ -205,11 +269,13 @@ while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only
     fi
 
     if [ "$available" = "true" ]; then
+        status_enum_val=$(status_enum "$status")
         printf '        items.append(DemoItem(\n'
         printf '            title: "%s",\n' "$swift_title"
         printf '            icon: "%s",\n' "$icon"
         printf '            subtitle: "%s",\n' "$swift_subtitle"
-        printf '            category: %s\n' "$cat_enum"
+        printf '            category: %s,\n' "$cat_enum"
+        printf '            status: %s\n' "$status_enum_val"
         printf '        ) { %s.destination })\n' "$type_name"
     else
         printf '        items.append(DemoItem(\n'
@@ -241,7 +307,7 @@ ALL_END
 
 # `allowedIds`: every scene id (available true AND false), sorted by id so
 # the diff stays stable and two parallel PRs never collide.
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
     printf '        "%s",\n' "$scene_id"
 done < "$TMP_FULL"
 
@@ -263,7 +329,7 @@ IDS_END
 # scenes fall through to `default: return nil` (→ placeholder), never their
 # own `EmptyView`. iOS-only scenes are guarded so a non-iOS build returns
 # `nil` (→ placeholder) rather than a blank view.
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
     [ "$available" = "true" ] || continue
     if [ "$ios_only" = "true" ]; then
         printf '        case "%s":\n' "$scene_id"


### PR DESCRIPTION
## Summary

Extends iOS's 2-state `DemoStatus` (`available`/`comingSoon`) to a 4-state enum mirroring Android's `DemoStatus` (`Working`/`KnownIssue`/`ComingSoon`/`InReview`, `samples/android-demo/.../DemoRegistry.kt:13-29`). Before this, iOS had no way to express a known bug on an already-implemented demo, or a newly-shipped demo awaiting on-device review sign-off — even though Android uses both states today: **44 Working / 5 KnownIssue / 2 ComingSoon / 2 InReview** (verified by grepping every Android `*Fragment.kt`, per the parity-manifest baseline from L0.3).

L0.4 of the iOS/Android catalog-ISO effort (#2798). Depends on L0.2 (#2800, merged) — the collator-generated registry.

- **`DemoItem.swift`** — `DemoStatus` grows to `.working` / `.knownIssue` / `.inReview` / `.comingSoon`. `isAvailable`/`isComingSoon` stay as computed accessors (no call-site churn beyond the exhaustive switches below); adds `badgeLabel` for the badge text. `DemoItem`'s "available" initializer takes an optional `status:` param (default `.working`) with a `precondition` rejecting `.comingSoon` (which must go through the `comingSoonTitle:` initializer instead — a demo with no destination can't claim to be working/knownIssue/inReview).
- **`collate-ios-demos.sh`** — adds an optional `@status` directive alongside `@sceneId`/`@title`/`@available`/etc. **Default when omitted**: `working` if `@available true`, `comingSoon` if `@available false` — so none of the 51 existing `*Scene.swift` files needed an edit. **Cross-validated against `@available`**: `working`/`knownIssue`/`inReview` require `@available true`; `comingSoon` requires `@available false` — the collator errors out (with the file name) on a contradictory pair instead of silently emitting something `DemoItem`'s own precondition would trap on at runtime.
- **`SamplesTab.swift`** — replaces the ad hoc inline `if scene.status.isComingSoon { Text("Soon")... }` with a reusable `StatusBadge` view covering all 4 states: no badge (`.working`), yellow "Preview" (`.knownIssue`), blue "In review" (`.inReview`), orange "Soon" (`.comingSoon`, unchanged from before). This is the iOS mirror of Android's `DemoListScreen.kt` `StatusChip` (lines 322-328) — same spirit (honest signal, not a red alarm), idiomatic SwiftUI rather than a Material 3 pixel copy (Android uses one neutral chip style for all 3 non-Working statuses; iOS keeps each badge's own restrained tint, continuing the pre-existing precedent that `.comingSoon`'s "Soon" badge was already orange). Updates the exhaustive `scene.status` switches (`sheetDestination`, `accessibilityLabel`) for the 2 new cases.
- **`DemoScene.swift`** — documents the `@status` directive in the directive-contract doc comment.

## Final enum + badge mapping

| iOS case | Android mirror | Badge | Real destination |
|---|---|---|---|
| `.working` | `Working` | none | Real view |
| `.knownIssue` | `KnownIssue` | "Preview" (yellow) | Real view |
| `.inReview` | `InReview` | "In review" (blue) | Real view |
| `.comingSoon` | `ComingSoon` | "Soon" (orange, unchanged) | None (placeholder) |

**Documented asymmetry with Android** (in `DemoItem.swift`'s doc comment): Android's `ComingSoon` fragments still ship a real (if partial) `Screen()` — e.g. `ArHandTrackingFragment` renders a static reference skeleton. iOS's `DemoScene` contract is binary (`@available` gates whether a real `destination` exists at all), so on iOS `.comingSoon` always means "no destination yet," never "a partial one." A demo that IS implemented on iOS but has a known bug is `.knownIssue`, not `.comingSoon`.

## Scope discipline (no over-reclassification)

Per the issue's explicit guidance, this PR does not repaint the 51 existing Scene files. All of them keep their inferred default (`working` for the 42 `@available true` scenes, `comingSoon` for the 9 `@available false` stubs — including the 5 ids that map to Android `KnownIssue` demos like `ar-cloud-anchor`/`ar-rooftop`/`ar-terrain`, which stay honestly `comingSoon` on iOS since they aren't ported yet, not falsely `knownIssue`). `knownIssue`/`inReview` are capability additions for future use (e.g. `wall-placement` landing `inReview` once ported in a later Phase-2 PR, mirroring Android's #2740 state) — proven to work via a temporary probe (see verification below), not applied permanently to any real demo in this PR.

## Verification

- `bash samples/ios-demo/scripts/collate-ios-demos.sh` regenerates cleanly — 51 scenes, 42 `.working` / 9 `.comingSoon` / 0 `.knownIssue` / 0 `.inReview` (unchanged distribution, confirming the default-inference path). `--check` is idempotent immediately after.
- `xcodebuild build` (iOS Simulator, iPhone, iOS 26.3): SUCCEEDED, zero new warnings (the one pre-existing warning is unrelated `SketchfabService.swift` code).
- `xcodebuild test`: 55 passed / 0 failed / 1 skipped (the skip is a pre-existing, network-gated Sketchfab test, unrelated to this change). All 19 `DemoRegistryGuardTests` (the L0.3 registry/deep-link guard suite) pass unchanged.
- Visual proof of all 4 badges: temporarily added `// @status knownIssue` to `AnimationScene.swift` and `// @status inReview` to `GeometryScene.swift` (both already-`@available true`, non-AR, no-hardware-dependency scenes — chosen so the probe has zero side effects), rebuilt, and screenshotted the Samples tab on the iOS Simulator. Confirmed: "Animation" shows a yellow "Preview" badge, "Geometry Primitives" shows a blue "In review" badge, sibling working demos (Model Viewer, Multi-Model Scene, Scene Gallery, ...) show no badge, and the AR category's existing `comingSoon` items ("Cloud Anchors", "Image Stabilization (EIS)") still show the orange "Soon" badge, unchanged. All edits (the 2 Scene-file directives, plus a temporary default-tab/default-filter tweak used only to land on the Samples tab without an interactive tap tool in this environment) were reverted before this commit -- `git diff` against `origin/main` on those files is empty, confirmed before committing.
- Disk-gated per repo policy: verified free disk stayed at or above 6 GiB throughout (started 6.72 GiB, dipped to 6.00 GiB mid-run, recovered to 7.16 GiB after purging this session's DerivedData (~1.0 GB) and shutting down the simulator).

## Test plan

- [x] `bash samples/ios-demo/scripts/collate-ios-demos.sh --check` passes
- [x] `xcodebuild build` succeeds on iOS Simulator
- [x] `xcodebuild test` -- `DemoRegistryGuardTests` + full suite green (55/0/1 skip)
- [x] Visual QA: all 4 badge states confirmed rendering distinctly (screenshots taken during the session, temporary probe reverted before commit)
- [ ] CI green (pending)

Closes #2802
Part of #2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)