### PR TITLE
test(ci): wire the ios device-QA leg + real render-tests iOS screenshots (#2803)

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -46,11 +46,14 @@
 #   --advisory=<csv> Comma-separated platforms whose result is ADVISORY for the
 #                    release gate — a failure on an advisory leg surfaces as a
 #                    WARN (not a hard block) in release-checklist.sh section 14
-#                    (#1651). Default: `android,ar,web-perf,sketchfab,arcore-cloud`.
+#                    (#1651). Default: `android,ar,ios,web-perf,sketchfab,arcore-cloud`.
 #                    `android,ar` run on the chronically flaky SwiftShader
 #                    emulator (#1643) and are `continue-on-error: true` in
 #                    device-qa.yml, so the release gate must not be hard-blocked
-#                    by them. `web-perf` is the Lighthouse perf sub-leg of `web`
+#                    by them. `ios` (#2803) is the nightly-only Maestro-on-
+#                    simulator leg on a costly macOS runner — advisory until the
+#                    simulator boot/timing is proven reliably green. `web-perf`
+#                    is the Lighthouse perf sub-leg of `web`
 #                    (#1879/#1898) — advisory until its budgets are proven against
 #                    real baseline data. `sketchfab` + `arcore-cloud` (#2343) are
 #                    the key-gated sub-legs — `skipped` (advisory) when their API
@@ -121,13 +124,18 @@ OUT_DIR="$REPO_ROOT"
 # Advisory legs (#1651): a failure here is a release-gate WARN, not a block.
 # `android,ar` ride the flaky SwiftShader emulator and are continue-on-error
 # in device-qa.yml; `web` is reliable and stays BLOCKING.
+# `ios` (#2803) is advisory for the same reason android/ar are: the iOS leg
+# runs Maestro on a CI simulator (flaky boot/timing) on a costly macOS runner
+# (nightly-only in device-qa.yml, `continue-on-error: true`) — a red iOS leg
+# surfaces as a release WARN, never a hard block, until the simulator leg is
+# proven reliably green. Promote it out of this CSV to make it blocking.
 # `web-perf` (#1898) is the Lighthouse perf sub-leg — advisory at first, until
 # its budgets are proven stable against real baseline data. Promote it out of
 # this CSV to make a budget breach a hard release block.
 # `sketchfab` + `arcore-cloud` (#2343) are the key-gated sub-legs: when their
 # API key is absent the path is reported `skipped` (advisory) — a missing LOCAL
 # key must surface as a WARN, never hard-block a dev's run.
-ADVISORY="android,ar,web-perf,sketchfab,arcore-cloud"
+ADVISORY="android,ar,ios,web-perf,sketchfab,arcore-cloud"
 ADVISORY_SET=false
 
 while [[ $# -gt 0 ]]; do
@@ -189,10 +197,17 @@ warn() { echo "[device-qa] WARNING: $*" >&2; }
 #                    ~300 MB ARCore APK. Well under a full pass — a 15 GB gate
 #                    false-aborted the advisory `ar` leg (#2640) exactly as it
 #                    once did the web leg.
+#   • ios            ~10 GB — a single `xcodebuild` sim build (SPM RealityKit +
+#                    the demo app) into a mktemp DerivedData plus a booted
+#                    simulator; heavier than android (which reuses a prebuilt
+#                    APK), lighter than a full pass. On a disk-tight self-hosted
+#                    Mac this trips → the advisory ios leg skips honestly (WARN),
+#                    never cratering the host (#2803).
 DISK_MIN_GB=15
 case "$PLATFORM" in
   web)        DISK_MIN_GB=5 ;;
   android|ar) DISK_MIN_GB=8 ;;
+  ios)        DISK_MIN_GB=10 ;;
 esac
 DISK_GATE_SKIP=false   # set below when an advisory-only --ci run trips the gate
 if ! bash "$SCRIPT_DIR/disk-gated-spawn-check.sh" --quiet --min-gb="$DISK_MIN_GB" >/dev/null 2>&1; then

--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -63,31 +63,36 @@ name: Device QA
 # record with `advisory: true|false` so the gate's behaviour is intentional,
 # not accidental — see `device-qa.sh` and `release-checklist.sh` section 14.
 #
-# FOUR-LEG SPLIT — PER-PUSH vs NIGHTLY-ONLY (#1601)
-# -------------------------------------------------
+# FOUR-LEG SPLIT — PER-PUSH vs NIGHTLY-ONLY (#1601, ios wired #2803)
+# -----------------------------------------------------------------
 # `device-qa.sh` orchestrates FOUR platform legs: web / android / ios / ar.
-# This workflow deliberately defines only the `web` and `android` jobs:
+# This workflow now defines all four, split by cost:
 #
 #   web      — Playwright on ubuntu-latest. Cheap, always feasible. Per-push.
+#              BLOCKING (not continue-on-error).
 #   android  — Maestro on a KVM-accelerated emulator (ubuntu-latest). Heavy
-#              but feasible on GitHub-hosted runners. Per-push.
-#   ios      — Maestro on an iOS Simulator. NIGHTLY-ONLY: needs a `macos-*`
-#              runner, which is ~10x the per-minute cost and has no KVM —
-#              not worth spending on every demo-source push.
-#   ar       — ARCore replay harness. NIGHTLY-ONLY: needs an ARCore-capable
-#              emulator plus committed AR recordings; setup is too slow and
-#              flaky to gate routine pushes on.
+#              but feasible on GitHub-hosted runners. Per-push. ADVISORY.
+#   ar       — ARCore replay harness on the KVM emulator (ubuntu-latest).
+#              Per-push. ADVISORY.
+#   ios      — Maestro on an iOS Simulator (#2803). NIGHTLY + release-checkpoint
+#              ONLY, NOT per-push: it needs a `macos-*` runner, which is ~10x
+#              the ubuntu per-minute cost and has no KVM — not worth spending on
+#              every demo-source push. The job is gated `if: github.event_name
+#              != 'push'`, so it runs on the nightly `workflow_call`
+#              (nightly-ci.yml) and on manual `workflow_dispatch` (a pre-tag
+#              release checkpoint), never on a push. It routes to the
+#              self-hosted Mac when the heartbeat reports it online and falls
+#              back to `macos-15` otherwise (same opt-in pattern as ios.yml /
+#              bridge-ios-compile.yml). ADVISORY: `continue-on-error: true` here
+#              and `ios` is in device-qa.sh's default advisory CSV, so a red iOS
+#              leg is a release WARN, never a hard block, until the CI simulator
+#              leg is proven reliably green.
 #
-# The `ios` and `ar` legs therefore run ONLY via the nightly `workflow_call`
-# (nightly-ci.yml), which executes `device-qa.sh --platform=all` on the
-# appropriate runners. A broken / always-skipped iOS or AR job in THIS
-# workflow would be worse than documenting the split, so they are omitted
-# here by design rather than stubbed.
-#
-# Path trigger consequence: `samples/ios-demo/**` is intentionally absent
-# from the `paths:` filter below — adding it would spin up the web+android
-# jobs for an iOS-only change while no iOS job exists to actually exercise
-# it. iOS demo changes are covered by the nightly run instead.
+# Path trigger consequence: `samples/ios-demo/**` is intentionally absent from
+# the `paths:` filter below — the iOS leg is nightly-only, so a push touching
+# only the iOS demo must not spin up the ubuntu web/android/ar jobs for a change
+# no per-push leg exercises. iOS demo changes are covered by the nightly run
+# (and by render-tests.yml's iOS screenshot job, #2803).
 
 on:
   push:
@@ -372,6 +377,90 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: device-qa-report-ar
+          path: |
+            device-qa-report.json
+            device-qa-artifacts/
+          if-no-files-found: ignore
+
+  # ── iOS leg — Maestro on an iOS Simulator (#2803) ─────────────────────────
+  # NIGHTLY + release-checkpoint ONLY (see the FOUR-LEG SPLIT header block):
+  # gated `if: github.event_name != 'push'` so it NEVER runs on a per-push
+  # build — a macOS runner is ~10x the ubuntu per-minute cost and has no KVM.
+  # It runs on the nightly `workflow_call` (nightly-ci.yml, event=schedule) and
+  # on manual `workflow_dispatch` (a pre-tag release checkpoint), never on push.
+  #
+  # Routes to the self-hosted Mac (label `sceneview-mac`) when its heartbeat
+  # reports it online, falling back to `macos-15` otherwise — the same opt-in
+  # pattern ios.yml / bridge-ios-compile.yml already use.
+  #
+  # ADVISORY: `continue-on-error: true` here, and `ios` is in device-qa.sh's
+  # default advisory CSV (#2803), so a red iOS leg is a release WARN, never a
+  # hard block — matching the android/ar posture on the flaky CI emulator. The
+  # simulator leg must prove reliably green before it is promoted to blocking.
+  ios:
+    name: Device QA — ios (Maestro / Simulator)
+    if: github.event_name != 'push'
+    runs-on: ${{ vars.SELF_HOSTED_MACOS_ONLINE == 'true' && 'sceneview-mac' || 'macos-15' }}
+    timeout-minutes: 45
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode
+        # DEVELOPER_DIR (Apple-canonical), NOT `sudo xcode-select -s`: the sudo
+        # form needs NOPASSWD in /etc/sudoers, which GitHub-hosted runners have
+        # but the self-hosted Mac (launchd, no TTY) does not — sudo would fail
+        # with `a password is required` (see bridge-ios-compile.yml). Works on
+        # both hosted and self-hosted, no sudo needed.
+        run: |
+          for cand in \
+            /Applications/Xcode_26.3.app \
+            /Applications/Xcode_26.2.app \
+            /Applications/Xcode_26.1.1.app \
+            /Applications/Xcode_26.0.1.app \
+            /Applications/Xcode.app; do
+            if [ -d "$cand" ]; then
+              echo "DEVELOPER_DIR=$cand/Contents/Developer" >> "$GITHUB_ENV"
+              echo "Using Xcode: $cand"
+              "$cand/Contents/Developer/usr/bin/xcodebuild" -version
+              exit 0
+            fi
+          done
+          echo "::error::No Xcode installation found in /Applications/"
+          exit 1
+
+      - name: Install Maestro
+        # device-qa.sh → ios-device-qa.sh → lib/maestro.sh does NOT auto-install
+        # under CI=1 — it expects the workflow to provide the binary (same as
+        # the android job). MAESTRO_VERSION KEPT IN SYNC with lib/maestro.sh.
+        # `set -o pipefail` so a network failure aborts HERE (obvious) rather
+        # than later as an opaque "maestro: not found". Canonical installer host
+        # is get.maestro.mobile.dev (get.maestro.dev does not resolve).
+        run: |
+          set -euo pipefail
+          MAESTRO_VERSION="2.6.1" curl -fsSL "https://get.maestro.mobile.dev" | bash
+          test -x "$HOME/.maestro/bin/maestro"
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Run device-qa.sh (ios leg)
+        # --fast runs the representative `3d-basics` iOS category flow instead of
+        # the full catalog, keeping costly macOS minutes down (matches the
+        # android leg). --ci makes a required-leg skip a failure — but `ios` is
+        # ADVISORY in device-qa.sh, so an honest simulator skip is a WARN,
+        # exit 0, and continue-on-error absorbs a hard failure. SKETCHFAB_API_KEY
+        # is injected so the keyed Explore / streamed-USDZ path is exercised
+        # (#2356); read into env only, never referenced from an `if:`.
+        env:
+          SKETCHFAB_API_KEY: ${{ secrets.SKETCHFAB_API_KEY }}
+        run: |
+          export PATH="$HOME/.maestro/bin:$PATH"
+          bash .claude/scripts/device-qa.sh --platform=ios --fast --ci
+
+      - name: Upload ios device-QA report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: device-qa-report-ios
           path: |
             device-qa-report.json
             device-qa-artifacts/

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -361,10 +361,22 @@ jobs:
           if-no-files-found: ignore
 
   # ── iOS render tests ──────────────────────────────────────────────────────
+  # Runs the `SceneViewDemoUITests` UI-testing target (#2803) — an XCUITest
+  # smoke that launches the demo in a simulator and captures an XCTAttachment
+  # screenshot of the launch screen, every tab, and a representative subset of
+  # working 3D demos (reached via the app's `-demo <id>` launch arg). Before
+  # #2803 this job ran the logic-only `SceneViewDemoTests` unit target via
+  # `-scheme SceneViewDemo`, which emits ZERO screenshots — so the job's name
+  # was a lie and it produced no PNG artifact.
+  #
+  # It uses its OWN dedicated scheme (`SceneViewDemoUITests`), NOT `SceneViewDemo`
+  # — so the per-PR iOS unit-test check in ios.yml (`-scheme SceneViewDemo test`)
+  # stays fast and simulator-free; the heavy UI/screenshot pass lives only here
+  # (main-push + nightly, non-blocking).
   ios-render:
     name: iOS screenshot tests (Simulator)
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v7
@@ -377,34 +389,55 @@ jobs:
         run: |
           xcodebuild -resolvePackageDependencies \
             -project SceneViewDemo.xcodeproj \
-            -scheme SceneViewDemo \
+            -scheme SceneViewDemoUITests \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             CODE_SIGNING_ALLOWED=NO || true
 
-      - name: Run screenshot tests
+      - name: Run UI screenshot tests
         working-directory: samples/ios-demo
         run: |
+          # UI tests build the host app + the UI test runner and launch on the
+          # simulator. CODE_SIGNING_ALLOWED=NO: a simulator build needs no
+          # signing. `|| true` keeps this leg non-blocking (render-tests is a
+          # post-merge signal, not a required check) — the screenshots are still
+          # captured into the xcresult even if an assertion trips, and the
+          # extract step below surfaces the real count.
           xcodebuild test \
             -project SceneViewDemo.xcodeproj \
-            -scheme SceneViewDemo \
+            -scheme SceneViewDemoUITests \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \
-            2>&1 | tail -200 || true
+            2>&1 | tail -300 || true
 
-      - name: Extract screenshots from xcresult
+      - name: Extract screenshot PNGs from xcresult
         if: always()
         working-directory: samples/ios-demo
         run: |
+          set -uo pipefail
           mkdir -p ios-render-screenshots
-          # Export attachments from xcresult bundle
-          if [ -d TestResults.xcresult ]; then
-            xcresulttool get --format json --path TestResults.xcresult > ios-render-screenshots/results.json 2>/dev/null || true
-            # Copy the entire xcresult for artifact upload
-            cp -R TestResults.xcresult ios-render-screenshots/ 2>/dev/null || true
+          if [ ! -d TestResults.xcresult ]; then
+            echo "::warning::no TestResults.xcresult produced — the UI test bundle did not run"
+            exit 0
+          fi
+          # Xcode 16: `xcresulttool export attachments` writes every XCTAttachment
+          # (our XCUIScreenshot PNGs) to disk as real image files, plus a
+          # manifest.json mapping each to its human-readable attachment name.
+          # THIS is what makes the job a genuine PNG producer (#2803): the old
+          # `xcresulttool get --format json` emitted JSON only, never an image.
+          xcrun xcresulttool export attachments \
+            --path TestResults.xcresult \
+            --output-path ios-render-screenshots \
+            || echo "::warning::xcresulttool export attachments failed — inspect the xcresult artifact"
+          COUNT=$(find ios-render-screenshots -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.heic' \) | wc -l | tr -d ' ')
+          echo "iOS screenshot images extracted: $COUNT"
+          if [ "$COUNT" -lt 4 ]; then
+            echo "::warning::fewer than 4 iOS screenshots extracted ($COUNT) — inspect the UI test run / xcresult"
+          else
+            echo "iOS screenshot job produced $COUNT real image(s)."
           fi
 
-      - name: Upload iOS test results
+      - name: Upload iOS screenshots
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -117,10 +117,18 @@ optionally, so a checkout without the file builds keyless and silently.
 
 ### iOS coverage and known gaps
 
-- **No CI wiring — 0 iOS Maestro runs have ever executed in CI.** `device-qa.yml`
-  defines no `ios` job (only `web`, `android`, `ar`); this leg is local-only
-  today (`bash .claude/scripts/device-qa.sh --platform=ios` / `ios-device-qa.sh`
-  on a dev machine). Tracked in [#2803](https://github.com/sceneview/sceneview/issues/2803).
+- **CI wiring — nightly + release-checkpoint, advisory
+  ([#2803](https://github.com/sceneview/sceneview/issues/2803)).** `device-qa.yml`
+  now defines an `ios` job that runs `device-qa.sh --platform=ios --fast --ci`
+  on a `macos-15` runner (routing to the self-hosted Mac when its heartbeat
+  reports it online). It is gated `if: github.event_name != 'push'`, so it runs
+  on the nightly `workflow_call` (nightly-ci.yml) and on manual
+  `workflow_dispatch` — NEVER on a per-push build (a macOS runner is ~10x the
+  ubuntu per-minute cost). The leg is **advisory** (`continue-on-error` + tagged
+  advisory in `device-qa.sh`): a red iOS leg is a release WARN, never a hard
+  block, until the CI simulator leg is proven reliably green. You can still run
+  it locally any time (`bash .claude/scripts/device-qa.sh --platform=ios` /
+  `ios-device-qa.sh`).
 - **Deep-link reachable set, not a strict subset.** iOS flows reach demos via
   the public `sceneview://demo/<id>` custom scheme. The reachable set is
   `DemoDeepLinkRegistry.allowedIds` (63 ids, up from 24 when
@@ -142,10 +150,15 @@ optionally, so a checkout without the file builds keyless and silently.
 - **`text` / `model-viewer`** render no overlaid SwiftUI chrome on a key-less
   simulator, so they use the assertion-free `flows/demo-noassert.yaml`; their
   crash detection falls to the log sweep below.
-- **This is not the same thing as `render-tests.yml`'s "iOS screenshot tests"
-  job** — that job runs the existing logic-only `SceneViewDemoTests` target and
-  captures no PNGs today (no UI-testing target, no `XCTAttachment` anywhere in
-  the iOS demo). Also tracked in #2803.
+- **Distinct from `render-tests.yml`'s "iOS screenshot tests" job — now REAL
+  (#2803).** That job runs the dedicated `SceneViewDemoUITests` UI-testing
+  target (an XCUITest that launches the app and captures an `XCTAttachment`
+  screenshot of the launch screen, every tab, and a representative subset of
+  working 3D demos reached via the `-demo <id>` launch arg), then exports the
+  attachments as real PNG artifacts. It uses its own `SceneViewDemoUITests`
+  scheme, so the per-PR unit-test check (`ios.yml`, `-scheme SceneViewDemo`)
+  stays fast and simulator-free. The Maestro leg here and that XCUITest leg are
+  complementary screenshot paths.
 
 ## How a demo is exercised
 

--- a/changelog.d/2803-ios-ci-honest.md
+++ b/changelog.d/2803-ios-ci-honest.md
@@ -1,0 +1,14 @@
+<!-- category: Tests -->
+- CI: the iOS device-QA leg is now real. `device-qa.yml` gained an `ios` job
+  (Maestro on an iOS Simulator via `ios-device-qa.sh`) that routes to the
+  self-hosted Mac when online and falls back to `macos-15`. It runs nightly and
+  on manual dispatch only — never per-push (a macOS runner is ~10x the ubuntu
+  cost) — and is **advisory** (a red iOS leg is a release WARN, never a hard
+  block), matching the android/ar posture. `device-qa.sh` tags `ios` advisory
+  in `device-qa-report.json` / `releaseGate` (#2803).
+- CI: `render-tests.yml`'s "iOS screenshot tests" job now produces real PNGs.
+  A dedicated `SceneViewDemoUITests` UI-testing target (XCUITest) launches the
+  demo in a simulator and captures an `XCTAttachment` screenshot of the launch
+  screen, every tab, and a representative subset of working 3D demos; the job
+  exports the attachments from the `.xcresult` as PNG artifacts. It uses its own
+  scheme so the per-PR iOS unit-test check stays fast and simulator-free (#2803).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -172,10 +172,18 @@
 		F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000060 /* SketchfabService+Tests.swift */; };
 		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
 		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
+		F10000000000000000000003 /* SceneViewDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000002 /* SceneViewDemoUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		F00000000000000000000031 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A90000010000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A50000010000000000000001;
+			remoteInfo = SceneViewDemo;
+		};
+		F10000000000000000000031 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A90000010000000000000001 /* Project object */;
 			proxyType = 1;
@@ -201,6 +209,8 @@
 		A20000010000000000000005 /* Secrets.xcconfig.template */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig.template; sourceTree = "<group>"; };
 		A20000010000000000000010 /* SceneViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SceneViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F00000000000000000000001 /* SceneViewDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SceneViewDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10000000000000000000001 /* SceneViewDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SceneViewDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10000000000000000000002 /* SceneViewDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneViewDemoUITests.swift; path = SceneViewDemoUITests/SceneViewDemoUITests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000002 /* AppStoreUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreUpdaterTests.swift; path = SceneViewDemoTests/AppStoreUpdaterTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000060 /* SketchfabService+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabService+Tests.swift"; path = "SceneViewDemo/Services/SketchfabService+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabAssetResolver+Tests.swift"; path = "SceneViewDemo/Services/SketchfabAssetResolver+Tests.swift"; sourceTree = SOURCE_ROOT; };
@@ -373,6 +383,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F10000000000000000000022 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -381,6 +398,7 @@
 			children = (
 				A40000010000000000000002 /* SceneViewDemo */,
 				F00000000000000000000010 /* SceneViewDemoTests */,
+				F10000000000000000000010 /* SceneViewDemoUITests */,
 				A40000010000000000000003 /* Products */,
 				5FA64989921B8BD7A9F30B31 /* ComingSoonScreen.swift */,
 				D77142EC848C995EDE06546D /* SketchfabConfig.swift */,
@@ -406,6 +424,14 @@
 				F00000000000000000000072 /* DemoRegistryGuardTests.swift */,
 			);
 			path = SceneViewDemoTests;
+			sourceTree = "<group>";
+		};
+		F10000000000000000000010 /* SceneViewDemoUITests */ = {
+			isa = PBXGroup;
+			children = (
+				F10000000000000000000002 /* SceneViewDemoUITests.swift */,
+			);
+			path = SceneViewDemoUITests;
 			sourceTree = "<group>";
 		};
 		A40000010000000000000002 /* SceneViewDemo */ = {
@@ -435,6 +461,7 @@
 			children = (
 				A20000010000000000000010 /* SceneViewDemo.app */,
 				F00000000000000000000001 /* SceneViewDemoTests.xctest */,
+				F10000000000000000000001 /* SceneViewDemoUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -648,6 +675,23 @@
 			productReference = F00000000000000000000001 /* SceneViewDemoTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		F10000000000000000000020 /* SceneViewDemoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F10000000000000000000042 /* Build configuration list for PBXNativeTarget "SceneViewDemoUITests" */;
+			buildPhases = (
+				F10000000000000000000021 /* Sources */,
+				F10000000000000000000022 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F10000000000000000000030 /* PBXTargetDependency */,
+			);
+			name = SceneViewDemoUITests;
+			productName = SceneViewDemoUITests;
+			productReference = F10000000000000000000001 /* SceneViewDemoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -662,6 +706,10 @@
 						CreatedOnToolsVersion = 16.0;
 					};
 					F00000000000000000000020 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A50000010000000000000001;
+					};
+					F10000000000000000000020 = {
 						CreatedOnToolsVersion = 16.0;
 						TestTargetID = A50000010000000000000001;
 					};
@@ -685,6 +733,7 @@
 			targets = (
 				A50000010000000000000001 /* SceneViewDemo */,
 				F00000000000000000000020 /* SceneViewDemoTests */,
+				F10000000000000000000020 /* SceneViewDemoUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -929,6 +978,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F10000000000000000000021 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10000000000000000000003 /* SceneViewDemoUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -936,6 +993,11 @@
 			isa = PBXTargetDependency;
 			target = A50000010000000000000001 /* SceneViewDemo */;
 			targetProxy = F00000000000000000000031 /* PBXContainerItemProxy */;
+		};
+		F10000000000000000000030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A50000010000000000000001 /* SceneViewDemo */;
+			targetProxy = F10000000000000000000031 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1164,6 +1226,48 @@
 			};
 			name = Release;
 		};
+		F10000000000000000000040 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5G3DZ3TH45;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.sceneview.demo.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SceneViewDemo;
+			};
+			name = Debug;
+		};
+		F10000000000000000000041 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5G3DZ3TH45;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.sceneview.demo.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SceneViewDemo;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1190,6 +1294,15 @@
 			buildConfigurations = (
 				F00000000000000000000040 /* Debug */,
 				F00000000000000000000041 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F10000000000000000000042 /* Build configuration list for PBXNativeTarget "SceneViewDemoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F10000000000000000000040 /* Debug */,
+				F10000000000000000000041 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/xcshareddata/xcschemes/SceneViewDemoUITests.xcscheme
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/xcshareddata/xcschemes/SceneViewDemoUITests.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A50000010000000000000001"
+               BuildableName = "SceneViewDemo.app"
+               BlueprintName = "SceneViewDemo"
+               ReferencedContainer = "container:SceneViewDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F10000000000000000000020"
+               BuildableName = "SceneViewDemoUITests.xctest"
+               BlueprintName = "SceneViewDemoUITests"
+               ReferencedContainer = "container:SceneViewDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F10000000000000000000020"
+               BuildableName = "SceneViewDemoUITests.xctest"
+               BlueprintName = "SceneViewDemoUITests"
+               ReferencedContainer = "container:SceneViewDemo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A50000010000000000000001"
+            BuildableName = "SceneViewDemo.app"
+            BlueprintName = "SceneViewDemo"
+            ReferencedContainer = "container:SceneViewDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
+++ b/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
@@ -1,0 +1,114 @@
+// SceneViewDemoUITests.swift
+//
+// UI-testing smoke suite for the SceneView iOS demo (#2803, part of the
+// iOS-parity tracker #2798). This target is what makes `render-tests.yml`'s
+// "iOS screenshot tests" job REAL: before it, that job ran the logic-only
+// `SceneViewDemoTests` unit target, which emits ZERO `XCTAttachment` images —
+// so the job captured nothing despite its name.
+//
+// The suite launches the app in a simulator and captures a screenshot of:
+//   1. the launch screen (Explore tab) and every tab in the tab bar, and
+//   2. a representative subset of WORKING 3D demos, each reached headlessly via
+//      the app's `-demo <id>` launch argument — the same deep-link path the App
+//      Store screenshot pipeline uses (see
+//      `.claude/scripts/capture-appstore-screenshots.sh`) — with `-qa_mode 1`
+//      to freeze auto-rotation for a deterministic frame.
+//
+// Every attachment sets `lifetime = .keepAlways` so the PNGs survive a GREEN
+// run and land in the `.xcresult`, from which `render-tests.yml` exports them
+// as real PNG artifacts.
+//
+// Scope is a deliberately honest smoke, not the full ~42-demo catalog (#2803):
+//   * AR demos are NOT screenshotted — the simulator has no camera, so ARKit
+//     demos never reach a rendered frame.
+//   * The tab-bar pass is anchored on the tab bar itself (not a demo id), so it
+//     always yields ≥4 PNGs even if every demo id were later renamed.
+//   * The demo-id pass is TOLERANT: it asserts only that the app stays alive,
+//     so a single renamed id degrades coverage but never red-fails this
+//     advisory job.
+
+import Foundation
+import XCTest
+
+final class SceneViewDemoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // A single unreachable demo must never abort the remaining captures.
+        continueAfterFailure = true
+    }
+
+    /// Attach the app's current screen as a keep-always PNG named `name`.
+    /// `.keepAlways` is required — a passing test discards its attachments by
+    /// default, which would leave the screenshot job with an empty artifact.
+    private func snapshot(_ app: XCUIApplication, _ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    /// Filesystem-safe token for an attachment name derived from a UI label.
+    private func slug(_ raw: String) -> String {
+        let lowered = raw.lowercased()
+        let mapped = lowered.map { ch -> Character in
+            (ch.isLetter || ch.isNumber) ? ch : "-"
+        }
+        return String(mapped)
+    }
+
+    /// Launch, then walk the tab bar. Anchored on the tab bar (not any demo
+    /// id), so it always produces launch + one PNG per tab (≥4 total on iOS).
+    func testLaunchAndTabScreenshots() {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30),
+                      "app never reached the foreground")
+        snapshot(app, "01-launch")
+
+        let tabBar = app.tabBars.firstMatch
+        guard tabBar.waitForExistence(timeout: 15) else {
+            XCTFail("no tab bar found after launch")
+            return
+        }
+        // Iterate by index so the pass never depends on a tab's title/label —
+        // the tab set (Explore, AR View, Samples, About) can change without
+        // breaking the smoke. The button's `label` still names the PNG.
+        let count = tabBar.buttons.count
+        for i in 0..<count {
+            let button = tabBar.buttons.element(boundBy: i)
+            guard button.exists else { continue }
+            let name = String(format: "%02d-tab-%@", i + 2, slug(button.label))
+            button.tap()
+            _ = app.wait(for: .runningForeground, timeout: 3)
+            snapshot(app, name)
+        }
+    }
+
+    /// A representative subset of WORKING 3D demos, each launched headlessly
+    /// via `-demo <id>`. Kept in sync (by intent) with the App Store screenshot
+    /// pipeline's `DEMOS` array — pure-3D demos proven to render on a CI
+    /// simulator without a camera.
+    func testWorkingDemoScreenshots() {
+        let demos = [
+            "model-viewer",
+            "dynamic-sky",
+            "multi-model",
+            "lighting",
+        ]
+        for (index, id) in demos.enumerated() {
+            let app = XCUIApplication()
+            // `-demo <id>` routes straight to the demo on the first frame;
+            // `-qa_mode 1` freezes auto-rotation for a deterministic capture.
+            app.launchArguments = ["-demo", id, "-qa_mode", "1"]
+            app.launch()
+            XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30),
+                          "app never reached the foreground for -demo \(id)")
+            // Let the scene load its model and settle its first frames. A fixed
+            // settle mirrors the App Store pipeline; the exact value is not
+            // load-bearing for a smoke — we only need a plausibly-rendered frame.
+            Thread.sleep(forTimeInterval: 5)
+            snapshot(app, String(format: "%02d-demo-%@", index + 6, slug(id)))
+            app.terminate()
+        }
+    }
+}


### PR DESCRIPTION
**Closes #2803. Part of #2798** (L0.5 — the last Phase-0 foundation lot).

Closes two documented-vs-real CI gaps for the iOS demo.

## (a) A real `ios` leg in `device-qa.yml`

`device-qa.yml` defined only `web` / `build-android-apk` / `android` / `ar` — **0 iOS Maestro runs had ever executed in CI**, despite the file's own header describing four legs. This wires the real thing:

- New `ios` job runs `.claude/scripts/device-qa.sh --platform=ios --fast --ci` (Maestro on a Simulator via the existing `ios-device-qa.sh`).
- `runs-on: ${{ vars.SELF_HOSTED_MACOS_ONLINE == 'true' && 'sceneview-mac' || 'macos-15' }}` — the self-hosted-Mac opt-in pattern already used by `ios.yml` / `bridge-ios-compile.yml` (Xcode picked via `DEVELOPER_DIR`, not `sudo xcode-select`, so it works in the launchd self-hosted context).
- Gated `if: github.event_name != 'push'` → runs on the **nightly** `workflow_call` (nightly-ci.yml) and on manual **`workflow_dispatch`** (a pre-tag release checkpoint), **never per-push** (a macOS runner is ~10x the ubuntu per-minute cost).
- **Advisory**: `continue-on-error: true` here, and `ios` is added to `device-qa.sh`'s default advisory CSV (+ a right-sized disk-gate case). So `device-qa-report.json` / `releaseGate` grade it `advisory: true` — a red iOS leg is a release **WARN, never a hard block**, matching the android/ar posture on the flaky CI emulator. `web` stays BLOCKING.

## (b) `render-tests.yml`'s "iOS screenshot tests" job now produces real PNGs

It ran the logic-only `SceneViewDemoTests` unit target and captured nothing. Now:

- New **`SceneViewDemoUITests`** UI-testing target (`com.apple.product-type.bundle.ui-testing`) + its own **shared scheme**. XCUITest that launches the demo and captures an `XCTAttachment` screenshot of the launch screen, every tab, and a representative subset of working 3D demos (reached via the app's `-demo <id>` launch arg + `-qa_mode 1`, the same headless path the App Store screenshot pipeline uses). AR demos are excluded (no camera on the simulator).
- The job switches to `-scheme SceneViewDemoUITests` and exports the `.xcresult` attachments as real PNG artifacts (`xcresulttool export attachments`).
- The **dedicated scheme** keeps the per-PR iOS unit-test check (`ios.yml` / `app-store.yml`, `-scheme SceneViewDemo`) fast and simulator-free — untouched.

## Safety / validation

- `project.pbxproj` change is **purely additive** (113 insertions, 0 deletions; `F1`-prefixed ids that don't collide with the L0.3 test target's `F0` ids). No existing entry touched; the `SceneViewDemo` scheme is untouched.
- `plutil -lint` **OK**; `xcodebuild -list` parses the project and shows the new **target** and **scheme**; a plist-graph integrity check confirms no dangling refs and correct `TEST_TARGET_NAME` wiring (no `BUNDLE_LOADER`/`TEST_HOST`).
- `.claude/scripts/check-workflow-scripts.sh` **OK** (only pre-existing app-store shellcheck warnings).
- The actual screenshot build was **not** run locally (host at 6 GB free — below the safe build budget); the UI-test build + PNG production are validated by the `render-tests.yml` iOS job on the next main-push / nightly.

### Divergence from the issue
The issue's dependency note assumes L0.4's 4-state `Working` enum exists; on `main` the registry is still 2-state (`.available` / `.comingSoon`). The black-box XCUITest doesn't need it — it drives the UI and uses proven `-demo` ids — so this is not blocked on L0.4. Noted for the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)