### PR TITLE
fix(ios-demo): 53/53 catalog parity — umbrella aliases, stub cards, Android-only labels

### DIFF
--- a/changelog.d/2804-ios-catalog-parity.md
+++ b/changelog.d/2804-ios-catalog-parity.md
@@ -14,7 +14,7 @@
   `contact-shadow-preview`, `placement-reticle-preview`, `point-and-ask`,
   `splat-preview`, `video-recording`, `wall-placement`) and the 11 ids
   previously hand-listed in `DemoDeepLinkRegistry.residualIds` with no
-  backing Scene (`ar-collaborative`, `ar-depth-collider`,
+  backing scene file (`ar-collaborative`, `ar-depth-collider`,
   `ar-depth-of-field`, `ar-depth-visualization`, `ar-fog`,
   `ar-hand-tracking`, `ar-ml-object-label`, `ar-raw-depth-point-cloud`,
   `ar-scene-semantics`, `ar-xr-face`, `placement-scene`) each get a

--- a/changelog.d/2804-ios-catalog-parity.md
+++ b/changelog.d/2804-ios-catalog-parity.md
@@ -1,0 +1,31 @@
+<!-- category: Fixed -->
+- iOS demo: every one of Android's 53 canonical demo ids now resolves to
+  something honest — a real screen, an alias to an existing equivalent
+  screen, or a clearly-labeled coming-soon/Android-only card — never a
+  silent no-op. Closes the real 12-id scope of #2769 (not just the 6 in its
+  title): the 6 ids Android consolidated via the #2239 catalog regroup
+  (`custom-geometry`, `camera-gestures`, `picking-collision`,
+  `animation-physics`, `lighting-lab`, `two-d-in-three-d`) now route via a
+  `DemoDeepLinkRegistry.legacyAliases` entry straight to the single
+  most-representative pre-regroup granular scene — real, already-shipped
+  content, not a new coming-soon card — chosen from Android's own default
+  segmented-button tab for each umbrella (`DemoSettings.initialDemoMode`).
+  7 ids with no iOS equivalent at all (`ar-plane-renderer-v2`,
+  `contact-shadow-preview`, `placement-reticle-preview`, `point-and-ask`,
+  `splat-preview`, `video-recording`, `wall-placement`) and the 11 ids
+  previously hand-listed in `DemoDeepLinkRegistry.residualIds` with no
+  backing Scene (`ar-collaborative`, `ar-depth-collider`,
+  `ar-depth-of-field`, `ar-depth-visualization`, `ar-fog`,
+  `ar-hand-tracking`, `ar-ml-object-label`, `ar-raw-depth-point-cloud`,
+  `ar-scene-semantics`, `ar-xr-face`, `placement-scene`) each get a
+  dedicated stub `*Scene.swift` with an honest `comingSoonTitle` —
+  `residualIds` is now `[]`. The 3 permanently platform-locked ids
+  (`ar-rooftop`, `ar-streetscape`, `ar-image-stabilization` — ARCore
+  Geospatial/VPS and EIS, no ARKit equivalent) get a new optional
+  `@androidOnlyReason` Scene directive so their card reads "Android-only:
+  <reason>" instead of "Coming soon", which would dishonestly imply a
+  future port (`ComingSoonScreen` + `DemoItem` gain the matching optional
+  field, `nil` by default — zero behavior change for every other demo).
+  `parity-manifest.yml` moves from 22 working / 18 stub / 13 android-only to
+  28 / 25 / 0 — `check-demo-id-parity.sh` (#2801) is green. Part of the iOS
+  catalog-parity effort (#2798, L0.6).

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -13,11 +13,17 @@
 #
 # `iosStatus` is a mechanically-checked CURRENT-STATE fact, not an aspiration:
 #   - working:      the id is a member of iOS's `DemoDeepLinkRegistry.allowedIds`
-#                    AND resolves to a real (non-placeholder) destination.
+#                    AND resolves to a real (non-placeholder) destination —
+#                    either its own Scene, or (L0.6, #2804) an alias to
+#                    another id's Scene (an umbrella id routed to the most
+#                    representative pre-regroup granular scene).
 #   - stub:         the id is a member of `allowedIds` but currently falls
 #                    through to the honest placeholder (a `*Scene.swift` file
-#                    exists but is `@available false`, or the id is only a
-#                    residual entry with no Scene file yet).
+#                    exists but is `@available false`). A stub whose Scene
+#                    also sets `@androidOnlyReason` (L0.6, #2804) shows an
+#                    "Android-only" card instead of "Coming soon" — for a
+#                    capability that is permanently platform-locked, not
+#                    merely not-yet-ported.
 #   - android-only: the id is NOT a member of `allowedIds` at all today —
 #                    either a genuinely platform-exclusive capability (no
 #                    ARKit equivalent, never planned) or a demo iOS simply
@@ -37,6 +43,27 @@
 #     aliases ∪ 11 residual ids). Of the 53 Android ids: 22 working, 18 stub,
 #     13 android-only.
 #
+# Updated by L0.6 (#2804, closes #2769) — every Android id now resolves to
+# SOMETHING honest on iOS (a real screen, an alias to an existing equivalent
+# screen, or a clearly-labeled coming-soon/Android-only card), never a
+# silent no-op:
+#   - Job A: the 6 `#2239`-umbrella ids got a `legacyAliases` entry to their
+#     most-representative pre-regroup granular scene (real content, not a
+#     coming-soon card) → promoted from `android-only` to `working`.
+#   - Job B: the 6 ids with no iOS equivalent at all (plus `contact-shadow-preview`,
+#     added to Android mid-chantier — 7 total) got a dedicated stub Scene file
+#     with an honest `comingSoonTitle` → promoted from `android-only` to `stub`.
+#   - Job C: the 11 residual ids (previously hand-listed in
+#     `DemoDeepLinkRegistry.residualIds` with no Scene file) each got their own
+#     stub Scene file — `residualIds` is now `[]`. The 3 platform-locked ids
+#     (`ar-rooftop`, `ar-streetscape`, `ar-image-stabilization`) additionally
+#     got `@androidOnlyReason` so their card reads "Android-only: <reason>"
+#     instead of "Coming soon" (their status stays `stub` — they ARE in
+#     `allowedIds` — only the CARD TREATMENT changed).
+#   - Post-L0.6: iOS: `DemoDeepLinkRegistry.allowedIds` = 79 (69 generated ∪
+#     10 legacy/umbrella aliases ∪ 0 residual ids). Of the 53 Android ids:
+#     28 working, 25 stub, 0 android-only.
+#
 # Checked by `.claude/scripts/check-demo-id-parity.sh` (`ci.yml` ->
 # `repo-hygiene`, ubuntu, blocking): fails if a Android id has neither an iOS
 # registry entry nor a row here, if a row's `iosStatus` disagrees with the
@@ -45,7 +72,10 @@
 # platform's registry — that's what keeps it honest.
 
 demos:
-  # ─── working (22) — iOS has a real, non-placeholder destination ─────────
+  # ─── working (28) — iOS has a real, non-placeholder destination ─────────
+  - id: animation-physics
+    androidStatus: Working
+    iosStatus: working
   - id: ar-body-tracker
     androidStatus: Working
     iosStatus: working
@@ -85,6 +115,12 @@ demos:
   - id: ar-scene-mesh
     androidStatus: Working
     iosStatus: working
+  - id: camera-gestures
+    androidStatus: Working
+    iosStatus: working
+  - id: custom-geometry
+    androidStatus: Working
+    iosStatus: working
   - id: debug-overlay
     androidStatus: Working
     iosStatus: working
@@ -100,6 +136,9 @@ demos:
   - id: lighting
     androidStatus: Working
     iosStatus: working
+  - id: lighting-lab
+    androidStatus: Working
+    iosStatus: working
   - id: lines-paths
     androidStatus: Working
     iosStatus: working
@@ -109,11 +148,17 @@ demos:
   - id: model-viewer
     androidStatus: Working
     iosStatus: working
+  - id: picking-collision
+    androidStatus: Working
+    iosStatus: working
   - id: spatial-audio
     androidStatus: Working
     iosStatus: working
+  - id: two-d-in-three-d
+    androidStatus: Working
+    iosStatus: working
 
-  # ─── stub (18) — iOS registry has the id, but it falls to the placeholder ──
+  # ─── stub (25) — iOS registry has the id, but it falls to the placeholder ──
   - id: ar-cloud-anchor
     androidStatus: KnownIssue
     iosStatus: stub
@@ -125,36 +170,40 @@ demos:
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — a CollaborativeSession SDK + demo is
-      not yet ported (Phase 2 Wave B, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false — a
+      CollaborativeSession SDK + demo is not yet ported (Phase 2 Wave B, #2798).
   - id: ar-depth-collider
     androidStatus: KnownIssue
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — depth-based collision not yet ported.
-      Android itself is KnownIssue too.
+      Scene file exists (L0.6, #2804 Job C) but @available false —
+      depth-based collision not yet ported. Android itself is KnownIssue too.
   - id: ar-depth-of-field
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — depth-of-field post-process not yet
-      ported (Phase 2 Wave B, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false —
+      depth-of-field post-process not yet ported (Phase 2 Wave B, #2798).
   - id: ar-depth-visualization
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — depth visualization + the SDK depth
-      API it needs are not yet ported (Phase 2 Wave B, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false — depth
+      visualization + the SDK depth API it needs are not yet ported (Phase 2
+      Wave B, #2798).
   - id: ar-fog
     androidStatus: Working
     iosStatus: stub
-    reason: "Residual id, no Scene file yet — the AR-specific fog demo is not yet ported."
+    reason: >-
+      Scene file exists (L0.6, #2804 Job C) but @available false — the
+      AR-specific fog demo is not yet ported.
   - id: ar-hand-tracking
     androidStatus: ComingSoon
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — Android itself is ComingSoon
-      (visionOS hand-tracking SDK work).
+      Scene file exists (L0.6, #2804 Job C) but @available false — Android
+      itself is ComingSoon (visionOS hand-tracking SDK work); the iOS card
+      title says "(visionOS)" rather than mirroring Android's "(Jetpack XR)".
   - id: ar-image-stabilization
     androidStatus: Working
     iosStatus: stub
@@ -162,12 +211,23 @@ demos:
       Platform-locked: ARCore's Electronic Image Stabilization (EIS) toggle
       has no public ARKit equivalent. Scene file exists but @available
       false — a permanent honest placeholder, not a port target (#2798).
+      Since L0.6 (#2804), the Scene sets @androidOnlyReason so its card reads
+      "Android-only" instead of "Coming soon".
   - id: ar-ml-object-label
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — Vision/CoreML object labeling not yet
-      ported (Phase 3, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false —
+      Vision/CoreML object labeling not yet ported (Phase 3, #2798); the iOS
+      card title drops Android's "ML Kit" branding (Apple's own Vision
+      framework would back a real port).
+  - id: ar-plane-renderer-v2
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog; needs LiDAR-backed
+      plane rendering.
   - id: ar-pose
     androidStatus: Working
     iosStatus: stub
@@ -176,8 +236,8 @@ demos:
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — raw depth point cloud not yet ported
-      (Phase 2 Wave B, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false — raw depth
+      point cloud not yet ported (Phase 2 Wave B, #2798).
   - id: ar-rooftop
     androidStatus: KnownIssue
     iosStatus: stub
@@ -186,12 +246,14 @@ demos:
       service with no ARKit equivalent. Scene file exists (canonicalized from
       ArRooftopAnchorsScene in #2799) but @available false — a permanent
       honest placeholder, not a port target. Android itself is KnownIssue too.
+      Since L0.6 (#2804), the Scene sets @androidOnlyReason so its card reads
+      "Android-only" instead of "Coming soon".
   - id: ar-scene-semantics
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — scene semantics not yet ported (Phase
-      3, honest-card candidate, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false — scene
+      semantics not yet ported (Phase 3, #2798).
   - id: ar-streetscape
     androidStatus: KnownIssue
     iosStatus: stub
@@ -199,7 +261,9 @@ demos:
       Platform-locked: ARCore Streetscape Geometry (Geospatial/VPS) is a
       Google-backend service with no ARKit equivalent. Scene file exists but
       @available false — a permanent honest placeholder, not a port target.
-      Android itself is KnownIssue too.
+      Android itself is KnownIssue too. Since L0.6 (#2804), the Scene sets
+      @androidOnlyReason so its card reads "Android-only" instead of
+      "Coming soon".
   - id: ar-terrain
     androidStatus: KnownIssue
     iosStatus: stub
@@ -211,103 +275,65 @@ demos:
     androidStatus: ComingSoon
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — Android itself is ComingSoon
-      (visionOS face-tracking SDK work).
+      Scene file exists (L0.6, #2804 Job C) but @available false — Android
+      itself is ComingSoon (visionOS face-tracking SDK work); the iOS card
+      title says "(visionOS)" rather than mirroring Android's "(Jetpack XR)".
+  - id: contact-shadow-preview
+    androidStatus: InReview
+    iosStatus: stub
+    reason: >-
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog (#2817, contact-shadow
+      sub-task C of #2740; Android itself is InReview); card subtitle notes
+      "(Android: in review)".
+  - id: placement-reticle-preview
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog.
   - id: placement-scene
     androidStatus: Working
     iosStatus: stub
     reason: >-
-      Residual id, no Scene file yet — this placement scene is not yet
-      ported (Phase 2 Wave A, #2798).
+      Scene file exists (L0.6, #2804 Job C) but @available false — this
+      placement scene is not yet ported (Phase 2 Wave A, #2798).
+  - id: point-and-ask
+    androidStatus: Working
+    iosStatus: stub
+    reason: >-
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog; a port would use
+      Apple's Foundation Models (#2648) rather than Gemini Nano.
   - id: secondary-camera
     androidStatus: Working
     iosStatus: stub
     reason: >-
       Scene file exists but @available false — picture-in-picture camera
       view not yet implemented.
-
-  # ─── android-only (13) — no iOS registry entry at all yet ───────────────
-  - id: animation-physics
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from the #2239 catalog regroup — iOS still only
-      carries its pre-regroup sub-ids (animation, physics), not the umbrella
-      id itself. Tracked for L0.6 (#2804).
-  - id: ar-plane-renderer-v2
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Added to Android after iOS stopped tracking the catalog — no iOS id
-      reserved yet; needs LiDAR-backed plane rendering. Tracked for L0.6 (#2804).
-  - id: camera-gestures
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from #2239 — iOS still only carries pre-regroup
-      sub-ids (camera-controls, gesture-editing). Tracked for L0.6 (#2804).
-  - id: contact-shadow-preview
-    androidStatus: InReview
-    iosStatus: android-only
-    reason: >-
-      Added to Android after iOS stopped tracking the catalog (#2817,
-      contact-shadow sub-task C of #2740; Android itself is InReview) — no
-      iOS id reserved yet. Tracked for L0.6 (#2804). Landed on main mid-PR;
-      this row is a live example of the drift class check-demo-id-parity.sh
-      now catches.
-  - id: custom-geometry
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from #2239 — iOS still only carries pre-regroup
-      sub-ids (custom-mesh, shape). Tracked for L0.6 (#2804).
-  - id: lighting-lab
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from #2239 — iOS still only carries pre-regroup
-      sub-ids (dynamic-sky, environment, reflection-probes, post-processing).
-      Tracked for L0.6 (#2804).
-  - id: picking-collision
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from #2239 — iOS still only carries pre-regroup
-      sub-ids (collision, view-node). Tracked for L0.6 (#2804).
-  - id: placement-reticle-preview
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Added to Android after iOS stopped tracking the catalog — no iOS id
-      reserved yet. Tracked for L0.6 (#2804).
-  - id: point-and-ask
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Added to Android after iOS stopped tracking the catalog — no iOS id
-      reserved yet; a port would use Apple's Foundation Models (#2648).
-      Tracked for L0.6 (#2804).
   - id: splat-preview
     androidStatus: Working
-    iosStatus: android-only
+    iosStatus: stub
     reason: >-
-      Added to Android after iOS stopped tracking the catalog — no iOS id
-      reserved yet; blocked on an iOS SplatNode renderer (#2768).
-  - id: two-d-in-three-d
-    androidStatus: Working
-    iosStatus: android-only
-    reason: >-
-      Android umbrella id from #2239 — iOS still only carries pre-regroup
-      sub-ids (text, image, video, billboard). Tracked for L0.6 (#2804).
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog; blocked on an iOS
+      SplatNode renderer (#2768).
   - id: video-recording
     androidStatus: Working
-    iosStatus: android-only
+    iosStatus: stub
     reason: >-
-      Added to Android after iOS stopped tracking the catalog — no iOS id
-      reserved yet. Tracked for L0.6 (#2804).
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog.
   - id: wall-placement
     androidStatus: InReview
-    iosStatus: android-only
+    iosStatus: stub
     reason: >-
-      Added to Android after iOS stopped tracking the catalog (Android itself
-      is InReview, #2740) — no iOS id reserved yet. Tracked for L0.6 (#2804).
+      Scene file exists (L0.6, #2804 Job B) but @available false — added to
+      Android after iOS stopped tracking the catalog (Android itself is
+      InReview, #2740); card subtitle notes "(Android: in review)".
+
+  # ─── android-only (0) — every id now has at least an honest stub ────────
+  # L0.6 (#2804) closed this section: the 6 #2239-umbrella ids became
+  # `working` (Job A aliases) and the remaining 7 became `stub` (Job B stub
+  # Scenes). Kept as a documented, currently-empty bucket — the landing spot
+  # for the next Android id iOS hasn't reserved an id for yet.

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -14,8 +14,8 @@
 # `iosStatus` is a mechanically-checked CURRENT-STATE fact, not an aspiration:
 #   - working:      the id is a member of iOS's `DemoDeepLinkRegistry.allowedIds`
 #                    AND resolves to a real (non-placeholder) destination —
-#                    either its own Scene, or (L0.6, #2804) an alias to
-#                    another id's Scene (an umbrella id routed to the most
+#                    either its own scene, or (L0.6, #2804) an alias to
+#                    another id's scene (an umbrella id routed to the most
 #                    representative pre-regroup granular scene).
 #   - stub:         the id is a member of `allowedIds` but currently falls
 #                    through to the honest placeholder (a `*Scene.swift` file

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -172,6 +172,24 @@
 		F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000060 /* SketchfabService+Tests.swift */; };
 		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
 		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
+		819AD79B996B8EE240D31FF6 /* ArPlaneRendererV2Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40DD4C3271CBFADB68D71777 /* ArPlaneRendererV2Scene.swift */; };
+		62EE9526D5ED0D7FE4053FAD /* ContactShadowPreviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16294DC5A7D862C38FE2FF4 /* ContactShadowPreviewScene.swift */; };
+		491E5281694990528BA8402A /* PlacementReticlePreviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082ADF6A2C2D1C4D7C316F93 /* PlacementReticlePreviewScene.swift */; };
+		9ED12B03B2BF3B253EC7D0A9 /* PointAndAskScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0863A011777F13DFB915D831 /* PointAndAskScene.swift */; };
+		A27232F7D9C6DE6491CB73D3 /* SplatPreviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C97E9F24DB261FABCB4838 /* SplatPreviewScene.swift */; };
+		D5217012AE3BFD3D86EE49E0 /* VideoRecordingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AE6F3C701D206B3B919BCC /* VideoRecordingScene.swift */; };
+		FF2214F77B752E9AB93A66B1 /* WallPlacementScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1767394F8DE920AA4961C04 /* WallPlacementScene.swift */; };
+		B676907D738F7541D5167DC7 /* ArCollaborativeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C3EA23146458101F73D2BA /* ArCollaborativeScene.swift */; };
+		1D4CD777A44CFD49CE0F02B3 /* ArDepthColliderScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F0C93174B1ABCF292626F4 /* ArDepthColliderScene.swift */; };
+		35B5934608FF05846E560048 /* ArDepthOfFieldScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC80E5393165708EE8840070 /* ArDepthOfFieldScene.swift */; };
+		2984E30408C3AB78802EF242 /* ArDepthVisualizationScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1EB4C3164FD50C6E810EB7 /* ArDepthVisualizationScene.swift */; };
+		1BBF2B6B04EFAB92D6E63F42 /* ArFogScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD495F1FF4C557321778236 /* ArFogScene.swift */; };
+		0C746850F68994C5A373E0FB /* ArHandTrackingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C41AF0B8726F5ECA161AD0E /* ArHandTrackingScene.swift */; };
+		7BDA3390D3CB5A407703BDEA /* ArMlObjectLabelScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11C40298E02898E297E687F /* ArMlObjectLabelScene.swift */; };
+		4E37F77D3CCD4DF63BA465E0 /* ArRawDepthPointCloudScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4FDFC2AEE02B40DAAA3D5 /* ArRawDepthPointCloudScene.swift */; };
+		5B14D9F3C8BA306921899FF2 /* ArSceneSemanticsScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9269F3DA3F899CAA453A79 /* ArSceneSemanticsScene.swift */; };
+		AF836789D014E4A5E9CD707B /* ArXrFaceScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B602283557AB26CD0CF0C /* ArXrFaceScene.swift */; };
+		6A052B88F0FEA671530C17BC /* PlacementSceneScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F43BF6C7AE57D84A840CE79 /* PlacementSceneScene.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -356,6 +374,24 @@
 		1600DF1563900D4EB6820A33 /* TextScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextScene.swift; path = SceneViewDemo/Views/Demos/Scenes/TextScene.swift; sourceTree = SOURCE_ROOT; };
 		27FB250D0AE339DB0EB9C6C7 /* VideoTextureScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VideoTextureScene.swift; path = SceneViewDemo/Views/Demos/Scenes/VideoTextureScene.swift; sourceTree = SOURCE_ROOT; };
 		1EC5EFF554D692141E61884F /* ViewNodeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewNodeScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ViewNodeScene.swift; sourceTree = SOURCE_ROOT; };
+		40DD4C3271CBFADB68D71777 /* ArPlaneRendererV2Scene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArPlaneRendererV2Scene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArPlaneRendererV2Scene.swift; sourceTree = SOURCE_ROOT; };
+		D16294DC5A7D862C38FE2FF4 /* ContactShadowPreviewScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ContactShadowPreviewScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ContactShadowPreviewScene.swift; sourceTree = SOURCE_ROOT; };
+		082ADF6A2C2D1C4D7C316F93 /* PlacementReticlePreviewScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlacementReticlePreviewScene.swift; path = SceneViewDemo/Views/Demos/Scenes/PlacementReticlePreviewScene.swift; sourceTree = SOURCE_ROOT; };
+		0863A011777F13DFB915D831 /* PointAndAskScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PointAndAskScene.swift; path = SceneViewDemo/Views/Demos/Scenes/PointAndAskScene.swift; sourceTree = SOURCE_ROOT; };
+		E1C97E9F24DB261FABCB4838 /* SplatPreviewScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SplatPreviewScene.swift; path = SceneViewDemo/Views/Demos/Scenes/SplatPreviewScene.swift; sourceTree = SOURCE_ROOT; };
+		61AE6F3C701D206B3B919BCC /* VideoRecordingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VideoRecordingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/VideoRecordingScene.swift; sourceTree = SOURCE_ROOT; };
+		E1767394F8DE920AA4961C04 /* WallPlacementScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WallPlacementScene.swift; path = SceneViewDemo/Views/Demos/Scenes/WallPlacementScene.swift; sourceTree = SOURCE_ROOT; };
+		10C3EA23146458101F73D2BA /* ArCollaborativeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArCollaborativeScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArCollaborativeScene.swift; sourceTree = SOURCE_ROOT; };
+		06F0C93174B1ABCF292626F4 /* ArDepthColliderScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArDepthColliderScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArDepthColliderScene.swift; sourceTree = SOURCE_ROOT; };
+		AC80E5393165708EE8840070 /* ArDepthOfFieldScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArDepthOfFieldScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArDepthOfFieldScene.swift; sourceTree = SOURCE_ROOT; };
+		EE1EB4C3164FD50C6E810EB7 /* ArDepthVisualizationScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArDepthVisualizationScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArDepthVisualizationScene.swift; sourceTree = SOURCE_ROOT; };
+		FFD495F1FF4C557321778236 /* ArFogScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArFogScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArFogScene.swift; sourceTree = SOURCE_ROOT; };
+		4C41AF0B8726F5ECA161AD0E /* ArHandTrackingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArHandTrackingScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArHandTrackingScene.swift; sourceTree = SOURCE_ROOT; };
+		F11C40298E02898E297E687F /* ArMlObjectLabelScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArMlObjectLabelScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArMlObjectLabelScene.swift; sourceTree = SOURCE_ROOT; };
+		89F4FDFC2AEE02B40DAAA3D5 /* ArRawDepthPointCloudScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArRawDepthPointCloudScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArRawDepthPointCloudScene.swift; sourceTree = SOURCE_ROOT; };
+		0F9269F3DA3F899CAA453A79 /* ArSceneSemanticsScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArSceneSemanticsScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArSceneSemanticsScene.swift; sourceTree = SOURCE_ROOT; };
+		941B602283557AB26CD0CF0C /* ArXrFaceScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArXrFaceScene.swift; path = SceneViewDemo/Views/Demos/Scenes/ArXrFaceScene.swift; sourceTree = SOURCE_ROOT; };
+		7F43BF6C7AE57D84A840CE79 /* PlacementSceneScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlacementSceneScene.swift; path = SceneViewDemo/Views/Demos/Scenes/PlacementSceneScene.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -915,6 +951,24 @@
 				A928A0266FD0B8196F11DF4A /* VideoTextureScene.swift in Sources */,
 				C100000000000000000000E1 /* TextureStreamingScene.swift in Sources */,
 				9D72C9CAE331B90315010DC3 /* ViewNodeScene.swift in Sources */,
+				819AD79B996B8EE240D31FF6 /* ArPlaneRendererV2Scene.swift in Sources */,
+				62EE9526D5ED0D7FE4053FAD /* ContactShadowPreviewScene.swift in Sources */,
+				491E5281694990528BA8402A /* PlacementReticlePreviewScene.swift in Sources */,
+				9ED12B03B2BF3B253EC7D0A9 /* PointAndAskScene.swift in Sources */,
+				A27232F7D9C6DE6491CB73D3 /* SplatPreviewScene.swift in Sources */,
+				D5217012AE3BFD3D86EE49E0 /* VideoRecordingScene.swift in Sources */,
+				FF2214F77B752E9AB93A66B1 /* WallPlacementScene.swift in Sources */,
+				B676907D738F7541D5167DC7 /* ArCollaborativeScene.swift in Sources */,
+				1D4CD777A44CFD49CE0F02B3 /* ArDepthColliderScene.swift in Sources */,
+				35B5934608FF05846E560048 /* ArDepthOfFieldScene.swift in Sources */,
+				2984E30408C3AB78802EF242 /* ArDepthVisualizationScene.swift in Sources */,
+				1BBF2B6B04EFAB92D6E63F42 /* ArFogScene.swift in Sources */,
+				0C746850F68994C5A373E0FB /* ArHandTrackingScene.swift in Sources */,
+				7BDA3390D3CB5A407703BDEA /* ArMlObjectLabelScene.swift in Sources */,
+				4E37F77D3CCD4DF63BA465E0 /* ArRawDepthPointCloudScene.swift in Sources */,
+				5B14D9F3C8BA306921899FF2 /* ArSceneSemanticsScene.swift in Sources */,
+				AF836789D014E4A5E9CD707B /* ArXrFaceScene.swift in Sources */,
+				6A052B88F0FEA671530C17BC /* PlacementSceneScene.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
+++ b/samples/ios-demo/SceneViewDemo/DemoDeepLinkRegistry.swift
@@ -26,14 +26,31 @@ import SwiftUI
 ///
 /// # What stays hand-maintained (the residual)
 ///
-/// Only ids that have **no** `*Scene.swift` file yet:
-///   - `legacyAliases` — pre-canonicalization ids (#2799) kept so existing QR
-///     codes keep resolving. Each maps to a canonical id a Scene declares, so
-///     the alias inherits that scene's destination.
+/// Only ids that have **no** `*Scene.swift` file of their own:
+///   - `legacyAliases` — an id with no Scene file that should route to a
+///     DIFFERENT id's Scene, in two flavors:
+///     1. **Rename aliases** — pre-canonicalization ids (#2799) kept so
+///        existing QR codes keep resolving (e.g. `ar-cloud-anchors` →
+///        `ar-cloud-anchor`).
+///     2. **Umbrella aliases** (L0.6, #2804/#2769) — a live Android id from
+///        the #2239 catalog regroup (e.g. `custom-geometry`) whose iOS
+///        constituent screens already exist under their pre-regroup granular
+///        ids (e.g. `custom-mesh`). Routing the umbrella id straight to the
+///        single most-representative granular scene resolves the deep link
+///        to REAL, already-shipped content — not a coming-soon card, which
+///        would dishonestly imply the capability doesn't exist on iOS yet.
+///        A full "regrouped umbrella UI" mirroring Android's exact
+///        combined-tab layout is a separate, larger, explicitly-deferred
+///        piece of work (#2804) — this only fixes deep-link resolution.
+///     Either way, the alias inherits its target scene's destination (or its
+///     placeholder, if the target is itself `@available false`).
 ///   - `residualIds` — AR demos present in Android's catalog whose iOS card is
-///     still to be ported (L0.6, #2804). They resolve to a placeholder until a
-///     Scene file lands; when one does, delete the id here and the generated
-///     union covers it automatically.
+///     still to be ported. They resolve to a placeholder until a Scene file
+///     lands; when one does, delete the id here and the generated union
+///     covers it automatically. Emptied by L0.6 (#2804) — every id that was
+///     here now has a Scene file — kept as an empty `Set` (rather than
+///     deleted) since it is still the documented landing spot for the NEXT
+///     not-yet-ported AR id.
 ///
 /// # Deep-link guarantee
 ///
@@ -43,11 +60,10 @@ import SwiftUI
 /// caller (`SceneViewDemoApp.onOpenURL`), never dropped into a silent no-op.
 enum DemoDeepLinkRegistry {
 
-    /// Legacy deep-link aliases → canonical scene id. Pre-canonicalization
-    /// ids (#2799) kept only so existing QR codes / bookmarks keep resolving.
-    /// The canonical target is declared by a `*Scene.swift` file, so the alias
-    /// resolves to exactly that scene's destination (or its placeholder, when
-    /// the canonical scene is `@available false`).
+    /// Legacy / umbrella deep-link aliases → canonical scene id (see the two
+    /// flavors documented above). Every value is declared by a `*Scene.swift`
+    /// file, so the alias resolves to exactly that scene's destination (or
+    /// its placeholder, when the canonical scene is `@available false`).
     ///
     /// Internal (not `private`) so `DemoRegistryGuardTests` (#2801) can assert
     /// the registry-integrity invariants directly against this table — e.g.
@@ -55,34 +71,56 @@ enum DemoDeepLinkRegistry {
     /// may also be a live scene id — mirroring how Android's
     /// `DeepLinkRouterTest` asserts directly against `DEMO_ID_ALIASES`.
     static let legacyAliases: [String: String] = [
+        // Rename aliases (#2799) — pre-canonicalization ids.
         "ar-recording": "ar-record-playback",
         "ar-cloud-anchors": "ar-cloud-anchor",
         "ar-rooftop-anchors": "ar-rooftop",
         "ar-terrain-anchors": "ar-terrain",
+
+        // Umbrella aliases (L0.6, #2804 Job A / #2769) — a live Android
+        // #2239-regrouped id routed to the single most-representative
+        // pre-regroup granular iOS scene. The target is Android's own
+        // default/first tab for that umbrella (`initialDemoMode`'s `default`
+        // parameter in `DemoSettings.kt`), not an arbitrary pick:
+        //   - custom-geometry   → custom-mesh   (default tab: CustomMesh)
+        //   - camera-gestures   → camera-controls (default tab: CameraModes)
+        //   - picking-collision → collision     (default tab: RayHitTest)
+        //   - animation-physics → animation     (default tab: Animation)
+        //   - two-d-in-three-d  → text          (default tab: Text)
+        //   - lighting-lab      → dynamic-sky   (default tab: Sky — NOT
+        //     `environment`; #2769's own suggestion predates checking
+        //     Android's actual default, which is Sky)
+        // A full "regrouped umbrella UI" (Android's exact combined-tab
+        // layout) is explicitly out of scope for this lot — see the doc
+        // comment above.
+        "custom-geometry": "custom-mesh",
+        "camera-gestures": "camera-controls",
+        "picking-collision": "collision",
+        "animation-physics": "animation",
+        "two-d-in-three-d": "text",
+        "lighting-lab": "dynamic-sky",
     ]
 
     /// Deep-linkable ids with no `*Scene.swift` file yet — AR demos present in
-    /// Android's catalog whose iOS card is still to be ported (L0.6, #2804).
-    /// They pass `allowedIds` so the URL is accepted, and resolve to the
-    /// coming-soon placeholder. Remove an id from here the moment a matching
-    /// Scene file is added; the generated union then covers it with no hand edit.
+    /// Android's catalog whose iOS card is still to be ported. They pass
+    /// `allowedIds` so the URL is accepted, and resolve to the coming-soon
+    /// placeholder. Remove an id from here the moment a matching Scene file is
+    /// added; the generated union then covers it with no hand edit.
+    ///
+    /// Empty as of L0.6 (#2804) — every AR id that was here (`ar-collaborative`,
+    /// `ar-depth-collider`, `ar-depth-of-field`, `ar-depth-visualization`,
+    /// `ar-fog`, `ar-hand-tracking`, `ar-ml-object-label`,
+    /// `ar-raw-depth-point-cloud`, `ar-scene-semantics`, `ar-xr-face`,
+    /// `placement-scene`) now has its own `*Scene.swift` stub with an honest
+    /// `comingSoonTitle`. Kept as an empty `Set` (not deleted) — it is still
+    /// the documented landing spot for the next not-yet-ported AR id, and
+    /// `check-demo-id-parity.sh` (#2801) is specifically tested against this
+    /// `[]` case.
     ///
     /// Internal (not `private`) for the same reason as `legacyAliases` above —
     /// `DemoRegistryGuardTests` (#2801) asserts this list never collides with a
     /// live generated scene id (a stale entry that should have been deleted).
-    static let residualIds: Set<String> = [
-        "ar-collaborative",
-        "ar-depth-collider",
-        "ar-depth-of-field",
-        "ar-depth-visualization",
-        "ar-fog",
-        "ar-hand-tracking",
-        "ar-ml-object-label",
-        "ar-raw-depth-point-cloud",
-        "ar-scene-semantics",
-        "ar-xr-face",
-        "placement-scene",
-    ]
+    static let residualIds: Set<String> = []
 
     /// Full set of accepted deep-link ids: the generated scene ids
     /// (`GeneratedScenes.allowedIds`) ∪ legacy aliases ∪ not-yet-ported

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoItem.swift
@@ -78,6 +78,18 @@ struct DemoItem: Identifiable {
     let status: DemoStatus
     let destination: AnyView
 
+    /// One-line, user-defensible reason this demo is **permanently**
+    /// Android-only (no ARKit/RealityKit equivalent exists — e.g. ARCore
+    /// Geospatial/VPS, a Google-backend service), as opposed to merely not
+    /// ported yet. `nil` for the common "coming soon, might land later" case.
+    ///
+    /// Always `nil` for an available item (`status.isAvailable`) — only a
+    /// `.comingSoon` item can be platform-locked. When non-nil,
+    /// ``ComingSoonScreen`` swaps its "Coming soon" pill and footer for an
+    /// honest "Android-only" treatment instead of implying a port is coming
+    /// (#2804 Job C — "not planned for iOS" must never read as "coming soon").
+    let androidOnlyReason: String?
+
     /// Demo with a real destination view. `status` must be one of the three
     /// "available" cases (`.working`, `.knownIssue`, `.inReview`) — enforced
     /// with a precondition since `.comingSoon` has no destination by
@@ -102,6 +114,7 @@ struct DemoItem: Identifiable {
         self.category = category
         self.status = status
         self.destination = AnyView(destination())
+        self.androidOnlyReason = nil
     }
 
     /// Coming-soon demo — tap routes to ``ComingSoonScreen`` instead of a real destination.
@@ -109,11 +122,16 @@ struct DemoItem: Identifiable {
     /// Mirrors an Android demo that is not yet ported to iOS. The item stays visible in the list
     /// (with a "Soon" badge) so users see the roadmap rather than discovering gaps. Status is
     /// always `.comingSoon` — there is no destination to attach any other status to.
+    ///
+    /// - Parameter androidOnlyReason: set only for a **permanently** Android-only capability
+    ///   (no ARKit/RealityKit equivalent) — see the field doc above. `nil` (default) for the
+    ///   ordinary "not ported yet" case.
     init(
         comingSoonTitle title: String,
         icon: String,
         subtitle: String,
-        category: DemoCategory
+        category: DemoCategory,
+        androidOnlyReason: String? = nil
     ) {
         self.title = title
         self.icon = icon
@@ -121,6 +139,7 @@ struct DemoItem: Identifiable {
         self.category = category
         self.status = .comingSoon
         self.destination = AnyView(EmptyView())
+        self.androidOnlyReason = androidOnlyReason
     }
 }
 

--- a/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Utilities/DemoScene.swift
@@ -43,6 +43,7 @@ import SwiftUI
 /// // @category    basics3D          (one of: basics3D|lighting|content|interaction|advanced|ar)
 /// // @available   true              (true = shows destination view; false = "Coming soon")
 /// // @status      working           (optional — see below)
+/// // @androidOnlyReason  <reason>   (optional — see below)
 /// ```
 ///
 /// `@sceneId`, `@title`, `@subtitle`, `@category`, and `@available` are
@@ -61,6 +62,15 @@ import SwiftUI
 ///   (`SamplesTab.swift`'s `StatusBadge` — "Preview" / "In review" / "Soon",
 ///   `.working` renders no badge) — the iOS mirror of Android's
 ///   `DemoListScreen.kt` `StatusChip`.
+///
+/// `@androidOnlyReason` is **optional** (#2804 Job C) and only valid on a
+/// `@available false` scene — the collator errors out if set alongside
+/// `@available true`. When present, the one-line text replaces "Coming soon"
+/// with an honest "Android-only" treatment on both the Samples-tab card and
+/// ``ComingSoonScreen`` (pill text, footer paragraph, nav title) — for a
+/// capability that is **permanently** platform-locked (no ARKit/RealityKit
+/// equivalent, e.g. ARCore Geospatial/VPS) rather than merely not ported yet.
+/// Omit it for the ordinary "not ported yet, might land later" case.
 ///
 /// The conforming type must also provide:
 /// - `static var destination: AnyView { get }` — SwiftUI view (ignored when

--- a/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/ComingSoonScreen.swift
@@ -1,15 +1,33 @@
 import SwiftUI
 
-/// Placeholder shown when the user taps a demo that is not yet ported to iOS.
+/// Placeholder shown when the user taps a demo that has no destination on iOS.
 ///
-/// Mirrors an Android-only feature with a friendly "Coming soon" message and
-/// links to track progress or try the equivalent on the Android demo app.
+/// Two distinct honest treatments (#2804 Job C — never conflate the two):
+/// - **Coming soon** (`androidOnlyReason == nil`, the common case): not yet
+///   ported, but expected to land eventually. Friendly message, links to
+///   track progress or try the equivalent on the Android demo app.
+/// - **Android-only** (`androidOnlyReason` set): a capability with no
+///   ARKit/RealityKit equivalent — e.g. ARCore Geospatial/VPS. Never implies
+///   a future port; the pill, nav title, and footer all say "Android-only"
+///   and state the one-line reason instead of "will be ported to iOS soon".
 struct ComingSoonScreen: View {
     let title: String
     let subtitle: String
     let icon: String
 
+    /// One-line, user-defensible reason this is **permanently** Android-only
+    /// — set only for a platform-locked capability, never for the ordinary
+    /// "not ported yet" case. See ``DemoItem/androidOnlyReason``.
+    var androidOnlyReason: String? = nil
+
     @Environment(\.dismiss) private var dismiss
+
+    private var isAndroidOnly: Bool { androidOnlyReason != nil }
+    private var pillText: String { isAndroidOnly ? "Android-only" : "Coming soon" }
+    private var footerText: String {
+        androidOnlyReason ??
+            "This sample is already available in the Android demo app and will be ported to iOS soon. SceneView aims for full Android↔iOS parity."
+    }
 
     private var androidPlayStoreURL: URL { URL(string: "https://play.google.com/store/apps/details?id=io.github.sceneview.demo")! }
     private var githubIssuesURL: URL { URL(string: "https://github.com/sceneview/sceneview/issues")! }
@@ -41,7 +59,7 @@ struct ComingSoonScreen: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 24)
 
-                    Text("Coming soon")
+                    Text(pillText)
                         .font(.caption.weight(.semibold))
                         .padding(.horizontal, 12)
                         .padding(.vertical, 5)
@@ -67,7 +85,7 @@ struct ComingSoonScreen: View {
                 }
                 .padding(.horizontal, 20)
 
-                Text("This sample is already available in the Android demo app and will be ported to iOS soon. SceneView aims for full Android↔iOS parity.")
+                Text(footerText)
                     .font(.footnote)
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)
@@ -78,7 +96,7 @@ struct ComingSoonScreen: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .navigationTitle("Coming soon")
+        .navigationTitle(pillText)
         .navigationBarTitleInline()
     }
 }
@@ -89,6 +107,17 @@ struct ComingSoonScreen: View {
             title: "Gesture Editing",
             subtitle: "Move, scale, and rotate models with one-finger drag, pinch, and rotate gestures.",
             icon: "hand.pinch.fill"
+        )
+    }
+}
+
+#Preview("Android-only") {
+    NavigationStack {
+        ComingSoonScreen(
+            title: "Streetscape Geometry",
+            subtitle: "Geospatial building and terrain meshes",
+            icon: "map.fill",
+            androidOnlyReason: "ARCore Streetscape Geometry (Geospatial/VPS) is a Google-backend service with no ARKit equivalent — not planned for iOS."
         )
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArCollaborativeScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArCollaborativeScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     ar-collaborative
+// @title       Collaborative AR
+// @subtitle    Multi-user session sync over a pluggable transport
+// @category    ar
+// @available   false
+// @icon        person.3.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-collaborative` demo (multi-user
+/// AR session sync) has no iOS port yet (Phase 2 Wave B, #2798). Was a
+/// hand-maintained residual id in `DemoDeepLinkRegistry` before this Scene
+/// file existed (#2804 Job C).
+enum ArCollaborativeScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthColliderScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthColliderScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     ar-depth-collider
+// @title       Depth Collider
+// @subtitle    Virtual balls bounce off the real floor / table (depth-driven physics)
+// @category    ar
+// @available   false
+// @icon        circle.grid.cross.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-depth-collider` demo (depth-driven
+/// physics collision, Android itself is `KnownIssue`) has no iOS port yet.
+/// Was a hand-maintained residual id in `DemoDeepLinkRegistry` before this
+/// Scene file existed (#2804 Job C).
+enum ArDepthColliderScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthOfFieldScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthOfFieldScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     ar-depth-of-field
+// @title       AR Depth of Field
+// @subtitle    Tap to focus — real-world bokeh blur
+// @category    ar
+// @available   false
+// @icon        camera.aperture
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-depth-of-field` demo
+/// (depth-of-field post-process) has no iOS port yet (Phase 2 Wave B,
+/// #2798). Was a hand-maintained residual id in `DemoDeepLinkRegistry`
+/// before this Scene file existed (#2804 Job C).
+enum ArDepthOfFieldScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthVisualizationScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthVisualizationScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     ar-depth-visualization
+// @title       Depth Visualization
+// @subtitle    False-color depth map with camera↔depth blend
+// @category    ar
+// @available   false
+// @icon        paintpalette.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-depth-visualization` demo
+/// (false-color depth map) has no iOS port yet (Phase 2 Wave B, #2798). Was
+/// a hand-maintained residual id in `DemoDeepLinkRegistry` before this Scene
+/// file existed (#2804 Job C).
+enum ArDepthVisualizationScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArFogScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArFogScene.swift
@@ -1,0 +1,23 @@
+// @sceneId     ar-fog
+// @title       AR Fog
+// @subtitle    Distance fog over real and virtual geometry
+// @category    ar
+// @available   false
+// @icon        cloud.fog.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-fog` demo (issue #1717; distance
+/// fog blended with the live AR camera feed) has no iOS port yet. Distinct
+/// from the non-AR `fog` id (`FogScene`, already working on iOS). Was a
+/// hand-maintained residual id in `DemoDeepLinkRegistry` before this Scene
+/// file existed (#2804 Job C).
+enum ArFogScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArHandTrackingScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArHandTrackingScene.swift
@@ -1,0 +1,19 @@
+// @sceneId     ar-hand-tracking
+// @title       Hand Tracking (visionOS)
+// @subtitle    Hand skeleton on visionOS headsets
+// @category    ar
+// @available   false
+// @icon        hand.raised.fill
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-hand-tracking` demo targets
+/// Android XR headsets (Jetpack XR); Android itself is `ComingSoon` there
+/// too. The iOS/Apple equivalent would be visionOS hand-tracking, not yet
+/// implemented — hence no `@iosOnly` guard (unlike the phone-camera AR
+/// placeholders): this is a roadmap card for visionOS specifically, so it
+/// stays visible on every Apple platform build rather than hiding on the one
+/// platform it actually targets. Was a hand-maintained residual id in
+/// `DemoDeepLinkRegistry` before this Scene file existed (#2804 Job C).
+enum ArHandTrackingScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArImageStabilizationScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArImageStabilizationScene.swift
@@ -5,6 +5,7 @@
 // @available   false
 // @icon        camera.metering.matrix
 // @iosOnly     true
+// @androidOnlyReason  ARCore's Electronic Image Stabilization toggle has no public ARKit equivalent — not planned for iOS.
 import SwiftUI
 
 enum ArImageStabilizationScene: DemoScene {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArMlObjectLabelScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArMlObjectLabelScene.swift
@@ -1,0 +1,23 @@
+// @sceneId     ar-ml-object-label
+// @title       ML Object Labels
+// @subtitle    On-device object detection with 3D labels anchored on real-world hits
+// @category    ar
+// @available   false
+// @icon        tag.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-ml-object-label` demo (ML Kit
+/// object detection) has no iOS port yet; a port would use Apple's
+/// Vision/CoreML frameworks instead of ML Kit (Phase 3, #2798). Was a
+/// hand-maintained residual id in `DemoDeepLinkRegistry` before this Scene
+/// file existed (#2804 Job C).
+enum ArMlObjectLabelScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArPlaneRendererV2Scene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArPlaneRendererV2Scene.swift
@@ -1,0 +1,21 @@
+// @sceneId     ar-plane-renderer-v2
+// @title       Plane Renderer V2
+// @subtitle    Depth + PBR + HDR + scan-in, with live V1 ↔ V2 toggle
+// @category    ar
+// @available   false
+// @icon        square.grid.3x3.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-plane-renderer-v2` demo (depth +
+/// PBR + HDR plane rendering with a live V1 ↔ V2 toggle) has no iOS port yet;
+/// added to Android after iOS stopped tracking the catalog (#2804 Job B).
+enum ArPlaneRendererV2Scene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRawDepthPointCloudScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRawDepthPointCloudScene.swift
@@ -1,0 +1,21 @@
+// @sceneId     ar-raw-depth-point-cloud
+// @title       Raw Depth Point Cloud
+// @subtitle    Confidence-filtered point cloud from raw depth
+// @category    ar
+// @available   false
+// @icon        circle.grid.2x2.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-raw-depth-point-cloud` demo has no
+/// iOS port yet (Phase 2 Wave B, #2798). Was a hand-maintained residual id
+/// in `DemoDeepLinkRegistry` before this Scene file existed (#2804 Job C).
+enum ArRawDepthPointCloudScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRooftopAnchorsScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArRooftopAnchorsScene.swift
@@ -5,6 +5,7 @@
 // @available   false
 // @icon        house.fill
 // @iosOnly     true
+// @androidOnlyReason  ARCore Geospatial rooftop anchors are a Google-backend service with no ARKit equivalent — not planned for iOS.
 import SwiftUI
 
 enum ArRooftopAnchorsScene: DemoScene {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArSceneSemanticsScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArSceneSemanticsScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     ar-scene-semantics
+// @title       Scene Semantics
+// @subtitle    12-class outdoor scene labeling — HUD shows top-3 labels in view
+// @category    ar
+// @available   false
+// @icon        leaf.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-scene-semantics` demo (12-class
+/// outdoor scene labeling) has no iOS port yet (Phase 3, #2798). Was a
+/// hand-maintained residual id in `DemoDeepLinkRegistry` before this Scene
+/// file existed (#2804 Job C).
+enum ArSceneSemanticsScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArStreetscapeScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArStreetscapeScene.swift
@@ -5,6 +5,7 @@
 // @available   false
 // @icon        map.fill
 // @iosOnly     true
+// @androidOnlyReason  ARCore Streetscape Geometry (Geospatial/VPS) is a Google-backend service with no ARKit equivalent — not planned for iOS.
 import SwiftUI
 
 enum ArStreetscapeScene: DemoScene {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArXrFaceScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArXrFaceScene.swift
@@ -1,0 +1,19 @@
+// @sceneId     ar-xr-face
+// @title       Face Tracking (visionOS)
+// @subtitle    Face mesh on visionOS headsets
+// @category    ar
+// @available   false
+// @icon        visionpro
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `ar-xr-face` demo targets Android XR
+/// headsets (Jetpack XR); Android itself is `ComingSoon` there too. The
+/// iOS/Apple equivalent would be visionOS face-tracking, not yet
+/// implemented — hence no `@iosOnly` guard (unlike the phone-camera AR
+/// placeholders): this is a roadmap card for visionOS specifically, so it
+/// stays visible on every Apple platform build rather than hiding on the one
+/// platform it actually targets. Was a hand-maintained residual id in
+/// `DemoDeepLinkRegistry` before this Scene file existed (#2804 Job C).
+enum ArXrFaceScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ContactShadowPreviewScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ContactShadowPreviewScene.swift
@@ -1,0 +1,22 @@
+// @sceneId     contact-shadow-preview
+// @title       Contact Shadow Preview
+// @subtitle    Non-AR preview of the procedural contact shadow — a TV grounded on a wall and a box on the floor, with per-surface presets (Android: in review)
+// @category    ar
+// @available   false
+// @icon        circle.bottomhalf.filled
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `contact-shadow-preview` demo (#2817,
+/// contact-shadow sub-task C of #2740; Android itself is `InReview`) has no
+/// iOS port yet; added to Android after iOS stopped tracking the catalog
+/// (#2804 Job B).
+enum ContactShadowPreviewScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementReticlePreviewScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementReticlePreviewScene.swift
@@ -1,0 +1,21 @@
+// @sceneId     placement-reticle-preview
+// @title       AR Placement Reticle Preview
+// @subtitle    Non-AR preview of AR placement — reticle (searching/ready, ring/disc) and a placed model with a contact shadow
+// @category    ar
+// @available   false
+// @icon        scope
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `placement-reticle-preview` demo has
+/// no iOS port yet; added to Android after iOS stopped tracking the catalog
+/// (#2804 Job B).
+enum PlacementReticlePreviewScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementSceneScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementSceneScene.swift
@@ -1,0 +1,23 @@
+// @sceneId     placement-scene
+// @title       Placement Scene
+// @subtitle    One-line tap-to-place AR — the simplest possible placement flow
+// @category    ar
+// @available   false
+// @icon        mappin.and.ellipse
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `placement-scene` demo (the simplest
+/// possible tap-to-place AR flow) has no iOS port yet (Phase 2 Wave A,
+/// #2798). Distinct from the already-working `ar-placement` id
+/// (`ArPlacementScene`). Was a hand-maintained residual id in
+/// `DemoDeepLinkRegistry` before this Scene file existed (#2804 Job C).
+enum PlacementSceneScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PointAndAskScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PointAndAskScene.swift
@@ -1,0 +1,21 @@
+// @sceneId     point-and-ask
+// @title       Point & Ask
+// @subtitle    Drop 3D props, tap the scene — an on-device model (Apple Foundation Models) explains what it sees
+// @category    ar
+// @available   false
+// @icon        brain.head.profile
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `point-and-ask` demo (on-device
+/// Gemini Nano Q&A over an AR scene, #2648) has no iOS port yet. A port
+/// would use Apple's Foundation Models instead of Gemini Nano (#2804 Job B).
+enum PointAndAskScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/SplatPreviewScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/SplatPreviewScene.swift
@@ -1,0 +1,14 @@
+// @sceneId     splat-preview
+// @title       Gaussian Splatting
+// @subtitle    Render a 3D Gaussian Splat radiance-field cloud
+// @category    advanced
+// @available   false
+// @icon        circle.grid.3x3.fill
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `splat-preview` demo (3D Gaussian
+/// Splatting, #2646) has no iOS port yet; blocked on an iOS SplatNode
+/// renderer (#2768, #2804 Job B).
+enum SplatPreviewScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/VideoRecordingScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/VideoRecordingScene.swift
@@ -1,0 +1,14 @@
+// @sceneId     video-recording
+// @title       Video Recording
+// @subtitle    Record the scene to MP4 in-app — no MediaProjection
+// @category    advanced
+// @available   false
+// @icon        record.circle.fill
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `video-recording` demo (in-app MP4
+/// recording via `SurfaceMirrorer`) has no iOS port yet; added to Android
+/// after iOS stopped tracking the catalog (#2804 Job B).
+enum VideoRecordingScene: DemoScene {
+    @MainActor static var destination: AnyView { AnyView(EmptyView()) }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/WallPlacementScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/WallPlacementScene.swift
@@ -1,0 +1,21 @@
+// @sceneId     wall-placement
+// @title       Wall Placement
+// @subtitle    Mount a TV on a wall — floor↔wall edge alignment, Amazon AR-View style (Android: in review)
+// @category    ar
+// @available   false
+// @icon        tv.fill
+// @iosOnly     true
+import SwiftUI
+
+/// Coming-soon placeholder — Android's `wall-placement` demo (#2740; Android
+/// itself is `InReview`) has no iOS port yet; added to Android after iOS
+/// stopped tracking the catalog (#2804 Job B).
+enum WallPlacementScene: DemoScene {
+    @MainActor static var destination: AnyView {
+        #if os(iOS)
+        return AnyView(EmptyView())
+        #else
+        return AnyView(EmptyView())
+        #endif
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/SamplesTab.swift
@@ -201,7 +201,8 @@ struct SamplesTab: View {
             ComingSoonScreen(
                 title: scene.title,
                 subtitle: scene.subtitle,
-                icon: scene.icon
+                icon: scene.icon,
+                androidOnlyReason: scene.androidOnlyReason
             )
         }
     }

--- a/samples/ios-demo/SceneViewDemoTests/DemoRegistryGuardTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/DemoRegistryGuardTests.swift
@@ -184,7 +184,7 @@ final class DemoRegistryGuardTests: XCTestCase {
         let mustBePlaceholder = [
             "ar-cloud-anchor", "ar-rooftop", "ar-terrain",   // #2799 canonicalized ids, still @available false
             "post-processing", "secondary-camera",           // long-standing coming-soon cards
-            "ar-collaborative", "placement-scene",           // residual — no Scene file yet (L0.6, #2804)
+            "ar-collaborative", "placement-scene",           // L0.6 (#2804) gave these a stub Scene file, still @available false
         ]
         for id in mustBePlaceholder {
             XCTAssertNil(GeneratedScenes.destination(for: id),
@@ -195,12 +195,15 @@ final class DemoRegistryGuardTests: XCTestCase {
     }
 
     /// The #2769 regression, pinned directly. Before #2800, `custom-geometry`
-    /// et al. (a different bug, still open — tracked by `parity-manifest.yml`
-    /// as `android-only`) and these 4 pre-#2799 ids silently 404'd because
-    /// `allowedIds` was a hand-copied literal that never got updated. Each of
-    /// these 4 must keep resolving — through its canonical target — to
-    /// exactly that target's current realness, whichever way the canonical
-    /// scene's own `@available` flag goes.
+    /// et al. silently 404'd because `allowedIds` was a hand-copied literal
+    /// that never got updated; L0.6 (#2804) then closed the REST of #2769's
+    /// real scope by adding umbrella aliases for the 6 #2239-regrouped ids
+    /// (`custom-geometry`, `camera-gestures`, `picking-collision`,
+    /// `animation-physics`, `two-d-in-three-d`, `lighting-lab`) alongside the
+    /// 4 pre-#2799 rename aliases. Each of these 10 must keep resolving —
+    /// through its canonical target — to exactly that target's current
+    /// realness, whichever way the canonical scene's own `@available` flag
+    /// goes.
     func testLegacyAliasesArePinnedAndInheritTheirCanonicalTargetsRealness() {
         let aliases = DemoDeepLinkRegistry.legacyAliases
         XCTAssertEqual(aliases, [
@@ -208,6 +211,12 @@ final class DemoRegistryGuardTests: XCTestCase {
             "ar-cloud-anchors": "ar-cloud-anchor",
             "ar-rooftop-anchors": "ar-rooftop",
             "ar-terrain-anchors": "ar-terrain",
+            "custom-geometry": "custom-mesh",
+            "camera-gestures": "camera-controls",
+            "picking-collision": "collision",
+            "animation-physics": "animation",
+            "two-d-in-three-d": "text",
+            "lighting-lab": "dynamic-sky",
         ], "legacyAliases changed — update this pin (and re-verify the new/changed alias " +
            "resolves sanely through DemoDeepLinkRegistry.destination(for:))")
 

--- a/samples/ios-demo/scripts/collate-ios-demos.sh
+++ b/samples/ios-demo/scripts/collate-ios-demos.sh
@@ -12,6 +12,11 @@
 #   // @available   <true|false>   false → "Coming soon" card in SamplesTab
 #   // @iosOnly     <true|false>   (optional, default false) wraps item in #if os(iOS)
 #   // @status      <value>        (optional) one of: working|knownIssue|comingSoon|inReview
+#   // @androidOnlyReason <text>   (optional, #2804) one-line reason this is PERMANENTLY
+#                                  Android-only (no ARKit/RealityKit equivalent) — only valid
+#                                  with @available false. Swaps the card's "Coming soon" for an
+#                                  honest "Android-only" treatment instead of implying a future
+#                                  port. Omit for the ordinary "not ported yet" case.
 #
 # `@status` (optional — mirrors Android's 4-state `DemoStatus`, #2802):
 #   - Default when omitted: `working` if @available true, `comingSoon` if @available false.
@@ -84,6 +89,7 @@ for f in "$SCENES_DIR"/*Scene.swift; do
     available=$(grep -m1 '// @available' "$f" | sed -E 's|.*// @available[[:space:]]+||; s/[[:space:]]+$//')
     ios_only=$(grep -m1 '// @iosOnly' "$f" 2>/dev/null | sed -E 's|.*// @iosOnly[[:space:]]+||; s/[[:space:]]+$//' || echo "false")
     status=$(grep -m1 '// @status' "$f" 2>/dev/null | sed -E 's|.*// @status[[:space:]]+||; s/[[:space:]]+$//' || echo "")
+    android_only_reason=$(grep -m1 '// @androidOnlyReason' "$f" 2>/dev/null | sed -E 's|.*// @androidOnlyReason[[:space:]]+||; s/[[:space:]]+$//' || echo "")
 
     for field in scene_id title subtitle icon category available; do
         if [ -z "${!field}" ]; then
@@ -148,9 +154,28 @@ for f in "$SCENES_DIR"/*Scene.swift; do
             ;;
     esac
 
-    # TAB-separated: sceneId title subtitle icon category available iosOnly status
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" >> "$TMP_META"
+    # @androidOnlyReason only makes sense for a scene with no destination — a
+    # permanently platform-locked capability can't also be "available" (#2804).
+    if [ -n "$android_only_reason" ] && [ "$available" != "false" ]; then
+        echo "Error: $base has @androidOnlyReason set but @available true — " \
+             "an Android-only reason only makes sense for a scene with no " \
+             "destination (@available false)." >&2
+        exit 1
+    fi
+
+    # TAB-separated: sceneId title subtitle icon category available iosOnly status androidOnlyReason
+    #
+    # `android_only_reason` is the only field that is legitimately empty most
+    # of the time — and bash's `read` (even with `IFS=$'\t'`) still treats tab
+    # as an IFS-*whitespace* character, so a genuinely empty field between two
+    # tabs gets silently squeezed away instead of preserved, shifting every
+    # later column left by one. Encode "absent" as a `-` sentinel (never a
+    # legitimate reason string) so the field always round-trips non-empty;
+    # decoded back to "" at the one place that reads it (step 4 below).
+    android_only_reason_field="$android_only_reason"
+    [ -z "$android_only_reason_field" ] && android_only_reason_field="-"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" "$android_only_reason_field" >> "$TMP_META"
     scene_count=$((scene_count + 1))
 done
 
@@ -202,7 +227,7 @@ status_enum() {
 TMP_FULL="$(mktemp)"
 trap 'rm -f "$TMP_META" "$SORTED_META" "$TMP_FULL"' EXIT
 
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status android_only_reason; do
     # Find the *Scene.swift file whose @sceneId matches.
     type_name=""
     for f in "$SCENES_DIR"/*Scene.swift; do
@@ -216,9 +241,9 @@ while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only
         echo "Error: no 'enum <Name>Scene: DemoScene' declaration found for sceneId='$scene_id'." >&2
         exit 1
     fi
-    # 9 columns: sceneId title subtitle icon category available iosOnly status typeName
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" "$type_name" >> "$TMP_FULL"
+    # 10 columns: sceneId title subtitle icon category available iosOnly status androidOnlyReason typeName
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$scene_id" "$title" "$subtitle" "$icon" "$category" "$available" "$ios_only" "$status" "$android_only_reason" "$type_name" >> "$TMP_FULL"
 done < "$SORTED_META"
 
 # ─── 4. Emit GeneratedScenes.swift ───────────────────────────────────────
@@ -257,7 +282,11 @@ enum GeneratedScenes {
         var items: [DemoItem] = []
 HEADER
 
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status android_only_reason type_name; do
+    # Decode the `-` "absent" sentinel back to a real empty string (see the
+    # TMP_META write in step 1 for why this round-trip is necessary).
+    [ "$android_only_reason" = "-" ] && android_only_reason=""
+
     cat_enum=$(category_enum "$category")
 
     # Escape title / subtitle for Swift string literals.
@@ -282,7 +311,13 @@ while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only
         printf '            comingSoonTitle: "%s",\n' "$swift_title"
         printf '            icon: "%s",\n' "$icon"
         printf '            subtitle: "%s",\n' "$swift_subtitle"
-        printf '            category: %s\n' "$cat_enum"
+        if [ -n "$android_only_reason" ]; then
+            swift_android_only_reason=$(printf '%s' "$android_only_reason" | sed 's/"/\\"/g')
+            printf '            category: %s,\n' "$cat_enum"
+            printf '            androidOnlyReason: "%s"\n' "$swift_android_only_reason"
+        else
+            printf '            category: %s\n' "$cat_enum"
+        fi
         printf '        ))\n'
     fi
 
@@ -307,7 +342,7 @@ ALL_END
 
 # `allowedIds`: every scene id (available true AND false), sorted by id so
 # the diff stays stable and two parallel PRs never collide.
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status android_only_reason type_name; do
     printf '        "%s",\n' "$scene_id"
 done < "$TMP_FULL"
 
@@ -329,7 +364,7 @@ IDS_END
 # scenes fall through to `default: return nil` (→ placeholder), never their
 # own `EmptyView`. iOS-only scenes are guarded so a non-iOS build returns
 # `nil` (→ placeholder) rather than a blank view.
-while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status type_name; do
+while IFS=$'\t' read -r scene_id title subtitle icon category available ios_only status android_only_reason type_name; do
     [ "$available" = "true" ] || continue
     if [ "$ios_only" = "true" ]; then
         printf '        case "%s":\n' "$scene_id"


### PR DESCRIPTION
## Summary

Every Android canonical demo id (53/53) now resolves to something honest on iOS — a real screen, an alias to an existing equivalent screen, or a clearly-labeled coming-soon/Android-only card — never a silent no-op. This closes #2769's real 12-id scope (not just the 6 in its title).

- **Job A (alias, 6 ids)** — `custom-geometry`, `camera-gestures`, `picking-collision`, `animation-physics`, `lighting-lab`, `two-d-in-three-d` (Android's #2239 catalog-regroup umbrellas) each get a `DemoDeepLinkRegistry.legacyAliases` entry straight to the single most-representative pre-regroup granular scene — **real, already-shipped content, not a new coming-soon card**. Targets chosen from Android's own default segmented-button tab per umbrella (`DemoSettings.initialDemoMode`):
  | umbrella id | alias target | justification |
  |---|---|---|
  | `custom-geometry` | `custom-mesh` | Android default tab: CustomMesh |
  | `camera-gestures` | `camera-controls` | Android default tab: CameraModes |
  | `picking-collision` | `collision` | Android default tab: RayHitTest |
  | `animation-physics` | `animation` | Android default tab: Animation |
  | `two-d-in-three-d` | `text` | Android default tab: Text |
  | `lighting-lab` | `dynamic-sky` | Android default tab: **Sky** — deliberately NOT `environment` (#2769's own suggestion predates checking Android's actual default) |

- **Job B (stub cards, 7 ids)** — `ar-plane-renderer-v2`, `contact-shadow-preview`, `placement-reticle-preview`, `point-and-ask`, `splat-preview`, `video-recording`, `wall-placement` (no iOS equivalent at all — the 7th, `contact-shadow-preview`, landed on `main` mid-chantier via #2817) each get a dedicated stub `*Scene.swift` with an honest `comingSoonTitle`.

- **Job C (residual → stub, 11 ids)** — `ar-collaborative`, `ar-depth-collider`, `ar-depth-of-field`, `ar-depth-visualization`, `ar-fog`, `ar-hand-tracking`, `ar-ml-object-label`, `ar-raw-depth-point-cloud`, `ar-scene-semantics`, `ar-xr-face`, `placement-scene` — previously hand-listed in `DemoDeepLinkRegistry.residualIds` with no backing Scene — each get their own stub Scene file. **`residualIds` is now `[]`.**

- **Job C (Android-only labels, 3 ids)** — `ar-rooftop`, `ar-streetscape`, `ar-image-stabilization` are permanently platform-locked (ARCore Geospatial/VPS + EIS, no ARKit equivalent). New optional `@androidOnlyReason` Scene directive (`collate-ios-demos.sh`) swaps their card's "Coming soon" pill/footer/nav-title for an honest **"Android-only: `<reason>`"** — never implying a future port. `ComingSoonScreen` + `DemoItem` gain the matching optional field, `nil` by default (zero behavior change for every other demo).

## Result

- `parity-manifest.yml`: 22 working / 18 stub / 13 android-only → **28 working / 25 stub / 0 android-only**.
- `bash .claude/scripts/check-demo-id-parity.sh` → **green**.
- `bash samples/ios-demo/scripts/collate-ios-demos.sh --check` → in sync (69 scenes, up from 51).
- All 11 `DemoRegistryGuardTests` self-checks pass conceptually (verified via the Python replica below — disk was too tight, see Verification); the hard-pinned `legacyAliases` test is updated to the new 10-entry table.

## Verification (disk ~5 GiB free — under the 6 GiB local-build threshold, so no local Xcode build; CI does the actual compile + simulator run)

- `collate-ios-demos.sh` / `collate-ios-demos.sh --check` — clean, idempotent, 69 scenes.
- `check-demo-id-parity.sh` — green (53 Android ids, 79 iOS allowedIds, 53 manifest rows, 0 errors).
- `test-check-demo-id-parity.sh` (the gate's own self-test) — 11/11 pass, including the `residualIds = []` single-line-array case this PR exercises for real.
- `check-sceneview-skill.sh` — no drift.
- `swiftc -parse` on every touched/new Swift file (21 files) and the freshly-generated `GeneratedScenes.swift` — 0 syntax errors.
- `plutil -lint` on `project.pbxproj` after manually registering the 18 new Scene files (this Xcode project hand-lists every source file — no synchronized groups) — valid plist.
- `shellcheck` on the modified `collate-ios-demos.sh` — 0 issues.
- Deep-link resolution: since a full simulator run wasn't feasible locally, replicated `DemoDeepLinkRegistry.destination(for:)`'s exact resolution algorithm (generated ids → alias indirection → placeholder) in a script fed with the **real** parsed `GeneratedScenes.swift` + `DemoDeepLinkRegistry.swift` content, and confirmed all 6 Job-A umbrella ids resolve through the alias to a real (non-placeholder) destination, and a sample of Job B/C ids resolve to the honest placeholder (never dropped). CI's iOS leg (device-qa / render-tests, wired up by the just-merged #2833) is the actual on-simulator confirmation.
- Found and fixed a real bug in `collate-ios-demos.sh` while adding the new `@androidOnlyReason` column: bash's `read` still treats tab as IFS-*whitespace*, silently squeezing a genuinely-empty field and shifting every later column left by one. Fixed with an explicit `-` "absent" sentinel, decoded back to `""` at the one consumption site.

## #2769 closure

All 12 of #2769's real-scope ids resolve now: the 6 umbrella ids via alias (this PR), plus `ar-cloud-anchors`→`ar-cloud-anchor`, `ar-rooftop-anchors`→`ar-rooftop`, `ar-terrain-anchors`→`ar-terrain`, `ar-recording`→`ar-record-playback` (already fixed by L0.1 #2799, unchanged here).

## Anti-collision note

L0.5 (#2803/#2833) merged to `main` while this branch was in flight and also touched `project.pbxproj` (a new `SceneViewDemoUITests` target). Merged `origin/main` in, resolved the resulting pbxproj conflict (both PRs' additions land right before `/* End PBXBuildFile section */`; kept both, no data loss — verified via `plutil -lint` + file-count cross-checks pre/post-merge), no other conflicts.

Closes #2804
Closes #2769
Part of #2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)