### PR TITLE
fix(mcp): symbols/* — index typealiases, resolve Companion imports, skip rebound receivers (#2760 follow-up)

### DIFF
--- a/mcp/scripts/generate-symbols.js
+++ b/mcp/scripts/generate-symbols.js
@@ -29,7 +29,7 @@
  * published tarball ships only the compiled `dist/generated/symbols.js`.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -64,6 +64,50 @@ function isNoiseClass(binaryName) {
     // Anonymous / local classes: a `$` segment starting with a digit.
     /\$\d/.test(binaryName)
   );
+}
+
+/** Recursively collect `.kt` files under `dir` (returns [] when absent). */
+function ktFilesUnder(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = resolve(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name.endsWith(".kt")) out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Public typealiases (`typealias Position = Float3`, `Rotation`, `Color`, …)
+ * are a first-class part of the import surface — `llms.txt` and every sample
+ * import them — but they are ABSENT from the `.api` dumps: the
+ * binary-compatibility validator erases aliases to their expansion, so an
+ * index built from the dumps alone flags `import io.github.sceneview.math.Position`
+ * as unknown (adversarial-review finding #1 on PR #2814). Recover them from
+ * the Kotlin sources: a top-level `[public ][actual|expect ]typealias Name`
+ * plus the file's `package` line. `internal`/`private` aliases don't match
+ * (the line must start at the visibility-or-keyword boundary). Only the
+ * monorepo layout carries sources; a standalone api-dumps build degrades to
+ * an index without typealiases, warned on stderr.
+ */
+function collectTypealiases(module) {
+  const srcRoot = resolve(mcpRoot, "..", module, "src");
+  const aliases = new Map(); // dotted FQCN -> { module, members: Set }
+  for (const file of ktFilesUnder(srcRoot)) {
+    const text = readFileSync(file, "utf-8");
+    const pkgMatch = /^package\s+([\w.]+)/m.exec(text);
+    if (!pkgMatch) continue;
+    const aliasRe = /^(?:public\s+)?(?:actual\s+|expect\s+)?typealias\s+(\w+)\b/gm;
+    for (const m of text.matchAll(aliasRe)) {
+      aliases.set(`${pkgMatch[1]}.${m[1]}`, { module, members: new Set() });
+    }
+  }
+  return aliases;
 }
 
 /** `getFoo`/`setFoo`/`isFoo` (JVM accessors) → the Kotlin property name. */
@@ -226,6 +270,29 @@ for (const [fqcn, entry] of [...allClasses]) {
   }
 }
 
+// Merge source-level typealiases (absent from the dumps by construction).
+// A real class always wins over an alias on FQCN collision (impossible in
+// valid Kotlin, but cheap to guarantee).
+let typealiasCount = 0;
+let typealiasSourcesFound = false;
+for (const module of MODULES) {
+  const aliases = collectTypealiases(module);
+  if (aliases.size > 0) typealiasSourcesFound = true;
+  for (const [fqcn, entry] of aliases) {
+    if (!allClasses.has(fqcn)) {
+      allClasses.set(fqcn, entry);
+      typealiasCount++;
+    }
+  }
+}
+if (!typealiasSourcesFound) {
+  console.error(
+    "[generate-symbols] WARNING: no Kotlin sources found next to the dumps — " +
+      "typealiases (Position, Rotation, Color, …) are not indexed, so " +
+      "legitimate typealias imports may be flagged as unknown."
+  );
+}
+
 // ─── Emit ─────────────────────────────────────────────────────────────────────
 
 const classesOut = {};
@@ -285,6 +352,7 @@ writeFileSync(outFile, `${header}\n${body}`);
 
 // stderr only — a stdout banner interleaves with `npm pack --json` (#1113).
 console.error(
-  `[generate-symbols] wrote ${outFile} (${Object.keys(classesOut).length} classes, ` +
-    `${Object.keys(topLevelOut).length} top-level functions from ${sources.join(", ")})`
+  `[generate-symbols] wrote ${outFile} (${Object.keys(classesOut).length} classes ` +
+    `incl. ${typealiasCount} typealiases, ${Object.keys(topLevelOut).length} top-level ` +
+    `functions from ${sources.join(", ")})`
 );

--- a/mcp/src/symbols.test.ts
+++ b/mcp/src/symbols.test.ts
@@ -54,6 +54,17 @@ describe("generated symbols index", () => {
     expect(SYMBOLS.packages).toContain("io.github.sceneview");
     expect(SYMBOLS.packages).toContain("io.github.sceneview.node");
   });
+
+  it("indexes source-level typealiases absent from the .api dumps", () => {
+    // binary-compatibility-validator erases typealiases to their expansion,
+    // yet `llms.txt` imports them everywhere — the generator recovers them
+    // from the Kotlin sources (PR #2814 adversarial-review finding #1).
+    expect(SYMBOLS.classes).toHaveProperty(["io.github.sceneview.math.Position"]);
+    expect(SYMBOLS.classes).toHaveProperty(["io.github.sceneview.math.Rotation"]);
+    expect(SYMBOLS.classes).toHaveProperty(["io.github.sceneview.math.Color"]);
+    expect(SYMBOLS.classes).toHaveProperty(["io.github.sceneview.model.Model"]);
+    expect(SYMBOLS.classes).toHaveProperty(["io.github.sceneview.model.ModelInstance"]);
+  });
 });
 
 // ─── Lookups ─────────────────────────────────────────────────────────────────
@@ -72,6 +83,15 @@ describe("symbol lookups", () => {
     expect(resolveImport("io.github.sceneview.node")).toBe("package");
     expect(resolveImport("io.github.sceneview.SceneView")).toBe("member");
     expect(resolveImport("io.github.sceneview.node.ShadowNode")).toBeNull();
+  });
+
+  it("resolves typealias and Companion imports", () => {
+    expect(resolveImport("io.github.sceneview.math.Position")).toBe("class");
+    expect(resolveImport("io.github.sceneview.math.Rotation")).toBe("class");
+    // The generator folds `X.Companion` members into X and drops the entry —
+    // the companion itself must still resolve through its host class.
+    expect(resolveImport("io.github.sceneview.node.ModelNode.Companion")).toBe("member");
+    expect(resolveImport("io.github.sceneview.node.ShadowNode.Companion")).toBeNull();
   });
 
   it("exposes loader members including suspend/async variants", () => {

--- a/mcp/src/symbols.ts
+++ b/mcp/src/symbols.ts
@@ -100,10 +100,14 @@ export function resolveImport(path: string): "class" | "package" | "member" | nu
   if (SYMBOLS.packages.includes(parent) && leaf in SYMBOLS.topLevel) {
     return "member";
   }
-  // `import io.github.sceneview.node.ModelNode.Companion` or a nested
-  // class member — accept when the parent class exists and declares it.
+  // A nested class member — accept when the parent class exists and
+  // declares it.
   const parentClass = SYMBOLS.classes[parent];
   if (parentClass?.members.includes(leaf)) return "member";
+  // `import io.github.sceneview.node.ModelNode.Companion` — the generator
+  // folds companion members into the host class and drops the `.Companion`
+  // entry, so resolve the companion itself through its host.
+  if (leaf === "Companion" && parent in SYMBOLS.classes) return "member";
   return null;
 }
 

--- a/mcp/src/validator.test.ts
+++ b/mcp/src/validator.test.ts
@@ -614,6 +614,44 @@ describe("symbols/unknown-member", () => {
     const code = `modelLoader.engine.createScene()`;
     expect(hasRule(code, RULE)).toBe(false);
   });
+
+  it("does not flag a receiver rebound to a non-loader type (PR #2814 finding #3)", () => {
+    // The snippet redefines `modelLoader` as its own repository — checking
+    // its members against the SceneView ModelLoader would be a false
+    // positive. Exact reviewer snippet.
+    const code = `
+      class MyRepository { fun fetchAll(): List<String> = emptyList() }
+
+      fun load() {
+          val modelLoader = MyRepository()
+          modelLoader.fetchAll()
+      }
+    `;
+    expect(hasRule(code, RULE)).toBe(false);
+  });
+
+  it("keeps checking when the rebinding IS the real loader", () => {
+    // `val modelLoader = rememberModelLoader(engine)` is the canonical
+    // pattern — the bogus-member check must survive it.
+    const code = `
+      val modelLoader = rememberModelLoader(engine)
+      val i = modelLoader.createModelInstanceAsync("m.glb")
+    `;
+    expect(hasRule(code, RULE)).toBe(true);
+  });
+
+  it("keeps checking a loader obtained as a property or with a type annotation", () => {
+    const viaProperty = `
+      val modelLoader = sceneView.modelLoader
+      modelLoader.createModelInstanceAsync("m.glb")
+    `;
+    expect(hasRule(viaProperty, RULE)).toBe(true);
+    const viaAnnotation = `
+      val modelLoader: ModelLoader = provide()
+      modelLoader.createModelInstanceAsync("m.glb")
+    `;
+    expect(hasRule(viaAnnotation, RULE)).toBe(true);
+  });
 });
 
 describe("symbols/unknown-type", () => {
@@ -644,6 +682,18 @@ describe("symbols/unknown-type", () => {
     const code = `PlacementNode(engine)`;
     expect(hasRule(code, RULE)).toBe(false);
     expect(hasRule(code, "migration/old-api")).toBe(true);
+  });
+
+  it("still flags a made-up type next to a declared one", () => {
+    // The locally-declared exemption must not blanket the whole snippet.
+    const code = `
+      class CursorNode(engine: Engine) : Node(engine)
+      val a = CursorNode(engine)
+      val b = HologramNode(engine)
+    `;
+    const issues = validateCode(code).filter((i) => i.rule === RULE);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("`HologramNode`");
   });
 });
 
@@ -678,6 +728,33 @@ import com.google.android.filament.Engine
     // but detectLanguage routes such snippets to WEB_RULES before the
     // symbol rules run. Guard the routing so this stays true.
     const code = `import io.github.sceneview.web.SceneView`;
+    expect(hasRule(code, RULE)).toBe(false);
+  });
+
+  it("accepts typealias imports — Position, Rotation, … (PR #2814 finding #1)", () => {
+    // Typealiases are erased from the .api dumps but recovered from the
+    // Kotlin sources at generation time. llms.txt imports them everywhere.
+    const code = `
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Rotation
+import io.github.sceneview.math.Color
+import io.github.sceneview.model.ModelInstance
+    `;
+    expect(hasRule(code, RULE)).toBe(false);
+  });
+
+  it("accepts a Companion import of a real class (PR #2814 finding #4)", () => {
+    const code = `import io.github.sceneview.node.ModelNode.Companion`;
+    expect(hasRule(code, RULE)).toBe(false);
+  });
+
+  it("skips aliased imports — tolerated false negative, never a false positive", () => {
+    // `import … as MN` doesn't match the end-of-line anchor: even a bogus
+    // aliased import goes unchecked rather than risking a wrong flag.
+    const code = `
+import io.github.sceneview.node.ModelNode as MN
+import io.github.sceneview.node.ShadowNode as SN
+    `;
     expect(hasRule(code, RULE)).toBe(false);
   });
 });

--- a/mcp/src/validator.ts
+++ b/mcp/src/validator.ts
@@ -562,6 +562,9 @@ const RULES: Rule[] = [
   {
     // `import io.github.sceneview.…` that resolves to nothing. Our own
     // namespace: nothing outside the index can legitimately live there.
+    // Known tolerated false NEGATIVE: aliased imports (`import … as MN`)
+    // don't match the end-of-line anchor and are silently skipped — an
+    // unchecked alias can never become a false positive.
     id: "symbols/unknown-import",
     severity: "error",
     check(code, lines) {
@@ -653,6 +656,28 @@ const RULES: Rule[] = [
         "use",
         "toString",
       ]);
+      // A snippet may rebind a canonical name to its own type
+      // (`val modelLoader = MyRepository()`) — member-checking that variable
+      // against the SceneView loader would be a false positive
+      // (adversarial-review finding #3 on PR #2814). Keep checking only when
+      // the declaration is recognizably the real loader: a `remember<Class>`
+      // call, a direct constructor, a `: <Class>` type annotation, or a
+      // `.<receiver>` property access — or when there is no local
+      // declaration at all (the scope provides it, the canonical case).
+      const rebound = new Set<string>();
+      for (const [receiver, className] of Object.entries(receivers)) {
+        const decl = new RegExp(
+          `\\b(?:val|var)\\s+${receiver}\\s*(?::\\s*([^=\\n]+?))?\\s*=\\s*(.+)`
+        ).exec(code);
+        if (!decl) continue;
+        const [, typeAnnotation, rhs] = decl;
+        const looksReal =
+          (typeAnnotation?.includes(className) ?? false) ||
+          rhs.includes(`remember${className}`) ||
+          rhs.includes(`${className}(`) ||
+          rhs.trimEnd().endsWith(`.${receiver}`);
+        if (!looksReal) rebound.add(receiver);
+      }
       const callRe = /\b(modelLoader|materialLoader|environmentLoader)\.(\w+)\s*\(/g;
       const reported = new Set<string>();
       for (const match of code.matchAll(callRe)) {
@@ -660,6 +685,7 @@ const RULES: Rule[] = [
         const key = `${receiver}.${member}`;
         if (reported.has(key)) continue;
         reported.add(key);
+        if (rebound.has(receiver)) continue;
         if (stdlib.has(member)) continue;
         const members = membersOfClass(receivers[receiver]);
         if (!members || members.has(member)) continue;


### PR DESCRIPTION
## What

Completes the adversarial-review findings from #2814 (merged with only the locally-declared-names fix). Three confirmed false-positive classes remained on `main` — **reproduced by execution against `origin/main`'s compiled validator before fixing**:

| # | Reviewer snippet | On main | Now |
|---|---|---|---|
| 1 | `import io.github.sceneview.math.Position` / `Rotation` | ❌ 2× `symbols/unknown-import` error | ✅ CLEAN |
| 3 | `val modelLoader = MyRepository()` + `modelLoader.fetchAll()` | ❌ `symbols/unknown-member` error | ✅ CLEAN |
| 4 | `import io.github.sceneview.node.ModelNode.Companion` | ❌ latent error | ✅ CLEAN |

## Why now

The gated `mcp-publish.yml` dispatch for **4.0.15** has not run yet (npm is live at 4.0.14). Finding #1 makes `validate_code` reject every canonical AR snippet — `llms.txt` imports `Position` everywhere — so this must land before the dispatch.

## How

- **Typealiases** (finding #1): `binary-compatibility-validator` erases aliases to their expansion, so the `.api` dumps can never carry them. `generate-symbols.js` now walks the three modules' Kotlin sources for top-level `[public ][actual|expect ]typealias` declarations (20 indexed: `Position`, `Rotation`, `Scale`, `Color`, `Transform`, `Model`, `ModelInstance`, …). `internal`/`private` aliases don't match. A standalone api-dumps build (no sources) degrades to an alias-free index with an stderr warning.
- **Companion** (finding #4): the generator folds `X.Companion` members into `X` and drops the entry — `resolveImport` now resolves the companion itself through its host class.
- **Rebound receivers** (finding #3): `symbols/unknown-member` skips a canonical receiver name that the snippet rebinds to something that is recognizably *not* the loader; a `remember<Class>` call, direct constructor, `: <Class>` annotation, or `.modelLoader` property access keeps the check, as does no local declaration at all (scope-provided — the canonical case).
- Aliased imports (`import … as MN`) documented as a **tolerated false negative** (end-of-line anchor skips them — never a false positive).
- Anti-blanket guard: a made-up type next to a locally-declared one still flags.

## Verification

- `npm test`: **1948/1948** (1939 on main + 9 new tests pinning the reviewer snippets), tsc clean via `prepare`.
- Re-ran the reviewer's exact snippets against the freshly compiled `dist/validator.js`: findings 1/3/4 → CLEAN; canonical bogus member (`createModelInstanceAsync`), bogus import, bogus type, bogus remember helper → still CAUGHT.
- No changelog fragment: this corrects unreleased behavior already covered by the merged `changelog.d/2760-validate-code-symbols.md` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)