### PR TITLE
ci(ios): compile the device code path on every PR (#2852)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -163,3 +163,39 @@ jobs:
             -skipMacroValidation \
             SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY" \
             | xcpretty --color 2>/dev/null || cat
+
+      # #2852 — the step above CANNOT see the AR code. Every AR demo wraps its
+      # real ARKit/RealityKit logic in `#if !targetEnvironment(simulator)`
+      # (14 files under `Views/Demos/` at the time of writing), because ARKit
+      # world tracking does not run on a Simulator. A Simulator destination
+      # therefore strips that branch before the compiler ever sees it: a type
+      # error, a renamed API or a bad call inside those blocks passes CI green
+      # and lands on main. Until this step existed, the FIRST compile of that
+      # code happened in `app-store.yml`'s `xcodebuild archive` — i.e. during a
+      # release, behind signing secrets. The worst possible moment to find out.
+      #
+      # `CODE_SIGNING_ALLOWED=NO` is what lets a device destination build with
+      # no certificates, so this runs on forks and on stock runners. Build-only
+      # on purpose: compiling AR code is not running it, and this step makes no
+      # claim about runtime behaviour — that still needs a physical device.
+      # NOTE: the name is quoted on purpose — an unquoted ` #2852` would start a
+      # YAML comment and the issue reference would vanish from the step name.
+      - name: "Compile the device code path (no signing) — #2852"
+        if: always()
+        env:
+          SKETCHFAB_API_KEY: ${{ secrets.SKETCHFAB_API_KEY }}
+        working-directory: samples/ios-demo
+        run: |
+          # `pipefail` so a failing xcodebuild is not masked by xcpretty — #1515.
+          set -o pipefail
+          xcodebuild build \
+            -project SceneViewDemo.xcodeproj \
+            -scheme SceneViewDemo \
+            -destination 'generic/platform=iOS' \
+            -clonedSourcePackagesDirPath SourcePackages \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY" \
+            | xcpretty --color 2>/dev/null || cat

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -198,4 +198,4 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY" \
-            | xcpretty --color 2>/dev/null || cat
+            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}

--- a/changelog.d/2852-ios-device-compile-ci.md
+++ b/changelog.d/2852-ios-device-compile-ci.md
@@ -1,0 +1,8 @@
+<!-- category: Tests -->
+- **CI now compiles the iOS device code path on every PR.** Every AR demo wraps its
+  real ARKit/RealityKit logic in `#if !targetEnvironment(simulator)`, so the existing
+  Simulator-destination build stripped that code before the compiler saw it — a type
+  error inside an AR demo could pass CI green and land on `main`, with the first real
+  compile happening only during an App Store archive. `ios.yml` now adds a build-only
+  `generic/platform=iOS` step with `CODE_SIGNING_ALLOWED=NO`, which needs no
+  certificates and so runs on forks too ([#2852](https://github.com/sceneview/sceneview/issues/2852)).


### PR DESCRIPTION
Closes #2852.

Every AR demo wraps its real ARKit/RealityKit logic in `#if !targetEnvironment(simulator)` — 14 files under `samples/ios-demo/SceneViewDemo/Views/Demos/` — because ARKit world tracking does not run on a Simulator. Every per-PR iOS check built **only** Simulator destinations, so the preprocessor stripped that branch before the compiler ever saw it.

**Consequence:** a type error, a renamed API, or a bad call inside those blocks passed CI green and landed on `main`.

The code was not literally never compiled — `app-store.yml:207-210` runs `xcodebuild archive -destination 'generic/platform=iOS'`, which does compile it — but that is a release-time job gated behind signing secrets. The worst possible moment to discover a broken AR demo.

## The change

One build-only step in `ios.yml`, after the existing Simulator build+test:

```yaml
-destination 'generic/platform=iOS'
CODE_SIGNING_ALLOWED=NO
CODE_SIGNING_REQUIRED=NO
```

`CODE_SIGNING_ALLOWED=NO` is what lets a device destination build with no certificates, so this runs on forks and stock runners with no new secret.

## Verified locally

- `python3 -c "yaml.safe_load(...)"` parses; the new step is last in the `build` job with the expected destination and no-signing flags.
- `bash .claude/scripts/check-workflow-scripts.sh` → `OK` (120 `if:` expressions checked).
- The step name is **quoted on purpose**: an unquoted ` #2852` starts a YAML comment and the issue reference silently vanishes from the step name. That bug was present in the first draft of this change and is called out in an inline comment so it does not come back.

## Not verified

The step has not yet run on a GitHub runner — a `generic/platform=iOS` build is slower than the Simulator one and its real cost on `macos-15` will only be visible on this PR's own CI run. If it proves expensive, gating it to PRs that touch `samples/ios-demo/**` is the obvious follow-up.

**Scope, stated plainly:** this compiles AR code, it does not run it. Actual ARKit behaviour still needs a physical device, which remains an open item on #2798.

Surfaced by a #2798 Wave A porting agent, which noticed that its own green Simulator build certified almost nothing about the AR code it had just written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)