### PR TITLE
fix(ci): export NODE_AUTH_TOKEN to the sceneview-web build step (#2787)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,18 @@ jobs:
 
       - name: Build sceneview-web JS library
         if: steps.check-web.outputs.skip != 'true'
+        # NODE_AUTH_TOKEN is needed by the BUILD step, not just the publish one.
+        # `setup-node` with `registry-url` writes an .npmrc containing
+        # `_authToken=${NODE_AUTH_TOKEN}`; the Kotlin/JS `:kotlinNpmInstall`
+        # task shells out to yarn, yarn expands that .npmrc, and when the var
+        # is unset it aborts with `Failed to replace env in config` instead of
+        # ignoring it. This is the only job that combines `registry-url` with
+        # a Gradle task, which is why the sibling npm jobs never hit it.
+        # Regression surfaced by the setup-node v6 -> v7 bump (#2787): it broke
+        # the v4.25.0 release *after* Maven Central had already published, and
+        # is invisible to PR CI because no PR job publishes. See #2787.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./gradlew :sceneview-web:jsBrowserProductionWebpack
 
       - name: Prepare and publish npm package

--- a/changelog.d/2787-release-web-npm-auth.md
+++ b/changelog.d/2787-release-web-npm-auth.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+- **Release pipeline — `sceneview-web` npm publish no longer fails on a missing npm auth token.**
+  `actions/setup-node` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; the
+  Kotlin/JS `:kotlinNpmInstall` task shells out to yarn, which expands that file and aborts
+  with `Failed to replace env in config` when the variable is unset. The `publish-web` job is
+  the only one combining `registry-url` with a Gradle task, so its *build* step now exports
+  `NODE_AUTH_TOKEN` too. Surfaced by the `setup-node` v6 → v7 bump (#2787): it broke the
+  v4.25.0 release after Maven Central had already published, which also skipped the
+  GitHub Release job. Invisible to PR CI, since no pull-request job publishes to npm.


### PR DESCRIPTION
The **v4.25.0 release published Maven Central, the MCP and the React Native package, then failed** on `Publish sceneview-web to npm` — which in turn **skipped `Create GitHub Release`**. So v4.25.0 currently has no release notes and no attached APKs, and npm still serves the previous version.

## Root cause — not the web code

`actions/setup-node` with `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. The Kotlin/JS `:kotlinNpmInstall` task shells out to yarn, yarn expands that `.npmrc`, and with the variable unset it aborts rather than ignoring it:

```
error Failed to replace env in config: ${NODE_AUTH_TOKEN}
    at NpmRegistry.normalizeConfig (yarn-v1.22.22/lib/cli.js)
> Task :kotlinNpmInstall FAILED
```

The token was exported to the *publish* step only, never to the *build* step.

## Why only this job

`publish-web` is the only job that combines `registry-url` with a Gradle task. `publish-mcp` and `publish-rn` use the same npm setup but run no Gradle, which is why they stayed green in the same run.

## Why CI never caught it

No pull-request job publishes to npm, so the `.npmrc` + Gradle combination only ever executes at release time. Surfaced by the `setup-node` v6 → v7 bump (#2787), merged after v4.25.0's predecessor shipped — the same job succeeded on the previous release.

## Verification

- `release.yml` parses (`yaml.safe_load`)
- Audited every workflow for the same `registry-url` + `gradlew` combination: `release.yml` is the only one
- Not runnable on a PR by construction (see above); the real proof is the next release publishing `sceneview-web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)