### PR TITLE
chore(claude): revive the ~17 dead hooks via a dispatcher + clear stale untracked root residue

### DIFF
--- a/.claude/scripts/hook-dispatch.sh
+++ b/.claude/scripts/hook-dispatch.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# hook-dispatch.sh — central dispatcher for Claude Code hooks (sceneview).
+#
+# Replaces the ~17 dead hooks that used permission-rule syntax in their
+# `matcher` field ("Bash(git commit*)", "Edit(*/gradle.properties)") — the
+# matcher is a regex on the TOOL NAME only, so those hooks never fired.
+# settings.json now uses valid matchers ("Bash", "Edit|Write") and routes
+# everything here.
+#
+# Usage (wired in .claude/settings.json):
+#   hook-dispatch.sh pre-bash    # PreToolUse  Bash
+#   hook-dispatch.sh post-bash   # PostToolUse Bash
+#   hook-dispatch.sh post-edit   # PostToolUse Edit|Write
+#
+# Reads the hook JSON payload on stdin, extracts tool_name and
+# tool_input.command / tool_input.file_path via jq.
+#
+# SAFETY RULES (this settings.json is shared by several live sessions):
+#   - exit 2 (blocking) ONLY for the gradle.properties VERSION MISMATCH
+#     guard before `git commit` — reliable condition, clearly a guard.
+#   - Everything else: exit 0 with a reminder on stderr (non-blocking).
+#   - Any internal failure (jq missing, git missing, empty/malformed
+#     stdin, missing files) => exit 0 silently. NEVER block on a hook bug.
+#   - Must run < 1s: no network, no gradle. Only jq/grep/git rev-parse.
+
+set +e
+set +u
+
+ROUTE="${1:-}"
+
+# Non-blocking reminder: message to stderr, keep going (final exit 0).
+remind() { printf '%s\n' "$1" >&2; }
+
+# --- Parse stdin safely --------------------------------------------------
+command -v jq >/dev/null 2>&1 || exit 0
+INPUT="$(cat 2>/dev/null)"
+[ -n "$INPUT" ] || exit 0
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)" || exit 0
+[ -n "$TOOL_NAME" ] || exit 0
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+FILE_PATH="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
+
+# Repo root resolved from the session's cwd (works in worktrees too).
+repo_root() {
+  local base="${HOOK_CWD:-$PWD}"
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$base" rev-parse --show-toplevel 2>/dev/null
+}
+
+case "$ROUTE" in
+
+  # ========================================================== PreToolUse Bash
+  pre-bash)
+    [ "$TOOL_NAME" = "Bash" ] || exit 0
+    [ -n "$CMD" ] || exit 0
+
+    case "$CMD" in
+      *"git commit"*)
+        # --- Guard 1 (BLOCKING): VERSION_NAME mismatch across gradle.properties
+        ROOT="$(repo_root)"
+        if [ -n "$ROOT" ] && [ -f "$ROOT/gradle.properties" ]; then
+          V="$(grep '^VERSION_NAME=' "$ROOT/gradle.properties" 2>/dev/null | head -1 | cut -d= -f2)"
+          if [ -n "$V" ]; then
+            for f in sceneview/gradle.properties arsceneview/gradle.properties sceneview-core/gradle.properties; do
+              if [ -f "$ROOT/$f" ]; then
+                FV="$(grep '^VERSION_NAME=' "$ROOT/$f" 2>/dev/null | head -1 | cut -d= -f2)"
+                if [ -n "$FV" ] && [ "$FV" != "$V" ]; then
+                  echo "VERSION MISMATCH: $f has VERSION_NAME=$FV but root gradle.properties has $V. Align them before committing (see .claude/scripts/sync-versions.sh)." >&2
+                  exit 2
+                fi
+              fi
+            done
+          fi
+        fi
+        # --- Guard 2 (non-blocking): deprecated API scan on staged files
+        if [ -n "$ROOT" ] && [ -x "$ROOT/.claude/scripts/check-deprecated-api.sh" ]; then
+          OUT="$(cd "$ROOT" 2>/dev/null && bash "$ROOT/.claude/scripts/check-deprecated-api.sh" 2>&1)"
+          RC=$?
+          if [ "$RC" -ne 0 ] && [ -n "$OUT" ]; then
+            remind "DEPRECATED API CHECK (non-blocking): $OUT"
+          fi
+        fi
+        ;;
+      *"git push"*)
+        remind 'PRE-PUSH QUALITY GATE: Before pushing, ensure you have verified: 1) Android compiles (sceneview + arsceneview), 2) Unit tests pass, 3) Bundle builds if store-affecting, 4) Website JS valid if website changed. Run: bash .claude/scripts/pre-push-check.sh'
+        ;;
+    esac
+    exit 0
+    ;;
+
+  # ========================================================= PostToolUse Bash
+  post-bash)
+    [ "$TOOL_NAME" = "Bash" ] || exit 0
+    [ -n "$CMD" ] || exit 0
+    case "$CMD" in
+      *"git push"*)
+        remind 'PUSHED — Remember: if this is a release, update CLAUDE.md session state and website version references. Run .claude/scripts/sync-versions.sh to verify.'
+        ;;
+    esac
+    exit 0
+    ;;
+
+  # =================================================== PostToolUse Edit|Write
+  post-edit)
+    case "$TOOL_NAME" in Edit|Write|MultiEdit|NotebookEdit) : ;; *) exit 0 ;; esac
+    [ -n "$FILE_PATH" ] || exit 0
+
+    case "$FILE_PATH" in
+      */gradle.properties|gradle.properties)
+        remind 'VERSION EDITED — Run: .claude/scripts/sync-versions.sh to check ALL 30+ version locations. Key files: gradle.properties (root+modules), mcp/package.json, llms.txt, README.md, CLAUDE.md, website-static/index.html, docs/docs/*.md, flutter pubspec+podspec, sceneview-web/package.json' ;;
+    esac
+    case "$FILE_PATH" in
+      */package.json|package.json)
+        remind 'NPM PACKAGE EDITED — Check version alignment: mcp/package.json, sceneview-web/package.json, react-native/*/package.json should align with gradle.properties VERSION_NAME' ;;
+    esac
+    case "$FILE_PATH" in
+      */pubspec.yaml|pubspec.yaml)
+        remind 'FLUTTER PUBSPEC EDITED — Also check: flutter/.../android/build.gradle version, flutter/.../ios/*.podspec version' ;;
+    esac
+    case "$FILE_PATH" in
+      */Package.swift|Package.swift)
+        remind 'SWIFT PACKAGE EDITED — SPM version comes from git tags (vX.Y.Z), not Package.swift. Ensure platform requirements are still correct.' ;;
+    esac
+    case "$FILE_PATH" in
+      */sceneview/src/*|sceneview/src/*)
+        remind 'ANDROID API CHANGED — Check if corresponding change is needed in: SceneViewSwift/, sceneview-web/, llms.txt, mcp/src/ tools' ;;
+    esac
+    case "$FILE_PATH" in
+      */SceneViewSwift/Sources/*|SceneViewSwift/Sources/*)
+        remind 'SWIFT API CHANGED — Check if corresponding change is needed in: sceneview/ (Android), llms.txt (iOS section), mcp/src/ tools' ;;
+    esac
+    case "$FILE_PATH" in
+      */sceneview-web/src/*|sceneview-web/src/*)
+        remind 'WEB API CHANGED — Check if corresponding change is needed in: sceneview/ (Android), llms.txt (Web section)' ;;
+    esac
+    case "$FILE_PATH" in
+      */sceneview-core/src/*|sceneview-core/src/*)
+        remind 'KMP CORE CHANGED — This affects ALL platforms: Android, iOS, Web. Run tests on all targets: :sceneview-core:jsTest, :sceneview-core:androidTest' ;;
+    esac
+    case "$FILE_PATH" in
+      */.github/workflows/*|.github/workflows/*)
+        remind 'CI WORKFLOW CHANGED — Verify: trigger conditions, secrets used, timeout values, concurrency groups' ;;
+    esac
+    case "$FILE_PATH" in
+      */samples/android-demo/src/main/java/*.kt|samples/android-demo/src/main/java/*.kt)
+        remind 'UI ANDROID MODIFIÉ — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/android_after.png' ;;
+    esac
+    case "$FILE_PATH" in
+      */samples/android-demo/src/main/res/*|samples/android-demo/src/main/res/*)
+        remind 'RESSOURCES ANDROID MODIFIÉES — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/android_after.png' ;;
+    esac
+    case "$FILE_PATH" in
+      */samples/ios-demo/*.swift|samples/ios-demo/*.swift)
+        remind 'UI iOS MODIFIÉ — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/ios_after.png' ;;
+    esac
+    case "$FILE_PATH" in
+      *.mat)
+        remind 'FILAMENT MATERIAL EDITED — Remember to run: bash tools/GenerateFilamat.sh && commit both the .mat source AND the regenerated .filamat blob together. The Filament runtime ↔ .filamat ABI invariant blocks PRs that ship one without the other (issue #1912).' ;;
+    esac
+    case "$FILE_PATH" in
+      */website-static/*|website-static/*)
+        remind 'WEBSITE MODIFIÉ — OBLIGATION: ouvrir website-static/index.html dans le navigateur et vérifier visuellement desktop + mobile. Vérifier: layout, couleurs, dark mode, responsive.' ;;
+    esac
+    exit 0
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,161 +10,31 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null); [ -f \"$ROOT/gradle.properties\" ] && V=$(grep \"^VERSION_NAME=\" \"$ROOT/gradle.properties\" | cut -d= -f2); for f in sceneview/gradle.properties arsceneview/gradle.properties sceneview-core/gradle.properties; do [ -f \"$ROOT/$f\" ] && FV=$(grep \"^VERSION_NAME=\" \"$ROOT/$f\" | cut -d= -f2) && [ \"$FV\" != \"$V\" ] && echo \"VERSION MISMATCH: $f has $FV but root has $V\" && exit 1; done; exit 0'"
-          },
-          {
-            "type": "command",
-            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null); [ -x \"$ROOT/.claude/scripts/check-deprecated-api.sh\" ] && bash \"$ROOT/.claude/scripts/check-deprecated-api.sh\" || exit 0'"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash(git push*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'PRE-PUSH QUALITY GATE: Before pushing, ensure you have verified: 1) Android compiles (sceneview + arsceneview), 2) Unit tests pass, 3) Bundle builds if store-affecting, 4) Website JS valid if website changed. Run: bash .claude/scripts/pre-push-check.sh'"
+            "command": "H=\"${CLAUDE_PROJECT_DIR:-.}/.claude/scripts/hook-dispatch.sh\"; if [ -f \"$H\" ]; then bash \"$H\" pre-bash; else exit 0; fi"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit(*/gradle.properties)",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'VERSION EDITED — Run: .claude/scripts/sync-versions.sh to check ALL 30+ version locations. Key files: gradle.properties (root+modules), mcp/package.json, llms.txt, README.md, CLAUDE.md, website-static/index.html, docs/docs/*.md, flutter pubspec+podspec, sceneview-web/package.json'"
+            "command": "H=\"${CLAUDE_PROJECT_DIR:-.}/.claude/scripts/hook-dispatch.sh\"; if [ -f \"$H\" ]; then bash \"$H\" post-edit; else exit 0; fi"
           }
         ]
       },
       {
-        "matcher": "Edit(*/package.json)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'NPM PACKAGE EDITED — Check version alignment: mcp/package.json, sceneview-web/package.json, react-native/*/package.json should align with gradle.properties VERSION_NAME'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/pubspec.yaml)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'FLUTTER PUBSPEC EDITED — Also check: flutter/.../android/build.gradle version, flutter/.../ios/*.podspec version'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/Package.swift)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'SWIFT PACKAGE EDITED — SPM version comes from git tags (vX.Y.Z), not Package.swift. Ensure platform requirements are still correct.'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/sceneview/src/*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'ANDROID API CHANGED — Check if corresponding change is needed in: SceneViewSwift/, sceneview-web/, llms.txt, mcp/src/ tools'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/SceneViewSwift/Sources/*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'SWIFT API CHANGED — Check if corresponding change is needed in: sceneview/ (Android), llms.txt (iOS section), mcp/src/ tools'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/sceneview-web/src/*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'WEB API CHANGED — Check if corresponding change is needed in: sceneview/ (Android), llms.txt (Web section)'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/sceneview-core/src/*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'KMP CORE CHANGED — This affects ALL platforms: Android, iOS, Web. Run tests on all targets: :sceneview-core:jsTest, :sceneview-core:androidTest'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/.github/workflows/*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'CI WORKFLOW CHANGED — Verify: trigger conditions, secrets used, timeout values, concurrency groups'"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash(git push*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'PUSHED — Remember: if this is a release, update CLAUDE.md session state and website version references. Run .claude/scripts/sync-versions.sh to verify.'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/samples/android-demo/src/main/java/**/*.kt)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'UI ANDROID MODIFIÉ — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/android_after.png'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/samples/android-demo/src/main/res/**)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'RESSOURCES ANDROID MODIFIÉES — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/android_after.png'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/samples/ios-demo/**/*.swift)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'UI iOS MODIFIÉ — OBLIGATION: capturer un screenshot et vérifier visuellement AVANT de continuer. Commande: bash .claude/scripts/visual-check.sh after && lire les images /tmp/sceneview-visual/ios_after.png'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*.mat)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'FILAMENT MATERIAL EDITED — Remember to run: bash tools/GenerateFilamat.sh && commit both the .mat source AND the regenerated .filamat blob together. The Filament runtime ↔ .filamat ABI invariant blocks PRs that ship one without the other (issue #1912).'"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit(*/website-static/**)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'WEBSITE MODIFIÉ — OBLIGATION: ouvrir website-static/index.html dans le navigateur et vérifier visuellement desktop + mobile. Vérifier: layout, couleurs, dark mode, responsive.'"
+            "command": "H=\"${CLAUDE_PROJECT_DIR:-.}/.claude/scripts/hook-dispatch.sh\"; if [ -f \"$H\" ]; then bash \"$H\" post-bash; else exit 0; fi"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,11 @@ samples/ios-demo/SourcePackages/
 # SwiftPM build dir at any depth (root `.build/` appears when `swift build` is
 # run from the worktree root).
 .build/
+# XcodeBuildMCP: config.yaml is tracked project config (it enables the
+# ui-automation + device workflows the iOS demo QA needs — AR cannot run on a
+# simulator). Anything else the tool drops in that directory is a local cache.
+.xcodebuildmcp/*
+!.xcodebuildmcp/config.yaml
 
 # ── Android artifacts ─────────────────────────────────────
 *.apk
@@ -203,10 +208,12 @@ docs/docs/*-contribution.md
 
 # ── Platform demo assets (copied via .claude/scripts/sync-assets.sh) ──
 # Note: android-demo-assets is NOT ignored (Play Asset Delivery, must be in git)
-# Note: samples/web-demo/src/jsMain/resources/{models,environments}/ are NOT
-# ignored — the web demo self-hosts its curated GLB catalog and IBL so it
-# never depends on a third-party CDN (#1573); they ride into the Kotlin/JS
-# jsBrowserDistribution output and the Playwright dev server serves them too.
+# Note: the web demo's self-hosted GLB catalog + IBL (#1573) now live under
+# samples/web-demo/site/, which is force-added (`git add -f`) like the rest of
+# site/ — see the kotlin-bundle note below. The old Kotlin/JS source set at
+# samples/web-demo/src/jsMain/resources/ was deleted with the dead source set
+# in #1946/#1950; anything reappearing there is a stale local copy of
+# assets/models/glb/, not source. Do not re-add a rule for it.
 samples/android-tv-demo/src/main/assets/
 samples/flutter-demo/models/
 samples/react-native-demo/assets/models/

--- a/.xcodebuildmcp/config.yaml
+++ b/.xcodebuildmcp/config.yaml
@@ -1,0 +1,8 @@
+# XcodeBuildMCP workflow configuration for the SceneView repo.
+# Default is ["simulator"] only; we also need UI automation (taps/swipes for
+# demo navigation) and device workflows (build/install/launch on a physical
+# iPhone for AR demo QA — AR cannot run on the simulator).
+enabledWorkflows:
+  - simulator
+  - ui-automation
+  - device


### PR DESCRIPTION
Triage of the 6 uncommitted entries that had been polluting `git status` in the main checkout for several sessions. One motivated decision per entry, each backed by a check rather than a guess.

## Verdicts

| Entry | Verdict | Proof |
|---|---|---|
| `.claude/scripts/hook-dispatch.sh` | **COMMIT** | Referenced by `settings.json`; 5 pipe-tests pass |
| `.claude/settings.json` (M) | **COMMIT, corrected** | Personal absolute path → `${CLAUDE_PROJECT_DIR:-.}` |
| `.xcodebuildmcp/config.yaml` | **COMMIT** | 338 B project config, no secret, no personal path |
| `.claude/settings.json.bak-20260711` | **DELETE** | `diff` vs `HEAD` → byte-identical |
| `qa-artifacts-2581/` | **DELETE** (archived first) | Issue #2581 closed 2026-07-16 |
| `samples/web-demo/src/` | **DELETE** | SHA-256 61/61 identical to `assets/models/glb/` |

## The real bug this fixes

`.claude/settings.json` declared ~17 hooks whose `matcher` used **permission-rule syntax** — `"Bash(git commit*)"`, `"Edit(*/gradle.properties)"`. A hook matcher is a regex on the **tool name** only, so **none of them ever fired**. Silently inert this whole time: the version-mismatch commit guard, the deprecated-API scan, the pre-push quality gate, and every cross-platform reminder.

`hook-dispatch.sh` re-implements all of them behind valid matchers (`Bash`, `Edit|Write`), dispatching on the hook's JSON payload.

## Verification performed

Pipe-tested against synthesized hook payloads:

- `git commit` with aligned versions → exit 0
- `git commit` with **misaligned** versions → **exit 2 + explicit message** (the one guard that is allowed to block)
- `git push` → pre-push quality-gate reminder, exit 0
- `Edit` on `gradle.properties` → sync-versions reminder, exit 0
- empty stdin / malformed JSON → exit 0, silent (a hook bug must never block)

End-to-end through the exact `settings.json` wrapper:

- `CLAUDE_PROJECT_DIR` = real repo → fires correctly
- `CLAUDE_PROJECT_DIR` = a worktree without the script yet → exit 0, no error spam

## Two deliberate details

**Why `${CLAUDE_PROJECT_DIR:-.}` and not the absolute path.** The incoming version hardcoded `/Users/…/Projects/sceneview/`, which breaks hooks on every other host and in every worktree, and violates the repo's no-personal-paths rule. `$CLAUDE_PROJECT_DIR` is the convention already used by `statusLine` since a8a0e37d7 (2026-05-31).

**Why `if [ -f "$H" ]` and not `|| exit 0`.** Existing worktrees don't carry the script until they rebase, so the guard prevents an error on every Bash call. It is deliberately an `if`, not a `|| exit 0` suffix — the latter would swallow the blocking `exit 2` and silently disarm the version guard (the `bash 3.2` guarded-abort trap this repo has been bitten by before).

## Deletions — why nothing was lost

- **`samples/web-demo/src/` (552 MB, 61 GLB).** The Kotlin/JS source set was deleted in #1946/#1950 (2026-05-21), which moved the static deliverable to `samples/web-demo/site/`. Only 12 GLB were ever tracked there. All 61 files on disk are **bit-identical (SHA-256) to `assets/models/glb/`**, and all 61 are cited in `assets/catalog.json` — the canonical copy is untouched (77 GLB). The `.gitignore` note asserting this path is deliberately *not* ignored outlived the path by two months; corrected here.
- **`qa-artifacts-2581/`.** Copied to a gitignored archive outside tracking, checksum-verified 12/12, then removed.
- **`.claude/settings.json.bak-20260711`.** `diff` against `HEAD` → identical; git already holds it.

## Notes for review

- **No changelog fragment.** This is internal tooling (`.claude/`, `.gitignore`, MCP config) with no SDK-consumer-visible effect; no CI check requires a fragment. Happy to add one if you'd rather.
- Authored from a dedicated worktree so the main checkout's `HEAD` never moved — another session was concurrently editing `.claude/scripts/check-demo-id-parity.sh` there, and that change is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)