### PR TITLE
ci(parity): gate the parity-manifest section tallies (#2801)

### DIFF
--- a/.claude/scripts/check-demo-id-parity.sh
+++ b/.claude/scripts/check-demo-id-parity.sh
@@ -146,6 +146,8 @@ awk '/static let residualIds: Set<String> = \[/{ rest=$0; sub(/^.*= \[/,"",rest)
 # (PyYAML is already asserted present in the repo-hygiene job before this
 # step runs — see ci.yml's "Install dash + shellcheck" step.)
 PYTHONPATH="" python3 - "$ANDROID_IDS_FILE" "$IOS_GENERATED_IDS_FILE" "$IOS_REAL_IDS_FILE" "$IOS_ALIASES_FILE" "$IOS_RESIDUAL_FILE" "$MANIFEST" <<'PYEOF'
+import collections
+import re
 import sys
 import yaml
 
@@ -207,6 +209,62 @@ for row_id, row in manifest_by_id.items():
                        f"(must be one of {sorted(VALID_STATUSES)})")
     if status and status != "working" and not str(row.get("reason", "")).strip():
         errors.append(f"manifest row '{row_id}' has iosStatus '{status}' but no 'reason'")
+
+# ─── Section-banner tallies must match the parsed reality (#2801) ─────────
+# The `# ─── working (N) ───` banners are COMMENTS, and everything above reads
+# the manifest through yaml.safe_load — which never sees a comment. So a stale
+# N used to sail through every other check in this file, and did: the tally
+# drifted four separate times during the Wave-A iOS-port run (#2798) alone,
+# ending 4 rows off reality with CI green throughout.
+#
+# This is the one part of the manifest safe to gate HARD rather than WARN:
+# it is exact counting, not a heuristic, so it cannot false-positive. A banner
+# is only checked when it is present — the self-test fixtures carry no banners,
+# and a manifest is not required to have them. But once ANY banner exists, every
+# non-empty status must carry one, so the gate cannot be dodged by deleting the
+# banner that has gone stale.
+status_counts = collections.Counter(
+    row.get("iosStatus") for row in manifest_by_id.values()
+)
+banner_re = re.compile(
+    r"^\s*#\s*─+\s*(working|stub|android-only)\s*\((\d+)\)"
+)
+banners = []
+with open(manifest_file) as f:
+    for lineno, line in enumerate(f, 1):
+        m = banner_re.match(line)
+        if m:
+            banners.append((lineno, m.group(1), int(m.group(2))))
+
+seen_banner_cats = set()
+for lineno, cat, declared in banners:
+    if cat in seen_banner_cats:
+        errors.append(
+            f"parity-manifest.yml line {lineno}: a second section banner for "
+            f"'{cat}' — there must be exactly one banner per iosStatus, "
+            f"otherwise 'the' count is ambiguous."
+        )
+        continue
+    seen_banner_cats.add(cat)
+    actual = status_counts.get(cat, 0)
+    if declared != actual:
+        errors.append(
+            f"parity-manifest.yml line {lineno}: the '{cat}' section banner "
+            f"says ({declared}) but {actual} row(s) actually carry "
+            f"iosStatus: {cat}. Banners are comments — yaml.safe_load never "
+            f"reads them, so a stale count passes every other check in this "
+            f"script silently. Recount at the parser, never by hand."
+        )
+
+if banners:
+    for cat in sorted(VALID_STATUSES):
+        if status_counts.get(cat, 0) > 0 and cat not in seen_banner_cats:
+            errors.append(
+                f"parity-manifest.yml has section banners but none for "
+                f"'{cat}', which holds {status_counts[cat]} row(s). Add a "
+                f"'# ─── {cat} ({status_counts[cat]}) ───' banner — a missing "
+                f"banner is how a stale one gets 'fixed' by deletion."
+            )
 
 # ─── The core gate: every Android id is accounted for ─────────────────────
 for demo_id in sorted(android_ids):

--- a/.claude/scripts/test-check-demo-id-parity.sh
+++ b/.claude/scripts/test-check-demo-id-parity.sh
@@ -332,6 +332,80 @@ run
     && ok "collapsed single-line legacyAliases (= [:]) does not leak, multi-line still works → PASS" \
     || bad "collapsed single-line legacyAliases must not leak (rc=$RC): $OUT"
 
+# ─── 12. A section banner whose count disagrees with the rows → FAIL ──────
+# The Wave-A drift class (#2798): the `# ─── working (N) ───` banners are
+# COMMENTS, so yaml.safe_load never sees them and a stale N used to pass every
+# other check in the script. Two rows are `working`, the banner claims one.
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "animation-physics" "AnimationPhysics"
+write_ios_generated "model-viewer animation-physics" ""
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  # ─── working (1) — iOS has a real, non-placeholder destination ─────────
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: animation-physics
+    androidStatus: Working
+    iosStatus: working
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "section banner" <<<"$OUT" \
+    && grep -q "says (1) but 2 row(s)" <<<"$OUT"; } \
+    && ok "stale section-banner tally → FAIL (the Wave-A drift class)" \
+    || bad "stale section-banner tally should FAIL (rc=$RC): $OUT"
+
+# ─── 13. Correct banners → PASS (the gate does not fire on an honest file) ──
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "animation-physics" "AnimationPhysics"
+write_ios_generated "model-viewer" "animation-physics"
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  # ─── working (1) — iOS has a real, non-placeholder destination ─────────
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+
+  # ─── stub (1) — iOS registry has the id, but it falls to the placeholder ──
+  - id: animation-physics
+    androidStatus: Working
+    iosStatus: stub
+    reason: "Scene file exists but @available false"
+EOF
+run
+{ [[ $RC -eq 0 ]] && grep -q "check-demo-id-parity.sh: OK" <<<"$OUT"; } \
+    && ok "accurate section banners → PASS" \
+    || bad "accurate section banners should PASS (rc=$RC): $OUT"
+
+# ─── 14. Deleting a stale banner must not dodge the gate → FAIL ───────────
+# Once ANY banner exists, every non-empty status needs one — otherwise the
+# cheapest way to "fix" a failing tally is to delete the banner, which throws
+# the information away instead of correcting it.
+rm -f "$FRAG_DIR"/*.kt
+write_fragment "model-viewer" "ModelViewer"
+write_fragment "animation-physics" "AnimationPhysics"
+write_ios_generated "model-viewer" "animation-physics"
+write_ios_registry "" ""
+write_manifest <<'EOF'
+demos:
+  # ─── working (1) — iOS has a real, non-placeholder destination ─────────
+  - id: model-viewer
+    androidStatus: Working
+    iosStatus: working
+  - id: animation-physics
+    androidStatus: Working
+    iosStatus: stub
+    reason: "Scene file exists but @available false"
+EOF
+run
+{ [[ $RC -ne 0 ]] && grep -q "banners but none for 'stub'" <<<"$OUT"; } \
+    && ok "deleting a banner to dodge the tally gate → FAIL" \
+    || bad "missing banner for a non-empty status should FAIL (rc=$RC): $OUT"
+
 # ─── Summary ───────────────────────────────────────────────────────────────
 echo ""
 echo "test-check-demo-id-parity.sh: $PASS passed, $FAIL failed"

--- a/changelog.d/2801-parity-manifest-tally-gate.md
+++ b/changelog.d/2801-parity-manifest-tally-gate.md
@@ -1,0 +1,13 @@
+<!-- category: Tests -->
+- **`check-demo-id-parity.sh` now gates the `parity-manifest.yml` section tallies.** The
+  `# ─── working (N) ───` banners are comments, and every other check in that script reads
+  the manifest through `yaml.safe_load`, which never sees a comment — so a stale `N` passed
+  CI silently. It did, four separate times during the Wave-A iOS-port run, ending four rows
+  off reality with the gate green throughout. The banners are now compared against the
+  parsed row counts, and once any banner exists every non-empty status must carry one, so a
+  stale tally cannot be "fixed" by deleting the banner
+  ([#2801](https://github.com/sceneview/sceneview/issues/2801)).
+- This is gated hard rather than WARN-only because it is exact counting, not a heuristic:
+  it cannot false-positive, the same reason `gpt/knowledge-*.md` drift is a blocking check.
+  Covered by three new `test-check-demo-id-parity.sh` cases (stale tally, accurate tally,
+  banner-deletion dodge).

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -30,20 +30,31 @@
 #                    hasn't reserved an id for yet.
 # `reason` is required for every non-`working` row (one line, honest, cites
 # the tracking issue). `androidStatus` mirrors Android's own `DemoStatus`
-# (Working/KnownIssue/ComingSoon/InReview) for context — the #2798 audit
-# found a strict correlation: every Android demo that is not itself `Working`
-# lands in iOS's `stub` or `android-only` bucket, with zero exceptions.
-# That correlation BROKE on 2026-07-21 — see the `wall-placement` note below.
+# (Working/KnownIssue/ComingSoon/InReview) for context. The #2798 audit once
+# observed a strict correlation here — every Android demo that was not itself
+# `Working` sat in iOS's `stub` or `android-only` bucket. That was a SNAPSHOT,
+# never an invariant, and the Wave-A port run (2026-07-21/22) broke it three
+# times over: `ar-depth-collider` (#2860) and `ar-cloud-anchor` (#2863), both
+# Android `KnownIssue`, and `wall-placement` (#2857), Android `InReview`, are
+# all genuinely ported and therefore honestly `working` on iOS. A non-`Working`
+# Android id belongs in iOS's `working` bucket as soon as its port is real —
+# `stub` would be a lie. Do not enforce the correlation, and do not describe
+# any single one of these as "the first exception": there are three.
 #
-# Verified against source 2026-07-21 (post L0.1 #2799 + L0.2 #2800, and
-# after #2817 added `contact-shadow-preview` — rebased onto that commit
-# during this PR's own preparation, a live demonstration of exactly the
-# drift class this manifest + check-demo-id-parity.sh now catch):
-#   - Android: 53 fragments, 44 Working / 5 KnownIssue / 2 ComingSoon / 2 InReview.
-#   - iOS: `DemoDeepLinkRegistry.allowedIds` = 66 (51 generated ∪ 4 legacy
-#     aliases ∪ 11 residual ids). Of the 53 Android ids: 22 working, 18 stub,
-#     13 android-only. (`placement-scene` promoted stub → working in #2839,
-#     after this snapshot was written: 23 working, 17 stub as of that PR.)
+# ⚠️  NUMBERS LIVE IN EXACTLY ONE PLACE: the `# ─── <status> (N) ───` section
+# banners below, which `check-demo-id-parity.sh` now verifies against the
+# parsed rows. Everything else in this header is PROSE — deliberately free of
+# tallies. Four separate Wave-A PRs each wrote their own count into this
+# header, and all four went stale, because `yaml.safe_load` cannot see a
+# comment and so nothing ever checked them. Never add a tally to the prose.
+#
+# First verified against source 2026-07-21 (post L0.1 #2799 + L0.2 #2800, and
+# after #2817 added `contact-shadow-preview` — rebased onto that commit during
+# that PR's own preparation, a live demonstration of exactly the drift class
+# this manifest + check-demo-id-parity.sh catch). The per-status counts that
+# used to live in this paragraph have been removed rather than refreshed: they
+# were three waves stale by the time anyone read them. Run the gate for the
+# current numbers — it prints them, and it fails if the banners disagree.
 #
 # Updated by L0.6 (#2804, closes #2769) — every Android id now resolves to
 # SOMETHING honest on iOS (a real screen, an alias to an existing equivalent
@@ -62,43 +73,32 @@
 #     got `@androidOnlyReason` so their card reads "Android-only: <reason>"
 #     instead of "Coming soon" (their status stays `stub` — they ARE in
 #     `allowedIds` — only the CARD TREATMENT changed).
-#   - Post-L0.6: iOS: `DemoDeepLinkRegistry.allowedIds` = 79 (69 generated ∪
-#     10 legacy/umbrella aliases ∪ 0 residual ids). Of the 53 Android ids:
-#     28 working, 25 stub, 0 android-only.
-#   - #2838 ported `ar-depth-collider` (SceneReconstructionNode.enablePhysics,
-#     gated on LiDAR with a static-floor fallback — Android itself is
-#     KnownIssue for this id, landing on iOS `@status knownIssue` too): 29
-#     working, 24 stub, 0 android-only. This breaks the #2798 audit's
-#     "zero exceptions" correlation above going forward — a non-`Working`
-#     Android id can land in iOS's `working` bucket once it is genuinely
-#     ported, same as any `Working` id. Not a one-off: `wall-placement`
-#     (`androidStatus: InReview`) is a second instance of the same break
-#     once its own iOS port lands, not a special case of this one.
+#   - Post-L0.6, `DemoDeepLinkRegistry.residualIds` is `[]`: every id has a
+#     real Scene file, so nothing is hand-listed as "known but unmodelled".
 #
-# Updated 2026-07-21 by the iOS-port wave (#2798): two `stub` rows became
-# `working` — `wall-placement` (#2840, this PR) and #2860's row — so the
-# tallies below read 30 working / 23 stub / 0 android-only. That count is the
-# POST-WAVE truth and assumes BOTH PRs land; whichever merges second must
-# re-check it, because `check-demo-id-parity.sh` validates rows against the
-# live registry and never reads these comments, so a wrong tally here passes
-# the gate silently.
+# Wave A of the iOS-port run (#2798) closed 2026-07-22: six Android demos got
+# a real iOS port and moved `stub` → `working` — `ar-pose` (#2849),
+# `placement-scene` (#2847), `placement-reticle-preview` (#2856),
+# `ar-depth-collider` (#2860), `ar-cloud-anchor` (#2863) and `wall-placement`
+# (#2857). Waves B+ (the remaining ports) are NOT authorised yet; do not open
+# them off the back of this file.
 #
-# `wall-placement` is the FIRST deliberate exception to the "strict
-# correlation" claimed above: its `androidStatus` is `InReview`, yet its
-# `iosStatus` is `working`. The iOS port (#2840) is real and reachable and
-# carries the matching `@status inReview` badge, so `stub` would be a lie. The
-# correlation is therefore a historical observation from the #2798 audit, not
-# an invariant — do not enforce it.
+# Each of those six PRs updated its own row correctly — the ROWS were never
+# the problem. What drifted, four times, was the tally each PR wrote into this
+# header from a base that a sibling PR had already moved underneath it. The
+# section banners are now machine-checked, which is why the prose no longer
+# carries counts at all.
 #
 # Checked by `.claude/scripts/check-demo-id-parity.sh` (`ci.yml` ->
 # `repo-hygiene`, ubuntu, blocking): fails if a Android id has neither an iOS
 # registry entry nor a row here, if a row's `iosStatus` disagrees with the
-# live registry, or if a row here no longer corresponds to a live Android id.
+# live registry, if a row here no longer corresponds to a live Android id, or
+# if a section banner's count disagrees with the rows it introduces.
 # Update this file (status + reason) in the SAME PR that changes either
 # platform's registry — that's what keeps it honest.
 
 demos:
-  # ─── working (30) — iOS has a real, non-placeholder destination ─────────
+  # ─── working (34) — iOS has a real, non-placeholder destination ─────────
   - id: animation-physics
     androidStatus: Working
     iosStatus: working
@@ -190,7 +190,7 @@ demos:
     androidStatus: InReview
     iosStatus: working
 
-  # ─── stub (23) — iOS registry has the id, but it falls to the placeholder ──
+  # ─── stub (19) — iOS registry has the id, but it falls to the placeholder ──
   - id: ar-cloud-anchor
     androidStatus: KnownIssue
     iosStatus: working


### PR DESCRIPTION
## Why

`parity-manifest.yml`'s `# ─── working (N) ───` banners are **comments**, and every
check in `check-demo-id-parity.sh` reads the manifest through `yaml.safe_load`, which
never sees a comment. A stale `N` therefore passes CI silently.

It did — **four separate times during Wave A of the iOS-port run (#2798)**, because each
PR wrote its tally from a base a sibling PR had already moved underneath it. At the
moment #2857 merged, the header claimed `30 working / 23 stub` while the rows were
`34 / 19`, with the gate green the whole way.

## What

- **`check-demo-id-parity.sh`** compares each section banner against the parsed row
  counts. Gated **hard** rather than WARN-only because it is exact counting, not a
  heuristic — it cannot false-positive, the same reason `gpt/knowledge-*.md` drift is a
  blocking check. Once any banner exists, every non-empty status must carry one, so a
  stale tally cannot be "fixed" by deleting the banner.
- **`parity-manifest.yml`** — banners corrected to the parsed truth
  (**34 working / 19 stub / 0 android-only**), and every tally removed from the header
  prose. Numbers now live in exactly one machine-checked place.
- The **"strict correlation … with zero exceptions"** claim is corrected, not patched:
  Wave A broke it three times over (`ar-depth-collider` #2860, `ar-cloud-anchor` #2863,
  `wall-placement` #2857). It is now recorded as a dated snapshot, never an invariant,
  and none of the three is described as "the first exception".

## Verification

| Check | Result |
|---|---|
| `check-demo-id-parity.sh` (before fix) | FAILED — caught `working (30)` vs 34 rows, `stub (23)` vs 19 |
| `check-demo-id-parity.sh` (after fix) | **OK** |
| `test-check-demo-id-parity.sh` | **14 passed, 0 failed** (3 new cases) |
| Parsed rows vs `HEAD` | **byte-identical** — this diff touches comments only |

New self-test cases: stale tally → FAIL, accurate banners → PASS, banner-deletion dodge → FAIL.

## Scope

Wave A closure only. Waves B+ (the remaining ports) are **not** authorised and are not
touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)