### PR TITLE
fix(ci): unbreak main — DemoScaffold snippet can never compile in :snippets-check (#2808)

### DIFF
--- a/changelog.d/2808-snippets-check-demoscaffold.md
+++ b/changelog.d/2808-snippets-check-demoscaffold.md
@@ -1,0 +1,10 @@
+- **CI:** unbreak `main`. The `:snippets-check` module added by #2808 compiles every
+  ` ```kotlin ` block in `llms.txt`, but the `DemoScaffold` signature listing added by
+  #2780 references `DemoBottomOverlayScope` — a type that lives in `samples/android-demo`,
+  which is deliberately not on `:snippets-check`'s classpath (the module depends on the
+  libraries, not on the sample app). Every PR opened since has been red on
+  `Build libraries & samples` through no fault of its own. The block is now tagged
+  ` ```kotlin notest <reason> `, the escape hatch the extractor documents for exactly this
+  case. (#2808)
+
+<!-- category: Fixed -->

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -610,7 +610,7 @@ Full recipe + add-a-slug checklist: `docs/docs/recipes/sketchfab-streaming.md`. 
 
 `DemoScaffold` is the shared scaffold every sample-app demo uses. v2 ([PR #1169](https://github.com/sceneview/sceneview/pull/1169)) renders the 3D / AR scene **full-screen** under the top app bar, with a `Tune` FAB pinned bottom-right that opens a `ModalBottomSheet` containing the demo's controls.
 
-```kotlin
+```kotlin notest DemoScaffold and DemoBottomOverlayScope live in samples/android-demo, which is deliberately not on :snippets-check's classpath (it depends on the libraries, not the sample app)
 @Composable
 fun DemoScaffold(
     title: String,

--- a/llms.txt
+++ b/llms.txt
@@ -4804,7 +4804,7 @@ Full recipe + add-a-slug checklist: `docs/docs/recipes/sketchfab-streaming.md`. 
 
 `DemoScaffold` is the shared scaffold every sample-app demo uses. v2 ([PR #1169](https://github.com/sceneview/sceneview/pull/1169)) renders the 3D / AR scene **full-screen** under the top app bar, with a `Tune` FAB pinned bottom-right that opens a `ModalBottomSheet` containing the demo's controls.
 
-```kotlin
+```kotlin notest DemoScaffold and DemoBottomOverlayScope live in samples/android-demo, which is deliberately not on :snippets-check's classpath (it depends on the libraries, not the sample app)
 @Composable
 fun DemoScaffold(
     title: String,


### PR DESCRIPTION
## main has been red for ~28h and no PR can fix it from its own branch

`#2808` added the `:snippets-check` module, which compiles **every** ` ```kotlin ` block in
`llms.txt`. `#2780` had already added a `DemoScaffold` signature listing that references
`DemoBottomOverlayScope` — declared in `samples/android-demo/.../DemoScaffold.kt`.

`:snippets-check` depends on `:sceneview` + `:arsceneview`, deliberately **not** on the sample
app, so the reference can never resolve:

```
e: docsnippets/llms/b170/Snippet.kt:88:33 Unresolved reference 'DemoBottomOverlayScope'.
```

`main` is red since `08725f59c` (2026-07-21 16:17Z) — the very commit that introduced the
guard. Every PR opened since is red on `Build libraries & samples` through no fault of its
own, because the failure lives in the merge commit.

## Fix

Tag the block ` ```kotlin notest <reason> ` — the escape hatch `tools/extract-doc-snippets.js`
documents for intentionally non-standalone fragments (a reason is mandatory and supplied).

Adding `:samples:android-demo` to the guard's classpath would be the **wrong** fix: the module
exists to prove the *library* snippets compile, and the demo app is not part of that contract.

## Verified, not assumed

- Ran `tools/extract-doc-snippets.js`: **150 compilable / 12 notest** (was 151/11), and no
  generated `Snippet.kt` references `DemoBottomOverlayScope` — it now appears only in
  `manifest.json`, as skip metadata.
- `node tools/generate-gpt-knowledge.js --check` → in sync (regenerated `knowledge-samples.md`).
- `samples/android-demo/scripts/collate-demos.sh --check` → in sync with 53 fragments.

Found while reviewing #2821, whose CI was red for this reason alone.