### PR TITLE
fix(sceneview): return the entity id to EntityManager on Node.destroy() (#2859)

### DIFF
--- a/changelog.d/2859-entity-id-recycling.md
+++ b/changelog.d/2859-entity-id-recycling.md
@@ -1,0 +1,18 @@
+<!-- category: Fixed -->
+
+- `Node.destroy()` now returns the entity id to Filament's `EntityManager`, instead of only
+  destroying the entity's components. Every node ever created used to burn one id for the
+  lifetime of the process — invisible in single-teardown tests, and measured by the #2762
+  leak-churn harness on its first run (#2859).
+- The release is gated on **ownership**, so a borrowed entity is left to its real owner: a node
+  recycles its id only when it allocated the entity itself (the constructor's `entity` argument
+  omitted). `ModelNode` wraps `modelInstance.root` and its children wrap `gltfio` node entities,
+  all owned by the `AssetLoader` — recycling those would let Filament reissue an id a live asset
+  still uses.
+- `SplatNode` also recycles the per-batch renderable entities it allocates.
+- `Node.destroy()` now removes its entities from the Filament `Scene` it is attached to before
+  recycling the id, so an imperative caller that destroys a node without detaching it first
+  cannot leave a reissued id behind in the scene.
+- New: `NULL_ENTITY` (the "no entity" sentinel, and the new default of every optional `entity`
+  constructor parameter) and `Engine.safeRecycleEntity(entity)`. Both are additive — no existing
+  signature changed, and `Node(engine)` / `Node(engine, entity)` still compile as before.

--- a/sceneview/api/sceneview.api
+++ b/sceneview/api/sceneview.api
@@ -139,6 +139,7 @@ public final class io/github/sceneview/EngineDestroyQueue$Companion {
 }
 
 public final class io/github/sceneview/EngineKt {
+	public static final field NULL_ENTITY I
 	public static final fun createCamera (Lcom/google/android/filament/Engine;)Lcom/google/android/filament/Camera;
 	public static final fun createEnvironmentLoader (Lcom/google/android/filament/Engine;Landroid/content/Context;)Lio/github/sceneview/loaders/EnvironmentLoader;
 	public static final fun createMaterialLoader (Lcom/google/android/filament/Engine;Landroid/content/Context;)Lio/github/sceneview/loaders/MaterialLoader;
@@ -168,6 +169,7 @@ public final class io/github/sceneview/EngineKt {
 	public static final fun safeDestroyTransformable (Lcom/google/android/filament/Engine;I)Ljava/lang/Object;
 	public static final fun safeDestroyVertexBuffer (Lcom/google/android/filament/Engine;Lcom/google/android/filament/VertexBuffer;)Ljava/lang/Object;
 	public static final fun safeDestroyView (Lcom/google/android/filament/Engine;Lcom/google/android/filament/View;)Ljava/lang/Object;
+	public static final fun safeRecycleEntity (Lcom/google/android/filament/Engine;I)Ljava/lang/Object;
 }
 
 public abstract interface annotation class io/github/sceneview/ExperimentalSceneViewApi : java/lang/annotation/Annotation {
@@ -2434,6 +2436,7 @@ public class io/github/sceneview/node/Node : android/view/GestureDetector$OnCont
 	public static final field $stable I
 	public fun <init> (Lcom/google/android/filament/Engine;I)V
 	public synthetic fun <init> (Lcom/google/android/filament/Engine;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun <init> (Lcom/google/android/filament/Engine;IZ)V
 	public final fun addChildNode (Lio/github/sceneview/node/Node;)Lio/github/sceneview/node/Node;
 	public final fun addChildNodes (Ljava/util/Set;)Lio/github/sceneview/node/Node;
 	public final fun animatePositions ([Ldev/romainguy/kotlin/math/Float3;)Landroid/animation/ObjectAnimator;

--- a/sceneview/src/androidTest/java/io/github/sceneview/leak/LeakChurnTest.kt
+++ b/sceneview/src/androidTest/java/io/github/sceneview/leak/LeakChurnTest.kt
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith
  * | `LightManager` component count | `getComponentCount()` ✅ | global baseline assert |
  * | `RenderableManager` component count | ❌ none (only `hasComponent(entity)`) | per-entity assert |
  * | `TransformManager` component count | ❌ none (only `hasComponent(entity)`) | per-entity assert |
- * | `EntityManager` alive count | ❌ none (only `isAlive(entity)`) | pinned, not asserted (see below) |
+ * | `EntityManager` alive count | ❌ none (only `isAlive(entity)`) | per-entity assert |
  * | `EngineDestroyQueue.size` | ✅ (`EngineDestroyQueue.kt:58`) | global assert |
  *
  * Per-entity probing is not a downgrade: a global counter tells you *that* something
@@ -69,10 +69,11 @@ import org.junit.runner.RunWith
  * canary fails loudly instead of letting every other test pass vacuously on a dead
  * instrument.
  *
- * One gap is **pinned rather than asserted**: `Node.destroy()` never returns the entity id
- * to `EntityManager` (see [entityIdRecycling_isTheKnownPreExistingGap]). That is a real,
- * pre-existing leak this suite measured on its first run; it is tracked in #2859 rather
- * than smuggled into a test PR as a runtime change.
+ * The id-recycling leak this suite measured on its first run — `Node.destroy()` never
+ * returned the entity id to `EntityManager` — was tracked as #2859 and fixed there rather
+ * than smuggled into the test PR as a runtime change. Both halves of that fix are asserted
+ * here: [ownedEntityId_isRecycledOnDestroy] (a self-allocated id comes back) and
+ * [borrowedEntityId_isLeftToItsOwner] (a caller-supplied one does not, the `gltfio` case).
  *
  * ## Scope, stated honestly
  *
@@ -122,16 +123,17 @@ class LeakChurnTest {
         InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
 
     /**
-     * Asserts every **component** attached to [entity] was released. A leaked component
-     * keeps native memory alive even when the Kotlin `Node` is long gone — that is exactly
-     * the #2036/#2039 shape.
+     * Asserts every **component** attached to [entity] was released, **and** that its id went
+     * back to the [EntityManager]. A leaked component keeps native memory alive even when the
+     * Kotlin `Node` is long gone — that is exactly the #2036/#2039 shape; a leaked id keeps
+     * burning a slot in Filament's bounded id space — #2859.
      *
-     * Deliberately does NOT assert `EntityManager.isAlive(entity) == false`: the SDK's
-     * `Node.destroy()` calls `Engine.destroyEntity()`, which in Filament destroys the
-     * components but does **not** return the id to `EntityManager` (only
-     * `EntityManager.destroy()` does). That id-recycling gap is real, measured, and
-     * pre-existing — see [entityIdRecycling_isTheKnownPreExistingGap] and #2859. Asserting
-     * it here would just paint this suite red for a bug it did not introduce and cannot fix.
+     * The `isAlive` half was `false` for the whole life of this suite: `Node.destroy()` called
+     * `Engine.destroyEntity()`, which destroys the components but does **not** return the id
+     * (only `EntityManager.destroy()` does). #2859 fixed that, so the assert is live now.
+     *
+     * Every caller destroys **all** the entities it collected before asserting, so a recycled
+     * id being handed back out mid-churn cannot make this read `true` spuriously.
      */
     private fun assertComponentsReleased(label: String, entity: Int) {
         assertFalse(
@@ -145,6 +147,12 @@ class LeakChurnTest {
         assertFalse(
             "$label: entity $entity still has a LightManager component after destroy()",
             engine.lightManager.hasComponent(entity),
+        )
+        assertFalse(
+            "$label: entity $entity is still alive in the EntityManager after destroy() — " +
+                "its id was never returned, so it is burnt for the lifetime of the process " +
+                "(#2859)",
+            EntityManager.get().isAlive(entity),
         )
     }
 
@@ -422,32 +430,81 @@ class LeakChurnTest {
     }
 
     /**
-     * Characterization test for a **pre-existing, measured** gap — not a new regression.
+     * A node that allocated its own entity returns the id on [Node.destroy] (#2859).
      *
-     * `Node.destroy()` → `Engine.destroyEntity(entity)` destroys the entity's *components*
-     * but does not return the id to `EntityManager`; only `EntityManager.destroy(entity)`
-     * does, and the SDK calls it in exactly two places (`PlaneVisualizer`,
-     * `PlaneVisualizerV2`) out of 15 creation sites. So every `Node` ever created burns an
-     * entity id for the lifetime of the process.
+     * Was a characterization test pinning the opposite: `Node.destroy()` called only
+     * `Engine.destroyEntity()`, which frees the components but not the id. #2859 added the
+     * `EntityManager.destroy()` half, gated on ownership, and this assertion was inverted in
+     * the same PR — the sequence the previous version of this KDoc prescribed.
      *
-     * This test pins today's behaviour so the churn suite above is not red for a bug it did
-     * not introduce, and so the gap is impossible to forget: **when #2859 is fixed, this
-     * test goes red — invert it then, and tighten
-     * [assertComponentsReleased] to also require `isAlive == false`.**
+     * Probed immediately after the destroy, on a single node, so no second allocation can
+     * reissue the id and make the result ambiguous.
      */
     @Test
-    fun entityIdRecycling_isTheKnownPreExistingGap() {
+    fun ownedEntityId_isRecycledOnDestroy() {
         var entity = 0
         onMain { entity = Node(engine).also { it.destroy() }.entity }
 
         onMain {
-            assertTrue(
-                "Entity ids are now recycled by Node.destroy() — the known gap this test " +
-                    "pins is FIXED. Invert this assertion and tighten assertComponentsReleased " +
-                    "to require EntityManager.isAlive(entity) == false.",
+            assertFalse(
+                "Node.destroy() did not return entity $entity to the EntityManager — every " +
+                    "node created would burn an id for the lifetime of the process (#2859)",
                 EntityManager.get().isAlive(entity),
             )
-            assertComponentsReleased("id-recycling gap probe", entity)
+            assertComponentsReleased("owned-entity probe", entity)
+        }
+    }
+
+    /**
+     * The other half of #2859, and the reason the fix is gated on ownership rather than
+     * applied unconditionally: an entity **handed in by the caller** is borrowed, and
+     * `destroy()` must leave its id alone.
+     *
+     * This is the `ModelNode` shape — it wraps `modelInstance.root`, and its child nodes wrap
+     * `gltfio` node entities, all owned by the `AssetLoader` that destroys them with the
+     * asset. Recycling a borrowed id would let Filament reissue it while the asset is still
+     * live, so a later node would silently drive an entity the model still uses.
+     *
+     * The assertions are **differential** (borrowed vs owned in the same run) on purpose: an
+     * absolute `isAlive == true` would also pass on a build where the recycling call was a
+     * no-op for everyone — which is precisely the regression
+     * [ownedEntityId_isRecycledOnDestroy] exists to catch. Requiring the owned one to be dead
+     * in the same breath is what proves the ownership flag actually discriminates.
+     */
+    @Test
+    fun borrowedEntityId_isLeftToItsOwner() {
+        var borrowed = 0
+        var owned = 0
+
+        onMain {
+            // Stands in for the AssetLoader: an entity whose owner is NOT the node.
+            borrowed = EntityManager.get().create()
+            Node(engine, entity = borrowed).destroy()
+
+            owned = Node(engine).also { it.destroy() }.entity
+        }
+
+        onMain {
+            assertTrue(
+                "Node.destroy() recycled entity $borrowed, which the caller passed in and " +
+                    "still owns. For a ModelNode that entity belongs to a live gltfio asset: " +
+                    "Filament may now reissue the id while the asset still uses it (#2859)",
+                EntityManager.get().isAlive(borrowed),
+            )
+            assertFalse(
+                "Ownership tracking is broken: the self-allocated entity $owned was not " +
+                    "recycled either, so the borrowed-entity assert above passes vacuously",
+                EntityManager.get().isAlive(owned),
+            )
+            // The node released the components either way — only the id is owner-gated.
+            assertFalse(
+                "borrowed entity $borrowed still has a TransformManager component after " +
+                    "destroy() — borrowing the id must not mean skipping component teardown",
+                engine.transformManager.hasComponent(borrowed),
+            )
+
+            // The test owns this one, so it cleans it up.
+            EntityManager.get().destroy(borrowed)
         }
     }
 }

--- a/sceneview/src/main/java/io/github/sceneview/Engine.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Engine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.google.android.filament.Camera
 import com.google.android.filament.Engine
+import com.google.android.filament.EntityManager
 import com.google.android.filament.Fence
 import com.google.android.filament.IndexBuffer
 import com.google.android.filament.IndirectLight
@@ -28,6 +29,17 @@ typealias Entity = Int
 typealias EntityInstance = Int
 typealias FilamentEntity = com.google.android.filament.Entity
 typealias FilamentEntityInstance = com.google.android.filament.EntityInstance
+
+/**
+ * The null [Entity] — Filament's "no entity" value, which [EntityManager.create] never returns.
+ *
+ * Used as the default of every SDK constructor that takes an optional `entity`, so a node can
+ * tell "the caller handed me an entity to borrow" from "no entity was given, allocate my own".
+ * That distinction is what makes it safe for [io.github.sceneview.node.Node.destroy] to return
+ * the id to the [EntityManager]: only self-allocated ids are recycled, never a borrowed one
+ * (a `gltfio` asset entity, say, whose real owner is the `AssetLoader`). See #2859.
+ */
+const val NULL_ENTITY: Entity = 0
 
 fun Engine.createModelLoader(context: Context) = ModelLoader(this, context)
 fun Engine.createMaterialLoader(context: Context) = MaterialLoader(this, context)
@@ -61,6 +73,20 @@ fun Engine.safeDestroy() = runCatching {
 }
 
 fun Engine.safeDestroyEntity(entity: Entity) = runCatching { destroyEntity(entity) }
+
+/**
+ * Returns [entity]'s id to the [EntityManager] so Filament can hand it out again.
+ *
+ * [Engine.destroyEntity] destroys the entity's *components* but deliberately does **not**
+ * release the id — only [EntityManager.destroy] does. Skipping it means every entity ever
+ * created burns an id for the lifetime of the process (#2859).
+ *
+ * **Only call this on an entity you allocated yourself.** Recycling a borrowed id — one owned
+ * by `gltfio`, or handed in by a caller — lets Filament reissue it while the real owner is
+ * still using it. Destroy the components first: this call invalidates the id.
+ */
+fun Engine.safeRecycleEntity(@FilamentEntity entity: Entity) =
+    runCatching { EntityManager.get().destroy(entity) }
 
 fun Engine.destroyTransformable(@FilamentEntity entity: Entity) = transformManager.destroy(entity)
 fun Engine.safeDestroyTransformable(@FilamentEntity entity: Entity) =

--- a/sceneview/src/main/java/io/github/sceneview/SceneNodeManager.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneNodeManager.kt
@@ -26,6 +26,10 @@ class SceneNodeManager(
         if (node.sceneEntities.isNotEmpty()) {
             scene.addEntities(node.sceneEntities.toIntArray())
         }
+        // Lets Node.destroy() un-register itself if it is destroyed without being removed
+        // first — an id recycled while still listed in the scene would resurface as a
+        // ghost renderable (#2859).
+        node.attachedScene = scene
         node.onChildAdded += ::addNode
         node.onChildRemoved += ::removeNode
         node.onAddedToScene(scene)
@@ -38,6 +42,7 @@ class SceneNodeManager(
         if (node.sceneEntities.isNotEmpty()) {
             scene.removeEntities(node.sceneEntities.toIntArray())
         }
+        node.attachedScene = null
         node.onChildAdded -= ::addNode
         node.onChildRemoved -= ::removeNode
         node.onRemovedFromScene(scene)

--- a/sceneview/src/main/java/io/github/sceneview/node/CameraNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/CameraNode.kt
@@ -4,11 +4,11 @@ import android.view.MotionEvent
 import com.google.android.filament.Camera
 import com.google.android.filament.Camera.Projection
 import com.google.android.filament.Engine
-import com.google.android.filament.EntityManager
 import com.google.android.filament.View
 import dev.romainguy.kotlin.math.Float3
 import dev.romainguy.kotlin.math.Ray as MathRay
 import io.github.sceneview.Entity
+import io.github.sceneview.NULL_ENTITY
 import io.github.sceneview.collision.HitResult
 import io.github.sceneview.collision.MathHelper
 import io.github.sceneview.collision.Matrix
@@ -66,7 +66,9 @@ open class CameraNode(engine: Engine, entity: Entity) : Node(engine, entity), Ca
 
     constructor(engine: Engine, camera: Camera.() -> Unit = {}) : this(
         engine = engine,
-        entity = EntityManager.get().create()
+        // NULL_ENTITY, not EntityManager.create(): letting Node allocate is what marks the
+        // entity as owned, so destroy() recycles its id instead of burning it (#2859).
+        entity = NULL_ENTITY
     ) {
         engine.createCamera(entity).apply(camera)
     }

--- a/sceneview/src/main/java/io/github/sceneview/node/DynamicSkyNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/DynamicSkyNode.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import com.google.android.filament.Engine
-import com.google.android.filament.EntityManager
 import com.google.android.filament.LightManager
+import io.github.sceneview.NULL_ENTITY
 import io.github.sceneview.SceneScope
 import io.github.sceneview.math.Direction
 import io.github.sceneview.math.colorOf
@@ -64,7 +64,7 @@ fun SceneScope.DynamicSkyNode(
  */
 internal class DynamicSkyNodeImpl(engine: Engine) : LightNode(
     engine = engine,
-    entity = EntityManager.get().create(),
+    entity = NULL_ENTITY,
     builder = LightManager.Builder(LightManager.Type.SUN).apply {
         intensity(110_000f)
         color(1f, 1f, 1f)

--- a/sceneview/src/main/java/io/github/sceneview/node/LightNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/LightNode.kt
@@ -1,11 +1,11 @@
 package io.github.sceneview.node
 
 import com.google.android.filament.Engine
-import com.google.android.filament.EntityManager
 import com.google.android.filament.LightManager
 import com.google.android.filament.Material
 import io.github.sceneview.Entity
 import io.github.sceneview.EntityInstance
+import io.github.sceneview.NULL_ENTITY
 import io.github.sceneview.components.LightComponent
 import io.github.sceneview.math.Color
 import io.github.sceneview.math.toColor
@@ -73,16 +73,18 @@ open class LightNode(
 
     constructor(
         engine: Engine,
-        entity: Entity = EntityManager.get().create(),
+        entity: Entity = NULL_ENTITY,
         builder: LightManager.Builder
     ) : this(engine, entity) {
-        builder.build(engine, entity)
+        // `this.entity` — NOT the `entity` parameter, which is the NULL_ENTITY sentinel when
+        // the caller let the node allocate its own. Node resolved it; the parameter did not.
+        builder.build(engine, this.entity)
     }
 
     constructor(
         engine: Engine,
         type: LightManager.Type,
-        entity: Entity = EntityManager.get().create(),
+        entity: Entity = NULL_ENTITY,
         apply: LightManager.Builder.() -> Unit
     ) : this(engine, entity, LightManager.Builder(type).apply(apply))
 

--- a/sceneview/src/main/java/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/Node.kt
@@ -42,8 +42,10 @@ import io.github.sceneview.math.times
 import io.github.sceneview.math.toMatrix
 import io.github.sceneview.math.toQuaternion
 import io.github.sceneview.math.worldToLocalQuaternion
+import io.github.sceneview.NULL_ENTITY
 import io.github.sceneview.safeDestroyEntity
 import io.github.sceneview.safeDestroyTransformable
+import io.github.sceneview.safeRecycleEntity
 
 /**
  * A Node represents a transformation within the scene graph's hierarchy.
@@ -71,9 +73,34 @@ import io.github.sceneview.safeDestroyTransformable
  *
  * +z ---- -y --------
  */
-open class Node(
+open class Node protected constructor(
     val engine: Engine,
-    @FilamentEntity val entity: Entity = EntityManager.get().create(),
+    /**
+     * The Filament entity this node drives — already resolved, never the [NULL_ENTITY]
+     * sentinel.
+     *
+     * Declared on the **primary** constructor on purpose: Kotlin resolves a bare `entity` in
+     * an `init` block or a property initializer to the constructor *parameter*, so a
+     * same-named property declared in the body would silently shadow it and every initializer
+     * below would read the sentinel instead of the real id (it did: `transformManager.create`
+     * ran on entity 0, and the #2762 canary caught it).
+     */
+    @FilamentEntity val entity: Entity,
+    /**
+     * Whether [destroy] returns [entity]'s id to the [EntityManager].
+     *
+     * `true` only when this node allocated the entity itself. An entity handed in by the
+     * caller is **borrowed**: [ModelNode] wraps `modelInstance.root` and its children wrap
+     * `gltfio` node entities, all owned by the `AssetLoader`, which destroys them with the
+     * asset. Recycling those ids here would let Filament reissue them while the asset is
+     * still alive — a use-after-free that surfaces as one node silently driving another's
+     * transform.
+     *
+     * Mirrors the ownership flags this codebase already uses for the same reason
+     * (`RenderableNode.destroyMaterialsOnDispose`, `MeshNode.destroyBuffersOnDispose`).
+     * Subclasses that allocate an entity through some other route can pass `true` here.
+     */
+    private val ownsEntity: Boolean,
 ) : GestureDetector.OnGestureListener,
     OnDoubleTapListener,
     OnContextClickListener,
@@ -81,6 +108,29 @@ open class Node(
     RotateGestureDetector.OnRotateListener,
     ScaleGestureDetector.OnScaleListener,
     TransformProvider {
+
+    /**
+     * @param entity the Filament entity to drive. Leave it out (the default) to have the node
+     * allocate — and, on [destroy], recycle — its own entity. Pass one to **borrow** an entity
+     * someone else owns: the node then drives its components but never returns the id to the
+     * [EntityManager] (#2859).
+     */
+    constructor(engine: Engine, @FilamentEntity entity: Entity = NULL_ENTITY) : this(
+        engine = engine,
+        entity = if (entity == NULL_ENTITY) EntityManager.get().create() else entity,
+        ownsEntity = entity == NULL_ENTITY,
+    )
+
+    /**
+     * The Filament scene this node's entities are currently registered in, or `null`.
+     *
+     * Tracked by [io.github.sceneview.SceneNodeManager] so [destroy] can un-register the
+     * entities before recycling their ids. The composable path already detaches before
+     * destroying (`SceneScope.detach` → `node.destroy()`), but an imperative caller may not:
+     * an id left in a `Scene` and then reissued would make the next renderable built on it
+     * appear in that scene without ever having been added to it.
+     */
+    internal var attachedScene: Scene? = null
 
     // ---- Delegates ----
 
@@ -1211,6 +1261,10 @@ open class Node(
      * imperatively-built node tree is released by a single call on the root.
      * Compose-declared children are disposed independently by `rememberNode`;
      * destroying them again here is a safe no-op.
+     *
+     * Releases the entity's components, then returns its id to the [EntityManager] — but only
+     * for a self-allocated entity, never a borrowed one (see the `ownsEntity` constructor
+     * parameter and #2859).
      */
     open fun destroy() {
         if (isDestroyed) return
@@ -1220,8 +1274,19 @@ open class Node(
         // ConcurrentModificationException.
         childNodes.toList().forEach { it.destroy() }
         runCatching { parent = null }
+        // Un-register before the id is recycled: a Scene holding a reissued id would render
+        // whatever renderable is built on it next (see [attachedScene]). No-op on the
+        // composable path, where SceneScope.detach() already removed the node.
+        attachedScene?.let { scene ->
+            runCatching { scene.removeEntities(sceneEntities.toIntArray()) }
+            attachedScene = null
+        }
         engine.safeDestroyTransformable(entity)
         engine.safeDestroyEntity(entity)
+        // Components are gone; the id itself is only ours to give back when we allocated it.
+        if (ownsEntity) {
+            engine.safeRecycleEntity(entity)
+        }
     }
 }
 

--- a/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/RenderableNode.kt
@@ -2,11 +2,11 @@ package io.github.sceneview.node
 
 import com.google.android.filament.Box
 import com.google.android.filament.Engine
-import com.google.android.filament.EntityManager
 import com.google.android.filament.MaterialInstance
 import com.google.android.filament.RenderableManager
 import io.github.sceneview.Entity
 import io.github.sceneview.FilamentEntity
+import io.github.sceneview.NULL_ENTITY
 import io.github.sceneview.components.RenderableComponent
 import io.github.sceneview.components.RenderableInstance
 import io.github.sceneview.math.toVector3Box
@@ -24,7 +24,7 @@ import io.github.sceneview.safeDestroyRenderable
  */
 open class RenderableNode(
     engine: Engine,
-    @FilamentEntity entity: Entity = EntityManager.get().create(),
+    @FilamentEntity entity: Entity = NULL_ENTITY,
 ) : Node(engine, entity), RenderableComponent {
 
     /**
@@ -60,7 +60,7 @@ open class RenderableNode(
 
     constructor(
         engine: Engine,
-        @FilamentEntity entity: Entity = EntityManager.get().create(),
+        @FilamentEntity entity: Entity = NULL_ENTITY,
         /**
          * Count the number of primitives that will be supplied to the builder
          */
@@ -104,7 +104,9 @@ open class RenderableNode(
                     materialInstance?.let { material(index, materialInstance) }
                 }
             }.apply(builder)
-            .build(engine, entity)
+            // `this.entity` — the parameter is the NULL_ENTITY sentinel when the caller let
+            // the node allocate its own entity; Node resolved it into the real id.
+            .build(engine, this.entity)
         updateCollisionShape()
     }
 

--- a/sceneview/src/main/java/io/github/sceneview/node/SplatNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/SplatNode.kt
@@ -19,6 +19,7 @@ import io.github.sceneview.safeDestroyEntity
 import io.github.sceneview.safeDestroyIndexBuffer
 import io.github.sceneview.safeDestroyRenderable
 import io.github.sceneview.safeDestroyVertexBuffer
+import io.github.sceneview.safeRecycleEntity
 import io.github.sceneview.splat.SplatBuffers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -367,6 +368,12 @@ open class SplatNode(
         batchEntities.forEach { engine.safeDestroyRenderable(it) }
         batchEntities.forEach { engine.safeDestroyEntity(it) }
         super.destroy()
+        // Ids last, and only AFTER super.destroy(): the batch entities are part of
+        // [sceneEntities], which Node.destroy() removes from the scene. Recycling them any
+        // earlier could let Filament reissue an id that this very teardown then removes from
+        // the scene on the new owner's behalf. They are allocated here and referenced nowhere
+        // else, so this node is unambiguously their owner (#2859).
+        batchEntities.forEach { engine.safeRecycleEntity(it) }
         materialInstances.forEach { materialLoader.destroyMaterialInstance(it) }
         engine.safeDestroyVertexBuffer(quadVertexBuffer)
         engine.safeDestroyIndexBuffer(quadIndexBuffer)


### PR DESCRIPTION
Fixes #2859.

## The bug

`Node.destroy()` ended with `Engine.destroyEntity(entity)`, which destroys the entity's
**components** but does **not** return the id — only `EntityManager.destroy(entity)` does.
Every `Node` ever created therefore burnt one Filament entity id for the lifetime of the
process. No GPU memory leaked, but the bounded id space only ever shrank.

Found by the #2762 leak-churn harness on its first real run, and pinned there as a
characterization test rather than smuggled into that test PR as a runtime change.

## Why this wasn't a one-liner: ownership

`EntityManager` is a process-wide singleton shared with `gltfio` (`ModelLoader` builds its
`AssetLoader` with `EntityManager.get()`). Some node entities are **borrowed**:

- `ModelNode` wraps `modelInstance.root`;
- its `RenderableNode` / `LightNode` / `CameraNode` / `EmptyNode` children wrap `gltfio`
  node entities.

All of those are owned by the `AssetLoader`, which destroys them with the asset. Recycling
a borrowed id would let Filament reissue it while the asset is still live.

So a node returns the id **only when it allocated the entity itself** — i.e. the
constructor's `entity` argument was omitted. This mirrors the ownership flags the codebase
already uses for the same class of problem (`RenderableNode.destroyMaterialsOnDispose`,
`MeshNode.destroyBuffersOnDispose`).

## Shape of the change

A `NULL_ENTITY` sentinel default, resolved by a secondary constructor before it reaches the
primary one:

```kotlin
open class Node protected constructor(
    val engine: Engine,
    @FilamentEntity val entity: Entity,   // already resolved
    private val ownsEntity: Boolean,
) {
    constructor(engine: Engine, @FilamentEntity entity: Entity = NULL_ENTITY) : this(
        engine = engine,
        entity = if (entity == NULL_ENTITY) EntityManager.get().create() else entity,
        ownsEntity = entity == NULL_ENTITY,
    )
}
```

`Node(engine)` and `Node(engine, entity)` still compile unchanged, and the `.api` diff is
**purely additive** — `NULL_ENTITY`, `Engine.safeRecycleEntity`, and one `protected`
constructor. Nothing removed, nothing retyped.

The resolved entity sits on the **primary** constructor deliberately. Kotlin resolves a bare
`entity` inside an `init` block to the constructor *parameter*, so a same-named property in
the class body silently shadows it — the first attempt at this fix ran
`transformManager.create()` on entity `0` and killed every node's transform component.
**Seven of the eight churn tests still passed; only the canary caught it**, which is exactly
what that permanent mutation test exists for.

Also: `destroy()` now removes the node's entities from the Filament `Scene` it is attached
to before recycling. The composable path already detaches first (`SceneScope.detach()` →
`node.destroy()`), but an imperative caller may not — and an id left in a scene and then
reissued would make the next renderable built on it appear in that scene uninvited.

`SplatNode` recycles the per-batch entities it allocates too, after `super.destroy()` has
removed them from the scene.

## Test changes (same PR, as #2762 prescribed)

- `entityIdRecycling_isTheKnownPreExistingGap` → `ownedEntityId_isRecycledOnDestroy`, with
  the assertion inverted.
- `assertComponentsReleased(...)` now also requires `EntityManager.isAlive(entity) == false`.
- New `borrowedEntityId_isLeftToItsOwner` — the `gltfio` non-regression, written
  **differentially** (borrowed vs owned in the same run) so it cannot pass vacuously on a
  build where recycling is a no-op for everyone.

## Verification (Pixel_7a emulator, arm64)

- `:sceneview:connectedDebugAndroidTest` — **207 tests, 0 failures**. The 23 SKIPPED are the
  `gpuReadback`-gated render tests (#803), already skipped before this change.
- `LeakChurnTest` — 8/8, canary included.
- Unit tests + `apiCheck` green on both modules.
- Visual: the `model-viewer` demo renders its glTF model with textures intact, before and
  after 15 create/destroy demo cycles — no crash, no ghost renderable, process alive.

Two `pre-push-check.sh` legs fail on this branch and are **pre-existing on its base**
(`08725f59c`), untouched by this diff: the iOS screenshot golden, and a Kotlin-version
mismatch in `llms.txt` / `docs/docs/llms-full.txt`.

## Not in this PR

`ARCameraStream` allocates an entity and never recycles it either, but `ARSceneView` adds
that entity to the scene and its `destroy()` has no matching `removeEntity` — recycling it
safely is a separate change with its own AR verification, not a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)