### PR TITLE
ci: guard llms.txt doc-snippets in a standalone workflow (close gate hole)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,12 @@ jobs:
         env:
           # Optional. Unset on forks → demo gracefully disables Geospatial/Streetscape.
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
+        # Root `assembleDebug` also compiles :snippets-check (the doc-snippet
+        # guard, settings.gradle:31) — this is the ONLY per-PR compile of the
+        # snippets on a library-API change. The docs-input direction is guarded
+        # separately by snippets-check.yml (llms.txt is `paths-ignore`d here).
+        # If this step is ever narrowed to explicit tasks, add
+        # `:snippets-check:compileDebugKotlin` so that coverage is kept.
         run: |
           ./gradlew \
             assembleDebug \

--- a/.github/workflows/snippets-check.yml
+++ b/.github/workflows/snippets-check.yml
@@ -1,0 +1,82 @@
+name: Snippets
+
+# Doc-snippet compile guard — standalone gate for the AI-first docs (#2759).
+#
+# WHY A SEPARATE WORKFLOW (not a job in ci.yml):
+# `llms*.txt` is workflow-level `paths-ignore`d in ci.yml (lines 45/55), so a
+# PR that only touches llms.txt never triggers ci.yml at all — its `build` job
+# (which compiles :snippets-check transitively via the root `assembleDebug`,
+# settings.gradle:31) is skipped, and a broken ```kotlin block sails through
+# green. That is exactly how #2871's own fix went un-verified by CI: main was
+# red on a snippet, the fix touched only llms.txt, and the guarding job was
+# skipped on the fix commit — it was only re-validated by the NEXT commit that
+# happened to touch a `samples/**` path. Un-ignoring llms.txt in ci.yml would
+# instead drop `changes` + `Repo hygiene` + `Quality gate (full)` (its three
+# non-gated jobs) + an 8-min Android build onto every frequent docs PR. A
+# positive `paths:` filter here costs ZERO everywhere else — the same pattern
+# ci.yml's own header (lines 102-104) points to for ios.yml / build-apks.yml.
+#
+# COVERAGE SPLIT (deliberate, no double compile):
+#   - snippet inputs (the `paths:` below)                       -> THIS workflow
+#   - a library API change (sceneview/**, arsceneview/**, shared gradle)
+#     -> ci.yml's `build` job, which already compiles :snippets-check via the
+#        root assembleDebug. So the "API drifted, snippets no longer compile"
+#        direction stays covered there and is NOT duplicated here.
+#
+# INPUTS: kept in lock-step with tools/snippets-check/build.gradle's
+# `generateDocSnippets` task (llms.txt + agents/sceneview/references/*.md +
+# tools/extract-doc-snippets.js). `agents/sceneview/references/**` is the
+# broad form so a newly-added reference file is covered without editing here.
+#
+# CI GATE (#1314): when this workflow runs, its `Doc snippets compile check`
+# check run is picked up automatically by the head-SHA poll and gates the
+# merge; when the `paths:` filter skips it, NO check run registers and the
+# aggregator simply doesn't wait for it. NEVER add this job's name to
+# ci-gate.yml's REQUIRED_CHECKS — that list is only for ci.yml's always-on
+# core jobs; adding it would make the gate block ~50 min waiting for a check
+# that never fires on a non-docs PR. Bonus: a llms-only PR now registers one
+# check run, which flips off the docs-only bypass (#2117) so the gate waits
+# for this compile's real verdict — precisely the intent.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'llms*.txt'
+      - 'agents/sceneview/references/**'
+      - 'tools/extract-doc-snippets.js'
+      - 'tools/snippets-check/**'
+      - '.github/workflows/snippets-check.yml'
+      - '.github/actions/setup-gradle/**'
+  push:
+    branches: [main]
+    paths:
+      - 'llms*.txt'
+      - 'agents/sceneview/references/**'
+      - 'tools/extract-doc-snippets.js'
+      - 'tools/snippets-check/**'
+      - '.github/workflows/snippets-check.yml'
+      - '.github/actions/setup-gradle/**'
+  workflow_dispatch:
+
+# Same head-SHA key as ci.yml (#2089): cancel only genuinely superseded runs,
+# never an unrelated PR's run after a base-ref recompute.
+concurrency:
+  group: snippets-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  snippets-check:
+    name: Doc snippets compile check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Compile doc snippets against the library API
+        run: ./gradlew :snippets-check:compileDebugKotlin --stacktrace

--- a/changelog.d/2875-snippets-standalone-gate.md
+++ b/changelog.d/2875-snippets-standalone-gate.md
@@ -1,0 +1,10 @@
+- **CI:** close a latent false-green hole in the doc-snippet guard. `:snippets-check`
+  compiles every ` ```kotlin ` block of `llms.txt`, but it only ran transitively inside
+  ci.yml's `Build libraries & samples` job — which is `paths-ignore`d for `llms*.txt`, so a
+  PR editing only `llms.txt` never compiled its snippets and a broken block could reach
+  `main` (this is how #2871's own fix went un-verified by CI). A standalone
+  `snippets-check.yml` now compiles the snippets whenever their real inputs change
+  (`llms.txt`, `agents/sceneview/references/**`, the extractor, the guard module), and its
+  check run is gated by CI Gate. (#2875)
+
+<!-- category: Fixed -->


### PR DESCRIPTION
## Problem

`main` had been red on `Build libraries & samples` (already fixed by #2871), but the root cause exposed a **latent false-green gate hole**:

`:snippets-check` compiles every ` ```kotlin ` block of `llms.txt`, yet it only runs **transitively** inside ci.yml's `build` job — which is (a) gated on the `android` path filter and (b) behind ci.yml's workflow-level `paths-ignore` of `llms*.txt` (lines 45/55). So **a PR that only edits `llms.txt` never triggers the guard**: a broken snippet passes green and breaks `main` on the next commit that touches a source path.

That is exactly how #2871's own fix went un-verified by CI — the guarding job was *skipped* on the llms-only fix commit, and only re-validated by the next `samples/**` commit.

## Fix

A **standalone** `snippets-check.yml` (not a job in ci.yml — since `llms.txt` is workflow-level `paths-ignore`d, widening the `android` filter alone would never fire). Positive `paths:` on the real snippet inputs, kept in lock-step with `tools/snippets-check/build.gradle`'s `generateDocSnippets` task:

- `llms*.txt`
- `agents/sceneview/references/**`
- `tools/extract-doc-snippets.js`
- `tools/snippets-check/**`

It runs `:snippets-check:compileDebugKotlin` **only** when those inputs change — zero cost on every other PR.

### Interaction with CI Gate (#1314) — verified against the code
- The `Doc snippets compile check` run is picked up automatically by the head-SHA poll → it gates the merge when present.
- A llms-only PR now registers one check run → this flips **off** the docs-only bypass (#2117), so the gate waits for the real compile verdict (the grace period only applies while `others` is empty — ci-gate.yml:219-221).
- **Not** added to `REQUIRED_CHECKS`: it legitimately skips on non-docs PRs, and that list is only for ci.yml's always-on core jobs.

### Coverage split (no double compile)
- Snippet inputs → **this** workflow.
- Library-API change (`sceneview/**`, `arsceneview/**`, shared gradle) → ci.yml's `build` job still compiles `:snippets-check` transitively (documented there with a guard comment).

## Validation
This PR touches `.github/workflows/snippets-check.yml`, which is in the new workflow's own `paths:`, so **the workflow runs on this very PR** — a green `Doc snippets compile check` here is its own proof.

Architecture decision by **Claude Fable 5** (hard-reasoning consult); the decisive finding — that `llms.txt` is workflow-level `paths-ignore`d — is what ruled out the simpler "widen the filter" option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
