### PR TITLE
chore(claude): narrow the commit-guard so it stops blocking `git commit-tree`

### DIFF
--- a/.claude/scripts/hook-dispatch.sh
+++ b/.claude/scripts/hook-dispatch.sh
@@ -57,7 +57,10 @@ case "$ROUTE" in
     [ -n "$CMD" ] || exit 0
 
     case "$CMD" in
-      *"git commit"*)
+      # A real `git commit` has end-of-string or a non-hyphen after "commit" —
+      # this excludes `git commit-tree` (the no-force-push reconcile playbook,
+      # which never reads the working tree) and `git commit-graph`.
+      *"git commit"|*"git commit"[!-]*)
         # --- Guard 1 (BLOCKING): VERSION_NAME mismatch across gradle.properties
         ROOT="$(repo_root)"
         if [ -n "$ROOT" ] && [ -f "$ROOT/gradle.properties" ]; then


### PR DESCRIPTION
## Problem

`hook-dispatch.sh` Guard 1 (the script's sole blocking hook, `exit 2`) matched the glob `*"git commit"*`, which also catches:

- `git commit-tree` — used by the no-force-push branch-reconcile playbook (#2429)
- `git commit-graph`

During a reconcile that coincides with a **transient inter-module `VERSION_NAME` mismatch** (a version-bump branch mid-flight), the guard fires `exit 2` and blocks the `commit-tree`. Two aggravations surfaced while triaging:

1. **Semantically void.** `git commit-tree` / `commit-graph` never read the index or working tree — they commit an already-built tree object. Inspecting the worktree's `gradle.properties` to gate them protects nothing, so matching them is a hook bug per the script's own charter (`# NEVER block on a hook bug`, l. 23).
2. **Actively misdirecting.** The error message ("Align them … see `sync-versions.sh`") would nudge an autonomous agent to run `sync-versions.sh --fix` **in the middle of a reconcile** — mutating the very branch meant to stay byte-identical. A work-loss vector, not just a broken flow.

## Fix

A **strict narrowing** of the pattern — same site, no regex, no new branch:

```diff
-      *"git commit"*)
+      *"git commit"|*"git commit"[!-]*)
```

A real `git commit` always has end-of-string or a non-hyphen after `commit`; the only strings the old pattern matched and the new one does not are those where *every* `git commit` is immediately followed by `-` — i.e. exclusively `commit-tree` / `commit-graph`.

## Verification

`bash -n` clean, plus a 10-case battery under **bash 3.2.57** (the macOS shell in the shebang), all green:

| Command | Old | New |
|---|---|---|
| `git commit` / `-m` / `--amend` / `-am` / composed / multi-line | MATCH | MATCH |
| `git commit-tree …` / `git commit-graph …` | MATCH (bug) | no-match |
| `$(git commit-tree …) && git commit -m both` (compound trap) | MATCH | **MATCH** |

The compound-trap row is the case a naive `*"git commit-tree"*) ;;` exclusion placed first would have broken — it would silence the guard on a command that *also* contains a real commit. The positional pattern handles it correctly.

The two pre-existing minor nits (`git  commit` double-space false-negative; CRLF in `cut -d=`) are deliberately **out of scope** — both are pre-existing, inert (`.gitattributes` forces LF), fail-closed, and covering the first would need a broader regex rewrite with its own bash-3.2 pitfalls for ~zero gain (real defense is downstream: `pre-push-check.sh`, CI, `release-checklist.sh`).

The decision to harden (vs leave as-is) was delegated to an independent reviewer agent, which confirmed the finding by direct read + battery and ruled the narrowing a proven strict subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
