### PR TITLE
docs(sceneview): honest entity-id-recycling — Web can't recycle (probed), MeshNode/GeometryNode KDoc fix (#2859)

### DIFF
--- a/changelog.d/2859-web-recycling-docs.md
+++ b/changelog.d/2859-web-recycling-docs.md
@@ -1,0 +1,12 @@
+<!-- category: Docs -->
+
+- Documented honestly that the **Web** renderer cannot recycle Filament entity ids: the pinned
+  `filament.js` 1.52.3 usably binds only `EntityManager.get()`/`create()` — its runtime `destroy()`
+  is a no-op on the id pool (verified by an in-browser probe: 2000 create/destroy/create yields zero
+  id reuse) and `isAlive()` is unbound. So the id-recycling that `Node.destroy()` gains on Android
+  (#2859) has no working Web equivalent until the `filament.js` pin is bumped. Corrected a comment in
+  the Web `SceneView.destroy()` that wrongly claimed the camera entity's id was reclaimed, and added a
+  guard note on the `EntityManager` binding so no future change naively calls the no-op `destroy()`.
+- Fixed the `MeshNode` / `GeometryNode` KDoc example, which referenced an undefined `renderable`
+  variable and showed low-level manual entity creation; it now shows real node usage and notes that
+  letting the node own its entity is preferred (#2859).

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/SceneView.kt
@@ -1410,10 +1410,14 @@ class SceneView private constructor(
         engine.destroyView(view)
         engine.destroyScene(scene)
         engine.destroyCameraComponent(cameraEntity)
-        // Free the camera entity's EntityManager handle too — destroying only
-        // the camera component leaks the integer entity slot, the exact inverse
-        // of the #1700 light leak. Component first, then entity (parity with the
-        // light teardown above).
+        // Destroys the camera component. NOTE: the integer entity slot is NOT reclaimed here,
+        // and cannot be with the pinned filament.js 1.52.3 — its bound EntityManager.destroy()
+        // is a no-op on the id pool (probed: 2000 create→destroy→create yields zero id reuse,
+        // ids climb unbounded) and isAlive() is not bound at all. This is the web side of
+        // #2859: Android's EntityManager.destroy() (filament 1.72.1 JNI) reclaims the id, the
+        // JS binding does not. Web id-recycle parity needs a filament.js pin bump, which drags
+        // the .filamat ABI invariant — tracked separately, not a rider here. destroyEntity()
+        // frees engine-side component bookkeeping only.
         engine.destroyEntity(cameraEntity)
         engine.destroySwapChain(swapChain)
         val filament: dynamic = js("Filament")

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/bindings/Filament.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/bindings/Filament.kt
@@ -478,6 +478,13 @@ external class Animator {
 
 // --- EntityManager ---
 
+// filament.js 1.52.3 binds only get() and create() usably. There is NO working id-recycle in
+// this pinned runtime: a runtime EntityManager.destroy() is present but is a no-op on the id pool
+// (probed — 2000 create/destroy/create yields zero id reuse, ids climb unbounded), and isAlive()
+// is not bound at all. So a node entity's id cannot be returned to the pool on the web the way
+// Android's Node.destroy() does (#2859). Do NOT add a destroy()/isAlive() binding here expecting a
+// fix — it reclaims nothing until the filament.js pin is bumped (which drags the .filamat ABI
+// invariant). See SceneView.destroy() for the same note at the camera-entity call site.
 external class EntityManager {
     companion object {
         fun get(): EntityManager

--- a/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/GeometryNode.kt
@@ -15,15 +15,16 @@ import io.github.sceneview.safeDestroyGeometry
  * they cast shadows or use vertex skinning. Kotlin usage example:
  *
  * ```
- * val entity = EntityManager.get().create()
- *
- * RenderableManager.Builder(1)
- *         .boundingBox(Box(0.0f, 0.0f, 0.0f, 9000.0f, 9000.0f, 9000.0f))
- *         .geometry(0, RenderableManager.PrimitiveType.TRIANGLES, vb, ib)
- *         .material(0, material)
- *         .build(engine, entity)
- *
- * scene.addEntity(renderable)
+ * // Prefer letting GeometryNode allocate and own its Filament entity — the node then
+ * // manages that entity's full lifecycle (and, once it owns it, frees it on destroy()).
+ * // Passing a manually-created entity makes the node *borrow* it instead.
+ * val node = GeometryNode(
+ *     engine = engine,
+ *     geometry = geometry,
+ *     materialInstance = material,
+ * )
+ * // Add it to the scene declaratively inside a SceneView { } content block, or
+ * // imperatively with parentNode.addChildNode(node).
  * ```
  *
  * To modify the state of an existing renderable, clients should first use RenderableManager to get

--- a/sceneview/src/main/java/io/github/sceneview/node/MeshNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/MeshNode.kt
@@ -18,15 +18,18 @@ import io.github.sceneview.safeDestroyVertexBuffer
  * they cast shadows or use vertex skinning. Kotlin usage example:
  *
  * ```
- * val entity = EntityManager.get().create()
- *
- * RenderableManager.Builder(1)
- *         .boundingBox(Box(0.0f, 0.0f, 0.0f, 9000.0f, 9000.0f, 9000.0f))
- *         .geometry(0, RenderableManager.PrimitiveType.TRIANGLES, vb, ib)
- *         .material(0, material)
- *         .build(engine, entity)
- *
- * scene.addEntity(renderable)
+ * // Prefer letting MeshNode allocate and own its Filament entity — the node then manages
+ * // that entity's full lifecycle (and, once it owns it, frees it on destroy()). Passing a
+ * // manually-created entity makes the node *borrow* it instead.
+ * val mesh = MeshNode(
+ *     engine = engine,
+ *     primitiveType = RenderableManager.PrimitiveType.TRIANGLES,
+ *     vertexBuffer = vertexBuffer,
+ *     indexBuffer = indexBuffer,
+ *     materialInstance = material,
+ * )
+ * // Add it to the scene declaratively inside a SceneView { } content block, or
+ * // imperatively with parentNode.addChildNode(mesh).
  * ```
  *
  * To modify the state of an existing renderable, clients should first use RenderableManager to get


### PR DESCRIPTION
Follow-up to #2859. The Android fix for `Node.destroy()` burning Filament entity ids landed in #2872 (which I reviewed independently — ownership-gated so `ModelNode`'s borrowed gltfio entity is never recycled, the Kotlin ctor-param-shadow trap avoided via a secondary constructor, and the #2762 characterization test inverted). This PR covers what #2872 did **not**: the **Web** renderer and the **docs**.

## Web: same leak, un-fixable in the pinned runtime — *proven, not assumed*

`sceneview-web` runs the same Filament C++ engine (Filament.js / WASM) and has the identical id leak at `FilamentNodeBackend.destroy()`, the `lightEntities` teardown, and the `cameraEntity` teardown — all call `engine.destroyEntity()`, which frees components but does **not** return the id.

The obvious mirror — call `EntityManager.get().destroy(entity)` like Android — **does not work** on the pinned `filament.js` **1.52.3**. I probed that exact runtime in a browser:

| probe | result |
|---|---|
| `EntityManager.destroy` bound? | present at runtime (but **absent** from the shipped `.d.ts`) |
| `EntityManager.isAlive` bound? | **not bound** (`undefined`) |
| 2000× `create → destroy → create` (past `MIN_FREE_INDICES` 1024) | **0 id reuse**; max id climbs `2010 → 132059` |

So the bound `destroy()` is a **no-op on the id pool**. Shipping a "fix" that calls it would leak exactly as before while *looking* fixed — the precise false-fix the ownership review was meant to prevent. (Android's `filament 1.72.1` JNI `EntityManager.destroy()` genuinely reclaims the id — that is why #2872's on-device `isAlive == false` assertion is valid there. The platforms diverge because their Filament versions/bindings differ.)

Real Web id-recycle parity needs a `filament.js` pin bump, which drags the `.filamat` ABI invariant (see CONTRIBUTING.md) — a separate change with its own verification, **not** a rider here.

This PR therefore does the honest thing for Web:
- **Corrects a false comment** in `SceneView.destroy()` that claimed the camera entity's id handle was freed (`// Free the camera entity's EntityManager handle too …`) — it never was, and cannot be on this runtime.
- **Adds a guard note** on the `EntityManager` binding so no future change naively re-adds a `destroy()`/`isAlive()` binding expecting it to recycle.

## Docs: MeshNode / GeometryNode KDoc

The KDoc example referenced an **undefined `renderable` variable** (`scene.addEntity(renderable)` after building on a variable named `entity`) and taught low-level `EntityManager.get().create()` passed into the node — which, post-#2872, makes the node **borrow** its entity and **never recycle** the id. Replaced with a real `MeshNode` / `GeometryNode` usage example that lets the node own (and free) its own entity.

## Verification
- `:sceneview:compileReleaseKotlin` **green** (comment/KDoc-only change — no executable code touched).
- Web finding is the in-browser probe above, against `filament@1.52.3` (the exact `npm("filament", "1.52.3")` pin in `sceneview-web/build.gradle.kts`). The `FilamentNodeBackend` WASM layer is not unit-testable under Karma (it is fake-backed by design), so a runtime probe is the honest bar here — same lesson as #2410 / #2611.
- CI covers the full Android + Web compile / lint / tests.

## Scope
Comment/KDoc only — **zero overlap** with #2872's files. No `filament.js` bump, no repo-wide `destroyEntity` audit. The Web id-recycle limitation is tracked here (comments + this PR body) pending a `filament.js` pin decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
