### PR TITLE
ci(ios): fail the iOS build job on real xcodebuild failures (drop || cat)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -58,14 +58,13 @@ jobs:
       - name: Build Swift Package (iOS)
         working-directory: SceneViewSwift
         run: |
-          # `pipefail` so a failing xcodebuild is not masked by xcpretty's
-          # exit 0 (the `|| cat` fallback also exits 0) — see #1515.
+          # `pipefail` so a failing xcodebuild is not masked by xcpretty — #1515.
           set -o pipefail
           xcodebuild build \
             -scheme SceneViewSwift \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
             -skipMacroValidation \
-            | xcpretty --color 2>/dev/null || cat
+            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}
 
       # Build the visionOS target so a visionOS-only API breakage can't slip
       # into main silently (#1366 — the xrOS target was broken on main for
@@ -96,7 +95,7 @@ jobs:
             -scheme SceneViewSwift \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
             -skipMacroValidation \
-            | xcpretty --color 2>/dev/null || cat
+            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}
 
       # Build the iOS sample demo so a missing pbxproj registration on a new
       # demo file fails the PR instead of slipping into main. Caught by
@@ -162,7 +161,7 @@ jobs:
             -skipPackagePluginValidation \
             -skipMacroValidation \
             SKETCHFAB_API_KEY="$SKETCHFAB_API_KEY" \
-            | xcpretty --color 2>/dev/null || cat
+            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}
 
       # #2852 — the step above CANNOT see the AR code. Every AR demo wraps its
       # real ARKit/RealityKit logic in `#if !targetEnvironment(simulator)`

--- a/changelog.d/2865-ios-ci-xcpretty-unmask.md
+++ b/changelog.d/2865-ios-ci-xcpretty-unmask.md
@@ -1,0 +1,9 @@
+<!-- category: Tests -->
+- **The iOS `build` job can now actually fail on a compile or test failure.** The
+  `Build Swift Package`, `Run tests`, and `Build & test iOS sample demo` steps ended their
+  xcodebuild pipeline with `| xcpretty … || cat`; in CI `cat` reads an empty stdin and exits 0,
+  which swallowed the non-zero status `set -o pipefail` had propagated from a failing xcodebuild —
+  so the job could not go red and the test step was effectively decorative. All three now use
+  `|| exit ${PIPESTATUS[0]}` (xcodebuild's own exit code), matching the device-compile step from
+  [#2865](https://github.com/sceneview/sceneview/issues/2865) and preserving the missing-`xcpretty`
+  tolerance ([#2852](https://github.com/sceneview/sceneview/issues/2852), [#1515](https://github.com/sceneview/sceneview/issues/1515)).


### PR DESCRIPTION
## What & why

Three pre-existing steps in `.github/workflows/ios.yml` ended their xcodebuild pipeline with `| xcpretty --color 2>/dev/null || cat`:

- `Build Swift Package (iOS)`
- `Run tests`
- `Build & test iOS sample demo`

`set -o pipefail` correctly propagates a failing `xcodebuild`'s non-zero status through the pipe (xcpretty itself exits 0), but the trailing `|| cat` then defeats it: in CI `cat` reads an already-empty stdin and exits 0, so the whole expression exits 0. The iOS `build` job therefore **could not go red on any compile or test failure** — the `Run tests` step was effectively decorative (a structural false-green, same class as #1515 / #2852).

#2865 fixed **only** the newly-added device-compile step (with `|| exit ${PIPESTATUS[0]}`) and deliberately left these three pre-existing occurrences out, because unmasking them may surface real, previously-hidden failures — which belongs in its own change with its own QA. **This is that change.**

## The fix

All three now use `| xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}`, identical to the device-compile step. `PIPESTATUS[0]` is `xcodebuild`'s own exit code, so:

- a real compile/test failure fails the step, **and**
- a missing `xcpretty` (127 in `PIPESTATUS[1]`) still does **not** fail an otherwise-green build (tolerance preserved).

Also drops the now-stale `|| cat` mention from the first step's comment, and adds a `Tests` changelog fragment.

## Verification / risk

This PR modifies `.github/workflows/ios.yml`, which is in the `pull_request` path filter, so **this PR's own iOS CI run is the test** — it runs the fixed workflow and will reveal anything the `|| cat` was masking. Merge is gated on that run being green: a red run means a real failure was hidden and must be fixed (or precisely filed) before merge — **no re-adding `|| cat`**.

Refs #2865, #2852, #1515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
