### PR TITLE
feat(claude): multi-LLM delegation wrapper + exploration plan (codex/antigravity/kimi)

### DIFF
--- a/.claude/plans/multi-llm-delegation.md
+++ b/.claude/plans/multi-llm-delegation.md
@@ -1,0 +1,74 @@
+# Délégation multi-LLM — Codex · Gemini/Antigravity · Kimi (exploration 2026-07-23)
+
+> Session d'exploration : comment déléguer certaines tâches SceneView à des LLMs
+> non-Claude, avec Claude Code comme **orchestrateur unique**. État : CLIs installés
+> et sondés sur le Mac ; **aucun authentifié** (étape Thomas, §Auth).
+> Entrée unique : [`llm-delegate.sh`](../scripts/llm-delegate.sh).
+
+## 1. État des lieux (mesuré sur cette machine, 2026-07-23)
+
+| Provider | CLI | Version | Headless | Sandbox | Auth | Piège mesuré |
+|---|---|---|---|---|---|---|
+| OpenAI Codex | `codex` (npm `@openai/codex`) | 0.145.0 | `codex exec "…"` + `codex exec review` | `--sandbox read-only\|workspace-write` | `codex login` (ChatGPT Plus/Pro) ou clé API ; `codex login status` rc=1 si déloggé | — |
+| Google Gemini | `agy` (Antigravity CLI) | 1.1.5 | `agy -p "…"` (`--print-timeout` 5m def.) | `--sandbox` (restrictions terminal) | Sign-in Google interactif (TTY requis) | ⛔ rc=0 même déloggé — détecter « sign in » dans la sortie |
+| Moonshot Kimi | `kimi` (uv `kimi-cli`) | 1.49.0 | `kimi --print --final-message-only -p "…"` | pas de sandbox ; `--yolo` = auto-approve | Setup interactif ou `MOONSHOT_API_KEY` | ⛔ rc=0 même déloggé — signature « LLM not set » |
+
+⚠️ **`gemini` CLI n'existe plus** : Google l'a coupé le 18/06/2026 (comptes individuels),
+remplacé par Antigravity CLI (`agy`, binaire Go, installeur curl officiel). Le free tier
+personnel Google passe par Antigravity.
+
+## 2. Pourquoi déléguer (par ordre de valeur)
+
+1. **Second avis cross-vendor** — une review par un modèle d'une autre famille n'a pas
+   les mêmes angles morts que 4 reviewers Claude. `codex exec review` est même un
+   sous-commande dédiée. Toujours **ADVISORY** : jamais un gate de merge.
+2. **Pools de quota indépendants** — le quota Claude Max est par modèle ; Codex
+   (abonnement ChatGPT), Antigravity (free tier Google) et Kimi (API ~0,60 $/M in)
+   sont des réservoirs séparés. Décharger le mécanique y préserve fable/opus pour le
+   raisonnement dur (règle mémoire « routage modèle »).
+3. **Contexte 1M de Gemini** — audits/synthèses sur très gros volumes (llms-full,
+   sweeps doc) sans découpage.
+4. **Coût marginal quasi nul pour le mécanique en masse** — Kimi K2.x est ~10-20×
+   moins cher que les tiers premium.
+
+## 3. Matrice de routage (extension de la règle mémoire existante)
+
+| Tâche | Moteur | Mode |
+|---|---|---|
+| Orchestration, archi, debug retors, décisions, tout ce qui committe | **Claude (fable/opus)** — jamais délégué | — |
+| Review adversariale 2e avis sur une PR | `codex exec review` + `agy -p` | read-only, ADVISORY dans le triptyque/review-fanout |
+| Audit/synthèse gros contexte (doc-drift, llms-full) | `agy -p` (Gemini, 1M ctx) | read-only |
+| Scaffolds, boilerplate de tests, flows Maestro, conversions mécaniques | `kimi` (ou codex) | `--write` dans un worktree/clone jeté uniquement |
+| Recherche ponctuelle, question factuelle croisée | n'importe lequel (le moins cher dispo) | read-only |
+
+## 4. Règles de sécurité (non négociables)
+
+- Les LLMs externes ne **committent jamais, ne pushent jamais, ne touchent jamais `gh`**.
+  Ils rendent du texte (réponse, diff, rapport) ; Claude review et applique.
+- **Read-only par défaut** ; `--write` refusé hors worktree jeté/clone `/tmp` (garde
+  codée dans le wrapper). Jamais `danger-full-access` / bypass d'approbations.
+- **SKIP honnête** (#2343) : CLI absent ou déloggé → exit 3 + `SKIP:`, jamais un vert
+  silencieux. `agy` et `kimi` rendent rc=0 déloggés → détection par signature de sortie.
+- Étanchéité pro/perso et zéro secret dans les prompts délégués — mêmes règles que
+  pour tout contenu sortant.
+
+## 5. Auth — étape Thomas (une fois par CLI)
+
+```bash
+codex login          # OAuth ChatGPT (Plus/Pro requis) — ou codex login --api-key
+agy                  # lancement nu → sign-in Google (free tier perso OK)
+kimi                 # setup interactif — ou export MOONSHOT_API_KEY (clé → profile-private)
+```
+
+Coûts : Codex inclus dans ChatGPT Plus (20 $/m) ; Antigravity free tier compte Google
+perso ; Kimi membership ~19 $/m ou API pay-as-you-go. **Aucun abonnement requis pour
+commencer : Antigravity seul suffit à valider le pattern.**
+
+## 6. Prochaines étapes
+
+1. Thomas authentifie ce qu'il veut activer (au minimum `agy`, gratuit).
+2. Smoke test : `bash .claude/scripts/llm-delegate.sh gemini "Résume llms.txt en 5 points"`.
+3. Premier usage réel : brancher un avis externe ADVISORY dans `review-fanout`
+   (une voix `codex exec review` + une voix `agy`), comparer la valeur sur 2-3 PRs.
+4. Si la valeur est là : promouvoir en étape optionnelle du triptyque + documenter
+   dans `.claude/workflows/README.md`.

--- a/.claude/scripts/llm-delegate.sh
+++ b/.claude/scripts/llm-delegate.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# llm-delegate.sh — single entry point to delegate a task to a non-Claude LLM CLI.
+#
+# Providers:
+#   codex   — OpenAI Codex CLI   (`codex exec`,   auth: `codex login` / OPENAI_API_KEY)
+#   gemini  — Google Antigravity (`agy -p`,       auth: interactive `agy` Google sign-in)
+#   kimi    — Moonshot Kimi Code (`kimi --print`, auth: interactive `kimi` / MOONSHOT_API_KEY)
+#
+# Usage:
+#   bash .claude/scripts/llm-delegate.sh <codex|gemini|kimi> [--write] [--model M] [--timeout SECS] "prompt"
+#   echo "long prompt" | bash .claude/scripts/llm-delegate.sh codex -
+#
+# Contract (designed for orchestration from Claude Code):
+#   - READ-ONLY by default. --write is only honored inside a throwaway checkout
+#     (a .claude/worktrees/* tree or a /tmp clone) — never in the main checkout.
+#   - External LLMs NEVER commit/push. They produce text (answer, diff, report)
+#     on stdout; the orchestrator reviews and applies.
+#   - Honest SKIP: exit 3 + "SKIP:" line when the CLI is missing or not
+#     authenticated. NOTE: agy and kimi exit 0 even when unauthenticated, so
+#     auth is detected by probing output signatures, never by exit code alone.
+#   - Exit codes: 0 = answer produced · 1 = provider error · 2 = usage · 3 = SKIP.
+#
+set -u
+
+PROVIDER="${1:-}"; shift 2>/dev/null || true
+WRITE=0
+MODEL=""
+TIMEOUT_SECS="${LLM_DELEGATE_TIMEOUT:-600}"
+PROMPT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --write) WRITE=1 ;;
+    --model) MODEL="${2:-}"; shift ;;
+    --timeout) TIMEOUT_SECS="${2:-600}"; shift ;;
+    -) PROMPT="$(cat)" ;;
+    *) PROMPT="$1" ;;
+  esac
+  shift
+done
+
+usage() { echo "usage: llm-delegate.sh <codex|gemini|kimi> [--write] [--model M] [--timeout SECS] \"prompt\" (or '-' for stdin)" >&2; exit 2; }
+skip()  { echo "SKIP: $1" >&2; exit 3; }
+[ -n "$PROVIDER" ] || usage
+[ -n "$PROMPT" ] || usage
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# timeout: coreutils `timeout` or `gtimeout`; degrade to no-timeout with a warning.
+TIMEOUT_BIN=""
+command -v timeout >/dev/null 2>&1 && TIMEOUT_BIN="timeout"
+[ -z "$TIMEOUT_BIN" ] && command -v gtimeout >/dev/null 2>&1 && TIMEOUT_BIN="gtimeout"
+[ -z "$TIMEOUT_BIN" ] && echo "WARN: no timeout binary — running unbounded" >&2
+run_bounded() { if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$TIMEOUT_SECS" "$@"; else "$@"; fi; }
+
+# --write guard: only in a throwaway tree, never the main checkout.
+if [ "$WRITE" = "1" ]; then
+  TOP="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$TOP" in
+    */.claude/worktrees/*|/tmp/*|/private/tmp/*) : ;;
+    *) echo "ERROR: --write refused outside a throwaway worktree or /tmp clone (cwd tree: $TOP)" >&2; exit 2 ;;
+  esac
+fi
+
+case "$PROVIDER" in
+  codex)
+    command -v codex >/dev/null 2>&1 || skip "codex CLI not installed (npm i -g @openai/codex)"
+    codex login status >/dev/null 2>&1 || skip "codex not authenticated — run: codex login"
+    SANDBOX="read-only"; [ "$WRITE" = "1" ] && SANDBOX="workspace-write"
+    OUT="$(mktemp)"
+    MODEL_ARGS=""; [ -n "$MODEL" ] && MODEL_ARGS="--model $MODEL"
+    # shellcheck disable=SC2086
+    run_bounded codex exec --sandbox "$SANDBOX" $MODEL_ARGS --color never \
+      --output-last-message "$OUT" "$PROMPT" >&2
+    RC=$?
+    [ $RC -ne 0 ] && { echo "ERROR: codex exec failed (rc=$RC)" >&2; rm -f "$OUT"; exit 1; }
+    cat "$OUT"; rm -f "$OUT"
+    ;;
+
+  gemini)
+    command -v agy >/dev/null 2>&1 || skip "Antigravity CLI not installed (curl -fsSL https://antigravity.google/cli/install.sh | bash)"
+    # agy exits 0 even when signed out — probe by output signature.
+    if agy models </dev/null 2>&1 | grep -qi "sign in"; then
+      skip "Antigravity not authenticated — run: agy (interactive Google sign-in)"
+    fi
+    AGY_ARGS="--sandbox"
+    [ "$WRITE" = "1" ] && AGY_ARGS="--dangerously-skip-permissions"
+    [ -n "$MODEL" ] && AGY_ARGS="$AGY_ARGS --model $MODEL"
+    # shellcheck disable=SC2086
+    RESPONSE="$(run_bounded agy -p "$PROMPT" $AGY_ARGS </dev/null 2>/dev/null)"
+    RC=$?
+    { [ $RC -ne 0 ] || [ -z "$RESPONSE" ]; } && { echo "ERROR: agy -p failed (rc=$RC)" >&2; exit 1; }
+    printf '%s\n' "$RESPONSE"
+    ;;
+
+  kimi)
+    command -v kimi >/dev/null 2>&1 || skip "kimi-cli not installed (uv tool install kimi-cli)"
+    KIMI_ARGS=""
+    [ "$WRITE" = "1" ] && KIMI_ARGS="--yolo"
+    [ -n "$MODEL" ] && KIMI_ARGS="$KIMI_ARGS --model $MODEL"
+    # shellcheck disable=SC2086
+    RESPONSE="$(run_bounded kimi --print --final-message-only $KIMI_ARGS -p "$PROMPT" </dev/null 2>/dev/null)"
+    RC=$?
+    # kimi exits 0 even unauthenticated — "LLM not set" is the signed-out signature.
+    printf '%s' "$RESPONSE" | grep -qi "LLM not set" && skip "kimi not authenticated — run: kimi (interactive setup) or set MOONSHOT_API_KEY"
+    { [ $RC -ne 0 ] || [ -z "$RESPONSE" ]; } && { echo "ERROR: kimi --print failed (rc=$RC)" >&2; exit 1; }
+    printf '%s\n' "$RESPONSE"
+    ;;
+
+  *) usage ;;
+esac


### PR DESCRIPTION
## Exploration: delegating tasks to Codex / Gemini (Antigravity) / Kimi

Exploration session (2026-07-23) — Claude Code remains the single orchestrator; external LLMs return text (answer / diff / report), never commit/push.

### Contents
- `.claude/scripts/llm-delegate.sh` — single entry point `<codex|gemini|kimi>`: read-only by default, `--write` refused outside a throwaway worktree, **honest SKIP** (exit 3) when the CLI is missing or not authenticated. Measured trap: `agy` and `kimi` return rc=0 even when signed out → failure detected via output signature.
- `.claude/plans/multi-llm-delegation.md` — measured state of the art, task→engine routing matrix, safety rules, auth steps.

### Key findings
- **Gemini CLI is dead** (2026-06-18, individual accounts) → replaced by **Antigravity CLI** (`agy` 1.1.5, installed).
- `codex` 0.145.0 and `kimi` 1.49.0 installed; `codex exec review` is a dedicated review subcommand, ideal for an ADVISORY cross-vendor second opinion.
- No CLI is authenticated yet — the script SKIPs cleanly until then (auth = Thomas's step, see plan §5).

### Risk
None: inert script (no caller yet), doc under `.claude/plans/` (force-add, existing pattern). No production code touched.

Follow-up: the plan document was initially committed in French and is translated to English in a follow-up PR (English-only rule for public content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)