### PR TITLE
fix(ci): filter iOS build by platform in App Store submit — kills the 409 platform mismatch (#2731 twin)

### DIFF
--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -331,20 +331,61 @@ jobs:
           # green having skipped submission entirely. Poll up to 10 more
           # minutes (well inside the 20-min JWT), then FAIL loudly — a tag
           # deploy whose build never turns VALID must be red, not green.
-          builds = []
+          #
+          # The build MUST be constrained to the iOS platform. The macOS
+          # deploy job runs in PARALLEL against the SAME app record (shared
+          # bundleId → shared app_id), so an unqualified `builds` query can
+          # return the macOS build; attaching it to the iOS version below 409s
+          # with "The specified build has a different platform than the
+          # version". This is the build-side twin of the #2731 version hijack —
+          # #2731 added filter[platform]=IOS to the *version* lookup but left
+          # this *build* lookup unfiltered, so iOS submission kept failing on
+          # 4.24.0 and 4.25.0. We resolve each build's platform via the
+          # included preReleaseVersion and select client-side (so the fix does
+          # not depend on filter[preReleaseVersion.platform] being honoured);
+          # if the include is unavailable for this key we fall back to the
+          # newest VALID build rather than regress into a 10-minute red poll.
+          build_id = None
+          build_version = None
           for attempt in range(1, 11):
-              r = requests.get(f"{BASE}/builds?filter[app]={app_id}&sort=-uploadedDate&limit=1&filter[processingState]=VALID", headers=headers)
-              builds = r.json().get("data", [])
-              if builds:
+              r = requests.get(
+                  f"{BASE}/builds?filter[app]={app_id}&filter[processingState]=VALID"
+                  f"&sort=-uploadedDate&limit=20&include=preReleaseVersion",
+                  headers=headers,
+              )
+              payload = r.json()
+              included = {(i["type"], i["id"]): i for i in payload.get("included", [])}
+              data = payload.get("data", [])
+              newest_valid = data[0] if data else None
+              platform_seen = False
+              for b in data:
+                  prv = b.get("relationships", {}).get("preReleaseVersion", {}).get("data")
+                  inc = included.get((prv["type"], prv["id"])) if prv else None
+                  platform = (inc or {}).get("attributes", {}).get("platform")
+                  if platform is not None:
+                      platform_seen = True
+                  if platform == "IOS":
+                      build_id = b["id"]
+                      build_version = b["attributes"]["version"]
+                      break
+              if build_id:
                   break
-              print(f"No VALID build yet (attempt {attempt}/10) — Apple still processing, retrying in 60s...")
+              # Apple returned VALID builds but NONE exposed a platform (the
+              # include failed for this service-account key) — don't spin for
+              # 10 min: fall back to the newest VALID build (pre-fix behaviour),
+              # loudly, so the platform filter never makes things worse.
+              if newest_valid is not None and not platform_seen:
+                  print("::warning::Could not resolve build platform via include=preReleaseVersion — "
+                        "falling back to newest VALID build (iOS platform filter inactive).")
+                  build_id = newest_valid["id"]
+                  build_version = newest_valid["attributes"]["version"]
+                  break
+              print(f"No VALID iOS build yet (attempt {attempt}/10) — Apple still processing, retrying in 60s...")
               time.sleep(60)
-          if not builds:
-              print("::error::No VALID build after ~12 minutes — Apple processing overran or the upload failed. The release was NOT submitted for review; re-run this job once the build shows as processed in App Store Connect.")
+          if not build_id:
+              print("::error::No VALID iOS build after ~12 minutes — Apple processing overran or the upload failed. The release was NOT submitted for review; re-run this job once the build shows as processed in App Store Connect.")
               raise SystemExit(1)
-          build_id = builds[0]["id"]
-          build_version = builds[0]["attributes"]["version"]
-          print(f"Latest build: {build_version} (ID: {build_id})")
+          print(f"Selected iOS build: {build_version} (ID: {build_id})")
 
           # Resolve the App Store version string. Tag pushes set
           # ASC_VERSION_STRING via env (e.g. "v4.2.0"). Drop the leading "v"

--- a/changelog.d/2731-ios-submit-build-platform-filter.md
+++ b/changelog.d/2731-ios-submit-build-platform-filter.md
@@ -1,0 +1,10 @@
+- **CI:** iOS App Store review submission failed on **4.24.0** and **4.25.0** with HTTP 409
+  `ENTITY_ERROR.RELATIONSHIP.INVALID` ("The specified build has a different platform than the
+  version"). The `deploy-ios` job's submit step selected "the latest VALID build" with no
+  platform filter, so — because the iOS and macOS deploy jobs run in **parallel** against the
+  **same** App Store record (shared bundleId → shared app_id) — it could attach the **macOS**
+  build to the iOS version. The build lookup now resolves each build's platform via the
+  included `preReleaseVersion` and selects the iOS build (the build-side twin of the #2731
+  version-hijack fix, which only filtered the *version* lookup). (#2731)
+
+<!-- category: Fixed -->


### PR DESCRIPTION
## Symptom

The **Submit build for App Store review** step of `app-store.yml` → `deploy-ios` failed on **two consecutive releases** — [v4.24.0](https://github.com/sceneview/sceneview/actions/runs/29780399360) and [v4.25.0](https://github.com/sceneview/sceneview/actions/runs/29843377341). The build itself uploads fine every time (`Build archive` ✅, `Export IPA and upload to TestFlight` ✅); only the automated review submission dies.

## Root cause

Not an Apple-side blocker (no expired agreement, no App Review rejection, no cert expiry). It's a **build-selection race in the workflow**:

```
Reused editable draft 1c66db23…: retargeted 4.24.0 → 4.25.0
##[error]Build attach failed: 409
    "status" : "409",
    "code" : "ENTITY_ERROR.RELATIONSHIP.INVALID",
    "detail" : "The specified build has a different platform than the version"
```

`deploy-ios` selected *"the latest VALID build"* with **no platform filter**:

```python
GET /builds?filter[app]={app_id}&sort=-uploadedDate&limit=1&filter[processingState]=VALID
```

Because `deploy-ios` and `deploy-macos` both `needs: check` only, they run **in parallel** against the **same** App Store record (both resolve `filter[bundleId]=io.github.sceneview.demo` → same `app_id`). Depending on Apple's processing timing, the newest VALID build is the **macOS** one, which then gets attached to the **iOS** version → HTTP 409 platform mismatch → step red, release never submitted.

This is the **build-side twin of #2731**: that fix added `filter[platform]=IOS` to the *version* lookup (and made the 409 fatal) but left the *build* lookup unfiltered. The same recycled draft `1c66db23` has been retargeted release-over-release (`4.23.0 → 4.24.0 → 4.25.0`) because the submission never completes.

## Fix

Constrain the build to the iOS platform. The build lookup now pulls the recent VALID builds with `include=preReleaseVersion`, resolves each build's platform, and selects the **iOS** build client-side (so it doesn't depend on `filter[preReleaseVersion.platform]` being honoured by the endpoint). If the include is unavailable for the service-account key, it falls back to the newest VALID build **with a warning** — never regressing into a red 10-minute poll.

Verified: workflow YAML parses and the 492-line inline Python heredoc compiles clean. A repo-wide grep confirms this was the only unfiltered `/builds?filter[app]` site.

## ⚠️ Not merged by me — your call (release-critical workflow)

- **Merge**: this touches the store-deploy pipeline; I'm leaving the merge to you.
- **Unblock 4.24.0 / 4.25.0**: their iOS builds are already on TestFlight. After merge, either re-dispatch `app-store.yml` (`workflow_dispatch`, `submit_for_review=true`) **or** submit 4.25.0 manually in App Store Connect (pick the iOS build), and clean up the stale `1c66db23` draft.
- I could **not** run `store-preflight.sh` against live ASC (no local creds) — but this failure class is outside its canary set anyway (it targets Apple-side blockers, not an intra-job build race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)