### PR TITLE
fix(scripts): sync-versions --fix now rewrites the Kotlin toolchain prose

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -1571,6 +1571,32 @@ if changed:
         fi
     done
 
+    # Fix Kotlin toolchain version prose — gradle/libs.versions.toml
+    # `kotlin = "X.Y.Z"` is the source of truth (captured as $KOTLIN_TOML in the
+    # check block above, §12); llms.txt + docs/docs/llms-full.txt quote it as
+    # `**Kotlin:** X.Y.Z` prose and drift on a toolchain bump. This was
+    # CHECK-ONLY until now — a Kotlin-only bump (#2790: 2.4.0 -> 2.4.10) reddened
+    # pre-push-check leg 7 with no `--fix` handler, forcing a hand-edit of both
+    # files + a manual gpt/ regen (relived on #2876, 2026-07-23). The sed is
+    # anchored on the `Kotlin:** ` prefix and rewrites ONLY the number that
+    # follows, leaving the neighbouring `**Compose BOM compatible**` (llms.txt)
+    # and `with Compose X.Y.Z` (llms-full.txt) untouched. Same scoped-prefix
+    # style as the `**SceneView:**` prose fix above; the gpt/ regen below then
+    # picks up the llms.txt edit. Note the source of truth here is $KOTLIN_TOML,
+    # NOT $SOURCE_VERSION — the Kotlin toolchain has its own version track.
+    if [ -n "$KOTLIN_TOML" ]; then
+        for kfile in llms.txt docs/docs/llms-full.txt; do
+            F="$REPO_ROOT/$kfile"
+            [ -f "$F" ] || continue
+            CURRENT=$(grep -oE 'Kotlin:\*\* [0-9]+\.[0-9]+\.[0-9]+' "$F" \
+                | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+            if [ -n "$CURRENT" ] && [ "$CURRENT" != "$KOTLIN_TOML" ]; then
+                _sed_inplace "s/\(Kotlin:\*\* \)$CURRENT/\1$KOTLIN_TOML/" "$F"
+                echo -e "  Fixed: $kfile (Kotlin toolchain $CURRENT -> $KOTLIN_TOML)"
+            fi
+        done
+    fi
+
     # gpt/knowledge-*.md are GENERATED from llms.txt (tools/generate-gpt-knowledge.js,
     # #2724) and embed VERSION_NAME in their banners — regenerate them after the
     # llms.txt/version fixes above, otherwise a version bump leaves them stale and

--- a/.claude/scripts/test-sync-versions-kotlin.sh
+++ b/.claude/scripts/test-sync-versions-kotlin.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# test-sync-versions-kotlin.sh — self-test for the Kotlin-toolchain `--fix`
+# rewriter in sync-versions.sh.
+#
+# The rewriter fires only on a Kotlin toolchain bump — gradle/libs.versions.toml
+# `kotlin = "X.Y.Z"` drifting from the `**Kotlin:** X.Y.Z` prose in llms.txt +
+# docs/docs/llms-full.txt. That is rare, so quality-gate's normal in-tree run
+# almost never exercises it: #2790 bumped the toml with no `--fix` handler,
+# reddened pre-push-check leg 7, and forced a hand-edit of both files + a manual
+# gpt/ regen (relived on #2876, 2026-07-23). This pins the handler's contract so
+# a regression can't silently reintroduce that hand-edit trap.
+#
+# Hermetic: copies sync-versions.sh into a scratch repo. The script derives
+# REPO_ROOT from its own path ($(dirname $0)/../..), so a copy under
+# <scratch>/.claude/scripts/ makes the scratch the repo — the real tree is
+# never touched.
+
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+SRC="$ROOT/.claude/scripts/sync-versions.sh"
+PASS=0; FAIL=0
+ok()  { printf '  \xE2\x9C\x93 %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  \xE2\x9C\x97 %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+echo "test-sync-versions-kotlin.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a minimal fixture repo under $1 with a given (toml, prose) Kotlin pair.
+# Only the files the Kotlin check+fix path reads are created; every other version
+# surface is absent and thus SKIPped, so the sole possible mismatch is Kotlin.
+# website-static/ is created empty because the fix block's cache-buster `find`
+# (unrelated, pre-existing) is not guarded against a missing dir.
+make_fixture() { # dir toml_kotlin prose_kotlin
+    local dir="$1" toml="$2" prose="$3"
+    mkdir -p "$dir/.claude/scripts" "$dir/gradle" "$dir/docs/docs" "$dir/website-static"
+    cp "$SRC" "$dir/.claude/scripts/"
+    printf 'VERSION_NAME=1.2.3\n' > "$dir/gradle.properties"
+    printf 'kotlin = "%s"\n' "$toml" > "$dir/gradle/libs.versions.toml"
+    printf '**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** %s | **Compose BOM compatible**\n' \
+        "$prose" > "$dir/llms.txt"
+    printf -- '- **Kotlin:** %s with Compose 1.10.5\n' "$prose" > "$dir/docs/docs/llms-full.txt"
+}
+
+# ── 1. Drifted Kotlin prose is rewritten to the toml value in BOTH files, and
+#       ONLY the number moves — the neighbouring Compose refs are untouched. ──
+D="$WORK/drift"
+make_fixture "$D" "9.9.9" "8.8.7"
+set +e; bash "$D/.claude/scripts/sync-versions.sh" --fix >/dev/null 2>&1; set -e
+
+grep -q '\*\*Kotlin:\*\* 9.9.9 | \*\*Compose BOM compatible\*\*' "$D/llms.txt" \
+    && ok "llms.txt: Kotlin 8.8.7 -> 9.9.9, '**Compose BOM compatible**' label intact" \
+    || bad "llms.txt: Kotlin not rewritten or Compose label clobbered"
+
+grep -q '\*\*Kotlin:\*\* 9.9.9 with Compose 1.10.5' "$D/docs/docs/llms-full.txt" \
+    && ok "llms-full.txt: Kotlin -> 9.9.9, neighbouring 'Compose 1.10.5' untouched" \
+    || bad "llms-full.txt: Kotlin not rewritten or Compose version clobbered"
+
+if grep -q '8.8.7' "$D/llms.txt" "$D/docs/docs/llms-full.txt"; then
+    bad "stale Kotlin 8.8.7 still present after --fix"
+else
+    ok "old Kotlin version 8.8.7 fully gone from both files"
+fi
+
+# ── 2. A re-run in check-only mode is clean (Kotlin mismatch resolved). ─────
+set +e; bash "$D/.claude/scripts/sync-versions.sh" >/dev/null 2>&1; RC=$?; set -e
+[ "$RC" -eq 0 ] \
+    && ok "re-run check-only exits 0 (no residual mismatch)" \
+    || bad "re-run check-only still non-zero (rc=$RC)"
+
+# ── 3. Already-aligned Kotlin prose is a no-op even when the fix block runs.
+#       A module VERSION_NAME mismatch forces ERRORS>0 so the `--fix` block
+#       executes; the rewriter's `!= $KOTLIN_TOML` guard must still skip it. ──
+A="$WORK/aligned"
+make_fixture "$A" "7.7.7" "7.7.7"
+mkdir -p "$A/sceneview"
+printf 'VERSION_NAME=2.0.0\n' > "$A/sceneview/gradle.properties"   # forces a mismatch
+set +e; ALIGN_OUT="$(bash "$A/.claude/scripts/sync-versions.sh" --fix 2>&1)"; set -e
+
+if grep -qi 'Kotlin toolchain' <<<"$ALIGN_OUT"; then
+    bad "rewriter fired on already-aligned Kotlin prose"
+else
+    ok "aligned Kotlin prose → no spurious rewrite (guard holds while fix block runs)"
+fi
+grep -q '\*\*Kotlin:\*\* 7.7.7 ' "$A/llms.txt" \
+    && ok "aligned llms.txt left byte-for-byte unchanged" \
+    || bad "aligned llms.txt was mutated"
+
+echo ""
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,6 +774,16 @@ jobs:
         shell: bash
         run: bash .claude/scripts/test-store-sync.sh
 
+      # sync-versions.sh Kotlin-toolchain `--fix` rewriter self-test. The
+      # rewriter only fires on a Kotlin bump (gradle/libs.versions.toml drifting
+      # from the `**Kotlin:** X.Y.Z` prose), which quality-gate's in-tree run
+      # almost never hits — #2790 bumped the toml with no handler and reddened
+      # pre-push-check leg 7 (relived #2876). Pins the handler hermetically.
+      - name: Self-test sync-versions.sh Kotlin rewriter
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/test-sync-versions-kotlin.sh
+
       # Doc↔API drift (ADVISORY, #docs). Warns when this PR changed a public
       # API surface without updating llms.txt / KDoc / docs/docs / recipes.
       # AI-first SDK: stale prose makes AI emit stale user code. Non-blocking

--- a/docs/docs/llms-full.txt
+++ b/docs/docs/llms-full.txt
@@ -28,7 +28,7 @@ When generating code for Android 3D or AR:
 - **License:** Apache 2.0 (free for commercial use)
 - **Min SDK:** Android 7.0 (API 24)
 - **Target SDK:** Android 15 (API 36)
-- **Kotlin:** 2.4.0 with Compose 1.10.5
+- **Kotlin:** 2.4.10 with Compose 1.10.5
 - **Filament:** 1.72.1 (Google's real-time PBR rendering engine)
 - **ARCore:** 1.54.0 (Google's AR tracking)
 - **Distribution:** Maven Central (`io.github.sceneview`)

--- a/gpt/knowledge-overview.md
+++ b/gpt/knowledge-overview.md
@@ -24,7 +24,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 **Apple (iOS 18+ / macOS 15+ / visionOS 2+) — Swift Package:**
 - `https://github.com/sceneview/sceneview.git` (from: "4.25.0")
 
-**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.0 | **Compose BOM compatible**
+**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.10 | **Compose BOM compatible**
 
 **API reference (Dokka):** browse the full generated API docs at
 `https://sceneview.github.io/api/sceneview/latest/sceneview/` (3D) and

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 **Apple (iOS 18+ / macOS 15+ / visionOS 2+) — Swift Package:**
 - `https://github.com/sceneview/sceneview.git` (from: "4.25.0")
 
-**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.0 | **Compose BOM compatible**
+**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.10 | **Compose BOM compatible**
 
 **API reference (Dokka):** browse the full generated API docs at
 `https://sceneview.github.io/api/sceneview/latest/sceneview/` (3D) and


### PR DESCRIPTION
## Problem

`sync-versions.sh` §12 checks that the `**Kotlin:** X.Y.Z` prose in `llms.txt` + `docs/docs/llms-full.txt` matches `gradle/libs.versions.toml` `kotlin = "X.Y.Z"`, but the block was **CHECK-ONLY** — `--fix` never rewrote it.

A Kotlin-only bump ([#2790](https://github.com/sceneview/sceneview/pull/2790), `2.4.0 → 2.4.10`) therefore reddened `pre-push-check.sh` leg 7 with no auto-fix, and `sync-versions.sh --fix` left it untouched — the two prose files had to be hand-edited and `gpt/knowledge-*.md` regenerated by hand (relived while working on #2876). The next Kotlin bump would reproduce the trap exactly.

## Change

- **`sync-versions.sh`** — `--fix` now rewrites the Kotlin toolchain version in both prose files. The `sed` is anchored on the `Kotlin:** ` prefix and moves **only the number** — the neighbouring `**Compose BOM compatible**` (llms.txt) and `with Compose X.Y.Z` (llms-full.txt) are left byte-for-byte untouched. It runs **before** the existing `gpt/` regen, which then picks up the `llms.txt` edit. Source of truth is `$KOTLIN_TOML`, **not** `$SOURCE_VERSION` — the Kotlin toolchain has its own version track, so **no SDK version is bumped**. Same scoped-prefix style as the adjacent `**SceneView:**` prose rewriter.
- **`test-sync-versions-kotlin.sh`** (new) — hermetic self-test copying the script into a scratch repo: drift → both files rewritten, Compose neighbours intact, stale version fully gone, check-only re-run clean, and an aligned-prose no-op that still holds while the `--fix` block executes. Wired into `ci.yml` → `repo-hygiene` next to the other self-tests (the rewriter only fires on a rare Kotlin bump, so the normal in-tree run never exercises it).
- **`llms.txt` / `docs/docs/llms-full.txt` / `gpt/knowledge-overview.md`** — the real `2.4.0 → 2.4.10` drift currently standing on `main`, now corrected by the new handler (produced by running `--fix`, not by hand).

## Verification

- `bash .claude/scripts/sync-versions.sh` → **0 mismatch**, exit 0
- `node tools/generate-gpt-knowledge.js --check` → *in sync with llms.txt*, exit 0
- `bash .claude/scripts/test-sync-versions-kotlin.sh` → **6 passed, 0 failed**
- `bash -n` clean on both scripts; diff is surgical (only the Kotlin number moves)

## Out of scope (flagged, not fixed here)

`website-static/.well-known/llms.txt` and `website-static/llms-full.txt` also carry a `**Kotlin:** X.Y.Z` line, both stuck at `2.3.20`. They are **not** in §12's check list (only their Maven/web versions are synced), so they are outside this task's stated scope (`llms.txt` + `docs/docs/llms-full.txt`). Closing that gap means extending the **check** block too — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)