### PR TITLE
ci(ios): harden xcpretty pipe in bridge/rn iOS compile workflows

### DIFF
--- a/.github/workflows/bridge-ios-compile.yml
+++ b/.github/workflows/bridge-ios-compile.yml
@@ -101,11 +101,19 @@ jobs:
             bridge-ios-spm-${{ runner.os }}-
 
       # Build SceneViewSwift for the iOS Simulator so the bridge type-check has
-      # a real `.swiftmodule` to import. `set -o pipefail` + `|| exit
-      # ${PIPESTATUS[0]}` so a failing build propagates its exit code instead
-      # of being swallowed by a `|| cat` that reads CI's empty stdin and exits
-      # 0 (#2878). PIPESTATUS[0] is xcodebuild's code, so a missing xcpretty is
-      # still tolerated (#1515).
+      # a real `.swiftmodule` to import.
+      #
+      # xcpretty only PRETTY-PRINTS — it is not a build tool, and it is optional.
+      # This job routes to the self-hosted `sceneview-mac` runner, where the
+      # xcpretty gem may be absent; piping xcodebuild into a MISSING command
+      # makes a verbose xcodebuild take SIGPIPE (exit 141) once the pipe buffer
+      # fills, so the old `| xcpretty ... || exit ${PIPESTATUS[0]}` form failed
+      # the step on a perfectly good build (the "missing xcpretty is tolerated"
+      # claim was false). Detect xcpretty first, run xcodebuild RAW when it is
+      # absent, capture the REAL xcodebuild exit code in a variable, and act on
+      # that — never an `exit` inline in the pipe. (#2878/#2865 replaced the
+      # `|| cat` that swallowed failures; this closes the xcpretty-absent hole
+      # an advisory cross-vendor review flagged.)
       - name: Build SceneViewSwift (iOS Simulator)
         working-directory: SceneViewSwift
         run: |
@@ -115,14 +123,30 @@ jobs:
           # runners produce only an x86_64 .swiftmodule and the arm64 type-check step
           # fails with "could not find module 'SceneViewSwift' for target arm64…;
           # found: x86_64-apple-ios-simulator". See #2223.
-          xcodebuild build \
-            -scheme SceneViewSwift \
-            -destination 'generic/platform=iOS Simulator' \
-            -skipMacroValidation \
-            -derivedDataPath "$RUNNER_TEMP/sv-dd" \
-            ONLY_ACTIVE_ARCH=NO \
-            ARCHS="arm64 x86_64" \
-            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}
+          run_xcodebuild() {
+            xcodebuild build \
+              -scheme SceneViewSwift \
+              -destination 'generic/platform=iOS Simulator' \
+              -skipMacroValidation \
+              -derivedDataPath "$RUNNER_TEMP/sv-dd" \
+              ONLY_ACTIVE_ARCH=NO \
+              ARCHS="arm64 x86_64"
+          }
+          # The trailing `|| STATUS=...` keeps errexit (GitHub's default
+          # `bash -eo pipefail`) from bailing out of the pipe before we read the
+          # code, and captures xcodebuild's REAL exit (`PIPESTATUS[0]`, not
+          # xcpretty's) so a xcpretty that is absent or merely crashes on a build
+          # that SUCCEEDED never turns the step red.
+          STATUS=0
+          if command -v xcpretty >/dev/null 2>&1; then
+            run_xcodebuild | xcpretty --color 2>/dev/null || STATUS=${PIPESTATUS[0]}
+          else
+            run_xcodebuild || STATUS=$?
+          fi
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::SceneViewSwift build failed (xcodebuild exit $STATUS)."
+            exit "$STATUS"
+          fi
 
       # Type-check the Flutter plugin's iOS Swift against the built
       # SceneViewSwift module + the Flutter.framework that ships with the SDK.

--- a/.github/workflows/rn-ios-compile.yml
+++ b/.github/workflows/rn-ios-compile.yml
@@ -103,14 +103,40 @@ jobs:
           # the type-check works on both Apple Silicon and Intel macos-15 runners.
           # Without it, Intel runners produce only x86_64 and the arm64 type-check
           # fails. See the matching fix in bridge-ios-compile.yml (#2223).
-          xcodebuild build \
-            -scheme SceneViewSwift \
-            -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath "$RUNNER_TEMP/sv-dd" \
-            -skipMacroValidation \
-            ONLY_ACTIVE_ARCH=NO \
-            ARCHS="arm64 x86_64" \
-            | xcpretty --color 2>/dev/null || exit ${PIPESTATUS[0]}
+          #
+          # xcpretty is optional pretty-printing, not a build tool. Piping into a
+          # MISSING xcpretty makes a verbose xcodebuild take SIGPIPE (exit 141),
+          # and — worse here — the old inline `|| exit ${PIPESTATUS[0]}` exited
+          # the whole step INSIDE the pipe, short-circuiting the `.swiftmodule`
+          # guard below (an xcpretty that exits non-zero after a green xcodebuild
+          # would make `exit ${PIPESTATUS[0]}` == `exit 0` and skip the guard).
+          # So: detect xcpretty, run xcodebuild raw when absent, capture the REAL
+          # exit code in a variable, test it AFTER — never `exit` inline — and
+          # only then run the module guard. (Advisory cross-vendor review.)
+          run_xcodebuild() {
+            xcodebuild build \
+              -scheme SceneViewSwift \
+              -destination 'generic/platform=iOS Simulator' \
+              -derivedDataPath "$RUNNER_TEMP/sv-dd" \
+              -skipMacroValidation \
+              ONLY_ACTIVE_ARCH=NO \
+              ARCHS="arm64 x86_64"
+          }
+          # The trailing `|| STATUS=...` keeps errexit (GitHub's default
+          # `bash -eo pipefail`) from bailing out of the pipe before we read the
+          # code, and captures xcodebuild's REAL exit (`PIPESTATUS[0]`, not
+          # xcpretty's). Only after testing it — never an `exit` inside the pipe —
+          # do we reach the `.swiftmodule` guard below.
+          STATUS=0
+          if command -v xcpretty >/dev/null 2>&1; then
+            run_xcodebuild | xcpretty --color 2>/dev/null || STATUS=${PIPESTATUS[0]}
+          else
+            run_xcodebuild || STATUS=$?
+          fi
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::SceneViewSwift build failed (xcodebuild exit $STATUS)."
+            exit "$STATUS"
+          fi
           MODULE_DIR="$RUNNER_TEMP/sv-dd/Build/Products/Debug-iphonesimulator"
           if [ ! -e "$MODULE_DIR/SceneViewSwift.swiftmodule" ]; then
             echo "::error::SceneViewSwift.swiftmodule was not produced — build failed."

--- a/changelog.d/xcpretty-bridge-rn-hardening.md
+++ b/changelog.d/xcpretty-bridge-rn-hardening.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+- The iOS bridge compile-check workflows (`bridge-ios-compile.yml`,
+  `rn-ios-compile.yml`) no longer fail — or, worse, pass while skipping their
+  `.swiftmodule` guard — when `xcpretty` is absent or crashes. Piping xcodebuild
+  into a missing `xcpretty` gave the producer a SIGPIPE (exit 141), and the
+  inline `|| exit ${PIPESTATUS[0]}` ran *inside* the pipe, short-circuiting the
+  post-build module check. Both workflows now detect `xcpretty` first, run
+  xcodebuild raw when it is missing, capture xcodebuild's real exit code in a
+  variable, and test it — never `exit` inline — so a good build stays green
+  (even on the self-hosted `sceneview-mac` runner without the gem) and a broken
+  one fails loudly. Same hardening #2878/#2865 gave `ios.yml`, extended to the
+  two bridge workflows an advisory cross-vendor review flagged.


### PR DESCRIPTION
## Context

An advisory cross-vendor review (OpenAI Codex + Google Gemini, via `.claude/scripts/llm-external-review.sh`) flagged that the `xcodebuild ... | xcpretty` pattern is still fragile in two iOS CI workflows — the same class #2865/#2852 addressed for `ios.yml`. I verified both findings against source; **both are real robustness holes**, though not the #2878 `|| cat` bug (that one was already replaced by `|| exit ${PIPESTATUS[0]}` in these files).

## Findings verified

**`bridge-ios-compile.yml`** — routes to the self-hosted `sceneview-mac` runner, where the `xcpretty` Ruby gem may be **absent**. Piping a verbose `xcodebuild` into a missing command makes xcodebuild take SIGPIPE (exit 141) once the pipe buffer fills → `PIPESTATUS[0]=141` → the step fails on a *perfectly good build*. The old comment ("a missing xcpretty is still tolerated") was factually wrong.

**`rn-ios-compile.yml`** — the `|| exit ${PIPESTATUS[0]}` ran **inside the pipe**, before the `.swiftmodule` guard on the following lines. An `exit` inline short-circuits that guard; and an xcpretty that exits non-zero after a green xcodebuild would make `exit ${PIPESTATUS[0]}` == `exit 0`, silently skipping the guard.

> Note: the "model fix" (`command -v xcpretty` + STATUS variable) described in the task does **not** actually exist in `ios.yml` — `ios.yml` uses the same `|| exit ${PIPESTATUS[0]}` pattern. I applied the genuinely robust fix rather than copying `ios.yml`. `ios.yml` runs on GitHub-hosted `macos-15` where xcpretty is preinstalled, so the hole doesn't materialise there; it's left untouched to keep this PR scoped, but the same pattern could be harmonised later.

## Fix

Both workflows now:
1. `command -v xcpretty` — run xcodebuild **raw** when absent (no pipe → no SIGPIPE).
2. Capture xcodebuild's **real** exit code via `|| STATUS=${PIPESTATUS[0]}` — robust against GitHub's default `bash -eo pipefail` (a bare pipe under `-e` would bail before we read the code), and tolerant of an xcpretty that merely *crashes* after a successful build (cosmetic tool, not a build tool).
3. Test `$STATUS` **after** the pipe — never `exit` inline — so rn's `.swiftmodule` guard is always reached on success.

## Verification

- YAML parses (`yaml.safe_load`) for both files ✅
- `bash -n` on every extracted `run:` block ✅
- Logic table tested under `bash -eo pipefail` across all cases (build ok/fail × xcpretty ok/absent/crash): good build stays green with or without xcpretty; broken build exits with the real code + `::error` message; rn's module guard reached only on success ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)