### PR TITLE
fix(scripts): extend the Kotlin toolchain prose sync to the website-static llms files

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -705,13 +705,21 @@ if [ -n "$SCENEVIEWJS_VERSION_TEST" ] && [ -f "$SCENEVIEWJS_VERSION_TEST" ]; the
 fi
 
 # Kotlin toolchain version — gradle/libs.versions.toml `kotlin = "X.Y.Z"` is
-# the source of truth; llms.txt + llms-full.txt quote it in prose and drift.
+# the source of truth; llms.txt + llms-full.txt quote it in prose and drift —
+# and so do their two website-static siblings, which sat outside this list and
+# rotted to 2.3.20 while the covered pair was fixed to 2.4.10 (#2886 follow-up).
+# `website-static/llms-full.txt` is a real hand-maintained file with no
+# canonical root counterpart (docs.yml says so explicitly), and
+# `website-static/.well-known/llms.txt` is repo-internal (docs.yml drops it
+# from the deployed site, #1998) but still a versioned surface swept above for
+# its Maven prose — both must track the toml like the first pair.
 # Reported under a separate "Kotlin" banner since it's not VERSION_NAME.
 # `docs/docs/llms.txt` is omitted — it is build-generated from root `llms.txt`
 # (swept here) and `.gitignore`d (issue #899 hardening).
 KOTLIN_TOML=$(grep -m1 '^kotlin = ' "$REPO_ROOT/gradle/libs.versions.toml" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+KOTLIN_PROSE_FILES="llms.txt docs/docs/llms-full.txt website-static/.well-known/llms.txt website-static/llms-full.txt"
 if [ -n "$KOTLIN_TOML" ]; then
-    for kfile in llms.txt docs/docs/llms-full.txt; do
+    for kfile in $KOTLIN_PROSE_FILES; do
         F="$REPO_ROOT/$kfile"
         [ -f "$F" ] || continue
         V=$(grep -oE 'Kotlin:\*\* [0-9]+\.[0-9]+\.[0-9]+' "$F" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
@@ -1573,19 +1581,23 @@ if changed:
 
     # Fix Kotlin toolchain version prose — gradle/libs.versions.toml
     # `kotlin = "X.Y.Z"` is the source of truth (captured as $KOTLIN_TOML in the
-    # check block above, §12); llms.txt + docs/docs/llms-full.txt quote it as
+    # check block above, §12); the $KOTLIN_PROSE_FILES surfaces quote it as
     # `**Kotlin:** X.Y.Z` prose and drift on a toolchain bump. This was
     # CHECK-ONLY until now — a Kotlin-only bump (#2790: 2.4.0 -> 2.4.10) reddened
     # pre-push-check leg 7 with no `--fix` handler, forcing a hand-edit of both
     # files + a manual gpt/ regen (relived on #2876, 2026-07-23). The sed is
     # anchored on the `Kotlin:** ` prefix and rewrites ONLY the number that
-    # follows, leaving the neighbouring `**Compose BOM compatible**` (llms.txt)
-    # and `with Compose X.Y.Z` (llms-full.txt) untouched. Same scoped-prefix
-    # style as the `**SceneView:**` prose fix above; the gpt/ regen below then
-    # picks up the llms.txt edit. Note the source of truth here is $KOTLIN_TOML,
-    # NOT $SOURCE_VERSION — the Kotlin toolchain has its own version track.
+    # follows, leaving the neighbouring `**Compose BOM compatible**` and
+    # `with Compose X.Y.Z` untouched. Same scoped-prefix style as the
+    # `**SceneView:**` prose fix above; the gpt/ regen below then picks up the
+    # llms.txt edit. The file list is the SAME $KOTLIN_PROSE_FILES variable the
+    # check block iterates — one list, so check and fix can never cover
+    # different surfaces again (the original gap: the two website-static
+    # siblings were in neither, and rotted to 2.3.20). Note the source of truth
+    # here is $KOTLIN_TOML, NOT $SOURCE_VERSION — the Kotlin toolchain has its
+    # own version track.
     if [ -n "$KOTLIN_TOML" ]; then
-        for kfile in llms.txt docs/docs/llms-full.txt; do
+        for kfile in $KOTLIN_PROSE_FILES; do
             F="$REPO_ROOT/$kfile"
             [ -f "$F" ] || continue
             CURRENT=$(grep -oE 'Kotlin:\*\* [0-9]+\.[0-9]+\.[0-9]+' "$F" \

--- a/.claude/scripts/test-sync-versions-kotlin.sh
+++ b/.claude/scripts/test-sync-versions-kotlin.sh
@@ -31,17 +31,25 @@ trap 'rm -rf "$WORK"' EXIT
 # Build a minimal fixture repo under $1 with a given (toml, prose) Kotlin pair.
 # Only the files the Kotlin check+fix path reads are created; every other version
 # surface is absent and thus SKIPped, so the sole possible mismatch is Kotlin.
-# website-static/ is created empty because the fix block's cache-buster `find`
-# (unrelated, pre-existing) is not guarded against a missing dir.
+# All four $KOTLIN_PROSE_FILES surfaces are present: the root pair plus the two
+# website-static siblings that sat outside the original list and rotted to
+# 2.3.20 (#2886 follow-up). website-static/ also satisfies the fix block's
+# cache-buster `find` (unrelated, pre-existing), which is not guarded against
+# a missing dir.
 make_fixture() { # dir toml_kotlin prose_kotlin
     local dir="$1" toml="$2" prose="$3"
-    mkdir -p "$dir/.claude/scripts" "$dir/gradle" "$dir/docs/docs" "$dir/website-static"
+    mkdir -p "$dir/.claude/scripts" "$dir/gradle" "$dir/docs/docs" "$dir/website-static/.well-known"
     cp "$SRC" "$dir/.claude/scripts/"
     printf 'VERSION_NAME=1.2.3\n' > "$dir/gradle.properties"
     printf 'kotlin = "%s"\n' "$toml" > "$dir/gradle/libs.versions.toml"
     printf '**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** %s | **Compose BOM compatible**\n' \
         "$prose" > "$dir/llms.txt"
     printf -- '- **Kotlin:** %s with Compose 1.10.5\n' "$prose" > "$dir/docs/docs/llms-full.txt"
+    # Same shapes as the real website-static files: .well-known mirrors the
+    # root llms.txt pipe line; llms-full mirrors the docs/docs bullet line.
+    printf '**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** %s | **Compose BOM compatible**\n' \
+        "$prose" > "$dir/website-static/.well-known/llms.txt"
+    printf -- '- **Kotlin:** %s with Compose 1.10.5\n' "$prose" > "$dir/website-static/llms-full.txt"
 }
 
 # ── 1. Drifted Kotlin prose is rewritten to the toml value in BOTH files, and
@@ -58,10 +66,19 @@ grep -q '\*\*Kotlin:\*\* 9.9.9 with Compose 1.10.5' "$D/docs/docs/llms-full.txt"
     && ok "llms-full.txt: Kotlin -> 9.9.9, neighbouring 'Compose 1.10.5' untouched" \
     || bad "llms-full.txt: Kotlin not rewritten or Compose version clobbered"
 
-if grep -q '8.8.7' "$D/llms.txt" "$D/docs/docs/llms-full.txt"; then
+grep -q '\*\*Kotlin:\*\* 9.9.9 | \*\*Compose BOM compatible\*\*' "$D/website-static/.well-known/llms.txt" \
+    && ok "website-static/.well-known/llms.txt: Kotlin -> 9.9.9, Compose label intact" \
+    || bad "website-static/.well-known/llms.txt: Kotlin not rewritten (the pre-#2886-follow-up gap)"
+
+grep -q '\*\*Kotlin:\*\* 9.9.9 with Compose 1.10.5' "$D/website-static/llms-full.txt" \
+    && ok "website-static/llms-full.txt: Kotlin -> 9.9.9, 'Compose 1.10.5' untouched" \
+    || bad "website-static/llms-full.txt: Kotlin not rewritten (the pre-#2886-follow-up gap)"
+
+if grep -q '8.8.7' "$D/llms.txt" "$D/docs/docs/llms-full.txt" \
+        "$D/website-static/.well-known/llms.txt" "$D/website-static/llms-full.txt"; then
     bad "stale Kotlin 8.8.7 still present after --fix"
 else
-    ok "old Kotlin version 8.8.7 fully gone from both files"
+    ok "old Kotlin version 8.8.7 fully gone from all four files"
 fi
 
 # ── 2. A re-run in check-only mode is clean (Kotlin mismatch resolved). ─────
@@ -87,6 +104,9 @@ fi
 grep -q '\*\*Kotlin:\*\* 7.7.7 ' "$A/llms.txt" \
     && ok "aligned llms.txt left byte-for-byte unchanged" \
     || bad "aligned llms.txt was mutated"
+grep -q '\*\*Kotlin:\*\* 7.7.7 ' "$A/website-static/.well-known/llms.txt" \
+    && ok "aligned website-static/.well-known/llms.txt left unchanged" \
+    || bad "aligned website-static/.well-known/llms.txt was mutated"
 
 echo ""
 echo "  $PASS passed, $FAIL failed"

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -9,7 +9,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 **Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
 - `https://github.com/sceneview/sceneview.git` (from: "4.25.0"))
 
-**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.3.20 | **Compose BOM compatible**
+**Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.10 | **Compose BOM compatible**
 
 ---
 

--- a/website-static/llms-full.txt
+++ b/website-static/llms-full.txt
@@ -28,7 +28,7 @@ When generating code for Android 3D or AR:
 - **License:** Apache 2.0 (free for commercial use)
 - **Min SDK:** Android 7.0 (API 24)
 - **Target SDK:** Android 15 (API 36)
-- **Kotlin:** 2.3.20 with Compose 1.10.5
+- **Kotlin:** 2.4.10 with Compose 1.10.5
 - **Filament:** 1.70.0 (Google's real-time PBR rendering engine)
 - **ARCore:** 1.53.0 (Google's AR tracking)
 - **Distribution:** Maven Central (`io.github.sceneview`)


### PR DESCRIPTION
## Problem

[#2886](https://github.com/sceneview/sceneview/pull/2886) added the Kotlin-prose `--fix` rewriter, scoped to §12's check list (`llms.txt` + `docs/docs/llms-full.txt`). Its review flagged (out of scope there): **two more versioned surfaces carry the same `**Kotlin:** X.Y.Z` prose and sat outside BOTH the check and the fix** — `website-static/.well-known/llms.txt` and `website-static/llms-full.txt`, rotted at `2.3.20` while the covered pair was fixed to `2.4.10`.

Both are real hand-maintained files, not build artifacts: `docs.yml` documents `website-static/llms-full.txt` as *"a real, version-synced file with no canonical root counterpart"*, and `.well-known/llms.txt` is repo-internal (dropped from the deployed site, #1998) but already swept by `sync-versions.sh` for its Maven prose — its Kotlin line must not lie either.

## Change

- **`sync-versions.sh`** — the file list is hoisted into one `$KOTLIN_PROSE_FILES` variable consumed by **both** the §12 check loop and the `--fix` rewriter, so the two loops can never cover different surfaces again (the original gap was exactly that divergence-by-duplication). The two website-static files are added to it. The sed stays anchored on the `Kotlin:** ` prefix — only the number moves; the neighbouring `**Compose BOM compatible**` / `with Compose 1.10.5` are untouched. Still `$KOTLIN_TOML`-sourced — **no SDK version is bumped**.
- **`test-sync-versions-kotlin.sh`** — the hermetic fixture now carries all four surfaces (same line shapes as the real files); assertions cover the two new files' rewrite, Compose neighbours intact, stale version fully gone, check-only re-run clean, and the aligned no-op — **9 checks**.
- **`website-static/.well-known/llms.txt` / `website-static/llms-full.txt`** — the standing `2.3.20 → 2.4.10` drift, corrected by running the extended `--fix` (not by hand).

## Verification

- Check before fix: both new files reported `MISMATCH 2.3.20` (detection works); after `--fix`: `bash .claude/scripts/sync-versions.sh` → **0 mismatch**, exit 0
- `bash .claude/scripts/test-sync-versions-kotlin.sh` → **9 passed, 0 failed**
- `node tools/generate-gpt-knowledge.js --check` → *in sync with llms.txt*
- `bash -n` clean on both scripts; diff is surgical (only the Kotlin number moves in each txt)

Scope is tooling + doc prose only (no Kotlin/Swift/JS source touched) — self-review per the trivial-diff rule; the extended self-test runs in `repo-hygiene` on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)