### PR TITLE
fix(mcp): regenerate stale LATEST_SCENEVIEW_RELEASE + guard freshness in sync-versions

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -374,10 +374,28 @@ if [ -f "$DEMO_GRADLE" ]; then
 fi
 
 # ─── 7. MCP source/dist version ─────────────────────────────────────────
-# SKIPPED: MCP has its own version track independent of gradle.properties.
-# mcp/src/index.ts PACKAGE_VERSION and mcp/package.json version must match
-# each other, but NOT gradle.properties VERSION_NAME.
-echo -e "${CYAN}--- MCP Source/Dist (independent track, not checked) ---${NC}"
+# The MCP's OWN npm version (PACKAGE_VERSION in mcp/src/generated/version.ts,
+# mirrored from mcp/package.json) is on an INDEPENDENT track and is NOT
+# checked here — forcing it to match VERSION_NAME once regressed it behind
+# the published npm @next tag (issue #1705). Do NOT add PACKAGE_VERSION to
+# add_check.
+#
+# BUT the SAME generated file also carries LATEST_SCENEVIEW_RELEASE — the SDK
+# version the MCP advertises to AI agents in the install snippet it emits.
+# That constant IS derived from gradle.properties:VERSION_NAME by
+# mcp/scripts/generate-version.js and MUST track it. Unlike its gitignored
+# siblings (llms-txt.ts / symbols.ts, regenerated fresh on every build),
+# version.ts is COMMITTED, so nothing regenerated it on an SDK bump and
+# v4.25.0 shipped it stale at 4.24.0 — telling agents to scaffold projects
+# against a one-release-old pin. Check it CRITICAL so a future bump that
+# forgets to regenerate is caught, and regenerate it in the --fix block.
+echo -e "${CYAN}--- MCP (PACKAGE_VERSION independent; LATEST_SCENEVIEW_RELEASE tracks VERSION_NAME) ---${NC}"
+MCP_VERSION_TS="$REPO_ROOT/mcp/src/generated/version.ts"
+if [ -f "$MCP_VERSION_TS" ]; then
+    V=$(grep -oE 'LATEST_SCENEVIEW_RELEASE = "[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?"' "$MCP_VERSION_TS" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1 || echo "NOT FOUND")
+    add_check "mcp/src/generated/version.ts (LATEST_SCENEVIEW_RELEASE)" "$V"
+fi
 
 # ─── 7b. Claude Code plugin ─────────────────────────────────────────────
 # Plugins live in github.com/sceneview/claude-marketplace (separate repo).
@@ -1606,6 +1624,22 @@ if changed:
             echo -e "  Fixed: gpt/knowledge-*.md regenerated from llms.txt"
         else
             echo -e "  ${YELLOW}WARN: gpt/ regeneration failed — run 'node tools/generate-gpt-knowledge.js' manually${NC}"
+        fi
+    fi
+
+    # mcp/src/generated/version.ts embeds LATEST_SCENEVIEW_RELEASE (the SDK
+    # version the MCP advertises to AI agents) and is COMMITTED — unlike its
+    # gitignored llms-txt.ts / symbols.ts siblings, nothing regenerated it on
+    # an SDK bump, so v4.25.0 shipped it stale (checked CRITICAL in section 7).
+    # generate-version.js rewrites BOTH the constant and the android-ok test
+    # fixture's SDK pin from package.json + gradle.properties. It NEVER changes
+    # PACKAGE_VERSION beyond mirroring mcp/package.json, so the independent MCP
+    # npm track (#1705) is preserved.
+    if [ -f "$REPO_ROOT/mcp/scripts/generate-version.js" ] && command -v node >/dev/null 2>&1; then
+        if node "$REPO_ROOT/mcp/scripts/generate-version.js" >/dev/null 2>&1; then
+            echo -e "  Fixed: mcp/src/generated/version.ts + android-ok fixture regenerated (LATEST_SCENEVIEW_RELEASE -> $SOURCE_VERSION)"
+        else
+            echo -e "  ${YELLOW}WARN: mcp version.ts regeneration failed — run 'node mcp/scripts/generate-version.js' manually${NC}"
         fi
     fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,7 +662,12 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 > tied to a `v*` tag, `mcp/` changes between releases leave npm stale (it once
 > rotted a month behind at 4.0.12). To ship the MCP on demand, bump
 > `mcp/package.json` + `mcp/package-lock.json` by a patch (the generated
-> `mcp/src/generated/version.ts` is refreshed automatically by `npm run prepare`),
+> `mcp/src/generated/version.ts` is refreshed by `npm run prepare` **only when the
+> MCP itself is (re)built** — a plain SDK-only release bumps `gradle.properties`
+> without touching `mcp/`, so it does NOT run that lifecycle and `version.ts` went
+> stale at v4.25.0; `sync-versions.sh` therefore independently checks its
+> `LATEST_SCENEVIEW_RELEASE` against `VERSION_NAME` (CRITICAL) and regenerates it in
+> `--fix` — that is the real backstop on the release path, #2906),
 > land it on `main`, then dispatch the **`mcp-publish.yml`** workflow
 > (`gh workflow run mcp-publish.yml -R sceneview/sceneview --ref main`). It
 > mirrors `release.yml`'s `publish-mcp` job (same `NPM_TOKEN`, build/test/publish)

--- a/changelog.d/2906-mcp-version-ts-freshness.md
+++ b/changelog.d/2906-mcp-version-ts-freshness.md
@@ -6,9 +6,9 @@
   without regenerating it, so `LATEST_SCENEVIEW_RELEASE` (and the `analyze-project`
   `android-ok` test fixture's SDK pin) stayed at `4.24.0`, the version the MCP hands out in
   its install snippets. Both are regenerated to `4.25.0`. The MCP's own npm version
-  (`PACKAGE_VERSION`) is on an independent track and is left untouched (#1705).
+  (`PACKAGE_VERSION`) is on an independent track and is left untouched (#1705, #2906).
 - **Tooling:** `sync-versions.sh` now verifies `LATEST_SCENEVIEW_RELEASE` against
   `VERSION_NAME` (CRITICAL) and regenerates `version.ts` + the fixture in `--fix`. A future SDK
   bump that forgets the MCP regeneration is now caught by the release pipeline
   (`release-fast.yml` re-runs the check for zero residuals) instead of silently shipping a
-  stale pin. `PACKAGE_VERSION` stays deliberately out of the check (#1705).
+  stale pin. `PACKAGE_VERSION` stays deliberately out of the check (#1705, #2906).

--- a/changelog.d/mcp-version-ts-freshness.md
+++ b/changelog.d/mcp-version-ts-freshness.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+
+- **MCP:** `sceneview-mcp` no longer advertises a one-release-old SDK pin to AI agents.
+  `mcp/src/generated/version.ts` is auto-generated but, unlike its gitignored `llms-txt.ts` /
+  `symbols.ts` siblings, **committed** — and the v4.25.0 release bumped `gradle.properties`
+  without regenerating it, so `LATEST_SCENEVIEW_RELEASE` (and the `analyze-project`
+  `android-ok` test fixture's SDK pin) stayed at `4.24.0`, the version the MCP hands out in
+  its install snippets. Both are regenerated to `4.25.0`. The MCP's own npm version
+  (`PACKAGE_VERSION`) is on an independent track and is left untouched (#1705).
+- **Tooling:** `sync-versions.sh` now verifies `LATEST_SCENEVIEW_RELEASE` against
+  `VERSION_NAME` (CRITICAL) and regenerates `version.ts` + the fixture in `--fix`. A future SDK
+  bump that forgets the MCP regeneration is now caught by the release pipeline
+  (`release-fast.yml` re-runs the check for zero residuals) instead of silently shipping a
+  stale pin. `PACKAGE_VERSION` stays deliberately out of the check (#1705).

--- a/mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts
+++ b/mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
     // doesn't break every time the SDK ships a new patch. The fixture's
     // whole purpose is to represent a happy-path consumer project — by
     // definition that means using the current version.
-    implementation("io.github.sceneview:sceneview:4.24.0")
+    implementation("io.github.sceneview:sceneview:4.25.0")
 }

--- a/mcp/src/generated/version.ts
+++ b/mcp/src/generated/version.ts
@@ -6,4 +6,4 @@
 // stale hardcoded constants. See #941.
 
 export const PACKAGE_VERSION = "4.0.15" as const;
-export const LATEST_SCENEVIEW_RELEASE = "4.24.0" as const;
+export const LATEST_SCENEVIEW_RELEASE = "4.25.0" as const;


### PR DESCRIPTION
## Problem

`sceneview-mcp` was advertising a one-release-old SDK pin to AI agents. `mcp/src/generated/version.ts` is auto-generated by `mcp/scripts/generate-version.js` but — unlike its gitignored siblings `llms-txt.ts` / `symbols.ts` — it is **committed**. The v4.25.0 release bumped `gradle.properties` (`VERSION_NAME=4.25.0`) without regenerating it, so on `main`:

- `mcp/src/generated/version.ts` → `LATEST_SCENEVIEW_RELEASE = "4.24.0"` (should be 4.25.0)
- `mcp/src/__fixtures__/analyze-project/android-ok/build.gradle.kts` → `sceneview:4.24.0` (auto-synced fixture pin)

Nothing in CI or the release pipeline caught it: `sync-versions.sh` section 7 skipped the MCP entirely. That skip is correct for the independent `PACKAGE_VERSION` npm track (the #1705 trap), but it also blinded the check to `LATEST_SCENEVIEW_RELEASE`, which *does* track `VERSION_NAME`.

## Fix

**One-off:** regenerated `version.ts` + the fixture to 4.25.0 via the canonical `generate-version.js` (deterministic; diff limited to the two version lines).

**Durable (root cause):** `sync-versions.sh` now
- **`--check`**: verifies `LATEST_SCENEVIEW_RELEASE` against `VERSION_NAME` (CRITICAL);
- **`--fix`**: regenerates `version.ts` + fixture via `generate-version.js`, next to the existing `gpt/knowledge-*.md` regen.

`release-fast.yml` already runs `--fix` then re-checks for zero residuals, so a future SDK bump that forgets the MCP regen is now caught by the release pipeline instead of silently shipping stale.

`PACKAGE_VERSION` (the MCP's own npm version, 4.0.15) is **never** checked or rewritten — the #1705 invariant is preserved.

## Verification

- Diff confirmed = only `LATEST_SCENEVIEW_RELEASE` 4.24.0→4.25.0 + the fixture pin; `PACKAGE_VERSION` stays `4.0.15`.
- `bash -n` clean.
- Existing self-test `test-sync-versions-kotlin.sh`: 6 passed, 0 failed.
- Regression: staled `version.ts` to 4.24.0 → `--check` raised MISMATCH (exit 1) → `--fix` regenerated both files back to 4.25.0, `PACKAGE_VERSION` untouched.

Independent review (sv-code / sv-impact / sv-doc-freshness) is running before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)