### PR TITLE
fix(ci): source iOS App Store whatsNew from release_notes.txt (#2893)

### DIFF
--- a/.github/workflows/app-store.yml
+++ b/.github/workflows/app-store.yml
@@ -549,46 +549,65 @@ jobs:
               attrs = {}
 
               # ── whatsNew (every tag) ──────────────────────────────────
-              # `gsub(/\./, "\\.", ver)` escapes the dots in `4.3.1` so the
-              # regex doesn't also match `4-3-1` etc. Same hygiene as
-              # play-store.yml's awk extractor.
-              awk_out = subprocess.run(
-                  ["awk", "-v", f"ver=## v{version_string}",
-                   r'BEGIN { gsub(/\./, "\\.", ver) } '
-                   r'$0 ~ "^"ver"( |$)" { found=1; next } '
-                   r'found && /^## v[0-9]/ { exit } '
-                   r'found { print }',
-                   "../../CHANGELOG.md"],
-                  capture_output=True, text=True, check=False,
-              )
-              raw = awk_out.stdout
-              if raw.strip():
-                  text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", raw)
-                  text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
-                  text = re.sub(r"`([^`]+)`", r"\1", text)
-                  text = re.sub(r"^#{1,6}\s*", "", text, flags=re.M)
-                  # Apple Guideline 2.3.10 (Accurate Metadata): App Store
-                  # reviewers reject "What's New" notes that reference other
-                  # platforms (Android/Google Play/etc.) — irrelevant to App
-                  # Store users. The CHANGELOG is cross-platform, so drop any
-                  # bullet line that mentions a non-Apple ecosystem before it
-                  # reaches the iOS/macOS whatsNew. #2252 follow-up.
-                  _other_platform = re.compile(
-                      r"\b(android|google play|play store|maven|gradle|"
-                      r"jetpack|kotlin|flutter|react[ -]native|web|webgl|"
-                      r"webxr|wasm|\.aar|desktop)\b",
-                      re.I,
+              # Preferred source: a hand-maintained, user-facing
+              # release_notes.txt. Apple's "What's New" must describe the
+              # DEMO app for its App Store users, NOT the SDK's technical,
+              # cross-platform CHANGELOG (Apple Guideline 2.3.10 rejects
+              # notes referencing other ecosystems). Deriving whatsNew from
+              # the CHANGELOG left the field near-empty for Web/Flutter-heavy
+              # releases (e.g. 4.25.0), and an empty *required* whatsNew makes
+              # the review submission 409 with ENTITY_STATE_INVALID far
+              # downstream (#2893).
+              whats_new = None
+              notes_file = pathlib.Path("distribution/app-store/en-US/release_notes.txt")
+              if notes_file.exists():
+                  whats_new = notes_file.read_text().strip() or None
+                  if whats_new:
+                      print(f"whatsNew sourced from release_notes.txt ({len(whats_new)}c)")
+              if not whats_new:
+                  # Fallback (file absent): extract the `## vX.Y.Z` CHANGELOG
+                  # section as before, so existing tags keep working.
+                  # `gsub(/\./, "\\.", ver)` escapes the dots in `4.3.1` so the
+                  # regex doesn't also match `4-3-1` etc. Same hygiene as
+                  # play-store.yml's awk extractor.
+                  awk_out = subprocess.run(
+                      ["awk", "-v", f"ver=## v{version_string}",
+                       r'BEGIN { gsub(/\./, "\\.", ver) } '
+                       r'$0 ~ "^"ver"( |$)" { found=1; next } '
+                       r'found && /^## v[0-9]/ { exit } '
+                       r'found { print }',
+                       "../../CHANGELOG.md"],
+                      capture_output=True, text=True, check=False,
                   )
-                  text = "\n".join(
-                      ln for ln in text.splitlines()
-                      if not (ln.lstrip()[:1] in "-*•" and _other_platform.search(ln))
-                  )
-                  text = re.sub(r"\n{3,}", "\n\n", text).strip()
-                  if len(text) > 4000:
-                      text = text[:3997].rstrip() + "…"
-                  attrs["whatsNew"] = text
-              else:
-                  print(f"::warning::No '## v{version_string}' section in CHANGELOG.md — whatsNew left untouched")
+                  raw = awk_out.stdout
+                  if raw.strip():
+                      text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", raw)
+                      text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
+                      text = re.sub(r"`([^`]+)`", r"\1", text)
+                      text = re.sub(r"^#{1,6}\s*", "", text, flags=re.M)
+                      # Apple Guideline 2.3.10 (Accurate Metadata): App Store
+                      # reviewers reject "What's New" notes that reference other
+                      # platforms (Android/Google Play/etc.) — irrelevant to App
+                      # Store users. The CHANGELOG is cross-platform, so drop any
+                      # bullet line that mentions a non-Apple ecosystem before it
+                      # reaches the iOS/macOS whatsNew. #2252 follow-up.
+                      _other_platform = re.compile(
+                          r"\b(android|google play|play store|maven|gradle|"
+                          r"jetpack|kotlin|flutter|react[ -]native|web|webgl|"
+                          r"webxr|wasm|\.aar|desktop)\b",
+                          re.I,
+                      )
+                      text = "\n".join(
+                          ln for ln in text.splitlines()
+                          if not (ln.lstrip()[:1] in "-*•" and _other_platform.search(ln))
+                      )
+                      whats_new = re.sub(r"\n{3,}", "\n\n", text).strip() or None
+                  if not whats_new:
+                      print(f"::warning::No release_notes.txt and no usable '## v{version_string}' CHANGELOG section — whatsNew left empty; the review submission will 409 (ENTITY_STATE_INVALID) if the field is blank on App Store Connect")
+              if whats_new:
+                  if len(whats_new) > 4000:
+                      whats_new = whats_new[:3997].rstrip() + "…"
+                  attrs["whatsNew"] = whats_new
 
               # ── Read file-backed metadata ─────────────────────────────
               meta_dir = pathlib.Path("distribution/app-store/en-US")

--- a/changelog.d/2893-ios-appstore-release-notes-source.md
+++ b/changelog.d/2893-ios-appstore-release-notes-source.md
@@ -1,0 +1,12 @@
+- **CI:** the iOS App Store submit step now sources the required "What's New"
+  (`whatsNew`) field from a user-facing
+  `samples/ios-demo/distribution/app-store/en-US/release_notes.txt` instead of
+  deriving it from the technical, cross-platform `CHANGELOG.md` (which left the
+  field near-empty for Web/Flutter-heavy releases). An empty *required*
+  `whatsNew` is rejected by App Store Connect with HTTP 409
+  `ENTITY_STATE_INVALID` ("not in valid state") at review submission — the
+  second blocker that stopped 4.25.0 even after the #2885 build-platform fix.
+  Falls back to the previous `CHANGELOG.md` extraction when the file is absent.
+  (#2893)
+
+<!-- category: Fixed -->

--- a/samples/ios-demo/distribution/app-store/en-US/release_notes.txt
+++ b/samples/ios-demo/distribution/app-store/en-US/release_notes.txt
@@ -1,0 +1,1 @@
+This update polishes the 3D and AR demos with rendering refinements and stability fixes. Explore SceneView's declarative building blocks for 3D and augmented reality on iOS.


### PR DESCRIPTION
## Why

While validating #2885 in production (dispatched run `30269459288` to submit 4.25.0), the build-platform fix worked — `Selected iOS build: 1300`, `Build attached: 204`, no more platform 409 — but the submission **still failed** on a *distinct downstream blocker*:

```
reviewSubmissionItems CREATE failed: 409
  code : STATE_ERROR.ENTITY_STATE_INVALID
  title: appStoreVersions '1c66db23-…' is not in valid state.
```

Root cause, confirmed in App Store Connect: the version's **required "What's New" (`whatsNew`)** field was **empty**. The submit step derived it from `CHANGELOG.md`'s `## vX.Y.Z` section, but that log is technical and cross-platform; the Guideline-2.3.10 filter that strips non-Apple bullets left the field near-empty for a Web/Flutter-heavy release like 4.25.0. The localization PATCH that would have set it `409 Conflict`-ed (a warning the job swallowed), so the field stayed blank → App Store Connect rejects the review submission as "not in valid state" ~12 minutes later, opaquely.

4.25.0 was unblocked **manually** (fill the field + submit). This PR fixes the source so it doesn't recur.

## What

- **New** `samples/ios-demo/distribution/app-store/en-US/release_notes.txt` — a hand-maintained, user-facing "What's New" describing the *demo app*, the correct content for an App Store listing (not the SDK's cross-platform CHANGELOG).
- **`app-store.yml`**: the iOS submit step now reads `release_notes.txt` **first** as the `whatsNew` source, and **falls back to the previous CHANGELOG extraction unchanged** when the file is absent (behaviour-preserving for any tag without the file).
- The "no whatsNew" warning now names the downstream consequence (409 `ENTITY_STATE_INVALID`) instead of a vague "left untouched".

## Validation

Local (all this workflow file allows without ASC creds):

- ✅ heredoc `py_compile` — the 511-line submit script compiles
- ✅ `app-store.yml` YAML parses
- ✅ path resolution from the step's cwd (`samples/ios-demo`) → file found, 173 chars, under the 4000 cap
- ✅ behaviour-preserving: the file-absent path is the old CHANGELOG extraction, unchanged

**Not locally testable:** the real ASC submission path (build → localization PATCH → reviewSubmission). It is only exercised at the **next release**. This touches the production deploy workflow, so it is left as a **draft for human review** rather than auto-merge.

## Scope

This is the **core of W4** on #2893 — the item that actually blocked a release. Deliberately **not** in this PR, tracked on #2893 for a separate, carefully-scoped change:

- **W5** — delete the orphan empty `reviewSubmission` when the item CREATE fails (a residue accrues on each failed run; one had to be deleted by hand today).
- Making the localization PATCH itself reliable / fail-fast (the `409 Conflict` is most likely a stale-submission lock — coupled with W5).

Refs #2893, #2885, #2731.
