### PR TITLE
fix(qa): hold the emulator lease for the whole run in the scripts that drive it (#2862)

### DIFF
--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -131,7 +131,20 @@ if [[ -z "$PARENT_PROVIDED_SERIAL" ]]; then
   # Adopt a token a `setup-ar-emulator.sh` run just published for this session,
   # so our OWN reservation is not mistaken for a peer's (no-op otherwise).
   [[ -n "${EMU_LEASE_SESSION:-}" ]] || emu_lease_session_inherit >/dev/null 2>&1 || true
-  if emu_serial_alive "$SERIAL" adb && emu_serial_avd_matches "$SERIAL" adb; then
+  if emu_serial_alive "$SERIAL" adb; then
+    # It sits on a pool console port, so it is pool-managed: it must be
+    # IDENTIFIABLE as the pool AVD and leasable, or we refuse outright. Falling
+    # through to "drive it unleased" would be worst-case wrong — the console
+    # goes mute mainly when the emulator is already busy, i.e. exactly when a
+    # peer is driving it (lib/emulator-select.sh: leasing an unidentified
+    # device is the failure the guard exists for).
+    if ! emu_serial_avd_matches "$SERIAL" adb; then
+      echo "[ar-replay-qa] $SERIAL is on a pool port but did not identify as" >&2
+      echo "[ar-replay-qa] ${EMU_REQUIRE_AVD:-$EMU_POOL_AVD} (wrong AVD, or its console did not answer)." >&2
+      echo "[ar-replay-qa] Refusing to drive an emulator this run cannot identify." >&2
+      echo "[ar-replay-qa]   bash .claude/scripts/setup-ar-emulator.sh" >&2
+      exit 2
+    fi
     if ! emu_lease_acquire "$SERIAL" adb; then
       echo "[ar-replay-qa] $SERIAL is a pool emulator reserved by another session —" >&2
       echo "[ar-replay-qa] refusing to drive it. Provision your own, or inherit the" >&2
@@ -140,6 +153,11 @@ if [[ -z "$PARENT_PROVIDED_SERIAL" ]]; then
       exit 2
     fi
     echo "[ar-replay-qa] leased pool emulator $SERIAL for this run"
+    # Arm the release NOW, not at the logcat block below: a `set -e` abort in
+    # the Gradle build between here and there would otherwise leave the lease
+    # file behind. (Harmless — a dead owner's lease is reclaimable — but a
+    # peer would wait needlessly.) Superseded by ar_cleanup once logcat runs.
+    trap 'emu_lease_release_all 2>/dev/null || true' EXIT
   fi
 fi
 

--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -83,6 +83,11 @@ cd "$REPO_ROOT"
 
 # shellcheck source=lib/android-cli.sh
 source "$SCRIPT_DIR/lib/android-cli.sh"
+# RAM-budgeted adaptive emulator pool helpers (#1647 → #1654, #2862) — so a
+# standalone replay run HOLDS a lease on the pool emulator it drives instead of
+# injecting input into an AVD a peer session is already interpreting.
+# shellcheck source=lib/emulator-select.sh
+source "$SCRIPT_DIR/lib/emulator-select.sh"
 
 INSTALL=1
 OUT_DIR=""
@@ -100,6 +105,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Device check ───────────────────────────────────────────────────────────
+# Remember whether a parent (device-qa.sh) handed us the serial: it already
+# owns the pool lease under its own pid, so we must NOT lease/release around it.
+PARENT_PROVIDED_SERIAL="${ANDROID_SERIAL:-}"
 SERIAL="$(android_cli_pick_serial || true)"
 if [[ -z "$SERIAL" ]]; then
   echo "[ar-replay-qa] no single device/emulator connected." >&2
@@ -107,6 +115,33 @@ if [[ -z "$SERIAL" ]]; then
   exit 2
 fi
 echo "[ar-replay-qa] target device: $SERIAL"
+
+# ── Pool-lease bookkeeping (#2862) ─────────────────────────────────────────
+# Standalone, ar-replay-qa.sh used to drive whatever android_cli_pick_serial
+# returned with NO notion of a reservation, so two standalone runs (or one
+# racing a peer's provisioning) could inject input into the same pool emulator
+# at once. HOLD a lease for the run when (a) we are standalone — a parent that
+# exported ANDROID_SERIAL already holds it — and (b) the target is a pool
+# emulator (a physical device is not pool-managed). The EXIT trap releases it.
+if [[ -z "$PARENT_PROVIDED_SERIAL" ]]; then
+  if [[ -z "${EMU_REQUIRE_AVD:-}" && "${GITHUB_ACTIONS:-}" != "true" ]]; then
+    EMU_REQUIRE_AVD="$EMU_POOL_AVD"
+  fi
+  export EMU_REQUIRE_AVD
+  # Adopt a token a `setup-ar-emulator.sh` run just published for this session,
+  # so our OWN reservation is not mistaken for a peer's (no-op otherwise).
+  [[ -n "${EMU_LEASE_SESSION:-}" ]] || emu_lease_session_inherit >/dev/null 2>&1 || true
+  if emu_serial_alive "$SERIAL" adb && emu_serial_avd_matches "$SERIAL" adb; then
+    if ! emu_lease_acquire "$SERIAL" adb; then
+      echo "[ar-replay-qa] $SERIAL is a pool emulator reserved by another session —" >&2
+      echo "[ar-replay-qa] refusing to drive it. Provision your own, or inherit the" >&2
+      echo "[ar-replay-qa] reservation with: export EMU_LEASE_SESSION=<its token>" >&2
+      echo "[ar-replay-qa]   bash .claude/scripts/setup-ar-emulator.sh" >&2
+      exit 2
+    fi
+    echo "[ar-replay-qa] leased pool emulator $SERIAL for this run"
+  fi
+fi
 
 # ── Build + install ────────────────────────────────────────────────────────
 # The replay harness needs the *debug* APK: the bundled ARCore recording
@@ -153,7 +188,12 @@ adb -s "$SERIAL" logcat -c || true
 # on a chatty multi-minute Filament run, so stream live into the artifact dir.
 LOGCAT_PID=""
 stop_logcat() { [[ -n "$LOGCAT_PID" ]] && kill "$LOGCAT_PID" >/dev/null 2>&1 || true; }
-trap stop_logcat EXIT
+# Release the pool lease (if this standalone run took one) on EVERY exit path,
+# together with stopping the logcat stream (#2862). emu_lease_release_all is a
+# no-op when device-qa.sh owns the lease under its own pid, and it keeps a
+# sticky session reservation (it only drops the plain pid lease taken above).
+ar_cleanup() { stop_logcat; emu_lease_release_all 2>/dev/null || true; }
+trap ar_cleanup EXIT
 adb -s "$SERIAL" logcat -v threadtime > "$LOGCAT_FILE" 2>&1 &
 LOGCAT_PID=$!
 
@@ -221,7 +261,8 @@ done
 
 # Stop the logcat stream now every shard is done so the file is complete.
 stop_logcat
-trap - EXIT
+# Logcat is stopped; keep only the lease-release on the exit paths below (#2862).
+trap 'emu_lease_release_all 2>/dev/null || true' EXIT
 
 # ── No shard produced a summary ────────────────────────────────────────────
 # Either every shard assumeTrue-skipped (bundled recording absent — a sparse

--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -445,9 +445,19 @@ run_android() {
       && log "android recording: $ARTIFACTS/$(basename "$android_rec")"
   fi
 
-  # Maestro has no flat summary JSON; the wrapper's exit code is the verdict.
-  if [[ $rc -eq 0 ]]; then
+  # Maestro has no flat summary JSON, so the wrapper's exit code carries the
+  # verdict — but rc=0 alone is NOT proof of a pass, exactly as on the iOS leg
+  # above. Measured on this host (bash 3.2.57): when a call that aborts sits in
+  # a `||`-guarded list AND an EXIT trap is installed, the script dies with
+  # exit 0 because the `||` already reset `$?` — and qa-android-demos.sh now
+  # installs an EXIT trap (it releases its pool lease, #2862) and runs Maestro
+  # as `maestro_run … || MAESTRO_RC=$?`. Preserving `$?` in the trap does NOT
+  # help (it preserves the 0). Require the positive `[qa] PASS` marker, which
+  # only the genuine success path prints.
+  if [[ $rc -eq 0 ]] && grep -q '^\[qa\] PASS — ' "$ARTIFACTS/android-output.txt" 2>/dev/null; then
     record android passed "flow=$flow" "" "$(( $(date +%s) - started ))"
+  elif [[ $rc -eq 0 ]]; then
+    record android failed "qa-android-demos.sh exited 0 without its PASS marker — harness aborted mid-run (flow=$flow)" "" "$(( $(date +%s) - started ))"
   else
     record android failed "qa-android-demos.sh rc=$rc (flow=$flow)" "" "$(( $(date +%s) - started ))"
   fi

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -105,6 +105,16 @@ export EMU_REQUIRE_AVD
 # a peer's reservation to us.
 [[ -n "${EMU_LEASE_SESSION:-}" ]] || emu_lease_session_inherit >/dev/null 2>&1 || true
 
+# Release any lease THIS run takes below, on exit, however it ends (#2862
+# follow-up). Selecting a free serial is NOT enough: without holding it, a
+# second standalone run would pick the same nu emulator and both would drive it
+# — the exact concurrent-input collision #2862 set out to kill. The trap is a
+# no-op when device-qa.sh owns the lease under its own pid (it exported
+# ANDROID_SERIAL and we take the branch just below, acquiring nothing), and it
+# KEEPS a sticky session reservation (emu_lease_release_all skips sticky) — it
+# only drops the plain pid lease a standalone run takes on a nu pool emulator.
+trap 'emu_lease_release_all' EXIT
+
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then
   if ! emu_serial_alive "$ANDROID_SERIAL" adb; then
     echo "[qa] ERROR: ANDROID_SERIAL=$ANDROID_SERIAL is not a running emulator." >&2
@@ -115,7 +125,17 @@ elif reuse_serial="$(emu_lease_free_serial adb)"; then
   # Standalone invocation. Take a LEASABLE emulator, not merely a running one
   # (#2862): a peer session's reservation — or a stray non-pool AVD sitting on a
   # pool port — must never be driven here.
-  echo "[qa] using running emulator: $reuse_serial"
+  # HOLD it for the whole run: emu_lease_free_serial only reports that the serial
+  # is takeable right now; a racing peer can lease it in the same instant. Acquire
+  # it (pins a nu emulator under our pid, or adopts our session's sticky
+  # reservation), and refuse to drive it if we lost that race — piloting an
+  # emulator we could not reserve is precisely the collision this fixes.
+  if ! emu_lease_acquire "$reuse_serial" adb; then
+    echo "[qa] ERROR: lost the race to lease $reuse_serial — a peer session took it first." >&2
+    echo "[qa]        Provision your own:  bash .claude/scripts/setup-ar-emulator.sh" >&2
+    exit 1
+  fi
+  echo "[qa] using running emulator: $reuse_serial (leased)"
   # Pin downstream adb / android-CLI / Maestro to this serial so a peer pool
   # emulator booting mid-run can never steal the QA target.
   export ANDROID_SERIAL="$reuse_serial"

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -107,13 +107,24 @@ export EMU_REQUIRE_AVD
 
 # Release any lease THIS run takes below, on exit, however it ends (#2862
 # follow-up). Selecting a free serial is NOT enough: without holding it, a
-# second standalone run would pick the same nu emulator and both would drive it
+# second standalone run would pick the same un-leased emulator and both would drive it
 # — the exact concurrent-input collision #2862 set out to kill. The trap is a
 # no-op when device-qa.sh owns the lease under its own pid (it exported
 # ANDROID_SERIAL and we take the branch just below, acquiring nothing), and it
 # KEEPS a sticky session reservation (emu_lease_release_all skips sticky) — it
-# only drops the plain pid lease a standalone run takes on a nu pool emulator.
-trap 'emu_lease_release_all' EXIT
+# only drops the plain pid lease a standalone run takes on an un-leased pool
+# emulator.
+#
+# ⚠️ Installing an EXIT trap here has a cost, measured on this host (bash
+# 3.2.57): once a trap is set, a script that aborts inside a `||`-guarded list
+# dies with status 0 (the `||` already reset `$?`) — the false-green documented
+# in lib/maestro.sh. This script had NO EXIT trap before, and it runs Maestro as
+# `maestro_run … || MAESTRO_RC=$?` below. Preserving `$?` in the trap does not
+# fix it (it preserves the 0), so the defence is the positive `[qa] PASS`
+# marker this script prints on the genuine success path — device-qa.sh's
+# run_android now requires that marker, exactly as run_ios does. Do not grade
+# this script on its exit code alone.
+trap 'emu_lease_release_all 2>/dev/null || true' EXIT
 
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then
   if ! emu_serial_alive "$ANDROID_SERIAL" adb; then
@@ -127,7 +138,7 @@ elif reuse_serial="$(emu_lease_free_serial adb)"; then
   # pool port — must never be driven here.
   # HOLD it for the whole run: emu_lease_free_serial only reports that the serial
   # is takeable right now; a racing peer can lease it in the same instant. Acquire
-  # it (pins a nu emulator under our pid, or adopts our session's sticky
+  # it (pins an un-leased emulator under our pid, or adopts our session's sticky
   # reservation), and refuse to drive it if we lost that race — piloting an
   # emulator we could not reserve is precisely the collision this fixes.
   if ! emu_lease_acquire "$reuse_serial" adb; then

--- a/.claude/scripts/setup-ar-emulator.sh
+++ b/.claude/scripts/setup-ar-emulator.sh
@@ -157,7 +157,17 @@ AVD_NAME="$EMU_POOL_AVD"
 if [[ -z "${EMU_REQUIRE_AVD:-}" && "${GITHUB_ACTIONS:-}" != "true" ]]; then
   EMU_REQUIRE_AVD="$AVD_NAME"
 fi
-[[ -n "${EMU_LEASE_SESSION:-}" ]] || EMU_LEASE_SESSION="$(emu_lease_session_new)"
+# Track whether WE minted the token (the caller passed none). Only a minted
+# token is published to the handoff file at the end (#2862): a caller that
+# exported its own token — device-qa.sh — already holds the reservation via that
+# shared export and needs no handoff, and re-publishing it would widen the
+# documented handoff-window leak (a concurrent session inheriting the token and
+# taking the emulator) to that caller too.
+EMU_LEASE_SESSION_MINTED=false
+if [[ -z "${EMU_LEASE_SESSION:-}" ]]; then
+  EMU_LEASE_SESSION="$(emu_lease_session_new)"
+  EMU_LEASE_SESSION_MINTED=true
+fi
 export EMU_REQUIRE_AVD EMU_LEASE_SESSION
 AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
 AVD_CONFIG="$AVD_HOME/$AVD_NAME.avd/config.ini"
@@ -1481,7 +1491,15 @@ fi
 # adopt it once.
 if ! $CHECK_ONLY && ! $STOP_AFTER && [[ -n "${serial:-}" ]]; then
   if emu_lease_mark_sticky "$serial" "setup-ar-emulator"; then
-    emu_lease_session_publish "$EMU_LEASE_SESSION"
+    # Publish the token for a QA script this session runs next in a SEPARATE
+    # shell to inherit — ONLY when we minted it. If the caller exported its own
+    # token it already shares the reservation, and publishing would let a
+    # concurrent peer inherit the token first and steal the emulator (the
+    # documented handoff-window leak). The sticky lease itself still reserves the
+    # emulator against every peer regardless; the handoff is only the token relay.
+    if [[ "$EMU_LEASE_SESSION_MINTED" == "true" ]]; then
+      emu_lease_session_publish "$EMU_LEASE_SESSION"
+    fi
   fi
 fi
 
@@ -1490,8 +1508,13 @@ if $STOP_AFTER; then
   log "emulator stopped. Re-run without --stop to leave it warm for QA."
 else
   log "emulator left running for QA on serial ${serial:-emulator-5554}. next steps:"
-  log "  export ANDROID_SERIAL=${serial:-emulator-5554}   # pin QA to the leased emulator"
-  log "  export EMU_LEASE_SESSION=${EMU_LEASE_SESSION}   # inherit this reservation (#2862)"
+  log "  # Export the token FIRST, in the shell that will drive QA — it makes THIS"
+  log "  # session the owner. The sticky reservation already guards the emulator"
+  log "  # against peers, but a token left only in the handoff file can be adopted"
+  log "  # by the first QA script to start within ${EMU_LEASE_HANDOFF_WINDOW}s — including a"
+  log "  # CONCURRENT session — which then drives the same emulator (#2862)."
+  log "  export EMU_LEASE_SESSION=${EMU_LEASE_SESSION}"
+  log "  export ANDROID_SERIAL=${serial:-emulator-5554}   # pin QA to this emulator"
   log "  source .claude/scripts/lib/android-cli.sh && android_cli_ensure"
   log "  android run --apks <apk> --activity io.github.sceneview.demo/.MainActivity"
   log "  stop it with: android emulator stop $AVD_NAME"

--- a/.claude/scripts/test-emulator-lease.sh
+++ b/.claude/scripts/test-emulator-lease.sh
@@ -16,7 +16,10 @@
 #   4. an expired sticky lease is reclaimed (no permanent pool deadlock);
 #   5. an emulator whose AVD is not the pool AVD is never leasable;
 #   6. a plain pid lease still behaves exactly as before (no regression);
-#   7. the handoff token is inherited AT MOST once.
+#   7. the handoff token is inherited AT MOST once;
+#   8. a LIVE plain-pid lease blocks a peer acquire, and is takeable again once
+#      its owner dies — the standalone qa-android-demos.sh / ar-replay-qa.sh
+#      hold-the-lease fix (#2862 follow-up).
 #
 # Hermetic: a stub `adb` and a scratch EMU_LEASE_DIR. No emulator, no SDK, no
 # host state touched — safe to run anywhere, including CI.
@@ -187,6 +190,33 @@ THIRD="$(EMU_LEASE_SESSION="" EMU_LEASE_HANDOFF_WINDOW=0 bash -c '
 [ -z "$THIRD" ] \
     && ok "handoff window of 0 disables inheritance" \
     || bad "token inherited with the window disabled (got '$THIRD')"
+
+# ── 8. A LIVE plain-pid lease on a nu emulator blocks a peer acquire. ───────
+# The standalone qa-android-demos.sh / ar-replay-qa.sh fix (#2862 follow-up)
+# rests on this: selecting a free serial is not enough — the run ACQUIRES it,
+# and a second standalone run racing for the same nu emulator must be refused.
+rm -f "$EMU_LEASE_DIR"/*.lease 2>/dev/null || true
+sleep 30 & HOLDER_PID=$!
+# A live pid owns a plain (non-sticky) lease on the nu emulator.
+printf '%s\nmode=pid\nsession=\navd=Pixel_7a\nsince=%s\nlabel=\n' \
+  "$HOLDER_PID" "$(date +%s)" > "$EMU_LEASE_DIR/emulator-5554.lease"
+if EMU_LEASE_SESSION="" bash -c '
+     export EMU_LEASE_DIR="'"$EMU_LEASE_DIR"'"; source "'"$LIB"'"
+     emu_lease_acquire emulator-5554 "'"$ADB"'"' >/dev/null 2>&1; then
+    bad "a peer acquired a nu emulator already held by a live pid lease (collision)"
+else
+    ok "a live plain-pid lease blocks a peer acquire (standalone qa hold-lease fix)"
+fi
+kill "$HOLDER_PID" 2>/dev/null || true
+wait "$HOLDER_PID" 2>/dev/null || true
+# Owner now dead → the ownerless lease is takeable again (no permanent wedge).
+if EMU_LEASE_SESSION="" bash -c '
+     export EMU_LEASE_DIR="'"$EMU_LEASE_DIR"'"; source "'"$LIB"'"
+     emu_lease_acquire emulator-5554 "'"$ADB"'"' >/dev/null 2>&1; then
+    ok "once the holder dies the ownerless pid lease is takeable again"
+else
+    bad "ownerless pid lease not reclaimable after the holder died"
+fi
 
 echo ""
 echo "  $PASS passed, $FAIL failed"

--- a/.claude/scripts/test-emulator-lease.sh
+++ b/.claude/scripts/test-emulator-lease.sh
@@ -191,19 +191,19 @@ THIRD="$(EMU_LEASE_SESSION="" EMU_LEASE_HANDOFF_WINDOW=0 bash -c '
     && ok "handoff window of 0 disables inheritance" \
     || bad "token inherited with the window disabled (got '$THIRD')"
 
-# ── 8. A LIVE plain-pid lease on a nu emulator blocks a peer acquire. ───────
+# ── 8. A live pid lease on an un-leased emulator blocks a peer acquire. ───
 # The standalone qa-android-demos.sh / ar-replay-qa.sh fix (#2862 follow-up)
 # rests on this: selecting a free serial is not enough — the run ACQUIRES it,
-# and a second standalone run racing for the same nu emulator must be refused.
+# and a second standalone run racing for the same un-leased emulator must be refused.
 rm -f "$EMU_LEASE_DIR"/*.lease 2>/dev/null || true
 sleep 30 & HOLDER_PID=$!
-# A live pid owns a plain (non-sticky) lease on the nu emulator.
+# A live pid owns a plain (non-sticky) lease on the un-leased emulator.
 printf '%s\nmode=pid\nsession=\navd=Pixel_7a\nsince=%s\nlabel=\n' \
   "$HOLDER_PID" "$(date +%s)" > "$EMU_LEASE_DIR/emulator-5554.lease"
 if EMU_LEASE_SESSION="" bash -c '
      export EMU_LEASE_DIR="'"$EMU_LEASE_DIR"'"; source "'"$LIB"'"
      emu_lease_acquire emulator-5554 "'"$ADB"'"' >/dev/null 2>&1; then
-    bad "a peer acquired a nu emulator already held by a live pid lease (collision)"
+    bad "a peer acquired an un-leased emulator already held by a live pid lease (collision)"
 else
     ok "a live plain-pid lease blocks a peer acquire (standalone qa hold-lease fix)"
 fi

--- a/changelog.d/2862-hold-lease-in-qa-callers.md
+++ b/changelog.d/2862-hold-lease-in-qa-callers.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+- Device-QA emulator pool (follow-up to #2862): the scripts that actually DRIVE
+  a pool emulator now HOLD a lease for their whole run, closing the last
+  concurrent-input gap where two sessions could inject taps/swipes into the same
+  running AVD. `qa-android-demos.sh` and `ar-replay-qa.sh` used to pick a running
+  emulator without acquiring it, so a second standalone run drove the same one;
+  they now `emu_lease_acquire` it (or adopt this session's sticky reservation),
+  refuse one a peer reserved, and release it on exit. ([#2862](https://github.com/sceneview/sceneview/issues/2862))
+- `setup-ar-emulator.sh` now publishes its session token to the handoff file
+  only when it minted the token itself. A caller that already exported one
+  (`device-qa.sh`) no longer has its reservation inherited — and the emulator
+  stolen — by a concurrent session inside the handoff window, and the ad-hoc
+  "next steps" hint leads with the token export that makes the reservation
+  exclusive. ([#2862](https://github.com/sceneview/sceneview/issues/2862))

--- a/changelog.d/2862-hold-lease-in-qa-callers.md
+++ b/changelog.d/2862-hold-lease-in-qa-callers.md
@@ -1,11 +1,24 @@
 <!-- category: Fixed -->
 - Device-QA emulator pool (follow-up to #2862): the scripts that actually DRIVE
-  a pool emulator now HOLD a lease for their whole run, closing the last
-  concurrent-input gap where two sessions could inject taps/swipes into the same
+  a pool emulator now HOLD a lease for their whole run, closing the main
+  remaining gap where two sessions could inject taps/swipes into the same
   running AVD. `qa-android-demos.sh` and `ar-replay-qa.sh` used to pick a running
   emulator without acquiring it, so a second standalone run drove the same one;
   they now `emu_lease_acquire` it (or adopt this session's sticky reservation),
-  refuse one a peer reserved, and release it on exit. ([#2862](https://github.com/sceneview/sceneview/issues/2862))
+  refuse one a peer reserved, and release it on exit. `ar-replay-qa.sh` also
+  refuses a pool-port emulator it cannot identify (wrong AVD, or a console that
+  does not answer — most likely precisely when a peer is driving it) instead of
+  falling through and driving it unleased. Not closed by this change: a serial
+  passed in via a pre-exported `ANDROID_SERIAL` is still trusted as "the caller
+  holds the lease", and `device-qa.sh` still drives its emulator on a
+  best-effort acquire. ([#2862](https://github.com/sceneview/sceneview/issues/2862))
+- `device-qa.sh` now grades its **android** leg on the positive `[qa] PASS`
+  marker in addition to the exit code, as the iOS leg already did. Holding the
+  pool lease means `qa-android-demos.sh` installs an EXIT trap, and on macOS
+  bash 3.2 (measured: 3.2.57) a script that aborts inside a `||`-guarded list
+  with a trap installed exits **0** — which would have graded a crashed sweep
+  as `passed`. Preserving `$?` inside the trap does not help: the `||` has
+  already reset it. ([#2862](https://github.com/sceneview/sceneview/issues/2862))
 - `setup-ar-emulator.sh` now publishes its session token to the handoff file
   only when it minted the token itself. A caller that already exported one
   (`device-qa.sh`) no longer has its reservation inherited — and the emulator


### PR DESCRIPTION
Follow-up to #2862. Two concurrent sessions could inject taps, swipes and installs into the **same running AVD** — observed live during visual device-QA of #2851: a bottom sheet opened on its own and the launcher flashed while the demo was still the foregrounded top activity, with no crash.

## Why the existing fix did not cover it

#2862 made `setup-ar-emulator.sh` leave a **sticky reservation** behind, and that part works — the live lease on disk is `mode=sticky`. The hole was one level up: the scripts that actually **drive** a device took no lease of their own, so an un-leased emulator was still fair game for two runs at once.

| Hole | Before | Now |
|---|---|---|
| `qa-android-demos.sh` (standalone) | selected a running emulator, drove it, acquired nothing | acquires it, fails loudly if a peer won the race, releases on exit |
| `ar-replay-qa.sh` | entirely outside the lease protocol | inherits the session token, acquires the pool emulator, refuses one it cannot identify, releases on exit |
| `setup-ar-emulator.sh` | always republished its token to the handoff file | publishes only when it **minted** the token, matching the convention `device-qa.sh` already used |

A caller that exported its own token no longer has its reservation adopted — and its emulator taken — by a concurrent session inside the 900 s handoff window.

## Second commit: what an independent adversarial review caught

`7d524d729` fixes three things found by reviewing `a06d0c514`, two of which were mine:

- **Holding the lease armed a false-green.** `qa-android-demos.sh` had no EXIT trap before; it does now. Measured on this host (bash 3.2.57): a script that aborts inside a `||`-guarded list **with a trap installed** exits **0**, and that script runs Maestro as `maestro_run … || MAESTRO_RC=$?` while `device-qa.sh` graded the leg on the exit code alone. A crashed sweep would have graded `passed`. Preserving `$?` in the trap does **not** help — the `||` already reset it to 0 (verified by probe, all variants still returned 0). The real defence is the positive `[qa] PASS` marker, which the script already prints and which `run_ios` already requires; `run_android` now requires it too.
- **`ar-replay-qa.sh` fell through silently** when a pool-port emulator had the wrong AVD *or* a mute console — and a console goes mute mainly when the emulator is busy, i.e. exactly when a peer is driving it. It now refuses instead of driving it unleased.
- **French in committed comments** ("nu emulator" → "un-leased"), and a changelog sentence claiming this closed the *last* gap.

## Not closed by this PR — stated explicitly

- A pre-exported `ANDROID_SERIAL` is still trusted as "the caller holds the lease".
- `device-qa.sh` still drives its emulator on a best-effort `emu_lease_acquire … || true`.
- A follow-up worth doing: the same positive-marker treatment for the `ar` leg.

## Verification

- `bash -n` on all five scripts.
- `shellcheck -S warning` clean on the changed lines (`device-qa.sh:94` SC2164 is pre-existing and untouched).
- `test-emulator-lease.sh` — **13 passed / 0 failed**, CI-wired in `ci.yml` → `repo-hygiene`. New case 8 pins the mechanism the fix rests on: a live pid lease blocks a peer acquire and becomes takeable once its owner dies (no permanent pool wedge).
- New grading simulated against the script's real PASS line: genuine pass → `passed`, rc=0 without marker → `failed`, rc=1 → `failed`.

Not run: a full on-device `device-qa.sh` pass — this touches the QA harness itself, not library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)