### PR TITLE
fix(android-demo): make the materials demo render a reproducible frame (#2874)

### DIFF
--- a/.claude/scripts/capture-play-store-screenshots.sh
+++ b/.claude/scripts/capture-play-store-screenshots.sh
@@ -94,8 +94,17 @@ android_cli_ensure || true
 #                    ship bar) — a weak store frame, not a fog showcase (#2854).
 #   double-pendulum  ignores camera_distance (own auto-fit); its auto-fit frame is
 #                    a tiny linkage in a ~95%-black rectangle — un-reframable (#2854).
-#   materials        picked a different HDRI each launch (not reproducible) and the
-#                    subject stayed small at every distance (#2874).
+#   materials        was not reproducible: it opened on a STREAMED slug, so the
+#                    subject depended on the API key / network / cache (a streamed
+#                    insect on one device, the bundled helmet on another), and it
+#                    drew the `studio_2k` skybox — a living-room interior, despite
+#                    its "neutral / studio / product" catalog tags — behind an
+#                    orbiting camera, so the backdrop changed with capture timing.
+#                    The subject also stayed small at every distance. The DEMO side
+#                    is fixed (#2874: bundled default subject, one fixed studio
+#                    HDRI, subject-independent framing) and the id is eligible
+#                    again — but do NOT add it back here without capturing it and
+#                    LOOKING at the frame against the other slots first.
 #   geometry         primitives are laid out wider than a phone-portrait frame;
 #                    every distance clipped one at an edge (#2873). Demo-side fix.
 #   animation        a static screenshot of a skeletal-animation demo is just a

--- a/changelog.d/2874-materials-deterministic-frame.md
+++ b/changelog.d/2874-materials-deterministic-frame.md
@@ -1,0 +1,33 @@
+<!-- category: Fixed -->
+- **Demo: the `materials` demo now produces a reproducible frame (#2874).** Two
+  things made it non-reproducible, and both are fixed. **(1) The subject was
+  streamed.** The **PBR Materials** section opened on a Sketchfab slug, so what
+  the first frame showed depended on the API key, the network and the disk cache
+  — two captures of the same demo id from the same build showed a different
+  model. It now opens on a **bundled** subject: Khronos' `ToyCar`, already in the
+  APK, whose GLB declares `KHR_materials_clearcoat`, `KHR_materials_sheen` and
+  `KHR_materials_transmission` — the three extension families the section is
+  about, on the car body, the seat fabric and the windows. That is strictly more
+  than the old offline path showed, since every slug fell back to
+  `khronos_damaged_helmet.glb`, which declares no `KHR_materials_*` extension at
+  all. The streamed catalogue is unchanged and stays one chip tap away, so
+  variety survives as an explicit user action. **(2) The backdrop was a
+  photograph swept by the camera.** The sections drew the `studio_2k` skybox,
+  which — despite its `neutral / studio / product` tags in `assets/catalog.json`
+  — decodes to a domestic living-room interior; drawn behind a camera that
+  orbits 360° every 18 s, one environment shows a different room feature in
+  every capture, which is what #2874 saw as "a different HDRI each launch".
+  Measured: swapping to a genuine photo-studio HDRI did **not** fix it (two
+  cold launches came back with the same subject against the studio's dark side
+  and its bright sweep), so the material sections now share one constant,
+  `MATERIALS_SHOWCASE_HDR = environments/studio_warm_2k.hdr`, used as **IBL
+  only** — the materials still read the environment through their reflections,
+  the backdrop is the demo's own surface at every orbit angle. Framing is
+  subject-independent too: every chip is normalised to the same size and viewed
+  from the same orbit radius instead of each model's own `scaleToUnits`
+  (0.15 m for the beetle, 0.90 m for the sofa), so the subject no longer reads
+  as a speck — measured on the phone capture, its base now spans 98–100% of the
+  frame width. The cold-launch contract (default subject is bundled, never
+  streamed) is asserted by `MaterialsSubjectsTest` on the JVM, because this
+  defect is invisible to a per-frame check: every capture looked fine, they just
+  differed from each other.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoEnvironment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoEnvironment.kt
@@ -54,10 +54,80 @@ fun rememberModelDemoEnvironment(environmentLoader: EnvironmentLoader): Environm
     // (no skybox) so the model keeps floating on the demo's surface background.
     val hdrEnvironment = rememberHDREnvironment(
         environmentLoader,
-        "environments/studio_2k.hdr",
+        MODEL_DEMO_HDR,
         createSkybox = false,
     )
     // Neutral fallback while the HDR is still decoding — avoids a black flash.
+    val fallbackEnvironment = rememberEnvironment(environmentLoader)
+    return hdrEnvironment ?: fallbackEnvironment
+}
+
+/** The single HDRI [rememberModelDemoEnvironment] lights every model demo with. */
+const val MODEL_DEMO_HDR: String = "environments/studio_2k.hdr"
+
+/**
+ * The **one** HDRI the material showcases light with.
+ *
+ * ## Why it is a named constant, and why it is not `studio_2k` (#2874)
+ *
+ * The `materials` demo has to produce the same frame on every cold launch: it is
+ * a store-screenshot candidate, a Maestro subject and a listing-diff input, and
+ * all three break when the lighting can vary run to run. Naming the HDRI here —
+ * one constant, shared by every section of the demo — makes "which environment
+ * does this demo use?" answerable by reading one line instead of auditing each
+ * section's own `rememberHDREnvironment` call.
+ *
+ * The sections used to draw the **`studio_2k`** skybox, and #2874 reported that
+ * as "the demo picks a different HDRI on each launch — a Christmas-tree room, a
+ * window with plants". It never picked anything: decoding the asset shows
+ * `studio_2k.hdr` is a **domestic living-room interior** (sofa, lamps, decorated
+ * tree, windows) despite the `neutral / studio / product` tags it carries in
+ * `assets/catalog.json`. See [rememberMaterialsShowcaseEnvironment] for why the
+ * skybox is no longer drawn at all.
+ *
+ * `studio_warm_2k.hdr` is the actual photo studio of the two — a dark surround,
+ * a seamless white sweep and a few big softboxes — so as an IBL it gives
+ * clearcoat, transmission and sheen the broad, directional highlights they need
+ * to read as materials rather than as flat colour.
+ *
+ * Demos whose *subject* is the environment
+ * ([io.github.sceneview.demo.demos.LightingLabDemo]) pick their own HDRI on
+ * purpose and must not use this.
+ */
+const val MATERIALS_SHOWCASE_HDR: String = "environments/studio_warm_2k.hdr"
+
+/**
+ * Image-based lighting for the material showcases — [MATERIALS_SHOWCASE_HDR],
+ * IBL only, **no skybox**.
+ *
+ * ## Why no skybox (#2874) — measured, not assumed
+ *
+ * Drawing the skybox is what made the demo's *backdrop* unreproducible, and
+ * switching HDRIs does not fix it. Two cold launches of the `materials` demo,
+ * same build, same device, captured with a drawn `studio_warm` skybox came back
+ * with the same subject in front of two completely different backgrounds: the
+ * studio's dark surround in one, its bright white sweep in the other. The cause
+ * is not the asset — it is that the hero camera orbits 360° every 18 s, so the
+ * capture sees whatever part of the environment sphere the orbit happens to be
+ * facing. Any photographic HDRI has that property; the fix is to stop painting
+ * it behind the subject.
+ *
+ * With IBL only, the subject sits on the demo's own flat surface background —
+ * identical at every yaw — while the *materials themselves* still read the
+ * environment: clearcoat highlights, sheen falloff and transmission all sample
+ * the same studio IBL as before. What is lost is a photo behind the model; what
+ * is gained is a frame that two captures agree on.
+ *
+ * Falls back to the neutral default while the HDR decodes, so the first frames
+ * never flash black.
+ */
+@Composable
+fun rememberMaterialsShowcaseEnvironment(environmentLoader: EnvironmentLoader): Environment {
+    val hdrEnvironment = rememberHDREnvironment(
+        environmentLoader,
+        MATERIALS_SHOWCASE_HDR,
+        createSkybox = false,
+    )
     val fallbackEnvironment = rememberEnvironment(environmentLoader)
     return hdrEnvironment ?: fallbackEnvironment
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -35,18 +35,18 @@ import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.ErrorScrim
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.rememberMaterialsShowcaseEnvironment
 import io.github.sceneview.demo.common.rememberModelDemoEnvironment
+import io.github.sceneview.demo.demos.internal.MaterialsSubject
+import io.github.sceneview.demo.demos.internal.MaterialsSubjects
 import io.github.sceneview.demo.initialDemoMode
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
-import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
-import io.github.sceneview.environment.rememberHDREnvironment
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Size
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
-import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
@@ -126,19 +126,28 @@ private fun ModeSelector(
 // extension-bearing models so the demo answers "what do KHR_materials_sheen
 // / _transmission / _iridescence look like in SceneView?" at a glance.
 //
-// Lighting uses the studio HDR so reflections + IBL hit the streamed
-// extension materials cleanly — sheen, transmission, and iridescence all
-// rely heavily on environment lighting to read.
+// Lighting uses the studio HDR as IBL (no skybox) so reflections hit the
+// extension materials cleanly — sheen, transmission, clearcoat and iridescence
+// all rely heavily on environment lighting to read — while the backdrop stays
+// the demo's own flat surface at every orbit angle. One shared constant:
+// [io.github.sceneview.demo.common.MATERIALS_SHOWCASE_HDR].
+//
+// **The first frame is deterministic (#2874).** The section opens on the
+// bundled [MaterialsSubjects.BUNDLED_DEFAULT] — Khronos' ToyCar, whose GLB
+// carries clearcoat + sheen + transmission — so what it renders on a cold
+// launch does not depend on an API key, the network or the disk cache.
+// Selecting a streamed chip is an explicit user action. Before this, the
+// section opened on streamed slug 0 and rendered either the Sketchfab model
+// or its bundled fallback depending on connectivity, which made the demo
+// unusable as a store frame or a screenshot-diff subject.
 //
 // Honours the umbrella's hard rules:
 //   - **No Sketchfab WebView / external link.** Local file URLs only.
-//   - **No network required to render something useful.** Empty key / cold
-//     cache → resolver stages the bundled fallback for each slug. The
-//     demo's fallback assets do not carry the actual extension materials
-//     (those are author-controlled) but they keep the viewport non-empty
-//     so the comparison UX stays understandable.
+//   - **No network required to render something useful.** The default subject
+//     is bundled outright, and a streamed chip whose resolve fails still
+//     stages its bundled fallback through the resolver.
 //
-// @see SampleAssets for the curated `materials` category.
+// @see MaterialsSubjects for the subject list + framing / determinism contract.
 // @see SketchfabAssetResolver for the resolve / fallback contract.
 
 @Composable
@@ -150,13 +159,25 @@ private fun PbrSection(
     val context = LocalContext.current
     val resolver = remember(context) { SketchfabAssetResolver.getInstance(context) }
 
-    // Three curated `materials` slugs — sheen, transmission, iridescence.
-    // Stage 2 keeps the count low so the offline-fallback footprint stays
-    // bounded; Stage 3 will expand once a CI maintenance cron validates each
-    // slug weekly.
-    val slugs = remember { SampleAssets.byCategory["materials"].orEmpty() }
-    var selectedIndex by remember { mutableStateOf(0) }
-    val selectedSlug = slugs.getOrNull(selectedIndex)
+    // The chips: the bundled default first, then the three curated `materials`
+    // slugs — sheen, transmission, iridescence. Stage 2 keeps the streamed count
+    // low so the offline-fallback footprint stays bounded; Stage 3 will expand
+    // once a CI maintenance cron validates each slug weekly.
+    //
+    // Cold launch lands on the BUNDLED subject, never a streamed one (#2874):
+    // what a streamed slug resolves to depends on the API key, the network and
+    // the cache, so the demo used to render a different subject run to run —
+    // measured as an insect on one device and the helmet fallback on another,
+    // from the same build. The determinism contract lives in [MaterialsSubjects]
+    // and is asserted by `MaterialsSubjectsTest`; the streamed catalogue is
+    // untouched and stays one tap away.
+    val subjects = remember { MaterialsSubjects.all() }
+    var selectedIndex by remember { mutableIntStateOf(MaterialsSubjects.DEFAULT_INDEX) }
+    val selectedSubject = subjects.getOrNull(selectedIndex)
+    // Non-null only while a STREAMED chip is selected — the resolve pipeline
+    // below keys off it, and a null value means "the bundled subject is on
+    // screen, nothing to resolve".
+    val selectedSlug = (selectedSubject as? MaterialsSubject.Streamed)?.slug
 
     // Bumped by the error scrim's Retry button. It is a `produceState` key so a
     // tap re-runs the resolve coroutine for the same slug instead of leaving the
@@ -171,23 +192,19 @@ private fun PbrSection(
     val modelLoader = rememberModelLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
 
-    // Studio HDR — extension materials (sheen / transmission / iridescence)
-    // are heavily IBL-dependent and read flatly under default ambient light.
-    // Skybox enabled so the user can see the same environment the materials
-    // are reflecting / refracting.
-    val hdrEnvironment = rememberHDREnvironment(
-        environmentLoader,
-        "environments/studio_2k.hdr",
-        createSkybox = true,
-    )
-    val fallbackEnvironment = rememberEnvironment(environmentLoader)
-    val activeEnvironment = hdrEnvironment ?: fallbackEnvironment
+    // The one showcase IBL, shared with the Streaming section (#2874). Extension
+    // materials (sheen / transmission / iridescence / clearcoat) are heavily
+    // IBL-dependent and read flatly under default ambient light. No skybox: the
+    // camera orbits, so a drawn environment put a different backdrop behind the
+    // subject on every capture — see the helper's KDoc for the measurement.
+    val activeEnvironment = rememberMaterialsShowcaseEnvironment(environmentLoader)
 
     // A failed resolve is surfaced as [MaterialResolveState.Error] instead of
     // being swallowed into a `null` path that hangs the loading scrim forever
     // (#2088). `retryTick` re-runs the resolve when the user taps Retry.
-    // A null slug (empty registry category) exits to [MaterialResolveState.Empty]
-    // so the loading scrim is not shown forever (#2122).
+    // A null slug — the bundled chip is selected (#2874), or the registry
+    // category is empty (#2122) — exits to [MaterialResolveState.Empty] and
+    // leaves the bundled instance driving the viewport.
     val resolveState: MaterialResolveState by produceState<MaterialResolveState>(
         initialValue = MaterialResolveState.Loading,
         key1 = resolver,
@@ -207,7 +224,13 @@ private fun PbrSection(
     }
     val resolvedFile = (resolveState as? MaterialResolveState.Resolved)?.file
     val resolveError = (resolveState as? MaterialResolveState.Error)?.message
-    val isEmpty = resolveState is MaterialResolveState.Empty
+
+    // The bundled default subject, loaded from `assets/` — no network, no cache,
+    // no API key, the same bytes on every launch. Loaded unconditionally (and
+    // kept loaded while a streamed chip is on screen) so its slot stays stable
+    // and so switching back to it is instant.
+    val bundledInstance =
+        rememberModelInstance(modelLoader, MaterialsSubjects.BUNDLED_DEFAULT.assetPath)
 
     // Load the resolved file (streamed GLB or bundled fallback) through
     // [rememberFileModelInstance] → `ModelLoader.loadModelInstance("file://…")`,
@@ -219,7 +242,13 @@ private fun PbrSection(
     // resolved instantly offline (#2302 — same root cause as #1422 / the
     // Multi-Model section of ModelViewerDemo). Called unconditionally so its
     // `produceState` slot stays stable (#1464).
-    val modelInstance = rememberFileModelInstance(modelLoader, resolvedFile)
+    val streamedInstance = rememberFileModelInstance(modelLoader, resolvedFile)
+
+    // What is actually on screen: the bundled subject unless a streamed chip is
+    // selected. Never a silent fallback between the two — a streamed chip that
+    // fails shows its error scrim rather than quietly swapping the subject,
+    // which is the ambiguity #2874 was about.
+    val modelInstance = if (selectedSlug == null) bundledInstance else streamedInstance
 
     val firstFrame = rememberFirstFrameState()
 
@@ -235,41 +264,43 @@ private fun PbrSection(
                     .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                slugs.forEachIndexed { index, slug ->
+                subjects.forEachIndexed { index, subject ->
                     FilterChip(
                         selected = index == selectedIndex,
                         onClick = { selectedIndex = index },
                         // displayName + the KHR_* tag give the user a clear
                         // read of "which extension am I looking at" without
-                        // needing a second line of copy. tags is a
-                        // List<String> from the registry — we surface the
-                        // first one (`KHR_materials_*`).
-                        label = { Text(slug.displayName) },
+                        // needing a second line of copy. The tag comes from the
+                        // registry's `tags[0]` for a streamed slug, and from the
+                        // GLB's own `extensionsUsed` for the bundled default.
+                        label = { Text(subject.displayName) },
                     )
                 }
             }
-            // Extension tag — the registry's `tags[0]` is the
-            // `KHR_materials_*` extension name. Displayed below the chips so
-            // the user can map the chip choice to the glTF extension being
-            // demonstrated.
-            selectedSlug?.let { slug ->
-                val extension = slug.tags.firstOrNull().orEmpty()
-                if (extension.isNotBlank()) {
+            // Extension tag — the `KHR_materials_*` family this subject
+            // demonstrates. Displayed below the chips so the user can map the
+            // chip choice to the glTF extension being demonstrated.
+            selectedSubject?.let { subject ->
+                if (subject.extensionTag.isNotBlank()) {
                     Text(
-                        text = extension,
+                        text = subject.extensionTag,
                         style = MaterialTheme.typography.labelMedium,
                     )
                 }
                 Text(
-                    text = stringResource(R.string.demo_materials_credit, slug.author),
+                    text = stringResource(R.string.demo_materials_credit, subject.author),
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
         },
     ) {
+        // One orbit radius for every chip (#2874). The subject is normalised to
+        // [MaterialsSubjects.FRAMING_UNITS] below, so the camera does not have to
+        // move when the chip changes — and no subject reads as a speck because it
+        // happens to be a 15 cm beetle next to a 90 cm sofa.
         val cameraManipulator = rememberHeroOrbitCameraManipulator(
             trigger = modelInstance != null,
-            radius = 1.2f,
+            radius = MaterialsSubjects.ORBIT_RADIUS_METERS,
             yHeight = 0f,
             durationMillis = 18_000,
         )
@@ -284,29 +315,45 @@ private fun PbrSection(
                 cameraManipulator = cameraManipulator,
             ) {
                 val instance = modelInstance
-                val slug = selectedSlug
-                if (instance != null && slug != null) {
+                if (instance != null) {
+                    // Every subject is normalised to the SAME size rather than to
+                    // its own `scaleToUnits` (#2874) — the camera is fixed, so a
+                    // per-model scale is what made one chip fill the viewport and
+                    // the next one read as a speck.
                     ModelNode(
                         modelInstance = instance,
-                        scaleToUnits = slug.scaleToUnits,
+                        scaleToUnits = MaterialsSubjects.FRAMING_UNITS,
                     )
                 }
             }
             // Mutually exclusive with LoadingScrim: a resolve failure shows the
             // error scrim (with Retry) instead of hanging on "Streaming…" (#2088).
-            // An empty registry category (no slugs) shows nothing — the viewport
-            // is already blank; do not show "Loading…" forever (#2122).
-            if (resolveError != null) {
+            // Only a STREAMED chip can fail to resolve; the bundled default has
+            // nothing to resolve, so it never reaches the error branch.
+            if (resolveError != null && selectedSlug != null) {
                 ErrorScrim(
                     message = resolveError,
                     onRetry = { retryTick++ },
                     label = stringResource(R.string.demo_materials_error),
                     retryLabel = stringResource(R.string.demo_materials_retry),
                 )
-            } else if (!isEmpty) {
+            } else {
+                // Covers both subjects: the bundled GLB decoding on a cold start
+                // and a streamed slug still resolving. `modelInstance` is the
+                // single source of "is there something to show yet", so an empty
+                // registry category can no longer strand the scrim (#2122) —
+                // there is always a bundled subject behind it. The label follows
+                // the subject: the default one is decoded from `assets/`, and
+                // saying "Streaming…" over it would be a lie.
                 LoadingScrim(
                     loading = modelInstance == null,
-                    label = stringResource(R.string.demo_materials_loading),
+                    label = stringResource(
+                        if (selectedSlug == null) {
+                            R.string.demo_materials_loading_bundled
+                        } else {
+                            R.string.demo_materials_loading
+                        }
+                    ),
                 )
             }
         }
@@ -422,16 +469,10 @@ private fun StreamingSection(
     val materialLoader = rememberMaterialLoader(engine)
     val environmentLoader = rememberEnvironmentLoader(engine)
 
-    // Studio HDR + skybox — metallic variants read flat without an
-    // environment to reflect. Falls back to the neutral IBL while the HDR
-    // streams in (rememberHDREnvironment returns null until decoded).
-    val hdrEnvironment = rememberHDREnvironment(
-        environmentLoader,
-        "environments/studio_2k.hdr",
-        createSkybox = true,
-    )
-    val fallbackEnvironment = rememberEnvironment(environmentLoader)
-    val activeEnvironment = hdrEnvironment ?: fallbackEnvironment
+    // The same showcase IBL the PBR section uses — metallic variants read flat
+    // without an environment to reflect. One shared constant so the two material
+    // sections cannot drift apart visually (#2874).
+    val activeEnvironment = rememberMaterialsShowcaseEnvironment(environmentLoader)
 
     // One MaterialInstance per variant, allocated up front and owned by the
     // composition. Pre-allocating all of them (instead of one re-keyed
@@ -685,8 +726,10 @@ private sealed interface MaterialResolveState {
     data object Loading : MaterialResolveState
 
     /**
-     * No slug available (empty registry category — the materials category has no entries).
-     * The viewport stays blank; the loading scrim is not shown (#2122).
+     * Nothing to resolve — either the bundled subject is selected (the cold-launch
+     * default, #2874) or the registry's `materials` category is empty (#2122).
+     * Either way the streamed pipeline stays idle; what the viewport shows is
+     * driven by the bundled instance.
      */
     data object Empty : MaterialResolveState
 
@@ -717,15 +760,16 @@ private sealed interface MaterialResolveState {
 private fun rememberFileModelInstance(
     modelLoader: io.github.sceneview.loaders.ModelLoader,
     file: File?,
-): io.github.sceneview.model.ModelInstance? {
-    if (file == null) return null
-    return produceState<io.github.sceneview.model.ModelInstance?>(
-        initialValue = null,
-        key1 = modelLoader,
-        key2 = file.absolutePath,
-    ) {
-        value = runCatching {
-            modelLoader.loadModelInstance("file://${file.absolutePath}")
-        }.getOrNull()
-    }.value
-}
+): io.github.sceneview.model.ModelInstance? = produceState<io.github.sceneview.model.ModelInstance?>(
+    initialValue = null,
+    key1 = modelLoader,
+    key2 = file?.absolutePath,
+) {
+    // The null check lives INSIDE produceState, not as an early `return null`
+    // above it: a null file now means "nothing streamed is selected" on every
+    // bundled-chip selection, and an early return would add / remove the
+    // `produceState` slot on each chip switch (#1464).
+    value = file?.let {
+        runCatching { modelLoader.loadModelInstance("file://${it.absolutePath}") }.getOrNull()
+    }
+}.value

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/MaterialsSubjects.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/MaterialsSubjects.kt
@@ -1,0 +1,151 @@
+package io.github.sceneview.demo.demos.internal
+
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
+
+/**
+ * One selectable subject in the Materials demo's **PBR Materials** section —
+ * either the bundled default or one of the curated streamed Sketchfab models.
+ *
+ * The split exists so the section's *cold-launch* state cannot depend on the
+ * network. See [MaterialsSubjects] for the determinism contract.
+ */
+sealed interface MaterialsSubject {
+
+    /** Chip label. */
+    val displayName: String
+
+    /** CC-BY attribution shown under the chips. */
+    val author: String
+
+    /** `KHR_materials_*` extension family this subject demonstrates. */
+    val extensionTag: String
+
+    /**
+     * A model shipped inside the APK. Renders with zero network access, from the
+     * same bytes on every launch and every device — the property the store /
+     * QA capture depends on.
+     *
+     * @property assetPath `assets/`-relative path, loadable by the asset-path
+     *   `rememberModelInstance(modelLoader, String)` overload.
+     */
+    data class Bundled(
+        val assetPath: String,
+        override val displayName: String,
+        override val author: String,
+        override val extensionTag: String,
+    ) : MaterialsSubject
+
+    /**
+     * A curated Sketchfab model streamed at runtime through
+     * [io.github.sceneview.demo.sketchfab.SketchfabAssetResolver]. What actually
+     * renders depends on the API key, the network and the disk cache — which is
+     * exactly why one is never the default subject (#2874).
+     */
+    data class Streamed(val slug: SketchfabSlug) : MaterialsSubject {
+        override val displayName: String get() = slug.displayName
+        override val author: String get() = slug.author
+        override val extensionTag: String get() = slug.tags.firstOrNull().orEmpty()
+    }
+}
+
+/**
+ * Subject list + framing constants for the **PBR Materials** section, kept out of
+ * the composable so the determinism contract below is unit-testable on a bare JVM
+ * (`MaterialsSubjectsTest`).
+ *
+ * ## Why this exists (#2874)
+ *
+ * The section used to render `SampleAssets.byCategory["materials"]` slug 0
+ * directly. That slug is *streamed*: with an API key and a warm network it
+ * resolves to the Sketchfab model, and without either it resolves to the slug's
+ * bundled fallback. So the very first frame after a cold launch showed a
+ * different subject depending on network state — measured on 2026-07-27, two
+ * captures of the same demo id on two tablet AVDs from the same build produced
+ * an insect and a helmet. A store slot, a Maestro assertion and a listing diff
+ * all need the opposite: the same pixels every run.
+ *
+ * The contract this object encodes:
+ *
+ *  1. **The default subject is [MaterialsSubject.Bundled]** — index
+ *     [DEFAULT_INDEX] is always local, so the cold-launch frame never depends on
+ *     the network, an API key or the cache. Enforced by `MaterialsSubjectsTest`.
+ *  2. **Variety stays, as an explicit user action** — the streamed slugs are
+ *     still there, one chip each, one tap away.
+ *  3. **Framing is subject-independent** — every subject is normalised to
+ *     [FRAMING_UNITS] and viewed from [ORBIT_RADIUS_METERS], instead of each
+ *     model's own `scaleToUnits` (0.15 m for the beetle, 0.90 m for the sofa),
+ *     which is why the subject used to read as a speck at some chips and not
+ *     others.
+ *
+ * The environment is pinned separately —
+ * [io.github.sceneview.demo.common.MATERIALS_SHOWCASE_HDR].
+ */
+object MaterialsSubjects {
+
+    /** Index of the subject a cold launch opens on. Always a [MaterialsSubject.Bundled]. */
+    const val DEFAULT_INDEX: Int = 0
+
+    /**
+     * Size, in metres, every subject's bounding cube is normalised to
+     * (`ModelNode(scaleToUnits = …)`).
+     *
+     * A single value for every chip is the point: the camera never moves between
+     * chips, so a per-model scale is what made one subject fill the viewport and
+     * the next one read as a speck.
+     */
+    const val FRAMING_UNITS: Float = 1.0f
+
+    /**
+     * Orbit radius, in metres, for the section's hero camera.
+     *
+     * Chosen by LOOKING at the capture (`capture-play-store-screenshots.sh
+     * --form-factor phone --demos materials`), not by maximising a metric.
+     * Measured on the resulting 1080-px-wide phone frames: the default subject's
+     * base spans 98–100% of the viewport width and the car body 35–46% of it,
+     * the spread being where the idle orbit happens to be. That is tight enough
+     * to read at Play-Store thumbnail size, where the previous framing — each
+     * model scaled to its own `scaleToUnits` (0.15 m for the beetle) and viewed
+     * from a fixed 1.2 m — left the subject small in a mostly-empty frame.
+     *
+     * Must stay clear of [FRAMING_UNITS] — an orbit radius inside the subject's
+     * own bounding cube puts the camera *inside* the model, the failure mode the
+     * store-capture script documents for `model-viewer` at 2.0 m.
+     */
+    const val ORBIT_RADIUS_METERS: Float = 2.4f
+
+    /**
+     * The bundled default subject: Khronos' **ToyCar**, already in the APK
+     * (`assets/models/khronos_toy_car.glb`, CC-BY 4.0 — see
+     * `assets/CREDITS.md`).
+     *
+     * It is the right default on the merits, not just because it is local: the
+     * GLB declares `KHR_materials_clearcoat`, `KHR_materials_sheen` and
+     * `KHR_materials_transmission` (read straight out of its `extensionsUsed`),
+     * i.e. the three extension families this whole section is about, on the
+     * car body, the seat fabric and the windows respectively. The previous
+     * offline path — every slug falling back to `khronos_damaged_helmet.glb`,
+     * a plain metallic-roughness model with no `KHR_materials_*` extension at
+     * all — showed none of them.
+     */
+    val BUNDLED_DEFAULT: MaterialsSubject.Bundled = MaterialsSubject.Bundled(
+        assetPath = "models/khronos_toy_car.glb",
+        displayName = "Toy Car",
+        author = "Khronos",
+        extensionTag = "KHR_materials_clearcoat · _sheen · _transmission",
+    )
+
+    /**
+     * The section's chips, in order: the bundled default first, then every
+     * curated streamed slug.
+     *
+     * @param slugs streamed candidates; defaults to the registry's `materials`
+     *   category. Injectable so the test can pin the input.
+     */
+    fun all(
+        slugs: List<SketchfabSlug> = SampleAssets.byCategory["materials"].orEmpty(),
+    ): List<MaterialsSubject> = buildList {
+        add(BUNDLED_DEFAULT)
+        slugs.forEach { add(MaterialsSubject.Streamed(it)) }
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings_demo_materials.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_materials.xml
@@ -12,6 +12,9 @@
     <string name="demo_materials_subtitle">PBR extension showcase, runtime material streaming, and occlusion material</string>
     <string name="demo_materials_credit">by %1$s · CC-BY 4.0</string>
     <string name="demo_materials_loading">Streaming material…</string>
+    <!-- Shown while the BUNDLED default subject decodes on a cold start — nothing
+         is being streamed there, so it must not claim otherwise (#2874). -->
+    <string name="demo_materials_loading_bundled">Loading material…</string>
     <string name="demo_materials_error">Couldn\'t load this material</string>
     <string name="demo_materials_retry">Retry</string>
 

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MaterialsSubjectsTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MaterialsSubjectsTest.kt
@@ -1,0 +1,135 @@
+package io.github.sceneview.demo.demos.internal
+
+import io.github.sceneview.demo.sketchfab.SampleAssets
+import io.github.sceneview.demo.sketchfab.SketchfabSlug
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Determinism contract for the Materials demo's **PBR Materials** section (#2874).
+ *
+ * The defect these guard against is invisible to a per-frame check: every
+ * individual capture of the demo looked fine, they just differed from each other
+ * — a streamed subject on a device with a warm network, a bundled fallback on one
+ * without. A store slot, a Maestro assertion and a listing diff all need the
+ * cold-launch frame to be the same every run, so the invariant is asserted here
+ * rather than left to a screenshot.
+ *
+ * Pure JVM — no Android framework, no network, no Filament.
+ */
+class MaterialsSubjectsTest {
+
+    @Test
+    fun `cold launch opens on a bundled subject, never a streamed one`() {
+        val subject = MaterialsSubjects.all()[MaterialsSubjects.DEFAULT_INDEX]
+        assertTrue(
+            "The default subject must be bundled — a streamed one makes the first " +
+                "frame depend on the network / API key / cache (#2874). Got: $subject",
+            subject is MaterialsSubject.Bundled,
+        )
+    }
+
+    @Test
+    fun `the default subject is the first chip`() {
+        assertEquals(0, MaterialsSubjects.DEFAULT_INDEX)
+        assertEquals(MaterialsSubjects.BUNDLED_DEFAULT, MaterialsSubjects.all().first())
+    }
+
+    @Test
+    fun `the bundled default points at an APK asset path`() {
+        val path = MaterialsSubjects.BUNDLED_DEFAULT.assetPath
+        assertTrue(
+            "Bundled subjects load through the asset-path overload, so the path must " +
+                "be `assets/`-relative (no scheme, no leading slash). Got: $path",
+            path.startsWith("models/") && path.endsWith(".glb"),
+        )
+    }
+
+    @Test
+    fun `the bundled default is attributed`() {
+        assertTrue(MaterialsSubjects.BUNDLED_DEFAULT.author.isNotBlank())
+        assertTrue(MaterialsSubjects.BUNDLED_DEFAULT.displayName.isNotBlank())
+        assertTrue(
+            "The chip's extension tag is what tells the user which KHR_materials_* " +
+                "family they are looking at",
+            MaterialsSubjects.BUNDLED_DEFAULT.extensionTag.contains("KHR_materials_"),
+        )
+    }
+
+    @Test
+    fun `every streamed subject comes from the materials registry category`() {
+        val registry = SampleAssets.byCategory["materials"].orEmpty()
+        val streamed = MaterialsSubjects.all()
+            .filterIsInstance<MaterialsSubject.Streamed>()
+            .map { it.slug }
+        assertEquals(registry, streamed)
+    }
+
+    @Test
+    fun `variety survives — the streamed slugs are still selectable`() {
+        val subjects = MaterialsSubjects.all()
+        assertTrue(
+            "The streamed catalogue must stay reachable as an explicit chip tap; " +
+                "pinning the default subject is not a reason to drop it (#2874)",
+            subjects.filterIsInstance<MaterialsSubject.Streamed>().isNotEmpty(),
+        )
+        assertEquals(subjects.size, subjects.map { it.displayName }.distinct().size)
+    }
+
+    @Test
+    fun `an empty registry still yields a renderable default`() {
+        val subjects = MaterialsSubjects.all(slugs = emptyList())
+        assertEquals(listOf(MaterialsSubjects.BUNDLED_DEFAULT), subjects)
+    }
+
+    @Test
+    fun `framing constants keep the camera outside the subject`() {
+        assertTrue(MaterialsSubjects.FRAMING_UNITS > 0f)
+        assertTrue(
+            "An orbit radius inside the subject's own bounding cube puts the camera " +
+                "inside the model — the framing failure the store-capture script " +
+                "documents for model-viewer at 2.0 m",
+            MaterialsSubjects.ORBIT_RADIUS_METERS > MaterialsSubjects.FRAMING_UNITS,
+        )
+        assertTrue(
+            "…and a radius far beyond the subject is the other failure mode: a speck " +
+                "in a black frame (#2874)",
+            MaterialsSubjects.ORBIT_RADIUS_METERS < 6f * MaterialsSubjects.FRAMING_UNITS,
+        )
+    }
+
+    @Test
+    fun `subject metadata is delegated, not copied, for streamed slugs`() {
+        val slug = SketchfabSlug(
+            uid = "0".repeat(32),
+            displayName = "Test Model",
+            author = "tester",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
+            scaleToUnits = 0.3f,
+            hasBakedAnimation = false,
+            category = "materials",
+            tags = listOf("KHR_materials_sheen"),
+        )
+        val subject = MaterialsSubject.Streamed(slug)
+        assertEquals("Test Model", subject.displayName)
+        assertEquals("tester", subject.author)
+        assertEquals("KHR_materials_sheen", subject.extensionTag)
+    }
+
+    @Test
+    fun `a tagless slug degrades to an empty extension tag, not a crash`() {
+        val slug = SketchfabSlug(
+            uid = "1".repeat(32),
+            displayName = "Untagged",
+            author = "tester",
+            licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
+            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
+            scaleToUnits = 0.3f,
+            hasBakedAnimation = false,
+            category = "materials",
+        )
+        assertEquals("", MaterialsSubject.Streamed(slug).extensionTag)
+    }
+}


### PR DESCRIPTION
Fixes #2874.

## The defect, and what actually caused it

`materials` could not be captured twice and yield the same frame. Reproduced on
`Pixel_7a` (API 36) against `main` before touching anything — the baseline
capture shows a **streamed Sketchfab beetle**, a speck in the frame, in front of
a blurred **living room with a Christmas tree**.

Two independent causes, and the issue's stated one ("picks a different HDRI on
each launch") is not what the code does:

1. **The subject was streamed.** The PBR Materials section opened on
   `SampleAssets.byCategory["materials"][0]`, resolved through
   `SketchfabAssetResolver`. With a key + network it renders the Sketchfab
   model; without either it renders that slug's bundled fallback
   (`khronos_damaged_helmet.glb`). Same build, two devices, two different
   subjects — exactly what #2874 measured.
2. **The backdrop was a room, not an HDRI roulette.** The section drew the
   `studio_2k` skybox. Decoding that asset (`ffmpeg -i studio_2k.hdr`) shows a
   **domestic living-room interior** — sofa, lamps, decorated tree, windows —
   despite the `neutral / studio / product` tags it carries in
   `assets/catalog.json`. Behind a camera that orbits 360° every 18 s, one
   environment shows a completely different room feature at every yaw, and the
   capture lands at whatever yaw the idle orbit happens to be at. That reads as
   "a Christmas-tree room, a window with plants" — one HDRI, not several.

Plus the framing complaint: each chip was scaled to its own
`SketchfabSlug.scaleToUnits` (0.15 m beetle, 0.35 m decanter, 0.90 m sofa) while
the camera stayed at a fixed 1.2 m, so the subject size in frame depended on
which model happened to load.

## The fix

- **A bundled default subject** (`MaterialsSubjects.BUNDLED_DEFAULT`): Khronos'
  `ToyCar`, already in the APK. Not just "something local" — its GLB declares
  `KHR_materials_clearcoat`, `KHR_materials_sheen` and
  `KHR_materials_transmission` (read from `extensionsUsed`), i.e. the three
  families this section exists to show, on the car body, the seat fabric and the
  windows. The old offline path fell back to `khronos_damaged_helmet.glb`, which
  declares none of them — so this shows *more* of the feature, offline, than
  before.
- **Streaming stays, as an explicit user action.** The three curated slugs are
  untouched and are still one chip tap away.
- **One named environment constant, used as IBL only** for both material
  sections: `MATERIALS_SHOWCASE_HDR = environments/studio_warm_2k.hdr` — the
  actual photo studio of the two bundled "studio" HDRIs (dark surround, seamless
  sweep, softboxes). Switching HDRI alone was **measured not to be enough**: with
  the studio skybox drawn, two cold launches still came back with the same
  subject against the studio's dark surround in one and its bright sweep in the
  other, because the camera orbits. The skybox is therefore not drawn at all —
  the materials still read the environment through their reflections, while the
  backdrop is the demo's own surface at every yaw. A side effect worth noting:
  the capture script's blank-frame guard is now *honest* for this demo, because a
  model-less frame is uniformly black instead of being covered by a textured
  skybox.
- **Subject-independent framing**: every chip is normalised to
  `FRAMING_UNITS` and viewed from `ORBIT_RADIUS_METERS`, so the framing is the
  same whichever chip is selected.
- **The loading scrim stops lying**: it said "Streaming material…" over a
  bundled asset; the bundled subject now gets its own string.

## Verification — by comparing captures to each other

The variance guard cannot catch this class of defect: each frame individually
looks fine, the defect is that they *differ*. So the check is a diff of two cold
launches of the same id, on the same build, on the same device:

```
bash .claude/scripts/capture-play-store-screenshots.sh \
  --form-factor phone --demos materials,materials --settle 60 --no-build --out <scratch>
```

Result (`Pixel_7a`, API 36, one build, two cold launches, 120 s settle each):

| | frame 1 | frame 2 |
|---|---|---|
| subject | Khronos ToyCar on the velvet base | **same** |
| background (4 corner samples) | `(0,0,0)` ×4 | **`(0,0,0)` ×4** |
| subject base width | 100.0% of frame | 97.7% of frame |
| car body width | 46.0% | 34.7% |
| mean abs pixel diff | — | 3.51 |

Same subject, same environment. The residual 3.51 mean diff — and the car-body
spread — is the idle orbit's yaw, i.e. the subject is rotated slightly
differently; nothing about *what* is rendered changes.

For contrast, the baseline capture on `main` (same script, same device) shows a
streamed Sketchfab beetle, small in the frame, in front of a blurred
living-room interior with a Christmas tree.

Also run: `:samples:android-demo:testDebugUnitTest` (new `MaterialsSubjectsTest`
asserts the cold-launch contract on the JVM) and the library compile gate.

## Scope notes

- **No store-listing change.** The committed PNGs under
  `distribution/play-store/` are untouched, and `materials` is **not** added back
  to any capture default — the script's "dropped, do not re-add by guesswork"
  note is updated to say the demo-side cause is fixed and that re-adding still
  requires a fresh visual pass against the other slots.
- **iOS needs nothing**: `samples/ios-demo/.../MaterialsDemo.swift` is a
  parameter explorer on `.environment(.studio)` with no streamed subject, so it
  has no equivalent non-determinism (checked, not assumed).
- **Known residual**, not fixed here: the idle hero orbit means the *camera yaw*
  still depends on capture timing, so two captures are not byte-identical. A
  pixel-stable capture needs `--ez qa_mode true` (which freezes yaw at 45°) and
  the capture script does not pass it today — a separate, store-set-facing
  change.
