### PR TITLE
fix(android-demo): keep both materials subjects mounted so a chip round-trip still renders (#2874)

### DIFF
--- a/.claude/scripts/capture-play-store-screenshots.sh
+++ b/.claude/scripts/capture-play-store-screenshots.sh
@@ -80,7 +80,8 @@ android_cli_ensure || true
 #   2 dynamic-sky    the strongest frame — a lit drone against a vivid procedural
 #                    sky; a sky/sun/environment theme no other slot carries and
 #                    the shot most likely to sell the SDK. Deterministic noon
-#                    default (no random HDRI, unlike the dropped `materials`).
+#                    default — no HDRI backdrop at all (see the `materials` note
+#                    at the bottom of this list: it never picked one at random).
 #   3 multi-model    the only non-helmet, non-sky frame — a rich photoreal-foliage
 #                    fidelity shot. Since #2913 the scene frames ITSELF from the
 #                    live viewport aspect, so it deliberately takes no

--- a/changelog.d/2874-materials-deterministic-frame.md
+++ b/changelog.d/2874-materials-deterministic-frame.md
@@ -1,5 +1,7 @@
 <!-- category: Fixed -->
-- **Demo: the `materials` demo now produces a reproducible frame (#2874).** Two
+- **Demo: the `materials` demo now shows the same subject on the same backdrop
+  on every launch (#2874).** The idle orbit still varies the camera yaw, so a
+  pixel-stable capture needs `--ez qa_mode true`. Two
   things made it non-reproducible, and both are fixed. **(1) The subject was
   streamed.** The **PBR Materials** section opened on a Sketchfab slug, so what
   the first frame showed depended on the API key, the network and the disk cache

--- a/changelog.d/2926-materials-chip-roundtrip.md
+++ b/changelog.d/2926-materials-chip-roundtrip.md
@@ -1,0 +1,19 @@
+<!-- category: Fixed -->
+- **Demo: the `materials` demo no longer goes black after a chip round-trip
+  (follow-up to #2874 / #2926).** Tapping **Toy Car** → any streamed chip →
+  **Toy Car** rendered an empty viewport with no loading scrim and no way back
+  short of leaving the demo. The section feeds one `ModelNode` call site an
+  instance that swaps when the chip changes; that re-keys
+  `remember(engine, modelInstance)` in `SceneScope.ModelNode`, and the outgoing
+  node's `DisposableEffect` runs `node.destroy()`, which walks `childNodes` and
+  calls `engine.safeDestroyEntity` on the entities the `ModelInstance` only
+  *borrows*. `ownsEntity` is `false`, so the entity ids survive but their
+  renderable components do not — and the bundled instance is retained for the
+  whole session and never reloaded, so it came back renderable-less. Both
+  subjects now stay mounted and the inactive one is hidden with `isVisible`.
+- **Docs: the demo's reproducibility claim now matches what is coded.** The
+  changelog fragment and `DemoEnvironment`'s KDoc said the demo "produces a
+  reproducible frame"; the subject and the backdrop are indeed identical on
+  every launch, but the section's idle orbit is time-driven and starts when the
+  model finishes loading, so two captures still differ in camera yaw unless the
+  app is launched with `--ez qa_mode true`. Both surfaces now say so.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoEnvironment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoEnvironment.kt
@@ -116,7 +116,10 @@ const val MATERIALS_SHOWCASE_HDR: String = "environments/studio_warm_2k.hdr"
  * identical at every yaw — while the *materials themselves* still read the
  * environment: clearcoat highlights, sheen falloff and transmission all sample
  * the same studio IBL as before. What is lost is a photo behind the model; what
- * is gained is a frame that two captures agree on.
+ * is gained is a backdrop that two captures agree on. The camera is NOT part of
+ * that guarantee: the section's idle orbit is time-driven and starts when the
+ * model finishes loading, so two captures still differ in yaw unless the app is
+ * launched with `--ez qa_mode true`, which pins it.
  *
  * Falls back to the neutral default while the HDR decodes, so the first frames
  * never flash black.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -314,15 +314,33 @@ private fun PbrSection(
                 environment = activeEnvironment,
                 cameraManipulator = cameraManipulator,
             ) {
-                val instance = modelInstance
-                if (instance != null) {
-                    // Every subject is normalised to the SAME size rather than to
-                    // its own `scaleToUnits` (#2874) — the camera is fixed, so a
-                    // per-model scale is what made one chip fill the viewport and
-                    // the next one read as a speck.
+                // Both subjects stay MOUNTED; the inactive one is hidden. Feeding
+                // one call site an instance that swaps on every chip re-keys
+                // `remember(engine, modelInstance)` in SceneScope.ModelNode, and the
+                // outgoing node's DisposableEffect runs `node.destroy()` — which
+                // walks `childNodes` and calls `engine.safeDestroyEntity` on the
+                // entities the ModelInstance only BORROWS (`ownsEntity` is false, so
+                // the id survives but the renderable component does not, Node.kt:1284).
+                // `bundledInstance` is retained for the whole session and never
+                // reloaded, so one chip round-trip left it with zero renderables:
+                // Toy Car → any streamed chip → Toy Car rendered a silent black
+                // viewport, with no scrim because the instance is still non-null.
+                //
+                // Every subject is normalised to the SAME size rather than to its own
+                // `scaleToUnits` (#2874) — the camera is fixed, so a per-model scale
+                // is what made one chip fill the viewport and the next read as a speck.
+                bundledInstance?.let { instance ->
                     ModelNode(
                         modelInstance = instance,
                         scaleToUnits = MaterialsSubjects.FRAMING_UNITS,
+                        isVisible = selectedSlug == null,
+                    )
+                }
+                streamedInstance?.let { instance ->
+                    ModelNode(
+                        modelInstance = instance,
+                        scaleToUnits = MaterialsSubjects.FRAMING_UNITS,
+                        isVisible = selectedSlug != null,
                     )
                 }
             }


### PR DESCRIPTION
Follow-up to #2926, which merged while an independent review of it was still running. The review found a use-after-destroy that the PR introduced; this fixes it.

## The bug

Tap **Toy Car** (the bundled default) → any streamed chip → **Toy Car** again. The viewport goes black permanently, with **no loading scrim** (the instance is still non-null, so `LoadingScrim(loading = modelInstance == null)` stays hidden) and no recovery short of leaving the demo.

The chain:

1. `MaterialsDemo.kt` feeds one `ModelNode` call site an instance that swaps on chip change (`modelInstance = if (selectedSlug == null) bundledInstance else streamedInstance`).
2. `SceneScope.kt:298` — `remember(engine, modelInstance)` is re-keyed, so a new node is built.
3. `SceneScope.kt` `NodeLifecycle`'s `DisposableEffect(node)` fires `onDispose { detach(node); node.destroy() }` for the **outgoing** node.
4. `Node.kt:1274-1285` — `destroy()` recurses `childNodes` and calls `engine.safeDestroyTransformable(entity)` / `engine.safeDestroyEntity(entity)`. A `ModelNodeImpl` builds its `renderableNodes` over the gltfio instance's **borrowed** entities, so those are the entities destroyed. `ownsEntity` is `false`, so the ids are not recycled (#2859) — but every Filament component on them, renderable included, is gone, and only gltfio's loader ever created them.
5. `bundledInstance` comes from a `produceState` whose keys (`modelLoader`, `"models/khronos_toy_car.glb"`) never change. It is never reloaded, so it comes back with zero renderables. `Node.kt:757` recreates the transform components so there is no crash, and `boundingBox` is read at asset level so `scaleToUnits` computes a sane scale — nothing draws.

This could not happen before #2926: every subject came from `rememberFileModelInstance`, which produced a fresh `ModelInstance` per selection. Retaining one instance across node identities is what made it reachable.

## The fix

Keep both subjects mounted and hide the inactive one with `isVisible`, which `SceneScope` already drives through `DisposableEffect(node, isVisible)`. No node identity ever changes for the bundled instance, so it is never destroyed.

The alternative — re-key the bundled load so a chip switch yields a fresh instance — trades away the "switching back is instant" property the KDoc explicitly claims, so it was not taken.

## Claims corrected (#2740 rule: stated intent must actually be coded)

`changelog.d/2874-materials-deterministic-frame.md` and `DemoEnvironment.kt` both asserted a "reproducible frame". The subject and the backdrop **are** now identical on every launch — that half is real and coded. But `rememberHeroOrbitCameraManipulator` runs an unbounded `while (true) { snapTo(0f); animateTo(360f, tween(18_000)) }` that starts when the model finishes loading, so the yaw at capture time is a function of load latency. #2926's own measurements show it: the car body spans 46.0% of the frame in one capture and 34.7% in the other. Both surfaces now state that a pixel-stable capture needs `--ez qa_mode true`.

Also: `capture-play-store-screenshots.sh:83` still described `materials` as picking a random HDRI, fourteen lines above the comment this repo added to correct exactly that.

## Verification

⚠️ **Not compiled locally** — this host is under the 6 GB disk gate (4.8 GB free), and the documented operational answer under disk pressure is to let CI build rather than build locally. The change is confined to `samples/android-demo` and one shell comment; CI's `Build libraries & samples` and `Unit tests` jobs are the gate. Please do not merge on a red check.

Not verified: the visual round-trip on an emulator. The reasoning above is read from the library source (`SceneScope.kt`, `Node.kt`, `ModelNode.kt`), not observed on a device.
