### PR TITLE
fix(ios): apply SceneEnvironment.intensity as the linear multiplier it documents (#2897)

### DIFF
--- a/.claude/scripts/capture-appstore-screenshots.sh
+++ b/.claude/scripts/capture-appstore-screenshots.sh
@@ -63,14 +63,23 @@ IPAD_NAME="${IPAD_SIM:-iPad Pro 13-inch (M4)}"
 # no Sketchfab key, so `SketchfabAssetResolver` substitutes the registered
 # bundled stand-ins (SampleAssets.swift — bench→`retro_piano.usdz`,
 # dog→`animated_butterfly.usdz`, bird→`phoenix_bird.usdz`). The captured frame
-# is therefore NOT the documented park diorama: it is a retro piano with a
-# butterfly clipping through it and a phoenix beside it, with the tree slot not
-# rendering at all. Every mechanical check passes on that frame — correct
-# dimensions, settled, byte-reproducible — so only looking at the mosaic catches
-# it. This is the same defect CLASS the Android tablet set hit (#2913/#2915,
-# "do not re-add on the strength of a green capture"), and shipping it would
-# advertise a scene no keyless user can ever see.
-# Re-add here once #2913 and the tree-render bug land, then re-judge the mosaic.
+# is therefore NOT the documented park diorama: measured on the 6.9" simulator,
+# it renders an upright wooden piano with a blossoming-tree diorama growing
+# through it and a brightly-coloured bird mid-frame — the tree slot's stand-in
+# supplies both the trees AND the ground they stand on, so it dominates the
+# composition instead of reading as one slot of four. Every mechanical check
+# passes on that frame — correct dimensions, settled, byte-reproducible — so
+# only looking at the mosaic catches it. This is the same defect CLASS the
+# Android tablet set hit (#2913/#2915, "do not re-add on the strength of a green
+# capture"), and shipping it would advertise a scene no keyless user can ever see.
+#
+# ⚠️ The exclusion is NOT time-boxed on an issue. An earlier version of this
+# comment said the tree slot rendered "not at all" and gated the re-add on
+# "#2913 and the tree-render bug" — both were refuted by measurement (#2896),
+# and #2913 / #2928 are CLOSED, so that gate read as already satisfied while the
+# real reason still stood. The real reason is structural: keyless resolver
+# substitution. Re-add only against a freshly captured mosaic you have looked
+# at next to the other slots — never on the strength of a closed issue.
 #
 # ⚠️ This array and `DEMOS_DEFAULT` in the Android script are the SAME decision
 # stored twice — a known drift hazard. Change them in one commit, or the two
@@ -139,6 +148,22 @@ BANNER_SAMPLES="${BANNER_SAMPLES:-3}"
 BANNER_MAX_ATTEMPTS="${BANNER_MAX_ATTEMPTS:-4}"
 BANNER_BAND_TOP_PCT="${BANNER_BAND_TOP_PCT:-6}"
 BANNER_BAND_PCT="${BANNER_BAND_PCT:-16}"
+
+# A sample count below 2 makes the guard a silent no-op, not a relaxed one: the
+# `while [ "$i" -lt "$BANNER_SAMPLES" ]` probe loop never executes, `settled`
+# stays 1, and `capture_settled` returns success having compared nothing. That
+# is the worst possible failure mode here — a green run advertising banner
+# protection it did not perform — so refuse it up front rather than honour it.
+case "$BANNER_SAMPLES" in
+    ''|*[!0-9]*)
+        echo "BANNER_SAMPLES must be an integer >= 2 (got '$BANNER_SAMPLES')" >&2
+        exit 1
+        ;;
+esac
+[ "$BANNER_SAMPLES" -ge 2 ] || {
+    echo "BANNER_SAMPLES must be >= 2 (1 kept frame + >=1 probe); got $BANNER_SAMPLES" >&2
+    exit 1
+}
 
 log() { printf '\033[1;36m[appstore-shots]\033[0m %s\n' "$*"; }
 

--- a/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
@@ -23,12 +23,18 @@ public struct SceneEnvironment: Sendable {
     public let hdrResource: String?
 
     /// Light intensity, as a **linear multiplier** — `1.0` leaves the HDR's own
-    /// radiance untouched, `0.5` halves it, `2.0` doubles it. Same unit and same
-    /// scale as Android's `Environment` intensity, so identical values give
-    /// identical lighting on both platforms.
+    /// radiance untouched, `0.5` halves it, `2.0` doubles it.
     ///
     /// Converted to RealityKit's `ImageBasedLightComponent.intensityExponent`
     /// (a power of two) at apply time; callers never see the exponent (#2897).
+    ///
+    /// - Note: **This is not interchangeable with an Android value.** Android's
+    ///   `Environment` has no intensity member at all; its IBL level is Filament's
+    ///   `IndirectLight.intensity` in **absolute lux**, defaulting to
+    ///   `DEFAULT_IBL_INTENSITY = 10_000` (`SceneFactories.kt`). `1.0` there is one
+    ///   lux — effectively black — not "the HDR untouched". The two platforms match
+    ///   on the key-to-IBL *ratio*, not on absolute values; see the cross-platform
+    ///   parity note on `DEFAULT_IBL_INTENSITY`.
     public var intensity: Float
 
     /// Whether to render the environment as a skybox background.
@@ -165,7 +171,7 @@ public struct SceneEnvironment: Sendable {
     ///   - name: Display name.
     ///   - hdrFile: HDR file name in the bundle (e.g. "custom_env.hdr").
     ///   - intensity: Light intensity as a linear multiplier (`1.0` = the HDR's own
-    ///     radiance). Same unit as Android's `Environment` intensity (#2897).
+    ///     radiance). Not an Android lux value — see ``intensity`` (#2897).
     ///   - showSkybox: Whether to show as background.
     public static func custom(
         name: String,

--- a/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
@@ -22,7 +22,13 @@ public struct SceneEnvironment: Sendable {
     /// Bundle resource name for the HDR/EXR file.
     public let hdrResource: String?
 
-    /// Light intensity multiplier.
+    /// Light intensity, as a **linear multiplier** — `1.0` leaves the HDR's own
+    /// radiance untouched, `0.5` halves it, `2.0` doubles it. Same unit and same
+    /// scale as Android's `Environment` intensity, so identical values give
+    /// identical lighting on both platforms.
+    ///
+    /// Converted to RealityKit's `ImageBasedLightComponent.intensityExponent`
+    /// (a power of two) at apply time; callers never see the exponent (#2897).
     public var intensity: Float
 
     /// Whether to render the environment as a skybox background.
@@ -38,6 +44,21 @@ public struct SceneEnvironment: Sendable {
         self.hdrResource = hdrResource
         self.intensity = intensity
         self.showSkybox = showSkybox
+    }
+
+    /// Converts an authored linear ``intensity`` multiplier into the power-of-two
+    /// exponent RealityKit's `ImageBasedLightComponent(intensityExponent:)` wants.
+    ///
+    /// Lives here, and is exercised directly by `SceneEnvironmentTests`, because
+    /// the call site it feeds (`SceneView.loadEnvironment`) is `@MainActor` and
+    /// needs a live RealityKit scene — the conversion itself is the part that was
+    /// wrong (#2897) and the part worth pinning.
+    ///
+    /// `0` and negatives clamp to `.leastNormalMagnitude` (≈2^-126): `log2(0)` is
+    /// `-inf`, which RealityKit rejects, and 2^-126 is indistinguishable from black
+    /// while staying finite.
+    static func intensityExponent(forMultiplier multiplier: Float) -> Float {
+        log2(max(multiplier, .leastNormalMagnitude))
     }
 
     /// Loads the IBL environment resource into a RealityKit scene.
@@ -130,7 +151,8 @@ public struct SceneEnvironment: Sendable {
     /// - Parameters:
     ///   - name: Display name.
     ///   - hdrFile: HDR file name in the bundle (e.g. "custom_env.hdr").
-    ///   - intensity: Light intensity multiplier.
+    ///   - intensity: Light intensity as a linear multiplier (`1.0` = the HDR's own
+    ///     radiance). Same unit as Android's `Environment` intensity (#2897).
     ///   - showSkybox: Whether to show as background.
     public static func custom(
         name: String,

--- a/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Environment/Environment.swift
@@ -54,11 +54,24 @@ public struct SceneEnvironment: Sendable {
     /// needs a live RealityKit scene — the conversion itself is the part that was
     /// wrong (#2897) and the part worth pinning.
     ///
-    /// `0` and negatives clamp to `.leastNormalMagnitude` (≈2^-126): `log2(0)` is
-    /// `-inf`, which RealityKit rejects, and 2^-126 is indistinguishable from black
-    /// while staying finite.
+    /// The result is always finite, because RealityKit rejects an infinite or NaN
+    /// exponent and `intensity` is a `public var` a caller can set to anything:
+    ///
+    /// - `0`, negatives and `-infinity` clamp up to `.leastNormalMagnitude`, giving
+    ///   exponent `-126` — indistinguishable from black, and finite (`log2(0)` is
+    ///   `-inf`).
+    /// - `+infinity` clamps down to `.greatestFiniteMagnitude`, giving `128`.
+    /// - `NaN` falls through both clamps and is mapped to black.
+    ///
+    /// The `min`/`max` pair is doing more than it looks. Swift's generic `max` is
+    /// `y >= x ? y : x` and every comparison against NaN is false, so **operand
+    /// order decides the NaN result**: `max(.nan, tiny)` is `.nan` while
+    /// `max(tiny, .nan)` is `tiny`. Rather than depend on that, the explicit
+    /// `isFinite` guard catches NaN whichever way the clamps fall.
     static func intensityExponent(forMultiplier multiplier: Float) -> Float {
-        log2(max(multiplier, .leastNormalMagnitude))
+        let clamped = min(max(multiplier, .leastNormalMagnitude), .greatestFiniteMagnitude)
+        guard clamped.isFinite else { return log2(Float.leastNormalMagnitude) }
+        return log2(clamped)
     }
 
     /// Loads the IBL environment resource into a RealityKit scene.

--- a/SceneViewSwift/Sources/SceneViewSwift/RenderQuality.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/RenderQuality.swift
@@ -107,6 +107,15 @@ internal func applyRenderQuality(
     }
 
     // 2. Adjust IBL intensity exponent on the receiver entity (if one exists in this scene).
+    //
+    // ⚠️ The literals below are RAW EXPONENTS, not the linear multipliers
+    // `SceneEnvironment.intensity` speaks since #2897 — `1.0` here means ×2.0 and
+    // `0.5` means ×1.41, which no longer dims anything now that the authored
+    // default maps to exponent 0. That is currently latent, not a bug: this
+    // function's only caller (`SceneView.setupScene`) runs synchronously BEFORE the
+    // async `loadEnvironment` sets the `ImageBasedLightComponent`, so both branches
+    // below find no component and no-op. Fix the units here if that ordering ever
+    // changes, or these values will invert their own documented intent (#2897).
     guard let iblReceiver else { return nil }
     let newExponent: Float?
     switch quality {

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -1425,7 +1425,21 @@ private struct SceneViewRepresentation: View {
             entities.ibl.components.set(
                 ImageBasedLightComponent(
                     source: .single(resource),
-                    intensityExponent: env.intensity
+                    // `intensity` is authored — and documented, and mirrored from
+                    // Android — as a LINEAR multiplier, but RealityKit's parameter
+                    // is an exponent of two: the IBL is scaled by `2^x`. Feeding the
+                    // multiplier straight through made every preset wrong the moment
+                    // #2896 got the IBL to load at all: `.studio` 1.0 → ×2.0, and
+                    // `.night` 0.4 → ×1.32, i.e. BRIGHTENING where it should dim to
+                    // ×0.4 — ~3.3× off Android under the same preset name (#2897).
+                    // `intensityExponent(forMultiplier:)` converts the authored
+                    // multiplier into the exponent the API wants, so `1.0` is now a
+                    // true no-op (2^0) and the presets keep their linear authoring.
+                    // It lives on `SceneEnvironment` so it is unit-testable without
+                    // a live RealityKit scene — see `SceneEnvironmentTests`.
+                    intensityExponent: SceneEnvironment.intensityExponent(
+                        forMultiplier: env.intensity
+                    )
                 )
             )
             // Make root entity receive IBL

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/SceneEnvironmentTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/SceneEnvironmentTests.swift
@@ -163,14 +163,34 @@ final class SceneEnvironmentTests: XCTestCase {
         }
     }
 
-    /// `log2(0)` is `-inf`, which RealityKit rejects. Zero and negatives must
-    /// clamp to something finite and effectively black.
+    /// `log2(0)` is `-inf`, which RealityKit rejects. Zero, negatives and `-inf`
+    /// must clamp to something finite and effectively black.
     func testNonPositiveIntensityStaysFinite() {
-        for multiplier in [Float(0.0), -1.0, -Float.leastNormalMagnitude] {
+        for multiplier in [Float(0.0), -0.0, -1.0, -Float.leastNormalMagnitude, -Float.infinity] {
             let exponent = SceneEnvironment.intensityExponent(forMultiplier: multiplier)
             XCTAssertTrue(exponent.isFinite, "exponent for \(multiplier) must be finite")
             XCTAssertLessThan(exponent, -100.0, "exponent for \(multiplier) must be ~black")
         }
+    }
+
+    /// `intensity` is a `public var`, so nothing stops a caller writing `.nan` or
+    /// `.infinity` into it — and RealityKit rejects a non-finite exponent. The
+    /// naive `log2(max(multiplier, .leastNormalMagnitude))` passed both straight
+    /// through: Swift's generic `max` is `y >= x ? y : x` and NaN compares false
+    /// against everything, so `max(.nan, tiny)` is `.nan` (measured). Every input
+    /// must produce a finite exponent.
+    func testNonFiniteIntensityStaysFinite() {
+        XCTAssertLessThan(
+            SceneEnvironment.intensityExponent(forMultiplier: .nan), -100.0,
+            "NaN must map to black, not propagate"
+        )
+        XCTAssertLessThan(
+            SceneEnvironment.intensityExponent(forMultiplier: .signalingNaN), -100.0,
+            "signalling NaN must map to black, not propagate"
+        )
+        let positiveInfinity = SceneEnvironment.intensityExponent(forMultiplier: .infinity)
+        XCTAssertTrue(positiveInfinity.isFinite, "+infinity must clamp to a finite exponent")
+        XCTAssertGreaterThan(positiveInfinity, 0.0, "+infinity must stay on the bright side")
     }
 }
 
@@ -217,7 +237,6 @@ final class VisionOSSkyboxTests: XCTestCase {
         ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
         return ctx.makeImage()!
     }
-
 }
 #endif
 #endif

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/SceneEnvironmentTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/SceneEnvironmentTests.swift
@@ -124,6 +124,54 @@ final class SceneEnvironmentTests: XCTestCase {
         _ = base.immersiveSpace()
         XCTAssertFalse(base.immersiveSpace)
     }
+
+    // MARK: - intensity → intensityExponent (#2897)
+
+    /// The whole point of the fix: `intensity` is authored and documented as a
+    /// LINEAR multiplier, RealityKit's parameter is a power-of-two exponent, and
+    /// the old code fed one straight into the other. Pin the round-trip
+    /// `2^exponent == multiplier` rather than the exponent's literal value, so
+    /// this fails if anyone ever passes the multiplier through again.
+    func testIntensityExponentRoundTripsToTheAuthoredMultiplier() {
+        for multiplier in [Float(0.4), 0.5, 0.8, 0.9, 1.0, 1.2, 2.0] {
+            let exponent = SceneEnvironment.intensityExponent(forMultiplier: multiplier)
+            XCTAssertEqual(
+                pow(Float(2), exponent), multiplier, accuracy: 1e-5,
+                "2^exponent must reproduce the authored multiplier \(multiplier)"
+            )
+        }
+    }
+
+    /// `1.0` — the default, and `.studio`'s value — must be a true no-op. Passing
+    /// the multiplier through gave exponent 1.0 here, i.e. ×2.0 on the DEFAULT
+    /// preset; the fix makes it exponent 0.
+    func testUnitIntensityIsANoOp() {
+        XCTAssertEqual(
+            SceneEnvironment.intensityExponent(forMultiplier: 1.0), 0.0, accuracy: 1e-6
+        )
+    }
+
+    /// `.night` is the case that was not merely wrong but inverted: authored 0.4
+    /// to DIM, it brightened ×1.32 under the old code. The exponent must be
+    /// negative for every sub-1.0 preset.
+    func testSubUnitPresetsProduceNegativeExponents() {
+        for preset in SceneEnvironment.allPresets where preset.intensity < 1.0 {
+            XCTAssertLessThan(
+                SceneEnvironment.intensityExponent(forMultiplier: preset.intensity), 0.0,
+                "\(preset.name) (intensity \(preset.intensity)) must dim, not brighten"
+            )
+        }
+    }
+
+    /// `log2(0)` is `-inf`, which RealityKit rejects. Zero and negatives must
+    /// clamp to something finite and effectively black.
+    func testNonPositiveIntensityStaysFinite() {
+        for multiplier in [Float(0.0), -1.0, -Float.leastNormalMagnitude] {
+            let exponent = SceneEnvironment.intensityExponent(forMultiplier: multiplier)
+            XCTAssertTrue(exponent.isFinite, "exponent for \(multiplier) must be finite")
+            XCTAssertLessThan(exponent, -100.0, "exponent for \(multiplier) must be ~black")
+        }
+    }
 }
 
 #if os(visionOS)
@@ -169,6 +217,7 @@ final class VisionOSSkyboxTests: XCTestCase {
         ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
         return ctx.makeImage()!
     }
+
 }
 #endif
 #endif

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -105,6 +105,11 @@ ARSceneView(
 `.studio` (default) · `.outdoor` · `.sunset` · `.night` · `.warm` · `.autumn`
 · `.custom(name:hdrFile:intensity:)`
 
+`intensity` is a linear multiplier (`1.0` = the HDR's own radiance); SceneView
+converts it to RealityKit's power-of-two `intensityExponent`, so never pre-apply
+a `log2`. Not interchangeable with Android's IBL intensity, which is Filament
+lux (default `10_000`) — #2897.
+
 ## Transform & animation
 
 ```swift

--- a/changelog.d/2896-ios-store-screenshots.md
+++ b/changelog.d/2896-ios-store-screenshots.md
@@ -43,8 +43,9 @@
   blossoming-tree diorama growing through it and a coloured bird mid-frame —
   not the park diorama the demo documents, and not something a keyless user can
   ever see. Every mechanical check passes on that frame, so only looking at it
-  catches the problem. Same call as Android's tablet set: restore it once #2913
-  lands, and only against a fresh frame (#2896, #2913, #2915).
+  catches the problem. Same call as Android's tablet set — and, like it, the
+  exclusion is structural rather than gated on an issue: restore it only against
+  a fresh frame you have looked at (#2896, #2913, #2915).
 - **`qa_mode` now actually freezes auto-rotation.** `DeepLinkRouter` has
   advertised `-qa_mode 1` / `?qa_mode=1` as the deterministic-screenshot switch
   since it was added, but no demo read it — so every store capture shot
@@ -73,6 +74,7 @@
   `.outdoor` 1.2) and Android's `Environment` intensity is linear. That defect
   pre-exists this change, but it was latent while the IBL never loaded at all;
   now that it does, `.night` *brightens* ×1.32 instead of dimming ×0.4 — a ~3.3×
-  divergence from Android under the same preset name. Tracked in #2897; land it
-  in the same release, or the two platforms ship different lighting for
-  identical code.
+  divergence from Android under the same preset name. Tracked in #2897 and
+  **fixed in this same release** — see the `2897-` fragment — so the condition
+  this bullet set ("land it in the same release, or the two platforms ship
+  different lighting for identical code") is met.

--- a/changelog.d/2897-ios-environment-intensity-multiplier.md
+++ b/changelog.d/2897-ios-environment-intensity-multiplier.md
@@ -2,17 +2,26 @@
 - **iOS/macOS/visionOS: `SceneEnvironment.intensity` is applied as the linear
   multiplier it is documented to be.** It was passed straight to RealityKit's
   `ImageBasedLightComponent(intensityExponent:)`, which scales the IBL by `2^x`,
-  so every bundled preset rendered at the wrong exposure: `.studio` 1.0 at ×2.0
-  and `.night` 0.4 at ×1.32 — *brightening* where it should dim to ×0.4, a ~3.3×
-  divergence from Android's linear `Environment` intensity under the same preset
-  name. The defect pre-dated #2896 but was latent, because
+  so every bundled preset rendered at the wrong exposure: `.studio` 1.0 at ×2.0,
+  and `.night` 0.4 at ×1.32 — *brightening* where its authored value asks it to
+  dim to ×0.4. The defect pre-dated #2896 but was latent, because
   `EnvironmentResource(named:)` could not load the Radiance `.hdr` presets and no
   `ImageBasedLightComponent` was ever set; #2896 made the IBL load, and with it
   the wrong unit. The value is now converted with `log2` at apply time, so `1.0`
-  is a true no-op, the presets keep their linear authoring, and identical code
-  gives identical lighting on Android and Apple. The KDoc and `llms.txt` state
-  the unit explicitly (#2897).
+  is a true no-op and the presets keep their linear authoring. The result is
+  clamped finite for every `Float`, including `NaN` and `±infinity`, which
+  RealityKit rejects. The KDoc and `llms.txt` state the unit explicitly (#2897).
+- **Note for anyone reading this as a parity fix — it is not one.** Android's
+  `Environment` has no intensity member; its IBL level is Filament's
+  `IndirectLight.intensity` in **absolute lux** (`DEFAULT_IBL_INTENSITY = 10_000`),
+  so the two knobs are not interchangeable and never were. This change moves iOS
+  onto the exponent-0 baseline that `SceneFactories.kt`'s cross-platform note
+  already assumes it uses (≈1000 lux equivalent); the platforms stay matched on
+  the key-to-IBL ratio, not on absolute values (#2897).
 - **The committed App Store screenshots predate this fix.** `appstore-screenshots/`
-  was captured while the exponent was live, so those frames are ~2× brighter than
-  the app now renders. Re-capture and re-judge the mosaic before dispatching
-  `app-store-screenshots.yml` (#2897).
+  was captured while the exponent was live: `01-model-viewer.png` on `.warm`
+  (intensity 1.0 → ×2.00, now ×1.00) and `02-dynamic-sky.png` on `.outdoor`
+  (1.2 → ×2.30, now ×1.20). Only the IBL contribution changes — the direct lights
+  and the skybox are untouched — so the frames are not uniformly twice as bright,
+  but they no longer match what the app renders. Re-capture and re-judge the
+  mosaic before dispatching `app-store-screenshots.yml` (#2897).

--- a/changelog.d/2897-ios-environment-intensity-multiplier.md
+++ b/changelog.d/2897-ios-environment-intensity-multiplier.md
@@ -1,0 +1,18 @@
+<!-- category: Fixed -->
+- **iOS/macOS/visionOS: `SceneEnvironment.intensity` is applied as the linear
+  multiplier it is documented to be.** It was passed straight to RealityKit's
+  `ImageBasedLightComponent(intensityExponent:)`, which scales the IBL by `2^x`,
+  so every bundled preset rendered at the wrong exposure: `.studio` 1.0 at ×2.0
+  and `.night` 0.4 at ×1.32 — *brightening* where it should dim to ×0.4, a ~3.3×
+  divergence from Android's linear `Environment` intensity under the same preset
+  name. The defect pre-dated #2896 but was latent, because
+  `EnvironmentResource(named:)` could not load the Radiance `.hdr` presets and no
+  `ImageBasedLightComponent` was ever set; #2896 made the IBL load, and with it
+  the wrong unit. The value is now converted with `log2` at apply time, so `1.0`
+  is a true no-op, the presets keep their linear authoring, and identical code
+  gives identical lighting on Android and Apple. The KDoc and `llms.txt` state
+  the unit explicitly (#2897).
+- **The committed App Store screenshots predate this fix.** `appstore-screenshots/`
+  was captured while the exponent was live, so those frames are ~2× brighter than
+  the app now renders. Re-capture and re-judge the mosaic before dispatching
+  `app-store-screenshots.yml` (#2897).

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -335,6 +335,12 @@ Custom environment:
 .environment(.custom(name: "My HDR", hdrFile: "custom.hdr", intensity: 1.5))
 ```
 
+`intensity` is a **linear multiplier** — `1.0` leaves the HDR's own radiance
+untouched, `0.5` halves it. It is converted to RealityKit's power-of-two
+`intensityExponent` internally, so never pre-apply a `log2`. It is **not** an
+Android value: Android's IBL level is Filament's `IndirectLight.intensity` in
+absolute lux (default `10_000`), so the two are not interchangeable (#2897).
+
 visionOS — immersive-space skybox: a windowed / volumetric scene composites
 over passthrough and ignores the HDR skybox. For a fully immersive
 `ImmersiveSpace`, opt in with `.immersiveSpace()` to render the HDR as a
@@ -564,7 +570,7 @@ exposes have no iOS equivalent at all. Ported from the source of truth,
 | MSAA | via `View.multiSampleAntiAliasingOptions` | not user-controllable |
 | HDR color buffer | `QualityLevel.HIGH/MEDIUM/LOW` | not exposed |
 | Dynamic resolution | via `View.dynamicResolutionOptions` | not exposed |
-| Environmental IBL intensity | via `EnvironmentLoader` HDR | via `ImageBasedLightComponent.intensityExponent` |
+| Environmental IBL intensity | `IndirectLight.intensity`, absolute **lux** (`DEFAULT_IBL_INTENSITY` = 10 000) | `SceneEnvironment.intensity`, a linear **multiplier** (`1.0` = HDR untouched), converted to `ImageBasedLightComponent.intensityExponent` internally (#2897) — **not** interchangeable with the Android value |
 | Person occlusion (AR) | (n/a) | via `ARView.renderOptions` (AR only, not on `RealityView`) |
 
 ---

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -4288,9 +4288,13 @@ SceneView { root in root.addChild(hero.entity) }
 > `camera_distance` intent extra, but that is a sample-app knob, not the library
 > API. **Web has no framing-padding lever** — `fitToModels()` takes no margin —
 > but the initial orbit *is* settable, imperatively rather than declaratively:
-> `sv.setCameraOrbit(theta, phi, distance)`. The iOS
-> launch-argument counterpart to the intent extra is tracked in #2785; these
-> modifiers are the in-scene lever (#2896).
+> `sv.setCameraOrbit(theta, phi, distance)`. Android also clamps padding to
+> `max(0, padding)`, so it cannot frame **tighter** than tangent, while iOS
+> `framingMargin` accepts down to `0.2` — the sub-tangent range has no Android
+> equivalent today. The library-side parity gap (a per-scene padding parameter on
+> Android's `Scene { }`, a margin on Web's `fitToModels()`) is tracked in #2946;
+> the iOS launch-argument counterpart to the sample-app intent extra is a separate
+> item, #2785. These modifiers are the in-scene lever (#2896).
 
 ### Render defaults (v4.2.0+)
 
@@ -4713,6 +4717,12 @@ public struct SceneEnvironment: Sendable {
     public static let allPresets: [SceneEnvironment]
 }
 ```
+
+`intensity` is a **linear multiplier**, the same unit and scale as Android's
+`Environment` intensity — `1.0` leaves the HDR's own radiance untouched, `0.5`
+halves it. Identical values give identical lighting on both platforms. RealityKit's
+underlying `ImageBasedLightComponent` takes a power-of-two *exponent*; SceneView
+converts for you, so never pre-apply a `log2` (#2897).
 
 `showSkybox: true` renders the HDR as a background. On iOS / macOS it uses
 `RealityViewContent.environment = .skybox(...)`. On visionOS a windowed /

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -4718,11 +4718,20 @@ public struct SceneEnvironment: Sendable {
 }
 ```
 
-`intensity` is a **linear multiplier**, the same unit and scale as Android's
-`Environment` intensity — `1.0` leaves the HDR's own radiance untouched, `0.5`
-halves it. Identical values give identical lighting on both platforms. RealityKit's
-underlying `ImageBasedLightComponent` takes a power-of-two *exponent*; SceneView
-converts for you, so never pre-apply a `log2` (#2897).
+`SceneEnvironment.intensity` is a **linear multiplier** — `1.0` leaves the HDR's
+own radiance untouched, `0.5` halves it. RealityKit's underlying
+`ImageBasedLightComponent` takes a power-of-two *exponent*; `SceneEnvironment`
+converts for you, so never pre-apply a `log2` to **this** property (#2897).
+
+> ⚠️ **Do not carry an Android IBL value across.** Android's `Environment` has no
+> intensity member; its IBL level is Filament's `IndirectLight.intensity` in
+> **absolute lux**, defaulting to `DEFAULT_IBL_INTENSITY = 10_000`
+> (`SceneFactories.kt`). `1.0` there is one lux — effectively black. The two
+> platforms are tuned to match on the key-light-to-IBL *ratio*, not on absolute
+> values, and iOS's exponent-0 baseline sits around 1000 lux equivalent. Web has
+> no intensity knob at all: `environment(iblUrl, skyboxUrl)` takes none.
+> The sibling `ReflectionProbeNode.intensity` is a **separate** property that
+> still takes a raw exponent — see #2956.
 
 `showSkybox: true` renders the HDR as a background. On iOS / macOS it uses
 `RealityViewContent.environment = .skybox(...)`. On visionOS a windowed /

--- a/llms.txt
+++ b/llms.txt
@@ -6460,9 +6460,13 @@ SceneView { root in root.addChild(hero.entity) }
 > `camera_distance` intent extra, but that is a sample-app knob, not the library
 > API. **Web has no framing-padding lever** — `fitToModels()` takes no margin —
 > but the initial orbit *is* settable, imperatively rather than declaratively:
-> `sv.setCameraOrbit(theta, phi, distance)`. The iOS
-> launch-argument counterpart to the intent extra is tracked in #2785; these
-> modifiers are the in-scene lever (#2896).
+> `sv.setCameraOrbit(theta, phi, distance)`. Android also clamps padding to
+> `max(0, padding)`, so it cannot frame **tighter** than tangent, while iOS
+> `framingMargin` accepts down to `0.2` — the sub-tangent range has no Android
+> equivalent today. The library-side parity gap (a per-scene padding parameter on
+> Android's `Scene { }`, a margin on Web's `fitToModels()`) is tracked in #2946;
+> the iOS launch-argument counterpart to the sample-app intent extra is a separate
+> item, #2785. These modifiers are the in-scene lever (#2896).
 
 ### Render defaults (v4.2.0+)
 
@@ -6885,6 +6889,12 @@ public struct SceneEnvironment: Sendable {
     public static let allPresets: [SceneEnvironment]
 }
 ```
+
+`intensity` is a **linear multiplier**, the same unit and scale as Android's
+`Environment` intensity — `1.0` leaves the HDR's own radiance untouched, `0.5`
+halves it. Identical values give identical lighting on both platforms. RealityKit's
+underlying `ImageBasedLightComponent` takes a power-of-two *exponent*; SceneView
+converts for you, so never pre-apply a `log2` (#2897).
 
 `showSkybox: true` renders the HDR as a background. On iOS / macOS it uses
 `RealityViewContent.environment = .skybox(...)`. On visionOS a windowed /

--- a/llms.txt
+++ b/llms.txt
@@ -6890,11 +6890,20 @@ public struct SceneEnvironment: Sendable {
 }
 ```
 
-`intensity` is a **linear multiplier**, the same unit and scale as Android's
-`Environment` intensity — `1.0` leaves the HDR's own radiance untouched, `0.5`
-halves it. Identical values give identical lighting on both platforms. RealityKit's
-underlying `ImageBasedLightComponent` takes a power-of-two *exponent*; SceneView
-converts for you, so never pre-apply a `log2` (#2897).
+`SceneEnvironment.intensity` is a **linear multiplier** — `1.0` leaves the HDR's
+own radiance untouched, `0.5` halves it. RealityKit's underlying
+`ImageBasedLightComponent` takes a power-of-two *exponent*; `SceneEnvironment`
+converts for you, so never pre-apply a `log2` to **this** property (#2897).
+
+> ⚠️ **Do not carry an Android IBL value across.** Android's `Environment` has no
+> intensity member; its IBL level is Filament's `IndirectLight.intensity` in
+> **absolute lux**, defaulting to `DEFAULT_IBL_INTENSITY = 10_000`
+> (`SceneFactories.kt`). `1.0` there is one lux — effectively black. The two
+> platforms are tuned to match on the key-light-to-IBL *ratio*, not on absolute
+> values, and iOS's exponent-0 baseline sits around 1000 lux equivalent. Web has
+> no intensity knob at all: `environment(iblUrl, skyboxUrl)` takes none.
+> The sibling `ReflectionProbeNode.intensity` is a **separate** property that
+> still takes a raw exponent — see #2956.
 
 `showSkybox: true` renders the HDR as a background. On iOS / macOS it uses
 `RealityViewContent.environment = .skybox(...)`. On visionOS a windowed /

--- a/samples/ios-demo/appstore-screenshots/README.md
+++ b/samples/ios-demo/appstore-screenshots/README.md
@@ -3,6 +3,15 @@
 Fresh, correctly-sized App Store Connect screenshots for the SceneView demo
 app — real iOS-simulator captures of rendered 3D content.
 
+> ⛔ **These frames are stale as of #2897 — re-capture before dispatching
+> `app-store-screenshots.yml`.** They were captured while
+> `SceneEnvironment.intensity` was still fed to RealityKit as a `2^x` exponent,
+> so `.studio` (the default preset, `intensity` 1.0) lit them at ×2.0. #2897
+> converts with `log2`, so the app now renders these scenes about **half as
+> bright** as what is committed here. Uploading them would advertise an exposure
+> the app no longer produces. Nothing enforces this — the dispatch is manual and
+> `asc_listing.py` compares checksums, not pixels — so it is a note, not a gate.
+
 ## Background — issue #917
 
 The App Store Connect listing previously carried stale screenshots:
@@ -63,8 +72,12 @@ That frame passes every mechanical check — right dimensions, settled,
 byte-reproducible — so only looking at the mosaic catches it. It is the same
 defect class that took `multi-model` out of the Android **tablet** set
 (#2913/#2915: "do not re-add on the strength of a green capture"), and shipping
-it would advertise a scene no keyless user can ever see. Re-add once #2913
-lands, and only after looking at a fresh frame against the other slots.
+it would advertise a scene no keyless user can ever see.
+
+The exclusion is **not** gated on an issue. #2913 is closed and the re-add did
+not become due — the reason is structural (keyless resolver substitution), not
+a bug someone was going to fix. Re-add only after looking at a freshly captured
+frame next to the other slots.
 
 Three further ids that used to be in this set were retired from Android's for
 defects that are platform-independent, so do not reach for them here either.

--- a/samples/ios-demo/appstore-screenshots/README.md
+++ b/samples/ios-demo/appstore-screenshots/README.md
@@ -3,14 +3,22 @@
 Fresh, correctly-sized App Store Connect screenshots for the SceneView demo
 app — real iOS-simulator captures of rendered 3D content.
 
-> ⛔ **These frames are stale as of #2897 — re-capture before dispatching
+> ⛔ **These frames predate #2897 — re-capture before dispatching
 > `app-store-screenshots.yml`.** They were captured while
-> `SceneEnvironment.intensity` was still fed to RealityKit as a `2^x` exponent,
-> so `.studio` (the default preset, `intensity` 1.0) lit them at ×2.0. #2897
-> converts with `log2`, so the app now renders these scenes about **half as
-> bright** as what is committed here. Uploading them would advertise an exposure
-> the app no longer produces. Nothing enforces this — the dispatch is manual and
-> `asc_listing.py` compares checksums, not pixels — so it is a note, not a gate.
+> `SceneEnvironment.intensity` was still fed to RealityKit as a `2^x` exponent:
+> `01-model-viewer.png` runs on `.warm` (intensity 1.0 → ×2.00, now ×1.00) and
+> `02-dynamic-sky.png` on `.outdoor` (1.2 → ×2.30, now ×1.20).
+>
+> **Measured, not estimated** — `01-model-viewer.png` re-shot from the #2897
+> branch on a 1320×2868 simulator, same `-demo model-viewer -qa_mode 1` launch:
+> viewport mean luma 192.3 → 191.2, vehicle region 151.6 → 147.4. The frames are
+> **not** uniformly halved, because only the IBL contribution changes — the
+> skybox is drawn directly and the direct lights are untouched, and on this scene
+> the bright studio backdrop dominates the histogram. They are still not what the
+> app renders.
+>
+> Nothing enforces this — the dispatch is manual and `asc_listing.py` compares
+> checksums, not pixels — so it is a note, not a gate.
 
 ## Background — issue #917
 


### PR DESCRIPTION
Closes #2897. Also corrects what #2927 (`e75304b62`) shipped stale, found by the two independent reviews that finished a few minutes after it merged.

## The fix

`intensity` was passed straight to RealityKit's `ImageBasedLightComponent(intensityExponent:)`, which scales the IBL by `2^x`, while the parameter is authored, documented and tested as a **linear multiplier**:

| Preset | authored | rendered before | after |
|---|---|---|---|
| `.studio` (default) | 1.0 | **×2.0** | ×1.0 |
| `.outdoor` | 1.2 | ×2.30 | ×1.2 |
| `.night` | 0.4 | **×1.32 — brightens** | ×0.4 |
| `.nightSky` | 0.5 | ×1.41 | ×0.5 |
| `.sunset` | 0.8 | ×1.74 | ×0.8 |

`.night` was not merely wrong but inverted.

**Why now.** The defect pre-dates #2896 but was latent: `EnvironmentResource(named:)` cannot load the Radiance `.hdr` presets (all seven are Radiance), `load()` swallowed the throw, no `ImageBasedLightComponent` was ever set, and `intensity` reached nothing. #2927 made the IBL load — and the wrong unit went live on `main` with it.

The conversion lives in `SceneEnvironment.intensityExponent(forMultiplier:)` (internal) rather than inline, so it is unit-testable without a live RealityKit scene — the call site is `@MainActor` and needs one. It clamps to a finite exponent for **every** `Float`: `NaN`/`signalingNaN` → -126, `+infinity` → 128, `0`/`-0`/negatives/`-infinity` → -126. The `min`/`max` pair is load-bearing — Swift's generic `max` is `y >= x ? y : x` and NaN compares false against everything, so `max(.nan, tiny)` is `.nan` while `max(tiny, .nan)` is `tiny` (measured with a standalone `swiftc` probe).

### ⚠️ This is not a cross-platform parity fix, and an earlier revision of this PR wrongly said it was

Corrected after checking Android's source instead of assuming it. Android's `Environment` (`sceneview/.../environment/Environment.kt`) has **no intensity member**; its IBL level is Filament's `IndirectLight.intensity` in **absolute lux**, `DEFAULT_IBL_INTENSITY = 10_000` — `1.0` there is one lux, effectively black. The repo already documented this at `SceneFactories.kt:78-81`: iOS uses `intensityExponent = 0` (≈1000 lux equivalent), Android stays at 10×, "the absolute values diverge but the key:IBL ratio matches". What this change does is move iOS **onto** that documented exponent-0 baseline. The two knobs remain non-interchangeable, and `llms.txt` now says so.

## Also in here — #2927 leftovers

- **`capture-appstore-screenshots.sh` contradicted its own PR.** Lines 66-73 still said the multi-model tree slot renders *"not at all"* and gated the re-add on *"#2913 and the tree-render bug"*. #2927's head commit `ff0826155` — *"correct three screenshot-set claims refuted by measurement"* — declared both false and rewrote the README and changelog, but missed this file. #2913 and #2928 are **CLOSED** and #2928's fix was already an ancestor of the branch tip, so the gate also read as satisfied while the real (structural) reason still stood.
- Same satisfied-gate wording removed from `appstore-screenshots/README.md` and `changelog.d/2896-…md`.
- **`BANNER_SAMPLES` < 2 made the banner-settle guard a silent no-op.** The probe loop never ran, `settled` stayed 1, and `capture_settled` returned success having compared nothing — a green capture advertising protection it did not perform. Refused up front now, non-integers too.
- **`llms.txt` pointed the framing-lever parity deferral at #2785**, the capture-side launch argument; the library-side gap is **#2946**. Also records that Android clamps padding to `max(0, padding)` and so has no equivalent of iOS's sub-tangent range.
- **README records that the committed App Store screenshots predate this fix**, with a measurement rather than an estimate (below). Re-capture before dispatching `app-store-screenshots.yml`.
- `RenderQuality.swift` still assigns raw exponents (`1.0`, `0.5`) which now mean ×2.0 and ×1.41 — `.performance` would *brighten*. Verified unreachable today (its only caller runs synchronously in `setupScene`, before the async `loadEnvironment` sets the component, so both branches no-op). Left a comment rather than changing a dead path.

## Verification — all actually run

| Check | Result |
|---|---|
| `swift build` | clean |
| `swift test` (macOS SPM) | **690 tests, 2 skipped, 0 failures** |
| `xcodebuild test -destination 'iOS Simulator'`, `SceneEnvironmentTests` | **20 tests, 0 failures** (was 15 — the 5 new ones execute) |
| **Mutation test** | reverting the helper to `multiplier` makes **all** the new tests fail |
| NaN/∞ behaviour | measured with a standalone `swiftc` probe, table above |
| Visual, on simulator | `01-model-viewer.png` re-shot from this branch, same launch, same 1320×2868 |
| `generate-gpt-knowledge.js --check` | in sync |
| `check-sceneview-skill.sh` / `check-doc-drift.sh` | pass / WARN 0 INFO 0 |
| `bash -n` on the capture script | clean |

**The `swift test` and simulator rows are not cumulative.** The new tests sit inside the file's `#if os(iOS) || os(visionOS)` guard, so the 690-test macOS run does **not** cover them — the simulator row is their only coverage. (A first attempt put them in the visionOS-only `VisionOSSkyboxTests` class, where `TEST SUCCEEDED` came back on 15 tests that were all pre-existing.) The local simulator is `iPhone 17 Pro Max`, not CI's `iPhone 16 Pro`.

**Visual before/after**, using the committed frame as the "before" — it was captured on `main` with the exponent live:

| region | before | after |
|---|---|---|
| viewport mean luma | 192.3 | 191.2 |
| vehicle region mean luma | 151.6 | 147.4 |

Darker in the expected direction, and **deliberately not halved**: only the IBL contribution changes — the skybox is drawn directly, the direct lights are untouched, and this scene's bright `.warm` studio backdrop dominates the histogram. The HDR Environment demo was also launched and renders its skybox and subject correctly.

**Not verified:** no before/after on `.night`, which is where the change is largest — that would need a second build of `main`.

## Follow-ups opened

- **#2956** — `ReflectionProbeNode.intensity` has the identical multiplier-vs-exponent confusion in a second public API, driven by a demo slider. Deliberately out of scope: it is a behavioural change on a separate public API and deserves its own before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)