### PR TITLE
fix(changelog): a multi-tag fragment no longer files every bullet under the last tag

### DIFF
--- a/.claude/scripts/collate-changelog.sh
+++ b/.claude/scripts/collate-changelog.sh
@@ -108,6 +108,26 @@ canonical_category() {
     esac
 }
 
+# Flush whatever `body` has accumulated into `$TMP_DIR/$category`, then reset it.
+#
+# This runs at EVERY category-tag transition and once more at EOF, because a
+# fragment may carry SEVERAL tags: `changelog.d/README.md` allows more than one
+# bullet per fragment and never forbids more than one category, so each tag must
+# own the bullets that FOLLOW it. Flushing only at EOF — the original behaviour —
+# filed a whole multi-tag fragment under whichever tag happened to appear LAST
+# (measured: a `Fixed` + `Tests` fragment shipped its Fixed bullets under
+# `### Tests`). Bullets that precede any tag flush under the `Changed` default.
+#
+# Reads `body`/`category`/`f` from the caller's scope and writes back `body`.
+flush_fragment_body() {
+    local trimmed
+    trimmed="$(printf '%s' "$body" | trim_blank_lines)"
+    body=""
+    [ -n "$trimmed" ] || return 0
+    printf '%s\n' "$trimmed" >> "$TMP_DIR/$category"
+    echo -e "  ${GREEN}+${NC} $(basename "$f") → ${CYAN}$category${NC}"
+}
+
 # ─── 1. Parse fragments ──────────────────────────────────────────────────
 for f in "${FRAGMENTS[@]}"; do
     category="Changed"
@@ -115,17 +135,14 @@ for f in "${FRAGMENTS[@]}"; do
     while IFS= read -r line || [ -n "$line" ]; do
         # Category tag line: <!-- category: Fixed -->  (anywhere in the file)
         if [[ "$line" =~ ^[[:space:]]*\<!--[[:space:]]*category:[[:space:]]*([A-Za-z]+)[[:space:]]*--\>[[:space:]]*$ ]]; then
+            # Close the preceding block BEFORE switching bucket.
+            flush_fragment_body
             category="$(canonical_category "${BASH_REMATCH[1]}")"
             continue
         fi
         body+="$line"$'\n'
     done < "$f"
-    # Trim leading/trailing blank lines from the body.
-    body="$(printf '%s' "$body" | trim_blank_lines)"
-    if [ -n "$body" ]; then
-        printf '%s\n' "$body" >> "$TMP_DIR/$category"
-        echo -e "  ${GREEN}+${NC} $(basename "$f") → ${CYAN}$category${NC}"
-    fi
+    flush_fragment_body
 done
 
 # ─── 2. Carry over legacy ## Unreleased entries ──────────────────────────

--- a/.claude/scripts/test-collate-changelog.sh
+++ b/.claude/scripts/test-collate-changelog.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Hermetic self-test for collate-changelog.sh — the fragment→category contract.
+#
+# The collator runs exactly once per release, on a directory of fragments that
+# are DELETED the moment it succeeds. A misfiled bullet is therefore discovered
+# after the release notes are published, with the source already gone — which is
+# how a fragment carrying two `<!-- category: -->` tags shipped all of its
+# `Fixed` bullets under `### Tests`: the parse loop reassigned the category on
+# every tag but accumulated the whole file into one buffer, written once at EOF
+# under whichever tag came LAST.
+#
+# `changelog.d/README.md` allows several bullets per fragment and never forbids
+# several categories, so multi-tag fragments are legal input, not misuse.
+#
+# Fixtures only: a fake repo root (its own .claude/scripts/, changelog.d/ and
+# CHANGELOG.md) with a copy of the script under test. No network, no git, no
+# writes outside $TMP.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLLATOR="$SCRIPT_DIR/collate-changelog.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+check() { # name expected actual
+  if [ "$2" = "$3" ]; then
+    echo "  ✓ $1"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ $1 — expected '$2', got '$3'"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# Build a fresh fake repo root at $ROOT around the given collator, and populate
+# changelog.d/ with the fixture fragments. The collator derives its repo root
+# from its own path (`dirname $0`/../..), so copying it into $ROOT/.claude/
+# scripts/ is what makes the run hermetic.
+setup_sandbox() { # collator_path -> sets $ROOT
+  ROOT="$TMP/repo"
+  rm -rf "$ROOT"
+  mkdir -p "$ROOT/.claude/scripts" "$ROOT/changelog.d"
+  cp "$1" "$ROOT/.claude/scripts/collate-changelog.sh"
+  printf '# Changelog\n\n## Unreleased\n\n## v4.0.0 — 2026-01-01\n\n### Fixed\n\n- PRIOR-RELEASE-BULLET\n' \
+    > "$ROOT/CHANGELOG.md"
+
+  # 1. Single-tag fragment — the common case, must keep working untouched.
+  cat > "$ROOT/changelog.d/0001-single-tag.md" <<'EOF'
+<!-- category: Added -->
+- MARKER-SINGLE-A
+- MARKER-SINGLE-B
+EOF
+
+  # 2. Multi-tag fragment — the regression. Each tag owns the bullets AFTER it,
+  #    and the leading bullet (before any tag) defaults to Changed.
+  cat > "$ROOT/changelog.d/0002-multi-tag.md" <<'EOF'
+- MARKER-PREAMBLE
+<!-- category: Fixed -->
+- MARKER-MULTI-FIXED
+
+<!-- category: Tests -->
+- MARKER-MULTI-TESTS
+EOF
+
+  # 3. Untagged fragment — documented default bucket.
+  cat > "$ROOT/changelog.d/0003-untagged.md" <<'EOF'
+- MARKER-UNTAGGED
+EOF
+
+  # 4. Unknown category name — falls back to Changed rather than creating a
+  #    bucket that the section builder would never emit (silently dropping it).
+  cat > "$ROOT/changelog.d/0004-unknown-category.md" <<'EOF'
+<!-- category: Wibble -->
+- MARKER-UNKNOWN
+EOF
+
+  # 5. Odd spacing + casing — the tag matcher and canonicalisation must both
+  #    tolerate it, otherwise the line reads as prose and lands in the body.
+  cat > "$ROOT/changelog.d/0005-odd-spacing.md" <<'EOF'
+   <!--   category:   dOcS   -->
+- MARKER-ODD
+EOF
+}
+
+# Which `### <Category>` heading does a marker end up under, inside the NEW
+# release section? Anything outside that section (or a marker that leaked into
+# a heading-less position) reports empty.
+section_of() { # marker -> "Added" | "" ...
+  awk -v marker="$1" '
+    /^## v4\.1\.0/ { in_new = 1; next }
+    in_new && /^## / { exit }
+    in_new && /^### / { heading = substr($0, 5); next }
+    in_new && index($0, marker) { print heading; exit }
+  ' "$ROOT/CHANGELOG.md"
+}
+
+echo "collate-changelog.sh — fragment→category contract"
+
+setup_sandbox "$COLLATOR"
+OUT="$(cd "$ROOT" && bash .claude/scripts/collate-changelog.sh 4.1.0 --date 2026-08-01 2>&1)"; RC=$?
+
+check "exit 0 on valid fragments" 0 "$RC"
+
+check "single-tag: first bullet"          Added   "$(section_of MARKER-SINGLE-A)"
+check "single-tag: second bullet"         Added   "$(section_of MARKER-SINGLE-B)"
+
+check "multi-tag: pre-tag bullet defaults" Changed "$(section_of MARKER-PREAMBLE)"
+check "multi-tag: Fixed block stays Fixed" Fixed   "$(section_of MARKER-MULTI-FIXED)"
+check "multi-tag: Tests block stays Tests" Tests   "$(section_of MARKER-MULTI-TESTS)"
+
+check "untagged fragment defaults"        Changed "$(section_of MARKER-UNTAGGED)"
+check "unknown category falls back"       Changed "$(section_of MARKER-UNKNOWN)"
+check "odd spacing/casing canonicalises"  Docs    "$(section_of MARKER-ODD)"
+
+# The tag lines themselves must never survive into the release notes.
+if grep -q 'category:' "$ROOT/CHANGELOG.md"; then
+  echo "  ✗ a category tag line leaked into CHANGELOG.md"; FAIL=$((FAIL + 1))
+else
+  echo "  ✓ category tag lines consumed, not emitted"; PASS=$((PASS + 1))
+fi
+
+# Pre-existing sections survive verbatim.
+check "prior release preserved" 1 "$(grep -c 'PRIOR-RELEASE-BULLET' "$ROOT/CHANGELOG.md")"
+
+# Consumed fragments are deleted; README.md is not a fragment and must remain
+# untouched (it is skipped by name, so it is never even in FRAGMENTS).
+check "fragments consumed" 0 "$(find "$ROOT/changelog.d" -name '*.md' | wc -l | tr -d ' ')"
+
+# --dry-run must not mutate anything — the escape hatch a release operator uses
+# to look before committing.
+setup_sandbox "$COLLATOR"
+BEFORE="$(cat "$ROOT/CHANGELOG.md")"
+(cd "$ROOT" && bash .claude/scripts/collate-changelog.sh 4.1.0 --dry-run >/dev/null 2>&1)
+check "--dry-run leaves CHANGELOG.md alone" "$BEFORE" "$(cat "$ROOT/CHANGELOG.md")"
+check "--dry-run keeps fragments"           5 "$(find "$ROOT/changelog.d" -name '*.md' | wc -l | tr -d ' ')"
+
+# ── Mutation test ────────────────────────────────────────────────────────────
+# The assertions above are only worth something if they are what FORCES the
+# per-tag flush. The mutation target is the flush call at the tag transition
+# (12-space indent, inside the `if`) — deleting it restores the original
+# EOF-only behaviour. The EOF flush (4-space indent) is deliberately left in
+# place, so the mutant still produces a complete-looking CHANGELOG: exactly the
+# failure mode that shipped, not a crash.
+MUT="$TMP/collate-mutant.sh"
+grep -v '^            flush_fragment_body$' "$COLLATOR" > "$MUT"
+if [ "$(grep -c 'flush_fragment_body' "$MUT")" = "$(grep -c 'flush_fragment_body' "$COLLATOR")" ]; then
+  echo "  ✗ mutation could not be applied — the anchor line moved, fix this test"
+  FAIL=$((FAIL + 1))
+else
+  setup_sandbox "$MUT"
+  (cd "$ROOT" && bash .claude/scripts/collate-changelog.sh 4.1.0 --date 2026-08-01 >/dev/null 2>&1)
+  mut_fixed="$(section_of MARKER-MULTI-FIXED)"
+  if [ "$mut_fixed" = "Fixed" ]; then
+    echo "  ✗ MUTATION SURVIVED — the per-tag flush is not what keeps Fixed bullets"
+    echo "    in Fixed; a regression to EOF-only flushing would go unnoticed"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  ✓ mutation killed — without the per-tag flush the Fixed block files under '${mut_fixed:-<none>}'"
+    PASS=$((PASS + 1))
+  fi
+fi
+
+echo
+echo "collate-changelog: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,6 +834,19 @@ jobs:
         shell: bash
         run: bash .claude/scripts/test-agent-cost-report.sh
 
+      # Changelog collation (collate-changelog.sh). It runs ONCE per release and
+      # DELETES the fragments it consumed, so a bullet filed under the wrong
+      # heading is found after the release notes are public, with the source
+      # already gone. Measured failure: a fragment carrying two
+      # `<!-- category: -->` tags shipped all of its Fixed bullets under
+      # `### Tests`, because the parser buffered the whole file and wrote it once
+      # under the LAST tag seen. Hermetic (fake repo root), with a mutation test
+      # on the per-tag flush — drop it and the multi-tag assertions must go red.
+      - name: Self-test changelog collator
+        if: always()
+        shell: bash
+        run: bash .claude/scripts/test-collate-changelog.sh
+
       # Doc↔API drift (ADVISORY, #docs). Warns when this PR changed a public
       # API surface without updating llms.txt / KDoc / docs/docs / recipes.
       # AI-first SDK: stale prose makes AI emit stale user code. Non-blocking

--- a/changelog.d/2963-collate-multi-tag-fragments.md
+++ b/changelog.d/2963-collate-multi-tag-fragments.md
@@ -1,0 +1,18 @@
+<!-- category: Fixed -->
+- **A changelog fragment carrying several `<!-- category: -->` tags no longer
+  files every bullet under the last one.** `collate-changelog.sh` reassigned the
+  category on each tag line but accumulated the whole fragment into a single
+  buffer, written once at EOF — so a `Fixed` + `Tests` fragment shipped its
+  Fixed bullets under `### Tests`. The parser now flushes at every tag
+  transition, so each tag owns the bullets that follow it (bullets before any
+  tag still default to `Changed`). Two uncollated fragments already carried the
+  pattern and would have misfiled at the next release. Multi-tag fragments are
+  now documented in `changelog.d/README.md`.
+
+<!-- category: Tests -->
+- `test-collate-changelog.sh` pins the fragment→category contract in
+  `repo-hygiene`: single-tag, multi-tag, untagged, unknown category name, and a
+  tag with odd spacing/casing, plus `--dry-run` immutability. The collator runs
+  once per release and **deletes** the fragments it consumed, so a misfiled
+  bullet is otherwise found only after the notes are public, with the source
+  already gone. Mutation-tested on the per-tag flush.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -46,6 +46,19 @@ change, no bug fix) — that's the distinction between this bucket and `Fixed` o
 You may include more than one bullet in a single fragment if the PR genuinely
 ships several related changes, but keep it to one PR's worth of notes.
 
+A fragment may also carry **more than one category tag**, when a PR ships
+changes that genuinely belong in different buckets. Each tag owns the bullets
+that **follow** it, up to the next tag or the end of the file; bullets written
+before any tag land in `Changed`:
+
+```markdown
+<!-- category: Fixed -->
+- **The bug this PR fixes.** …
+
+<!-- category: Added -->
+- **The API it adds along the way.** …
+```
+
 ## At release time
 
 `.claude/scripts/collate-changelog.sh X.Y.Z` reads every `*.md` fragment here


### PR DESCRIPTION
Found during the review of PR #2963 (#2893).

## The bug

`collate-changelog.sh`'s parse loop reassigns `category` on every
`<!-- category: X -->` line, but accumulates the **entire** fragment into a
single `body` and writes it **once after EOF** to `$TMP_DIR/$category` — i.e.
under whichever tag was seen **last**. A fragment carrying more than one tag
therefore ships all of its bullets under the wrong heading.

Reproduced against the real parse loop before touching it — a `Fixed` + `Tests`
fragment:

```
### Tests

- FIXED-BULLET-ONE      <- declared Fixed
- FIXED-BULLET-TWO      <- declared Fixed
- TESTS-BULLET-ONE
```

`changelog.d/README.md` explicitly allows several bullets per fragment and
never forbade several tags, so this is a parser bug on legal input, not misuse.

**Two uncollated fragments already carry the pattern** and would have misfiled
at the next release: `2854-store-screenshot-set-v2.md` (2 tags) and
`2896-ios-store-screenshots.md` (3 tags). Verified by collating the real
`changelog.d/` in a sandbox — all five of their bullets now land in their
declared buckets (`Added` / `Changed` / `Fixed`), where before the fix each
fragment collapsed onto its last tag.

## The fix

`body` is flushed into `$TMP_DIR/$category` at **every tag transition** and
once more at EOF, so each tag owns the bullets that follow it. Preserved
unchanged: single-tag fragments, untagged fragments, and bullets written before
any tag (still `Changed`). Multi-tag fragments are now documented in
`changelog.d/README.md`.

## The self-test

The collator runs **once per release** and **deletes** the fragments it
consumed, so a misfiled bullet is found only after the release notes are
public, with the source already gone. `test-collate-changelog.sh` (hermetic —
fake repo root, no network, no git) pins the contract in `repo-hygiene`:
single-tag · multi-tag · untagged · unknown category name · odd spacing/casing
(`<!--   category:   dOcS   -->`) · `--dry-run` immutability · tag lines never
leaking into the notes · prior sections preserved. 15 assertions.

Mutation-tested on the per-tag flush: delete that one call and the multi-tag
`Fixed` block files under `Tests`, turning the suite red. The suite was also
run against the **pre-fix** script and confirmed RED on exactly the two
multi-tag assertions — the assertions bind to the fix, not to incidental
behaviour.

`#2963`'s own fragments are untouched — they were split into one category each
as a workaround and are correct as-is.

## Verification

- `bash .claude/scripts/test-collate-changelog.sh` → 15 passed, 0 failed
- Suite against the pre-fix script → 3 failed (the 2 multi-tag assertions + the
  mutation-anchor guard), as intended
- Real `changelog.d/` collated in a sandbox → #2854 and #2896 bullets correct
- `bash -n` on both scripts, `yaml.safe_load` on `ci.yml`

⚠️ **`pre-push-check.sh` reported 2 red checks that this PR did not cause, and
I could not clear them locally — flagging rather than hiding them.**
`arsceneview` unit tests and the Android Roborazzi goldens came back red. This
diff is 5 files, all shell/YAML/Markdown — zero Kotlin, zero assets, zero
goldens. Evidence they are environmental: the local `arsceneview` run wrote
**no `test-results` at all** (it died before running a single test — not an
assertion failure), and CI's `Unit tests` job passed that same step on this
PR's exact base sha `89fef647`. Re-running to confirm is blocked by the host
disk gate (4.0 GB free < the 6 GB Gradle threshold), so **CI on this PR is the
authority for those two checks** — please read them there before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
