### PR TITLE
fix(ci): the merge grader was loaded from the code it grades

### DIFF
--- a/.claude/scripts/test-grade-pr-review.sh
+++ b/.claude/scripts/test-grade-pr-review.sh
@@ -131,6 +131,30 @@ else
   fi
 fi
 
+# ── The judge must not come from the code being judged ──────────────────────
+# `pr-review.yml` checks out the PR's tree. If it then ran the grader from that
+# tree, a PR editing grade-pr-review.sh would be graded by its own version of
+# the grader — the generator≠evaluator split is worth nothing if the generator
+# can rewrite the evaluator. It also simply crashes on any PR branched before
+# this script existed (measured: run 30764492028, "No such file or directory").
+# The workflow must read the grader from the default branch instead.
+echo "── grader is pinned to the default branch, not the checkout ──"
+WF="$(dirname "$0")/../../.github/workflows/pr-review.yml"
+if [ ! -f "$WF" ]; then
+  echo "  ✗ cannot find pr-review.yml at $WF"
+  FAIL=$((FAIL + 1))
+elif grep -qE '^[[:space:]]*bash[[:space:]]+\.claude/scripts/grade-pr-review\.sh' "$WF"; then
+  echo "  ✗ pr-review.yml runs the grader straight out of the checkout —"
+  echo "    a PR that edits grade-pr-review.sh would grade itself"
+  FAIL=$((FAIL + 1))
+elif ! grep -q 'git show "origin/\$DEFAULT_BRANCH:.claude/scripts/grade-pr-review.sh"' "$WF"; then
+  echo "  ✗ pr-review.yml no longer reads the grader from origin/\$DEFAULT_BRANCH"
+  FAIL=$((FAIL + 1))
+else
+  echo "  ✓ grader is read from origin/\$DEFAULT_BRANCH"
+  PASS=$((PASS + 1))
+fi
+
 echo
 echo "grade-pr-review: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -451,6 +451,7 @@ jobs:
         if: steps.budget.outputs.within_budget == 'true' && steps.creds.outputs.has_token == 'true' && steps.selfmod.outputs.self_modified == 'false'
         env:
           PR_NUM: ${{ steps.pr.outputs.number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # `set +e` is REQUIRED and not redundant: GitHub invokes run: steps as
           # `/usr/bin/bash -e {0}`, so errexit is on before the first line and a
@@ -462,7 +463,48 @@ jobs:
           # and only then fail on (in the `Enforce the verdict` step).
           set +e
           set -uo pipefail
-          bash .claude/scripts/grade-pr-review.sh review-verdict.json \
+          # ⛔ THE JUDGE MUST NOT COME FROM THE CODE BEING JUDGED.
+          #   `$GRADER` is fetched from the default branch, never read out of the
+          #   checkout. Two distinct reasons, and the second is the serious one:
+          #   1. The checkout is the PR's tree. A PR branched before this script
+          #      existed simply does not contain it — measured on run
+          #      30764492028, a dispatch on #2962: `No such file or directory`,
+          #      and the whole review died at the last step after the reviewers
+          #      had already been paid for.
+          #   2. A PR that EDITS `grade-pr-review.sh` would otherwise have its
+          #      own verdict computed by its own version of the grader. That is
+          #      the `pull_request_target` footgun wearing different clothes:
+          #      the generator≠evaluator split is worth nothing if the generator
+          #      can rewrite the evaluator. Pinning to the default branch means
+          #      a PR improving the grader is graded by the CURRENT grader —
+          #      which is the correct semantics anyway.
+          #   The self-modification guard covers pr-review.yml only, so it does
+          #   NOT cover this file; this pin is what closes that gap.
+          DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+          GRADER="$RUNNER_TEMP/grade-pr-review.sh"
+          git fetch origin "$DEFAULT_BRANCH" --depth=1 --quiet 2>/dev/null
+          if ! git show "origin/$DEFAULT_BRANCH:.claude/scripts/grade-pr-review.sh" > "$GRADER" 2>/dev/null; then
+            echo "::error title=Grader unavailable::Could not read .claude/scripts/grade-pr-review.sh from origin/$DEFAULT_BRANCH. Refusing to grade with whatever copy the PR happens to carry."
+            echo "gate_rc=1" >> "$GITHUB_OUTPUT"
+            echo "verdict=REVIEW_INCOMPLETE" >> "$GITHUB_OUTPUT"
+            echo "blocking=true" >> "$GITHUB_OUTPUT"
+            # The downstream steps read this file unconditionally; write the
+            # explanation rather than letting them fail on a missing path and
+            # leave the PR with an unexplained red check again.
+            {
+              echo '<!-- sceneview-agent-review -->'
+              echo '## ⛔ Agent review incomplete — the grader could not be loaded'
+              echo
+              echo "The merge verdict is computed by \`.claude/scripts/grade-pr-review.sh\`"
+              echo "read from \`$DEFAULT_BRANCH\`, never from this PR's tree — a PR must not"
+              echo 'be able to supply the script that grades it. That read failed here, so'
+              echo 'no verdict was computed and none is implied.'
+              echo
+              echo '**This is a CI configuration problem, not a finding about this PR.**'
+            } > review-comment.md
+            exit 0
+          fi
+          bash "$GRADER" review-verdict.json \
             --comment-out review-comment.md --pr "$PR_NUM" > grade.out
           echo "gate_rc=$?" >> "$GITHUB_OUTPUT"
           cat grade.out >> "$GITHUB_OUTPUT"

--- a/changelog.d/2964-grader-pinned-to-default-branch.md
+++ b/changelog.d/2964-grader-pinned-to-default-branch.md
@@ -1,0 +1,24 @@
+<!-- category: Fixed -->
+- **The merge grader was being loaded from the code it was grading.**
+  `pr-review.yml` checks out the PR's tree and then ran
+  `.claude/scripts/grade-pr-review.sh` from it, so a PR that edited the grader
+  would have had its own verdict computed by its own version of the grader. The
+  generator≠evaluator split this workflow is built on is worth nothing if the
+  generator can rewrite the evaluator — this is the `pull_request_target`
+  footgun in different clothes, and the self-modification guard did not cover
+  it (it watches `pr-review.yml` only). The grader is now read from the default
+  branch with `git show`, so a PR improving the grader is graded by the current
+  one, which is the correct semantics regardless of trust.
+  The same bug had a second, louder symptom that is how it was found: a
+  dispatch on a PR branched before the script existed died with `No such file
+  or directory` at the very last step, after the four reviewers had already
+  been paid for (measured, run 30764492028 on #2962). A failure to read the
+  grader now posts an explicit comment saying it is a CI configuration problem
+  and not a finding about the PR, instead of leaving another unexplained red
+  check.
+
+<!-- category: Tests -->
+- `test-grade-pr-review.sh` pins the above: it fails if `pr-review.yml` ever
+  runs the grader straight out of the checkout again, or stops reading it from
+  `origin/$DEFAULT_BRANCH`. Mutation-tested — restoring the checkout-relative
+  invocation takes the suite from 14 passed to 13 passed / 1 failed.


### PR DESCRIPTION
## The defect

`pr-review.yml` checks out the PR's tree, then ran
`.claude/scripts/grade-pr-review.sh` **out of that tree**. A PR that edits the
grader would therefore have had its own verdict computed by its own version of
the grader.

The generator ≠ evaluator split this entire workflow rests on is worth nothing
if the generator can rewrite the evaluator. This is the `pull_request_target`
footgun wearing different clothes, and the self-modification guard does **not**
close it — that guard watches `pr-review.yml` only.

## How it surfaced

A dispatch on #2962 — a PR branched before `grade-pr-review.sh` existed — died
with `No such file or directory` at the *final* step, after the four reviewers
had already been paid for
([run 30764492028](https://github.com/sceneview/sceneview/actions/runs/30764492028)).
The crash is the cheap symptom; the trust problem is the reason to fix it.

## Changes

- The grader is read from the default branch with `git show`. A PR that improves
  the grader is graded by the **current** grader — the correct semantics
  regardless of trust.
- A failed read posts a comment saying it is a CI configuration problem and *not*
  a finding about the PR, instead of leaving a fourth unexplained red check.
- `test-grade-pr-review.sh` fails if the checkout-relative invocation ever comes
  back, or if the pin to `origin/$DEFAULT_BRANCH` disappears.

## Verification

- suite: **14 passed, 0 failed**
- **mutation test**: restoring `bash .claude/scripts/grade-pr-review.sh …` takes it to **13 passed / 1 failed**; reverting returns it to 14/0
- the grader fetched from `main` was run against a 4/4 PASS fixture → `verdict=MERGE`, `rc=0`
- `check-workflow-scripts: OK`; `bash -n` on the modified step

`Agent review` will be red on this PR — it edits `pr-review.yml`, so
`claude-code-action` refuses to run. That check is advisory and does not gate
the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)