### PR TITLE
fix(android-demo): floatHoverY KDoc claimed a face clearance the constants deny (#2961)

### DIFF
--- a/changelog.d/2961-float-hover-clearance.md
+++ b/changelog.d/2961-float-hover-clearance.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- Contact-shadow preview (android-demo): `DemoMath.CONTACT_FLOAT_CENTER_Y_METERS` no longer
+  documents a face-to-face clearance the constants do not provide. The floating box's lowest
+  bottom face sits at 0.38 m — exactly flush with the grounded box's top face at its landing
+  pose (0.00 m of clearance), and 0.34 m *below* that box's top face at the peak of the hop.
+  The KDoc now states the measured geometry, the 0.040 m top-face margin that actually carries
+  the "aloft" reading, and why a clearance over the hop peak is impossible in this room (it
+  would need a rest centre above 0.96 m, whose top face punches through the wall TV at 0.93 m).
+  The accompanying test now asserts on box **faces** with the margins in metres, instead of
+  comparing box centres — a comparison two interpenetrating boxes also satisfy (#2961, #2931).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
@@ -408,10 +408,38 @@ internal object DemoMath {
     const val CONTACT_FLOAT_PERIOD_NANOS = 3_400_000_000L
 
     /**
-     * Rest height (metres, box **centre**) of the floating box. Chosen so the box hovers well
-     * clear of the floor at all times — its lowest point (`centre − bob − half-edge`) never
-     * reaches the grounded box's highest point, and its highest point stays below the wall TV.
-     * See the `floatHoverY … stays clear of the floor and the grounded box` test.
+     * Rest height (metres, box **centre**) of the floating box.
+     *
+     * The two boxes are 0.38 m apart along X and never intersect, so what this constant buys is
+     * a **vertical reading order on screen**, not a physical gap. The real geometry, with the
+     * demo's 0.38 m box edge (half-edge 0.19 m) and 0.34 m hop peak:
+     *
+     * | face | metres |
+     * |---|---|
+     * | grounded box top, at its landing pose | 0.38 |
+     * | grounded box top, at the peak of the hop | 0.72 |
+     * | floating box bottom, at the bottom of the bob | 0.38 |
+     * | floating box top, at the bottom of the bob | 0.76 |
+     * | floating box top, at the top of the bob | 0.86 |
+     *
+     * So there is **no face-to-face clearance over the hopping box**: at the peak of the hop the
+     * grounded box's top face is 0.34 m *above* the floating box's lowest bottom face — the two
+     * silhouettes overlap in screen-Y, and they are only told apart by their 0.38 m horizontal
+     * separation. Against the grounded box's *landing* pose the two faces are exactly flush
+     * (0.38 m vs 0.38 m, 0.00 m of clearance), which is the floor this constant may never sink
+     * below.
+     *
+     * A genuine clearance over the *peak* is geometrically impossible in this room and was not
+     * what shipped: it would need a rest centre above `0.72 + bob + half-edge = 0.96 m`, whose
+     * top face at 1.20 m punches through the wall TV's bottom edge (0.93 m). The room affords a
+     * rest centre of at most 0.69 m.
+     *
+     * What the constants *do* guarantee, and what carries the "aloft" reading at every phase, is
+     * a **top-face** ordering: the floating box's top face at its lowest (0.76 m) still sits
+     * 0.04 m above the grounded box's top face at its highest (0.72 m), so the floating box is
+     * never overtaken by its hopping twin. Its own top face stays 0.07 m below the wall TV
+     * (0.86 m vs 0.93 m). All four figures are pinned by the
+     * `floatHoverY box faces clear the landed box and stay below the wall TV` test.
      */
     const val CONTACT_FLOAT_CENTER_Y_METERS = 0.62f
 

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
@@ -592,26 +592,61 @@ class DemoMathTest {
     }
 
     @Test
-    fun `floatHoverY keeps the floating box clear of the floor and the grounded box`() {
-        // The whole redesign rests on the floating box reading as unmistakably ALOFT at every
-        // phase: its lowest point must clear the grounded box's highest point, and its highest
-        // point must stay below the wall TV. Box edge is 0.38 m (BOX_EDGE_METERS in the demo),
-        // so the half-edge is 0.19 m.
+    fun `floatHoverY box faces clear the landed box and stay below the wall TV`() {
+        // Asserts on box FACES, never on centres: a centre comparison is satisfied by two boxes
+        // that visibly interpenetrate, so it cannot testify to any clearance (#2961 — the
+        // predecessor of this test compared centres while its comment claimed a face clearance).
+        // Box edge is 0.38 m (BOX_EDGE_METERS in the demo), so the half-edge is 0.19 m; the demo
+        // seats the grounded box at (half-edge + hop) and the floating box at floatHoverY().
         val boxHalfEdge = 0.38f / 2f
-        // Grounded box centre peaks at (rest half-edge + bounce max); floating centre dips to
-        // (rest centre − bob). The floating box must never come down to the grounded box.
-        val groundedHighestCentre = boxHalfEdge + DemoMath.CONTACT_BOUNCE_MAX_HEIGHT_METERS
-        val floatingLowestCentre = floatCenter - floatBob
-        assertTrue(
-            "floating lowest centre ($floatingLowestCentre) must exceed grounded highest centre ($groundedHighestCentre)",
-            floatingLowestCentre > groundedHighestCentre,
-        )
-        // Floating box top (centre + bob + half-edge) must stay below the wall TV's bottom edge
-        // (TV centre y = 1.3 m, height 0.74 m → bottom 0.93 m) so they never visually overlap.
+        val groundedLandedTop = boxHalfEdge + boxHalfEdge
+        val groundedPeakTop = boxHalfEdge + DemoMath.CONTACT_BOUNCE_MAX_HEIGHT_METERS + boxHalfEdge
+        val floatingLowestBottom = floatCenter - floatBob - boxHalfEdge
+        val floatingLowestTop = floatCenter - floatBob + boxHalfEdge
         val floatingHighestTop = floatCenter + floatBob + boxHalfEdge
+
+        // 1. Floor of the design: the floating box's bottom face never sinks below the grounded
+        // box's top face at its LANDING pose. Measured clearance is 0.000 m — the two faces are
+        // exactly flush (0.38 m), so this bound is knife-edge and any downward drift breaks it.
+        val landedClearance = floatingLowestBottom - groundedLandedTop
         assertTrue(
-            "floating box top ($floatingHighestTop) must stay below the TV bottom (0.93)",
-            floatingHighestTop < 0.93f,
+            "floating bottom ($floatingLowestBottom m) must not sink below the landed box's top " +
+                "($groundedLandedTop m) — clearance ${landedClearance} m, must be >= 0.000 m",
+            landedClearance >= -eps,
         )
+
+        // 2. And the honest converse: over the PEAK of the hop there is NO clearance at all. The
+        // grounded box's top face rises 0.340 m ABOVE the floating box's lowest bottom face; the
+        // silhouettes overlap in screen-Y and are told apart only by their 0.38 m X separation.
+        // Pinned so the KDoc's stated overlap can never quietly stop matching the constants.
+        assertEquals(
+            "grounded peak top ($groundedPeakTop m) vs floating lowest bottom " +
+                "($floatingLowestBottom m): overlap must be 0.340 m, not a clearance",
+            0.340f,
+            groundedPeakTop - floatingLowestBottom,
+            eps,
+        )
+
+        // 3. What actually carries the "aloft" reading at every phase is the TOP-face ordering:
+        // the floating box's top face at its lowest still clears the grounded box's top face at
+        // its highest by 0.040 m, so the hopping twin never overtakes it.
+        val topMargin = floatingLowestTop - groundedPeakTop
+        assertTrue(
+            "floating top at the bottom of the bob ($floatingLowestTop m) must stay above the " +
+                "grounded top at the peak of the hop ($groundedPeakTop m) — margin ${topMargin} m, " +
+                "expected 0.040 m",
+            topMargin > eps,
+        )
+        assertEquals("top-face margin, metres", 0.040f, topMargin, eps)
+
+        // 4. Headroom: the floating box's top face stays 0.070 m below the wall TV's bottom edge
+        // (TV centre y = 1.3 m, height 0.74 m → bottom 0.93 m) so they never visually overlap.
+        val tvMargin = 0.93f - floatingHighestTop
+        assertTrue(
+            "floating box top ($floatingHighestTop m) must stay below the TV bottom (0.93 m) — " +
+                "margin ${tvMargin} m, expected 0.070 m",
+            tvMargin > eps,
+        )
+        assertEquals("wall-TV headroom, metres", 0.070f, tvMargin, eps)
     }
 }


### PR DESCRIPTION
Closes #2961. Follow-up to #2931 (`0e881ece5`), which listed the centre-comparison test as a verification bullet — which is how the false claim shipped.

## Re-derived geometry

From the constants alone — `BOX_EDGE_METERS = 0.38` (full extents, so half-edge **0.19 m**; `Cube.Builder.size` is documented as full extents and the demo seats the grounded box at `BOX_EDGE_METERS / 2 + hopHeight`), `CONTACT_BOUNCE_MAX_HEIGHT_METERS = 0.34`, `CONTACT_FLOAT_CENTER_Y_METERS = 0.62`, `CONTACT_FLOAT_BOB_METERS = 0.05`:

| face | metres |
|---|---|
| grounded box top, at its landing pose | 0.38 |
| grounded box top, at the peak of the hop | 0.72 |
| floating box bottom, at the bottom of the bob | 0.38 |
| floating box top, at the bottom of the bob | 0.76 |
| floating box top, at the top of the bob | 0.86 |
| wall-TV bottom edge | 0.93 |

**Measured before:** clearance over the grounded box's **landing** pose = `0.38 − 0.38` = **0.000 m** (exactly flush, not a clearance). Against its **peak** pose = `0.38 − 0.72` = **−0.340 m**, i.e. a 0.34 m overlap. The KDoc's claim ("its lowest point never reaches the grounded box's highest point") is false by 0.34 m.

## Which fix the numbers support

**Not** the constants. A genuine face clearance over the hop peak needs a rest centre above `0.72 + 0.05 + 0.19 = 0.96 m`, whose top face at `0.96 + 0.24 = 1.20 m` punches through the wall TV's bottom edge at 0.93 m — the room caps the rest centre at **0.69 m**. Buying it back from the hop instead would require `maxHeight < 0.07 m` against today's 0.34 m, gutting the strike-the-floor choreography the demo exists to show (and invalidating the device-QA-calibrated 0.45 fade factor).

The current visual is the intended one: the two boxes are **0.38 m apart on X and never intersect**, so what the constant buys is a vertical reading order on screen, not a physical gap. **So the KDoc is corrected, not the geometry — `CONTACT_FLOAT_CENTER_Y_METERS` stays at 0.62 f. Measured after = measured before; nothing on screen moves.** The KDoc now carries the face table above, the 0.000 m flush floor, the 0.340 m peak overlap, the impossibility proof, and the property that actually carries the "aloft" reading: the **top-face ordering**, floating top at the bottom of the bob (0.76 m) clearing grounded top at the peak of the hop (0.72 m) by **0.040 m**.

## Test: faces, not centres

`DemoMathTest.kt:595` compared box **centres** (0.57 > 0.53) — a property two interpenetrating boxes also satisfy, so it could never testify to a clearance. Renamed to `floatHoverY box faces clear the landed box and stay below the wall TV` and rewritten to assert on faces, every margin stated in metres in the assertion message:

1. floating bottom never sinks below the landed box's top — clearance **0.000 m** (knife-edge floor)
2. the peak-of-hop **overlap is 0.340 m**, pinned so the KDoc's stated figure cannot silently stop matching the constants
3. **top-face margin 0.040 m** — floating top @ bob bottom vs grounded top @ hop peak
4. wall-TV headroom **0.070 m**

## Mutation test (mandatory, #2947)

**Baseline**, `./gradlew :samples:android-demo:testDebugUnitTest` on `main` before any edit:
```
BUILD SUCCESSFUL in 22s
tests=331 failures/errors=0 skipped=1
```

**Mutation A — `CONTACT_FLOAT_CENTER_Y_METERS` 0.62f → 0.58f** (−0.04 m, the top-face margin this test claims):
```
DemoMathTest > floatHoverY box faces clear the landed box and stay below the wall TV FAILED
    java.lang.AssertionError: floating bottom (0.33999997 m) must not sink below the landed box's
    top (0.38 m) — clearance -0.04000002 m, must be >= 0.000 m
        at ...DemoMathTest.kt:612
BUILD FAILED in 2s
```

**Mutation B — 0.62f → 0.66f** (+0.04 m; assertion 1 stays green, so this proves the equality guards are live and not decoration):
```
DemoMathTest > floatHoverY box faces clear the landed box and stay below the wall TV FAILED
    java.lang.AssertionError: grounded peak top (0.71999997 m) vs floating lowest bottom
    (0.42000002 m): overlap must be 0.340 m, not a clearance expected:<0.34> but was:<0.29999995>
BUILD FAILED in 2s
```

**Restored**, full suite:
```
BUILD SUCCESSFUL in 16s
tests=331 failures/errors=0 skipped=1
```

No device/emulator pass — this is pure math plus a KDoc. No emulator was touched, no lease taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
