### PR TITLE
fix(android-demo): make the six ar_placement fallbacks pairwise distinct (#2940)

### DIFF
--- a/changelog.d/2983-ar-placement-fallback-distinctness.md
+++ b/changelog.d/2983-ar-placement-fallback-distinctness.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **android-demo:** the six `ar_placement` slugs no longer share bundled fallbacks
+  — `khronos_lantern.glb` was claimed by three of them and
+  `khronos_damaged_helmet.glb` by two, so on a keyless build `ARPlacementDemo` /
+  `ARInstantPlacementDemo` (which accumulate placed models) rendered several
+  differently-labelled chips as the identical asset in one frame. Potted Monstera,
+  Wooden End Table and Picture Frame now point at distinct already-bundled GLBs,
+  making the six-slug → six-GLB mapping a bijection with no new binary. Guarded by
+  a new `SampleAssetsTest` case that derives the slug set from the registry by
+  category, mirroring the iOS guard (#2940, #2355, #2973).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SampleAssets.kt
@@ -270,6 +270,28 @@ object SampleAssets {
         // category as a chip row — 6 entries balances variety against the
         // curation surface (each new entry implies a permanent third-party
         // dependency on a model an author can delete or relicense).
+        //
+        // The six fallbacks below are PAIRWISE DISTINCT (#2355), pinned by
+        // `SampleAssetsTest.ar_placement fallbacks are pairwise distinct`. Both
+        // demos in this category ACCUMULATE placed models — `TapToPlaceState`
+        // owns the list, every tap appends — so on a keyless build two chips
+        // sharing one fallback render as the identical asset side by side in a
+        // single frame, under two different labels. That is the #2940 defect,
+        // fixed on iOS by #2962 and guarded there by #2973; it was still live
+        // here, with `khronos_lantern.glb` claimed by three slugs and
+        // `khronos_damaged_helmet.glb` by two.
+        //
+        // The demo bundles exactly six GLBs, so the mapping is a bijection and
+        // has no slack: repointing one slug now forces a swap, not a free pick.
+        // Distinctness is the guarantee — resemblance is NOT. Three of these
+        // fallbacks (`shiba`, `khronos_fox`, `threejs_soldier`) are animals or
+        // a character standing in for furniture and are chosen on silhouette
+        // class alone (compact ground mass / four-legged horizontal / upright).
+        // A keyless user sees six distinguishable objects, not six plausible
+        // ones. Closing that semantic gap needs assets this APK does not ship,
+        // so it is deliberately out of scope here, where the fix must add no
+        // binary. #2960 tracks that same mismatch class on the iOS registry;
+        // the Android side has no equivalent tracker yet.
         SketchfabSlug(
             uid = "5f5ccee1514c440887c072fae8e0d699",
             displayName = "Coffee Mug",
@@ -289,7 +311,10 @@ object SampleAssets {
             displayName = "Potted Monstera",
             author = "ChubbyPanda",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
-            fallbackBundledPath = "models/khronos_lantern.glb",
+            // Was `khronos_lantern.glb`, which the Floor Lamp entry below has the
+            // stronger claim to (a lantern IS a lamp). Shiba is the compact
+            // ground-level mass left in the bundle — silhouette-class only (#2960).
+            fallbackBundledPath = "models/shiba.glb",
             scaleToUnits = 0.45f,
             hasBakedAnimation = false,
             category = "ar_placement",
@@ -313,7 +338,10 @@ object SampleAssets {
             displayName = "Wooden End Table",
             author = "mozillareality",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
-            fallbackBundledPath = "models/khronos_lantern.glb",
+            // Was `khronos_lantern.glb` (collided with Potted Monstera AND Floor
+            // Lamp). The fox is the four-legged horizontal silhouette in the
+            // bundle — the closest shape class to a low table (#2960).
+            fallbackBundledPath = "models/khronos_fox.glb",
             scaleToUnits = 0.60f,
             hasBakedAnimation = false,
             category = "ar_placement",
@@ -335,7 +363,12 @@ object SampleAssets {
             displayName = "Picture Frame",
             author = "jamiemcfarlane",
             licenseUrl = "https://creativecommons.org/licenses/by/4.0/",
-            fallbackBundledPath = "models/khronos_damaged_helmet.glb",
+            // Was `khronos_damaged_helmet.glb` (collided with Crates & Barrels).
+            // The soldier is the only upright silhouette left — the shape class a
+            // wall-hung frame reads closest to. It ships baked animation clips,
+            // but `hasBakedAnimation = false` describes the STREAMED Sketchfab
+            // model, and no demo asks a fallback to play: it renders at rest.
+            fallbackBundledPath = "models/threejs_soldier.glb",
             scaleToUnits = 0.40f,
             hasBakedAnimation = false,
             category = "ar_placement",

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SampleAssetsTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SampleAssetsTest.kt
@@ -131,6 +131,53 @@ class SampleAssetsTest {
     }
 
     @Test
+    fun `ar_placement fallbacks are pairwise distinct`() {
+        // Mirrors iOS `testARPlacementFallbacksArePairwiseDistinct`
+        // (SceneViewDemoTests/BundledAssetPrimBudgetTests.swift, #2973).
+        //
+        // Scope is `ar_placement` ONLY, and that is deliberate: other categories
+        // share a fallback legitimately (the four `solar` butterflies all fall
+        // back to the same animated character), so a registry-wide version of
+        // this assertion would fail on entries that are not defects. What makes
+        // this category different is that ARPlacementDemo / ARInstantPlacementDemo
+        // ACCUMULATE placed models — two chips sharing a fallback render as the
+        // identical asset, side by side, under two labels (#2940 / #2355).
+        // Distinctness is all this guard asserts — it says nothing about a
+        // fallback RESEMBLING its label; that wider mismatch class is tracked
+        // for the iOS registry under #2960.
+        //
+        // The slug set is derived from the registry BY CATEGORY, never from a
+        // hardcoded list of names: a slug added to `ar_placement` tomorrow is
+        // covered by this guard without anyone remembering to update it.
+        val slugs = SampleAssets.byCategory["ar_placement"].orEmpty()
+
+        // Distinctness over fewer than two slugs is vacuously true, so a
+        // registry that lost the category would pass silently without this.
+        assertTrue(
+            "ar_placement has ${slugs.size} slug(s) — pairwise distinctness is " +
+                "vacuous below two, so this guard is no longer guarding anything",
+            slugs.size > 1,
+        )
+
+        // First slug to claim each fallback path, in registry order.
+        val claimedBy = mutableMapOf<String, String>()
+        slugs.forEach { slug ->
+            val owner = claimedBy[slug.fallbackBundledPath]
+            if (owner != null) {
+                fail(
+                    "ar_placement fallback collision: \"$owner\" and " +
+                        "\"${slug.displayName}\" both fall back to " +
+                        "${slug.fallbackBundledPath}. Both demos in this category " +
+                        "place several models in one scene, so in keyless mode the " +
+                        "two labels render the identical asset — the #2940 defect. " +
+                        "Point one of them at a distinct bundled model (#2355).",
+                )
+            }
+            claimedBy[slug.fallbackBundledPath] = slug.displayName
+        }
+    }
+
+    @Test
     fun `constructor rejects a non-CC-BY license`() {
         try {
             SketchfabSlug(


### PR DESCRIPTION
## Problem

`SampleAssets.byCategory["ar_placement"]` shipped six slugs pointing at four
distinct GLBs. Measured on `origin/main` (`a1e994957`):

| slug | fallback |
|---|---|
| Coffee Mug | `models/khronos_toy_car.glb` |
| Potted Monstera | `models/khronos_lantern.glb` ← collision |
| Crates & Barrels | `models/khronos_damaged_helmet.glb` ← collision |
| Wooden End Table | `models/khronos_lantern.glb` ← collision |
| Floor Lamp | `models/khronos_lantern.glb` ← collision |
| Picture Frame | `models/khronos_damaged_helmet.glb` ← collision |

`khronos_lantern.glb` was claimed by three slugs, `khronos_damaged_helmet.glb`
by two — a violation of the #2355 distinctness rule, and the same defect class
as #2940 (fixed on iOS by #2962, guarded there by #2973).

It matters here specifically because both consumers of this category
**accumulate** placed models: `TapToPlaceState` owns the placed list and every
tap appends to it (`ARPlacementDemo.kt:107`, `ARInstantPlacementDemo.kt:111`).
On a keyless build a user can place several chips and see two differently
labelled objects render as the identical model, side by side, in one frame.

## Fix — a bijection, no new binary

`samples/android-demo/src/main/assets/models/` bundles exactly six GLBs
(`khronos_damaged_helmet`, `khronos_fox`, `khronos_lantern`, `khronos_toy_car`,
`shiba`, `threejs_soldier`) for six slugs, so the mapping is now one-to-one and
has no slack. Three slugs move:

| slug | before | after |
|---|---|---|
| Potted Monstera | `khronos_lantern.glb` | `shiba.glb` |
| Wooden End Table | `khronos_lantern.glb` | `khronos_fox.glb` |
| Picture Frame | `khronos_damaged_helmet.glb` | `threejs_soldier.glb` |

Floor Lamp keeps `khronos_lantern.glb` — a lantern *is* a lamp, and it is the
same assignment the iOS registry makes. Coffee Mug and Crates & Barrels are
untouched. No file was added to the repo, so `assets/catalog.json` and the
generated `assets/CREDITS.md` are unaffected; all six GLBs are already credited
in `samples/android-demo/src/main/assets/CREDITS.md`.

**What this does not claim.** Distinctness is guaranteed; resemblance is not.
`shiba`, `khronos_fox` and `threejs_soldier` are animals and a character
standing in for a plant, a table and a wall frame — chosen on silhouette class
alone (compact ground mass / four-legged horizontal / upright). A keyless user
now sees six *distinguishable* objects, not six plausible ones. Closing that
semantic gap needs assets this APK does not ship, which is out of scope for a
fix that must add no binary. #2960 tracks the same mismatch class on the iOS
registry; the Android side has no equivalent tracker yet — worth filing.

`threejs_soldier.glb` carries baked animation clips while the Picture Frame
slug declares `hasBakedAnimation = false`. That flag describes the *streamed*
Sketchfab model, and neither placement demo drives an animator (verified: no
`playAnimation` / `animator` reference in `ARPlacementDemo.kt`,
`ARInstantPlacementDemo.kt` or `common/placement/*.kt`), so the fallback
renders at rest.

## Guard

New `SampleAssetsTest.ar_placement fallbacks are pairwise distinct`, mirroring
iOS `testARPlacementFallbacksArePairwiseDistinct` (#2973):

- the slug set is derived from the registry **by category**, never from a
  hardcoded list of names, so a slug added to `ar_placement` tomorrow is covered
  without anyone remembering to update the test;
- a `slugs.size > 1` precondition, because pairwise distinctness is vacuously
  true below two entries — a registry that lost the category would otherwise
  pass silently;
- scope is `ar_placement` only, deliberately: other categories share a fallback
  legitimately (the four `solar` butterflies all fall back to the same animated
  character), so a registry-wide assertion would fail on non-defects.

## Verification

`./gradlew :samples:android-demo:testDebugUnitTest`

| run | tests | failures |
|---|---|---|
| green (fix in place) | **335** | **0** (1 skipped) |
| mutated (Wooden End Table repointed at `shiba.glb`, colliding with Potted Monstera) | **335** | **1** — `SampleAssetsTest > ar_placement fallbacks are pairwise distinct` |
| green again (mutation reverted) | **335** | **0** (1 skipped) |

The mutation failed on the new test *specifically*, and the message names both
colliding slugs and the shared path:

```
ar_placement fallback collision: "Potted Monstera" and "Wooden End Table" both
fall back to models/shiba.glb. Both demos in this category place several models
in one scene, so in keyless mode the two labels render the identical asset —
the #2940 defect. Point one of them at a distinct bundled model (#2355).
```

Also run green: `./gradlew :sceneview:compileReleaseKotlin :arsceneview:compileReleaseKotlin`.

Note for reviewers: the first test run in this worktree failed with
`Unresolved reference` errors on files this PR does not touch — the known
poisoned-Gradle-cache false red. Every run quoted above was made after
`rm -rf <module>/build` **and** with `--no-build-cache`.

Refs #2940, #2355, #2960, #2973.
