### PR TITLE
fix(android-demo): enforce the 12-byte GLB floor iOS enforces on the staged fallback (#2974)

### DIFF
--- a/changelog.d/2974-staged-glb-size-floor.md
+++ b/changelog.d/2974-staged-glb-size-floor.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+- The Android demo's staged-fallback guard now enforces the same 12-byte floor iOS does.
+  `stagedLooksComplete` gated on `length() > 0` plus the `glTF` magic, so a 4-byte file whose
+  entire content *is* that magic counted as a complete GLB and was served once the bundled
+  asset vanished from the APK. iOS gates the same last-resort path on `boundsAreSane`, which
+  carries the floor — the two platforms disagreed about the same file while both comments
+  claimed parity. Reaching it needs a racy truncated write, and it degrades to the wrong model
+  rather than crashing; the reason to fix it is the false parity claim, which is the shape this
+  repo keeps paying for (#2961, #2943).
+- The new test is mutation-tested: restoring `length() > 0L` makes it fail with the 4-byte file
+  served instead of refused.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolver.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolver.kt
@@ -307,11 +307,11 @@ class SketchfabAssetResolver private constructor(
         val cacheRoot = service.cacheRoot()
         val fallbackDir = File(cacheRoot, FALLBACK_DIR_NAME).also { it.mkdirs() }
         val target = File(fallbackDir, "${slug.uid}.glb")
-        // Same floor + magic pair [boundsAreSane] applies to a fresh download, and
-        // the same one iOS's `boundsAreSane` applies to this very path — a 4-byte
-        // file whose only content is the `glTF` magic passes a `> 0` test and is
-        // not a GLB. Android served it and iOS refused it while both comments
-        // claimed parity (#2974).
+        // Size floor + magic header, the same pair `boundsAreSane` applies to a
+        // fresh download and iOS applies to this very path. A 4-byte file whose
+        // entire content is the `glTF` magic passes a `> 0` length test and is
+        // not a GLB: Android served it, iOS refused it, and both comments
+        // claimed the two platforms agreed (#2974).
         val stagedLooksComplete =
             target.exists() && target.length() >= MIN_GLB_SIZE_BYTES && hasGlbMagic(target)
         val bundledSize = bundledAssets.sizeOf(slug.fallbackBundledPath)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolver.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolver.kt
@@ -307,7 +307,13 @@ class SketchfabAssetResolver private constructor(
         val cacheRoot = service.cacheRoot()
         val fallbackDir = File(cacheRoot, FALLBACK_DIR_NAME).also { it.mkdirs() }
         val target = File(fallbackDir, "${slug.uid}.glb")
-        val stagedLooksComplete = target.exists() && target.length() > 0L && hasGlbMagic(target)
+        // Same floor + magic pair [boundsAreSane] applies to a fresh download, and
+        // the same one iOS's `boundsAreSane` applies to this very path — a 4-byte
+        // file whose only content is the `glTF` magic passes a `> 0` test and is
+        // not a GLB. Android served it and iOS refused it while both comments
+        // claimed parity (#2974).
+        val stagedLooksComplete =
+            target.exists() && target.length() >= MIN_GLB_SIZE_BYTES && hasGlbMagic(target)
         val bundledSize = bundledAssets.sizeOf(slug.fallbackBundledPath)
         // Trust the cached copy only if it is a *complete* GLB **and** still
         // matches the asset currently in the APK. A truncated file left

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolverTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/SketchfabAssetResolverTest.kt
@@ -302,6 +302,40 @@ class SketchfabAssetResolverTest {
     }
 
     /**
+     * The cross-platform half of that degradation shape (#2974).
+     *
+     * `stagedLooksComplete` used to gate on `length() > 0`, so a staged copy
+     * holding nothing but the 4-byte `glTF` magic counted as complete and was
+     * served once the bundled asset vanished. iOS gates the same last-resort
+     * path on `boundsAreSane`, which carries a 12-byte floor, so the two
+     * platforms disagreed on the same file while both comments claimed parity.
+     *
+     * Mutation-tested: restoring `target.length() > 0L` in `stagedLooksComplete`
+     * makes this fail — the 4-byte file is served instead of throwing.
+     */
+    @Test
+    fun `fallbackBundle refuses a staged copy shorter than a GLB header`() {
+        val bundle = FakeBundledAssets(glb(size = 2048, filler = 'A'.code.toByte()))
+        val truncating = SketchfabAssetResolver.forTesting(context, service, bundle)
+        val slug = SampleAssets.all.first().copy(uid = "4".repeat(32))
+
+        val staged = truncating.fallbackBundle(slug)
+        // A racy write that landed the magic and nothing else — 4 bytes, so it
+        // passes `hasGlbMagic` and every `> 0` length test.
+        staged.writeBytes(byteArrayOf(0x67, 0x6C, 0x54, 0x46))
+        assertEquals(4, staged.length().toInt())
+
+        bundle.bytes = null // asset pruned from the APK, so re-staging cannot rescue it
+
+        try {
+            truncating.fallbackBundle(slug)
+            fail("a 4-byte staged copy is not a GLB — it must not be served as the fallback")
+        } catch (e: SketchfabAssetResolver.FallbackUnavailable) {
+            assertEquals(slug.uid, e.uid)
+        }
+    }
+
+    /**
      * The freshness check compares `target.length()` against the *bundled*
      * length, and everything above proves that with a fake. This proves the
      * assumption underneath it holds for the REAL `AssetManager`: that


### PR DESCRIPTION
## What

`stagedLooksComplete` in the Android demo's `SketchfabAssetResolver` now requires
`length() >= MIN_GLB_SIZE_BYTES` (12) instead of `length() > 0`, matching the floor
`boundsAreSane` already applies to a fresh download — and the one iOS applies to this
very path.

## Why

Closes #2974.

A staged copy holding nothing but the 4-byte `glTF` magic passed `length() > 0` and
`hasGlbMagic`, so it counted as a complete GLB. When the bundled asset has vanished from
the APK, `fallbackBundle` serves that copy as a last resort — Android served the 4-byte
file, iOS refused it (`boundsAreSane`, 12-byte floor, `SketchfabAssetResolver.swift:212`).

Reaching it needs a racy truncated write, and it degrades to the wrong model rather than
crashing. What makes it worth a line of code is the second half: the iOS comment asserts
this path is *"in step with Android, which gates the same last-resort path on a complete
GLB"*. That claim was false as written. A false parity claim is the shape this repo keeps
paying for (#2961 for the same thing in a KDoc). Fixing Android makes the existing comment
true rather than adding a comment describing a divergence nobody wants.

## Testing

`fallbackBundle refuses a staged copy shorter than a GLB header` — stages a fallback,
truncates it to the 4 magic bytes, prunes the bundled asset, asserts `FallbackUnavailable`.

**Mutation-tested, both directions measured locally:**

| `stagedLooksComplete` | result |
|---|---|
| `length() >= MIN_GLB_SIZE_BYTES` (this PR) | `tests="16" failures="0"` |
| `length() > 0L` (mutation) | `tests="16" failures="1"` — the new test, and only it |

Without that, the test would pass with the bug present, which is what #2947 shipped.
