### PR TITLE
fix(android-demo): measure the two AR asset-source pills from the file, not the key (#2953)

### DIFF
--- a/changelog.d/2953-ar-asset-source-pills.md
+++ b/changelog.d/2953-ar-asset-source-pills.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+- **android-demo** — the AR Placement and Orbital AR asset-source pills now report the
+  origin they actually rendered. Both inferred it from `SketchfabConfig.apiKey`, so a
+  build with a key configured but a failed resolve — no network, aeroplane mode, a stale
+  key, a 4xx, the WAF, a bounds-drifted asset, exhausted retries, all of which end at the
+  bundled fallback — showed "Streamed (cached)" over the offline stand-in. Both now ask
+  the resolved file via `SketchfabAssetResolver.isBundledFallback`, and consult the key
+  only while nothing has resolved yet and there is no file to ask. Orbital AR takes the
+  whole-scene pessimistic verdict Multi-Model uses: one fallen-back planet reads "Offline
+  model" for the formation. The rule now lives in one testable place
+  (`AssetSourceProbe`) instead of being re-derived per demo (#2953, follows #2936).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -33,6 +33,7 @@ import io.github.sceneview.demo.common.ForceTrackingFailureMenu
 import io.github.sceneview.demo.common.placement.PlacementSpec
 import io.github.sceneview.demo.common.placement.TapToPlaceArSession
 import io.github.sceneview.demo.common.placement.rememberTapToPlaceState
+import io.github.sceneview.demo.sketchfab.AssetSourceProbe
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
 import io.github.sceneview.demo.sketchfab.SketchfabConfig
@@ -154,11 +155,22 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // Per-demo offline indicator chip (#1152 Stage 3). The chip reflects the
     // selected slug's resolve state — `null` means no slug picked yet (cycle
     // mode), so we surface "Offline model" (the cycle is 100% bundled).
-    val assetSource = when {
-        selectedSlug == null -> AssetSourceState.Bundled
-        SketchfabConfig.apiKey == null -> AssetSourceState.Bundled
-        selectedFile == null -> AssetSourceState.Streaming
-        else -> AssetSourceState.Streamed
+    //
+    // Once a slug IS picked the origin is MEASURED from the file the resolver handed
+    // back, never inferred from `SketchfabConfig.apiKey` (#2953): a key can be present
+    // and the resolve still land on the bundled fallback — no network, aeroplane mode, a
+    // 4xx, the WAF — and this chip then claimed "Streamed (cached)" over the stand-in
+    // the next tap would actually place. `loaded` is the FILE here, not a parsed
+    // `ModelInstance`: a tap places whatever `selectedFile` holds, so that is the moment
+    // the chip has something true to say. See [AssetSourceProbe].
+    val assetSource = if (selectedSlug == null) {
+        AssetSourceState.Bundled
+    } else {
+        AssetSourceProbe.of(
+            resolvedFile = selectedFile,
+            hasApiKey = SketchfabConfig.apiKey != null,
+            loaded = selectedFile != null,
+        )
     }
 
     // What the next tap will spawn — drives the "Next tap places:" preview and the

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
@@ -44,6 +44,7 @@ import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.sketchfab.AssetSourceProbe
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
 import io.github.sceneview.demo.sketchfab.SketchfabConfig
@@ -91,12 +92,14 @@ import kotlinx.coroutines.delay
  * ### Streaming pipeline (Stage 2, issue #1152)
  *
  * Four of the eight planets are now streamed via [SketchfabAssetResolver] from the
- * curated `solar` category in [SampleAssets]. When [SketchfabConfig.apiKey] is
- * missing (App Store / first-launch / no-network) the resolver returns the bundled
- * fallback declared in the registry — so the demo always renders eight planets,
- * just sometimes with duplicate visuals. The four bundled GLBs (helmet, lantern,
- * toy car, soldier) are always read straight from `assets/models/` and have no
- * network dependency.
+ * curated `solar` category in [SampleAssets]. The resolver never fails a slot: a missing
+ * [SketchfabConfig.apiKey] (App Store / first-launch) short-circuits to the bundled
+ * fallback declared in the registry, and so does every *runtime* failure with a key
+ * present — no network, aeroplane mode, a stale key, a 4xx, exhausted retries. So the demo
+ * always renders eight planets, just sometimes with duplicate visuals, and a configured key
+ * is never evidence that any of them streamed (which is why the asset-source pill asks the
+ * resolved files instead — #2953). The four bundled GLBs (helmet, lantern, toy car,
+ * soldier) are always read straight from `assets/models/` and have no network dependency.
  *
  * This replaces the previous "2 duplicate dragons + 2 duplicate soldiers" workaround
  * that the bundle-only design was forced into (the old #978 audit flagged the dups
@@ -401,22 +404,32 @@ fun OrbitalARDemo(onBack: () -> Unit) {
         }
     }
 
-    // Per-demo offline indicator (#1152 Stage 3): if every streamed slot has
-    // resolved to a real `File` (Sketchfab CDN), surface "Streamed". If some
-    // are still null, we're "Streaming…". If `SketchfabConfig.apiKey` is
-    // absent up-front, the resolver short-circuits to the bundled fallback
-    // and every slot resolves quickly to its fallback file — chip says
-    // "Offline model" instead.
-    val streamedSlugs = ORBITAL_PLANETS.mapNotNull { it.streamedSlug }
-    val assetSource: AssetSourceState? = if (streamedSlugs.isEmpty()) {
+    // Per-demo offline indicator (#1152 Stage 3), MEASURED from the resolved files rather
+    // than inferred from `SketchfabConfig.apiKey` (#2953). The old rule read "no key ⇒
+    // Offline, key ⇒ Streamed once every slot holds a File", and the second half of that
+    // is the guess: a key says nothing about whether the download succeeded. Every failure
+    // path in `resolve` — no network, aeroplane mode, a stale key, a 4xx, the WAF, a
+    // bounds-drifted asset, exhausted retries — hands back a *bundled fallback* File, which
+    // is still a non-null File, so a keyed build with four stand-ins in orbit reported
+    // "Streamed (cached)". Asking the file cannot be wrong that way.
+    //
+    // Whole-scene and pessimistic, like Multi-Model: one fallen-back planet reads "Offline
+    // model" for the formation, and the pill never says which one swapped. See
+    // [AssetSourceProbe] for the full rule.
+    //
+    // Only the streamed slots are probed — the four bundled planets (helmet, lantern, toy
+    // car, soldier) read straight from `assets/` and have no origin question to answer.
+    val streamedSlots = streamedFiles.filterIndexed { i, _ ->
+        ORBITAL_PLANETS[i].streamedSlug != null
+    }
+    val assetSource: AssetSourceState? = if (streamedSlots.isEmpty()) {
         null
-    } else if (SketchfabConfig.apiKey == null) {
-        AssetSourceState.Bundled
-    } else if (streamedFiles.filterIndexed { i, _ -> ORBITAL_PLANETS[i].streamedSlug != null }
-            .all { it != null }) {
-        AssetSourceState.Streamed
     } else {
-        AssetSourceState.Streaming
+        AssetSourceProbe.ofAll(
+            resolvedFiles = streamedSlots,
+            hasApiKey = SketchfabConfig.apiKey != null,
+            loaded = streamedSlots.all { it != null },
+        )
     }
 
     // No Settings FAB: this demo has nothing to configure. The orbit runs

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
@@ -26,11 +26,12 @@ import java.io.File
  *
  * ### Why the key survives at all
  *
- * Before anything resolves there is no file to ask, and the key is then the best available
- * signal: with none we already know where this ends, with one the download is genuinely in
- * flight. It is only ever consulted on that pre-resolve path — [SketchfabAssetResolver.resolve]
- * short-circuits to `fallbackBundle` when the key is null, so any file that exists in a
- * keyless build is a fallback and the measured branch has already claimed it.
+ * While the demo is not yet `loaded` there may be nothing to ask, and the key is then the
+ * best available signal: with none we already know where this ends, with one the download is
+ * genuinely in flight. It is read on that not-yet-loaded path only, and it cannot overrule a
+ * measurement — [SketchfabAssetResolver.resolve] short-circuits to `fallbackBundle` when the
+ * key is null, so any file that exists in a keyless build is a fallback and the measured
+ * branch has already claimed it before the key is reached.
  */
 internal object AssetSourceProbe {
 
@@ -39,8 +40,13 @@ internal object AssetSourceProbe {
      *
      * @param resolvedFile the file the resolver handed back, or `null` while it is still
      *   working — the only thing worth measuring.
-     * @param hasApiKey whether a Sketchfab key is configured. Consulted only while
-     *   [resolvedFile] is `null`; see the class KDoc for why that is not a loophole.
+     * @param hasApiKey whether a Sketchfab key is configured. Read only when [loaded] is
+     *   `false` — NOT when [resolvedFile] is `null`. The two coincide for AR Placement, which
+     *   defines `loaded` as "the file arrived", but not for a caller that defines it as "the
+     *   model parsed": there, a resolved-but-still-parsing streamed file reaches the key
+     *   branch. That is harmless (a resolved *fallback* is claimed by the measured branch
+     *   first, whatever `loaded` says), but do not restate this gate as a test on
+     *   [resolvedFile] — see the class KDoc.
      * @param loaded whether the demo has finished doing what it considers "loaded". Each
      *   caller owns that definition — Gallery waits for the parsed `ModelInstance` so the
      *   chip and the centre `LoadingScrim` stay in lockstep (#1465), AR Placement waits only

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
@@ -20,8 +20,9 @@ import java.io.File
  * AR demos kept the guess (#2953). Extracting it is what makes it *testable* — the inline
  * copies sat inside `@Composable` bodies where no unit test could reach them, which is why
  * three fixes shipped with no test pinning the rule. The two AR demos call it here;
- * Gallery and Multi-Model still hold their (correct, equivalent) inline copies and should
- * be migrated in their own PR rather than inside a bug fix.
+ * Gallery and Multi-Model still hold their (correct, equivalent) inline copies and are
+ * migrated in their own PR rather than inside a bug fix — tracked by **#2989**, which
+ * carries the equivalence argument. Do not add a fifth inline copy: call this instead.
  *
  * ### Why the key survives at all
  *

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/sketchfab/AssetSourceProbe.kt
@@ -1,0 +1,77 @@
+package io.github.sceneview.demo.sketchfab
+
+import io.github.sceneview.demo.AssetSourceState
+import java.io.File
+
+/**
+ * The one rule every demo uses to decide what its asset-source pill says.
+ *
+ * The pill must report what was RESOLVED, never what was CONFIGURED. "An API key is
+ * configured" says nothing about whether the download succeeded: every failure path in
+ * [SketchfabAssetResolver.resolve] — no network, aeroplane mode, a stale or 4xx-rejected
+ * key, the WAF, a bounds-drifted asset, exhausted retries — ends at the bundled fallback,
+ * so a keyed build renders the offline stand-in under whatever the pill claims. That is
+ * measured, not theoretical: on the QA emulator (2026-07-28, key configured) all four
+ * Multi-Model slots staged out of `cache/sketchfab/fallback/`, the download endpoint
+ * answering 429 (#2933).
+ *
+ * The rule lived inline at four call sites, expressed three different ways, and was fixed
+ * one site at a time — Multi-Model (#2933/#2934), then Gallery (#2936/#2938), while the two
+ * AR demos kept the guess (#2953). Extracting it is what makes it *testable* — the inline
+ * copies sat inside `@Composable` bodies where no unit test could reach them, which is why
+ * three fixes shipped with no test pinning the rule. The two AR demos call it here;
+ * Gallery and Multi-Model still hold their (correct, equivalent) inline copies and should
+ * be migrated in their own PR rather than inside a bug fix.
+ *
+ * ### Why the key survives at all
+ *
+ * Before anything resolves there is no file to ask, and the key is then the best available
+ * signal: with none we already know where this ends, with one the download is genuinely in
+ * flight. It is only ever consulted on that pre-resolve path — [SketchfabAssetResolver.resolve]
+ * short-circuits to `fallbackBundle` when the key is null, so any file that exists in a
+ * keyless build is a fallback and the measured branch has already claimed it.
+ */
+internal object AssetSourceProbe {
+
+    /**
+     * The pill for a demo showing a SINGLE streamed slot.
+     *
+     * @param resolvedFile the file the resolver handed back, or `null` while it is still
+     *   working — the only thing worth measuring.
+     * @param hasApiKey whether a Sketchfab key is configured. Consulted only while
+     *   [resolvedFile] is `null`; see the class KDoc for why that is not a loophole.
+     * @param loaded whether the demo has finished doing what it considers "loaded". Each
+     *   caller owns that definition — Gallery waits for the parsed `ModelInstance` so the
+     *   chip and the centre `LoadingScrim` stay in lockstep (#1465), AR Placement waits only
+     *   for the file, since a tap places whatever has resolved.
+     */
+    fun of(resolvedFile: File?, hasApiKey: Boolean, loaded: Boolean): AssetSourceState =
+        ofAll(listOf(resolvedFile), hasApiKey, loaded)
+
+    /**
+     * The pill for a demo showing SEVERAL streamed slots at once.
+     *
+     * A WHOLE-SCENE verdict: one fallen-back slot out of four reads "Offline model" for all
+     * of them, and the pill never says which slot swapped. Pessimistic on purpose — of the
+     * two imprecise answers, the optimistic one is the one that misleads. It is also a
+     * MOVING verdict during load, since [loaded] and the fallback probe watch different
+     * signals: a slot that falls back last flips the pill Streaming → Offline after the fact.
+     *
+     * @param resolvedFiles one entry per streamed slot; `null` for a slot still resolving.
+     *   Slots the demo renders straight from `assets/` have no origin question to answer and
+     *   must not be passed in.
+     */
+    fun ofAll(
+        resolvedFiles: List<File?>,
+        hasApiKey: Boolean,
+        loaded: Boolean,
+    ): AssetSourceState = when {
+        // MEASURED. Beats every other branch, including a `loaded` demo with a key.
+        resolvedFiles.any { it != null && SketchfabAssetResolver.isBundledFallback(it) } ->
+            AssetSourceState.Bundled
+        // Nothing to measure yet — the pre-resolve guess, and the only place the key is read.
+        !loaded -> if (hasApiKey) AssetSourceState.Streaming else AssetSourceState.Bundled
+        // Everything resolved, nothing came from `fallback/`: genuinely streamed.
+        else -> AssetSourceState.Streamed
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/AssetSourceProbeTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/AssetSourceProbeTest.kt
@@ -1,0 +1,174 @@
+package io.github.sceneview.demo.sketchfab
+
+import io.github.sceneview.demo.AssetSourceState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+/**
+ * Unit tests for [AssetSourceProbe] — the rule behind every demo's asset-source pill.
+ *
+ * Pure JVM: [SketchfabAssetResolver.isBundledFallback] keys on the parent directory NAME,
+ * so a `File` path is enough and nothing has to touch the disk or Robolectric.
+ *
+ * The defect these pin (#2933 → #2936 → #2953) always had the same shape: **a key is
+ * configured AND the resolver fell back**, which the config-based inference called
+ * "streamed". Every test below that carries `hasApiKey = true` with a fallback file is a
+ * direct regression probe — flip the measured branch off and it goes red.
+ */
+class AssetSourceProbeTest {
+
+    private val cacheRoot = File("/data/user/0/io.github.sceneview.demo/cache/sketchfab")
+
+    /** What the resolver hands back on the network path. */
+    private fun streamed(uid: String) = File(cacheRoot, "$uid.glb")
+
+    /** What it hands back on every failure path — `cache/sketchfab/fallback/<uid>.glb`. */
+    private fun fallback(uid: String) =
+        File(File(cacheRoot, SketchfabAssetResolver.FALLBACK_DIR_NAME), "$uid.glb")
+
+    // ─── the regression: a KEYED build that fell back ──────────────────────
+
+    @Test
+    fun `a keyed build that fell back reports Bundled, not Streamed`() {
+        assertEquals(
+            "a configured key says nothing about whether the download succeeded — " +
+                "the resolved file came out of fallback/, so the pill must say Bundled",
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(fallback("car"), hasApiKey = true, loaded = true),
+        )
+    }
+
+    @Test
+    fun `one fallen-back slot out of four sinks the whole scene`() {
+        val files = listOf(streamed("a"), streamed("b"), fallback("c"), streamed("d"))
+        assertEquals(
+            "the verdict is whole-scene and pessimistic: one stand-in in the formation " +
+                "means the pill must not promise a streamed scene",
+            AssetSourceState.Bundled,
+            AssetSourceProbe.ofAll(files, hasApiKey = true, loaded = true),
+        )
+    }
+
+    @Test
+    fun `a fallback beats loaded — the measured branch wins over every guess`() {
+        // Same inputs as the Streamed case below except the parent directory. If the
+        // measured branch is removed, `loaded = true` + a key falls through to Streamed
+        // and this test is the one that catches it.
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(fallback("car"), hasApiKey = true, loaded = true),
+        )
+        assertEquals(
+            AssetSourceState.Streamed,
+            AssetSourceProbe.of(streamed("car"), hasApiKey = true, loaded = true),
+        )
+    }
+
+    // ─── the pre-resolve path: the only place the key is read ──────────────
+
+    @Test
+    fun `nothing resolved yet with a key reads Streaming`() {
+        assertEquals(
+            AssetSourceState.Streaming,
+            AssetSourceProbe.of(null, hasApiKey = true, loaded = false),
+        )
+    }
+
+    @Test
+    fun `nothing resolved yet without a key reads Bundled`() {
+        // Keyless is where this ends regardless: `resolve` short-circuits to the bundled
+        // fallback, so claiming "Streaming…" would be a spinner that never lands.
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(null, hasApiKey = false, loaded = false),
+        )
+    }
+
+    @Test
+    fun `a resolved streamed file that has not finished loading still reads Streaming`() {
+        // AR Placement ties `loaded` to the file and Gallery ties it to the parsed
+        // ModelInstance; this is the Gallery shape — file in hand, parse still running.
+        assertEquals(
+            AssetSourceState.Streaming,
+            AssetSourceProbe.of(streamed("car"), hasApiKey = true, loaded = false),
+        )
+    }
+
+    @Test
+    fun `a resolved fallback reports Bundled before the parse finishes`() {
+        // The origin is settled the moment the file is known, so the chip does NOT wait
+        // for the parse to say so — #1465 is about never claiming *completion* early, and
+        // "Offline model" claims an origin, not a finished download.
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(fallback("car"), hasApiKey = true, loaded = false),
+        )
+    }
+
+    // ─── the happy path ────────────────────────────────────────────────────
+
+    @Test
+    fun `every slot streamed and loaded reports Streamed`() {
+        val files = listOf(streamed("a"), streamed("b"), streamed("c"), streamed("d"))
+        assertEquals(
+            AssetSourceState.Streamed,
+            AssetSourceProbe.ofAll(files, hasApiKey = true, loaded = true),
+        )
+    }
+
+    @Test
+    fun `a partially resolved keyed scene reads Streaming, not Streamed`() {
+        val files = listOf(streamed("a"), null, streamed("c"), null)
+        assertEquals(
+            AssetSourceState.Streaming,
+            AssetSourceProbe.ofAll(files, hasApiKey = true, loaded = false),
+        )
+    }
+
+    @Test
+    fun `a partially resolved keyless scene reads Bundled`() {
+        val files = listOf(streamed("a"), null, null, null)
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.ofAll(files, hasApiKey = false, loaded = false),
+        )
+    }
+
+    // ─── the single-slot form is the list form, and must stay that way ─────
+
+    @Test
+    fun `the single-slot form agrees with the one-element list form everywhere`() {
+        val files = listOf(null, streamed("car"), fallback("car"))
+        for (file in files) {
+            for (hasApiKey in listOf(true, false)) {
+                for (loaded in listOf(true, false)) {
+                    assertEquals(
+                        "of($file, key=$hasApiKey, loaded=$loaded) must equal ofAll of the " +
+                            "same single slot — the two forms differ only in arity",
+                        AssetSourceProbe.ofAll(listOf(file), hasApiKey, loaded),
+                        AssetSourceProbe.of(file, hasApiKey, loaded),
+                    )
+                }
+            }
+        }
+    }
+
+    // ─── the fallback probe is keyed on the directory the resolver stages into ─
+
+    @Test
+    fun `the probe reads the real staging directory name, not a hardcoded string`() {
+        // If FALLBACK_DIR_NAME ever changes, `fallback()` above follows it and these tests
+        // keep testing the truth. This asserts the constant is what the resolver's KDoc
+        // promises, so the helpers above cannot quietly drift into testing nothing.
+        assertEquals("fallback", SketchfabAssetResolver.FALLBACK_DIR_NAME)
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(
+                File(File(cacheRoot, "fallback"), "car.glb"),
+                hasApiKey = true,
+                loaded = true,
+            ),
+        )
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/AssetSourceProbeTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/sketchfab/AssetSourceProbeTest.kt
@@ -106,6 +106,24 @@ class AssetSourceProbeTest {
         )
     }
 
+    @Test
+    fun `the key gate is on loaded, not on whether a file resolved`() {
+        // Pins the @param contract. A streamed file HAS resolved, yet `loaded = false` still
+        // routes through the key branch — so with no key this reads Bundled, not Streaming.
+        // AR Placement can't reach this state (its `loaded` IS `file != null`), but Gallery
+        // will once it migrates (#2989), since its `loaded` is a parsed ModelInstance.
+        // Documenting the gate as "consulted only while resolvedFile is null" would be wrong
+        // exactly here, which is why this case is pinned rather than left to the comment.
+        assertEquals(
+            AssetSourceState.Bundled,
+            AssetSourceProbe.of(streamed("car"), hasApiKey = false, loaded = false),
+        )
+        assertEquals(
+            AssetSourceState.Streaming,
+            AssetSourceProbe.of(streamed("car"), hasApiKey = true, loaded = false),
+        )
+    }
+
     // ─── the happy path ────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #2953. Follows #2938 (Gallery half of the same defect class).

## The defect

`ARPlacementDemo.kt:159` and `OrbitalARDemo.kt:413` both decided the asset-source pill from `SketchfabConfig.apiKey`. A configured key says nothing about whether the download succeeded — every failure path in `SketchfabAssetResolver.resolve` (no network, aeroplane mode, a stale key, a 4xx, the WAF, a bounds-drifted asset, exhausted retries) hands back a **bundled fallback File, which is still a non-null File**. Both pills then read "Streamed (cached)" while the viewport showed the bundled stand-in.

For Orbital AR the guess was worse than Gallery's: its "all slots hold a File ⇒ Streamed" branch is satisfied *exactly* by four fallbacks.

## The fix

Both now ask the resolved file via `SketchfabAssetResolver.isBundledFallback`, and consult the key only on the pre-resolve path where there is genuinely no file to ask. Orbital AR takes the whole-scene pessimistic verdict Multi-Model uses — one fallen-back planet reads "Offline model" for the formation, and the pill never says which one swapped.

## Why a shared helper, and where I drew the scope line

The rule was inline at **four** call sites in **three** different shapes, and had already been fixed one site at a time (#2933/#2934 Multi-Model, then #2936/#2938 Gallery) **with no test pinning it** — the inline copies sit inside `@Composable` bodies where no unit test can reach them. That is the mechanism by which this reached a third instance.

So the rule now lives in `AssetSourceProbe` (`internal`, pure, no Android deps), the two AR demos call it, and 12 unit tests cover it.

**I deliberately did not migrate Gallery and Multi-Model.** Their inline copies are correct and provably equivalent, and rewriting two sites merged two days ago is a refactor that deserves its own PR rather than diff noise around a bug fix. Push back if you'd rather have it all in one.

Both AR rewrites are behaviour-preserving on the reachable domain: `resolve` short-circuits to `fallbackBundle` when the key is null, so any file that exists in a keyless build *is* a fallback and the measured branch claims it before the key is ever read. The only divergent case (`no key` + `loaded` + a genuinely streamed file, e.g. a cache surviving a key removal) is unreachable through `resolve`, and the new answer would be the more honest one anyway.

Also refreshes the stale KDoc at `OrbitalARDemo.kt:94`, which implied a configured key meant the planets streamed.

## Verification

| Gate | Result |
|---|---|
| `:samples:android-demo:testDebugUnitTest` | **348 tests, 0 failures, 1 skipped** (XML report, not an UP-TO-DATE claim) |
| `AssetSourceProbeTest` | 12 tests, 0 failures |
| `pre-push-check.sh` | **11/11** — iOS golden leg honestly SKIPPED (no simulator booted) |
| `apiCheck` | public API unchanged (samples module, no ABI surface) |

**Mutation-tested**, because a probe that stays green when you delete what it guards is worthless:

- remove the measured `isBundledFallback` branch → **5 of 12 tests go red**, including `a keyed build that fell back reports Bundled, not Streamed`;
- ignore the key on the pre-resolve path → **2 go red**.

## Not verified

Emulator QA is reported separately in a comment below — the pill is a Compose chip over an ARCore session, and this host's AR story is constrained (#2754, #1645).

## Incidental findings (not fixed here)

- `impact-check.sh` reports **10 pre-existing FAILs** on `main`: every doc surface claims **44** node types, the source has **46**. Untouched by this PR (no node class changes). Filing separately.
- `impact-check.sh` skips its `assembleDebug` leg inside a **git worktree**: it tests `[[ ! -d .git ]]`, and a worktree's `.git` is a *file*. It reports `not a git repository` and passes. Filing separately.
- `arsceneview/build/tmp/kotlin-classes/debug` held **0 `.class` files** while Gradle reported `BUILD SUCCESSFUL` / up-to-date, producing a false red in `android-demo` (unresolved `ARSceneScope`, `PlaneDiscoveryGuideOverlay`). Known class; remedy `rm -rf <module>/build` + `--no-build-cache` worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)