### PR TITLE
fix(context): the follow-up the first real use of #2985 demanded

### DIFF
--- a/.claude/scripts/context-budget.sh
+++ b/.claude/scripts/context-budget.sh
@@ -50,28 +50,36 @@ TOTAL=0
 
 human() { awk -v b="$1" 'BEGIN{ printf (b<1024) ? "%d B" : "%.1f Ko", (b<1024)?b:b/1024 }'; }
 
+# Rows are COLLECTED, then printed LARGEST FIRST. The first version printed them
+# in the order I happened to write them, so the biggest item sat in the middle
+# behind a one-character `!` — and the reader (me) optimised the file at the top
+# of the list instead of the file at the top of the cost. Sorting is the whole
+# point of a budget report: it must answer "what do I cut next", not "did the
+# thing I already cut get smaller".
+ROWS=""
+
 # row <path> <soft-ceiling-bytes> <why> [base-dir]
 row() {
   local rel="$1" cap="$2" why="$3" f="${4:-$ROOT}/$1"
   if [ ! -f "$f" ]; then
-    printf "  %-34s %10s   %s\n" "$rel" "absent" "$why"
+    ROWS="$ROWS$(printf '%012d\t%s\t%s\t%s\t%s' 0 "$rel" "absent" "-" "$why")
+"
     return
   fi
-  local bytes lines flag
+  local bytes flag
   bytes=$(wc -c < "$f" | tr -d ' ')
-  lines=$(wc -l < "$f" | tr -d ' ')
   TOTAL=$((TOTAL + bytes))
-  flag="   "
+  flag="  "
   if [ "$cap" -gt 0 ] && [ "$bytes" -gt "$cap" ]; then
-    flag=" ! "
+    flag="!!"
     OVER=$((OVER + 1))
+    OVER_NAMES="${OVER_NAMES:+$OVER_NAMES, }$rel"
   fi
-  printf "  %-34s %10s %s ~%5s tok  %4s l  %s\n" \
-    "$rel" "$(human "$bytes")" "$flag" "$((bytes / 4))" "$lines" "$why"
+  ROWS="$ROWS$(printf '%012d\t%s\t%s\t%s\t%s' "$bytes" "$rel" "$(human "$bytes")" "$flag" "$why")
+"
 }
 
-echo "Standing context — re-sent on every turn of every session"
-echo
+OVER_NAMES=""
 row "CLAUDE.md"                  24576 "always loaded; ceiling gated in CI"
 row ".claude/STATE.md"           16384 "session start; spec = NOW + IN-FLIGHT + NEXT(<=6) + BOOTSTRAP" "$MAIN"
 row ".claude/workflows/README.md" 24576 "read when choosing a workflow"
@@ -82,17 +90,32 @@ row ".claude/workflows/README.md" 24576 "read when choosing a workflow"
 MEM="$HOME/.claude/projects/$(printf '%s' "$MAIN" | tr '/.' '--')/memory/MEMORY.md"
 if [ -f "$MEM" ]; then
   b=$(wc -c < "$MEM" | tr -d ' '); TOTAL=$((TOTAL + b))
-  printf "  %-34s %10s     ~%5s tok  %4s l  %s\n" \
-    "MEMORY.md (agent memory index)" "$(human "$b")" "$((b / 4))" "$(wc -l < "$MEM" | tr -d ' ')" \
-    "always loaded; index only, topic files load on demand"
+  ROWS="$ROWS$(printf '%012d\t%s\t%s\t%s\t%s' "$b" "MEMORY.md (agent memory index)" "$(human "$b")" "  " "always loaded; index only, topic files load on demand")
+"
 fi
 
+echo "Standing context — re-sent on every turn of every session (largest first)"
 echo
-printf "  %-34s %10s     ~%5s tok\n" "TOTAL standing context" "$(human "$TOTAL")" "$((TOTAL / 4))"
+printf '%s' "$ROWS" | grep -v '^$' | sort -rn | while IFS="$(printf '\t')" read -r _b rel size flag why; do
+  # 10# forces base-10: the sort key is zero-padded, and a leading zero would
+  # otherwise make bash read it as octal and fail on any digit 8 or 9.
+  printf "  %-34s %10s %s ~%5s tok  %s\n" "$rel" "$size" "$flag" "$(( 10#$_b / 4 ))" "$why"
+done
+echo
+printf "  %-34s %10s    ~%5s tok\n" "TOTAL standing context" "$(human "$TOTAL")" "$((TOTAL / 4))"
 echo
 echo "  (token column is an ESTIMATE at ~4 chars/token — orders of magnitude only)"
+if [ -n "$OVER_NAMES" ]; then
+  echo
+  echo "  !! OVER SPEC: $OVER_NAMES — this is the next thing to cut, not the"
+  echo "     file you cut last time."
+fi
 
-# --- lazy surface, for contrast -------------------------------------------
+# --- deferred is NOT free -------------------------------------------------
+# The first version said the skills held N Ko "that is NOT in the standing cost",
+# which reads as a saving. It is a DEFERRAL: a session pays per skill it opens,
+# and one 15 Ko skill is ~19% of the whole standing budget. Measured on the first
+# real use (#2986): one skill opened, 14.9 Ko paid. Print the price list.
 if [ -d "$ROOT/.claude/skills" ]; then
   sb=0; sn=0
   for f in "$ROOT"/.claude/skills/*/SKILL.md; do
@@ -100,8 +123,16 @@ if [ -d "$ROOT/.claude/skills" ]; then
     sb=$((sb + $(wc -c < "$f" | tr -d ' '))); sn=$((sn + 1))
   done
   echo
-  printf "  %s skills hold %s (~%s tok) that is NOT in the standing cost.\n" \
-    "$sn" "$(human "$sb")" "$((sb / 4))"
+  echo "  Deferred — NOT free. $sn skills, $(human "$sb") total, charged per skill OPENED:"
+  for f in "$ROOT"/.claude/skills/*/SKILL.md; do
+    [ -f "$f" ] || continue
+    b=$(wc -c < "$f" | tr -d ' ')
+    printf '%012d\t%s\t%s\n' "$b" "$(basename "$(dirname "$f")")" "$(human "$b")"
+  done | sort -rn | head -3 | while IFS="$(printf '\t')" read -r b name size; do
+    printf "    %-24s %9s   %s%% of the standing budget if opened\n" \
+      "$name" "$size" "$(( 100 * 10#$b / (TOTAL > 0 ? TOTAL : 1) ))"
+  done
+  echo "    (top 3 shown — open three of these and you are back to pre-split cost)"
 fi
 
 # --- the local half CI can never see --------------------------------------
@@ -140,10 +171,20 @@ fi
 
 if [ "$OVER" -gt 0 ]; then
   echo
-  echo "  ${OVER} item(s) over spec. Remedies, cheapest first:"
-  echo "    - move a CLAUDE.md section into .claude/skills/<name>/SKILL.md + index it"
-  echo "    - move finished STATE.md entries into .claude/handoff.md (its documented home)"
-  echo "    - run /handoff to reconcile STATE.md -> handoff.md"
+  # Ordered by what the report ACTUALLY flagged, not by a fixed list. The first
+  # version led with the CLAUDE.md remedy regardless of which file was over —
+  # which is how the largest item got left alone through three passes.
+  echo "  ${OVER} item(s) over spec — remedies for those items, in order:"
+  case "$OVER_NAMES" in
+    *STATE.md*)
+      echo "    1. move finished NOW bullets into .claude/handoff.md (their documented home);"
+      echo "       the spec is <=8 bullets and 'done' means MOVED, not kept"
+      echo "    2. run /handoff to reconcile the rest" ;;
+  esac
+  case "$OVER_NAMES" in
+    *CLAUDE.md*)
+      echo "    - move a CLAUDE.md section into .claude/skills/<name>/SKILL.md + index it" ;;
+  esac
 fi
 
 [ "$STRICT" -eq 1 ] && [ "$OVER" -gt 0 ] && exit 1

--- a/.claude/scripts/impact-check.sh
+++ b/.claude/scripts/impact-check.sh
@@ -304,7 +304,15 @@ echo -e "${CYAN}--- Sample app build (fast check) ---${NC}"
 trace "Android sample build dry-run gate"
 
 # Only check if Android SDK source changed.
-if [[ ! -d ".git" ]]; then
+#
+# `.git` is a DIRECTORY only in a primary checkout. In a linked worktree — how
+# `.claude/worktrees/*` and every agent-isolated session runs — it is a regular
+# FILE holding `gitdir: …`, so a `-d` test declared "not a git repository" and
+# skipped this leg exactly where most work now happens (#2988). Worse, it
+# announced itself as an environment limitation, so the skip read as expected
+# and nobody looked. Ask git whether this is a work tree instead of guessing
+# from the shape of `.git`.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     check "Android demo assembleDebug" "SKIP" "not a git repository"
 elif [[ ! -x "./gradlew" ]]; then
     check "Android demo assembleDebug" "SKIP" "gradlew not present in checkout"

--- a/.claude/skills/android-tooling/SKILL.md
+++ b/.claude/skills/android-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-tooling
-description: Google's android CLI (screenshots, UI dumps, install+launch) and when to still use adb; the RAM-budgeted adaptive emulator pool with its per-SESSION lease protocol and the blocking PreToolUse hook that enforces it; the golden qa-clean snapshot; the Rosetta x86_64 AR rig (measured NOT to deliver live-camera AR — kept as evidence); and the three agents/sceneview* skill installers. Use when driving an Android emulator, capturing a screenshot or UI tree, installing a demo APK, or hitting an emulator lease refusal.
+description: Google's android CLI (screenshots, UI dumps, install+launch) and when to still use adb; the RAM-budgeted adaptive emulator pool with its per-SESSION lease protocol and the blocking PreToolUse hook that enforces it; the golden qa-clean snapshot; the Rosetta x86_64 AR rig (measured NOT to deliver live-camera AR — kept as evidence); and the three agents/sceneview* skill installers. USE THIS ONE for driving a device BY HAND. For the scripted QA harness and its release gate, use `device-qa` instead. Use when driving an Android emulator yourself, capturing a screenshot or UI tree, installing a demo APK, or hitting an emulator lease refusal.
 ---
 
 ## Android CLI (preferred for agent-driven QA)

--- a/.claude/skills/device-qa/SKILL.md
+++ b/.claude/skills/device-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: device-qa
-description: The autonomous device-QA harness for the SceneView demo apps — device-qa.sh and its four legs (Maestro Android/iOS, Playwright web, AR replay), the GRADED release gate (blocking web leg vs advisory android/ar/ios legs), the ARCore-ready emulator pool, the golden boot snapshot, Android Vitals and Play-review triage. Use when running or debugging QA on an emulator or simulator, when a demo must be proven not to crash on a real screen, or at any release checkpoint before tagging.
+description: The autonomous device-QA harness for the SceneView demo apps — device-qa.sh and its four legs (Maestro Android/iOS, Playwright web, AR replay), the GRADED release gate (blocking web leg vs advisory android/ar/ios legs), the ARCore-ready emulator pool, the golden boot snapshot, Android Vitals and Play-review triage. USE THIS ONE for the SCRIPTED harness — you are running device-qa.sh / the Maestro flows / the release gate and reading their verdicts. For driving a device BY HAND (screenshots, taps, ad-hoc install, lease refusals), use `android-tooling` instead. Use when running or debugging a QA harness run, when a demo must be proven not to crash on a real screen, or at any release checkpoint before tagging.
 ---
 
 ## Device QA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,18 @@ the documentation until it can.
 2. **Unit tests**: `./gradlew :sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest`
 3. **Bundle build** (if store-affecting): `./gradlew :samples:android-demo:bundleRelease`
 4. **Website JS** (if website changed): `node -c website-static/js/sceneview.js`
-5. **Full gate**: `bash .claude/scripts/pre-push-check.sh`
+5. **Impact check** (after ANY code, API or doc change): `bash .claude/scripts/impact-check.sh`
+6. **Full gate**: `bash .claude/scripts/pre-push-check.sh`
+
+> ⚠️ **This list is a floor, not the full set** — `.claude/scripts/` holds ~40 more
+> checks, indexed in the `automation-map` skill. Read it as "never push with less
+> than this", never as "these are all the gates". Item 5 is here because it was
+> not: a session ran it from memory alone and it surfaced 10 pre-existing failures
+> ([#2987](https://github.com/sceneview/sceneview/issues/2987)) plus a gate that
+> silently skipped itself inside every worktree
+> ([#2988](https://github.com/sceneview/sceneview/issues/2988)). A short list reads
+> as complete precisely *because* it is short — when this file was 1126 lines
+> nobody believed they held the whole picture.
 
 ### Rules:
 - NEVER push code that doesn't compile
@@ -46,8 +57,8 @@ one-line description is what a session sees until it actually needs the body.
 
 | Skill | Load it when |
 |---|---|
-| `device-qa` | Running QA on an emulator/simulator, or at a release checkpoint |
-| `android-tooling` | Driving an emulator, screenshots, UI dumps, APK install, lease refusals |
+| `device-qa` | Running the SCRIPTED QA harness (device-qa.sh, Maestro) or the release gate |
+| `android-tooling` | Driving a device BY HAND — screenshots, UI dumps, APK install, lease refusals |
 | `ci-agents` | Touching the review fan-out, the `@claude` bot, event-driven jobs, agent cost |
 | `versioning` | Bumping the version, releasing, republishing the MCP |
 | `doc-drift` | A public API changed, or a drift/CREDITS/knowledge gate failed |

--- a/changelog.d/2991-context-budget-followup.md
+++ b/changelog.d/2991-context-budget-followup.md
@@ -1,0 +1,26 @@
+<!-- category: Fixed -->
+- `impact-check.sh` no longer skips its Android build leg inside a git worktree.
+  It tested `[[ -d .git ]]`, but in a linked worktree — how `.claude/worktrees/*`
+  and every agent-isolated session runs — `.git` is a regular file, so the leg
+  that catches a sample app which no longer configures was skipped exactly where
+  most work happens, and announced itself as "not a git repository" so the skip
+  read as an environment limitation rather than a bug (#2988).
+- `context-budget.sh` now sorts by size and names the over-spec file. It
+  previously printed rows in authoring order with a one-character flag, which is
+  how the largest item in the budget sat unnoticed through three passes while the
+  smaller one got optimised.
+- `context-budget.sh` stops describing the skills as bytes "NOT in the standing
+  cost". They are deferred, not free: opening one 15 Ko skill is ~19% of the whole
+  standing budget, measured on the first real use (#2986). It now prints the three
+  most expensive skills with their price if opened.
+
+<!-- category: Changed -->
+- `CLAUDE.md`'s "Before EVERY push" list adds `impact-check.sh` and says out loud
+  that it is a floor, not the full set. A session ran impact-check from agent
+  memory alone — it is not in that list — and surfaced 10 pre-existing failures
+  (#2987) plus #2988. Shortening the file to 217 lines made its lists read as
+  authoritative: at 1126 lines nobody believed they held the whole picture.
+- The `device-qa` and `android-tooling` skills both claimed "QA on an emulator" and
+  neither said which was which. `device-qa` is the scripted harness and the release
+  gate; `android-tooling` is driving a device by hand. Both descriptions and both
+  index rows now say so.


### PR DESCRIPTION
A session did real work under the split `CLAUDE.md` ([#2953](https://github.com/sceneview/sceneview/issues/2953) / [#2986](https://github.com/sceneview/sceneview/pull/2986)) and reported back. Three findings were right and are fixed here.

The common thread is mine: **I verified what I changed, not what I left.**

## 1. The target had moved and I did not look

After the split, `STATE.md` is 27 Ko — **2.2× `CLAUDE.md`**, the largest item in the standing budget and the only one over spec. `context-budget.sh` printed that on every run I made. It sat mid-list behind a one-character `!` while the totals told a flattering story about the file I had chosen to cut.

Rows are now sorted **largest-first**, and the over-spec file is named in a block that says it is the next thing to cut, *"not the file you cut last time"*.

## 2. "NOT in the standing cost" oversold it

I wrote that line. Deferred is not free: the session opened **one** skill and paid **14.9 Ko — 19% of the entire standing budget** — in a run that opened the minimum. The report now prices the three most expensive skills per-open, and says that opening three puts you back at pre-split cost.

## 3. A short list reads as complete

"Before EVERY push" had five items and `impact-check.sh` was not among them. The session ran it **from agent memory alone**; it surfaced 10 pre-existing failures ([#2987](https://github.com/sceneview/sceneview/issues/2987)) and a gate that silently skips itself in every worktree ([#2988](https://github.com/sceneview/sceneview/issues/2988)).

At 1126 lines nobody believed they held the whole picture. Brevity manufactured a false one. The list gains impact-check and an explicit *"this is a floor, not the full set"*.

## And #2988 itself

Adding a mandatory command while knowing it skips itself would have manufactured the same false completeness one level down.

`impact-check.sh` tested `[[ -d .git ]]` — but a linked worktree has `.git` as a **file**, so the leg that catches a sample app which no longer configures was skipped exactly where most agent work happens, announcing itself as *"not a git repository"* so the skip read as an environment limitation. It asked the wrong question; `git rev-parse --is-inside-work-tree` asks git instead of guessing from shape.

Verified both directions: this worktree now **runs** the leg, `/tmp` still **SKIPs**.

## Index ambiguity

`device-qa` and `android-tooling` both claimed "QA on an emulator" with nothing to separate them. Scripted harness vs driving by hand — now stated in both descriptions and both index rows.

## STATE.md (gitignored — not in this diff)

27.3 → **9.2 Ko**. Its `NOW` block held 16 bullets against a spec of ≤8, but a reference probe showed **only one** was fully closed: the problem was size (~1.7 Ko per bullet — mini-handoffs living in the file every session reads at startup), not count.

Full text archived **verbatim** to `handoff.md` first, then compressed to 8 state bullets plus 3 standing rules held explicitly out of the count. Verified both ways: all **13 still-OPEN** references survive in `NOW`, and every reference from the old block exists in `handoff.md`.

## Standing budget

| | Before #2985 | After #2985 | Now |
|---|---|---|---|
| Standing context | ~174 Ko | 79.8 Ko | **~62 Ko** |
| Largest item | `CLAUDE.md` 72.7 Ko | `STATE.md` 27.3 Ko | `MEMORY.md` 20 Ko |

## Not in scope, deliberately

[#2987](https://github.com/sceneview/sceneview/issues/2987) (node-count drift across 10 doc surfaces) and [#2990](https://github.com/sceneview/sceneview/issues/2990) (`android_cli_install_and_launch` reports success while installing nothing) are **pre-existing and unrelated to the split** — the broken `android run --apks` line was in `CLAUDE.md:230` before it moved. Fixing them here would be silent scope expansion; they keep their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)