### PR TITLE
fix(ios-demo): tell the user when a keyless build swapped the model (#2960)

### DIFF
--- a/changelog.d/2960-ios-keyless-fallback-honesty.md
+++ b/changelog.d/2960-ios-keyless-fallback-honesty.md
@@ -1,0 +1,19 @@
+<!-- category: Fixed -->
+- **iOS demo: a keyless build now says which model it is actually showing, and
+  four stand-ins stopped contradicting their own label (#2960).** App Store
+  builds ship no Sketchfab key, so `SketchfabAssetResolver` silently substitutes
+  each slug's bundled USDZ — and iOS had no cue at all that a substitution had
+  happened, so "Cushioned Sofa" over a mosquito in amber read as the real model
+  (the #2913 failure mode: a confident wrong scene beats a visible stall). Every
+  demo that streams (Scene Gallery, Materials, Physics, Animation, Multi-Model,
+  Orbital AR, both AR placement demos) now shows an `AssetSourcePill` —
+  "Streamed (cached)" / "Streaming…" / "Offline model" — driven by
+  `AssetSourceProbe`, a port of Android's probe (#2989) that measures the file
+  the resolver returned rather than trusting that a configured API key means the
+  download succeeded. Four fallbacks were also re-pointed at bundled assets that
+  match their label, with no new binary: *PBR Low-Poly Fox* → `khronos_fox`,
+  *Desk Lamp* → `khronos_lantern` (both matching what Android already maps),
+  *Walking Robot* and *Enforcer Mk1* → `cyberpunk_character` (verified to carry
+  a baked `SkelAnimation`, so the playback demo still animates). The remaining
+  mismatches in #2960 need a new bundled asset and stay open — the pill is what
+  makes them honest in the meantime.

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		0C0448E495F77BF795D1C647 /* ComingSoonScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA64989921B8BD7A9F30B31 /* ComingSoonScreen.swift */; };
 		593E4FADBA93AF1190A3A67E /* SketchfabModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C214F8F9A1B35560E551895 /* SketchfabModels.swift */; };
 		95BE47B4B9B828745697FB4B /* SketchfabConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77142EC848C995EDE06546D /* SketchfabConfig.swift */; };
+		A10000000000000000002960 /* AssetSourceProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002960 /* AssetSourceProbe.swift */; };
 		A10000010000000000000001 /* SceneViewDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000001 /* SceneViewDemoApp.swift */; };
 		A10000010000000000000002 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000002 /* Assets.xcassets */; };
 		B4A94ABD8B5DA5F4E4CE4834 /* SketchfabService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFA4BE9A50A8347603AA10E /* SketchfabService.swift */; };
@@ -128,6 +129,7 @@
 		C10000000000000000000051 /* CreditsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000051 /* CreditsSheet.swift */; };
 		C10000000000000000000060 /* AppStoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000060 /* AppStoreUpdater.swift */; };
 		C10000000000000000000061 /* UpdateBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000061 /* UpdateBanner.swift */; };
+		A10000000000000000002961 /* AssetSourcePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002961 /* AssetSourcePill.swift */; };
 		D10000000000000000000001 /* game_boy_classic.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D20000000000000000000001 /* game_boy_classic.usdz */; };
 		D10000000000000000000002 /* tree_scene.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D20000000000000000000002 /* tree_scene.usdz */; };
 		D10000000000000000000003 /* red_car.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D20000000000000000000003 /* red_car.usdz */; };
@@ -172,6 +174,7 @@
 		F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000060 /* SketchfabService+Tests.swift */; };
 		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
 		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
+		A10000000000000000002962 /* AssetSourceProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002962 /* AssetSourceProbeTests.swift */; };
 		F00000000000000000000075 /* BundledAssetPrimBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */; };
 		819AD79B996B8EE240D31FF6 /* ArPlaneRendererV2Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40DD4C3271CBFADB68D71777 /* ArPlaneRendererV2Scene.swift */; };
 		62EE9526D5ED0D7FE4053FAD /* ContactShadowPreviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16294DC5A7D862C38FE2FF4 /* ContactShadowPreviewScene.swift */; };
@@ -234,6 +237,7 @@
 		F00000000000000000000060 /* SketchfabService+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabService+Tests.swift"; path = "SceneViewDemo/Services/SketchfabService+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabAssetResolver+Tests.swift"; path = "SceneViewDemo/Services/SketchfabAssetResolver+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000072 /* DemoRegistryGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoRegistryGuardTests.swift; path = SceneViewDemoTests/DemoRegistryGuardTests.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002962 /* AssetSourceProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourceProbeTests.swift; path = SceneViewDemoTests/AssetSourceProbeTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BundledAssetPrimBudgetTests.swift; path = SceneViewDemoTests/BundledAssetPrimBudgetTests.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000002 /* DemoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoItem.swift; sourceTree = "<group>"; };
 		C20000000000000000000003 /* ExploreTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreTab.swift; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 		C20000000000000000000051 /* CreditsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CreditsSheet.swift; path = SceneViewDemo/Views/CreditsSheet.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000060 /* AppStoreUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreUpdater.swift; path = SceneViewDemo/Services/AppStoreUpdater.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000061 /* UpdateBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UpdateBanner.swift; path = SceneViewDemo/Views/Components/UpdateBanner.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002961 /* AssetSourcePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourcePill.swift; path = SceneViewDemo/Views/Components/AssetSourcePill.swift; sourceTree = SOURCE_ROOT; };
 		D20000000000000000000001 /* game_boy_classic.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = game_boy_classic.usdz; sourceTree = "<group>"; };
 		D20000000000000000000002 /* tree_scene.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = tree_scene.usdz; sourceTree = "<group>"; };
 		D20000000000000000000003 /* red_car.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = red_car.usdz; sourceTree = "<group>"; };
@@ -326,6 +331,7 @@
 		18D000109AEAF964E5DDC143 /* khronos_fox.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = khronos_fox.usdz; sourceTree = "<group>"; };
 		2C26CC8CC5834E15CDD1F062 /* khronos_damaged_helmet.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = khronos_damaged_helmet.usdz; sourceTree = "<group>"; };
 		D77142EC848C995EDE06546D /* SketchfabConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SketchfabConfig.swift; path = SceneViewDemo/Services/SketchfabConfig.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002960 /* AssetSourceProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourceProbe.swift; path = SceneViewDemo/Services/AssetSourceProbe.swift; sourceTree = SOURCE_ROOT; };
 		E20000000000000000000001 /* studio.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = studio.hdr; sourceTree = "<group>"; };
 		E20000000000000000000002 /* outdoor_cloudy.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = outdoor_cloudy.hdr; sourceTree = "<group>"; };
 		E20000000000000000000003 /* sunset.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = sunset.hdr; sourceTree = "<group>"; };
@@ -440,6 +446,7 @@
 				A40000010000000000000003 /* Products */,
 				5FA64989921B8BD7A9F30B31 /* ComingSoonScreen.swift */,
 				D77142EC848C995EDE06546D /* SketchfabConfig.swift */,
+				A20000000000000000002960 /* AssetSourceProbe.swift */,
 				6C214F8F9A1B35560E551895 /* SketchfabModels.swift */,
 				8FFA4BE9A50A8347603AA10E /* SketchfabService.swift */,
 				E11525101A2B40A19EAECE6700000001 /* SketchfabSlug.swift */,
@@ -460,6 +467,7 @@
 				F00000000000000000000060 /* SketchfabService+Tests.swift */,
 				F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */,
 				F00000000000000000000072 /* DemoRegistryGuardTests.swift */,
+				A20000000000000000002962 /* AssetSourceProbeTests.swift */,
 				F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */,
 			);
 			path = SceneViewDemoTests;
@@ -521,6 +529,7 @@
 			children = (
 				C20000000000000000000050 /* DemoSheet.swift */,
 				C20000000000000000000061 /* UpdateBanner.swift */,
+				A20000000000000000002961 /* AssetSourcePill.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -913,6 +922,7 @@
 				C10000000000000000000024 /* DemoDeepLinkRegistry.swift in Sources */,
 				0C0448E495F77BF795D1C647 /* ComingSoonScreen.swift in Sources */,
 				95BE47B4B9B828745697FB4B /* SketchfabConfig.swift in Sources */,
+				A10000000000000000002960 /* AssetSourceProbe.swift in Sources */,
 				593E4FADBA93AF1190A3A67E /* SketchfabModels.swift in Sources */,
 				B4A94ABD8B5DA5F4E4CE4834 /* SketchfabService.swift in Sources */,
 				E11525001A2B40A19EAECE6700000001 /* SketchfabSlug.swift in Sources */,
@@ -952,6 +962,7 @@
 				C10000000000000000000051 /* CreditsSheet.swift in Sources */,
 				C10000000000000000000060 /* AppStoreUpdater.swift in Sources */,
 				C10000000000000000000061 /* UpdateBanner.swift in Sources */,
+				A10000000000000000002961 /* AssetSourcePill.swift in Sources */,
 				7E28E9DEA941B656301CDA67 /* DemoScene.swift in Sources */,
 				F962AD205078EAFC5201865B /* AnimationScene.swift in Sources */,
 				96C00DAEDB204FF3E420ED1B /* ArAugmentedFacesScene.swift in Sources */,
@@ -1032,6 +1043,7 @@
 				F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */,
 				F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */,
 				F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */,
+				A10000000000000000002962 /* AssetSourceProbeTests.swift in Sources */,
 				F00000000000000000000075 /* BundledAssetPrimBudgetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/samples/ios-demo/SceneViewDemo/Services/AssetSourceProbe.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/AssetSourceProbe.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Where the asset a demo is currently rendering actually came from.
+///
+/// Mirror of Android's `AssetSourceState` (`DemoScaffold.kt:98`) — keep the
+/// three cases and their meaning identical across platforms.
+///
+///  - ``streamed`` — the model came from the Sketchfab CDN and is now cached on
+///    disk. Subsequent launches are instant.
+///  - ``streaming`` — a fetch is in flight; nothing has been measured yet.
+///  - ``bundled`` — no API key, no network, or a failed download → the offline
+///    stand-in declared by `SketchfabSlug.fallbackBundledPath` is on screen.
+enum AssetSourceState: Equatable {
+    case streamed
+    case streaming
+    case bundled
+}
+
+/// The one rule every iOS demo uses to decide what its asset-source pill says.
+///
+/// Port of Android's `AssetSourceProbe` (`sketchfab/AssetSourceProbe.kt`, #2989)
+/// — same three branches, same precedence, same reasoning. Read that file's
+/// KDoc before changing a branch here; the two must not drift.
+///
+/// The pill must report what was **resolved**, never what was **configured**.
+/// "An API key is configured" says nothing about whether the download
+/// succeeded: every failure path in `SketchfabAssetResolver.resolve` — no
+/// network, aeroplane mode, a stale or 4xx-rejected key, the WAF, a
+/// bounds-drifted asset, exhausted retries — ends at `fallbackBundle(for:)`, so
+/// a keyed build renders the offline stand-in under whatever the pill claims.
+/// Android measured exactly that on the QA emulator (2026-07-28, key
+/// configured): all four Multi-Model slots staged out of `fallback/` while the
+/// download endpoint answered 429 (#2933).
+///
+/// Why iOS needs it at all: 14 of the 29 registry slugs fall back to a
+/// semantically incompatible bundled USDZ (#2960), and most of those cannot be
+/// re-pointed without shipping a new binary. The pill is the systemic
+/// mitigation — it makes every remaining substitution *honest* instead of
+/// silently confident, which is the #2913 rule ("a confident wrong scene is
+/// worse than a visible stall"). Per `feedback_demo_cue_positive_not_absence`
+/// it states positively what is on screen rather than flagging an absence.
+enum AssetSourceProbe {
+
+    /// The pill for a demo showing a SINGLE streamed slot.
+    ///
+    /// - Parameters:
+    ///   - resolvedURL: the URL the resolver handed back, or `nil` while it is
+    ///     still working — the only thing worth measuring.
+    ///   - hasAPIKey: whether a Sketchfab key is configured. Read only when
+    ///     `loaded` is `false` — NOT when `resolvedURL` is `nil`. The two
+    ///     coincide for a demo that calls itself loaded the moment the file
+    ///     arrives, but not for one that waits for the model to parse: there, a
+    ///     resolved-but-still-parsing streamed file reaches the key branch.
+    ///     That is harmless (a resolved *fallback* is claimed by the measured
+    ///     branch first, whatever `loaded` says), but do not restate this gate
+    ///     as a test on `resolvedURL`.
+    ///   - loaded: whether the demo has finished doing what it considers
+    ///     "loaded". Each caller owns that definition.
+    static func of(
+        resolvedURL: URL?,
+        hasAPIKey: Bool,
+        loaded: Bool
+    ) -> AssetSourceState {
+        ofAll(resolvedURLs: [resolvedURL], hasAPIKey: hasAPIKey, loaded: loaded)
+    }
+
+    /// The pill for a demo showing SEVERAL streamed slots at once.
+    ///
+    /// A WHOLE-SCENE verdict: one fallen-back slot out of four reads
+    /// ``AssetSourceState/bundled`` for all of them, and the pill never says
+    /// which slot swapped. Pessimistic on purpose — of the two imprecise
+    /// answers, the optimistic one is the one that misleads. It is also a
+    /// MOVING verdict during load, since `loaded` and the fallback probe watch
+    /// different signals: a slot that falls back last flips the pill
+    /// streaming → bundled after the fact.
+    ///
+    /// - Parameter resolvedURLs: one entry per streamed slot; `nil` for a slot
+    ///   still resolving. Slots the demo renders straight from the app bundle
+    ///   have no origin question to answer and must not be passed in.
+    static func ofAll(
+        resolvedURLs: [URL?],
+        hasAPIKey: Bool,
+        loaded: Bool
+    ) -> AssetSourceState {
+        // MEASURED. Beats every other branch, including a `loaded` demo with a key.
+        if resolvedURLs.contains(where: { url in
+            url.map(SketchfabAssetResolver.isBundledFallback) ?? false
+        }) {
+            return .bundled
+        }
+        // Nothing to measure yet — the pre-resolve guess, and the only place
+        // the key is read.
+        guard loaded else { return hasAPIKey ? .streaming : .bundled }
+        // Everything resolved, nothing came from `fallback/`: genuinely streamed.
+        return .streamed
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
@@ -99,7 +99,12 @@ enum SampleAssets {
             displayName: "PBR Low-Poly Fox",
             author: "Ida..Faber",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
-            fallbackBundledPath: "Models/phoenix_bird.usdz",
+            // Keyless fallback: a fox for a fox (#2960). `khronos_fox` is already
+            // bundled and is what the Android registry maps this slug to
+            // (`SampleAssets.kt` → `models/khronos_fox.glb`), so the two platforms
+            // now show the same subject under the same label. The previous
+            // `phoenix_bird` rendered a mythical bird under "PBR Low-Poly Fox".
+            fallbackBundledPath: "Models/khronos_fox.usdz",
             scaleToUnits: 0.40,
             hasBakedAnimation: false,
             category: "gallery",
@@ -110,7 +115,14 @@ enum SampleAssets {
             displayName: "Desk Lamp",
             author: "BlueHour",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
-            fallbackBundledPath: "Models/fantasy_book.usdz",
+            // Keyless fallback: a lantern is a lamp (#2960). Already bundled, and
+            // the Android registry maps this slug the same way
+            // (`models/khronos_lantern.glb`). The previous `fantasy_book` rendered
+            // a book under "Desk Lamp". `khronos_lantern` is also the ar_placement
+            // "Floor Lamp" fallback, which is fine: both consumers are one-model
+            // pickers, so the two are never on screen together (#2355 binds only
+            // where several slots render at once).
+            fallbackBundledPath: "Models/khronos_lantern.usdz",
             scaleToUnits: 0.45,
             hasBakedAnimation: false,
             category: "gallery",
@@ -156,7 +168,13 @@ enum SampleAssets {
             displayName: "Walking Robot",
             author: "ArtsByKev",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
-            fallbackBundledPath: "Models/animated_butterfly.usdz",
+            // Keyless fallback: an animated humanoid for a walking robot (#2960).
+            // The previous `animated_butterfly` was picked for its baked clip, not
+            // its subject — `cyberpunk_character` carries one too (verified: its
+            // `scene.usdc` declares a `SkelAnimation`) and is already
+            // `AnimationDemo`'s own bundled hero, so the playback point survives
+            // while the subject stops contradicting the label.
+            fallbackBundledPath: "Models/cyberpunk_character.usdz",
             scaleToUnits: 0.40,
             hasBakedAnimation: true,
             category: "animation",
@@ -167,7 +185,11 @@ enum SampleAssets {
             displayName: "Enforcer Mk1",
             author: "Mr0btainable",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
-            fallbackBundledPath: "Models/animated_butterfly.usdz",
+            // Keyless fallback: same reasoning as "Walking Robot" above — a mech
+            // reads as an animated humanoid, never as a butterfly (#2960). Sharing
+            // `cyberpunk_character` with the other three animation slugs is safe:
+            // `AnimationDemo` is a picker, one model at a time.
+            fallbackBundledPath: "Models/cyberpunk_character.usdz",
             scaleToUnits: 0.55,
             hasBakedAnimation: true,
             category: "animation",

--- a/samples/ios-demo/SceneViewDemo/Services/SketchfabAssetResolver.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SketchfabAssetResolver.swift
@@ -38,6 +38,25 @@ actor SketchfabAssetResolver {
     static let minBoundsRadiusMeters: Float = 0.05
     static let maxBoundsRadiusMeters: Float = 5.0
 
+    /// Cache subdirectory the bundled fallbacks are staged into, directly under
+    /// the streamed-download root. Both paths hand back a `URL`, so this
+    /// directory name is the only thing that distinguishes them — see
+    /// ``isBundledFallback(_:)``. Mirrors Android's `FALLBACK_DIR_NAME`.
+    static let fallbackDirName = "fallback"
+
+    /// Whether `url` is a staged bundled fallback rather than a streamed download.
+    ///
+    /// A demo that wants to tell the user which one it is rendering has to ask
+    /// the FILE, not the configuration: "an API key is configured" does not mean
+    /// the download succeeded. Every failure mode in ``resolve(_:)`` — no
+    /// network, 401 on a stale key, a bounds-drifted asset, exhausted retries —
+    /// ends at ``fallbackBundle(for:)``, so a keyed build can quietly render the
+    /// offline stand-in. Mirrors Android's `isBundledFallback` (#2933), and is
+    /// what ``AssetSourceProbe`` measures.
+    nonisolated static func isBundledFallback(_ url: URL) -> Bool {
+        url.deletingLastPathComponent().lastPathComponent == fallbackDirName
+    }
+
     /// Max retries for a transient network failure (429 / 5xx).
     static let maxRetries = 3
 
@@ -181,7 +200,10 @@ actor SketchfabAssetResolver {
     /// is served as a last resort rather than throwing — see the guard below.
     func fallbackBundle(for slug: SketchfabSlug) throws -> URL {
         let root = try cacheRoot()
-        let fallbackDir = root.appendingPathComponent("fallback", isDirectory: true)
+        let fallbackDir = root.appendingPathComponent(
+            Self.fallbackDirName,
+            isDirectory: true
+        )
         try fileManager.createDirectory(at: fallbackDir, withIntermediateDirectories: true)
         let target = fallbackDir.appendingPathComponent("\(slug.uid).usdz")
 

--- a/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Compact pill telling the user where the model on screen came from.
+///
+/// iOS port of the Android asset-source chip (`DemoScaffold.AssetSourceChip`,
+/// #1152 Stage 3 / #2936). Until now iOS had **no** cue at all, which is what
+/// made #2960 a user-facing defect rather than a registry wart: on a keyless
+/// build — every App Store build, since no Sketchfab key ships — 14 of the 29
+/// curated slugs resolve to a bundled USDZ whose subject does not match the
+/// label printed next to it, and nothing on screen said a substitution had
+/// happened. A visible "Offline model" is what turns a confident wrong scene
+/// into an honest stand-in (#2913).
+///
+/// Copy is kept **identical to Android's** (`strings.xml`
+/// `demo_chip_streamed` / `demo_chip_streaming` / `demo_chip_bundled`) so the
+/// two demo apps read the same in screenshots and QA transcripts.
+struct AssetSourcePill: View {
+    let state: AssetSourceState
+
+    private var label: String {
+        switch state {
+        case .streamed: return "Streamed (cached)"
+        case .streaming: return "Streaming…"
+        case .bundled: return "Offline model"
+        }
+    }
+
+    private var tint: Color {
+        switch state {
+        // Android maps these to tertiary / primary / outline. SwiftUI has no
+        // Material colour roles, so this is the nearest fixed equivalent: a
+        // positive accent for a real stream, the app accent while in flight,
+        // and a muted grey for the stand-in — never red, because a bundled
+        // model is a supported state, not an error.
+        case .streamed: return .green
+        case .streaming: return .accentColor
+        case .bundled: return .secondary
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(tint)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(.ultraThinMaterial, in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Asset source: \(label)")
+        // The QA harness and the screenshot suite locate the pill by this id;
+        // keep it stable.
+        .accessibilityIdentifier("assetSourcePill")
+    }
+}
+
+extension View {
+    /// Pins an ``AssetSourcePill`` to the top-trailing corner of the scene,
+    /// inside the safe area — the same corner Android uses, and the one corner
+    /// no demo's own controls occupy (settings sit bottom-trailing, chips sit
+    /// bottom-centre).
+    ///
+    /// Pass `nil` for a demo that never touches `SketchfabAssetResolver`: it
+    /// has no origin question to answer and must show no pill.
+    @ViewBuilder
+    func assetSourcePill(_ state: AssetSourceState?) -> some View {
+        if let state {
+            overlay(alignment: .topTrailing) {
+                AssetSourcePill(state: state)
+                    .padding(.top, 12)
+                    .padding(.trailing, 16)
+            }
+        } else {
+            self
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        AssetSourcePill(state: .streamed)
+        AssetSourcePill(state: .streaming)
+        AssetSourcePill(state: .bundled)
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
@@ -69,6 +69,19 @@ struct ARInstantPlacementDemo: View {
 
     private let placementSlugs: [SketchfabSlug] = SampleAssets.byCategory["ar_placement"] ?? []
 
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
+
+    /// Same rule as `ARPlacementDemo`: `nil` in bundled-cycle mode (nothing was
+    /// substituted), measured from the resolved file otherwise (#2960).
+    private var assetSource: AssetSourceState? {
+        guard selectedSlug != nil else { return nil }
+        return AssetSourceProbe.of(
+            resolvedURL: armedURL,
+            hasAPIKey: hasSketchfabKey,
+            loaded: armedURL != nil
+        )
+    }
+
     var body: some View {
         ZStack {
             #if !targetEnvironment(simulator)
@@ -91,8 +104,16 @@ struct ARInstantPlacementDemo: View {
             simulatorPlaceholder
             #endif
 
-            VStack {
+            VStack(spacing: 8) {
                 statusPill
+                // Under the status pill, not in the corner — see ARPlacementDemo.
+                if let assetSource {
+                    HStack {
+                        Spacer()
+                        AssetSourcePill(state: assetSource)
+                    }
+                    .padding(.horizontal, 16)
+                }
                 Spacer()
             }
         }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
@@ -72,6 +72,23 @@ struct ARPlacementDemo: View {
 
     private let placementSlugs: [SketchfabSlug] = SampleAssets.byCategory["ar_placement"] ?? []
 
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
+
+    /// `nil` in bundled-cycle mode: those five models load by name and the
+    /// caption names each one for what it is, so nothing was substituted.
+    /// With a slug armed, the caption claims "Next tap places: <slug>" — the
+    /// pill is what keeps that claim honest when the resolver quietly handed
+    /// back the offline stand-in (#2960).
+    private var assetSource: AssetSourceState? {
+        guard selectedSlug != nil else { return nil }
+        return AssetSourceProbe.of(
+            resolvedURL: armedURL,
+            hasAPIKey: hasSketchfabKey,
+            // "Loaded" is "the file arrived": a tap places whatever has resolved.
+            loaded: armedURL != nil
+        )
+    }
+
     var body: some View {
         ZStack {
             #if !targetEnvironment(simulator)
@@ -81,8 +98,18 @@ struct ARPlacementDemo: View {
             simulatorPlaceholder
             #endif
 
-            VStack {
+            VStack(spacing: 8) {
                 statusPill
+                // Stacked under the status pill rather than pinned to the
+                // corner: both sit at the top and a trailing overlay collides
+                // with the centred "N models placed" text on a narrow device.
+                if let assetSource {
+                    HStack {
+                        Spacer()
+                        AssetSourcePill(state: assetSource)
+                    }
+                    .padding(.horizontal, 16)
+                }
                 Spacer()
                 if let lastError {
                     errorBanner(lastError)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
@@ -89,13 +89,30 @@ struct AnimationDemo: View {
     @State private var speed: Float = 1.0
     @State private var loadedNode: ModelNode?
     @State private var loadError: String?
+    /// What the resolver handed back for a *streamed* subject (#2960).
+    @State private var resolvedURL: URL?
+
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
 
     private var selectedSubject: AnimationSubject {
         Self.subjects[selectedIndex]
     }
 
+    /// `nil` for slot 0: "Soldier" is loaded straight from the app bundle and
+    /// labelled as itself, so it has no origin question to answer — showing a
+    /// pill there would invent a substitution that never happened.
+    private var assetSource: AssetSourceState? {
+        guard selectedSubject.streamedSlug != nil else { return nil }
+        return AssetSourceProbe.of(
+            resolvedURL: resolvedURL,
+            hasAPIKey: hasSketchfabKey,
+            loaded: loadedNode != nil
+        )
+    }
+
     var body: some View {
         sceneContent
+            .assetSourcePill(assetSource)
             .demoSettingsSheet {
                 controlsSheet
             }
@@ -278,10 +295,12 @@ struct AnimationDemo: View {
         let subject = selectedSubject
         loadedNode = nil
         loadError = nil
+        resolvedURL = nil
         do {
             let node: ModelNode
             if let slug = subject.streamedSlug {
                 let url = try await SketchfabAssetResolver.shared.resolve(slug)
+                resolvedURL = url
                 node = try await ModelNode.load(contentsOf: url)
             } else if let bundled = subject.bundledAsset {
                 node = try await ModelNode.load(bundled)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
@@ -24,10 +24,23 @@ struct MaterialsDemo: View {
     @State private var selectedIndex: Int = 0
     @State private var loadedNode: ModelNode?
     @State private var loadError: String?
+    /// What the resolver actually handed back — the pill measures this, never
+    /// the API-key configuration (#2960).
+    @State private var resolvedURL: URL?
+
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
 
     private var selectedSlug: SketchfabSlug? {
         guard slugs.indices.contains(selectedIndex) else { return nil }
         return slugs[selectedIndex]
+    }
+
+    private var assetSource: AssetSourceState {
+        AssetSourceProbe.of(
+            resolvedURL: resolvedURL,
+            hasAPIKey: hasSketchfabKey,
+            loaded: loadedNode != nil
+        )
     }
 
     var body: some View {
@@ -38,6 +51,7 @@ struct MaterialsDemo: View {
                 controls
             }
         }
+        .assetSourcePill(assetSource)
         .background(Color.black)
         .task(id: selectedSlug?.uid) {
             await loadSelectedSlug()
@@ -138,8 +152,10 @@ struct MaterialsDemo: View {
         guard let slug = selectedSlug else { return }
         loadedNode = nil
         loadError = nil
+        resolvedURL = nil
         do {
             let url = try await SketchfabAssetResolver.shared.resolve(slug)
+            resolvedURL = url
             let node = try await ModelNode.load(contentsOf: url)
             _ = node.scaleToUnits(slug.scaleToUnits)
             _ = node.centerOrigin()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
@@ -27,8 +27,9 @@ import SceneViewSwift
 ///
 /// > Important: the chip names the CATALOGUE ENTRY, not the geometry. On a
 /// > keyless build a slot still reads "Oak Trees" over its bundled stand-in.
-/// > Android surfaces that with the scaffold's asset-source pill; iOS has no
-/// > equivalent chrome yet, so a keyless build here is silent about the swap.
+/// > Both platforms now say so on screen — Android through the scaffold's
+/// > asset-source chip, iOS through ``AssetSourcePill`` (#2960), which reads
+/// > "Offline model" as soon as any one slot resolves out of `fallback/`.
 ///
 /// ⚠️ That swap is also why this demo is deliberately absent from the App Store
 /// screenshot set (#2896). The bundled stand-ins are intentionally distinct
@@ -53,6 +54,9 @@ struct MultiModelDemo: View {
     /// re-evaluate visibility every recomposition.
     @State private var loadedEntities: [String: Entity] = [:]
     @State private var loadError: String?
+    /// What the resolver handed back per slot uid — the pill's only honest
+    /// input (#2960). A slot still resolving simply has no entry yet.
+    @State private var resolvedURLs: [String: URL] = [:]
     /// Anchor under which every model lives. Stored so we can attach / detach
     /// individual entities without rebuilding the entire scene.
     @State private var sceneAnchor: AnchorEntity?
@@ -112,8 +116,24 @@ struct MultiModelDemo: View {
         }
     }()
 
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
+
+    /// A WHOLE-SCENE verdict over the four park slots: one stand-in makes the
+    /// pill read "Offline model" for the scene. This demo's header already
+    /// admits in prose that a keyless slot reads "Oak Trees" over a stand-in
+    /// — the pill is that admission made visible on screen (#2960).
+    private var assetSource: AssetSourceState {
+        let slugs = Self.slots.compactMap(\.slug)
+        return AssetSourceProbe.ofAll(
+            resolvedURLs: slugs.map { resolvedURLs[$0.uid] },
+            hasAPIKey: hasSketchfabKey,
+            loaded: slugs.allSatisfy { loadedEntities[$0.uid] != nil }
+        )
+    }
+
     var body: some View {
         sceneContent
+            .assetSourcePill(assetSource)
             .demoSettingsSheet { controlsSheet }
             .task {
                 _ = await SketchfabAssetResolver.shared.prefetchAll(category: "park")
@@ -275,6 +295,7 @@ struct MultiModelDemo: View {
         guard let slug = slot.slug else { return }
         do {
             let url = try await SketchfabAssetResolver.shared.resolve(slug)
+            resolvedURLs[slug.uid] = url
             let node = try await ModelNode.load(contentsOf: url)
             _ = node.scaleToUnits(slot.scale)
             _ = node.centerOrigin()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OrbitalARDemo.swift
@@ -119,6 +119,30 @@ struct OrbitalARDemo: View {
     @State private var loadedNodes: [Int: ModelNode] = [:]
     @State private var anchorAdded = false
     @State private var orbitTimer: Timer?
+    /// What the resolver handed back per planet index, for the streamed slots
+    /// only — the pill's only honest input (#2960).
+    @State private var resolvedURLs: [Int: URL] = [:]
+
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
+
+    /// Indices of the planets that go through the resolver. The bundled-only
+    /// planets load by name and are labelled as themselves, so they have no
+    /// origin question to answer and must stay out of the verdict.
+    private static let streamedPlanetIndices: [Int] = planets.enumerated()
+        .filter { $0.element.streamedSlug != nil }
+        .map(\.offset)
+
+    /// A WHOLE-SCENE verdict over the streamed planets: this demo renders all
+    /// eight at once, so one stand-in is enough to make the ring dishonest —
+    /// all four `solar` slugs currently resolve to the same
+    /// `animated_butterfly.usdz` on a keyless build.
+    private var assetSource: AssetSourceState {
+        AssetSourceProbe.ofAll(
+            resolvedURLs: Self.streamedPlanetIndices.map { resolvedURLs[$0] },
+            hasAPIKey: hasSketchfabKey,
+            loaded: Self.streamedPlanetIndices.allSatisfy { loadedNodes[$0] != nil }
+        )
+    }
 
     var body: some View {
         ZStack {
@@ -129,8 +153,17 @@ struct OrbitalARDemo: View {
             simulatorPlaceholder
             #endif
 
-            VStack {
+            VStack(spacing: 8) {
                 statusPill
+                // Deliberately stacked UNDER the status pill rather than pinned
+                // top-trailing like every other demo: the status text is wide
+                // ("Turn around — 8 of 8 models orbiting") and a corner overlay
+                // collides with it on a narrow device.
+                HStack {
+                    Spacer()
+                    AssetSourcePill(state: assetSource)
+                }
+                .padding(.horizontal, 16)
                 Spacer()
             }
         }
@@ -176,6 +209,7 @@ struct OrbitalARDemo: View {
                         let node: ModelNode
                         if let slug = planet.streamedSlug {
                             let url = try await SketchfabAssetResolver.shared.resolve(slug)
+                            resolvedURLs[index] = url
                             node = try await ModelNode.load(contentsOf: url)
                         } else if let bundled = planet.bundledAsset {
                             node = try await ModelNode.load(bundled)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
@@ -34,8 +34,27 @@ struct PhysicsDemo: View {
 
     private let physicsSlugs: [SketchfabSlug] = SampleAssets.byCategory["physics"] ?? []
 
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
+
+    /// `nil` while the demo drops its own generated cubes — they are not a
+    /// substitution for anything, so there is nothing to declare. With a slug
+    /// selected the caption reads "Streamed <name> falling", which is exactly
+    /// the claim the pill has to keep honest on a keyless build (#2960): all
+    /// four physics slugs currently resolve to `fantasy_book.usdz`.
+    private var assetSource: AssetSourceState? {
+        guard selectedSlug != nil else { return nil }
+        return AssetSourceProbe.of(
+            resolvedURL: streamedURL,
+            hasAPIKey: hasSketchfabKey,
+            // "Loaded" here is "the file arrived" — the scene consumes the URL
+            // directly, there is no separate parse step to wait for.
+            loaded: streamedURL != nil
+        )
+    }
+
     var body: some View {
         sceneContent
+            .assetSourcePill(assetSource)
             .demoSettingsSheet { controlsSheet }
             .task {
                 _ = await SketchfabAssetResolver.shared.prefetchAll(category: "physics")

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
@@ -24,10 +24,25 @@ struct SceneGalleryDemo: View {
     @State private var selectedIndex: Int = 0
     @State private var loadedNode: ModelNode?
     @State private var loadError: String?
+    /// What the resolver actually handed back for the selected slug — the only
+    /// honest input to the asset-source pill (#2960). `nil` while resolving.
+    @State private var resolvedURL: URL?
+
+    private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
 
     private var selectedSlug: SketchfabSlug? {
         guard slugs.indices.contains(selectedIndex) else { return nil }
         return slugs[selectedIndex]
+    }
+
+    /// "Loaded" here means the model *parsed*, not merely that the file
+    /// arrived, so the pill and the centre spinner stay in lockstep.
+    private var assetSource: AssetSourceState {
+        AssetSourceProbe.of(
+            resolvedURL: resolvedURL,
+            hasAPIKey: hasSketchfabKey,
+            loaded: loadedNode != nil
+        )
     }
 
     var body: some View {
@@ -38,6 +53,7 @@ struct SceneGalleryDemo: View {
                 controls
             }
         }
+        .assetSourcePill(assetSource)
         .background(Color.black)
         .task(id: selectedSlug?.uid) {
             await loadSelectedSlug()
@@ -134,8 +150,10 @@ struct SceneGalleryDemo: View {
         guard let slug = selectedSlug else { return }
         loadedNode = nil
         loadError = nil
+        resolvedURL = nil
         do {
             let url = try await SketchfabAssetResolver.shared.resolve(slug)
+            resolvedURL = url
             let node = try await ModelNode.load(contentsOf: url)
             _ = node.scaleToUnits(slug.scaleToUnits)
             _ = node.centerOrigin()

--- a/samples/ios-demo/SceneViewDemoTests/AssetSourceProbeTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/AssetSourceProbeTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+// Deliberately NOT wrapped in `#if DEBUG` — see BundledAssetPrimBudgetTests for
+// why: `ENABLE_TESTABILITY` is Debug-only, so a Release test run must fail to
+// COMPILE rather than silently compile to an empty, green file.
+@testable import SceneViewDemo
+
+/// Unit tests for ``AssetSourceProbe`` — the rule behind every demo's
+/// asset-source pill.
+///
+/// Port of Android's `AssetSourceProbeTest`, case for case, so a divergence
+/// between the two platforms shows up as a failing test rather than as two
+/// demos that disagree about what they are showing.
+///
+/// Pure Foundation: ``SketchfabAssetResolver/isBundledFallback(_:)`` keys on the
+/// parent directory NAME, so a synthetic `URL` is enough and nothing touches the
+/// disk, the bundle, or RealityKit.
+///
+/// The defect these pin is #2960's premise: on a keyless build 14 of the 29
+/// registry slugs resolve to a bundled USDZ whose subject contradicts the label
+/// beside it, and until now iOS showed no cue at all. Every case below carrying
+/// `hasAPIKey: true` with a fallback URL is also the Android regression (#2933):
+/// a configured key is not evidence that the download succeeded.
+final class AssetSourceProbeTests: XCTestCase {
+
+    private let cacheRoot = URL(fileURLWithPath: "/tmp/Caches/sketchfab", isDirectory: true)
+
+    /// What the resolver hands back on the network path.
+    private func streamed(_ uid: String) -> URL {
+        cacheRoot.appendingPathComponent("\(uid).usdz")
+    }
+
+    /// What it hands back on every failure path — `sketchfab/fallback/<uid>.usdz`.
+    private func fallback(_ uid: String) -> URL {
+        cacheRoot
+            .appendingPathComponent(SketchfabAssetResolver.fallbackDirName, isDirectory: true)
+            .appendingPathComponent("\(uid).usdz")
+    }
+
+    // MARK: - The regression: a KEYED build that fell back
+
+    func testAKeyedBuildThatFellBackReportsBundledNotStreamed() {
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: fallback("car"), hasAPIKey: true, loaded: true),
+            .bundled,
+            "a configured key says nothing about whether the download succeeded — "
+            + "the resolved file came out of fallback/, so the pill must say Offline model"
+        )
+    }
+
+    func testOneFallenBackSlotOutOfFourSinksTheWholeScene() {
+        let urls: [URL?] = [streamed("a"), streamed("b"), fallback("c"), streamed("d")]
+        XCTAssertEqual(
+            AssetSourceProbe.ofAll(resolvedURLs: urls, hasAPIKey: true, loaded: true),
+            .bundled,
+            "the verdict is whole-scene and pessimistic: one stand-in in the park "
+            + "formation means the pill must not promise a streamed scene"
+        )
+    }
+
+    func testAFallbackBeatsLoadedTheMeasuredBranchWinsOverEveryGuess() {
+        // Same inputs as the streamed case below except the parent directory. If
+        // the measured branch is removed, `loaded: true` + a key falls through to
+        // `.streamed` and this is the test that catches it.
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: fallback("car"), hasAPIKey: true, loaded: true),
+            .bundled
+        )
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: streamed("car"), hasAPIKey: true, loaded: true),
+            .streamed
+        )
+    }
+
+    // MARK: - The pre-resolve path: the only place the key is read
+
+    func testNothingResolvedYetWithAKeyReadsStreaming() {
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: nil, hasAPIKey: true, loaded: false),
+            .streaming
+        )
+    }
+
+    func testNothingResolvedYetWithoutAKeyReadsBundled() {
+        // Keyless is where this ends regardless: `resolve` short-circuits to the
+        // bundled fallback, so claiming "Streaming…" would be a spinner that
+        // never lands.
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: nil, hasAPIKey: false, loaded: false),
+            .bundled
+        )
+    }
+
+    func testAResolvedStreamedFileThatHasNotFinishedLoadingStillReadsStreaming() {
+        // AR Placement ties `loaded` to the file; Gallery ties it to the parsed
+        // ModelNode. This is the Gallery shape — file in hand, parse still running.
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: streamed("car"), hasAPIKey: true, loaded: false),
+            .streaming
+        )
+    }
+
+    func testAResolvedFallbackReportsBundledBeforeTheParseFinishes() {
+        // The origin is settled the moment the file is known, so the pill does
+        // not wait for the parse to say so: "Offline model" claims an origin,
+        // not a finished download.
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: fallback("car"), hasAPIKey: true, loaded: false),
+            .bundled
+        )
+    }
+
+    func testTheKeyGateIsOnLoadedNotOnWhetherAFileResolved() {
+        // Pins the parameter contract. A streamed file HAS resolved, yet
+        // `loaded: false` still routes through the key branch — so with no key
+        // this reads `.bundled`, not `.streaming`. Gallery and Materials reach
+        // exactly this state, since their `loaded` is a parsed model.
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: streamed("car"), hasAPIKey: false, loaded: false),
+            .bundled
+        )
+        XCTAssertEqual(
+            AssetSourceProbe.of(resolvedURL: streamed("car"), hasAPIKey: true, loaded: false),
+            .streaming
+        )
+    }
+
+    // MARK: - The happy path
+
+    func testEverySlotStreamedAndLoadedReportsStreamed() {
+        let urls: [URL?] = [streamed("a"), streamed("b"), streamed("c"), streamed("d")]
+        XCTAssertEqual(
+            AssetSourceProbe.ofAll(resolvedURLs: urls, hasAPIKey: true, loaded: true),
+            .streamed
+        )
+    }
+
+    func testAPartiallyResolvedKeyedSceneReadsStreamingNotStreamed() {
+        let urls: [URL?] = [streamed("a"), nil, streamed("c"), nil]
+        XCTAssertEqual(
+            AssetSourceProbe.ofAll(resolvedURLs: urls, hasAPIKey: true, loaded: false),
+            .streaming
+        )
+    }
+
+    func testAPartiallyResolvedKeylessSceneReadsBundled() {
+        let urls: [URL?] = [streamed("a"), nil, nil, nil]
+        XCTAssertEqual(
+            AssetSourceProbe.ofAll(resolvedURLs: urls, hasAPIKey: false, loaded: false),
+            .bundled
+        )
+    }
+
+    // MARK: - The single-slot form is the list form, and must stay that way
+
+    func testTheSingleSlotFormAgreesWithTheOneElementListFormEverywhere() {
+        let urls: [URL?] = [nil, streamed("car"), fallback("car")]
+        for url in urls {
+            for hasAPIKey in [true, false] {
+                for loaded in [true, false] {
+                    XCTAssertEqual(
+                        AssetSourceProbe.of(
+                            resolvedURL: url, hasAPIKey: hasAPIKey, loaded: loaded
+                        ),
+                        AssetSourceProbe.ofAll(
+                            resolvedURLs: [url], hasAPIKey: hasAPIKey, loaded: loaded
+                        ),
+                        "of(\(String(describing: url)), key=\(hasAPIKey), loaded=\(loaded)) "
+                        + "must equal ofAll of the same single slot — the two forms differ "
+                        + "only in arity"
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - The probe reads the directory the resolver actually stages into
+
+    func testTheProbeReadsTheRealStagingDirectoryNameNotAHardcodedString() {
+        // If `fallbackDirName` ever changes, `fallback()` above follows it and
+        // these tests keep testing the truth. This asserts the constant is what
+        // `fallbackBundle(for:)` uses, so the helpers cannot quietly drift into
+        // testing nothing.
+        XCTAssertEqual(SketchfabAssetResolver.fallbackDirName, "fallback")
+        XCTAssertEqual(
+            AssetSourceProbe.of(
+                resolvedURL: cacheRoot
+                    .appendingPathComponent("fallback", isDirectory: true)
+                    .appendingPathComponent("car.usdz"),
+                hasAPIKey: true,
+                loaded: true
+            ),
+            .bundled
+        )
+    }
+
+    /// A streamed file sits directly under the cache root, one level above the
+    /// staging directory — the discriminator is the PARENT name, so a file whose
+    /// own name merely contains "fallback" must not be mistaken for one.
+    func testAStreamedFileNamedLikeTheStagingDirectoryIsStillStreamed() {
+        XCTAssertFalse(
+            SketchfabAssetResolver.isBundledFallback(
+                cacheRoot.appendingPathComponent("fallback.usdz")
+            )
+        )
+        XCTAssertTrue(SketchfabAssetResolver.isBundledFallback(fallback("car")))
+    }
+}


### PR DESCRIPTION
## What

Two changes to the iOS demo, no new binary:

1. **An asset-source pill on every streaming demo.** `AssetSourcePill` +
   `AssetSourceProbe` — a port of Android's `AssetSourceProbe` (#2989), branch
   for branch. It **measures** the file the resolver returned
   (`SketchfabAssetResolver.isBundledFallback`, keyed on the `fallback/` staging
   directory) rather than inferring from "an API key is configured". Wired into
   all eight demos that stream: Scene Gallery, Materials, Physics, Animation,
   Multi-Model, Orbital AR, AR Placement, AR Instant Placement.
2. **Four fallbacks re-pointed** at bundled assets that match their label:
   `PBR Low-Poly Fox` → `khronos_fox`, `Desk Lamp` → `khronos_lantern` (both
   matching what Android already maps), `Walking Robot` and `Enforcer Mk1` →
   `cyberpunk_character`.

## Why

Closes part of #2960. App Store builds ship no Sketchfab key, so the resolver
silently substitutes each slug's bundled USDZ — and iOS had **no cue at all**.
A keyless user reads "Cushioned Sofa" over a mosquito in amber and nothing says
a substitution happened: #2913's failure mode, where a confident wrong scene
beats a visible stall. Per `feedback_demo_cue_positive_not_absence` the pill
states positively what is on screen ("Offline model") rather than flagging an
absence.

`animated_butterfly` was chosen for the two animation slugs for its baked clip,
not its subject. `cyberpunk_character` carries one too — verified, its
`scene.usdc` declares a `SkelAnimation` — so the playback point survives while
the subject stops contradicting the label.

## Verification

**Simulator, keyless build** (QA-iPhone16-c, iOS 26.3, no `SKETCHFAB_API_KEY`):
the pill reads "Offline model" in Scene Gallery, Multi-Model and Animation;
"PBR Low-Poly Fox" now renders a fox, "Desk Lamp" a lantern, and the
bundled-only Animation slot ("Soldier") correctly shows **no** pill.

**Tests**: 14 new cases in `AssetSourceProbeTests`, ported case for case from
`AssetSourceProbeTest.kt`. **Mutation-tested** — deleting the measured branch in
`ofAll` turns 5 of them red. Full iOS unit suite: 76/76 (1 skipped, the live
network test with no key). `impact-check.sh`: PASS with 2 pre-existing parity
warnings unrelated to this diff.

## Deliberately not in scope

- The mismatches that need a **new bundled asset** — the whole `physics`
  category, Crates & Barrels, Picture Frame, Nile — stay open on #2960. The
  pill is what makes them honest until then.
- **Found while verifying, pre-existing, filed separately**: `Walking Robot`
  renders a fully black viewport in `AnimationDemo`. Measured on **both** the
  new fallback and the old one (control build re-pointed to
  `animated_butterfly` → still black), while `Retro TV Robot` and `Catfish
  Mech` — the *same* asset at a larger `scaleToUnits` — render fine. So this
  diff neither causes nor fixes it.
- #2966 (the attribution line crediting the streamed author next to a fallback)
  is its own issue; `isBundledFallback` now exists to fix it cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)