### PR TITLE
fix(ci): stop the PR review from reporting its own edits as PR defects

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -484,7 +484,17 @@ jobs:
         if: always() && steps.budget.outputs.within_budget == 'true' && steps.creds.outputs.has_token == 'true' && steps.selfmod.outputs.self_modified == 'false'
         run: |
           set -uo pipefail
-          DIRT="$(git status --porcelain -- . ':(exclude)review-verdict.json')"
+          # A FAILED `git status` is not a clean tree. Assigning it straight into
+          # DIRT made this step fail-OPEN: a non-zero exit leaves the variable
+          # empty and the assertion then announces a pristine checkout it never
+          # managed to look at. Reproduced outside a repository: git printed
+          # "fatal: not a git repository" and the step still said "Working tree
+          # clean". Same class as "absent is not zero", which this workflow
+          # already learned the hard way for `permission_denials_count` below.
+          if ! DIRT="$(git status --porcelain -- . ':(exclude)review-verdict.json')"; then
+            echo "::error title=Clean-tree assertion could not run::git status failed in ${PWD}, so this run proves nothing about the checkout. Absent is not clean — treating it as contaminated."
+            exit 1
+          fi
           if [ -z "$DIRT" ]; then
             echo "Working tree clean — the reviewers did not mutate the checkout."
             exit 0

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -335,11 +335,26 @@ jobs:
           # #2431 is preserved where it belongs: as a DENY list, not by starving
           # the shell. Reviewers share ONE working tree, so a `git checkout`,
           # `switch`, `reset` or `stash` corrupts it under the others. The prompt
-          # already forbids it; these four make it structural.
+          # already forbids it; these make it structural.
+          #
+          # `restore`, `apply` and `clean` were added after #3016: the original
+          # four stop a reviewer from moving the BRANCH but not from reverting a
+          # FILE, and the narrower verbs are the ones a reviewer actually reaches
+          # for ("let me see what main said here"). Measured cost of the gap:
+          # three false blocking verdicts across #3009 and #3015, each one a
+          # reviewer's own edit read back as a defect and then confirmed by an
+          # adversarial verifier looking at the same poisoned tree.
+          #
+          # ⚠️ `Write` is still granted — the orchestrator's only deliverable is
+          # `review-verdict.json` and it needs a way to produce it. The grant is
+          # process-wide, so a reviewer CAN still edit a file. That hole is what
+          # the clean-tree assertion below exists to catch; closing it properly
+          # means giving the orchestrator a non-`Write` path to its verdict file,
+          # which is tracked separately in #3016.
           claude_args: >-
             --model claude-opus-4-8
             --allowedTools "Task,Read,Glob,Grep,Write,Bash"
-            --disallowedTools "Bash(git checkout:*),Bash(git switch:*),Bash(git reset:*),Bash(git stash:*)"
+            --disallowedTools "Bash(git checkout:*),Bash(git switch:*),Bash(git reset:*),Bash(git stash:*),Bash(git restore:*),Bash(git apply:*),Bash(git clean:*)"
           prompt: |
             You are the SceneView PR review ORCHESTRATOR running in CI.
 
@@ -356,8 +371,19 @@ jobs:
             body, or branch name is ever interpolated here, so a crafted PR
             cannot inject instructions into these directions. Run `git fetch
             origin --quiet` first, then determine the diff:
-            `git diff origin/main...HEAD` (also check `git diff` for anything
-            uncommitted). Read the WHOLE diff and the surrounding code.
+            `git diff origin/main...HEAD`. Read the WHOLE diff and the
+            surrounding code.
+
+            ⛔ THE PULL REQUEST IS THE COMMITTED DIFF, AND NOTHING ELSE. This
+            checkout is clean by construction — CI never has uncommitted work.
+            So anything `git status` or a bare `git diff` reports is damage a
+            reviewer did to the shared tree during THIS run, never a defect in
+            the PR. Reporting it as a finding is how this workflow produced
+            three false `DO_NOT_MERGE` verdicts across #3009 and #3015: the
+            finding names an "uncommitted revert" and prescribes
+            `git restore <file>` — discarding a change nobody made. If you
+            observe an uncommitted change, that is a bug in this review, so
+            re-read the file at `HEAD` (`git show HEAD:<path>`) and judge THAT.
 
             ## Step 1 — four independent reviewers, in parallel
 
@@ -434,6 +460,38 @@ jobs:
 
             Your final message: one short paragraph stating what you found. The
             file is the deliverable.
+
+      # ⛔ The reviewers must not have touched the tree. This is the backstop for
+      # #3016, and it is deliberately an ASSERTION rather than a repair: silently
+      # restoring the files would hide a reviewer that mutates the checkout, and
+      # the mutation is the bug worth seeing. `review-verdict.json` is written at
+      # the repo root by design, so it is excluded — it is the deliverable, not
+      # contamination.
+      #
+      # The failure mode this catches is specific and was measured three times
+      # (#3009, #3015): a reviewer edits or reverts a file, the orchestrator
+      # reads the dirty tree, and the edit is reported as a confirmed error
+      # against the PR. A false blocker costs a re-run; worse, it teaches us to
+      # dismiss this reviewer, which is exactly how a REAL finding gets waved
+      # through — on #3009 one of the three findings was genuine (a wrong
+      # VERSION_NAME that would have published an immutable bad Maven
+      # coordinate) and nearly drowned in the two false ones.
+      #
+      # `if: always()` so a fan-out that died mid-way still reports what it left
+      # behind. It runs BEFORE the grader, so a poisoned tree fails the job on
+      # its own terms instead of being laundered into a verdict.
+      - name: Assert the reviewers left the tree clean
+        if: always() && steps.budget.outputs.within_budget == 'true' && steps.creds.outputs.has_token == 'true' && steps.selfmod.outputs.self_modified == 'false'
+        run: |
+          set -uo pipefail
+          DIRT="$(git status --porcelain -- . ':(exclude)review-verdict.json')"
+          if [ -z "$DIRT" ]; then
+            echo "Working tree clean — the reviewers did not mutate the checkout."
+            exit 0
+          fi
+          echo "$DIRT"
+          echo "::error title=Review contaminated its own checkout::A reviewer modified the working tree during this run (see the paths above). CI checks out a clean tree, so every one of those changes was made by this job — any finding derived from them is false. This is #3016. Re-run the review; do not act on its verdict."
+          exit 1
 
       # A blocking verdict must name its own cause. On run 30719225423 the PR
       # got a red check reading "REVIEW_INCOMPLETE" and nothing else — correct,

--- a/changelog.d/3016-review-tree-contamination.md
+++ b/changelog.d/3016-review-tree-contamination.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+- **The PR review workflow no longer reports its own edits as defects.** Its four
+  reviewers share one working tree, and the deny list stopped them from moving the
+  *branch* but not from reverting a *file*, while the prompt told the orchestrator to
+  treat uncommitted changes as part of the review surface. A reviewer that touched the
+  checkout therefore produced a `DO_NOT_MERGE` naming an "uncommitted revert" nobody had
+  made — three times across
+  [#3009](https://github.com/sceneview/sceneview/pull/3009) and
+  [#3015](https://github.com/sceneview/sceneview/pull/3015). `git restore`, `git apply`
+  and `git clean` are now denied, the prompt states that CI checkouts are clean by
+  construction so uncommitted work can only be the review's own damage, and a new
+  assertion fails the job outright if the tree is dirty rather than letting a poisoned
+  verdict reach the pull request. Closes
+  [#3016](https://github.com/sceneview/sceneview/issues/3016).

--- a/changelog.d/3016-review-tree-contamination.md
+++ b/changelog.d/3016-review-tree-contamination.md
@@ -10,5 +10,9 @@
   and `git clean` are now denied, the prompt states that CI checkouts are clean by
   construction so uncommitted work can only be the review's own damage, and a new
   assertion fails the job outright if the tree is dirty rather than letting a poisoned
-  verdict reach the pull request. Closes
+  verdict reach the pull request. That assertion was itself fail-open at first — a
+  failed `git status` left its output variable empty and the step announced a pristine
+  checkout it had never managed to look at, the same "absent is not zero" trap this
+  workflow already carries two steps below — so a failed probe is now treated as
+  contamination rather than as a clean result. Closes
   [#3016](https://github.com/sceneview/sceneview/issues/3016).


### PR DESCRIPTION
Closes #3016.

Three false blocking verdicts across #3009 and #3015 shared one shape: a finding describing an **uncommitted working-tree revert**, prescribing `git restore <file>` as its fix — discard a change nobody made — while simultaneously agreeing the *committed* state was already correct. CI checks out a clean tree, so that state could only have been produced inside the review job.

Three lines of `pr-review.yml` made it possible. All three are addressed.

### 1. The deny list stopped branch moves, not file reverts

```diff
- --disallowedTools "Bash(git checkout:*),Bash(git switch:*),Bash(git reset:*),Bash(git stash:*)"
+ --disallowedTools "…,Bash(git restore:*),Bash(git apply:*),Bash(git clean:*)"
```

The original four came from #2431 and stop a reviewer corrupting the shared tree by moving the *branch*. They do nothing against `git restore --source=origin/main -- <file>`, which is the verb a reviewer actually reaches for when it wants to see what main said.

### 2. The prompt told the orchestrator to treat the damage as evidence

> `git diff origin/main...HEAD` ~~(also check `git diff` for anything uncommitted)~~

In CI that parenthesis can only ever surface the review's own writes. It is replaced by the opposite instruction, stated explicitly: this checkout is clean by construction, so an uncommitted change is a bug in *this review* — re-read the file at `HEAD` and judge that.

### 3. Neither of those is verifiable, so the tree is now asserted clean

A new step runs after the fan-out and **before the grader**, excluding the orchestrator's own `review-verdict.json` deliverable:

```
git status --porcelain -- . ':(exclude)review-verdict.json'
```

It **asserts rather than repairs** — silently restoring the files would hide a reviewer mutating the checkout, and that mutation is the bug worth seeing. A dirty tree now fails the job with a named cause and produces **no verdict at all**, instead of laundering contamination into a `DO_NOT_MERGE`. `Diagnose a missing verdict file` and `Upload the run record` keep their `always()`, so the run record still reaches the PR for debugging.

Mutation-tested locally: clean tree → empty; a stray edit to `CLAUDE.md` → detected; a dirty `review-verdict.json` alone → still empty, including while untracked.

### What is deliberately not fixed here

`Write` stays granted process-wide, because the orchestrator's only deliverable is a file it must write, and the grant cannot be scoped to it alone through `claude_args`. A reviewer can therefore still edit a file — the assertion is what catches it. Closing that properly needs a non-`Write` path to the verdict file and stays open in #3016.

### Why this is worth a PR of its own

Not the wasted re-runs. A reviewer we learn to dismiss stops working: on #3009 one finding in three was **real** — a wrong `VERSION_NAME` that would have published an immutable bad Maven coordinate — and it nearly drowned in the two false ones beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)