### PR TITLE
fix(ios): swap a model without re-creating the RealityView (#3008)

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/RenderQuality.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/RenderQuality.swift
@@ -111,11 +111,20 @@ internal func applyRenderQuality(
     // ⚠️ The literals below are RAW EXPONENTS, not the linear multipliers
     // `SceneEnvironment.intensity` speaks since #2897 — `1.0` here means ×2.0 and
     // `0.5` means ×1.41, which no longer dims anything now that the authored
-    // default maps to exponent 0. That is currently latent, not a bug: this
-    // function's only caller (`SceneView.setupScene`) runs synchronously BEFORE the
-    // async `loadEnvironment` sets the `ImageBasedLightComponent`, so both branches
-    // below find no component and no-op. Fix the units here if that ordering ever
-    // changes, or these values will invert their own documented intent (#2897).
+    // default maps to exponent 0. That is currently latent, not a bug — but it
+    // is kept latent DELIBERATELY, by every caller, not by luck:
+    //
+    //   * `SceneView.buildContent(isInitialBuild: true)` (from `setupScene`)
+    //     runs synchronously BEFORE the async `loadEnvironment` installs the
+    //     `ImageBasedLightComponent`, so both branches below find no component
+    //     and no-op.
+    //   * `buildContent(isInitialBuild: false)` — the `.contentID(_:)` swap
+    //     path (#3008) — runs long AFTER that load, so it passes
+    //     `iblReceiver: nil` on purpose and never reaches this half at all.
+    //
+    // Fix the units here before letting any caller pass a live receiver
+    // post-load, or these values will invert their own documented intent
+    // (#2897) and pop the scene's brightness.
     guard let iblReceiver else { return nil }
     let newExponent: Float?
     switch quality {

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -129,6 +129,13 @@ public struct SceneView: View {
     // Default `false` — pan-then-orbit keeps the panned pivot. Closes #1236.
     var recentersTargetOnOrbit: Bool = false
 
+    // Identity of the value the `content` closure builds from. `nil` (the
+    // default) means the content is built exactly once, on `RealityView`
+    // `make:` — the behaviour every existing caller gets. Set via
+    // `.contentID(_:)` to re-run the builder in place when the value changes.
+    // Closes #3008.
+    var contentIdentity: AnyHashable?
+
     /// Creates a 3D scene with imperative content setup.
     ///
     /// - Parameter content: A closure that populates the scene. Receives a root
@@ -174,7 +181,8 @@ public struct SceneView: View {
             initialOrbitAzimuth: initialOrbitAzimuth,
             initialOrbitElevation: initialOrbitElevation,
             immersiveSpace: immersiveSpace,
-            recentersTargetOnOrbit: recentersTargetOnOrbit
+            recentersTargetOnOrbit: recentersTargetOnOrbit,
+            contentIdentity: contentIdentity
         )
     }
 
@@ -213,6 +221,49 @@ public struct SceneView: View {
     public func recentersTargetOnOrbit(_ enabled: Bool) -> SceneView {
         var copy = self
         copy.recentersTargetOnOrbit = enabled
+        return copy
+    }
+
+    /// Re-runs the content closure, in place, whenever `id` changes.
+    ///
+    /// Use this — **not** SwiftUI's `.id(_:)` — to swap the model a scene
+    /// displays. `.id(_:)` changes the view's identity, which makes SwiftUI
+    /// discard the whole `RealityView` and build a brand-new one; on iOS 26
+    /// Simulator a re-created `RealityView` intermittently renders nothing at
+    /// all — no model, and no skybox either — and never recovers (#3008).
+    /// `.contentID(_:)` keeps one `RealityView` for the scene's lifetime and
+    /// only rebuilds what is under the content root, so the renderer is never
+    /// torn down.
+    ///
+    /// ```swift
+    /// SceneView { root in
+    ///     if let model { root.addChild(model.entity) }
+    /// }
+    /// .contentID(model?.id)          // ← swaps the model
+    /// .environment(.studio)
+    /// ```
+    ///
+    /// The id must change **every time the closure would build something
+    /// different**, including the transition from "still loading" to "loaded":
+    /// keying on the selected item alone leaves the scene empty forever,
+    /// because the id is already at its final value while the model is still
+    /// being fetched. Passing an `Optional` covers that — it changes from `nil`
+    /// to a value when the load lands.
+    ///
+    /// On each change the previous content is removed from the scene (its
+    /// per-entity gesture handlers are unregistered first, so it deallocates
+    /// rather than leaking — see #2038), the closure repopulates the content
+    /// root, the render-quality preset is re-applied to the new subtree, and
+    /// the auto-framing pass is re-armed so the new content gets fitted to the
+    /// viewport instead of inheriting the previous subject's camera distance.
+    ///
+    /// Without this modifier the closure runs exactly once, when the scene is
+    /// created — the behaviour of every scene written before this API existed.
+    ///
+    /// - Parameter id: A value identifying what the content closure builds.
+    public func contentID(_ id: some Hashable) -> SceneView {
+        var copy = self
+        copy.contentIdentity = AnyHashable(id)
         return copy
     }
 
@@ -548,6 +599,12 @@ private struct SceneViewRepresentation: View {
     /// content centroid so repeated pan→orbit cycles don't drift. Closes #1236.
     let recentersTargetOnOrbit: Bool
 
+    /// Identity of what the `content` closure builds, from
+    /// ``SceneView/contentID(_:)``. `nil` means the closure runs once in
+    /// `setupScene` and never again — the pre-#3008 behaviour. Any other value
+    /// makes a change re-run the closure under the *same* `RealityView`.
+    let contentIdentity: AnyHashable?
+
     /// Mutable camera-orbit state, held in a **reference type** so mutating it
     /// (auto-rotate, drag, pinch) does NOT invalidate the SwiftUI body. The
     /// value default `CameraControls(mode: .orbit)` uses the struct's own
@@ -642,6 +699,14 @@ private struct SceneViewRepresentation: View {
     /// never re-frames. Closes #1026 / #1041.
     @State private var framingTick: Int = 0
 
+    /// Identity of the framing-driver task. Bumped by
+    /// ``rebuildContentIfNeeded()`` so a `.contentID(_:)` swap restarts the
+    /// driver: the driver exits for good once ``didCenterContent`` latches (or
+    /// after its timeout), so merely clearing the latch would leave the new
+    /// content un-framed on any static scene — nothing else pumps `update:`
+    /// once auto-rotate is driving `applyCamera()` directly. Closes #3008.
+    @State private var framingEpoch: Int = 0
+
     /// Live viewport aspect ratio (`width / height`), captured by the
     /// `GeometryReader` wrapping the `RealityView`. Drives the
     /// fit-to-bounds framing (#1041) so the camera distance accounts for
@@ -703,6 +768,15 @@ private struct SceneViewRepresentation: View {
         /// when no skybox host is attached. Closes #2278.
         var immersiveSkyboxHost: Entity? = nil
         #endif
+        /// `true` once `setupScene` has populated the content root at least
+        /// once. Guards the `.contentID(_:)` rebuild against firing before
+        /// the scene exists — SwiftUI gives no ordering guarantee between a
+        /// `.task(id:)` and the `RealityView` `make:` closure. Closes #3008.
+        var didBuildContent = false
+        /// The ``SceneViewRepresentation/contentIdentity`` the currently-built
+        /// content was built from, so an identity that did not actually change
+        /// (a re-run `.task(id:)`) rebuilds nothing. Closes #3008.
+        var contentIdentity: AnyHashable? = nil
     }
     @State private var appliedCache = AppliedCache()
 
@@ -780,7 +854,15 @@ private struct SceneViewRepresentation: View {
                     }
                 }
             }
-            .task {
+            .task(id: contentIdentity) {
+                // Re-run the content closure in place when `.contentID(_:)`
+                // reports the caller would now build something different.
+                // Keyed rather than `onChange`-driven so the closure that runs
+                // is the one from the latest body evaluation — the same
+                // guarantee the environment loader below relies on. Closes #3008.
+                rebuildContentIfNeeded()
+            }
+            .task(id: framingEpoch) {
                 // Content-framing driver (#1026 / #1041). The RealityView
                 // `update:` closure only fires while SwiftUI re-evaluates
                 // the view — for a static (non-auto-rotating) scene that is
@@ -1096,6 +1178,20 @@ private struct SceneViewRepresentation: View {
         // instead of `root` directly so the auto-center translation in
         // `refreshContentCentering()` only affects user content, not the
         // lights provisioned just above.
+        buildContent()
+    }
+
+    // MARK: - Content (re)build (#3008)
+
+    /// Runs the caller's content closure into `entities.contentRoot` and
+    /// applies the render-quality preset to the resulting tree.
+    ///
+    /// Shared by the initial `setupScene` and the ``SceneView/contentID(_:)``
+    /// rebuild so a swapped model goes through exactly the same provisioning
+    /// as the first one — a second code path here is how a rebuilt scene ends
+    /// up with different shadows or IBL from a freshly-created one.
+    @MainActor
+    private func buildContent() {
         content(entities.contentRoot)
 
         // Apply RenderQuality preset to all directional lights + the IBL receiver entity.
@@ -1108,6 +1204,57 @@ private struct SceneViewRepresentation: View {
             to: entities.root,
             iblReceiver: entities.ibl
         )
+
+        appliedCache.didBuildContent = true
+        appliedCache.contentIdentity = contentIdentity
+    }
+
+    /// Swaps the scene's content in place when ``SceneView/contentID(_:)``
+    /// reports a change, without touching the `RealityView` itself.
+    ///
+    /// This is the fix for #3008: the demos used to re-key the whole view with
+    /// SwiftUI's `.id(_:)` to show a different model, which destroys and
+    /// re-creates the `RealityView` — and a re-created `RealityView` on iOS 26
+    /// Simulator intermittently renders nothing at all (no model, no skybox)
+    /// for the rest of its life. Rebuilding under a stable view keeps the
+    /// renderer that is already working.
+    @MainActor
+    private func rebuildContentIfNeeded() {
+        // `.task(id:)` also fires on first appearance, and SwiftUI does not
+        // order it against the `RealityView` `make:` closure. If the scene has
+        // not been set up yet there is nothing to rebuild — `setupScene` will
+        // build the current identity itself.
+        guard appliedCache.didBuildContent else { return }
+        guard appliedCache.contentIdentity != contentIdentity else { return }
+
+        // Detach the previous content. Unregister its gesture handlers first:
+        // a handler closure that captures the node it is registered on forms a
+        // retain cycle (entity → GestureHandlers → closure → node → entity), so
+        // without this the outgoing model stays alive for the process lifetime
+        // and every swap leaks another one — the same cycle `SceneEntities.deinit`
+        // breaks at scene teardown (#2038).
+        for child in Array(entities.contentRoot.children) {
+            NodeGesture.removeAllHandlers(under: child)
+            child.removeFromParent()
+        }
+
+        buildContent()
+
+        // Re-arm the auto-framing pass for the new content. Without this the
+        // new subject inherits the previous one's orbit radius and pivot —
+        // `refreshContentCentering()` latches `didCenterContent` once the first
+        // subject's bounds hold steady and then returns immediately forever.
+        // The stability tracker has to be re-armed too, or the new bounds are
+        // compared against the *old* subject's diagonal and latch on the first
+        // tick, before a streamed model has finished landing (#1391).
+        framingStability = FramingStabilityTracker(
+            epsilon: Self.framingStabilityEpsilon,
+            stableHoldSeconds: Self.framingStableHoldSeconds
+        )
+        didCenterContent = false
+        // Restart the driver task: it exits permanently once the latch is set,
+        // and clearing the latch alone does not bring it back.
+        framingEpoch &+= 1
     }
 
     // MARK: - Light slot reactive plumbing (#1017)

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -239,7 +239,7 @@ public struct SceneView: View {
     /// SceneView { root in
     ///     if let model { root.addChild(model.entity) }
     /// }
-    /// .contentID(model?.id)          // ← swaps the model
+    /// .contentID(model == nil ? nil : selectedID)   // ← swaps the model
     /// .environment(.studio)
     /// ```
     ///
@@ -1195,7 +1195,7 @@ private struct SceneViewRepresentation: View {
         // instead of `root` directly so the auto-center translation in
         // `refreshContentCentering()` only affects user content, not the
         // lights provisioned just above.
-        buildContent()
+        buildContent(isInitialBuild: true)
     }
 
     // MARK: - Content (re)build (#3008)
@@ -1207,8 +1207,20 @@ private struct SceneViewRepresentation: View {
     /// rebuild so a swapped model goes through exactly the same provisioning
     /// as the first one — a second code path here is how a rebuilt scene ends
     /// up with different shadows or IBL from a freshly-created one.
+    ///
+    /// - Parameter isInitialBuild: `true` from `setupScene`, `false` from a
+    ///   `.contentID(_:)` swap. It gates the IBL half of the render-quality
+    ///   preset, and it has to: `applyRenderQuality`'s IBL branch is written in
+    ///   RAW EXPONENTS, not the linear multipliers `SceneEnvironment.intensity`
+    ///   speaks since #2897, and it says in as many words that this is latent
+    ///   only because its sole caller runs *before* the async `loadEnvironment`
+    ///   installs the `ImageBasedLightComponent`, so it always finds no
+    ///   component and no-ops. A swap runs long after that load, so passing the
+    ///   receiver here would wake those inverted units up and pop the scene's
+    ///   brightness on the first swap under `.cinematic` / `.performance`.
+    ///   The shadow / light half still applies to the new subtree either way.
     @MainActor
-    private func buildContent() {
+    private func buildContent(isInitialBuild: Bool) {
         content(entities.contentRoot)
 
         // Apply RenderQuality preset to all directional lights + the IBL receiver entity.
@@ -1219,7 +1231,7 @@ private struct SceneViewRepresentation: View {
         _ = applyRenderQuality(
             renderQualityPreset,
             to: entities.root,
-            iblReceiver: entities.ibl
+            iblReceiver: isInitialBuild ? entities.ibl : nil
         )
 
         appliedCache.didBuildContent = true
@@ -1257,12 +1269,18 @@ private struct SceneViewRepresentation: View {
         // without this the outgoing model stays alive for the process lifetime
         // and every swap leaks another one — the same cycle `SceneEntities.deinit`
         // breaks at scene teardown (#2038).
+        // `under: contentRoot`, not per-child: a handler registered on the root
+        // the closure is handed (`root.onTap { … }` capturing the outgoing
+        // node) is not under any child, so a per-child sweep would leave that
+        // cycle intact and retain the previous model until scene teardown.
+        // The closure re-registers whatever it wants on the root when it runs
+        // again, just below.
+        NodeGesture.removeAllHandlers(under: entities.contentRoot)
         for child in Array(entities.contentRoot.children) {
-            NodeGesture.removeAllHandlers(under: child)
             child.removeFromParent()
         }
 
-        buildContent()
+        buildContent(isInitialBuild: false)
 
         // Re-arm the auto-framing pass for the new content. Without this the
         // new subject inherits the previous one's orbit radius and pivot —

--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -1045,6 +1045,14 @@ private struct SceneViewRepresentation: View {
             setupScene(&content)
         } update: { content in
             applyCamera()
+            // Also here, not only in the `.task(id:)`: `update:` always runs on
+            // the CURRENT view, so this closes the one ordering hole the task
+            // cannot — a `make:` that ran from a stale view value would record
+            // an identity the task has already moved past, and nothing else
+            // would ever re-fire. Costs one `AnyHashable?` compare per tick,
+            // and short-circuits on `nil != nil` for every scene that does not
+            // use `.contentID(_:)`. Closes #3008.
+            rebuildContentIfNeeded()
             refreshLightSlot(.main, slot: mainLightSlot)
             refreshLightSlot(.fill, slot: fillLightSlot)
             if autoCenterContentEnabled {
@@ -1062,6 +1070,15 @@ private struct SceneViewRepresentation: View {
             setupScene(&realityContent)
         } update: { content in
             applyCamera()
+            // Re-run the content closure if `.contentID(_:)` moved. Duplicated
+            // from the `.task(id:)` on purpose: `update:` always runs on the
+            // CURRENT view, so it closes the one ordering hole the task cannot
+            // — a `make:` that ran from a stale view value would record an
+            // identity the task has already moved past, and nothing else would
+            // ever re-fire, leaving the previous model on screen for good.
+            // Costs one `AnyHashable?` compare per tick, and short-circuits on
+            // `nil != nil` for every scene that does not use the modifier.
+            rebuildContentIfNeeded()
             // Diff light slots and swap entities when the caller's modifier value
             // changed since last frame. Closes #1017 (Android `prevFillLightRef`
             // pattern in `SceneView.kt:287-305` ported to iOS).
@@ -1224,6 +1241,13 @@ private struct SceneViewRepresentation: View {
         // order it against the `RealityView` `make:` closure. If the scene has
         // not been set up yet there is nothing to rebuild — `setupScene` will
         // build the current identity itself.
+        //
+        // This early return is why `update:` calls this method too: it means a
+        // pre-`make:` invocation is a no-op, so if `make:` then ran from a
+        // stale view value the task would never fire again (its id has already
+        // settled) and the scene would keep the wrong content forever. The
+        // `update:` call is on the current view by construction and corrects
+        // that on the very next tick.
         guard appliedCache.didBuildContent else { return }
         guard appliedCache.contentIdentity != contentIdentity else { return }
 

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -43,7 +43,34 @@ SceneView { … }
     .mainLight(.systemDefault)   // see LightSlot
     .fillLight(.systemDefault)
     .renderQuality(.default)     // .cinematic | .default | .performance
+    .contentID(model?.id)        // re-runs the content closure IN PLACE when the id changes
 ```
+
+**Swapping the model: `.contentID(_:)`, never SwiftUI's `.id(_:)`.** The content
+closure runs once, when the scene is created. Change `.contentID(_:)` to show a
+different model, and do not wrap the `SceneView` in an `if let model` that
+unmounts it while the next one loads — put the spinner in an overlay. Both
+change the view's *identity*, so SwiftUI discards the `RealityView` and builds a
+new one, and a re-created `RealityView` on iOS 26 Simulator intermittently
+renders nothing at all — no model, no skybox — permanently (#3008). The id must
+change every time the closure would build something different, **including
+"loading" → "loaded"**, so make it an `Optional`: keyed on the selection alone
+it already sits at its final value while the model is still being fetched and
+the scene stays empty forever.
+
+```swift
+ZStack {
+    SceneView { root in
+        guard let model else { return }
+        root.addChild(model.entity)
+    }
+    .contentID(model == nil ? nil : selectedID)
+
+    if model == nil { ProgressView() }
+}
+```
+
+Android needs no equivalent — its DSL content is re-read on recomposition.
 
 The auto-fit fits the content's **bounding sphere** to the narrower frustum
 axis, then scales that distance by `framingMargin` — lower it to fill a tall

--- a/agents/sceneview-ios/references/cheatsheet.md
+++ b/agents/sceneview-ios/references/cheatsheet.md
@@ -43,7 +43,7 @@ SceneView { … }
     .mainLight(.systemDefault)   // see LightSlot
     .fillLight(.systemDefault)
     .renderQuality(.default)     // .cinematic | .default | .performance
-    .contentID(model?.id)        // re-runs the content closure IN PLACE when the id changes
+    .contentID(model == nil ? nil : selectedID)  // re-runs the content closure IN PLACE when the id changes
 ```
 
 **Swapping the model: `.contentID(_:)`, never SwiftUI's `.id(_:)`.** The content

--- a/changelog.d/3008-black-viewport-probe.md
+++ b/changelog.d/3008-black-viewport-probe.md
@@ -1,0 +1,15 @@
+<!-- category: Tests -->
+- **iOS demo: an opt-in measurement rig for the intermittent black viewport of
+  [#3008](https://github.com/sceneview/sceneview/issues/3008).** A `SceneView`
+  re-created by `.id()` sometimes renders nothing at all — no model, no skybox —
+  and it does so on roughly a quarter to three-quarters of subject switches
+  depending on the session, which makes any fix impossible to sign off by eye.
+  `testBlackViewportProbe` drives the `AnimationDemo` subject row and attaches
+  two samples per switch, so a viewport counts as black only when it is *still*
+  black on the second one — a frame that has not rendered yet is not a black
+  viewport, and the first calibration run caught exactly that case (black at
+  +12 s, rendered at +20 s) which a single-sample method scores as a failure.
+  It skips unless `SV_BLACK_PROBE=1` is set, so it never runs in CI; it also
+  deliberately does **not** pass `-qa_mode 1`, because a zero auto-rotate speed
+  short-circuits `SceneView`'s auto-rotate task (#2896) and would exercise a
+  different render path from the one the defect lives on.

--- a/changelog.d/3008-contentid.md
+++ b/changelog.d/3008-contentid.md
@@ -34,3 +34,8 @@
   consecutive picks with the same title left the key unchanged and the swap
   silently did not happen. It is keyed on a monotonic load counter now. The
   same collision existed with the previous `.id(_:)`.
+- **Docs: the iOS model-viewer recipe now renders its model.** `samples/recipes/model-viewer.md`
+  loaded a model asynchronously into a scene with no `.contentID(_:)`, so the
+  content closure — which runs once, at scene creation, while the model is still
+  `nil` — never ran again and the viewer stayed empty. It now carries the key
+  plus a model-swap section.

--- a/changelog.d/3008-contentid.md
+++ b/changelog.d/3008-contentid.md
@@ -29,3 +29,8 @@
   now applies the overlay unconditionally and drops only the pill. This was
   measured re-creating `AnimationDemo`'s scene on exactly the first subject
   change and no other.
+- **iOS demo: `Model Viewer`'s "Surprise me" no longer skips a model when two
+  rolls share a title.** Its scene key was the model's display name, so two
+  consecutive picks with the same title left the key unchanged and the swap
+  silently did not happen. It is keyed on a monotonic load counter now. The
+  same collision existed with the previous `.id(_:)`.

--- a/changelog.d/3008-contentid.md
+++ b/changelog.d/3008-contentid.md
@@ -1,0 +1,31 @@
+<!-- category: Added -->
+- **`SceneView.contentID(_:)` on Apple platforms — swap a model without
+  re-creating the renderer.** The content closure used to run only when the
+  scene was created, so every demo that shows a different model re-keyed the
+  whole view with SwiftUI's `.id(_:)`. That destroys the `RealityView` and
+  builds a new one, and a re-created `RealityView` on iOS 26 Simulator
+  intermittently renders *nothing at all* — no model, and no skybox either —
+  permanently ([#3008](https://github.com/sceneview/sceneview/issues/3008)).
+  `.contentID(_:)` keeps one renderer for the scene's lifetime: it removes the
+  previous content (unregistering its gesture handlers first, so it deallocates
+  instead of leaking), re-runs the closure, re-applies the render-quality
+  preset, and re-arms the auto-framing pass so the new subject is fitted to the
+  viewport instead of inheriting the previous one's camera distance. Additive
+  and non-breaking — a scene without the modifier builds its content exactly
+  once, as before. Android needs no equivalent: its DSL content is already
+  re-read on recomposition.
+
+<!-- category: Fixed -->
+- **iOS demo: `Animation`, `Scene Gallery` and `Model Viewer` no longer go
+  permanently black when you change the model.** All three now keep their
+  `SceneView` mounted — spinner as an overlay rather than an `if let` that
+  unmounts the scene — and swap subjects through `.contentID(_:)`. Measured on
+  `QA-iPhone16-c` (iOS 26.3): a subject change used to build **two** fresh
+  `RealityView` instances and now builds **zero**.
+- **iOS demo: the asset-source pill no longer tears the scene down the first
+  time it appears.** `assetSourcePill(_:)` branched between `overlay(…)` and
+  `self`, which are structurally different views, so the first transition from
+  no-pill to pill discarded the modified subtree — `RealityView` included. It
+  now applies the overlay unconditionally and drops only the pill. This was
+  measured re-creating `AnimationDemo`'s scene on exactly the first subject
+  change and no other.

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -53,7 +53,45 @@ SceneView { root in
 .mainLight(.systemDefault)         // v4.2.0+ — see LightSlot
 .fillLight(.systemDefault)         // v4.2.0+
 .renderQuality(.default)           // v4.2.0+ — .cinematic | .default | .performance
+.contentID(model?.id)              // v4.26.0+ — re-runs the content closure IN PLACE when the id changes. Use this to swap the model, NEVER SwiftUI's .id()
 ```
+
+!!! danger "Swapping the model: `contentID`, never `.id()`"
+    The content closure runs **once**, when the scene is created. To show a
+    different model, change `.contentID(_:)`. Do **not** re-key the view with
+    SwiftUI's `.id(_:)`, and do not wrap the `SceneView` in an
+    `if let model` that unmounts it while the next one loads — put the spinner
+    in an overlay instead. Both change the view's *identity*, so SwiftUI
+    discards the `RealityView` and builds a new one, and on iOS 26 Simulator a
+    re-created `RealityView` intermittently renders nothing at all — no model,
+    and no skybox either — permanently
+    ([#3008](https://github.com/sceneview/sceneview/issues/3008)).
+
+    The id has to change **every time the closure would build something
+    different**, including "still loading" → "loaded". An `Optional` covers
+    that; keyed on the selected item alone it already sits at its final value
+    while the model is still being fetched, and the scene stays empty forever.
+
+    ```swift
+    ZStack {
+        SceneView { root in
+            guard let model else { return }        // scene stays mounted
+            root.addChild(model.entity)
+        }
+        .contentID(model == nil ? nil : selectedID)
+        .environment(.studio)
+
+        if model == nil { ProgressView() }         // spinner as an OVERLAY
+    }
+    ```
+
+    On each change the previous content is removed (its per-entity gesture
+    handlers unregistered first, so it deallocates instead of leaking), the
+    render-quality preset is re-applied, and the auto-framing pass is re-armed
+    so the new subject is fitted rather than inheriting the previous camera
+    distance. **Android has no equivalent and needs none** — `SceneView { }`
+    there is a composable whose DSL content is re-read on recomposition, so
+    swapping a model is an ordinary state change.
 
 !!! tip "Getting a scene to fill the frame — and to show its sky"
     The auto-fit pass fits the content's **bounding sphere** to the narrower

--- a/docs/docs/cheatsheet-ios.md
+++ b/docs/docs/cheatsheet-ios.md
@@ -53,7 +53,7 @@ SceneView { root in
 .mainLight(.systemDefault)         // v4.2.0+ — see LightSlot
 .fillLight(.systemDefault)         // v4.2.0+
 .renderQuality(.default)           // v4.2.0+ — .cinematic | .default | .performance
-.contentID(model?.id)              // v4.26.0+ — re-runs the content closure IN PLACE when the id changes. Use this to swap the model, NEVER SwiftUI's .id()
+.contentID(model == nil ? nil : selectedID)  // v4.26.0+ — re-runs the content closure IN PLACE when the id changes. Use this to swap the model, NEVER SwiftUI's .id()
 ```
 
 !!! danger "Swapping the model: `contentID`, never `.id()`"

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -4254,7 +4254,46 @@ View modifiers (chainable):
 .autoCenterContent(_ enabled: Bool) -> SceneView            // v4.3.0+ — default true; translates content so its centroid lands on the world origin
 .framingMargin(_ margin: Float) -> SceneView                // v4.26.0+ — padding on the auto-fit distance; 1.15 default, 1.0 = sphere tangent, < 1 = tighter. NO EFFECT when autoCenterContent(false)
 .cameraOrbit(azimuth: Float? = nil, elevation: Float? = nil) -> SceneView  // v4.26.0+ — seeds the INITIAL orbit pose (radians); default elevation 30°
+.contentID(_ id: some Hashable) -> SceneView                // v4.26.0+ — re-runs the content closure IN PLACE when id changes. Use this, NEVER SwiftUI .id(), to swap the model
 ```
+
+**Swapping the model in a scene (`contentID`, v4.26.0+).** The content closure
+runs once, when the scene is created. To show a different model, change
+`.contentID(_:)` — **never** SwiftUI's `.id(_:)`, and never wrap the `SceneView`
+in an `if let model` that unmounts it while loading. Both of those change the
+view's *identity*, so SwiftUI throws the `RealityView` away and builds a new
+one, and on iOS 26 Simulator a re-created `RealityView` intermittently renders
+nothing at all — no model and no skybox — permanently (#3008). `.contentID(_:)`
+keeps one renderer for the scene's lifetime: it removes the previous content
+(unregistering its gesture handlers first, so it deallocates), re-runs the
+closure, re-applies the render-quality preset, and re-arms the auto-framing pass
+so the new subject gets fitted instead of inheriting the previous camera
+distance.
+
+The id must change **every time the closure would build something different**,
+including "still loading" → "loaded". An `Optional` covers that; keying on the
+selected item alone leaves the scene empty forever, because the id already sits
+at its final value while the model is still being fetched.
+
+```swift
+@State private var model: ModelNode?
+
+ZStack {
+    SceneView { root in
+        guard let model else { return }        // scene stays mounted while loading
+        root.addChild(model.entity)
+    }
+    .contentID(model == nil ? nil : selectedID) // nil → id when the model lands
+    .environment(.studio)
+
+    if model == nil { ProgressView() }          // spinner as an OVERLAY
+}
+```
+
+> **Android has no equivalent and needs none.** `SceneView { }` there is a
+> Compose composable whose DSL content is already re-read on recomposition, so
+> swapping a model is an ordinary state change. This modifier closes an iOS-only
+> gap; there is nothing to mirror.
 
 **Framing the subject (`framingMargin` / `cameraOrbit`, v4.26.0+).** The auto-fit
 pass dollies the camera until the content's *bounding sphere* fits the narrower

--- a/llms.txt
+++ b/llms.txt
@@ -6426,7 +6426,46 @@ View modifiers (chainable):
 .autoCenterContent(_ enabled: Bool) -> SceneView            // v4.3.0+ — default true; translates content so its centroid lands on the world origin
 .framingMargin(_ margin: Float) -> SceneView                // v4.26.0+ — padding on the auto-fit distance; 1.15 default, 1.0 = sphere tangent, < 1 = tighter. NO EFFECT when autoCenterContent(false)
 .cameraOrbit(azimuth: Float? = nil, elevation: Float? = nil) -> SceneView  // v4.26.0+ — seeds the INITIAL orbit pose (radians); default elevation 30°
+.contentID(_ id: some Hashable) -> SceneView                // v4.26.0+ — re-runs the content closure IN PLACE when id changes. Use this, NEVER SwiftUI .id(), to swap the model
 ```
+
+**Swapping the model in a scene (`contentID`, v4.26.0+).** The content closure
+runs once, when the scene is created. To show a different model, change
+`.contentID(_:)` — **never** SwiftUI's `.id(_:)`, and never wrap the `SceneView`
+in an `if let model` that unmounts it while loading. Both of those change the
+view's *identity*, so SwiftUI throws the `RealityView` away and builds a new
+one, and on iOS 26 Simulator a re-created `RealityView` intermittently renders
+nothing at all — no model and no skybox — permanently (#3008). `.contentID(_:)`
+keeps one renderer for the scene's lifetime: it removes the previous content
+(unregistering its gesture handlers first, so it deallocates), re-runs the
+closure, re-applies the render-quality preset, and re-arms the auto-framing pass
+so the new subject gets fitted instead of inheriting the previous camera
+distance.
+
+The id must change **every time the closure would build something different**,
+including "still loading" → "loaded". An `Optional` covers that; keying on the
+selected item alone leaves the scene empty forever, because the id already sits
+at its final value while the model is still being fetched.
+
+```swift
+@State private var model: ModelNode?
+
+ZStack {
+    SceneView { root in
+        guard let model else { return }        // scene stays mounted while loading
+        root.addChild(model.entity)
+    }
+    .contentID(model == nil ? nil : selectedID) // nil → id when the model lands
+    .environment(.studio)
+
+    if model == nil { ProgressView() }          // spinner as an OVERLAY
+}
+```
+
+> **Android has no equivalent and needs none.** `SceneView { }` there is a
+> Compose composable whose DSL content is already re-read on recomposition, so
+> swapping a model is an ordinary state change. This modifier closes an iOS-only
+> gap; there is nothing to mirror.
 
 **Framing the subject (`framingMargin` / `cameraOrbit`, v4.26.0+).** The auto-fit
 pass dollies the camera until the content's *bounding sphere* fits the narrower

--- a/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
@@ -66,16 +66,22 @@ extension View {
     ///
     /// Pass `nil` for a demo that never touches `SketchfabAssetResolver`: it
     /// has no origin question to answer and must show no pill.
-    @ViewBuilder
+    ///
+    /// The overlay is applied unconditionally and the *pill* is what the `nil`
+    /// case drops. Branching on `if let state { overlay(…) } else { self }`
+    /// instead handed SwiftUI two structurally different views, so the first
+    /// time a demo went from no-pill to pill — `AnimationDemo` moving off its
+    /// bundled slot 0 — the whole modified subtree was discarded and rebuilt,
+    /// taking the scene's `RealityView` with it. That is the same teardown
+    /// `.contentID(_:)` exists to avoid, and it was measured re-creating the
+    /// scene on exactly the first subject change and no other (#3008).
     func assetSourcePill(_ state: AssetSourceState?) -> some View {
-        if let state {
-            overlay(alignment: .topTrailing) {
+        overlay(alignment: .topTrailing) {
+            if let state {
                 AssetSourcePill(state: state)
                     .padding(.top, 12)
                     .padding(.trailing, 16)
             }
-        } else {
-            self
         }
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
@@ -130,23 +130,36 @@ struct AnimationDemo: View {
     @ViewBuilder
     private var sceneContent: some View {
         ZStack {
-            if let loadedNode {
-                SceneView { root in
-                    loadedNode.entity.position = .init(x: 0, y: 0, z: -2)
-                    root.addChild(loadedNode.entity)
-                }
-                .cameraControls(.orbit)
-                .autoRotate(speed: 0.3)
-                // Every subject here is a curated PBR model — the bundled
-                // cyberpunk_character.usdz or a streamed Sketchfab character —
-                // and a PBR surface is defined by what it reflects. With no
-                // IBL there is nothing to reflect and the carousel undersells
-                // its own subjects. Same `.studio` preset as ModelViewerDemo
-                // (#2114).
-                .environment(.studio)
-                .ignoresSafeArea()
-                .id("animation-\(selectedSubject.streamedSlug?.uid ?? selectedSubject.bundledAsset ?? "none")")
-            } else {
+            // The scene stays mounted for the whole demo — it is never wrapped
+            // in `if let loadedNode` and never re-keyed with SwiftUI's `.id(_:)`.
+            // Both of those discard the `RealityView` and build a new one, and a
+            // re-created `RealityView` on iOS 26 Simulator intermittently comes
+            // back rendering nothing at all — no model, and no skybox either —
+            // permanently (#3008). `.contentID(_:)` swaps the model inside the
+            // scene that is already rendering instead.
+            //
+            // The key is an `Optional` on purpose: it must also change when the
+            // model finishes loading, not only when the subject chip changes.
+            // Keyed on the subject alone it would already sit at its final value
+            // while `loadedNode` is still `nil`, and the scene would stay empty.
+            SceneView { root in
+                guard let loadedNode else { return }
+                loadedNode.entity.position = .init(x: 0, y: 0, z: -2)
+                root.addChild(loadedNode.entity)
+            }
+            .cameraControls(.orbit)
+            .autoRotate(speed: 0.3)
+            // Every subject here is a curated PBR model — the bundled
+            // cyberpunk_character.usdz or a streamed Sketchfab character —
+            // and a PBR surface is defined by what it reflects. With no
+            // IBL there is nothing to reflect and the carousel undersells
+            // its own subjects. Same `.studio` preset as ModelViewerDemo
+            // (#2114).
+            .environment(.studio)
+            .contentID(loadedContentKey)
+            .ignoresSafeArea()
+
+            if loadedNode == nil {
                 VStack(spacing: 12) {
                     ProgressView()
                         .tint(.white)
@@ -165,6 +178,14 @@ struct AnimationDemo: View {
             }
         }
         .background(Color.black)
+    }
+
+    /// What the scene's content closure currently builds: `nil` while the
+    /// subject is loading, the subject's identifier once its model is in hand.
+    /// Feeds ``SceneView/contentID(_:)`` — see the comment in `sceneContent`.
+    private var loadedContentKey: String? {
+        guard loadedNode != nil else { return nil }
+        return selectedSubject.streamedSlug?.uid ?? selectedSubject.bundledAsset ?? "none"
     }
 
     @ViewBuilder

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -58,6 +58,13 @@ struct ModelViewerDemo: View {
     /// bundled hero. We surface the title in the status pill so the user can
     /// tell which model is on screen right now.
     @State private var streamedDisplayName: String?
+    /// Monotonic count of models loaded into the scene, and the only reliable
+    /// half of the `.contentID(_:)` key. The display name is not: two
+    /// consecutive "Surprise me" rolls can land on models with the *same*
+    /// title, and a key that does not change is a swap that silently does not
+    /// happen. Bumped on every successful load, so the id changes even when
+    /// the name repeats.
+    @State private var loadCount: Int = 0
 
     private let hasSketchfabKey: Bool = SketchfabConfig.apiKey != nil
 
@@ -100,9 +107,11 @@ struct ModelViewerDemo: View {
             // `.id(_:)` — both throw the `RealityView` away and build a new one,
             // which on iOS 26 Simulator intermittently comes back rendering
             // nothing at all, no model and no skybox, permanently (#3008).
-            // `.contentID(_:)` swaps the model inside the live scene. The key is
-            // optional so it changes when the model lands, not only when
-            // "Surprise me" picks a different one.
+            // `.contentID(_:)` swaps the model inside the live scene. The key
+            // is `loadCount`, not the model's title — see its declaration: two
+            // "Surprise me" rolls can return the same title, and an unchanged
+            // key is a swap that silently does not happen. Optional so it also
+            // changes when the first model lands.
             SceneView { root in
                 guard let loadedNode else { return }
                 loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
@@ -127,7 +136,7 @@ struct ModelViewerDemo: View {
             // adrift in empty backdrop: the hero's bounding sphere is set by
             // its display plinth, not by the car (#2896).
             .framingMargin(qaMode ? Self.captureFramingMargin : 0.95)
-            .contentID(loadedNode == nil ? nil : streamedDisplayName ?? "bundled")
+            .contentID(loadedNode == nil ? nil : loadCount)
             .ignoresSafeArea()
 
             if loadedNode == nil {
@@ -216,6 +225,7 @@ struct ModelViewerDemo: View {
             _ = node.scaleToUnits(0.6)
             _ = node.centerOrigin()
             loadedNode = node
+            loadCount += 1
         } catch {
             loadError = "Could not load bundled hero: \(error.localizedDescription)"
         }
@@ -271,6 +281,7 @@ struct ModelViewerDemo: View {
             _ = node.scaleToUnits(0.6)
             _ = node.centerOrigin()
             loadedNode = node
+            loadCount += 1
             streamedDisplayName = pick.name
         } catch {
             // Keep the current hero on screen, but surface a transient banner so

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -95,8 +95,16 @@ struct ModelViewerDemo: View {
 
     @ViewBuilder
     private var sceneView: some View {
-        if let loadedNode {
+        ZStack {
+            // Mounted for the demo's whole lifetime, and never re-keyed with
+            // `.id(_:)` — both throw the `RealityView` away and build a new one,
+            // which on iOS 26 Simulator intermittently comes back rendering
+            // nothing at all, no model and no skybox, permanently (#3008).
+            // `.contentID(_:)` swaps the model inside the live scene. The key is
+            // optional so it changes when the model lands, not only when
+            // "Surprise me" picks a different one.
             SceneView { root in
+                guard let loadedNode else { return }
                 loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
                 root.addChild(loadedNode.entity)
             }
@@ -119,22 +127,24 @@ struct ModelViewerDemo: View {
             // adrift in empty backdrop: the hero's bounding sphere is set by
             // its display plinth, not by the car (#2896).
             .framingMargin(qaMode ? Self.captureFramingMargin : 0.95)
+            .contentID(loadedNode == nil ? nil : streamedDisplayName ?? "bundled")
             .ignoresSafeArea()
-            .id("model-viewer-\(streamedDisplayName ?? "bundled")")
-        } else {
-            VStack(spacing: 12) {
-                ProgressView()
-                    .tint(.white)
-                if let loadError {
-                    Text(loadError)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 24)
-                } else {
-                    Text("Loading model…")
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
+
+            if loadedNode == nil {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .tint(.white)
+                    if let loadError {
+                        Text(loadError)
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 24)
+                    } else {
+                        Text("Loading model…")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
                 }
             }
         }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
@@ -67,8 +67,19 @@ struct SceneGalleryDemo: View {
 
     @ViewBuilder
     private var sceneView: some View {
-        if let loadedNode {
+        ZStack {
+            // Mounted for the demo's whole lifetime, and never re-keyed with
+            // `.id(_:)`. Both a conditional mount and an `.id(_:)` change throw
+            // the `RealityView` away and build a new one, and a re-created
+            // `RealityView` on iOS 26 Simulator intermittently renders nothing
+            // at all — no model, no skybox — permanently (#3008). This gallery
+            // was measured going black that way on a cold launch.
+            // `.contentID(_:)` swaps the model without touching the renderer;
+            // the previous entity is removed by the library, so nothing is
+            // overlaid. The key is optional so it also changes when the model
+            // lands, not only when the chip changes.
             SceneView { root in
+                guard let loadedNode else { return }
                 loadedNode.entity.position = .init(x: 0, y: 0, z: -2)
                 root.addChild(loadedNode.entity)
             }
@@ -79,24 +90,24 @@ struct SceneGalleryDemo: View {
             // fall back to flat shading and the gallery undersells every model
             // it exists to show off. Same preset as ModelViewerDemo (#2114).
             .environment(.studio)
+            .contentID(loadedNode == nil ? nil : selectedSlug?.uid)
             .ignoresSafeArea()
-            // Re-keys the SceneView when the selected slug changes so the
-            // previous entity is fully torn down rather than overlaid.
-            .id("gallery-\(selectedSlug?.uid ?? "none")")
-        } else {
-            VStack(spacing: 12) {
-                ProgressView()
-                    .tint(.white)
-                if let loadError {
-                    Text(loadError)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 24)
-                } else {
-                    Text("Streaming model…")
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
+
+            if loadedNode == nil {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .tint(.white)
+                    if let loadError {
+                        Text(loadError)
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 24)
+                    } else {
+                        Text("Streaming model…")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
                 }
             }
         }

--- a/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
+++ b/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
@@ -119,13 +119,24 @@ final class SceneViewDemoUITests: XCTestCase {
     /// skybox — permanently.
     ///
     /// **Opt-in on purpose.** It takes minutes and it is a measurement rig, not
-    /// a smoke test, so it skips unless `SV_BLACK_PROBE=1` is exported. Run it
-    /// with `-only-testing:` and read the counts off the exported attachments:
+    /// a smoke test, so it skips unless `SV_BLACK_PROBE=1` reaches the *runner*
+    /// process. Neither exporting it in the shell nor passing
+    /// `TEST_RUNNER_SV_BLACK_PROBE=1` to `xcodebuild test` does that — measured:
+    /// the test then sees no `SV_*` key at all. Put it in the `.xctestrun`
+    /// instead, which also makes repeated passes cheap (no rebuild between
+    /// runs, which is what an interleaved baseline/fixed window needs):
     ///
     /// ```
-    /// SV_BLACK_PROBE=1 SV_PROBE_SWITCHES=8 xcodebuild test \
-    ///   -only-testing:SceneViewDemoUITests/SceneViewDemoUITests/testBlackViewportProbe …
+    /// xcodebuild build-for-testing -scheme SceneViewDemoUITests \
+    ///   -destination '…' -derivedDataPath DD
+    /// # add SV_BLACK_PROBE / SV_PROBE_SWITCHES / SV_PROBE_LABEL to every
+    /// # target's EnvironmentVariables in DD/Build/Products/*.xctestrun, then:
+    /// xcodebuild test-without-building -xctestrun <patched> -destination '…' \
+    ///   -only-testing:SceneViewDemoUITests/SceneViewDemoUITests/testBlackViewportProbe
     /// ```
+    ///
+    /// Read the counts off the exported attachments: a viewport is black when
+    /// the brightest subpixel over the viewport crop is `0`.
     ///
     /// Two things here are load-bearing and must not be "tidied up":
     ///

--- a/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
+++ b/samples/ios-demo/SceneViewDemoUITests/SceneViewDemoUITests.swift
@@ -111,4 +111,76 @@ final class SceneViewDemoUITests: XCTestCase {
             app.terminate()
         }
     }
+
+    // MARK: - Black-viewport probe (#3008)
+
+    /// Opt-in probe for the intermittent black viewport of #3008: a `SceneView`
+    /// re-created by `.id()` sometimes renders nothing at all — no model, no
+    /// skybox — permanently.
+    ///
+    /// **Opt-in on purpose.** It takes minutes and it is a measurement rig, not
+    /// a smoke test, so it skips unless `SV_BLACK_PROBE=1` is exported. Run it
+    /// with `-only-testing:` and read the counts off the exported attachments:
+    ///
+    /// ```
+    /// SV_BLACK_PROBE=1 SV_PROBE_SWITCHES=8 xcodebuild test \
+    ///   -only-testing:SceneViewDemoUITests/SceneViewDemoUITests/testBlackViewportProbe …
+    /// ```
+    ///
+    /// Two things here are load-bearing and must not be "tidied up":
+    ///
+    /// - **No `-qa_mode 1`.** Every other capture in this file freezes
+    ///   auto-rotation for determinism, but `qa_mode` passes
+    ///   `autoRotate(speed: 0)`, and a zero speed makes `SceneView`'s
+    ///   auto-rotate task return immediately instead of driving `applyCamera()`
+    ///   at 60 Hz (#2896). That is a different render path from the one the
+    ///   defect was measured on, so the probe runs the shipping path.
+    /// - **Two samples per switch.** A viewport is only counted black when it
+    ///   is still black on the *second* sample — a frame that has not rendered
+    ///   yet is not a black viewport, and conflating the two is how a "black
+    ///   screen" verdict gets manufactured.
+    ///
+    /// The subject row alternates between the two *streamed* chips that stay
+    /// fully on-screen. Slot 0 ("Soldier") is deliberately not in the rotation:
+    /// it is bundled and renders on the process's first `RealityView`, which
+    /// has never been observed to fail, so including it would dilute the rate
+    /// with switches that cannot reproduce.
+    func testBlackViewportProbe() throws {
+        guard ProcessInfo.processInfo.environment["SV_BLACK_PROBE"] == "1" else {
+            throw XCTSkip("Set SV_BLACK_PROBE=1 to run the #3008 measurement rig.")
+        }
+        let switches = Int(
+            ProcessInfo.processInfo.environment["SV_PROBE_SWITCHES"] ?? "8"
+        ) ?? 8
+        let label = ProcessInfo.processInfo.environment["SV_PROBE_LABEL"] ?? "run"
+
+        let app = XCUIApplication()
+        app.launchArguments = ["-demo", "animation"]
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30),
+                      "app never reached the foreground")
+
+        let fab = app.buttons["demo-settings-fab"]
+        XCTAssertTrue(fab.waitForExistence(timeout: 20), "settings FAB never appeared")
+        // Let slot 0 settle first: it is the control that proves the rig is
+        // driving a live scene rather than a stalled app.
+        Thread.sleep(forTimeInterval: 12)
+        snapshot(app, "\(label)-00-control-soldier")
+        fab.tap()
+
+        let chips = ["Retro TV Robot", "Catfish Mech"]
+        for i in 0..<switches {
+            let name = chips[i % chips.count]
+            let chip = app.buttons[name]
+            guard chip.waitForExistence(timeout: 10) else {
+                XCTFail("subject chip '\(name)' never appeared on switch \(i + 1)")
+                return
+            }
+            chip.tap()
+            Thread.sleep(forTimeInterval: 12)
+            snapshot(app, String(format: "%@-%02d-a-%@", label, i + 1, slug(name)))
+            Thread.sleep(forTimeInterval: 8)
+            snapshot(app, String(format: "%@-%02d-b-%@", label, i + 1, slug(name)))
+        }
+    }
 }

--- a/samples/recipes/model-viewer.md
+++ b/samples/recipes/model-viewer.md
@@ -42,6 +42,12 @@ struct ModelViewer: View {
         }
         .cameraControls(.orbit)
         .environment(.studio)
+        // Required, not optional polish (v4.26.0+). The content closure runs
+        // ONCE, when the scene is created — at which point `model` is still
+        // `nil`, because the load below has not finished. Without a
+        // `.contentID(_:)` that changes when the model lands, the closure never
+        // runs again and the viewer stays empty forever.
+        .contentID(model == nil ? "loading" : "helmet")
         .task {
             var node = try? await ModelNode.load("models/helmet.usdz")
             node = node?.scaleToUnits(1.0)
@@ -51,6 +57,53 @@ struct ModelViewer: View {
     }
 }
 ```
+
+### Swapping the model
+
+Change `.contentID(_:)` — **never** SwiftUI's `.id(_:)`, and never wrap the
+`SceneView` in an `if let model` that unmounts it while the next one loads. Both
+change the view's *identity*, so SwiftUI discards the `RealityView` and builds a
+new one, and on iOS 26 Simulator a re-created `RealityView` intermittently
+renders nothing at all — no model, and no skybox either — permanently
+([#3008](https://github.com/sceneview/sceneview/issues/3008)). Put the spinner in
+an overlay so the scene never leaves the tree:
+
+```swift
+struct ModelSwitcher: View {
+    let paths: [String]
+    @State private var selected = 0
+    @State private var model: ModelNode?
+    /// Monotonic, so the id changes even if two picks resolve to the same name.
+    @State private var loadCount = 0
+
+    var body: some View {
+        ZStack {
+            SceneView { root in
+                guard let model else { return }     // scene stays mounted
+                root.addChild(model.entity)
+            }
+            .cameraControls(.orbit)
+            .environment(.studio)
+            .contentID(model == nil ? nil : loadCount)
+
+            if model == nil { ProgressView() }      // spinner as an OVERLAY
+        }
+        .task(id: selected) {
+            model = nil
+            let node = try? await ModelNode.load(paths[selected])
+            model = node?.scaleToUnits(1.0)
+            loadCount += 1
+        }
+    }
+}
+```
+
+The id has to change **every time the closure would build something different**,
+including "still loading" → "loaded" — hence the `Optional`. On each change the
+previous content is removed (its gesture handlers unregistered first, so it
+deallocates instead of leaking) and the auto-framing pass is re-armed for the new
+model. Android needs none of this: its DSL content is re-read on recomposition,
+so `modelInstance` changing is an ordinary state change.
 
 ## Key concepts
 
@@ -62,3 +115,4 @@ struct ModelViewer: View {
 | Environment | `rememberEnvironment(loader, path)` | `.environment(.studio)` |
 | Scale to fit | `scaleToUnits = 1f` | `.scaleToUnits(1.0)` |
 | Auto-animate | `autoAnimate = true` | `.playAllAnimations()` |
+| Swap the model | state change (content is re-read) | `.contentID(_:)` — never `.id(_:)` |


### PR DESCRIPTION
Closes #3008.

## What was actually wrong

A `SceneView` re-created by SwiftUI's `.id(_:)` intermittently renders **nothing
at all** on iOS 26 Simulator — no model, and no skybox either — and never
recovers. The original report blamed `scaleToUnits: 0.40` on two specific
subjects; that is disproved in the issue. The two subjects cited as *working*
went black too, the subject cited as proof that `0.40` is fine went black too,
and when it happens the scene graph and camera are provably correct: finite
bounds, camera fitted to 1.36 m and aimed at the model's centroid, camera entity
parented, framing converged, no RealityKit error in the log. The renderer is
being torn down and rebuilt; the content is fine.

14 demos re-key a `SceneView` this way. The pattern is the bug.

## The change

`SceneView.contentID(_:)` — additive, non-breaking — re-runs the content closure
**in place** instead of re-creating the view:

- one `RealityView` for the scene's lifetime;
- the previous content is removed, with its per-entity gesture handlers
  unregistered first so it deallocates rather than leaking (the #2038 cycle);
- the render-quality preset is re-applied to the new subtree, through the same
  `buildContent()` the initial setup uses — a second provisioning path is how a
  rebuilt scene ends up with different shadows from a fresh one;
- the auto-framing pass is re-armed: `didCenterContent`, the
  `FramingStabilityTracker` **and** the driver task. All three, or the new
  subject inherits the previous one's camera distance — the driver exits for
  good once the latch is set, so clearing the latch alone does not bring it
  back, and a tracker still holding the previous subject's diagonal latches on
  the first tick, before a streamed model has finished landing (#1391).

Without the modifier the closure runs exactly once, as before.

Three demos move onto it — `AnimationDemo`, `SceneGalleryDemo`,
`ModelViewerDemo` — and stay mounted while loading: the spinner is an overlay
now, not an `if let` that unmounts the scene. A demo-local mitigation was not
possible: the content builder only ran in `make:`, and `didCenterContent` is a
private `@State` of the internal view.

`assetSourcePill(_:)` is fixed in the same pass. It branched between
`overlay(…)` and `self`, which are structurally different views, so the first
no-pill → pill transition discarded the modified subtree with the `RealityView`
in it. This was found by measurement, not by reading: it re-created
`AnimationDemo`'s scene on exactly the first subject change and no other.

## Proof

The symptom is non-deterministic — measured between 1-in-4 and 3-in-4 subject
switches depending on the session — so "it looked fine" is not a signoff.

**Structural (the blocking criterion).** Instrumented `setupScene` count on
`QA-iPhone16-c` (iOS 26.3), 4-switch probe:

| | `setupScene` per subject change | per run |
|---|---|---|
| before | 2 | 1 (launch) + 2×switches |
| after | **0** | **1**, at launch |

**Visual (statistical guard-rail).** Interleaved baseline/fixed runs, same
simulator, same sitting — interleaved because the rate drifts enough between
sessions that back-to-back "before then after" runs cannot tell a fix from a
quiet afternoon. 8 switches per run, viewport sampled at +12 s and re-checked at
+20 s; a switch counts black only when the brightest subpixel over the viewport
crop is `0` at **both** samples. A frame that has not rendered yet is not a
black viewport — the first calibration run caught exactly that case (black at
+12 s, rendered at +20 s), which a single-sample method scores as a failure.

Run order B,F,B,F,B,F on `QA-iPhone16-c` (iOS 26.3), 20:05→20:29 on 2026-08-05,
same simulator, no reboot, no other build in flight:

| run | black | transiently black (+12 s only) |
|---|---|---|
| baseline 1 | 4/8 | 2 |
| fixed 1 | **0/8** | 0 |
| baseline 2 | 2/8 | 3 |
| fixed 2 | **0/8** | 0 |
| baseline 3 | 3/8 | 2 |
| fixed 3 | **0/8** | 0 |
| **totals** | **baseline 9/24 · fixed 0/24** | **baseline 7 · fixed 0** |

The environment gate is met with room to spare: the protocol required ≥ 3
baseline failures across the 24 baseline switches to call the window readable,
and baseline run 1 alone produced 4.

The fixed arm is cleaner than "0 black": across all **48 samples** (24 switches
× 2) not one read `0`. Every baseline run, by contrast, had a black frame on
two thirds of its switches counting the transients. Cold launches: 3 fixed-run
controls (slot 0, brightest subpixel 200 / 198 / 200) plus the 2 calibration
runs — all rendered.

Animations keep playing and the new subject is re-framed rather than inheriting
the previous camera distance — verified on the exported frames, where the pose
differs between captures of the same subject and two subjects with different
`scaleToUnits` (1.30 and 1.45) come out at the same on-screen size.

The rig is `testBlackViewportProbe` (opt-in, never runs in CI), added in
623aa032d. Its doc block is corrected here too:
`TEST_RUNNER_SV_BLACK_PROBE=1` on an `xcodebuild test` command line never
reaches the runner — measured, the test sees no `SV_*` key at all — so the env
has to go in the `.xctestrun`.

## Scope and residual risk

- **Not all 14 demos.** The remaining `.id(_:)` uses are heterogeneous — `FogDemo`
  re-keys on *density*, `ReflectionProbesDemo` on *intensity*, `DynamicSkyDemo`
  on `timeOfDay`. Those are continuous parameters, not model swaps, and each
  needs different work. Bundling a public-API decision with a mass refactor,
  verified against a non-deterministic symptom, makes regressions
  unattributable. Follow-up issue for the other 11.
- **Physical device untested.** Everything here is iOS 26.3 Simulator; whether
  the defect is simulator-only stays a deliberate unknown.
- **First-`RealityView` failures are not covered.** The fix removes the measured
  trigger (re-creation); a failure on the process's very first `RealityView`
  would survive it. No such failure was observed in either arm.
- **The framing re-arm touches scar tissue** (#1391 / #1026, the `AnchorEntity`
  re-pin loop). It re-arms state only; it does not change what
  `refreshContentCentering()` does.

## Cross-platform

Nothing to mirror. Android's `SceneView { }` is a composable whose DSL content
is re-read on recomposition, so swapping a model is already an ordinary state
change there. This closes an iOS gap rather than opening one.

`llms.txt` and `docs/docs/cheatsheet-ios.md` both document the modifier and say
in as many words: use `contentID`, never `.id()`.

## Gates

`pre-push-check.sh` — 10 green, 1 honest skip: the iOS screenshot-golden leg
needs the demo running on the About tab of the booted simulator and says so
rather than passing silently. `impact-check.sh` — no blockers (two pre-existing
node-parity WARNs, unrelated: `ContactShadowNode`/`SplatNode` Android-only,
`AugmentedImageNode`/`SceneReconstructionNode` Swift-only). 860 `SceneViewSwift`
tests, 0 failures.

Both gates need `ANDROID_HOME` exported inside a worktree — `local.properties`
is gitignored, so it exists only in the main checkout and Gradle fails with
"SDK location not found" until you set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
