### PR TITLE
ci(flutter): gate the published plugin, not just the demo

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -81,7 +81,7 @@ add_check() {
 # the plugin's own version — it is a dependency on the *published* Maven Central
 # artifact. It MUST lag to the last released version: it cannot point at the
 # in-flight release (e.g. 4.7.0 is not on Maven Central until the release PR is
-# published — pointing at it breaks the `Build flutter-demo APK` CI check). So
+# published — pointing at it breaks the `Flutter plugin + demo APK` CI check). So
 # this coordinate is checked REPORT-ONLY (WARN, never MISMATCH) and is
 # deliberately excluded from every `--fix` sweep below. See issue #1494.
 check_plugin_sdk_dep() {
@@ -1717,7 +1717,7 @@ fi
 
 # ─── Flutter CHANGELOG stub (--fix; deliberately OUTSIDE the ERRORS gate) ──
 # The pub.dev publish preflight (`flutter pub publish --dry-run`, #2735 —
-# ci.yml → "Build flutter-demo APK") requires the plugin CHANGELOG to mention
+# ci.yml → "Flutter plugin + demo APK") requires the plugin CHANGELOG to mention
 # the current pubspec version. A bump that updates the pubspec without adding
 # the entry therefore turns that job red on EVERY non-path-gated PR and
 # nightly until someone backfills it by hand — this bit twice, for 4.23.0 AND

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ name: CI
 #   - unit-test      JVM unit tests (PR-blocking gate) (gated on `android`)
 #   - coverage       JaCoCo coverage (advisory, off the critical path) (gated on `android`)
 #   - web-desktop    Kotlin/JS + Compose Desktop     (gated on `web`)
-#   - flutter-demo   flutter-demo APK               (gated on `flutter`)
+#   - flutter-demo   plugin analyze+test, demo APK  (gated on `flutter`)
 #   - compile-kmp    iOS Kotlin/Native targets       (gated on `kmp`)
 #   - repo-hygiene   grep/validate micro-gates       (always, when workflow runs)
 #   - quality-gate   full .claude/scripts/quality-gate.sh (gated on `quality_gate`)
@@ -608,13 +608,21 @@ jobs:
           path: samples/web-demo/test-results/
           if-no-files-found: ignore
 
-  # ── Flutter demo build ──────────────────────────────────────────────────
+  # ── Flutter plugin + demo build ─────────────────────────────────────────
   # Protects the Kotlin 2.0 Compose Compiler plugin wiring in
   # flutter/sceneview_flutter/android/build.gradle. Without this job, a
   # direct push to main that removes the plugin (or downgrades Kotlin)
   # only shows up the next time someone runs `flutter build apk`.
+  #
+  # It also gates the PUBLISHED Dart package itself. Until #3053 every step
+  # here except the publish dry-run ran in `samples/flutter-demo`, so
+  # `flutter/sceneview_flutter/lib` and `test` were analyzed by nothing and
+  # their 18 unit tests were run by nothing — an analyzer ERROR in the
+  # package we ship to pub.dev could sit on main indefinitely. Building the
+  # demo does NOT cover this: the demo consumes the plugin from Maven/pub,
+  # and `flutter build apk` never compiles the plugin's `test/` tree at all.
   flutter-demo:
-    name: Build flutter-demo APK
+    name: Flutter plugin + demo APK
     needs: changes
     if: inputs.force-all || needs.changes.outputs.flutter == 'true'
     runs-on: ubuntu-latest
@@ -645,6 +653,21 @@ jobs:
       - name: pub.dev publish preflight (--dry-run)
         working-directory: flutter/sceneview_flutter
         run: flutter pub publish --dry-run
+
+      # ── The published package (#3053) ──────────────────────────────────
+      # Same flags as the demo step below: `--no-fatal-infos` /
+      # `--no-fatal-warnings` keep the ~300 style lints advisory while any
+      # analyzer ERROR still fails the job. Measured on this commit: 0
+      # errors, 2 warnings (example/pubspec.yaml declares `models/` and
+      # `environments/` asset dirs that do not exist) and 1 info. Tightening
+      # to fatal warnings means fixing those two first.
+      - name: flutter analyze (published plugin)
+        working-directory: flutter/sceneview_flutter
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: flutter test (published plugin)
+        working-directory: flutter/sceneview_flutter
+        run: flutter test
 
       - name: flutter analyze
         working-directory: samples/flutter-demo

--- a/changelog.d/3053-flutter-plugin-ci-gate.md
+++ b/changelog.d/3053-flutter-plugin-ci-gate.md
@@ -1,0 +1,8 @@
+<!-- category: Tests -->
+- CI now runs `flutter analyze` and `flutter test` against the published
+  `flutter_sceneview` package itself. Previously every check in the
+  `flutter-demo` job except the pub.dev publish dry-run ran in
+  `samples/flutter-demo`, so the package's `lib/` and `test/` trees were
+  analyzed by nothing and its 18 Dart unit tests were run by nothing — an
+  analyzer error in the code shipped to pub.dev could reach `main` unnoticed.
+  The job is renamed `Flutter plugin + demo APK` to match what it now covers.


### PR DESCRIPTION
## The reported error does not exist on `main`

The starting report was an analyzer error in the Flutter plugin's test file:

```
error • Undefined name 'isTrue' • test/flutter_sceneview_test.dart:160:37 • undefined_identifier
```

It does not reproduce. On this commit, `flutter analyze` in
`flutter/sceneview_flutter` reports **3 issues, 0 errors**, and `flutter test`
is **18/18 green**. The file's `import 'package:flutter_test/flutter_test.dart';`
(line 8) is present and correct, and `flutter_test` re-exports `isTrue` from
`package:matcher`. There is nothing to fix in the test file, so this PR does not
touch it.

The error *is* reproducible — but only with package resolution missing. Removing
`.dart_tool/` and running `dart analyze` (which, unlike `flutter analyze`, does
not implicitly run `pub get`) yields **266 issues**, led by:

```
error - test/flutter_sceneview_test.dart:8:8   - Target of URI doesn't exist: 'package:flutter_test/flutter_test.dart'
error - test/flutter_sceneview_test.dart:121:37 - Undefined name 'isTrue'
error - test/flutter_sceneview_test.dart:134:37 - Undefined name 'isTrue'
error - test/flutter_sceneview_test.dart:143:37 - Undefined name 'isTrue'
error - test/flutter_sceneview_test.dart:153:37 - Undefined name 'isTrue'
error - test/flutter_sceneview_test.dart:160:37 - Undefined name 'isTrue'   <-- the reported line:col
```

The reported `160:37` matches exactly, and the "hundreds of issues, almost all
lints" shape matches the unresolved-import cascade. The tell is that the real
run flags *five* `isTrue` occurrences, not one: the import is unresolved, not
missing. `flutter pub get` first (or `flutter analyze`, which does it for you)
clears all 266.

## The gate was the real finding

`flutter analyze` was already wired in `ci.yml` — but in `samples/flutter-demo`.
Every step of the `flutter-demo` job except the pub.dev publish dry-run ran
there. So `flutter/sceneview_flutter/lib` and `test` were analyzed by nothing,
and the package's 18 Dart unit tests were run by nothing. An analyzer error in
the code we publish to pub.dev could reach `main` unnoticed.

Building the demo APK does not cover this: the demo consumes the plugin from
Maven/pub, and `flutter build apk` never compiles the plugin's `test/` tree.

This PR adds two steps in `flutter/sceneview_flutter`, with the same
`--no-fatal-infos --no-fatal-warnings` flags as the existing demo step, so style
lints stay advisory while an analyzer ERROR fails the job.

## Cost measured before wiring it in

| Check | Result |
|---|---|
| `flutter analyze` (plugin) | 0 errors · 2 warnings · 1 info |
| `flutter test` (plugin) | 18/18 pass |

The gate is green today. The two warnings are `example/pubspec.yaml` declaring
`models/` and `environments/` asset directories that do not exist; the info is an
unnecessary `package:flutter/rendering.dart` import in `lib/flutter_sceneview.dart`.
Both are left alone — tightening to fatal warnings means fixing them first, which
is out of scope here.

Note the plugin has **no `analysis_options.yaml`**, so its `flutter_lints` dev
dependency is inert — that is why it reports 3 issues where `samples/flutter-demo`
(which has one) reports 27. Wiring that up would be a separate, larger change.

## Mutation-tested

A gate nobody proved can fire looks exactly like a gate that always passes, so
each step was verified to actually go red:

| Mutation | `analyze` | `test` |
|---|---|---|
| baseline (clean tree) | exit 0 | exit 0 |
| analyzer error in `test/` (the reported class) | **exit 1** | — |
| analyzer error in `lib/` (shipped code) | **exit 1** | — |
| failing assertion in `test/` | exit 0 | **exit 1** |

The last row is why `flutter test` is not redundant with `flutter analyze`.

Also verified: `python3 -c yaml.safe_load` on `ci.yml`, and
`.claude/scripts/check-workflow-scripts.sh` → OK (its 2 shellcheck warnings are
pre-existing, in `app-store.yml`). `.claude/scripts/impact-check.sh` → PASS with
2 warnings, both pre-existing cross-platform node-parity warnings unrelated to
this change.

## Rename

The job's display name becomes `Flutter plugin + demo APK` to match what it now
covers. Branch protection on `main` requires only `CI Gate`, which polls the
Checks API rather than naming jobs, so the rename is inert there; the two stale
references in `sync-versions.sh` comments are updated in the same commit.

## Not verified locally

All measurements above are from this Mac (Flutter 3.41.6 / Dart 3.11.4, the same
version `ci.yml` pins). Local is not the runner — the CI run on this PR is the
real measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)