### PR TITLE
docs(branding): drop tool-name provenance from branding and docs styles

### DIFF
--- a/branding/ICON_AUDIT.md
+++ b/branding/ICON_AUDIT.md
@@ -11,9 +11,9 @@ Audited: 2026-03-26 · **Refreshed: 2026-07-18 (#2773)**
 | `branding/app-icon-1024.svg` | **Store app icon** — cube on a blue→violet diagonal gradient |
 | `website-static/favicon.svg` | Favicon — 32x32, compact isometric cube + brackets |
 
-### Brand Colors (current — Stitch palette)
+### Brand Colors (current — SceneView design system palette)
 
-> **2026-07-18:** the palette below supersedes the pre-Stitch values this doc
+> **2026-07-18:** the palette below supersedes the older values this doc
 > originally listed (`#1A73E8` primary etc.). The whole codebase now uses
 > `#005BC1` — see `samples/android-demo/src/main/res/values/colors.xml`
 > (`md_theme_primary #005BC1`) and `samples/ios-demo/.../Theme.swift`.
@@ -49,7 +49,7 @@ Audited: 2026-03-26 · **Refreshed: 2026-07-18 (#2773)**
 - `AppIcon.appiconset/AppIcon.png` (1024×1024) is present and committed; it is
   pixel-identical to `branding/app-icon-1024.svg` (blue→violet gradient, cube,
   viewport brackets). `AppIcon_512x512.png` matches the Play Store `icon-512.png`.
-- AccentColor: `#005BC1` (light) / `#A4C1FF` (dark) — matches the Stitch palette.
+- AccentColor: `#005BC1` (light) / `#A4C1FF` (dark) — matches the [`DESIGN.md`](../DESIGN.md) palette.
 - **Store icons are consistent iOS ↔ Android** (both the gradient icon).
 
 ### Website (`website-static/`)

--- a/branding/README.md
+++ b/branding/README.md
@@ -52,6 +52,6 @@ See `DESIGN.md` for full font scale, weights, and letter spacing.
 - [x] Package icon — `branding/npm-icon.svg` (256x256, for sceneview-mcp and sceneview.js)
 
 ### Website
-- [x] Favicon (blue cube) — `website-static/favicon.svg` (Stitch #005bc1 palette)
+- [x] Favicon (blue cube) — `website-static/favicon.svg` (`DESIGN.md` #005bc1 palette)
 - [x] OG image (1200x630) — `website-static/og-image.svg`
 - [x] Apple touch icon (180x180) — `website-static/apple-touch-icon.svg`

--- a/changelog.d/2827-followup-stitch-provenance.md
+++ b/changelog.d/2827-followup-stitch-provenance.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- Finished the provenance cleanup started in #2827: the branding audit, the branding README favicon entry and the MkDocs stylesheet now credit the SceneView design system (`DESIGN.md`) instead of the tool that once produced those values. Colors and tokens are unchanged.

--- a/changelog.d/2827-followup-stitch-provenance.md
+++ b/changelog.d/2827-followup-stitch-provenance.md
@@ -1,2 +1,2 @@
 <!-- category: Docs -->
-- Finished the provenance cleanup started in #2827: the branding audit, the branding README favicon entry and the MkDocs stylesheet now credit the SceneView design system (`DESIGN.md`) instead of the tool that once produced those values. Colors and tokens are unchanged.
+- Continued the provenance cleanup started in #2827: the branding audit, the branding README favicon entry and the MkDocs stylesheet now credit the SceneView design system (`DESIGN.md`) for palette and token *values* instead of the tool that once produced them. Colors and tokens are unchanged. References describing the `DESIGN.md` *file format* are intentionally kept.

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -1,7 +1,7 @@
 /* SceneView — Polished developer docs styling */
 /* Extends MkDocs Material with branded hero, stats, feature cards */
 
-/* SceneView M3 Expressive tokens — aligned with Stitch design system */
+/* SceneView M3 Expressive tokens — aligned with the SceneView design system (DESIGN.md) */
 :root {
   --md-primary-fg-color: #005bc1;
   --md-primary-fg-color--light: #3d7fd9;


### PR DESCRIPTION
Follow-up to #2827, which only cleaned `samples/**` and `website-static/**`.

Four remaining provenance mentions credited the design tool for palette values that
`DESIGN.md` actually owns:

- `branding/ICON_AUDIT.md` — palette section heading, the 2026-07-18 note, the iOS AccentColor line
- `branding/README.md` — favicon entry
- `docs/docs/stylesheets/extra.css` — token header comment

Names only. **No color, token or value changed** — this is a provenance correction, not a rebrand.

Deliberately **not** changed:
- `DESIGN.md:3` / `:357` and `branding/README.md:3` describe the *file format* and the tool as a
  marketing-surface option, which #2824 kept on purpose.
- `docs/docs/assets/images/device-ios-preview.svg` — "toe cap stitching" (sneaker illustration).
- `website-static/models/platforms/sneaker_vibe.glb` — a `Stitches_Mat` material name inside the
  model. Unrelated; the model is not re-encoded.

## Verification

`bash .claude/scripts/impact-check.sh` → PASS with 2 warnings, both pre-existing cross-platform
node-parity warnings (`ContactShadowNode`/`SplatNode`, `AugmentedImageNode`/`SceneReconstructionNode`)
unrelated to this diff. No code compiled or shipped by this change (Markdown + MkDocs CSS only).