### PR TITLE
fix(release): release-fast died right after collating the changelog

### DIFF
--- a/.github/workflows/release-fast.yml
+++ b/.github/workflows/release-fast.yml
@@ -120,8 +120,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          # Version/changelog surfaces only — never QA artifacts.
-          git add -A ':!device-qa-report.json' ':!device-qa-artifacts' ':!ar-qa-summary.json' ':!web-qa-summary.json'
+          # Version/changelog surfaces only — never QA artifacts. Stage everything, then
+          # unstage the artifacts: an exclude pathspec makes `git add` treat a gitignored
+          # match as explicitly named and EXIT 1 ("paths are ignored by .gitignore"), which
+          # under `bash -e` killed the whole release right after the changelog collate.
+          git add -A
+          git reset -q -- device-qa-report.json device-qa-artifacts ar-qa-summary.json web-qa-summary.json
           git commit -m "release: $V — version bump + changelog collate" \
             -m "Automated by release-fast.yml (web QA verdict gated, sync-versions 0 mismatch). Merging this PR tags v$V via tag-release.yml, which dispatches release.yml on the tag."
           git push origin "$BRANCH"

--- a/.github/workflows/release-fast.yml
+++ b/.github/workflows/release-fast.yml
@@ -122,8 +122,9 @@ jobs:
           git checkout -b "$BRANCH"
           # Version/changelog surfaces only — never QA artifacts. Stage everything, then
           # unstage the artifacts: an exclude pathspec makes `git add` treat a gitignored
-          # match as explicitly named and EXIT 1 ("paths are ignored by .gitignore"), which
-          # under `bash -e` killed the whole release right after the changelog collate.
+          # match as explicitly named and EXIT 1 ("paths are ignored by .gitignore"). Only
+          # device-qa-report.json is gitignored today (.gitignore:317) — one is enough, and
+          # under `bash -e` it killed the whole release right after the changelog collate.
           git add -A
           git reset -q -- device-qa-report.json device-qa-artifacts ar-qa-summary.json web-qa-summary.json
           git commit -m "release: $V — version bump + changelog collate" \

--- a/changelog.d/3087-release-fast-git-add-exclude.md
+++ b/changelog.d/3087-release-fast-git-add-exclude.md
@@ -1,0 +1,5 @@
+<!-- category: Fixed -->
+- `release-fast.yml` no longer dies right after collating the changelog. Staging the release
+  commit with exclude pathspecs (`git add -A ':!device-qa-report.json' …`) makes git treat a
+  gitignored match as explicitly named and exit 1, and under `bash -e` that killed the run before
+  the release branch was ever pushed. The artifacts are now unstaged with `git reset` instead.

--- a/changelog.d/3087-release-fast-git-add-exclude.md
+++ b/changelog.d/3087-release-fast-git-add-exclude.md
@@ -1,5 +1,6 @@
 <!-- category: Fixed -->
 - `release-fast.yml` no longer dies right after collating the changelog. Staging the release
   commit with exclude pathspecs (`git add -A ':!device-qa-report.json' …`) makes git treat a
-  gitignored match as explicitly named and exit 1, and under `bash -e` that killed the run before
+  gitignored match as explicitly named and exit 1 — only `device-qa-report.json` is actually
+  gitignored, which is one too many — and under `bash -e` that killed the run before
   the release branch was ever pushed. The artifacts are now unstaged with `git reset` instead.


### PR DESCRIPTION
`release-fast.yml` staged the release commit with exclude pathspecs:

```
git add -A ':!device-qa-report.json' ':!device-qa-artifacts' ':!ar-qa-summary.json' ':!web-qa-summary.json'
```

An exclude pathspec makes `git add` treat a **gitignored** match as explicitly named, so it prints `The following paths are ignored by one of your .gitignore files` and **exits 1**. `device-qa-report.json` is gitignored (`.gitignore:317`) and the web QA leg writes it into the workspace, so under `shell: bash -e` the step died — after the version bump and the changelog collate, before the release branch was pushed. Reproduced locally:

```
git add -A ':!device-qa-report.json'   -> rc=1   (ignored-path error)
git add -A                             -> rc=0   (gitignored file simply skipped)
```

Adding `--` or a leading `.` does not help; only dropping the exclude pathspecs does. The artifacts are now unstaged with `git reset` after a plain `git add -A`, which is also correct for the three that are *not* gitignored.

Observed on [run 31388015747](https://github.com/sceneview/sceneview/actions/runs/31388015747) (4.28.0). The web-perf leg reported `failed` in the same run but is advisory (`warn`, not a release blocker) and did not cause this.