### PR TITLE
feat(samples): add an AR measurement demo, honest about its accuracy (#531)

### DIFF
--- a/changelog.d/531-ar-measure-sample.md
+++ b/changelog.d/531-ar-measure-sample.md
@@ -1,0 +1,25 @@
+<!-- category: Added -->
+- New Android demo **`ar-measure`** — tap points on the real world and read the distance between
+  them in centimetres on a 3D label anchored at the segment midpoint. Keep tapping for a chain
+  with a running total, close the loop for a perimeter, and read the bounding box (W · H · D) of
+  every point placed. Points are resolved in accuracy order — a detected plane's polygon first,
+  then a `DepthPoint`, then the depth image directly via `Frame.hitTestDepth` (so clutter, slopes
+  and edges that never grow a plane are measurable too), then a raw feature point — and the demo
+  names on screen which source produced each point. Answers
+  [#531](https://github.com/sceneview/sceneview/issues/531), asked in 2024, closed unanswered by
+  the stale bot, and re-asked by a second user in 2025.
+- [`samples/android-demo/AR_MEASURE.md`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/AR_MEASURE.md)
+  documents the use case (surveying a real space to size something you will build or 3D-print for
+  it) and, explicitly, the accuracy ceiling: several centimetres without a ToF sensor, approaching
+  one centimetre with ToF/LiDAR — enough for layout, never for a fitting dimension on a printed
+  part.
+
+<!-- Ships as DemoStatus.InReview on purpose: the demo's own accuracy table in AR_MEASURE.md is
+     empty until someone runs the documented 5-reading protocol against a known reference on real
+     ARCore hardware. Neither CI nor the ARCore emulator can produce that figure — the emulator
+     replays a synthetic scene, so a number obtained there would describe the simulation. Flip the
+     status to Working in the same PR that fills the table.
+
+     The Rerun export path is documented in AR_MEASURE.md but deliberately not wired into the
+     demo: RerunBridge already exists in arsceneview (TCP -> Python sidecar -> .rrd, no NDK), so
+     it is ~6 lines whenever it is wanted. -->

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -608,6 +608,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `ar-image` — Image Tracking. Detect and track reference images.
 - `ar-image-stabilization` — Image Stabilization (EIS). EIS for smoother AR camera feed.
 - `ar-instant-placement` — Instant Placement. Place models before plane detection converges.
+- `ar-measure` — Measure. Tap two points, read the distance in cm.
 - `ar-ml-object-label` — ML Kit Object Labels. ML Kit object detection with 3D labels anchored on real-world hits.
 - `ar-orbital` — Orbital AR. Models orbit around you in a personal solar system.
 - `ar-people-occlusion` — People Occlusion. Real people hide virtual objects behind them.

--- a/llms.txt
+++ b/llms.txt
@@ -4897,6 +4897,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 - `ar-image` — Image Tracking. Detect and track reference images.
 - `ar-image-stabilization` — Image Stabilization (EIS). EIS for smoother AR camera feed.
 - `ar-instant-placement` — Instant Placement. Place models before plane detection converges.
+- `ar-measure` — Measure. Tap two points, read the distance in cm.
 - `ar-ml-object-label` — ML Kit Object Labels. ML Kit object detection with 3D labels anchored on real-world hits.
 - `ar-orbital` — Orbital AR. Models orbit around you in a personal solar system.
 - `ar-people-occlusion` — People Occlusion. Real people hide virtual objects behind them.

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -63,12 +63,14 @@
 #   python3 -c "import yaml,collections; print(collections.Counter(
 #     r['iosStatus'] for r in yaml.safe_load(open('parity-manifest.yml'))['demos']))"
 #
-# Measured 2026-07-22, after the Wave-A iOS ports (#2836 #2837 #2838 #2839
-# #2840 #2841) all landed:
-#   - Android: 53 fragments — 44 Working / 5 KnownIssue / 2 ComingSoon / 2 InReview.
+# Measured 2026-08-10, after `ar-measure` landed on Android (#531). Previous
+# reading: 2026-07-22, once the Wave-A iOS ports (#2836 #2837 #2838 #2839
+# #2840 #2841) had all landed — 53 Android ids, 34 working / 19 stub / 0
+# android-only.
+#   - Android: 54 fragments — 44 Working / 5 KnownIssue / 2 ComingSoon / 3 InReview.
 #   - iOS: `DemoDeepLinkRegistry.allowedIds` = 79 (69 generated ∪ 10 legacy/
 #     umbrella aliases ∪ 0 residual ids).
-#   - Of the 53 Android ids: 34 working, 19 stub, 0 android-only.
+#   - Of the 54 Android ids: 34 working, 19 stub, 1 android-only.
 #
 # How it got here — STRUCTURE, deliberately without counts (the banners below
 # are the live numbers). L0.6 (#2804, closes #2769) made every Android id
@@ -360,8 +362,16 @@ demos:
       Scene file exists (L0.6, #2804 Job B) but @available false — added to
       Android after iOS stopped tracking the catalog.
 
-  # ─── android-only (0) — every id now has at least an honest stub ────────
-  # L0.6 (#2804) closed this section: the 6 #2239-umbrella ids became
+  # ─── android-only (1) — iOS has not reserved an id for these yet ────────
+  # L0.6 (#2804) had emptied this section: the 6 #2239-umbrella ids became
   # `working` (Job A aliases) and the remaining 7 became `stub` (Job B stub
-  # Scenes). Kept as a documented, currently-empty bucket — the landing spot
-  # for the next Android id iOS hasn't reserved an id for yet.
+  # Scenes). It is the landing spot for the next Android id iOS hasn't
+  # reserved an id for yet — which is exactly what `ar-measure` is.
+  - id: ar-measure
+    androidStatus: InReview
+    iosStatus: android-only
+    reason: >-
+      Landed on Android only (#531). NOT platform-locked — ARKit raycasting
+      plus scene reconstruction covers every brick this demo needs, so an iOS
+      port is expected rather than excluded; iOS simply has no id reserved for
+      it yet. Porting it is tracked by the iOS-parity epic #894 / #2798.

--- a/samples/android-demo/AR_MEASURE.md
+++ b/samples/android-demo/AR_MEASURE.md
@@ -1,0 +1,175 @@
+# AR Measure — measuring a real space with SceneView
+
+`ar-measure` in the demo app · [`ARMeasureDemo.kt`](src/main/java/io/github/sceneview/demo/demos/ARMeasureDemo.kt)
+· deep link `sceneview://demo/ar-measure`
+
+Tap two points on the real world; read the distance between them in centimetres, on a label
+anchored in 3D at the midpoint of the segment. Keep tapping to build a chain, close the loop
+to get a perimeter, and read the bounding box of every point placed so far.
+
+## Why this demo exists
+
+Surveying a real space so you can build something that fits into it.
+
+You are about to 3D-print a bracket for a shelf, a spacer between two studs, a mount for a
+cable run behind a workbench. Before you can model it you need the space's numbers: how wide
+is the gap, how much clear height is above the bench, how far apart are those two uprights.
+Fetching a tape measure and holding it against an awkward corner alone is the annoying part
+of that workflow, and it is exactly what a phone that already understands the room's geometry
+should be able to do.
+
+That is the case this demo serves: **taking the room's dimensions, so you can design against
+them afterwards.** It is not an abstract "look, AR can draw a line" demo.
+
+It also answers a question users have actually asked and never had answered:
+[#531 — "is it possible to measure dimension of object in compose"](https://github.com/sceneview/sceneview/issues/531),
+which was closed by the stale bot in 2024 and re-asked by a second user in July 2025.
+
+## How accurate is it — read this before trusting a number
+
+**Short version: this is a layout tool, not a caliper.**
+
+ARCore produces the 3D point under your finger in one of two ways:
+
+- **On a phone with no depth sensor** (most Android phones), depth is *inferred* from motion
+  stereo — the device compares camera frames as you move and solves for depth. Google
+  documents this path as usable for occlusion and placement, not metrology, and the practical
+  error on a single measured point is **on the order of several centimetres**. Two points
+  compound: a 2 m span can be off by 5 cm or more, and the error is not a stable bias you
+  could calibrate away — it varies with texture, lighting, how much parallax your movement
+  gave the tracker, and how long the session has been running.
+- **On a phone with a ToF / LiDAR-class depth sensor**, depth is measured rather than
+  inferred, and the error comes down **towards the centimetre**.
+
+### What that is good for
+
+- Will this cabinet fit in this alcove? (alcove 84 cm, cabinet 78 cm → yes, comfortably)
+- How far apart are these two studs? (roughly 40 cm → design a bracket that spans them, with
+  slots rather than fixed holes)
+- What is the clear height under this shelf?
+- Rough floor outline of a room, for planning where things go.
+
+### What it is emphatically NOT good for
+
+- **Any fitting dimension on a printed part.** A press fit, a bearing seat, a snap hook, a
+  shaft diameter — these live at ±0.1 mm, three orders of magnitude below what this can see.
+- Anything where being wrong by 3 cm is a scrapped print or a part that will not go in.
+
+The working rule for the 3D-printing use case: **use AR to get the envelope, use calipers for
+the interface.** Measure the alcove with your phone; measure the rail the bracket clips onto
+with a caliper. Design tolerance and adjustment slots into anything dimensioned from an AR
+reading.
+
+### Measured error
+
+> **Not yet measured on hardware.** This table is deliberately empty rather than filled with
+> a plausible number. Filling it requires an Android device with ARCore and a reference
+> object of known size, which no CI machine or emulator can stand in for: the ARCore
+> emulator replays a synthetic scene, so any figure obtained there would describe the
+> simulation, not the sensor. The demo ships with the `In review` badge until this table has
+> real rows in it.
+
+Protocol to fill it in — please add your rows rather than replacing them, device class is
+the whole point:
+
+1. Pick a reference object whose true dimension you can measure with a tape or caliper to
+   ±1 mm. A door frame width, a table edge, a printed calibration bar. Record the true value.
+2. Move the phone around the object for ~10 s before the first tap, so ARCore has parallax
+   to work with. Wait until the plane renderer shows a stable plane on the surface.
+3. Take **five** independent measurements of the same span: clear between each one, and
+   re-approach from a slightly different angle. One reading tells you nothing about the
+   spread, and the spread is the interesting number.
+4. Record device, whether it has a ToF sensor, the true value, the five readings, and the
+   lighting/texture conditions.
+
+| Device | ToF? | True | Readings (5×) | Mean error | Spread | Conditions |
+|---|---|---|---|---|---|---|
+| _(pending a device pass)_ | | | | | | |
+
+## How it works
+
+### Hit-test strategy
+
+Each tap is resolved in a fixed preference order, which is an *accuracy* order:
+
+1. **A detected plane**, when the tap lands inside the plane polygon. ARCore has fitted this
+   surface over many frames, so it is the most stable target available. The
+   `isPoseInPolygon` check matters: ARCore will happily report a hit on the *infinite
+   extension* of a plane, so without it a tap past the edge of a table places a point in
+   mid-air and reports a confidently wrong distance.
+2. **A `DepthPoint`** returned by the same hit test — geometry ARCore has depth for but has
+   not grown a plane over.
+3. **The depth image directly**, via SceneView's `Frame.hitTestDepth(x, y)`. This is what
+   makes a *cluttered* space measurable rather than just its flat floor: a sofa, a slope, the
+   lip of a workbench, where no plane will ever appear. Toggleable in the settings sheet, and
+   disabled automatically on devices that report no depth support.
+4. **A raw feature point**, last resort and the noisiest of the four.
+
+The demo names the source of each point on screen ("Point 3 on depth map"), because a
+measuring tool that hides how it got its number is a measuring tool you cannot calibrate.
+
+### Anchors, not positions
+
+Every point is an ARCore `Anchor`, not a captured coordinate. ARCore corrects anchor poses as
+it refines its map of the room, and a measurement that ignored those corrections would slowly
+drift away from the marker the user is looking at. The demo re-reads every anchor pose on
+every frame — but only pushes the result into Compose state when a point has actually moved
+more than 1 mm, so sub-millimetre tracking jitter does not recompose the scene at 60 Hz.
+
+### Bounding box caveat
+
+The `W · H · D` readout is axis-aligned to the **ARCore world frame**, not to the object.
+`+Y` is gravity-up, so `H` is a physically meaningful vertical extent. `X` and `Z`, though,
+are fixed at session start from wherever the device happened to be pointing — so `W` and `D`
+are extents along two arbitrary horizontal axes, not along the object's own edges. A table
+sitting at 45° to the session axes yields a box noticeably larger than the table. Start the
+session roughly square to what you are measuring.
+
+An object-aligned box would need a horizontal-plane PCA over the point set plus a convention
+for which side is "width"; that would become the thing the demo teaches, instead of AR
+measurement. It is left out on purpose.
+
+## Testing
+
+The arithmetic behind every displayed number is a pure Kotlin file with no ARCore or Filament
+types, [`MeasureMath.kt`](src/main/java/io/github/sceneview/demo/demos/internal/MeasureMath.kt),
+covered by [`MeasureMathTest`](src/test/java/io/github/sceneview/demo/demos/internal/MeasureMathTest.kt):
+
+```bash
+./gradlew :samples:android-demo:testDebugUnitTest --tests '*MeasureMathTest*'
+```
+
+This is not ceremony. A wrong distance formula renders a perfectly plausible centimetre label
+— the app does not crash, the screenshot looks right, and the number is simply false. No
+device pass, emulator run or visual QA catches that; only these tests do. (Verified by
+mutation: dropping the `z` term from the distance formula fails 4 of the 18 tests.)
+
+## Exporting a session to Rerun (not wired up)
+
+For offline inspection of *why* a measurement came out the way it did — where the camera
+actually went, which planes existed at tap time, how dense the point cloud was around each
+anchor — SceneView already ships a [Rerun](https://rerun.io) bridge:
+`io.github.sceneview.ar.rerun.RerunBridge`, exercised by the `ar-rerun` demo. There is no
+official Rerun SDK for Kotlin; the bridge streams JSON lines over TCP to a Python sidecar,
+which writes an `.rrd` you can open in the Rerun viewer. No NDK work involved.
+
+This demo deliberately **does not** wire it up — measuring and debugging are separate
+concerns and the demo stays about measuring. If you want it, it is a handful of lines:
+
+```kotlin
+val rerun = rememberRerunBridge()
+// in onSessionUpdated:
+rerun.logCameraPose(frame.camera.pose, frame.timestamp)
+rerun.logPlanes(session.getAllTrackables(Plane::class.java), frame.timestamp)
+rerun.logAnchors(points.map { it.anchor }, frame.timestamp)
+```
+
+See [`RECORDING_PLAYBACK.md`](RECORDING_PLAYBACK.md) and the `ar-rerun` demo for the sidecar
+setup.
+
+## Related
+
+- `ar-placement` — tap-to-place a model on a plane (the hit-test brick this demo builds on)
+- `ar-depth-collider` — the depth mesh, rendered
+- `ar-raw-depth-point-cloud` — what the depth sensor actually returns
+- [`AR_TESTING.md`](AR_TESTING.md) — running the AR demos on device and on the AR emulator

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMeasureDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMeasureDemo.kt
@@ -1,0 +1,527 @@
+package io.github.sceneview.demo.demos
+
+import android.view.MotionEvent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.ar.core.Anchor
+import com.google.ar.core.Config
+import com.google.ar.core.DepthPoint
+import com.google.ar.core.Frame
+import com.google.ar.core.Plane
+import com.google.ar.core.Pose
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARSceneView
+import io.github.sceneview.ar.arcore.hitTestDepth
+import io.github.sceneview.ar.rememberARCameraNode
+import io.github.sceneview.demo.ARCameraInitScrim
+import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.common.SceneAction
+import io.github.sceneview.demo.common.SceneActionBar
+import io.github.sceneview.demo.demos.internal.BoxDimensions
+import io.github.sceneview.demo.demos.internal.formatCentimeters
+import io.github.sceneview.demo.demos.internal.measureBoundingBox
+import io.github.sceneview.demo.demos.internal.measureDistanceMeters
+import io.github.sceneview.demo.demos.internal.measureMidpoint
+import io.github.sceneview.demo.demos.internal.measurePerimeterMeters
+import io.github.sceneview.demo.demos.internal.measurePointsMoved
+import io.github.sceneview.demo.rememberArPlaybackDataset
+import io.github.sceneview.math.Position
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberMaterialLoader
+import io.github.sceneview.rememberOnGestureListener
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
+
+/** Radius of the sphere dropped on each measured point, in metres (~2.4 cm across). */
+private const val MARKER_RADIUS_METERS = 0.012f
+
+/** Height of a segment's floating label above the segment midpoint, in metres. */
+private const val LABEL_LIFT_METERS = 0.04f
+
+/** World size of a segment label's quad. 4:1 to match the label bitmap's aspect ratio. */
+private const val LABEL_WIDTH_METERS = 0.16f
+private const val LABEL_HEIGHT_METERS = 0.04f
+
+/**
+ * Where a measured point came from. Surfaced to the user because the three sources do not
+ * carry the same accuracy — a plane hit is the most trustworthy, a raw feature point the
+ * least — and a measuring tool that hides which one it used is a measuring tool you cannot
+ * calibrate. See `AR_MEASURE.md`.
+ */
+private enum class MeasureHitSource(val label: String) {
+    Plane("plane"),
+    Depth("depth map"),
+    FeaturePoint("feature point"),
+}
+
+/** A point the user placed: its ARCore [Anchor] plus where the hit came from. */
+private data class MeasurePoint(
+    val anchor: Anchor,
+    val source: MeasureHitSource,
+)
+
+/**
+ * AR measurement demo — tap two or more points on the real world and read the distance
+ * between them.
+ *
+ * ## What it does
+ * Each tap raycasts the camera pixel into the scene and drops an ARCore [Anchor] on
+ * whatever it lands on. Consecutive points are joined by a line carrying a world-anchored
+ * 3D label with the distance in centimetres. Keep tapping to build a chain (a running
+ * perimeter), close the loop to measure an outline, and read the bounding box of every
+ * point placed so far — width, height and depth.
+ *
+ * ## What it is for
+ * Surveying a real space — a workshop, a room, a piece of furniture — to size something you
+ * are about to 3D-print or build for it. That is the use case the sample's README documents,
+ * and it is also the honest limit of the sample: see the accuracy section below.
+ *
+ * ## Hit-test strategy
+ * Three sources, in descending order of trustworthiness:
+ *  1. **A detected [Plane]**, when the tap lands inside its polygon. ARCore has fitted this
+ *     surface over many frames, so it is the most stable target available.
+ *  2. **A [DepthPoint]** from the same [Frame.hitTest] call, which resolves geometry ARCore
+ *     has depth for but has not grown a plane over.
+ *  3. **The depth image directly**, via [hitTestDepth] — this catches the case that matters
+ *     most for surveying a cluttered space: a sofa, a slope, the edge of a workbench, where
+ *     no plane will ever appear. Toggleable, because on a device with no depth support it
+ *     can only ever return `null`.
+ *
+ * A raw feature [com.google.ar.core.Point] is accepted last and labelled as such, since its
+ * position is the noisiest of the three.
+ *
+ * ## Accuracy — read this before trusting a number
+ * On a phone with no time-of-flight sensor, ARCore synthesises depth from motion stereo and
+ * the error is **several centimetres**. With ToF/LiDAR hardware it approaches the
+ * centimetre. That is enough to lay out a space — will this cabinet fit, how far apart are
+ * these studs, what is the clear height — and it is **not** enough for a fitting dimension
+ * on a printed part, which lives at tenths of a millimetre. The full protocol and the
+ * measured figures are in
+ * [`samples/android-demo/AR_MEASURE.md`](../../../../../../../../AR_MEASURE.md).
+ *
+ * The arithmetic behind every displayed number lives in
+ * [io.github.sceneview.demo.demos.internal.MeasureMathKt] and is unit-tested headlessly —
+ * a wrong distance formula renders a perfectly plausible label that no device pass catches.
+ */
+@Composable
+fun ARMeasureDemo(onBack: () -> Unit) {
+    val engine = rememberEngine()
+    val materialLoader = rememberMaterialLoader(engine)
+    val cameraNode = rememberARCameraNode(engine)
+    // Replay a recorded ARCore dataset when the device-QA harness deep-links this demo
+    // with `--es ar_playback_file <path>` (#1576). `null` for every normal launch.
+    val arPlaybackDataset = rememberArPlaybackDataset()
+
+    val points = remember { mutableStateListOf<MeasurePoint>() }
+    // World positions of `points`, refreshed from the anchors only when they actually move
+    // (see `measurePointsMoved`). Anchors drift as ARCore refines tracking, so this cannot
+    // be computed once at tap time — but neither can it be pushed into Compose state on
+    // every frame without recomposing the scene subtree at 60 Hz for invisible jitter.
+    var worldPoints by remember { mutableStateOf<List<Position>>(emptyList()) }
+    var closedLoop by remember { mutableStateOf(false) }
+
+    var session by remember { mutableStateOf<Session?>(null) }
+    var latestFrame by remember { mutableStateOf<Frame?>(null) }
+    var isTracking by remember { mutableStateOf(false) }
+    // Cover the jet-black ARSceneView surface until ARCore delivers its first camera frame,
+    // so the ~1-3 s warm-up on entry doesn't read as a frozen screen (#2484).
+    var cameraReady by remember { mutableStateOf(false) }
+    var depthSupported by remember { mutableStateOf(false) }
+    var useDepthFallback by remember { mutableStateOf(true) }
+    // Why the last tap placed nothing, or where the last placed point came from. Both are
+    // shown to the user: a tap that silently does nothing is the single most confusing
+    // thing a measuring tool can do.
+    var lastTapFeedback by remember { mutableStateOf<String?>(null) }
+
+    // Anchors are native ARCore handles: dropping the composable without detaching them
+    // leaks them into the session for as long as it lives.
+    DisposableEffect(Unit) {
+        onDispose { points.forEach { it.anchor.detach() } }
+    }
+
+    val markerMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Accent)
+    val lineMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.Primary)
+
+    val boundingBox: BoxDimensions? = measureBoundingBox(worldPoints)
+    val totalMeters = measurePerimeterMeters(worldPoints, closed = closedLoop)
+    val lastSegmentMeters = if (worldPoints.size >= 2) {
+        measureDistanceMeters(worldPoints[worldPoints.size - 2], worldPoints.last())
+    } else {
+        null
+    }
+
+    DemoScaffold(
+        title = stringResource(R.string.demo_ar_measure_title),
+        onBack = onBack,
+        peekHeader = when {
+            worldPoints.isEmpty() -> stringResource(R.string.demo_ar_measure_hint_first)
+            worldPoints.size == 1 -> stringResource(R.string.demo_ar_measure_hint_second)
+            closedLoop -> stringResource(
+                R.string.demo_ar_measure_perimeter,
+                formatCentimeters(totalMeters),
+            )
+            else -> stringResource(
+                R.string.demo_ar_measure_total,
+                formatCentimeters(totalMeters),
+            )
+        },
+        onReset = {
+            points.forEach { it.anchor.detach() }
+            points.clear()
+            worldPoints = emptyList()
+            closedLoop = false
+            lastTapFeedback = null
+        },
+        controls = {
+            Text(
+                text = stringResource(R.string.demo_ar_measure_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.demo_ar_measure_depth_toggle),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = if (depthSupported) {
+                            stringResource(R.string.demo_ar_measure_depth_supported)
+                        } else {
+                            stringResource(R.string.demo_ar_measure_depth_unsupported)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = useDepthFallback && depthSupported,
+                    onCheckedChange = { useDepthFallback = it },
+                    enabled = depthSupported,
+                )
+            }
+            // The accuracy caveat is not buried in the README only: a user reading a
+            // centimetre figure on screen needs to know what it is worth, right there.
+            Text(
+                text = stringResource(R.string.demo_ar_measure_accuracy_notice),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+        },
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            ARSceneView(
+                modifier = Modifier.fillMaxSize(),
+                engine = engine,
+                materialLoader = materialLoader,
+                cameraNode = cameraNode,
+                playbackDataset = arPlaybackDataset,
+                planeRenderer = true,
+                sessionConfiguration = { configuredSession: Session, config: Config ->
+                    config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
+                    // Depth widens what can be measured from "surfaces ARCore grew a plane
+                    // over" to "anything the depth camera sees". Probe before enabling:
+                    // requesting an unsupported mode fails session configuration outright.
+                    val supported =
+                        configuredSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
+                    depthSupported = supported
+                    config.depthMode = if (supported) {
+                        Config.DepthMode.AUTOMATIC
+                    } else {
+                        Config.DepthMode.DISABLED
+                    }
+                },
+                onSessionCreated = { created: Session -> session = created },
+                onSessionUpdated = { _: Session, frame: Frame ->
+                    cameraReady = true
+                    latestFrame = frame
+                    isTracking = frame.camera.trackingState == TrackingState.TRACKING
+
+                    // Re-read every anchor pose: ARCore corrects them as it refines its map,
+                    // and a measurement that ignored those corrections would drift away from
+                    // the marker the user is looking at.
+                    if (points.isNotEmpty()) {
+                        val next = points.map { it.anchor.pose.toPosition() }
+                        if (measurePointsMoved(worldPoints, next)) {
+                            worldPoints = next
+                        }
+                    }
+                },
+                onGestureListener = rememberOnGestureListener(
+                    onSingleTapConfirmed = { event: MotionEvent, _ ->
+                        val frame = latestFrame
+                        val currentSession = session
+                        when {
+                            frame == null || currentSession == null || !isTracking ->
+                                lastTapFeedback = "Not tracking yet — move the device slowly"
+
+                            else -> {
+                                val placed = placeMeasurePoint(
+                                    frame = frame,
+                                    session = currentSession,
+                                    event = event,
+                                    allowDepthFallback = useDepthFallback && depthSupported,
+                                )
+                                if (placed != null) {
+                                    points.add(placed)
+                                    // A new point re-opens the chain: the closing segment
+                                    // referred to the outline as it stood before this tap.
+                                    closedLoop = false
+                                    worldPoints = points.map { it.anchor.pose.toPosition() }
+                                    lastTapFeedback = "Point ${points.size} on ${placed.source.label}"
+                                } else {
+                                    lastTapFeedback =
+                                        "No surface there — aim at a detected plane or textured surface"
+                                }
+                            }
+                        }
+                    },
+                ),
+            ) {
+                // One AnchorNode per measured point. The library keeps each node glued to
+                // its anchor every frame without a recomposition, so the markers stay put
+                // even between the throttled `worldPoints` refreshes.
+                points.forEach { point ->
+                    key(point.anchor) {
+                        AnchorNode(anchor = point.anchor) {
+                            SphereNode(
+                                radius = MARKER_RADIUS_METERS,
+                                materialInstance = markerMaterial,
+                            )
+                        }
+                    }
+                }
+
+                // Segments + their anchored labels, in world space. `LineNode` renders a
+                // 1-px GPU line: thin, but geometrically exact and free — the alternative
+                // (a rotated cylinder) would need a direction-to-Euler conversion whose
+                // convention risk buys nothing a measuring overlay needs.
+                val pts = worldPoints
+                for (i in 0 until pts.size - 1) {
+                    key("segment-$i") {
+                        MeasureSegment(
+                            start = pts[i],
+                            end = pts[i + 1],
+                            materialInstance = lineMaterial,
+                            cameraPositionProvider = { cameraNode.worldPosition },
+                        )
+                    }
+                }
+                if (closedLoop && pts.size > 2) {
+                    key("segment-closing") {
+                        MeasureSegment(
+                            start = pts.last(),
+                            end = pts.first(),
+                            materialInstance = lineMaterial,
+                            cameraPositionProvider = { cameraNode.worldPosition },
+                        )
+                    }
+                }
+            }
+
+            // Readout pill — the last segment, and the bounding box once there is one.
+            // Screen-anchored rather than world-anchored on purpose: the per-segment labels
+            // are already in the world, and a summary that can drift off-screen is a summary
+            // you cannot read (#2727).
+            if (worldPoints.size >= 2) {
+                Surface(
+                    modifier = Modifier.align(Alignment.TopCenter).padding(top = 8.dp),
+                    color = Color(0xCC161B22),  // SceneView SurfaceDim
+                    contentColor = Color.White,
+                    shape = MaterialTheme.shapes.large,
+                ) {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        lastSegmentMeters?.let {
+                            Text(
+                                text = stringResource(
+                                    R.string.demo_ar_measure_last_segment,
+                                    formatCentimeters(it),
+                                ),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                        }
+                        boundingBox?.let { box ->
+                            Text(
+                                text = stringResource(
+                                    R.string.demo_ar_measure_bounding_box,
+                                    formatCentimeters(box.widthMeters),
+                                    formatCentimeters(box.heightMeters),
+                                    formatCentimeters(box.depthMeters),
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Per-tap feedback, including the hit source that produced the point.
+            AnimatedVisibility(
+                visible = lastTapFeedback != null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                Text(
+                    text = lastTapFeedback.orEmpty(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier
+                        .padding(bottom = 88.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                            shape = RoundedCornerShape(24.dp),
+                        )
+                        .padding(horizontal = 20.dp, vertical = 10.dp),
+                )
+            }
+
+            SceneActionBar(
+                SceneAction(
+                    label = stringResource(R.string.demo_ar_measure_action_undo),
+                    onClick = {
+                        points.removeLastOrNull()?.anchor?.detach()
+                        worldPoints = points.map { it.anchor.pose.toPosition() }
+                        if (points.size < 3) closedLoop = false
+                        lastTapFeedback = null
+                    },
+                    enabled = points.isNotEmpty(),
+                ),
+                SceneAction(
+                    label = if (closedLoop) {
+                        stringResource(R.string.demo_ar_measure_action_open)
+                    } else {
+                        stringResource(R.string.demo_ar_measure_action_close)
+                    },
+                    onClick = { closedLoop = !closedLoop },
+                    enabled = points.size > 2,
+                ),
+                SceneAction(
+                    label = stringResource(R.string.demo_ar_measure_action_clear),
+                    onClick = {
+                        points.forEach { it.anchor.detach() }
+                        points.clear()
+                        worldPoints = emptyList()
+                        closedLoop = false
+                        lastTapFeedback = null
+                    },
+                    enabled = points.isNotEmpty(),
+                ),
+            )
+
+            // Cover the still-black AR viewport until the first camera frame (#2484).
+            ARCameraInitScrim(initializing = !cameraReady)
+        }
+    }
+}
+
+/**
+ * One measured segment: the line itself plus its distance label, floating just above the
+ * midpoint and turned toward the camera so it stays readable from any angle.
+ */
+@Composable
+private fun io.github.sceneview.ar.ARSceneScope.MeasureSegment(
+    start: Position,
+    end: Position,
+    materialInstance: com.google.android.filament.MaterialInstance,
+    cameraPositionProvider: () -> Position,
+) {
+    LineNode(
+        start = start,
+        end = end,
+        materialInstance = materialInstance,
+    )
+    val midpoint = measureMidpoint(start, end)
+    TextNode(
+        text = formatCentimeters(measureDistanceMeters(start, end)),
+        widthMeters = LABEL_WIDTH_METERS,
+        heightMeters = LABEL_HEIGHT_METERS,
+        position = Position(
+            x = midpoint.x,
+            y = midpoint.y + LABEL_LIFT_METERS,
+            z = midpoint.z,
+        ),
+        cameraPositionProvider = cameraPositionProvider,
+    )
+}
+
+/**
+ * Resolves a tap into an anchored measurement point, or `null` when the tap hit nothing
+ * measurable.
+ *
+ * Preference order is accuracy order, not convenience order — see [MeasureHitSource].
+ * A plane hit is only accepted when the tap lands *inside* the plane's polygon: ARCore
+ * happily reports a hit on the infinite extension of a plane, which would silently place a
+ * point in mid-air past the edge of a table and produce a confidently wrong measurement.
+ */
+private fun placeMeasurePoint(
+    frame: Frame,
+    session: Session,
+    event: MotionEvent,
+    allowDepthFallback: Boolean,
+): MeasurePoint? {
+    val hits = runCatching { frame.hitTest(event) }.getOrNull().orEmpty()
+
+    hits.firstOrNull { hit ->
+        val trackable = hit.trackable
+        trackable is Plane &&
+            trackable.trackingState == TrackingState.TRACKING &&
+            trackable.isPoseInPolygon(hit.hitPose)
+    }?.let { return MeasurePoint(it.createAnchor(), MeasureHitSource.Plane) }
+
+    hits.firstOrNull { it.trackable is DepthPoint }
+        ?.let { return MeasurePoint(it.createAnchor(), MeasureHitSource.Depth) }
+
+    // Nothing ARCore has modelled as a trackable. Sample the depth image directly — this is
+    // what makes a cluttered real space measurable rather than only its flat floor.
+    if (allowDepthFallback) {
+        frame.hitTestDepth(event.x, event.y)?.let { depthHit ->
+            val pose = Pose(
+                floatArrayOf(depthHit.position.x, depthHit.position.y, depthHit.position.z),
+                floatArrayOf(0f, 0f, 0f, 1f),
+            )
+            return MeasurePoint(session.createAnchor(pose), MeasureHitSource.Depth)
+        }
+    }
+
+    // Last resort: a raw tracking feature point. Noisiest of the three, and labelled as
+    // such on screen so the user knows this particular reading deserves less trust.
+    hits.firstOrNull { it.trackable is com.google.ar.core.Point }
+        ?.let { return MeasurePoint(it.createAnchor(), MeasureHitSource.FeaturePoint) }
+
+    return null
+}
+
+/** ARCore [Pose] translation as a SceneView world [Position]. */
+private fun Pose.toPosition(): Position = Position(x = tx(), y = ty(), z = tz())

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/MeasureMath.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/MeasureMath.kt
@@ -1,0 +1,127 @@
+package io.github.sceneview.demo.demos.internal
+
+import io.github.sceneview.math.Position
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+/**
+ * Pure measurement maths for the `ar-measure` demo.
+ *
+ * Deliberately free of ARCore and Filament types: everything here takes plain world-space
+ * [Position]s so it runs in a JVM unit test with no device, no emulator and no GL context.
+ * The demo composable owns the AR plumbing (hit tests, anchors, node rendering); this file
+ * owns the arithmetic that produces the numbers shown to the user — which is the part that
+ * can be *wrong* in a way no screenshot would reveal.
+ *
+ * See `samples/android-demo/AR_MEASURE.md` for what these numbers are actually worth: the
+ * arithmetic below is exact, the world-space points it is fed are not.
+ */
+
+/** Straight-line distance between two world-space points, in metres. */
+fun measureDistanceMeters(a: Position, b: Position): Float {
+    val dx = b.x - a.x
+    val dy = b.y - a.y
+    val dz = b.z - a.z
+    return sqrt(dx * dx + dy * dy + dz * dz)
+}
+
+/** Midpoint of the segment `a`–`b` — where the demo anchors a segment's 3D label. */
+fun measureMidpoint(a: Position, b: Position): Position =
+    Position(x = (a.x + b.x) / 2f, y = (a.y + b.y) / 2f, z = (a.z + b.z) / 2f)
+
+/**
+ * Formats a metre distance as centimetres for display.
+ *
+ * One decimal, never more: a second decimal would render tenths of a millimetre, which
+ * would be a lie about the precision of the underlying pose (see `AR_MEASURE.md`). The
+ * value is reported in centimetres at every magnitude — "312.7 cm" rather than "3.13 m" —
+ * so a chain of segments stays visually comparable without a unit switch mid-list.
+ */
+fun formatCentimeters(meters: Float): String =
+    "%.1f cm".format(Locale.US, meters * 100f)
+
+/**
+ * Total length of the polyline through [points], in metres.
+ *
+ * @param closed when `true`, also counts the segment from the last point back to the first,
+ *               turning the chain into a perimeter.
+ */
+fun measurePerimeterMeters(points: List<Position>, closed: Boolean): Float {
+    if (points.size < 2) return 0f
+    var total = 0f
+    for (i in 0 until points.size - 1) {
+        total += measureDistanceMeters(points[i], points[i + 1])
+    }
+    if (closed && points.size > 2) {
+        total += measureDistanceMeters(points.last(), points.first())
+    }
+    return total
+}
+
+/**
+ * The three side lengths of the bounding box around [points], in metres.
+ *
+ * **Axis-aligned to the ARCore *world* frame, not to the measured object.** ARCore's `+Y`
+ * is gravity-up, so [heightMeters] is a physically meaningful vertical extent. `X` and `Z`,
+ * however, are fixed at session start from wherever the device happened to be pointing —
+ * so [widthMeters] and [depthMeters] are the extents along two arbitrary horizontal axes,
+ * *not* along the object's own edges. Measuring a table that sits at 45° to the session
+ * axes yields a box noticeably larger than the table.
+ *
+ * This is a deliberate limitation, not an oversight: an object-aligned box would need a
+ * horizontal-plane PCA over the point set and a convention for which side is "width", and
+ * the demo would then be teaching that instead of teaching AR measurement. To get useful
+ * `W`/`D` numbers, start the AR session roughly square to the object.
+ */
+data class BoxDimensions(
+    val widthMeters: Float,
+    val heightMeters: Float,
+    val depthMeters: Float,
+)
+
+/** Returns `null` for fewer than two points — a single point has no extent to report. */
+fun measureBoundingBox(points: List<Position>): BoxDimensions? {
+    if (points.size < 2) return null
+    var minX = points[0].x; var maxX = points[0].x
+    var minY = points[0].y; var maxY = points[0].y
+    var minZ = points[0].z; var maxZ = points[0].z
+    for (p in points) {
+        if (p.x < minX) minX = p.x
+        if (p.x > maxX) maxX = p.x
+        if (p.y < minY) minY = p.y
+        if (p.y > maxY) maxY = p.y
+        if (p.z < minZ) minZ = p.z
+        if (p.z > maxZ) maxZ = p.z
+    }
+    return BoxDimensions(
+        widthMeters = abs(maxX - minX),
+        heightMeters = abs(maxY - minY),
+        depthMeters = abs(maxZ - minZ),
+    )
+}
+
+/**
+ * True when any point of [current] has moved more than [epsilonMeters] from [previous],
+ * or when the two lists have different sizes.
+ *
+ * The demo re-reads every anchor pose on every ARCore frame, because anchors drift as
+ * tracking refines. Pushing those poses into Compose state unconditionally would
+ * recompose the whole scene subtree at frame rate for sub-millimetre jitter that no user
+ * can see. Gating the state write on this predicate keeps the labels stable and the
+ * recompositions rare, while still following a real anchor correction when one lands.
+ *
+ * 1 mm is well below the demo's own accuracy floor (centimetres at best — `AR_MEASURE.md`),
+ * so nothing observable is discarded.
+ */
+fun measurePointsMoved(
+    previous: List<Position>,
+    current: List<Position>,
+    epsilonMeters: Float = 0.001f,
+): Boolean {
+    if (previous.size != current.size) return true
+    for (i in previous.indices) {
+        if (measureDistanceMeters(previous[i], current[i]) > epsilonMeters) return true
+    }
+    return false
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArMeasureFragment.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/ArMeasureFragment.kt
@@ -1,0 +1,30 @@
+package io.github.sceneview.demo.fragments
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Straighten
+import androidx.compose.runtime.Composable
+import io.github.sceneview.demo.DemoCategory
+import io.github.sceneview.demo.DemoEntry
+import io.github.sceneview.demo.DemoStatus
+import io.github.sceneview.demo.R
+import io.github.sceneview.demo.demos.ARMeasureDemo
+
+/** Append-only fragment for the `ar-measure` demo. See [DemoFragment]. */
+object ArMeasureFragment : DemoFragment {
+    override val entry: DemoEntry = DemoEntry(
+        id = "ar-measure",
+        titleRes = R.string.demo_ar_measure_title,
+        subtitleRes = R.string.demo_ar_measure_subtitle,
+        category = DemoCategory.AUGMENTED_REALITY,
+        icon = Icons.Filled.Straighten,
+        // Ships unverified on AR hardware: the accuracy figure this demo exists to be
+        // honest about has not been measured on a real device yet (AR_MEASURE.md,
+        // "Measured error"). Flip to Working once a device pass fills that table in.
+        status = DemoStatus.InReview,
+    )
+
+    @Composable
+    override fun Screen(onBack: () -> Unit) {
+        ARMeasureDemo(onBack)
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_measure.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_measure.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Strings for the `ar-measure` demo (registered by
+     `ArMeasureFragment.kt`). Android's resource merger
+     fans every `res/values/*.xml` file in, so `R.string.demo_ar_measure_title` etc.
+     remains globally resolvable. Adding a new demo never needs to touch
+     this file or `strings.xml` — see #1870. -->
+<resources>
+    <string name="demo_ar_measure_title">Measure</string>
+    <string name="demo_ar_measure_subtitle">Tap two points, read the distance in cm</string>
+
+    <string name="demo_ar_measure_hint_first">Tap a surface to drop the first point</string>
+    <string name="demo_ar_measure_hint_second">Tap again to measure the distance</string>
+    <string name="demo_ar_measure_total">Chain: %1$s</string>
+    <string name="demo_ar_measure_perimeter">Perimeter: %1$s</string>
+    <string name="demo_ar_measure_last_segment">Last segment: %1$s</string>
+    <string name="demo_ar_measure_bounding_box">Bounding box  W %1$s · H %2$s · D %3$s</string>
+
+    <string name="demo_ar_measure_action_undo">Undo</string>
+    <string name="demo_ar_measure_action_close">Close loop</string>
+    <string name="demo_ar_measure_action_open">Open loop</string>
+    <string name="demo_ar_measure_action_clear">Clear</string>
+
+    <string name="demo_ar_measure_description">Survey a real space — a workshop, a room, a piece of furniture — to size something you are about to build or 3D-print for it. Each tap anchors a point on a detected plane or on the depth map; consecutive points are joined by a labelled segment. Keep tapping for a chain, close the loop for a perimeter.</string>
+    <string name="demo_ar_measure_depth_toggle">Depth-map fallback</string>
+    <string name="demo_ar_measure_depth_supported">Lets you measure clutter, slopes and edges that never grow a plane.</string>
+    <string name="demo_ar_measure_depth_unsupported">Not supported on this device — plane hits only.</string>
+    <string name="demo_ar_measure_accuracy_notice">Accuracy: several centimetres on a phone without a ToF sensor, approaching one centimetre with ToF/LiDAR. Good enough to lay out a space (will it fit, how far apart, what is the clear height). Not a caliper — never use it for a fitting dimension on a printed part. See AR_MEASURE.md.</string>
+</resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MeasureMathTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MeasureMathTest.kt
@@ -1,0 +1,166 @@
+package io.github.sceneview.demo.demos.internal
+
+import io.github.sceneview.math.Position
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for [MeasureMath][measureDistanceMeters] — the arithmetic behind the
+ * `ar-measure` demo's on-screen numbers.
+ *
+ * A wrong distance formula produces a plausible-looking centimetre figure that no
+ * screenshot, emulator run or device QA pass would flag: the label renders, the app does
+ * not crash, and the number is simply false. These tests are the only place that failure
+ * mode is caught, so they pin the value, not merely the shape.
+ */
+class MeasureMathTest {
+
+    private fun p(x: Float, y: Float, z: Float) = Position(x = x, y = y, z = z)
+
+    // ── measureDistanceMeters ───────────────────────────────────────────────
+
+    @Test
+    fun `distance is euclidean across all three axes`() {
+        // 3-4-5 in the XZ plane, lifted 12 on Y: sqrt(25 + 144) = 13.
+        assertEquals(13f, measureDistanceMeters(p(0f, 0f, 0f), p(3f, 12f, 4f)), 1e-4f)
+    }
+
+    @Test
+    fun `distance is symmetric and zero for a degenerate segment`() {
+        val a = p(0.3f, -1.2f, 2f)
+        val b = p(-0.7f, 0.5f, 1f)
+        assertEquals(measureDistanceMeters(a, b), measureDistanceMeters(b, a), 1e-6f)
+        assertEquals(0f, measureDistanceMeters(a, a), 0f)
+    }
+
+    @Test
+    fun `distance ignores sign of the offset`() {
+        // A point behind the origin must read the same as one in front of it — a bug that
+        // dropped the sign would still render a positive-looking centimetre label.
+        assertEquals(2f, measureDistanceMeters(p(0f, 0f, 0f), p(0f, 0f, -2f)), 1e-6f)
+    }
+
+    // ── measureMidpoint ─────────────────────────────────────────────────────
+
+    @Test
+    fun `midpoint is the average of both ends`() {
+        val mid = measureMidpoint(p(0f, 0f, 0f), p(1f, 3f, -5f))
+        assertEquals(0.5f, mid.x, 1e-6f)
+        assertEquals(1.5f, mid.y, 1e-6f)
+        assertEquals(-2.5f, mid.z, 1e-6f)
+    }
+
+    // ── formatCentimeters ───────────────────────────────────────────────────
+
+    @Test
+    fun `formatting converts metres to centimetres with one decimal`() {
+        assertEquals("83.4 cm", formatCentimeters(0.834f))
+        assertEquals("100.0 cm", formatCentimeters(1f))
+    }
+
+    @Test
+    fun `formatting stays in centimetres well past one metre`() {
+        // No unit switch at 1 m: a chain of segments must stay visually comparable.
+        assertEquals("312.7 cm", formatCentimeters(3.127f))
+    }
+
+    @Test
+    fun `formatting never renders sub-millimetre precision`() {
+        // 0.83449 m is 83.449 cm — the tenth-of-a-millimetre digit must not survive,
+        // because the underlying pose has nothing like that precision.
+        assertEquals("83.4 cm", formatCentimeters(0.83449f))
+    }
+
+    @Test
+    fun `formatting uses a dot regardless of the device locale`() {
+        val previous = java.util.Locale.getDefault()
+        try {
+            // fr-FR formats decimals with a comma; the label must not follow it, so a
+            // screenshot or a copied figure reads the same everywhere.
+            java.util.Locale.setDefault(java.util.Locale.FRANCE)
+            assertEquals("83.4 cm", formatCentimeters(0.834f))
+        } finally {
+            java.util.Locale.setDefault(previous)
+        }
+    }
+
+    // ── measurePerimeterMeters ──────────────────────────────────────────────
+
+    @Test
+    fun `perimeter of fewer than two points is zero`() {
+        assertEquals(0f, measurePerimeterMeters(emptyList(), closed = false), 0f)
+        assertEquals(0f, measurePerimeterMeters(listOf(p(1f, 1f, 1f)), closed = true), 0f)
+    }
+
+    @Test
+    fun `open chain sums only the consecutive segments`() {
+        val chain = listOf(p(0f, 0f, 0f), p(1f, 0f, 0f), p(1f, 0f, 1f))
+        assertEquals(2f, measurePerimeterMeters(chain, closed = false), 1e-5f)
+    }
+
+    @Test
+    fun `closing a square adds the fourth side`() {
+        val square = listOf(
+            p(0f, 0f, 0f), p(2f, 0f, 0f), p(2f, 0f, 2f), p(0f, 0f, 2f),
+        )
+        assertEquals(6f, measurePerimeterMeters(square, closed = false), 1e-5f)
+        assertEquals(8f, measurePerimeterMeters(square, closed = true), 1e-5f)
+    }
+
+    @Test
+    fun `closing a two-point chain does not double-count the single segment`() {
+        // Two points make a segment, not a loop: closing must not walk back along it.
+        val pair = listOf(p(0f, 0f, 0f), p(1.5f, 0f, 0f))
+        assertEquals(1.5f, measurePerimeterMeters(pair, closed = true), 1e-5f)
+    }
+
+    // ── measureBoundingBox ──────────────────────────────────────────────────
+
+    @Test
+    fun `bounding box needs at least two points`() {
+        assertNull(measureBoundingBox(emptyList()))
+        assertNull(measureBoundingBox(listOf(p(1f, 2f, 3f))))
+    }
+
+    @Test
+    fun `bounding box spans the extremes on every axis`() {
+        val box = measureBoundingBox(
+            listOf(p(-1f, 0f, 0.5f), p(2f, 1.5f, -0.5f), p(0f, -0.5f, 0f)),
+        )!!
+        assertEquals(3f, box.widthMeters, 1e-5f)   // -1 → 2
+        assertEquals(2f, box.heightMeters, 1e-5f)  // -0.5 → 1.5
+        assertEquals(1f, box.depthMeters, 1e-5f)   // -0.5 → 0.5
+    }
+
+    @Test
+    fun `a flat point set reports a zero extent rather than failing`() {
+        // Every point on one horizontal plane — a floor outline. Height must be 0, not NaN.
+        val box = measureBoundingBox(listOf(p(0f, 1f, 0f), p(1f, 1f, 0f), p(1f, 1f, 1f)))!!
+        assertEquals(0f, box.heightMeters, 0f)
+    }
+
+    // ── measurePointsMoved ──────────────────────────────────────────────────
+
+    @Test
+    fun `a resized point list always counts as moved`() {
+        assertTrue(measurePointsMoved(emptyList(), listOf(p(0f, 0f, 0f))))
+        assertTrue(measurePointsMoved(listOf(p(0f, 0f, 0f)), emptyList()))
+    }
+
+    @Test
+    fun `sub-millimetre anchor jitter does not count as movement`() {
+        val before = listOf(p(0f, 0f, 0f), p(1f, 0f, 0f))
+        val after = listOf(p(0.0002f, 0f, 0f), p(1f, 0.0003f, 0f))
+        assertFalse(measurePointsMoved(before, after))
+    }
+
+    @Test
+    fun `a real anchor correction counts as movement`() {
+        val before = listOf(p(0f, 0f, 0f), p(1f, 0f, 0f))
+        val after = listOf(p(0f, 0f, 0f), p(1.01f, 0f, 0f))
+        assertTrue(measurePointsMoved(before, after))
+    }
+}


### PR DESCRIPTION
Closes #531 — asked in 2024, closed unanswered by the stale bot, re-asked by a second user in July 2025.

## What this adds

`ar-measure`: tap points on the real world, read the distance between them in centimetres on a 3D label anchored at the segment midpoint. Keep tapping for a chain with a running total, close the loop for a perimeter, and read the bounding box (W · H · D) of every point placed.

| File | |
|---|---|
| `demos/ARMeasureDemo.kt` | the demo composable — hit tests, anchors, markers, segments, labels, action bar |
| `demos/internal/MeasureMath.kt` | the arithmetic, pure Kotlin, no ARCore/Filament types |
| `test/.../MeasureMathTest.kt` | 18 JVM tests over that arithmetic |
| `fragments/ArMeasureFragment.kt` | append-only registration (#1797) |
| `res/values/strings_demo_ar_measure.xml` | per-demo strings (#1870) |
| `AR_MEASURE.md` | the sample README — use case and accuracy ceiling |

## Why a new demo rather than extending an existing one

Checked first, as asked. Nothing among the 55 demos measures anything. The closest bricks are `ar-placement` (tap → hit-test → anchor), `ar-depth-collider` (depth), `point-and-ask` (anchored labels) and `lines-paths` (segments) — each contributes a technique, none is a measurement demo. Grafting onto `ar-placement` would have mixed "place a model" with "place survey markers" in one screen; the repo's append-only registration convention makes a separate fragment the cheaper and more honest choice.

## Hit-test order is an accuracy order

1. A detected plane, **gated on `isPoseInPolygon`**. ARCore reports hits on a plane's *infinite extension*; without that check, a tap past the edge of a table anchors in mid-air and reports a confidently wrong distance.
2. A `DepthPoint`.
3. The depth image directly, via `Frame.hitTestDepth` — this is what makes a cluttered space measurable rather than just its flat floor. Auto-disabled where depth is unsupported.
4. A raw feature point, last resort.

The demo names the source of each point on screen ("Point 3 on depth map"): a measuring tool that hides how it got its number cannot be calibrated.

## Anchors, not coordinates

Every point is an ARCore `Anchor`. Poses are re-read every frame, but only pushed into Compose state past a **1 mm** delta — so a real anchor correction is followed while sub-millimetre jitter does not recompose the scene subtree at 60 Hz. Anchors are detached in `onDispose`.

## Honesty about accuracy — the point of the README

`AR_MEASURE.md` states the ceiling plainly: **several centimetres** from motion stereo on a phone with no depth sensor, **towards one centimetre** with ToF/LiDAR. Good for layout (will this cabinet fit this alcove, how far apart are these studs, what is the clear height). Never for a fitting dimension on a printed part, which lives at ±0.1 mm — three orders of magnitude below what this can see. The working rule it gives: *use AR to get the envelope, use calipers for the interface.*

**The "Measured error" table ships empty, on purpose**, with a 5-reading protocol to fill it. No emulator can produce that figure — the ARCore emulator replays a synthetic scene, so a number obtained there would describe the simulation, not the sensor. The demo carries `DemoStatus.InReview` until a device pass fills the table in; flipping it to `Working` belongs in that same PR.

## Rerun export: evaluated, documented, deliberately not wired

There is indeed no official Rerun SDK for Kotlin — but this does **not** require NDK work, and it is not out of scope for a sample. SceneView already ships `io.github.sceneview.ar.rerun.RerunBridge` (JSON lines over TCP → Python sidecar → `.rrd`), exercised by the `ar-rerun` demo. `AR_MEASURE.md` documents the ~6-line wiring and leaves it out: measuring and debugging are separate concerns, and the demo stays about measuring.

## Bounding box caveat

`W · H · D` is axis-aligned to the ARCore **world** frame. `+Y` is gravity-up so `H` is meaningful; `X`/`Z` are fixed at session start, so `W`/`D` are extents along two arbitrary horizontal axes. An object-aligned box would need a horizontal PCA plus a "which side is width" convention, and would become the thing the demo teaches. Documented in both the KDoc and the README.

## Verification

- `:samples:android-demo:testDebugUnitTest --tests '*MeasureMathTest*'` → **18/18**, 0 failures. Mutation-tested: dropping the `z` term from the distance formula fails 4 of the 18, so the suite bites. This layer matters because a wrong formula produces a plausible label — no crash, a screenshot that looks right, a false number that no visual QA catches.
- `impact-check.sh` → PASS (2 warnings, both pre-existing node-parity ones).
- `pre-push-check.sh` → **all 14 green** (`gpt/knowledge-*.md` regenerated via `tools/generate-gpt-knowledge.js`, never hand-edited).
- On `emulator-5554`: screen mounts, title, hint pill and settings FAB render, process alive, no crash. The viewport stays black because the AVD is arm64 and ARCore has no arm64 emulator build (#2754) — which is exactly why the accuracy table is empty and the status is `InReview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)