### PR TITLE
test(android-demo): tighten the render-golden guards after review (#3100)

### DIFF
--- a/changelog.d/2323-demo-render-goldens.md
+++ b/changelog.d/2323-demo-render-goldens.md
@@ -3,9 +3,11 @@
   its fourteen baselines had been recorded as empty viewports — four as 320×544 all-black
   captures, three (`fog`, `lighting`, `lines-paths`) as full-size frames whose SceneView
   band never rendered — and one (`secondary-camera`) was missing entirely, so those cases
-  either compared against nothing or compared nothing against nothing. All fourteen
-  goldens are re-recorded from settled renders and verified over two consecutive full
-  runs ([#2323](https://github.com/sceneview/sceneview/issues/2323)).
+  either compared against nothing or compared nothing against nothing. Eleven goldens are
+  re-recorded from settled renders and one (`secondary-camera`) is added; the two that
+  already depicted a correct settled render (`custom-geometry`, `two-d-in-three-d`) are
+  left byte-for-byte untouched. All fourteen cases pass under the new guards over two
+  consecutive full runs ([#2323](https://github.com/sceneview/sceneview/issues/2323)).
 - The harness refuses the states that produced those baselines: a committed golden with a
   flat SceneView band fails as `DEGENERATE`, a capture whose viewport never rendered fails
   instead of being recorded, and the run waits for the `qa_mode` badge so a splash screen

--- a/changelog.d/3100-render-golden-review-followups.md
+++ b/changelog.d/3100-render-golden-review-followups.md
@@ -1,0 +1,6 @@
+<!-- category: Tests -->
+- `DemoRenderingScreenshotTest` validates each demo slug against a lower-kebab pattern
+  before it reaches the shell command that launches the demo, and waits on the qa_mode
+  pill's full text (`QA ×`) rather than the bare substring `QA`, which demo copy and
+  control labels can also contain. Review follow-ups to
+  [#3100](https://github.com/sceneview/sceneview/pull/3100).

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/render/DemoRenderingScreenshotTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/render/DemoRenderingScreenshotTest.kt
@@ -38,12 +38,16 @@ import kotlin.math.abs
  *   - Or simply `connectedDebugAndroidTest` against a tethered Pixel during local dev
  *
  * **Goldens**: PNGs in `samples/android-demo/src/androidTest/assets/render-goldens/`.
- * On first run (no golden), the captured image is saved as the new golden and the
- * test is `assumeTrue`-skipped — re-run to verify.
+ * On first run (no golden), the captured image is saved for promotion and the test is
+ * `assumeTrue`-skipped — re-run to verify. That skip is available ONLY to a golden that
+ * has never been baselined: once a name is listed in [BASELINED_GOLDENS], a missing
+ * asset is a hard failure, so deleting a baseline cannot turn its case green by absence.
  *
- * **Diff images**: when a comparison fails, the diff image is written to
- * `getExternalFilesDir("render-test-output")` on the device with failing pixels
- * highlighted in red. Pull via `adb pull` for review.
+ * **Diff images**: when a comparison fails, the diff image is written with failing
+ * pixels highlighted in red — to `/sdcard/Download/SceneView/test-captures` when that
+ * is writable (it survives AGP's post-test uninstall), otherwise to
+ * `getExternalFilesDir("render-test-output")`. Every failure message states the path it
+ * actually used. Pull via `adb pull` for review.
  */
 @RunWith(AndroidJUnit4::class)
 class DemoRenderingScreenshotTest {
@@ -284,6 +288,20 @@ class DemoRenderingScreenshotTest {
         device.wakeUp()
         device.executeShellCommand("wm dismiss-keyguard")
 
+        // The slug is interpolated into a string that a shell interprets, so it is
+        // validated rather than quoted. Quoting was tried first and is WRONG here:
+        // `UiDevice.executeShellCommand` does not give the argument full shell-quoting
+        // semantics, and the quotes ended up inside the extra — every one of the 14
+        // demos then launched to the demo LIST, and the suite failed with "never
+        // composed". A whitelist is both correct and stricter: today every caller passes
+        // a constant, but the tab-aware deep-link parameter noted below is exactly the
+        // change that would start sourcing a slug from a Gradle property or a
+        // parameterised test.
+        require(demoSlug.matches(DEMO_SLUG_PATTERN)) {
+            "Refusing to build a shell command from slug '$demoSlug': demo slugs must " +
+                "match ${DEMO_SLUG_PATTERN.pattern}."
+        }
+
         // Launch the demo with qa_mode = true so spin loops, scene rotation, and
         // cinematic camera scripts freeze at deterministic values
         // (DemoMath.nextSpinDegrees pinned, rememberHeroYaw → staticYaw, AnimationDemo
@@ -312,7 +330,13 @@ class DemoRenderingScreenshotTest {
         // present on whatever screen preceded the launch, so it reads as "ready" a frame too
         // early. Measured on all 14 demo slugs: badge absent on the splash, present once the
         // demo is composed.
-        val demoComposed = device.wait(Until.hasObject(By.textContains("QA")), DEMO_COMPOSE_TIMEOUT_MS)
+        // Match the pill's full text, not the bare word: "QA" alone appears in demo copy
+        // and control labels, and a substring that loose would report "composed" on the
+        // wrong screen. The pill is `" QA ×"` in DemoScaffold — its testTag is not
+        // reachable from UiAutomator (the app does not set `testTagsAsResourceId`), so
+        // the visible text is the cue. Renaming the pill breaks this wait loudly, by
+        // timeout, which is the failure mode we want.
+        val demoComposed = device.wait(Until.hasObject(By.textContains(QA_PILL_TEXT)), DEMO_COMPOSE_TIMEOUT_MS)
         assertTrue(
             "Demo '$demoSlug' never composed: the qa_mode badge never appeared within " +
                 "${DEMO_COMPOSE_TIMEOUT_MS}ms, so the screen on display is not the demo. " +
@@ -597,6 +621,12 @@ class DemoRenderingScreenshotTest {
          * and ~6x below the weakest signal, so neither population is near the boundary.
          */
         const val MIN_CONTENT_SPREAD = 32
+
+        /** Exact text of `DemoScaffold`'s qa_mode pill — the positive cue that the demo composed. */
+        const val QA_PILL_TEXT = "QA ×"
+
+        /** Every demo slug in `DemoRegistry` is lower-kebab; nothing here reaches a shell unchecked. */
+        val DEMO_SLUG_PATTERN = Regex("[a-z0-9]+(-[a-z0-9]+)*")
 
         const val MAX_SETTLE_MS = 25_000L
 


### PR DESCRIPTION
Follow-up to #3100 (merged), addressing the five reviewer warnings it carried. Part of #2323.

- **[doc]** The changelog fragment claimed "all fourteen goldens re-recorded". Eleven were
  re-recorded and one added; `custom-geometry` and `two-d-in-three-d` were deliberately left
  byte-for-byte untouched because they already depicted a correct settled render. Corrected.
- **[code]** *"Confirm the two untouched goldens were actually exercised."* They were, and are:
  every run below is a full-suite run under the new light-mode pinning, and both cases pass —
  **14 tests, 0 failed, 0 skipped** on emulator-5554. Their goldens predate the pinning but
  were recorded light, which the passing comparison is the evidence for.
- **[security]** The demo slug reached a shell command uninterpolated. It is now validated
  against `[a-z0-9]+(-[a-z0-9]+)*` before use.

  Worth recording for whoever touches this next: **quoting it was tried first, and is wrong.**
  `UiDevice.executeShellCommand` does not apply shell-quoting semantics, so `--es demo
  '$slug'` put the quote characters *inside* the extra. All fourteen demos launched to the
  demo list instead of the demo, and the suite failed 14/14 with `never composed`. The
  whitelist is both correct and stricter than quoting would have been.
- **[code]** `By.textContains("QA")` accepted any visible text containing `QA`. Now matches the
  pill's full text `QA ×`. The pill's `testTag` is not reachable from UiAutomator (the app does
  not set `testTagsAsResourceId`), so visible text is the only cue available — a rename breaks
  this wait loudly, by timeout, which is the failure mode we want.
- **[doc]** Class KDoc described `getExternalFilesDir` as the only artifact path and omitted the
  `BASELINED_GOLDENS` hard-failure path. Both now match the code.

## Verification

`connectedDebugAndroidTest` on emulator-5554 (Pixel_7a, 1080×2400): **14 tests, 0 failed,
0 skipped**. The intermediate 14/14 red described above is the measurement that rejected the
quoting approach — it is quoted here rather than hidden because it is the reason the final
shape is a whitelist.

Test-only change: no library or public-API source touched, no version file touched.