### PR TITLE
fix(scripts): make check-doc-drift see uncommitted public-API declarations

### DIFF
--- a/.claude/scripts/check-doc-drift.sh
+++ b/.claude/scripts/check-doc-drift.sh
@@ -194,16 +194,26 @@ run_diff_mode() {
     local decl_changed=false
     if [[ -n "${DOC_DRIFT_FILES:-}" ]]; then
         decl_changed=true   # explicit file injection → no hunk to inspect, check docs
-    elif [[ -n "$range" ]]; then
-        # shellcheck disable=SC2086
-        local apidiff; apidiff="$(git diff $range -- $api_changed 2>/dev/null || true)"
-        if grep -E "^[+-]" <<<"$apidiff" \
-             | grep -vE "$nonpublic_re" \
-             | grep -qE "$public_decl_re|$swift_decl_re"; then
+    else
+        # The hunk delta MUST be computed over the same universe as
+        # `changed_files()` — commit range UNION working tree. A commit range
+        # alone excludes uncommitted work, so a developer running this by hand
+        # before committing (the case CLAUDE.md's quality list points at) got a
+        # false "no public declaration was added/removed/retyped": the file list
+        # saw the working tree, the decl regex never did (#3008).
+        # shellcheck disable=SC2086  # $range is word-split into "A B"; $api_changed is a file list.
+        local apidiff; apidiff="$(
+            { [[ -n "$range" ]] && git diff $range -- $api_changed 2>/dev/null || true
+              git diff -- $api_changed 2>/dev/null || true          # unstaged
+              git diff --cached -- $api_changed 2>/dev/null || true # staged
+            })"
+        if [[ -z "$apidiff" ]]; then
+            decl_changed=true   # can't compute a hunk diff → assume worth checking
+        elif grep -E "^[+-]" <<<"$apidiff" \
+               | grep -vE "$nonpublic_re" \
+               | grep -qE "$public_decl_re|$swift_decl_re"; then
             decl_changed=true
         fi
-    else
-        decl_changed=true   # can't compute a hunk diff → assume worth checking
     fi
 
     if [[ "$decl_changed" == false ]]; then

--- a/.claude/scripts/test-check-doc-drift.sh
+++ b/.claude/scripts/test-check-doc-drift.sh
@@ -98,5 +98,27 @@ set -e
     && ok "body-only change → no false-positive warning" \
     || bad "body-only change should not warn (rc=$RC)"
 
+# 6c. UNCOMMITTED public-decl change — the local pre-commit case a developer
+#     actually runs by hand. `changed_files()` unions the working tree, so the
+#     FILE list sees it; the decl delta must see it too. Before the fix it was
+#     computed from a COMMIT range only, so the hunk was invisible and the check
+#     reported a false "no public declaration was added/removed/retyped" —
+#     structurally blind exactly where CLAUDE.md points developers (#3008).
+(
+    cd "$SCRATCH"
+    mkdir -p SceneViewSwift/Sources
+    printf 'struct SceneView {\n    func internalThing() {}\n}\n' > SceneViewSwift/Sources/SceneView.swift
+    git add -A && git commit -qm "swift base"
+    # Uncommitted: add a genuinely public Swift declaration.
+    printf 'struct SceneView {\n    func internalThing() {}\n\n    public func contentID(_ id: String) {}\n}\n' \
+        > SceneViewSwift/Sources/SceneView.swift
+)
+set +e
+OUT="$(cd "$SCRATCH" && bash "$SCRIPT" 2>&1)"; RC=$?
+set -e
+{ [[ $RC -eq 0 ]] && ! grep -q "no public declaration was added" <<<"$OUT"; } \
+    && ok "uncommitted public-decl change → detected (not reported as 'no public declaration')" \
+    || bad "uncommitted public-decl change must not report 'no public declaration' (rc=$RC)"
+
 echo "  → $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/changelog.d/3008-doc-drift-uncommitted-blindspot.md
+++ b/changelog.d/3008-doc-drift-uncommitted-blindspot.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- `check-doc-drift.sh` no longer reports a false "no public declaration was added/removed/retyped" for an uncommitted public-API change. The changed-file list unioned the working tree while the public-declaration delta was computed from a commit range only, so the gate was blind in the local pre-commit case a developer actually runs by hand.
+<!-- Measured on SceneViewSwift/Sources/SceneViewSwift/SceneView.swift (#3008): before → "✓ OK Public-API files changed, but no public declaration was added/removed/retyped."; after → "⚠ WARN Public API changed but `llms.txt` was not updated." Regression test 6c in test-check-doc-drift.sh fails before the fix (7/8) and passes after (8/8). -->


### PR DESCRIPTION
## Problem

`run_diff_mode` in `.claude/scripts/check-doc-drift.sh` reported a false **OK** for any public-API change that was not yet committed.

The two halves of the check looked at different things:

- `changed_files()` unions the commit range with `git diff --name-only` (unstaged) and `--cached` (staged) — so the **file list** sees the working tree.
- The public-declaration delta ran `git diff $range -- $api_changed`, where `resolve_range()` returns a **commit** range (`origin/$BASE_REF HEAD`, …). A commit range excludes uncommitted work entirely, so the regex matched nothing and `decl_changed` stayed `false`.

Net effect: the gate was structurally blind exactly in the local pre-commit case — the one a developer runs by hand, and the one CLAUDE.md's quality list points at.

## Fix

The decl delta now spans the same universe as the file list: commit range **plus** unstaged **plus** staged. The commit-range path is unchanged for CI / `BASE_REF` (a clean CI tree contributes two empty diffs).

## Measurement

Real repro, uncommitted `public func` appended to `SceneViewSwift/Sources/SceneViewSwift/SceneView.swift` (#3008):

```
=== BEFORE FIX ===
✓ OK   Public-API files changed, but no public declaration was added/removed/retyped.
=== AFTER FIX ===
⚠ WARN Public API changed but `llms.txt` was not updated.
```

Regression test **6c** added to `.claude/scripts/test-check-doc-drift.sh` — commits a Swift file, then adds a `public func` and leaves it uncommitted:

```
before fix:  ✗ uncommitted public-decl change must not report 'no public declaration' (rc=0)
             → 7 passed, 1 failed
after fix:   ✓ uncommitted public-decl change → detected (not reported as 'no public declaration')
             → 8 passed, 0 failed
```

## Gates

- `bash .claude/scripts/test-check-doc-drift.sh` → 8/8
- `shellcheck -S warning` on both scripts → clean
- `bash .claude/scripts/impact-check.sh` → PASS (2 pre-existing cross-platform parity warnings, unrelated)
- `bash .claude/scripts/pre-push-check.sh` → **ALL CHECKS PASSED** (14/14; iOS golden step is the usual "no golden yet" ⚠)

## Known adjacent gap (not fixed here)

`swift_decl_re` does not match `public extension Foo { … }` — a `public extension` whose members carry no explicit `public` keyword still slips past. Separate blind spot, filed separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)