### PR TITLE
refactor(method): make the statusline answer the question /status was asked 546 times

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -38,8 +38,17 @@ if [[ -z "$ROOT" ]]; then
   exit 0
 fi
 
-# Branch — short, omit "(HEAD detached at …)" verbosity.
-BRANCH="$(git -C "$ROOT" symbolic-ref --short HEAD 2>/dev/null || git -C "$ROOT" rev-parse --short HEAD 2>/dev/null)"
+# Branch — short, omit "(HEAD detached at …)" verbosity. A detached HEAD is called out
+# explicitly: in a repo worked through worktrees it is a real footgun (commits land on no
+# branch, and the checkout silently serves weeks-old files), and a bare SHA does not say
+# so. The main clone sat detached for three weeks before anyone noticed.
+# `|| true` is load-bearing: under `set -e`, symbolic-ref's non-zero exit on a detached
+# HEAD kills the whole statusline and prints nothing at all.
+BRANCH="$(git -C "$ROOT" symbolic-ref --short HEAD 2>/dev/null || true)"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="detached@$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null)"
+  DETACHED=1
+fi
 
 # Worktree marker: when ROOT lives under .claude/worktrees/, prefix the slug.
 WORKTREE_MARKER=""
@@ -56,6 +65,15 @@ if [[ -f "$ROOT/gradle.properties" ]]; then
   VERSION="$(awk -F= '$1=="VERSION_NAME"{print $2; exit}' "$ROOT/gradle.properties" 2>/dev/null)"
 fi
 
+# Unsafe work — the two signals that answer "is anything of mine still stranded?".
+# Both are local git, sub-10ms; deliberately SILENT when zero, so the line only speaks
+# when something can actually be lost. This is what a /status turn used to cost a model
+# call to find out (546 invocations in 30 days, measured 2026-08-11).
+DIRTY="$( { git -C "$ROOT" status --porcelain 2>/dev/null || true; } | wc -l | tr -d ' ')"
+[[ "$DIRTY" == "0" ]] && DIRTY=""
+UNPUSHED="$(git -C "$ROOT" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+[[ "$UNPUSHED" == "0" ]] && UNPUSHED=""
+
 # Free RAM (GB) — useful for the emulator pool. macOS-only path; Linux fallback skipped.
 FREE_RAM=""
 if command -v vm_stat >/dev/null 2>&1; then
@@ -70,7 +88,12 @@ fi
 
 # Compose the line — terse, single-line, no trailing newline (Claude adds one).
 parts=()
-[[ -n "$BRANCH" ]]     && parts+=("${CYAN}${BRANCH}${RESET}${WORKTREE_MARKER}")
+if [[ -n "$BRANCH" ]]; then
+  BRANCH_COLOR="$CYAN"; [[ -n "${DETACHED:-}" ]] && BRANCH_COLOR="$YELLOW"
+  parts+=("${BRANCH_COLOR}${BRANCH}${RESET}${WORKTREE_MARKER}")
+fi
+[[ -n "$DIRTY" ]]      && parts+=("${YELLOW}●${DIRTY}${RESET}")
+[[ -n "$UNPUSHED" ]]   && parts+=("${YELLOW}↑${UNPUSHED}${RESET}")
 [[ -n "$VERSION" ]]    && parts+=("${GREEN}v${VERSION}${RESET}")
 [[ -n "$FREE_RAM" ]]   && parts+=("${YELLOW}${FREE_RAM}GB free${RESET}")
 [[ -n "$MODEL_NAME" ]] && parts+=("${DIM}${MODEL_NAME}${RESET}")

--- a/changelog.d/3113-status-close-statusline.md
+++ b/changelog.d/3113-status-close-statusline.md
@@ -1,0 +1,10 @@
+<!-- category: Changed -->
+<!-- Maintainer note: phase 2 of the measurement-driven method refactor (#3111).
+     `/status` was invoked 546 times in 30 days — ~18/day, an order of magnitude more
+     than any other surface, and every project slash command measured zero. It was also
+     the least useful: its own "finish the work instead of reporting" rule sat in the
+     last section, after 40 lines of report format, so the model reported and stopped. -->
+
+The Claude Code statusline now shows unsafe work: `●n` uncommitted files and `↑n`
+unpushed commits, both silent when zero. These are the two signals that answer "is
+anything still stranded?" — previously that question cost a full model turn to answer.


### PR DESCRIPTION
Closes #3113. Phase 2 of the measurement-driven method refactor (#3111).

## What the telemetry said

| Surface | Invocations / 30 days |
|---|---|
| `/status` | **546** (~18/day) |
| `/compact` | 333 |
| `/close` | 145 |
| every project slash command (`/release`, `/review`, `/version-bump`, …) | **0** |

`/status` is the most-used surface in the setup by an order of magnitude, and the one
that returned the least — its reported failure mode was a report whose verdict is "in
progress", which costs the next turn to type "continue".

## Why it failed

1. **Instruction ordering defeated the instruction.** The skill already carried "finish
   the work instead of reporting it" — in its *last* section, after 40 lines of report
   format. The model produced the report and stopped.
2. **Five separate shell calls** per invocation, at ~15k billed tokens each.
3. **The verdict taxonomy encoded the bug.** `ARCHIVABLE / IN PROGRESS / BLOCKED` — "in
   progress" is a non-answer. A status able to say "work is advancing" should advance it.
4. **The question was never "which branch".** A statusline was already configured, showing
   branch, version and free RAM — but not uncommitted or unpushed work, which is exactly
   the "did you leave something stranded?" signal being asked for 18 times a day.

## Changes

- **`statusline.sh` carries the stranded-work signals**: `●n` uncommitted, `↑n` unpushed.
  Both **silent when zero**, so the line only speaks when something can actually be lost.
  This answers, at zero tokens, the question that was costing a model turn.
- **Detached HEAD is now called out** — `detached@<sha>` in yellow instead of a bare SHA.
  In a repo worked through worktrees a detached checkout silently serves weeks-old files
  and lands commits on no branch. This is not hypothetical: the main clone on this host
  has been detached for three weeks, and the new line renders it as
  `detached@7c55690b8 ●4 v4.26.0` while `main` is at 4.28.0 — it fooled this session once
  before the marker existed.
- **`/status` and `/close` rebuilt** (in the private preferences repo, installed by
  `apply-rules.sh`): routing decision **first**, one batched measurement call, three
  exits, and no "in progress". Exit 1 is *do the work now, do not report*.

## What was deliberately NOT changed

- **No skill was deleted.** All 8 project skills were audited by **entry point**, not by
  invocation count: each has 1–16 referencing files. Six of them were never loaded in 30
  days, which makes them insurance rarely claimed — not dead code. Deleting on
  "never invoked" is precisely the inference that broke `triptych.js` in #3111.
- `model-handoff`, `mcp-session-start`, `publish-preflight` were left alone — they have no
  measured defect, and churning them would be the over-engineering this refactor removes.

## Claude Code feature audit (2.1.226)

The setup is already current: `crossSessionInbound` and `dialogExpiry` (2.1.224) are
configured, sandbox and Remote Control changes need no action. One genuinely unexploited
native capability was the statusline, adopted here. Cross-session `SendMessage` (2.1.224)
partly supersedes the RELAY file for *live* recipients; the `/relay` skill now draws the
line — live recipient → message, future recipient → RELAY.

## Verification

- `bash .claude/scripts/pre-push-check.sh` — full gate, output quoted in the thread.
- Statusline rendered in all three states: branch + dirty, detached + dirty, and not-in-git.
- **A regression was caught by that test and fixed**: under `set -eo pipefail`,
  `git symbolic-ref` exits non-zero on a detached HEAD, which killed the whole script and
  printed *nothing* — in exactly the case the change was meant to flag. The `|| true` is
  load-bearing and commented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
