### PR TITLE
fix(workflows): keep an unverified ERROR blocking in review-fanout

### DIFF
--- a/.claude/workflows/review-fanout.js
+++ b/.claude/workflows/review-fanout.js
@@ -123,9 +123,17 @@ const reviewed = await pipeline(
 
 Try to REFUTE it. Read the actual code at that location and reproduce the failure if it is a runtime/compile claim (e.g. grep the call site, check the signature, trace the thread). Default to real=false if you cannot independently confirm a genuine, merge-blocking problem. Only real=true if you confirm it.`,
           { label: `verify:${r.key}`, phase: 'Verify', schema: VERDICT_SCHEMA, model: 'opus', effort: 'xhigh' },
-        ).then((v) => ({ ...f, reviewer: r.key, verified: v })),
+        ).then((v) => ({ ...f, reviewer: r.key, verified: v || null })),
       ),
-    ).then((verified) => ({ ...res, verifiedErrors: verified.filter(Boolean) }))
+      // A verifier that returned NOTHING refuted nothing. Dropping it (the old
+      // `.filter(Boolean)`) erased the ERROR and let merge_recommendation reach MERGE on a
+      // finding nobody ever checked — the exact false-green this workflow guards against one
+      // branch up (REVIEW_INCOMPLETE). A dead verifier is reachable: `model:'opus'` above is
+      // hard-pinned, so an exhausted Opus quota kills it. Keep the finding, mark it unverified.
+    ).then((verified) => ({
+      ...res,
+      verifiedErrors: verified.map((v, i) => v || { ...errors[i], reviewer: r.key, verified: null }),
+    }))
   },
 )
 
@@ -133,6 +141,8 @@ const results = reviewed.filter(Boolean)
 const reviewersRan = results.length
 const reviewersExpected = REVIEWERS.length
 const confirmedErrors = results.flatMap((res) => (res.verifiedErrors || []).filter((f) => f.verified?.real))
+// Neither confirmed nor refuted — the verifier died. These are NOT clean.
+const unverifiedErrors = results.flatMap((res) => (res.verifiedErrors || []).filter((f) => !f.verified))
 const allWarnings = results.flatMap((res) => (res.findings || []).filter((f) => f.severity === 'warning').map((f) => ({ ...f, reviewer: res.reviewer })))
 const propagation = results.flatMap((res) => res.propagation || [])
 
@@ -144,7 +154,7 @@ const breakingApi = confirmedErrors.some((f) => f.reviewer === 'impact')
 // NEVER recommend MERGE on an incomplete review — a dropped reviewer makes "no findings"
 // meaningless (absence of evidence ≠ evidence of safety).
 const merge_recommendation =
-  reviewersRan < reviewersExpected ? 'REVIEW_INCOMPLETE'
+  reviewersRan < reviewersExpected || unverifiedErrors.length ? 'REVIEW_INCOMPLETE'
     : confirmedErrors.length ? 'DO_NOT_MERGE'
       : allWarnings.length ? 'MERGE_AFTER_WARNINGS'
         : 'MERGE'
@@ -154,12 +164,15 @@ const merge_recommendation =
 const autonomousAction =
   merge_recommendation === 'MERGE' ? 'auto-merge (squash --auto), no maintainer gate'
     : merge_recommendation === 'MERGE_AFTER_WARNINGS' ? 'fix warnings in the same PR, then auto-merge'
-      : merge_recommendation === 'REVIEW_INCOMPLETE' ? 'NEVER merge — re-run, investigate why a reviewer dropped'
+      : merge_recommendation === 'REVIEW_INCOMPLETE' ? 'NEVER merge — re-run, investigate why a reviewer or a verifier dropped'
         : breakingApi ? 'DRAFT PR + STOP for the maintainer — breaking public-API / cross-platform divergence'
           : 'fix the confirmed root cause, then re-run review-fanout (do not merge)'
 
 if (reviewersRan < reviewersExpected) {
   log(`⚠️ only ${reviewersRan}/${reviewersExpected} reviewers completed — REVIEW_INCOMPLETE, not MERGE`)
+}
+if (unverifiedErrors.length) {
+  log(`⚠️ ${unverifiedErrors.length} ERROR finding(s) got no verdict (verifier died) — REVIEW_INCOMPLETE, not MERGE`)
 }
 log(`Verdict: ${merge_recommendation}${breakingApi ? ' (BREAKING public-API — maintainer gate)' : ''} → ${autonomousAction}`)
 
@@ -195,6 +208,7 @@ return {
   reviewersRan,
   reviewersExpected,
   confirmedErrors,
+  unverifiedErrors,
   warnings: allWarnings,
   propagation,
   perReviewer: results.map((r) => ({ reviewer: r.reviewer, verdict: r.verdict, errorCount: (r.findings || []).filter((f) => f.severity === 'error').length })),

--- a/changelog.d/3119-review-fanout-unverified-error.md
+++ b/changelog.d/3119-review-fanout-unverified-error.md
@@ -1,0 +1,6 @@
+<!-- category: Fixed -->
+`review-fanout` no longer recommends MERGE when an ERROR finding got no verdict. A
+verifier agent that dies (reachable via an exhausted quota on its pinned model) used to
+have its finding silently dropped, taking `confirmedErrors` to zero and clearing the
+auto-merge gate on a change whose blocking findings were never checked. Such a finding is
+now kept and marked unverified, which routes the run to `REVIEW_INCOMPLETE`.


### PR DESCRIPTION
Closes #3119. Follow-up to the measurement-driven method refactor (#3111, #3113): the
audit of the most-invoked *model-invoked* surfaces, as opposed to the typed slash commands
covered by #3113.

## The defect

`review-fanout.js` is the autonomous-merge safety gate. It already guards the case where a
**reviewer** dies — `REVIEW_INCOMPLETE`, carrying the comment *"Absence of evidence is
NEVER evidence of safety; this can never become a false MERGE."*

The symmetric case — a **verifier** dying — was not guarded:

1. Every ERROR finding is adversarially verified by its own agent.
2. That agent can return `null`; the Workflow contract states an agent returns null when
   it "dies on a terminal API error after retries".
3. `.filter(Boolean)` then dropped the finding entirely.
4. `confirmedErrors` reached zero, `reviewersRan === reviewersExpected` held, so
   `merge_recommendation` returned **`MERGE`** and `autonomousAction` returned
   *"auto-merge (squash --auto), no maintainer gate"*.

A change with confirmed blocking findings could auto-merge because the agent meant to
check them never answered.

This is reachable rather than theoretical: the verifier is pinned `model: 'opus'`, so an
exhausted Opus quota is enough to kill it — and quota exhaustion correlates with heavy
sessions, which are exactly the sessions producing large diffs.

## The fix

A verifier that returned no verdict refuted nothing. The finding is kept and marked
`verified: null`, and any such finding routes the run to `REVIEW_INCOMPLETE` — reusing the
semantics already present one branch up rather than inventing a new verdict. The result
object now also exposes `unverifiedErrors` so the orchestrator can see *why* the review
was incomplete.

The failure mode is inverted: an infrastructure failure now blocks a merge instead of
clearing one.

## Also in this PR's scope, not in this diff

`model-handoff` carried the same defect class as `/status` in #3113 — its decisive rule
("a handoff with a leak is not finished") sat in the **last line, below the output
template**, so it never fired. Fixed in the private preferences repo that installs it.

## Verification

- `bash .claude/scripts/pre-push-check.sh` — `✓ ALL CHECKS PASSED — safe to push`,
  including `[18/20] ✓ workflow shell/JS blocks parse` and `[14/20] ✓ public API matches
  the committed .api dumps`. The one warning (third-party CDN in HTML) is the documented
  jsDelivr distribution path for `sceneview-web`, unrelated to this diff.
- Script parsed as an async function body (how the Workflow runtime evaluates it) —
  `PARSE OK`. Note that `node --check` is the *wrong* probe here and reports a false
  failure on `return` at top level, on this file before the change as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
