### PR TITLE
fix(ci): a fork PR showed a green review check nobody had read

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -211,6 +211,27 @@ jobs:
 
       # Positive cue, not an absence: say out loud that no review happened and
       # exactly how to get one. A quiet pass here would read as "reviewed, clean".
+      #
+      # It ALSO exits non-zero (#3117). Writing the summary was not enough: on a
+      # fork `pull_request` the `GITHUB_TOKEN` is read-only, so this workflow
+      # cannot comment on the PR either — the warning ends up on the job summary
+      # page, one click away, while `gh pr checks` shows a plain
+      # `Agent review  pass`. Measured on PR #3109 (fork
+      # `ber4444:fix-compose-isrendering`, run 31519731643): green check, no
+      # comment, no reviewer having read a line. A fork PR is by definition code
+      # from outside the repo and is the case that needs the loudest signal, not
+      # the quietest.
+      #
+      # Red does NOT hold the merge button: `Agent review` is in
+      # `ADVISORY_CHECKS` in `ci-gate.yml`, deliberately and documented there.
+      # This only stops the check from READING as reviewed. `neutral` would look
+      # better in the UI, but setting a conclusion needs the Checks API and a
+      # write token — precisely what a fork run does not have. Red-and-honest
+      # beats green-and-silent.
+      #
+      # It goes green again on any PR that can actually be reviewed, and the
+      # documented rescue path is unchanged:
+      #     gh workflow run pr-review.yml -f pr=<N>
       # The budget guard is NOT redundant with the credentials check. Over
       # budget, `Check reviewer credentials` never runs, so `has_token` is the
       # empty string — which satisfies `!= 'true'` and would make this step
@@ -242,7 +263,10 @@ jobs:
             echo "gh workflow run pr-review.yml -f pr=$PR_NUM"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::warning title=PR not reviewed::No reviewer credentials in this run — see the job summary. Do not read this check as a clean review."
+          echo "::error title=PR not reviewed::No reviewer credentials in this run — no reviewer read this PR. See the job summary. This check is ADVISORY and does not block the merge; it is red so it cannot be mistaken for a clean review."
+          # See the block above this step: red-and-honest, deliberately, and the
+          # last thing the step does so the summary is always written first.
+          exit 1
 
       # claude-code-action refuses to run when the workflow file differs from
       # the copy on the default branch — an anti-exfiltration guard, since a PR

--- a/changelog.d/3117-fork-pr-unreviewed-false-green.md
+++ b/changelog.d/3117-fork-pr-unreviewed-false-green.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **A fork PR could show a green review check nobody had read ([#3117](https://github.com/sceneview/sceneview/issues/3117)).** A run without reviewer credentials — every pull request from a fork — reported its inability to review as a warning and exited zero, so `Agent review` went green on a PR no reviewer had opened (measured on #3109). The step now fails, which is honest rather than blocking: `Agent review` is advisory, so a red mark there does not stop the merge; it only stops the run from being mistaken for a clean review.


### PR DESCRIPTION
Closes #3117

## The false green

`pr-review.yml` has no reviewer credentials on a pull request from a fork — that is
by design, GitHub does not hand secrets to fork runs. The workflow reported that
condition as a `::warning` and exited **zero**, so `Agent review` showed a green tick
on a PR that no reviewer had opened.

Measured on #3109, run [31519731643](https://github.com/sceneview/sceneview/actions/runs/31519731643).

This is the project's most expensive bug class: a chain that reports a verdict it
never computed. A red check gets investigated; a green one that means "nobody looked"
gets merged on.

## The fix

The step now exits 1.

That is **honest rather than blocking**. `Agent review` is in `ADVISORY_CHECKS`, so a
red mark there does not gate the merge — a fork contributor is not stuck. It only
stops the run from being read as a clean review.

`neutral` would be the ideal conclusion, and the code comment says so: it needs the
Checks API and a write token, which a credential-less fork run does not have. That is
the same missing credential that caused the problem, so there is no version of this
where the run quietly concludes `neutral` on its own.

Ordering is deliberate: the job summary is written first and the `::error` is the last
thing the step does, so a reader lands on the explanation instead of a bare failure.

## Why this is its own PR

`claude-code-action` refuses to run on any PR that edits `pr-review.yml` — an
anti-exfiltration guard, since a PR able to rewrite the workflow could redirect the
credential. It was originally bundled into #3124, which turned that PR's `Agent
review` red by design and would have left a security-adjacent bridge fix unread by
every reviewer lens. Split so #3124 gets a real review.

The consequence here is unavoidable and expected: **this** PR's `Agent review` will be
red for the self-modification reason, and the diff needs human eyes. It is 26 lines,
25 of which are the comment block explaining the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
