### PR TITLE
fix(ci): keep the NOT REVIEWED comment out of the checkout, and out of pagination (#3028)

### DIFF
--- a/.claude/scripts/test-selfmod-guard.sh
+++ b/.claude/scripts/test-selfmod-guard.sh
@@ -199,6 +199,25 @@ run_guard() {
   return 0
 }
 
+# calls_were <expected-log> <pass-message> <fail-message>
+#
+# Compares the WHOLE recorded call log, never a line within it. `grep -qx` was
+# not enough and this is not theoretical: a lookup that returns three ids builds
+# the endpoint `…/comments/99123<newline>99123<newline>99123`, whose FIRST LINE
+# is byte-identical to the correct call — so `grep -qx` passed on a mutant that
+# had removed the pagination guard entirely. An exact comparison also makes
+# "PATCHed and then POSTed as well" a failure without a separate assertion.
+calls_were() {
+  local expected="$1" pass_msg="$2" fail_msg="$3"
+  local actual
+  actual="$(cat "$TMP/gh-calls" 2>/dev/null)"
+  if [ "$actual" = "$expected" ]; then
+    ok "$pass_msg"
+  else
+    bad "$fail_msg — expected exactly [$expected], got [$(tr '\n' ';' <<< "$actual")]"
+  fi
+}
+
 echo
 echo "a PR that is merely behind main"
 run_guard "$TMP/step.sh" behind
@@ -232,9 +251,9 @@ grep -qF '<!-- sceneview-agent-review -->' "$TMP/posted-comment.md" 2>/dev/null 
 grep -q 'gh workflow run pr-review.yml -f pr=4242' "$TMP/posted-comment.md" 2>/dev/null \
   && ok "names the dispatch that DOES review this PR, with its number" \
   || bad "the comment does not carry the runnable dispatch command for this PR"
-grep -qxF 'POST repos/sceneview/sceneview/issues/4242/comments' "$TMP/gh-calls" 2>/dev/null \
-  && ok "with no marker comment present it POSTs a new one" \
-  || bad "did not POST to the PR's comments endpoint (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
+calls_were "POST repos/sceneview/sceneview/issues/4242/comments" \
+  "with no marker comment present it POSTs a new one" \
+  "did not POST exactly once to the PR's comments endpoint"
 # The comment is scratch, and the checkout is what `Assert the reviewers left
 # the tree clean` measures a few steps later.
 [ -z "$GUARD_DIRT" ] \
@@ -256,12 +275,9 @@ echo "a second run on the same PR, with the marker comment already there"
 # later case would silently run with a marker comment present.
 GH_STUB_EXISTING_ID=99123
 run_guard "$TMP/step.sh" selfmod
-grep -qxF 'PATCH repos/sceneview/sceneview/issues/comments/99123' "$TMP/gh-calls" 2>/dev/null \
-  && ok "updates the existing comment in place, by its id" \
-  || bad "did not PATCH the existing marker comment (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
-grep -q '^POST ' "$TMP/gh-calls" 2>/dev/null \
-  && bad "posted a second comment even though the marker was already on the PR — a re-run stacks duplicates" \
-  || ok "does not also POST — no duplicate comment on a re-run"
+calls_were "PATCH repos/sceneview/sceneview/issues/comments/99123" \
+  "updates the existing comment in place, by its id, and does not also POST" \
+  "did not PATCH the existing marker comment exactly once"
 grep -q 'NOT REVIEWED' "$TMP/posted-comment.md" 2>/dev/null \
   && ok "the updated body still carries the explanation" \
   || bad "the PATCH sent a body that does not say NOT REVIEWED"
@@ -274,9 +290,9 @@ echo "the same, on a PR whose comments span several API pages"
 # posting a duplicate.
 GH_STUB_PAGES=3
 run_guard "$TMP/step.sh" selfmod
-grep -qxF 'PATCH repos/sceneview/sceneview/issues/comments/99123' "$TMP/gh-calls" 2>/dev/null \
-  && ok "keeps one id across pages" \
-  || bad "a paginated lookup produced a malformed endpoint (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
+calls_were "PATCH repos/sceneview/sceneview/issues/comments/99123" \
+  "keeps one id across pages" \
+  "a paginated lookup produced a malformed endpoint"
 GH_STUB_PAGES=1
 
 # ---------------------------------------------------------------------------

--- a/.claude/scripts/test-selfmod-guard.sh
+++ b/.claude/scripts/test-selfmod-guard.sh
@@ -141,8 +141,14 @@ while [ $# -gt 0 ]; do
 done
 if [ "$method" = "GET" ]; then
   # The step reads this through `--jq '… | .[0].id // empty'`; the stub answers
-  # post-jq, which is what the step's `$(...)` actually consumes.
-  [ -n "${GH_STUB_EXISTING_ID:-}" ] && echo "$GH_STUB_EXISTING_ID"
+  # post-jq, which is what the step's `$(...)` actually consumes. `--paginate`
+  # applies the filter ONCE PER PAGE, so a real multi-page lookup emits one id
+  # per matching page — the stub reproduces that with GH_STUB_PAGES, and a step
+  # that takes the raw output would build `repos/…/comments/99123\n99123`.
+  if [ -n "${GH_STUB_EXISTING_ID:-}" ]; then
+    n=0
+    while [ "$n" -lt "${GH_STUB_PAGES:-1}" ]; do echo "$GH_STUB_EXISTING_ID"; n=$((n + 1)); done
+  fi
   exit 0
 fi
 echo "$method $url" >> "$GH_STUB_LOG"
@@ -157,7 +163,9 @@ chmod +x "$STUB_BIN/gh"
 run_guard() {
   local step="$1" branch="$2" event="${3:-pull_request}"
   local work="$TMP/work.$$"
-  rm -rf "$work"
+  RUNNER_TMP="$TMP/runner-temp"
+  rm -rf "$work" "$RUNNER_TMP"
+  mkdir -p "$RUNNER_TMP"
   git clone -q "$UPSTREAM" "$work" 2>/dev/null
   git -C "$work" config core.hooksPath "$NOHOOKS"
   git -C "$work" checkout -q "$branch"
@@ -173,13 +181,19 @@ run_guard() {
     GITHUB_REPOSITORY=sceneview/sceneview \
     PR_NUM=4242 \
     GH_STUB_EXISTING_ID="${GH_STUB_EXISTING_ID:-}" \
+    GH_STUB_PAGES="${GH_STUB_PAGES:-1}" \
     GH_STUB_OUT="$TMP/posted-comment.md" \
     GH_STUB_LOG="$TMP/gh-calls" \
     GITHUB_OUTPUT="$TMP/output" \
     GITHUB_STEP_SUMMARY="$TMP/summary" \
+    RUNNER_TEMP="$RUNNER_TMP" \
     bash -e "$step"
   ) > "$TMP/out" 2>&1
   GUARD_RC=$?
+  # What the step left behind in the CHECKOUT. `Assert the reviewers left the
+  # tree clean` runs on the same working directory, so a scratch file written
+  # here is later blamed on a reviewer.
+  GUARD_DIRT="$(git -C "$work" status --porcelain 2>/dev/null)"
   GUARD_VERDICT="$(grep -oE 'self_modified=(true|false)' "$TMP/output" | tail -1 | cut -d= -f2)"
   rm -rf "$work"
   return 0
@@ -221,6 +235,11 @@ grep -q 'gh workflow run pr-review.yml -f pr=4242' "$TMP/posted-comment.md" 2>/d
 grep -qxF 'POST repos/sceneview/sceneview/issues/4242/comments' "$TMP/gh-calls" 2>/dev/null \
   && ok "with no marker comment present it POSTs a new one" \
   || bad "did not POST to the PR's comments endpoint (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
+# The comment is scratch, and the checkout is what `Assert the reviewers left
+# the tree clean` measures a few steps later.
+[ -z "$GUARD_DIRT" ] \
+  && ok "leaves the checkout clean — the comment file is written under RUNNER_TEMP" \
+  || bad "the step dirtied the checkout ($GUARD_DIRT); a later step blames that on a reviewer"
 # The comment must not be mistaken for the check going green.
 [ "$GUARD_RC" -eq 1 ] \
   && ok "still exits 1 — the comment explains the red, it does not replace it" \
@@ -246,6 +265,19 @@ grep -q '^POST ' "$TMP/gh-calls" 2>/dev/null \
 grep -q 'NOT REVIEWED' "$TMP/posted-comment.md" 2>/dev/null \
   && ok "the updated body still carries the explanation" \
   || bad "the PATCH sent a body that does not say NOT REVIEWED"
+
+echo
+echo "the same, on a PR whose comments span several API pages"
+# `gh api --paginate --jq` applies the filter per page, so the lookup emits one
+# id per matching page. Taking the raw output would build the endpoint
+# `…/issues/comments/99123 99123 99123` and every re-run would 404 back into
+# posting a duplicate.
+GH_STUB_PAGES=3
+run_guard "$TMP/step.sh" selfmod
+grep -qxF 'PATCH repos/sceneview/sceneview/issues/comments/99123' "$TMP/gh-calls" 2>/dev/null \
+  && ok "keeps one id across pages" \
+  || bad "a paginated lookup produced a malformed endpoint (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
+GH_STUB_PAGES=1
 
 # ---------------------------------------------------------------------------
 # MUTATION. Make the step ignore the lookup and always POST. The check is red

--- a/.claude/scripts/test-selfmod-guard.sh
+++ b/.claude/scripts/test-selfmod-guard.sh
@@ -114,24 +114,38 @@ fi
 
 # A `gh` that records instead of calling GitHub (#3028). The step now posts the
 # "NOT REVIEWED" explanation onto the PR, and a stub is the only way to assert
-# WHAT it posts. It answers the lookup with nothing (no existing comment) and
-# copies the `-F body=@<file>` payload out, so the assertions read the bytes the
-# step would have sent.
+# WHAT it posts. It copies the `-F body=@<file>` payload out, so the assertions
+# read the bytes the step would have sent, and logs `<method> <endpoint>` for
+# every write.
+#
+# The lookup answer is a KNOB, not a constant. A stub that always replies "no
+# existing comment" exercises the POST branch and leaves the PATCH branch — the
+# entire point of the `<!-- sceneview-agent-review -->` marker — untested, so a
+# regression that posts a duplicate on every re-run would pass. `GH_STUB_EXISTING_ID`
+# makes the second run of the same PR a real case.
 STUB_BIN="$TMP/bin"
 mkdir -p "$STUB_BIN"
 cat > "$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 method=GET
 body=""
+url=""
 while [ $# -gt 0 ]; do
   case "$1" in
     -X) method="${2:-}"; shift 2 ;;
     -F) case "${2:-}" in body=@*) body="${2#body=@}" ;; esac; shift 2 ;;
-    *) shift ;;
+    --jq) shift 2 ;;
+    api|--paginate|-*) shift ;;
+    *) [ -n "$url" ] || url="$1"; shift ;;
   esac
 done
-if [ "$method" = "GET" ]; then exit 0; fi   # lookup: no existing comment
-echo "$method" >> "$GH_STUB_LOG"
+if [ "$method" = "GET" ]; then
+  # The step reads this through `--jq '… | .[0].id // empty'`; the stub answers
+  # post-jq, which is what the step's `$(...)` actually consumes.
+  [ -n "${GH_STUB_EXISTING_ID:-}" ] && echo "$GH_STUB_EXISTING_ID"
+  exit 0
+fi
+echo "$method $url" >> "$GH_STUB_LOG"
 [ -n "$body" ] && cp "$body" "$GH_STUB_OUT"
 exit 0
 STUB
@@ -158,6 +172,7 @@ run_guard() {
     GITHUB_BASE_REF=main \
     GITHUB_REPOSITORY=sceneview/sceneview \
     PR_NUM=4242 \
+    GH_STUB_EXISTING_ID="${GH_STUB_EXISTING_ID:-}" \
     GH_STUB_OUT="$TMP/posted-comment.md" \
     GH_STUB_LOG="$TMP/gh-calls" \
     GITHUB_OUTPUT="$TMP/output" \
@@ -203,10 +218,55 @@ grep -qF '<!-- sceneview-agent-review -->' "$TMP/posted-comment.md" 2>/dev/null 
 grep -q 'gh workflow run pr-review.yml -f pr=4242' "$TMP/posted-comment.md" 2>/dev/null \
   && ok "names the dispatch that DOES review this PR, with its number" \
   || bad "the comment does not carry the runnable dispatch command for this PR"
+grep -qxF 'POST repos/sceneview/sceneview/issues/4242/comments' "$TMP/gh-calls" 2>/dev/null \
+  && ok "with no marker comment present it POSTs a new one" \
+  || bad "did not POST to the PR's comments endpoint (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
 # The comment must not be mistaken for the check going green.
 [ "$GUARD_RC" -eq 1 ] \
   && ok "still exits 1 — the comment explains the red, it does not replace it" \
   || bad "posting the comment changed the verdict (rc=$GUARD_RC); a PR nobody reviewed must not look reviewed"
+
+echo
+echo "a second run on the same PR, with the marker comment already there"
+# The marker exists so the explanation is UPDATED rather than stacked: a push
+# burst on a workflow-editing PR must not leave five identical "NOT REVIEWED"
+# comments, and a genuine verdict later has to be able to replace this one in
+# place. Both properties live entirely in the PATCH branch.
+# Set as a plain variable, not as a `VAR=x run_guard …` prefix: bash keeps an
+# assignment that precedes a FUNCTION call in the shell afterwards, and every
+# later case would silently run with a marker comment present.
+GH_STUB_EXISTING_ID=99123
+run_guard "$TMP/step.sh" selfmod
+grep -qxF 'PATCH repos/sceneview/sceneview/issues/comments/99123' "$TMP/gh-calls" 2>/dev/null \
+  && ok "updates the existing comment in place, by its id" \
+  || bad "did not PATCH the existing marker comment (calls: $(tr '\n' ';' < "$TMP/gh-calls"))"
+grep -q '^POST ' "$TMP/gh-calls" 2>/dev/null \
+  && bad "posted a second comment even though the marker was already on the PR — a re-run stacks duplicates" \
+  || ok "does not also POST — no duplicate comment on a re-run"
+grep -q 'NOT REVIEWED' "$TMP/posted-comment.md" 2>/dev/null \
+  && ok "the updated body still carries the explanation" \
+  || bad "the PATCH sent a body that does not say NOT REVIEWED"
+
+# ---------------------------------------------------------------------------
+# MUTATION. Make the step ignore the lookup and always POST. The check is red
+# either way and the comment is still posted, so only the two assertions above
+# can notice — which is the point of asserting the METHOD and the endpoint
+# rather than "a comment was sent".
+# ---------------------------------------------------------------------------
+echo
+echo "mutation: always POST, ignoring the existing marker comment"
+sed 's|if \[ -n "\$EXISTING" \]; then|if false; then|' "$TMP/step.sh" > "$TMP/step-alwayspost.sh"
+if cmp -s "$TMP/step.sh" "$TMP/step-alwayspost.sh"; then
+  bad "the mutation changed nothing — the step no longer branches on an existing marker comment"
+else
+  run_guard "$TMP/step-alwayspost.sh" selfmod
+  if grep -q '^POST ' "$TMP/gh-calls" 2>/dev/null && ! grep -q '^PATCH ' "$TMP/gh-calls" 2>/dev/null; then
+    ok "the mutant stacks a duplicate comment — the update-in-place assertions have teeth"
+  else
+    bad "the mutant did not reproduce the duplicate-comment shape (calls: $(tr '\n' ';' < "$TMP/gh-calls")); expected a POST and no PATCH"
+  fi
+fi
+unset GH_STUB_EXISTING_ID
 
 echo
 echo "a workflow_dispatch"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -360,6 +360,13 @@ jobs:
             # a maintainer actually looks. Same `<!-- sceneview-agent-review -->`
             # marker as a real review comment, so it is updated in place and
             # replaced outright by a genuine verdict on the next run.
+            # Under RUNNER_TEMP, never in the checkout: `Assert the reviewers
+            # left the tree clean` compares the working tree against the base,
+            # so a file this job writes itself would be reported as a reviewer
+            # having edited the repo. Same defect shape as the `tee publish.log`
+            # one fixed in #3130. The `:-.` fallback is for the self-test, which
+            # runs the step outside a runner.
+            COMMENT_FILE="${RUNNER_TEMP:-.}/selfmod-comment.md"
             # shellcheck disable=SC2016  # the backticks below are Markdown code spans written into the summary and the comment, not command substitution — single quotes are exactly right here.
             {
               echo '<!-- sceneview-agent-review -->'
@@ -380,23 +387,29 @@ jobs:
               echo '```bash'
               echo "gh workflow run pr-review.yml -f pr=${PR_NUM:-<N>}"
               echo '```'
-            } > selfmod-comment.md
-            cat selfmod-comment.md >> "$GITHUB_STEP_SUMMARY"
+            } > "$COMMENT_FILE"
+            cat "$COMMENT_FILE" >> "$GITHUB_STEP_SUMMARY"
 
             # Best effort, deliberately: a comment API failure must not swallow
             # the annotation and the `exit 1` below, which are what actually
             # redden this check. A warning is the honest report for it.
             if [ -n "${PR_NUM:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
               MARKER='<!-- sceneview-agent-review -->'
+              # `--paginate` applies `--jq` PER PAGE, so this filter emits one
+              # id per page that contains a match, not one id overall. It is
+              # safe today only because the marker comment is unique — `awk
+              # NR==1` makes that guarantee local instead of inherited. `awk`
+              # rather than `head -1`, which would SIGPIPE `gh` under pipefail.
               EXISTING="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUM/comments" --paginate \
-                --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty" 2>/dev/null || echo "")"
+                --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty" 2>/dev/null \
+                | awk 'NR == 1 { print }' || echo "")"
               if [ -n "$EXISTING" ]; then
                 gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING" \
-                  -F body=@selfmod-comment.md >/dev/null \
+                  -F "body=@$COMMENT_FILE" >/dev/null \
                   || echo "::warning title=Could not update the PR comment::The job summary still carries the explanation."
               else
                 gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUM/comments" \
-                  -F body=@selfmod-comment.md >/dev/null \
+                  -F "body=@$COMMENT_FILE" >/dev/null \
                   || echo "::warning title=Could not post the PR comment::The job summary still carries the explanation."
               fi
             fi
@@ -1206,8 +1219,12 @@ jobs:
         run: |
           set -euo pipefail
           MARKER='<!-- sceneview-agent-review -->'
+          # `--paginate` runs `--jq` once per page, so this emits one id per
+          # matching PAGE. `awk NR==1` keeps the first — `head -1` would
+          # SIGPIPE `gh` under the `pipefail` set above.
           EXISTING="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUM/comments" --paginate \
-            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty" 2>/dev/null || echo "")"
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty" 2>/dev/null \
+            | awk 'NR == 1 { print }' || echo "")"
           if [ -n "$EXISTING" ]; then
             gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING" \
               -F body=@review-comment.md >/dev/null

--- a/changelog.d/3028-selfmod-comment-followup.md
+++ b/changelog.d/3028-selfmod-comment-followup.md
@@ -1,0 +1,6 @@
+<!-- category: Tests -->
+The "NOT REVIEWED" comment a self-modifying PR gets (#3028) no longer writes its
+scratch file into the checkout, where `Assert the reviewers left the tree clean`
+would blame it on a reviewer, and its marker-comment lookup no longer depends on
+`gh api --paginate --jq` returning a single id. `test-selfmod-guard.sh` covers
+the update-in-place branch that had no test at all.

--- a/changelog.d/3028-selfmod-comment-followup.md
+++ b/changelog.d/3028-selfmod-comment-followup.md
@@ -1,6 +1,2 @@
 <!-- category: Tests -->
-The "NOT REVIEWED" comment a self-modifying PR gets (#3028) no longer writes its
-scratch file into the checkout, where `Assert the reviewers left the tree clean`
-would blame it on a reviewer, and its marker-comment lookup no longer depends on
-`gh api --paginate --jq` returning a single id. `test-selfmod-guard.sh` covers
-the update-in-place branch that had no test at all.
+- **The "NOT REVIEWED" comment a self-modifying PR gets ([#3028](https://github.com/sceneview/sceneview/issues/3028)) no longer writes its scratch file into the checkout.** `Assert the reviewers left the tree clean` compares the tree against the base, so a file the job wrote itself would be reported as a reviewer having edited the repo — the same defect shape as the `tee publish.log` one fixed in #3130. The file now lives under `RUNNER_TEMP`. Its marker-comment lookup no longer depends on `gh api --paginate --jq` returning a single id either: `--jq` runs once per page, so a match on several pages emitted several ids and built a malformed endpoint. `test-selfmod-guard.sh` now covers the update-in-place branch, which had no test at all, and asserts the exact sequence of API calls rather than the presence of one.


### PR DESCRIPTION
Follow-up to #3132 (#3028). Two defects found in the by-hand review of that PR, plus the
coverage gap that let one of them through.

## The comment file was written into the checkout

`selfmod-comment.md` was created in the working directory. `Assert the reviewers left the
tree clean` measures that same working directory a few steps later, so a scratch file this
job wrote itself reads as a reviewer having edited the repo — the same shape as the
`tee publish.log` defect #3130 is fixing one PR over. It now lives under `RUNNER_TEMP`.

Newly asserted, not assumed: `run_guard` reports `git status --porcelain` of the checkout
after the step runs. Mutation — put `COMMENT_FILE` back to a bare filename:

```
✗ the step dirtied the checkout (?? selfmod-comment.md); a later step blames that on a reviewer
```

## The marker lookup depended on the comment being unique

`gh api --paginate --jq` applies the filter **once per page**, so
`map(select(...)) | .[0].id // empty` emits one id per matching *page*, not one id overall.
It happened to be safe only because the marker comment is unique. `awk 'NR == 1 { print }'`
makes that guarantee local — `awk` rather than `head -1`, which would SIGPIPE `gh` under
the `pipefail` those steps set. Both copies of the lookup are fixed, including the real
review-comment step, which carries the identical shape.

The stub now answers the lookup over `GH_STUB_PAGES` pages. Mutation — drop the `awk`:

```
✗ a paginated lookup produced a malformed endpoint — expected exactly
  [PATCH repos/sceneview/sceneview/issues/comments/99123], got
  [PATCH repos/sceneview/sceneview/issues/comments/99123;99123;99123;]
```

## The PATCH branch had no test at all — and the first version of the new one was a false green

The `gh` stub in #3132 answered every lookup with "no existing comment", so only the POST
branch ever ran. The update-in-place branch — the entire reason the body carries the
`<!-- sceneview-agent-review -->` marker — was untested, and a regression posting a
duplicate on every re-run would have passed 14/14.

Worth stating plainly, because it is the bug class this whole series is about: **my first
version of the pagination assertion passed against the mutant.** It was
`grep -qxF 'PATCH …/comments/99123'`, and three ids build the endpoint
`…/comments/99123\n99123\n99123`, whose *first line* is byte-identical to the correct call.
Replaced with `calls_were`, which compares the **whole** recorded call log — that also makes
"PATCHed and then POSTed as well" a failure without a second assertion.

21 → 20 assertions (two collapsed into one exact comparison), 3 mutations, all killing on a
named assertion.

## Gate

```
bash .claude/scripts/pre-push-check.sh
✓ 34 gate self-test(s) pass
✓ ALL CHECKS PASSED — safe to push
```
