### PR TITLE
Fix Materials section not deriving autoAnimate from qaMode (#2958)

### DIFF
--- a/changelog.d/2958-materials-autoanimate.md
+++ b/changelog.d/2958-materials-autoanimate.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **`android-demo`: the Materials section now derives `autoAnimate` from QA mode ([#2958](https://github.com/sceneview/sceneview/issues/2958)).** Both subject nodes were mounted without `autoAnimate`, inheriting `ModelNode`'s `true` default, while QA mode only freezes the orbit yaw — so an animated subject would have made the section's golden screenshots drift. They now pass `autoAnimate = !DemoSettings.qaMode` like `ModelViewerDemo`, guarded by a unit test since every subject shipping today is static.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
+import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.ErrorScrim
 import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
@@ -333,11 +334,26 @@ private fun PbrSection(
                 // Every subject is normalised to the SAME size rather than to its own
                 // `scaleToUnits` (#2874) — the camera is fixed, so a per-model scale
                 // is what made one chip fill the viewport and the next read as a speck.
+                //
+                // `autoAnimate = !qaMode` mirrors ModelViewerDemo (#2958): `qaMode`
+                // freezes the orbit yaw but NOT model animation, so a subject with a
+                // baked animation would keep moving under it and the section's golden
+                // screenshots would drift frame to frame. Every subject the section can
+                // show today is static (ToyCar declares no animation; the three
+                // `materials` slugs are `hasBakedAnimation = false`), so this changes no
+                // pixel now — it is what keeps the contract true when the CATALOG gains
+                // an animated slug, which is a data edit no code review would catch.
+                // Read once at node creation, like ModelViewerDemo: the QA harness sets
+                // `DemoSettings.qaMode` before launching a demo, so the value is already
+                // settled when these nodes mount. Re-keying on it instead would destroy
+                // and rebuild the nodes, which is exactly the entity-teardown defect
+                // #2939 fixed above.
                 bundledInstance?.let { instance ->
                     ModelNode(
                         modelInstance = instance,
                         scaleToUnits = MaterialsSubjects.FRAMING_UNITS,
                         isVisible = selectedSlug == null,
+                        autoAnimate = !DemoSettings.qaMode,
                     )
                 }
                 streamedInstance?.let { instance ->
@@ -345,6 +361,7 @@ private fun PbrSection(
                         modelInstance = instance,
                         scaleToUnits = MaterialsSubjects.FRAMING_UNITS,
                         isVisible = selectedSlug != null,
+                        autoAnimate = !DemoSettings.qaMode,
                     )
                 }
             }

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MaterialsSubjectsTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/MaterialsSubjectsTest.kt
@@ -2,6 +2,7 @@ package io.github.sceneview.demo.demos.internal
 
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabSlug
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -116,6 +117,84 @@ class MaterialsSubjectsTest {
         assertEquals("Test Model", subject.displayName)
         assertEquals("tester", subject.author)
         assertEquals("KHR_materials_sheen", subject.extensionTag)
+    }
+
+    /**
+     * Every subject node in the section must derive `autoAnimate` from
+     * `DemoSettings.qaMode` (#2958).
+     *
+     * `qaMode` freezes the orbit yaw (`DemoHelpers`) but not model animation, and
+     * `SceneScope.ModelNode` defaults `autoAnimate` to `true` — so a subject with a
+     * baked animation would keep moving under `qaMode` and the section's golden
+     * screenshots would drift frame to frame.
+     *
+     * This is asserted on the SOURCE rather than on a frame on purpose: every subject
+     * the section can show today is static, so no capture — on any device, in either
+     * mode — can tell the fixed version from the broken one. The trigger is a CATALOG
+     * edit (one animated slug added to `SampleAssets`' `materials` category), which is
+     * a data change no rendering test would attribute to this parameter.
+     */
+    @Test
+    fun `every subject node derives autoAnimate from qaMode`() {
+        val subjectCalls = modelNodeCallArguments(demoSource("MaterialsDemo.kt"))
+            .filter { it.contains("MaterialsSubjects.FRAMING_UNITS") }
+        assertTrue(
+            "Expected the bundled + streamed subject nodes to be mounted with " +
+                "`scaleToUnits = MaterialsSubjects.FRAMING_UNITS`; found " +
+                "${subjectCalls.size}. If the section was restructured, update this " +
+                "test rather than dropping the contract it guards.",
+            subjectCalls.size >= 2,
+        )
+        subjectCalls.forEach { call ->
+            assertTrue(
+                "A Materials subject node is mounted without " +
+                    "`autoAnimate = !DemoSettings.qaMode` (#2958). `ModelNode` defaults " +
+                    "it to true, so an animated subject would break the section's qaMode " +
+                    "determinism contract. Offending call args: ${call.trim()}",
+                call.contains("autoAnimate = !DemoSettings.qaMode"),
+            )
+        }
+    }
+
+    /**
+     * The argument list of every `ModelNode(…)` call in [source], balanced on parentheses
+     * so a nested `Position(…)` / `Scale(…)` argument does not truncate the match.
+     */
+    private fun modelNodeCallArguments(source: String): List<String> = buildList {
+        var from = source.indexOf(CALL)
+        while (from >= 0) {
+            var depth = 1
+            var i = from + CALL.length
+            while (i < source.length && depth > 0) {
+                when (source[i]) {
+                    '(' -> depth++
+                    ')' -> depth--
+                }
+                i++
+            }
+            if (depth == 0) add(source.substring(from + CALL.length, i - 1))
+            from = source.indexOf(CALL, from + CALL.length)
+        }
+    }
+
+    /**
+     * Reads a demo source file. The Gradle test task's working directory is the module
+     * directory, but the search walks up so the test also passes when a runner starts it
+     * from the repository root.
+     */
+    private fun demoSource(fileName: String): String {
+        val relative = "samples/android-demo/src/main/java/io/github/sceneview/demo/demos/$fileName"
+        var dir: File? = File("").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, relative)
+            if (candidate.isFile) return candidate.readText()
+            dir = dir.parentFile
+        }
+        throw AssertionError("Could not locate $relative from ${File("").absolutePath}")
+    }
+
+    private companion object {
+        const val CALL = "ModelNode("
     }
 
     @Test


### PR DESCRIPTION
Closes #2958

## What changed

`MaterialsDemo.PbrSection` mounted both PBR subject nodes (bundled + streamed) without `autoAnimate`, so both inherited `SceneScope.ModelNode`'s `autoAnimate = true` default. `DemoSettings.qaMode` freezes the orbit yaw (`DemoHelpers`) but not model animation, so the section's QA determinism contract — the one #2926 built it around — was one notch weaker than its sibling `ModelViewerDemo`, which passes `autoAnimate = !DemoSettings.qaMode` deliberately.

Both call sites now pass `autoAnimate = !DemoSettings.qaMode`.

## Challenge verdict

The issue's prescribed cause **held under probe**, and the probe also confirmed its own "measured impact: none" claim, which is what decided the shape of the fix:

- `SceneScope.kt:274` — `autoAnimate: Boolean = true`, confirmed; the two call sites passed nothing.
- `DemoHelpers.kt` — every `qaMode` read is a yaw freeze (`:347`, `:440`, `:492`, `:709`); nothing touches animation. Confirmed.
- Parsed `assets/models/khronos_toy_car.glb` directly: **0 animations, 0 skins**. The three streamed `materials` slugs all declare `hasBakedAnimation = false`. So no frame, on any device, in either mode, can distinguish the fixed build from the broken one — the defect is real but latent.

One divergence from the issue text: it asked for the fix plus "a `MaterialsSubjectsTest` assertion that pins the intent". A value assertion cannot pin it (the contract lives at a Compose call site, and the parameter is read once at node creation, so no pure-value test observes it). The guard is therefore asserted on the source of `MaterialsDemo.kt`: every `ModelNode(…)` carrying `scaleToUnits = MaterialsSubjects.FRAMING_UNITS` must also carry `autoAnimate = !DemoSettings.qaMode`. Verified both ways — green as committed, and **red when the parameter is deleted from one call site** (negative probe run, `AssertionError` quoted the offending call). A guard that cannot fail would have been a fake green.

## Gates

- `:samples:android-demo:compileDebugKotlin` — BUILD SUCCESSFUL
- `:samples:android-demo:testDebugUnitTest` (full module) — BUILD SUCCESSFUL
- `:arsceneview:testDebugUnitTest` — BUILD SUCCESSFUL
- `pre-push-check.sh --quick` reported `ShadowReceiverPlaneContractTest` red; traced to `Expected …/tools/GenerateFilamat.sh` — an artifact of the lean sparse checkout, not of this diff. Re-ran with `tools/` restored: green. No `arsceneview` file is touched here.

## Self-review (5 angles)

- **Correctness** — matches the sibling exactly. Reading `DemoSettings.qaMode` (a `mutableStateOf`) inside the scene content lambda adds a snapshot read, but `ModelNode`'s `remember(engine, modelInstance)` is not keyed on it, so a runtime toggle recomposes without rebuilding the node. That is deliberate: re-keying would destroy and recreate nodes that only *borrow* their entities — the exact teardown defect #2939 fixed in this very block. The QA harness sets `qaMode` before launching a demo, so the creation-time read is the one that matters; documented at the call site rather than left implicit.
- **Threading** — no Filament work added; `autoAnimate` is evaluated during composition on the main thread. No coroutine, no lifecycle change.
- **API consistency** — no public API touched. Named argument, sibling's idiom and ordering.
- **Minimality** — 2 functional lines + 1 import in `main`; the rest is the comment and the guard test. No dead code, no unrelated churn.
- **Cross-platform** — `DemoSettings.qaMode` is Android-demo-only harness state; no iOS/Web/`llms.txt`/skill surface is implicated, so nothing to mirror or defer.

scope: medium-plus

🤖 Generated with [Claude Code](https://claude.com/claude-code)