### PR TITLE
docs(versioning): say the Flutter README's pub.dev caret range must not be bumped

### DIFF
--- a/.claude/commands/version-bump.md
+++ b/.claude/commands/version-bump.md
@@ -11,6 +11,10 @@ Bump the SceneView version across ALL locations in a single, atomic operation.
 > releasing the MCP, never to the SDK `VERSION_NAME` (#1705). The flutter/RN **consumed**
 > `io.github.sceneview:*` dependency lines lag to the **last published** release, never the
 > in-flight one — `sync-versions.sh` reports them WARN-only and never auto-bumps (#1494).
+> The Flutter README's `flutter_sceneview: ^X.Y.Z` pub.dev snippet is the same class: a
+> caret range against a version that must already be **live on pub.dev** (which lags
+> `VERSION_NAME`), so `^<unpublished>` resolves to nothing and fails `flutter pub get`.
+> Its `WARN` row is the designed steady state — do not "fix" it (#3149).
 
 **Usage:** `/version-bump 3.6.0` or just `/version-bump` (will ask for version)
 

--- a/.claude/skills/versioning/SKILL.md
+++ b/.claude/skills/versioning/SKILL.md
@@ -48,6 +48,18 @@ Every file below MUST be updated when bumping the version. Use `/version-bump` o
 > `package.json`) bump to the release version. `sync-versions.sh` reports these
 > consumed-dep coordinates WARN-only and never auto-bumps them (issue #1494).
 
+> ⚠️ **Do NOT bump the Flutter README's pub.dev install snippet.**
+> `flutter_sceneview: ^X.Y.Z` in `flutter/sceneview_flutter/README.md` is a caret
+> range against a version that must already be **live on pub.dev**, which lags
+> `VERSION_NAME` whenever the `pub-publish` job has not shipped the newest release
+> (measured 2026-08-14: pub.dev `4.24.0` vs `VERSION_NAME` `4.30.0` — #3142). A
+> range against an unpublished version resolves to **nothing** and fails
+> `flutter pub get`. `sync-versions.sh` reports it WARN-only and has no `--fix`
+> handler for it *on purpose*: a `WARN` row here is the designed steady state, not
+> a task. Raise it only once pub.dev actually serves that version.
+> The RN README's SwiftPM `- Version: X.Y.Z` is the opposite case and **is** swept
+> — SPM resolves against a git tag this repo's own release creates. (issue #3149)
+
 > ⚠️ **`mcp/package.json` and `mcp/src/index.ts` follow an INDEPENDENT version
 > track — do NOT sync them to `VERSION_NAME`.**
 > `sceneview-mcp` (npm) has its own release cadence (e.g. `4.0.12` while the

--- a/changelog.d/3149-pubdev-caret-warn-doc.md
+++ b/changelog.d/3149-pubdev-caret-warn-doc.md
@@ -1,0 +1,2 @@
+<!-- category: Docs -->
+- **Version-bump docs now say the Flutter README's pub.dev caret range must not be bumped ([#3149](https://github.com/sceneview/sceneview/issues/3149)).** `sync-versions.sh` already enforced it, but neither the `versioning` skill nor `/version-bump` said so — a session that "fixed" the `WARN` row would point `flutter_sceneview: ^X.Y.Z` at a version pub.dev does not serve yet, which resolves to nothing and fails `flutter pub get`.


### PR DESCRIPTION
Closes #3149.

## The hole

`sync-versions.sh` already treats `flutter_sceneview: ^X.Y.Z` in `flutter/sceneview_flutter/README.md` as **REPORT-ONLY (WARN), never bumped**, and deliberately ships no `--fix` handler for it. But neither of the two surfaces a session actually reads *before* bumping — the `versioning` skill and `/version-bump` — said so. A `WARN` row with no stated reason reads as an unfinished task, so the next bumping session "fixes" it.

## Why fixing it breaks the build

That caret range targets a version that must already be **live on pub.dev**, which lags `VERSION_NAME` whenever the `pub-publish` job has not shipped the newest release. Measured 2026-08-14: pub.dev serves `4.24.0` while `VERSION_NAME` is `4.30.0` (the gap is #3142, an admin click only Thomas can make). `^4.30.0` against a pub.dev that stops at `4.24.0` resolves to **nothing** and fails `flutter pub get` for every downstream Flutter user.

So the `WARN` row is the **designed steady state**, not a task. It is raised only once pub.dev actually serves that version.

The RN README's SwiftPM `- Version: X.Y.Z` is the opposite case and **is** swept — SPM resolves against a git tag this repo's own release creates. Both cases are now stated side by side so the distinction is legible.

## Changes

- `.claude/skills/versioning/SKILL.md` — warning block between the consumed-dep block and the `mcp/` block.
- `.claude/commands/version-bump.md` — same rule appended to the "What is NOT bumped here" blockquote.
- `changelog.d/3149-pubdev-caret-warn-doc.md` — `Docs` fragment.

## Validation

Docs-only, three markdown files, zero source. `pre-push-check.sh`: **0 failed**, `apiCheck` green ("public API matches the committed .api dumps"), both unit-test legs green. One leg could not run — the Roborazzi screenshot comparison produced no report — which a documentation-only diff cannot affect.

Self-reviewed inline; the fan-out is skipped because the diff touches no source, no public API and no machine-readable contract.