### PR TITLE
fix(gate): stop a relative path reading as another clone's tree (#3195)

### DIFF
--- a/.claude/scripts/lib/gradle-run.sh
+++ b/.claude/scripts/lib/gradle-run.sh
@@ -92,9 +92,13 @@ GRADLE_RUN_FOREIGN_TREE=199
 # to withhold a pass (COULD NOT RUN), never to grant one.
 #
 # The match is deliberately narrow: only absolute paths containing `/src/`, so
-# `~/.gradle/caches/...` jars, JDK and toolchain paths cannot trip it. Measured
-# on a clean run of the full gate: 0 hits across all 60 logs, `file://` and
-# absolute paths alike — Gradle prints module-relative paths for the local tree.
+# `~/.gradle/caches/...` jars, JDK and toolchain paths cannot trip it. Gradle
+# prints module-relative paths for the local tree, which is what makes the
+# narrowness safe — and also what made the missing anchor dangerous, since those
+# same relative paths are the ones that used to be misread as foreign (#3195).
+# The "0 hits across all 60 logs" this comment used to claim was measured before
+# the gate wrote `roborazzi.log`; it is asserted now instead of remembered, by
+# the clean-run case in `test-gradle-run.sh` that reads the real artefacts.
 gradle_foreign_tree_paths() {
     local log="$1"
     local proj="${2:-$PWD}"
@@ -105,7 +109,17 @@ gradle_foreign_tree_paths() {
     # project's own files foreign.
     proj="$(cd "$proj" 2>/dev/null && pwd -P)" || return 0
 
-    grep -oE '(file://)?/[^ :"'"'"']*/src/[^ :"'"'"']*' "$log" 2>/dev/null \
+    # The leading `/` must actually BEGIN a path. Without that anchor the pattern
+    # also matches the tail of a RELATIVE one, and the gate's own `roborazzi.log`
+    # carries `samples/android-demo/src/main/.../GeneratedDemos.kt already in
+    # sync`: grep started at the slash after `samples` and yielded
+    # `/android-demo/src/…`, a tree that exists on no host. This repository's own
+    # clean run was graded foreign and the gate refused every push (#3195).
+    # A path begins at start-of-line or after a delimiter — which is then
+    # stripped back off, before `file://`, so the two sed passes cannot collide.
+    local bound='(^|[[:space:]:="'"'"'(])'
+    grep -oE "${bound}(file://)?/[^ :\"']*/src/[^ :\"']*" "$log" 2>/dev/null \
+    | sed -E 's|^[[:space:]:="'"'"'(]||' \
     | sed 's|^file://||' \
     | while IFS= read -r p; do
         # Same /private normalisation for the candidate, which may name a

--- a/.claude/scripts/test-gradle-run.sh
+++ b/.claude/scripts/test-gradle-run.sh
@@ -721,6 +721,17 @@ Resolving /Users/someone/.gradle/caches/modules-2/files-2.1/androidx.core/core/1
 BUILD SUCCESSFUL in 12s
 LOG
 
+# Verbatim from this repo's own roborazzi.log, line 148 (#3195). The path is
+# RELATIVE, and it is the reason the gate refused every push: the pattern used
+# to start at the slash after `samples` and yield `/android-demo/src/…`, which
+# is under no project root because it is under no root at all. A relative path
+# is the local tree by definition — it can never name another clone.
+cat > "$TMP/relative.log" <<'LOG'
+> Task :samples:android-demo:generateDemoFragments
+OK: samples/android-demo/src/main/java/io/github/sceneview/demo/fragments/GeneratedDemos.kt already in sync with 54 fragment(s).
+BUILD SUCCESSFUL in 3s
+LOG
+
 ft() { gradle_foreign_tree_paths "$1" "$FT_PROJ"; }
 
 if [ -n "$(ft "$TMP/foreign.log")" ]; then
@@ -728,7 +739,7 @@ if [ -n "$(ft "$TMP/foreign.log")" ]; then
 else
     bad "another clone's source path went UNDETECTED — a verdict could be issued about the wrong tree"
 fi
-for f in local cachepaths; do
+for f in local cachepaths relative; do
     if [ -z "$(ft "$TMP/$f.log")" ]; then
         ok "$f.log is not flagged"
     else
@@ -739,18 +750,31 @@ done
 # The measured clean-run baseline: 0 hits across every log the gate writes. If
 # this repo's real logs ever trip the check, the gate is unusable, so assert it
 # against the actual artefacts when a previous run left them behind.
-REAL_LOGS="$(ls -td "${TMPDIR:-/tmp}"/sceneview-pre-push/*/ 2>/dev/null | head -1)"
-if [ -n "$REAL_LOGS" ] && [ -d "$REAL_LOGS" ]; then
+#
+# THIS WORKTREE's logs, resolved through the same lib the gate writes through
+# (#3074) — not `ls -td …/*/ | head -1`, which returned whichever worktree ran
+# last. That made the assertion non-deterministic across the ~10 worktrees this
+# repo runs in parallel: it passed here while reading a NEIGHBOUR's directory,
+# on the very run whose own roborazzi.log carried the #3195 defect. An assertion
+# that reads someone else's artefacts is the false green of #3159 turned inward.
+source "$SCRIPT_DIR/lib/log-dir.sh"
+REAL_LOGS="$(pre_push_log_dir "$(cd "$SCRIPT_DIR/../.." && pwd)")"
+if [ -d "$REAL_LOGS" ] && [ -n "$(find "$REAL_LOGS" -maxdepth 1 -name '*.log' -print -quit)" ]; then
     ft_hits=0
-    for f in "$REAL_LOGS"*.log; do
+    ft_seen=0
+    for f in "$REAL_LOGS"/*.log; do
         [ -f "$f" ] || continue
+        ft_seen=$((ft_seen + 1))
         [ -z "$(gradle_foreign_tree_paths "$f" "$SCRIPT_DIR/../..")" ] || ft_hits=$((ft_hits + 1))
     done
     if [ "$ft_hits" -eq 0 ]; then
-        ok "no real gate log in $REAL_LOGS trips the check"
+        ok "none of this worktree's $ft_seen real gate log(s) trip the check"
     else
-        bad "$ft_hits real gate log(s) trip the check — it would block this repo's own clean runs"
+        bad "$ft_hits of $ft_seen real gate log(s) trip the check — it would block this repo's own clean runs"
     fi
+else
+    # Say it. A silently skipped assertion reads exactly like a passing one.
+    echo "  ⚠ no gate log in $REAL_LOGS yet — real-artefact check NOT run (run pre-push-check.sh first)"
 fi
 
 # `gradle_report_failure` must route contamination to INCOMPLETE, never to
@@ -811,10 +835,15 @@ ft_mutant() { # name sed-expr fixture expectation(detect|silent)
 }
 
 ft_mutant 'match any absolute path, not just /src/' \
-    's|/src/\[\^ :"|/[^ :"|' cachepaths detect
+    's|\*/src/|*/|' cachepaths detect
 ft_mutant 'never exclude the project dir' \
     's|case "\$p_norm" in "\$proj_norm"/\*) ;; \*) printf|case "$p_norm" in "$proj_norm"/*) ;; "") printf|' \
     foreign silent
+# C — drop the start-of-path anchor: the pattern matches mid-token again, every
+#     relative path containing /src/ reads as another clone, and the gate blocks
+#     this repository's own clean runs (#3195).
+ft_mutant 'drop the start-of-path anchor' \
+    's|local bound=.*|local bound=""|' relative detect
 
 echo ""
 echo "test-gradle-run: $PASS passed, $FAIL failed"

--- a/changelog.d/3195-relative-path-false-foreign.md
+++ b/changelog.d/3195-relative-path-false-foreign.md
@@ -1,0 +1,6 @@
+<!-- category: Fixed -->
+The pre-push gate no longer reads a relative path as another clone's tree. Its
+foreign-tree detector required a leading `/` without checking what preceded it,
+so `samples/android-demo/src/main/.../GeneratedDemos.kt` — a line the gate writes
+itself — yielded `/android-demo/src/…` and graded the repository's own clean run
+`COULD NOT RUN`, refusing every push.


### PR DESCRIPTION
Closes #3195.

## The defect

`gradle_foreign_tree_paths()` graded a gate run `COULD NOT RUN` whenever a log
named a path outside the project root. Its pattern required a leading `/` but
never checked what preceded it:

```
grep -oE '(file://)?/[^ :"]*/src/[^ :"]*'
```

The gate writes this line itself, into `roborazzi.log`:

```
OK: samples/android-demo/src/main/java/.../GeneratedDemos.kt already in sync with 54 fragment(s).
```

grep started at the slash after `samples` and returned `/android-demo/src/main/…`
— a path under no project root, because it is under no root at all. **Every push
in the repository was refused.** Any relative path containing `/src/` did it.

The pattern now anchors on start-of-line or a delimiter, stripped back off before
the `file://` strip so the two `sed` passes cannot collide. A relative path is the
local tree by definition; it can never name another clone.

## The assertion that should have caught it, and why it did not

The "no real gate log trips the check" case read
`ls -td "$TMPDIR"/sceneview-pre-push/*/ | head -1` — the most recent directory
**across every worktree**. On the run that exposed this bug it read a *neighbour's*
logs (`bridge-cse_01ApxVk1LUJJrpDCZM49qM4m-…`) and went green, while this
worktree's own `roborazzi.log` carried the defect. That is #3159's false green
turned inward, and it is non-deterministic across the ~10 worktrees this repo runs
in parallel.

It now resolves through `pre_push_log_dir()` (the per-worktree lib from #3074, the
same one the gate writes through), reports how many real logs it actually checked,
and prints an explicit ⚠ when none exist yet — a silently skipped assertion reads
exactly like a passing one.

## Tests

- `relative.log`, verbatim from the real log line, added to the not-flagged loop.
- Third mutant, `local bound=""`, must make `relative.log` flag. It does.
- The `/src/`-narrowing mutant was **rewritten**: the anchor refactor moved the
  pattern into double quotes, so its `sed` matched nothing and it silently stopped
  applying to the lib. The suite's own `cmp -s` guard caught that — the mutation
  harness proving itself.

```
test-gradle-run: 81 passed, 0 failed
```

`pre-push-check.sh`: `✓ CHECKS PASSED — safe to push`, 42 gate self-tests, 0 legs
unable to run (2 not covered on this host, gated in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)