### PR TITLE
fix(app-store): defer, don't crash, when a predecessor is still in review (#3143)

### DIFF
--- a/.claude/scripts/test-app-store-submit.py
+++ b/.claude/scripts/test-app-store-submit.py
@@ -132,9 +132,19 @@ class FakeASC(types.ModuleType):
             self.build_polls += 1
             return s["builds"](self.build_polls)
         if "appStoreVersions?filter" in url:
-            return Response(200, {"data": [{"id": "VER1", "attributes": {
-                "versionString": "4.26.0",
-                "appStoreState": "PREPARE_FOR_SUBMISSION"}}]})
+            # Two different questions land on this path. The get-or-create asks
+            # for the EDITABLE states; the #3143 diagnosis probe asks for the
+            # OCCUPYING ones after a 409. Split on a state only the latter
+            # names, so each stays separately scriptable.
+            if "IN_REVIEW" in url:
+                return s.get("occupying", lambda: Response(200, {"data": []}))()
+            return s.get("versions", lambda: Response(200, {"data": [
+                {"id": "VER1", "attributes": {
+                    "versionString": "4.26.0",
+                    "appStoreState": "PREPARE_FOR_SUBMISSION"}}]}))()
+        if url.endswith("/appStoreVersions") and method == "POST":
+            return s.get("version_create",
+                         lambda: Response(201, {"data": {"id": "VER1"}}))()
         if "/relationships/build" in url:
             return Response(204)
         if "appStoreVersionLocalizations" in url:
@@ -634,6 +644,67 @@ def main():
           "Target App Store versionString: 4.26.0" in out, out[-400:])
     check("the dispatch path does not crash resolving the workspace",
           not str(code).startswith("EXC NameError"), f"code={code}")
+
+    # ── the appStoreVersions 409 while a predecessor is in review (#3143) ──
+    #
+    # The get-or-create GET filters on PREPARE_FOR_SUBMISSION,READY_FOR_REVIEW.
+    # A version in IN_REVIEW matches neither, so the program falls through to
+    # POST /v1/appStoreVersions believing nothing exists — and Apple, which
+    # allows one non-live version at a time, 409s. Before the fix that was a
+    # bare `raise_for_status()`: a raw traceback, and 4.30.0 was never
+    # submitted (run 31619452239, 2026-08-12).
+    #
+    # The second assertion is the load-bearing one. Step 5a cancels every open
+    # reviewSubmission and its OPEN_STATES includes IN_REVIEW, so a fix that
+    # "handles" the 409 by continuing would withdraw the PREVIOUS release from
+    # App Review. The program must stop above 5a, having touched nothing.
+    print("\nappStoreVersions 409 while a predecessor is in review (#3143)")
+    blocked = {
+        "builds": lambda n: builds_page([1300]),
+        "versions": lambda: Response(200, {"data": []}),
+        "version_create": lambda: Response(
+            409, {"errors": [{"code": "ENTITY_ERROR", "detail":
+                              "The version number has been previously used."}]}),
+        "occupying": lambda: Response(200, {"data": [{"id": "VPREV", "attributes": {
+            "versionString": "4.25.0", "appStoreState": "IN_REVIEW"}}]}),
+        # The predecessor's review submission is OPEN — that is what "in review"
+        # means, and it is what step 5a would cancel. Without this the "never
+        # cancels" assertion below is vacuous: there would be nothing to cancel
+        # and it would pass on a fix that cancels everything.
+        "stale_list": lambda: Response(200, {"data": [
+            {"id": "RSPREV", "attributes": {"state": "IN_REVIEW"}}]}),
+    }
+    out, code, api = run_step(blocked, {"ASC_EXPECTED_BUILD": "1300"})
+    check("a 409 names the version holding the slot and its state",
+          "4.25.0 is IN_REVIEW" in out, out[-600:])
+    check("a 409 is reported as DEFERRED, not as a crash",
+          "DEFERRED" in out and not str(code).startswith("EXC"), f"code={code}")
+    check("a 409 exits 2 — distinct from a broken run, still non-zero",
+          code == 2, f"code={code}")
+    check("a 409 never cancels a reviewSubmission (the previous release stays in review)",
+          cancellations(api) == [],
+          f"cancelled: {cancellations(api)}")
+    check("a 409 never reaches the reviewSubmissions CREATE at all",
+          not any(c[0] == "POST" and c[1].endswith("/reviewSubmissions")
+                  for c in api.calls),
+          f"calls: {[c[1] for c in api.calls]}")
+
+    # An unidentifiable holder must still defer — the 409 is the finding, the
+    # identification only the courtesy. A probe that 403s must not resurrect
+    # the traceback it replaced.
+    out, code, api = run_step({**blocked, "occupying": lambda: Response(403, {})},
+                              {"ASC_EXPECTED_BUILD": "1300"})
+    check("an unidentifiable holder still defers cleanly",
+          "could not identify which" in out and code == 2, f"code={code}\n{out[-400:]}")
+
+    # And the negative case: a 201 must still create the record and carry on,
+    # or the guard above would be indistinguishable from "never create".
+    out, code, api = run_step({**blocked, "version_create":
+                               lambda: Response(201, {"data": {"id": "VNEW"}})},
+                              {"ASC_EXPECTED_BUILD": "1300"})
+    check("a 201 still creates the version record and proceeds",
+          "Created new version record: VNEW" in out and "DEFERRED" not in out,
+          out[-400:])
 
     print()
     if FAILURES:

--- a/.github/scripts/app_store_submit.py
+++ b/.github/scripts/app_store_submit.py
@@ -371,6 +371,59 @@ if not version_id:
         }
     }
     r = requests.post(f"{BASE}/appStoreVersions", headers=headers, json=payload)
+    if r.status_code == 409:
+        # App Store Connect allows exactly ONE non-live version at a time, and
+        # the GET above cannot see the one holding the slot: its filter admits
+        # only PREPARE_FOR_SUBMISSION and READY_FOR_REVIEW, so a predecessor
+        # sitting in IN_REVIEW / WAITING_FOR_REVIEW is invisible. We reach this
+        # POST believing nothing exists, and Apple 409s (#3143). Measured:
+        # 4.30.0's release run died here at 16:48 on 2026-08-12 while 4.29.0
+        # was still in review — it went live at 20:39 the same day.
+        #
+        # STOP HERE. Do not route around it. Step 5a below cancels every open
+        # reviewSubmission, and its OPEN_STATES includes IN_REVIEW: carrying on
+        # would pull the PREVIOUS release out of App Review to make room for
+        # this one. Deferring costs a re-run; continuing costs a release.
+        #
+        # Not every state can hold the slot, so name the one that does rather
+        # than guess. A probe failure degrades to "could not determine" — the
+        # 409 is the finding, the identification is the courtesy.
+        OCCUPYING_STATES = ",".join([
+            "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_APPLE_RELEASE",
+            "PENDING_DEVELOPER_RELEASE", "PROCESSING_FOR_APP_STORE",
+            "WAITING_FOR_EXPORT_COMPLIANCE", "REJECTED", "METADATA_REJECTED",
+            "DEVELOPER_REJECTED", "INVALID_BINARY", "PENDING_CONTRACT",
+        ])
+        holder = ""
+        try:
+            probe = requests.get(
+                f"{BASE}/apps/{app_id}/appStoreVersions"
+                f"?filter[appStoreState]={OCCUPYING_STATES}&filter[platform]=IOS&limit=5",
+                headers=headers,
+            )
+            if probe.status_code == 200:
+                for v in (probe.json() or {}).get("data", []):
+                    a = v.get("attributes", {})
+                    holder = f"{a.get('versionString', '?')} is {a.get('appStoreState', '?')}"
+                    break
+        except Exception as e:  # noqa: BLE001 — diagnosis must never mask the 409
+            print(f"::warning::Could not identify the blocking version: {e}")
+        if not holder:
+            holder = "another version is in a non-live state (could not identify which)"
+        print(
+            f"::error::iOS submission for {version_string} DEFERRED, not failed: {holder}. "
+            "App Store Connect allows one non-live version at a time, so its version record "
+            "cannot be created yet. Re-run app-store.yml once that version is live (or reject "
+            "it in App Store Connect). Nothing was cancelled and no review was touched; "
+            "Maven Central and npm publish earlier in the release and are unaffected."
+        )
+        print(f"POST /v1/appStoreVersions → 409: {r.text[:400]}")
+        # Exit 2, not 1: this run is deferred by Apple's state machine, not
+        # broken. A distinct code lets app-store.yml grade it without parsing
+        # prose. It is still non-zero — nothing was submitted, and a green
+        # badge over an unsubmitted release is the false green this repo pays
+        # for most.
+        raise SystemExit(2)
     r.raise_for_status()
     version_id = r.json()["data"]["id"]
     print(f"Created new version record: {version_id} ({version_string})")

--- a/changelog.d/3143-appstore-409-in-review.md
+++ b/changelog.d/3143-appstore-409-in-review.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+An iOS release cut while the previous one is still in App Review now defers with
+a readable message naming the blocking version and its state, instead of dying on
+a raw traceback. App Store Connect allows one non-live version at a time, so the
+`POST /v1/appStoreVersions` 409 is Apple's normal answer — not a broken run. The
+submission stops there and touches nothing: continuing would have reached the
+stale-submission cleanup, whose open states include `IN_REVIEW`, and withdrawn the
+previous release from review.


### PR DESCRIPTION
Closes #3143.

## What is actually broken

The App Store has been on **4.29.0 since 2026-08-12T20:39:43Z** (`itunes.apple.com/lookup`)
while Maven Central and npm shipped 4.30.0. 4.30.0 was never submitted.

`app_store_submit.py` lists versions with
`filter[appStoreState]=PREPARE_FOR_SUBMISSION,READY_FOR_REVIEW`. A version in
`IN_REVIEW` / `WAITING_FOR_REVIEW` matches neither, so it is invisible to that GET:

1. no record matches `versionString` (l.331)
2. no `PREPARE_FOR_SUBMISSION` draft to absorb (l.345)
3. fall through to `POST /v1/appStoreVersions` (l.373)
4. Apple allows one non-live version at a time → **409**
5. `raise_for_status()` → raw traceback, red run

Run 31619452239 died there at **16:48**; 4.29.0 went live at **20:39** the same day.
A transient state conflict, reported as a crash.

## The trap this fix deliberately does not fall into

Step 5a (l.706-747) cancels *every* open reviewSubmission, and `OPEN_STATES` (l.724)
includes `IN_REVIEW`. The 4.30.0 run died far above it. **A fix that "handles" the
409 by reusing a record and carrying on would reach 5a and withdraw the previous
release from App Review** to make room for the new one.

So the program stops at the 409, having touched nothing:

- names the version holding the slot and its state, by querying the *occupying*
  states (a probe failure degrades to "could not identify which" — the 409 is the
  finding, the identification is the courtesy)
- one `::error::` line saying what to do: re-run once that version is live
- `SystemExit(2)` — distinct from a broken run so the workflow can grade it without
  parsing prose, still non-zero because nothing was submitted. A green badge over an
  unsubmitted release is the false green this repo pays for most.
- Maven Central and npm publish earlier in the release and are unaffected

## Tests

7 new cases, **61 green**. Three mutants, because one is not enough here:

| Mutant | Fails |
|---|---|
| `if False:` — guard removed, pre-fix behaviour restored | 4 cases |
| `if True:` — defer unconditionally, never create | the happy-path case |
| hand-written *"naive fix: reuse the record and carry on"* | **exactly the 2 cases protecting the in-flight review** |

That third mutant is why the scenario now scripts an open `IN_REVIEW`
reviewSubmission: without one, "never cancels a reviewSubmission" passes by
vacuity — there is nothing to cancel — and would stay green on a fix that cancels
everything.

`pre-push-check.sh`: `✓ CHECKS PASSED — safe to push`, 42 gate self-tests.

## Note

This recurs by construction at every release cut while the previous one is still in
review, which is where 4.31.0 is heading. Submitting 4.30.0 is a separate,
deliberate step — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)