### PR TITLE
Declare the generated changelog asset so the release lint can see it

### DIFF
--- a/changelog.d/3233-lintvital-changelog-asset.md
+++ b/changelog.d/3233-lintvital-changelog-asset.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+
+- **Shipping the demo to Play stopped working the moment the "What's new" card landed; the build now declares the asset it generates.** [#3232](https://github.com/sceneview/sceneview/pull/3232) added a `bundleChangelogAsset` task that copies the repo-root `CHANGELOG.md` into the demo's assets, and registered the output directory by appending it to `sourceSets.main.assets.srcDirs`. A `srcDirs` entry is invisible to Gradle's task graph, so every consumer had to be named by hand — the task list did name the asset merge, package and compress tasks, and missed `lintVitalAnalyzeRelease`. Gradle refused the build with *"uses this output of task `bundleChangelogAsset` without declaring an explicit or implicit dependency"*, and `Deploy Demo to Play Internal` went red on `main`.
+
+  **`lintVital` only exists in release**, which is exactly why no pull-request check could catch it: the whole PR pipeline was green, and the failure appeared for the first time on the merge commit, at deploy time. Naming consumers by hand was the defect, not the missing name — the next task to read that directory would have broken the same way.
+
+  The generated directory is now registered through `variant.sources.assets.addGeneratedSourceDirectory(...)`, the AGP API whose contract is precisely that the producer becomes a declared dependency of *every* consumer AGP wires, present and future. The copy moved from a `Copy` task to a small typed task with a `@OutputDirectory`, because that API owns the output location.

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -356,20 +356,36 @@ tasks.matching { it.name == "preBuild" }.configureEach {
 // (collate-changelog.sh) and can never silently go stale — shipping a release
 // IS updating the screen. WhatsNewAssetIntegrityTest (Robolectric) fails if
 // this wiring rots: it opens the merged asset and requires it to parse.
-def whatsNewAssetsDir = layout.buildDirectory.dir("generated/whatsNewAssets").get().asFile
-def bundleChangelogAsset = tasks.register("bundleChangelogAsset", Copy) {
-    description = "Copies the repo-root CHANGELOG.md into the demo assets for the What's new screen."
-    group = "build"
-    from rootProject.file("CHANGELOG.md")
-    into whatsNewAssetsDir
+//
+// The directory is registered through `sources.assets.addGeneratedSourceDirectory`
+// rather than appended to `sourceSets.main.assets.srcDirs`: AGP then owns the
+// output location and declares the producer as a dependency of *every* consumer
+// it generates. A plain srcDirs entry is invisible to the task graph, so each
+// consumer has to be named by hand — and the one nobody thinks of,
+// `lintVitalAnalyzeRelease`, only exists in release, which is why it broke the
+// Play deploy instead of PR CI.
+abstract class BundleChangelogAsset extends DefaultTask {
+    @InputFile
+    abstract RegularFileProperty getChangelog()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @TaskAction
+    void bundle() {
+        def target = outputDir.get().file("CHANGELOG.md").asFile
+        target.parentFile.mkdirs()
+        target.text = changelog.get().asFile.text
+    }
 }
-android.sourceSets.main.assets.srcDirs += whatsNewAssetsDir
-// Every asset merge/package task (app variants, androidTest, and the unit-test
-// merged assets Robolectric reads via includeAndroidResources) must run after
-// the copy, or Gradle fails the build with an implicit-dependency error.
-tasks.configureEach { task ->
-    def lower = task.name.toLowerCase()
-    if (lower.contains("assets") && (lower.startsWith("merge") || lower.startsWith("package") || lower.startsWith("compress"))) {
-        task.dependsOn(bundleChangelogAsset)
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        def bundleChangelogAsset = tasks.register(
+                "bundle${variant.name.capitalize()}ChangelogAsset", BundleChangelogAsset) {
+            it.description = "Copies the repo-root CHANGELOG.md into the ${variant.name} assets for the What's new screen."
+            it.group = "build"
+            it.changelog.set(rootProject.file("CHANGELOG.md"))
+        }
+        variant.sources.assets.addGeneratedSourceDirectory(bundleChangelogAsset) { it.outputDir }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/whatsnew/WhatsNewChangelog.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/whatsnew/WhatsNewChangelog.kt
@@ -12,7 +12,7 @@ import android.content.res.AssetManager
  * author forgot to update it. `CHANGELOG.md` cannot rot the same way: it is
  * regenerated on every release by `.claude/scripts/collate-changelog.sh` from
  * the per-PR `changelog.d/` fragments, and the demo build copies it into the
- * APK assets on every assemble (`bundleChangelogAsset` in
+ * APK assets on every assemble (`bundle<Variant>ChangelogAsset` in
  * `samples/android-demo/build.gradle`). Shipping a release *is* updating this
  * screen. `WhatsNewAssetIntegrityTest` fails the build if the asset goes
  * missing or the collator's format drifts past what this parser understands.

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/whatsnew/WhatsNewAssetIntegrityTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/whatsnew/WhatsNewAssetIntegrityTest.kt
@@ -11,7 +11,7 @@ import org.robolectric.RuntimeEnvironment
  * Staleness guard for the "What's new" surface.
  *
  * The Samples tab derives its What's new content from `CHANGELOG.md`, which
- * `bundleChangelogAsset` (samples/android-demo/build.gradle) copies into the
+ * `bundle<Variant>ChangelogAsset` (samples/android-demo/build.gradle) copies into the
  * APK assets on every build. Two independent failure modes would silently
  * blank the card while everything still compiled:
  *


### PR DESCRIPTION
`Deploy Demo to Play Internal (per-push)` went red on `main` at the merge of #3232 ([run 32061757423](https://github.com/sceneview/sceneview/actions/runs/32061757423)):

```
> Task :samples:android-demo:lintVitalAnalyzeRelease FAILED
A problem was found with the configuration of task ':samples:android-demo:lintVitalAnalyzeRelease'.
  Reason: Task ':samples:android-demo:lintVitalAnalyzeRelease' uses this output of task
  ':samples:android-demo:bundleChangelogAsset' without declaring an explicit or implicit
  dependency.
```

#3232 registered the generated assets directory by appending it to `sourceSets.main.assets.srcDirs`. That is invisible to Gradle's task graph, so the PR then had to name every consumer by hand — it named the asset merge, package and compress tasks, and missed `lintVitalAnalyzeRelease`.

**Why no pull-request check caught it:** `lintVital` only runs in release. The whole PR pipeline was green and the failure appeared for the first time on the merge commit, at deploy time. `main` still carries the defect right now — the leg was not re-run on `44c2cadd` because #3231 is iOS-only and the path filter skipped it, so the next Android-touching push would have hit the same wall.

**The fix is not the missing name.** Naming consumers by hand is the defect; the next task to read that directory would break the same way. The directory is now registered through `variant.sources.assets.addGeneratedSourceDirectory(...)`, the AGP API whose contract is that the producer becomes a declared dependency of every consumer AGP wires. AGP owns the output location, so the copy becomes a small typed task with an `@OutputDirectory` instead of a `Copy`, and the task is registered per variant.

## Verification

The exact task that failed on `main`, plus the Robolectric guard that reads the generated asset:

```
$ ./gradlew :samples:android-demo:lintVitalAnalyzeRelease \
            :samples:android-demo:testDebugUnitTest --tests '*WhatsNewAssetIntegrityTest*'
> Task :samples:android-demo:lintVitalAnalyzeRelease
WhatsNewAssetIntegrityTest > bundled changelog asset exists and parses to real releases STARTED
WhatsNewAssetIntegrityTest > latest bundled release is newest-first and carries a date STARTED
BUILD SUCCESSFUL in 44s
```

`bash .claude/scripts/pre-push-check.sh` → `✓ ALL CHECKS PASSED — safe to push` (22/22; the two warnings are pre-existing and non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)