### PR TITLE
The demo app reads its spacing and radius from DESIGN.md instead of repeating it

### DIFF
--- a/changelog.d/3240-design-tokens-compose.md
+++ b/changelog.d/3240-design-tokens-compose.md
@@ -1,0 +1,9 @@
+<!-- category: Changed -->
+<!-- breaking: false -->
+The Android demo app now reads its spacing, radius, motion and layout constants from a
+single `SceneViewTokens` object that mirrors `DESIGN.md` token-for-token, instead of
+repeating the numbers as literals. Two Material shape roles move as a result, because
+`Shape.kt` claimed to follow `DESIGN.md` while using values it never defined: the `large`
+role goes from 28dp to 24dp (`radius-lg`) and `extraLarge` from 32dp to 28dp
+(`radius-xl`). Cards, bottom sheets, buttons and chips in the demo app render with
+slightly tighter corners; nothing outside the demo app changes.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
@@ -1,0 +1,62 @@
+package io.github.sceneview.demo.theme
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.dp
+
+/**
+ * Compose translation of the non-colour, non-typography tokens in `DESIGN.md`.
+ *
+ * Names mirror the token names in `DESIGN.md` one-for-one — `Space.md` is `space-md` —
+ * so a reader (human or AI) can move between the spec and the code without a lookup
+ * table. Material 3 slot names stay on the Material side of the boundary: `Shape.kt`
+ * writes `extraSmall = RoundedCornerShape(SceneViewTokens.Radius.xs)`, which reads as
+ * the translation it is.
+ *
+ * An immutable object fits these application-wide constants better than a
+ * CompositionLocal: none of the source tokens varies with theme or composition.
+ */
+@Immutable
+object SceneViewTokens {
+    /** `DESIGN.md` — Spacing scale (`space-*`). */
+    object Space {
+        val xs = 4.dp
+        val sm = 8.dp
+        val md = 16.dp
+        val lg = 24.dp
+        val xl = 32.dp
+        val x2l = 48.dp
+        val x3l = 64.dp
+        val x4l = 96.dp
+    }
+
+    /** `DESIGN.md` — Corner radius scale (`radius-*`). */
+    object Radius {
+        val xs = 8.dp
+        val sm = 12.dp
+        val md = 16.dp
+        val lg = 24.dp
+        val xl = 28.dp
+        val full = 9999.dp
+    }
+
+    /** `DESIGN.md` — Motion durations (`duration-*`). */
+    object Duration {
+        const val shortMillis = 200
+        const val mediumMillis = 350
+        const val longMillis = 700
+    }
+
+    /** `DESIGN.md` — Easing curves (`ease-*`). */
+    object Ease {
+        val spring = CubicBezierEasing(0.34f, 1.56f, 0.64f, 1f)
+        val expressive = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+    }
+
+    /** `DESIGN.md` — Layout constants (`container-padding`, `nav-height`). */
+    object Layout {
+        val containerPaddingDesktop = 24.dp
+        val containerPaddingMobile = 16.dp
+        val navigationHeight = 64.dp
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Shape.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Shape.kt
@@ -2,22 +2,22 @@ package io.github.sceneview.demo.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
-import androidx.compose.ui.unit.dp
 
 /**
  * SceneView M3 Expressive Shape System
  *
- * Dynamic shapes from DESIGN.md:
+ * Material shape roles mapped to the radius tokens defined in [SceneViewTokens].
+ * The role names and usage descriptions below are Compose-specific mappings:
  * - ExtraSmall (8dp): utility elements, chips
- * - Small (12dp): buttons, text fields
- * - Medium (16dp): cards, dialogs
- * - Large (28dp): prominent cards, bottom sheets
- * - ExtraLarge (32dp): hero cards, large surfaces
+ * - Small (12dp): code blocks, inputs, badges, tooltips
+ * - Medium (16dp): buttons, medium cards, dialogs
+ * - Large (24dp): section cards, bottom sheets
+ * - ExtraLarge (28dp): prominent cards, showcase items, hero panels
  */
 val SceneViewShapes = Shapes(
-    extraSmall = RoundedCornerShape(8.dp),
-    small = RoundedCornerShape(12.dp),
-    medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(28.dp),
-    extraLarge = RoundedCornerShape(32.dp),
+    extraSmall = RoundedCornerShape(SceneViewTokens.Radius.xs),
+    small = RoundedCornerShape(SceneViewTokens.Radius.sm),
+    medium = RoundedCornerShape(SceneViewTokens.Radius.md),
+    large = RoundedCornerShape(SceneViewTokens.Radius.lg),
+    extraLarge = RoundedCornerShape(SceneViewTokens.Radius.xl),
 )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Theme.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/Theme.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.platform.LocalContext
  *
  * Color system from the SceneView design system (source: #005bc1).
  * Typography: M3 Expressive scale with Inter-weight equivalents.
- * Shapes: M3 Expressive with DESIGN.md radius tokens (8/12/16/28/32dp).
+ * Shapes: M3 Expressive with DESIGN.md radius tokens (8/12/16/24/28dp).
  * Motion: Expressive spring animations.
  *
  * ## Dynamic colour is OFF by default, on purpose

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/ThemePreview.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/ThemePreview.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 private fun ThemeSampler() {
     Surface {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(modifier = Modifier.padding(SceneViewTokens.Space.md)) {
             Text("SceneView Theme", style = MaterialTheme.typography.headlineSmall)
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -51,21 +51,21 @@ private fun ThemeSampler() {
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
                 Button(onClick = {}, shape = MaterialTheme.shapes.extraLarge) { Text("Primary") }
                 FilledTonalButton(onClick = {}, shape = MaterialTheme.shapes.extraLarge) { Text("Tonal") }
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
                 FilterChip(selected = true, onClick = {}, label = { Text("Selected") }, shape = MaterialTheme.shapes.extraLarge)
                 FilterChip(selected = false, onClick = {}, label = { Text("Unselected") }, shape = MaterialTheme.shapes.extraLarge)
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
                 listOf("primary", "secondary", "tertiary", "error").forEach { name ->
                     val color = when (name) {
                         "primary" -> MaterialTheme.colorScheme.primary


### PR DESCRIPTION
## What was wrong

`Shape.kt` carried a comment claiming its corner radii came from `DESIGN.md`, and used
values `DESIGN.md` never defines: 28dp and 32dp, against `radius-lg` 24px and `radius-xl`
28px. Spacing had the same shape of problem without the false claim — literals repeated
at each call site, nothing tying them to the spec.

That comment is how the drift survived: anyone checking whether the theme followed the
design system read the comment and stopped there.

## What changes

`SceneViewTokens` holds the non-colour, non-typography tokens once — spacing, radius,
motion durations, easing curves, layout constants — named after the `DESIGN.md` tokens
one-for-one. `Space.x4l` is `space-4xl`; no lookup table, which is the point for a repo
whose test is *can an AI read this and emit working code*.

Material 3 slot names stay on the Material side of the boundary, so the mapping reads as
the translation it is:

```kotlin
extraSmall = RoundedCornerShape(SceneViewTokens.Radius.xs)
```

## Real pixels move, on purpose

Two Material shape roles change in the demo app:

| Role | Before | After | Token |
|---|---|---|---|
| `large` | 28dp | 24dp | `radius-lg` |
| `extraLarge` | 32dp | 28dp | `radius-xl` |

Cards, bottom sheets, buttons and chips render with slightly tighter corners. This is the
correction, not a side effect — the file's own comment was already promising these values.
Nothing outside `samples/android-demo` is affected.

## Deliberately left alone

The 12dp preview gaps (12 is not on the spacing scale), and the icon sizes, elevations and
strokes that merely happen to equal a token numerically — equal is not the same as *meant
to be this token*. Colours, the dark palette, `dynamicColor` and the typography font
families are untouched.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin` — `BUILD SUCCESSFUL in 23s`
- `pre-push-check.sh` — `ALL CHECKS PASSED`, 24/24, including the new leg 15
  (`PASS  80 tokens, 6 inline repeat(s), no contradiction`) added in #3239
- Two pre-existing non-blocking warnings unrelated to this change: the worktree-prune
  regression suite and a third-party CDN load in HTML

Implementation delegated to Codex. The token names, the replacement of its
`DESIGN.md:166`-style line-number comments with stable token names, and the compile
verification are mine — Codex reported honestly that it could not compile in its worktree
rather than claiming it had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)