### PR TITLE
A delegated agent gets a working Android build without being handed anyone's secrets

### DIFF
--- a/.claude/scripts/codex-delegate.sh
+++ b/.claude/scripts/codex-delegate.sh
@@ -101,6 +101,36 @@ run_codex() {
 }
 
 # ------------------------------------------------------------------- preflight
+# A fresh worktree inherits no gitignored file, so it has no local.properties and
+# every Android build in it dies at configuration time. The obvious fix — copy the
+# one from the main checkout — is a leak: on 2026-08-18 that file held a live
+# sketchfab.api.key next to sdk.dir, and the sibling ar-model-viewer checkout holds
+# the Play upload keystore's passwords in the same file.
+#
+# So the default is inverted. No value is ever copied except sdk.dir, which is a
+# path and not a secret. Every other key keeps its NAME and loses its VALUE, which
+# is what Gradle needs to configure: a key read as an empty string configures, a
+# missing key can throw. Nothing has to be recognised as secret for this to hold —
+# a key nobody has thought of yet is neutralised like the rest.
+provision_local_properties() {
+  local wt="$1" src="$REPO_ROOT/local.properties" dst="$1/local.properties"
+  [ -f "$src" ] || return 0
+  [ -f "$dst" ] && return 0
+  awk -F= '
+    /^[[:space:]]*#/ || NF == 0 { next }
+    {
+      key = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+      if (key == "") next
+      if (key == "sdk.dir") { print; kept++ } else { print key "="; blanked++ }
+    }
+    END { printf "%d %d\n", kept, blanked > "/dev/stderr" }
+  ' "$src" > "$dst" 2> /tmp/codex-lp-counts.$$
+  read -r kept blanked < /tmp/codex-lp-counts.$$ || true
+  rm -f /tmp/codex-lp-counts.$$
+  ok "local.properties: sdk.dir kept, ${blanked:-0} other key(s) blanked (no value copied)"
+}
+
 preflight() {
   local quiet="${1:-}"
   # CODEX_HOME wins when set — Codex itself honours it, so reading ~/.codex
@@ -321,6 +351,7 @@ case "$CMD" in
           || die "Could not create worktree: $WT_PATH"
         ok "Dedicated worktree: $WT_PATH (branch codex/$NEW_WT)"
       fi
+      provision_local_properties "$WT_PATH"
       DIR="$WT_PATH"
     fi
 

--- a/.claude/skills/codex-delegation/SKILL.md
+++ b/.claude/skills/codex-delegation/SKILL.md
@@ -71,6 +71,20 @@ After Codex returns: **inspect the diff, check coherence, run the relevant
 tests, then integrate.** Codex never commits, pushes or merges — `AGENTS.md`
 tells it so, and Git stays Claude's responsibility.
 
+A fresh worktree inherits no gitignored file, so Codex reports "no Android SDK"
+and cannot compile. **Never fix that by copying `local.properties` across** — on
+2026-08-18 that file held a live `sketchfab.api.key` beside `sdk.dir`, and the
+sibling `ar-model-viewer` checkout keeps the Play upload keystore's passwords in
+the same file. `--new-worktree` now writes a safe one itself: `sdk.dir` is kept
+because it is a path, every other key keeps its name and loses its value. A key
+read as an empty string still configures; a missing key can throw. Nothing has to
+be recognised as a secret for this to hold, so a key nobody has thought of yet is
+neutralised like the rest.
+
+Codex still cannot always compile — the Gradle user-home lock is shared with the
+main checkout. When it says so, that is the honest report; **compile it yourself
+before integrating.**
+
 ## Cost policy — Claude quota is the scarce resource (2026-08-18)
 
 The weekly Claude 20x allowance was at **66% by Tuesday 18 August**, resetting

--- a/changelog.d/3241-codex-worktree-local-properties.md
+++ b/changelog.d/3241-codex-worktree-local-properties.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+`codex-delegate.sh --new-worktree` now provisions a safe `local.properties` in the
+worktree it creates, so a delegated agent can configure an Android build without anyone
+copying the developer's own file across. Only `sdk.dir` is carried over; every other key
+keeps its name and loses its value, which is what Gradle needs to configure and what a
+secret must never be given.


### PR DESCRIPTION
## The trap

`codex-delegate.sh --new-worktree` creates a worktree, and a fresh worktree inherits no
gitignored file. So there is no `local.properties`, every Android build dies at
configuration time, and Codex reports "no Android SDK" — which reads like a broken
environment rather than a missing file.

The obvious fix is to copy `local.properties` from the main checkout. That is a leak.
This repo's own file holds a live `sketchfab.api.key` next to `sdk.dir`. The sibling
`ar-model-viewer` checkout holds the Play upload keystore's file, alias and both
passwords in the same file — and a key that signs a production release is not revoked
and reissued the way an API key is.

## Why the first attempt was not good enough

The guard used this morning matched key names against `key|token|password|secret` before
copying. It worked, and it is still a blacklist: it catches what it has thought of. A key
named `sketchfab.access`, or anything added next year, walks straight through.

## What this does instead

Inverts the default. **No value is ever copied except `sdk.dir`**, which is a path, not a
secret. Every other key keeps its **name** and loses its **value** — that is what Gradle
needs, since a key read as an empty string configures while a missing key can throw.

Nothing has to be *recognised as* a secret for this to hold.

## Verification

Against a fixture with sentinel values under three key names, one deliberately innocuous:

```
✓ local.properties: sdk.dir kept, 3 other key(s) blanked (no value copied)
sdk.dir=/Users/x/Library/Android/sdk
sketchfab.api.key=
ARCAMERA_KEYSTORE_PASSWORD=
some.future.key=
--- une sentinelle a-t-elle fuité ? --- aucune fuite
--- idempotence (2nd call must not overwrite) --- 1
```

`some.future.key` is the point: no rule names it, and it is neutralised anyway.

Then run for real on the worktree this PR was written in — which had no
`local.properties`, and was therefore **skipping six gate checks while reporting no
failure**. With the file provisioned, `pre-push-check.sh` runs complete:
`ALL CHECKS PASSED`, 24/24. The two remaining warnings (worktree-prune suite,
third-party CDN in HTML) are pre-existing and unrelated.

## Note

The gate's own help text already advised the safe form (`echo "sdk.dir=…" > local.properties`).
The gap was never the advice — it was that following it was manual, per worktree, and an
agent in a hurry reaches for `cp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)