### PR TITLE
Redesign the demo app Explore screen as a spatial gallery

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,6 +67,10 @@ Glassmorphism adds depth and layering to surfaces that float over content (nav, 
 | `surface` | #ffffff | #0D1117 | Page background |
 | `surface-dim` | #f1f3f5 | #161B22 | Secondary background, cards |
 | `surface-container` | #ffffff | #161c2c | Elevated surfaces |
+| `stage-scrim-start` | transparent | transparent | Spatial Gallery media scrim start |
+| `stage-scrim-end` | rgba(0,0,0,0.90) | rgba(0,0,0,0.90) | Spatial Gallery media scrim end |
+| `glass-surface` | rgba(255,255,255,0.72) | rgba(255,255,255,0.05) | Floating Spatial Gallery controls |
+| `glass-border` | 1px rgba(255,255,255,0.08) | 1px rgba(255,255,255,0.08) | Floating control outline |
 
 ### Text
 
@@ -171,6 +175,13 @@ Base unit: **8px**
 | `space-2xl` | 48px | Large section gaps |
 | `space-3xl` | 64px | Section separators |
 | `space-4xl` | 96px | Section top/bottom padding |
+
+### Spatial Gallery Media
+
+| Token | Value | Usage |
+|---|---|---|
+| `hero-stage-height` | 360px | Explore hero stage height |
+| `media-aspect` | 1.25 | Explore model-card media aspect ratio |
 
 ---
 

--- a/changelog.d/3242-explore-spatial-gallery-redesign.md
+++ b/changelog.d/3242-explore-spatial-gallery-redesign.md
@@ -1,0 +1,6 @@
+<!-- category: Changed -->
+<!-- RELEASE NOTE (maintainer-only):
+     Explore redesign, screen 1 of the demo-app UI/UX refonte plan.
+     Designed against DESIGN.md, referenced on Sketchfab/Polycam/Reality Composer.
+     Emulator QA: light, dark and search states captured and verified. -->
+- **Redesigned the demo app Explore screen as a spatial gallery.** A full-bleed hero stage with a glass search pill replaces the old list header; trending models flow in an asymmetric media-first rail, sources move into a compact chip rail, and the search state now opens the keyboard immediately and shows a single, focused results layout. New glass/scrim design tokens back the treatment in light and dark.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
@@ -2,6 +2,7 @@ package io.github.sceneview.demo.theme
 
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 /**
@@ -18,6 +19,17 @@ import androidx.compose.ui.unit.dp
  */
 @Immutable
 object SceneViewTokens {
+    /** `DESIGN.md` — Spatial Gallery overlay colours. */
+    object SpatialGalleryColor {
+        val stageScrimStart = Color.Transparent
+        val stageScrimEnd = Color(0xE6000000)
+        val glassSurfaceLight = Color(0xB8FFFFFF)
+        val glassSurfaceDark = Color(0x0DFFFFFF)
+        val glassBorderLight = Color(0x14FFFFFF)
+        val glassBorderDark = Color(0x14FFFFFF)
+        val glassBorderWidth = 1.dp
+    }
+
     /** `DESIGN.md` — Spacing scale (`space-*`). */
     object Space {
         val xs = 4.dp
@@ -58,5 +70,7 @@ object SceneViewTokens {
         val containerPaddingDesktop = 24.dp
         val containerPaddingMobile = 16.dp
         val navigationHeight = 64.dp
+        val heroStageHeight = 360.dp
+        const val mediaAspect = 1.25f
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -83,11 +83,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 
 /**
- * Curated 3D-model discovery feed. Mirrors the iOS `ExploreTab` so QA can
- * compare both apps side-by-side.
+ * Curated 3D-model discovery feed — the demo app's Spatial Gallery home: a
+ * static featured stage, expandable catalog search, media-first trending rail,
+ * compact source filters, and sample showcase.
  *
- * Spatial Gallery home: a static featured stage, expandable catalog search,
- * media-first trending rail, compact source filters, and sample showcase.
+ * The iOS `ExploreTab` still shows the previous layout; it catches up in the
+ * iOS leg of the demo-app redesign plan.
  */
 @Composable
 fun ExploreTabScreen(
@@ -350,6 +351,10 @@ private fun ExploreBody(
     // the CC sources never reach it, and a missing Sketchfab key simply drops the
     // chip from the picker rather than showing dead UI (#1909/#2095, #2645).
     val showSketchfabBanner = selectedSource.id == ModelSourceId.SKETCHFAB && keyRejected
+    // The featured stage fronts the first available model; the trending rail
+    // below filters it out so the same card never appears twice on screen.
+    val hero = feedsByKind[FeedKind.TRENDING]?.firstOrNull()
+        ?: selectedSource.feedKinds.asSequence().flatMap { feedsByKind[it].orEmpty().asSequence() }.firstOrNull()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -394,8 +399,6 @@ private fun ExploreBody(
                 onToggleAnimated = onToggleAnimated,
             )
         } else {
-            val hero = feedsByKind[FeedKind.TRENDING]?.firstOrNull()
-                ?: selectedSource.feedKinds.asSequence().flatMap { feedsByKind[it].orEmpty().asSequence() }.firstOrNull()
             // The pill is anchored to the hero card, not the display: this Box lives
             // inside the scrolled column, whose host applies the window insets.
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -454,11 +457,13 @@ private fun ExploreBody(
                 )
             }
         } else if (!searchExpanded) {
-            val trending = feedsByKind[FeedKind.TRENDING]
-                ?: selectedSource.feedKinds.firstNotNullOfOrNull { kind ->
-                    feedsByKind[kind]?.takeIf { models -> models.isNotEmpty() }
-                }
-                ?: emptyList()
+            val trending = (
+                feedsByKind[FeedKind.TRENDING]
+                    ?: selectedSource.feedKinds.firstNotNullOfOrNull { kind ->
+                        feedsByKind[kind]?.takeIf { models -> models.isNotEmpty() }
+                    }
+                    ?: emptyList()
+                ).filterNot { it.cardKey == hero?.cardKey }
             TrendingRail(models = trending, loading = loadingFeeds, onModelClick = onModelClick)
 
             CompactBrowseRail(
@@ -521,10 +526,6 @@ private fun SearchField(
             placeholder = { Text(stringResource(R.string.explore_search_placeholder, sourceName)) },
             leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
             singleLine = true,
-            // When the API key is missing the search bar is purely cosmetic —
-            // the LaunchedEffect short-circuits in ExploreTabScreen.kt:165, so
-            // disabling the input is honest UX rather than letting users type
-            // queries that go into a black hole (#1909).
             shape = RoundedCornerShape(SceneViewTokens.Radius.full),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(onSearch = { onSubmit(value) }),
@@ -535,7 +536,7 @@ private fun SearchField(
                     }
                 } else {
                     IconButton(onClick = onCollapse) {
-                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.explore_clear_search))
+                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.explore_close_search))
                     }
                 }
             },
@@ -748,73 +749,6 @@ private fun SketchfabDisabledBanner(keyRejected: Boolean = false) {
 }
 
 @Composable
-private fun FiltersBar(animatedOnly: Boolean, onToggle: () -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
-        FilterChip(
-            selected = animatedOnly,
-            onClick = onToggle,
-            label = { Text(stringResource(R.string.explore_filter_animated)) },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Filled.AutoAwesome,
-                    contentDescription = null,
-                    modifier = Modifier.size(FilterChipDefaults.IconSize),
-                )
-            },
-            colors = FilterChipDefaults.filterChipColors(
-                selectedContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                selectedLabelColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                selectedLeadingIconColor = MaterialTheme.colorScheme.onTertiaryContainer,
-            ),
-        )
-    }
-}
-
-/**
- * Source-picker chip row (#2645): one [FilterChip] per available [ModelSource]
- * (Sketchfab | Icosa Gallery | Poly Haven), the selected one highlighted.
- * Horizontally scrollable so three chips never crowd a narrow phone.
- */
-@Composable
-private fun SourcePickerRow(
-    sources: List<ModelSource>,
-    selected: ModelSource,
-    onSelect: (ModelSource) -> Unit,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
-        modifier = Modifier.horizontalScroll(rememberScrollState()),
-    ) {
-        Text(
-            text = stringResource(R.string.explore_source_label),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontWeight = FontWeight.Medium,
-            modifier = Modifier.align(Alignment.CenterVertically),
-        )
-        sources.forEach { source ->
-            FilterChip(
-                selected = source.id == selected.id,
-                onClick = { onSelect(source) },
-                label = { Text(source.id.displayName) },
-                colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                    selectedLabelColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                ),
-            )
-        }
-    }
-}
-
-/** Localised carousel title for a [FeedKind]. */
-@Composable
-private fun feedTitle(kind: FeedKind): String = when (kind) {
-    FeedKind.TRENDING -> stringResource(R.string.explore_trending_models)
-    FeedKind.STAFF_PICKS -> stringResource(R.string.explore_staff_picks)
-    FeedKind.RECENTLY_ADDED -> stringResource(R.string.explore_recently_added)
-}
-
-@Composable
 private fun CarouselSection(
     title: String,
     content: @Composable () -> Unit,
@@ -936,6 +870,20 @@ private fun SampleCard(sample: DemoEntry, onClick: () -> Unit) {
             )
             .clickable(onClick = onClick),
     ) {
+        // Full-card scrim, same treatment as FeaturedModelCard: the white title
+        // must stay readable whatever the accent gradient behind it resolves to.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            SceneViewTokens.SpatialGalleryColor.stageScrimStart,
+                            SceneViewTokens.SpatialGalleryColor.stageScrimEnd,
+                        ),
+                    ),
+                ),
+        )
         Icon(
             imageVector = sample.icon,
             contentDescription = null,
@@ -948,14 +896,6 @@ private fun SampleCard(sample: DemoEntry, onClick: () -> Unit) {
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .fillMaxWidth()
-                .background(
-                    androidx.compose.ui.graphics.Brush.verticalGradient(
-                        listOf(
-                            SceneViewTokens.SpatialGalleryColor.stageScrimStart,
-                            SceneViewTokens.SpatialGalleryColor.stageScrimEnd,
-                        ),
-                    ),
-                )
                 .padding(SceneViewTokens.Space.sm),
             verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.xs),
         ) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -3,6 +3,7 @@
 package io.github.sceneview.demo.ui.explore
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -46,9 +48,12 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,11 +61,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import io.github.sceneview.demo.DemoEntry
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.sketchfab.SketchfabService
@@ -70,6 +75,8 @@ import io.github.sceneview.demo.sources.ModelSource
 import io.github.sceneview.demo.sources.ModelSourceId
 import io.github.sceneview.demo.sources.rememberModelSources
 import io.github.sceneview.demo.ui.explore.components.FeaturedModelCard
+import io.github.sceneview.demo.ui.explore.components.SpatialHero
+import io.github.sceneview.demo.theme.SceneViewTokens
 import io.github.sceneview.sample.ui.demoCategoryAccent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -79,19 +86,8 @@ import kotlinx.coroutines.supervisorScope
  * Curated 3D-model discovery feed. Mirrors the iOS `ExploreTab` so QA can
  * compare both apps side-by-side.
  *
- * Top-down layout:
- *   1. Search bar (Sketchfab queries)
- *   2. Filter chips — currently "Animated" (toggle reloads the three feeds)
- *   3. "Try a sample" curated row — links straight into existing demos
- *   4. "Staff Picks"     carousel (Sketchfab)
- *   5. "Most Liked"      carousel (Sketchfab)
- *   6. "Recently Added"  carousel (Sketchfab)
- *   7. Categories grid (18 official Sketchfab slugs)
- *   8. Recent searches (SharedPreferences-backed)
- *
- * When `BuildConfig.SKETCHFAB_API_KEY` is empty the three Sketchfab carousels
- * are hidden and only the curated sample row + categories are shown — keeps
- * the public Play Store build useful even without the proprietary key.
+ * Spatial Gallery home: a static featured stage, expandable catalog search,
+ * media-first trending rail, compact source filters, and sample showcase.
  */
 @Composable
 fun ExploreTabScreen(
@@ -109,6 +105,7 @@ fun ExploreTabScreen(
     val selectedSource = sources.selected
 
     var searchQuery by remember { mutableStateOf("") }
+    var searchExpanded by remember { mutableStateOf(false) }
     var animatedOnly by remember { mutableStateOf(false) }
     var selectedModel by remember { mutableStateOf<GalleryModel?>(null) }
 
@@ -278,6 +275,9 @@ fun ExploreTabScreen(
             },
             activeSearchQuery = activeSearchQuery,
             searchResults = searchResults,
+            searchExpanded = searchExpanded,
+            onSearchExpandedChange = { searchExpanded = it },
+            recentSearches = recentSearches,
             animatedOnly = animatedOnly,
             onToggleAnimated = { animatedOnly = !animatedOnly },
             curatedSamples = curatedSamples,
@@ -334,6 +334,9 @@ private fun ExploreBody(
     onSearchSubmit: (String) -> Unit,
     activeSearchQuery: String,
     searchResults: List<GalleryModel>?,
+    searchExpanded: Boolean,
+    onSearchExpandedChange: (Boolean) -> Unit,
+    recentSearches: RecentSearchesState,
     animatedOnly: Boolean,
     onToggleAnimated: () -> Unit,
     curatedSamples: List<DemoEntry>,
@@ -352,43 +355,70 @@ private fun ExploreBody(
             .fillMaxSize()
             .verticalScroll(scroll)
             .padding(
-                start = 16.dp,
-                end = 16.dp,
-                top = 8.dp,
+                start = SceneViewTokens.Layout.containerPaddingMobile,
+                end = SceneViewTokens.Layout.containerPaddingMobile,
+                top = SceneViewTokens.Space.sm,
                 bottom = LIST_BOTTOM_GUTTER,
             ),
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.lg),
     ) {
-        Spacer(Modifier.height(0.dp))
-        // Hide the page title when the user is actively searching (#2229) —
-        // it's noise that pushes the results below the fold. The SearchField
-        // below carries the "what is this page" affordance on its own.
-        if (!isSearching) {
-            Text(
-                text = stringResource(R.string.explore_heading),
-                style = MaterialTheme.typography.headlineLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
+        Spacer(Modifier.height(SceneViewTokens.Space.xs))
+
+        if (searchExpanded || isSearching) {
+            SearchField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                onSubmit = onSearchSubmit,
+                sourceName = selectedSource.id.displayName,
+                onCollapse = {
+                    if (searchQuery.isBlank()) onSearchExpandedChange(false)
+                },
             )
-        }
-
-        SearchField(
-            value = searchQuery,
-            onValueChange = onSearchQueryChange,
-            onSubmit = onSearchSubmit,
-            // Placeholder names the catalog being searched so the field reflects
-            // the picked source (Sketchfab / Icosa Gallery / Poly Haven), #2645.
-            sourceName = selectedSource.id.displayName,
-            // The selected source is always usable (Sketchfab is dropped from the
-            // picker when it has no key), so the search field is always live.
-            apiKeyAvailable = true,
-        )
-
-        // Source picker (#2645) — stays visible even mid-search so switching
-        // catalogs re-runs the query against the new one. Hidden only when a
-        // single source is available (nothing to choose between).
-        if (sources.size > 1) {
-            SourcePickerRow(sources = sources, selected = selectedSource, onSelect = onSelectSource)
+            if (searchQuery.isBlank() && recentSearches.items.isNotEmpty()) {
+                RecentSearchesSection(
+                    items = recentSearches.items,
+                    onClear = recentSearches::clear,
+                    onClick = { query ->
+                        onSearchQueryChange(query)
+                        onSearchSubmit(query)
+                    },
+                    onRemove = recentSearches::remove,
+                )
+            }
+            CompactBrowseRail(
+                sources = sources,
+                selectedSource = selectedSource,
+                onSelectSource = onSelectSource,
+                showAnimated = selectedSource.supportsAnimatedFilter && !isSearching,
+                animatedOnly = animatedOnly,
+                onToggleAnimated = onToggleAnimated,
+            )
+        } else {
+            val hero = feedsByKind[FeedKind.TRENDING]?.firstOrNull()
+                ?: selectedSource.feedKinds.asSequence().flatMap { feedsByKind[it].orEmpty().asSequence() }.firstOrNull()
+            Box {
+                if (hero != null) {
+                    SpatialHero(model = hero, onViewIn3D = { onModelClick(hero) })
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(SceneViewTokens.Layout.heroStageHeight)
+                            .clip(RoundedCornerShape(SceneViewTokens.Radius.xl))
+                            .background(MaterialTheme.colorScheme.surfaceDim),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (loadingFeeds) CircularProgressIndicator()
+                    }
+                }
+                FloatingSearchPill(
+                    sourceName = selectedSource.id.displayName,
+                    onClick = { onSearchExpandedChange(true) },
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(SceneViewTokens.Space.md),
+                )
+            }
         }
 
         // "Sketchfab unavailable" banner (#2095) — only when the Sketchfab key was
@@ -396,35 +426,6 @@ private fun ExploreBody(
         // is degraded but functional (samples + other sources still work).
         if (showSketchfabBanner) {
             SketchfabDisabledBanner(keyRejected = true)
-        }
-
-        // FiltersBar (Animated chip) and the "Try a sample" carousel both belong
-        // to the browse experience — hidden while searching (#2229). The Animated
-        // filter is meaningful only for Sketchfab; the CC sources don't expose it.
-        if (selectedSource.supportsAnimatedFilter && !isSearching) {
-            FiltersBar(animatedOnly = animatedOnly, onToggle = onToggleAnimated)
-        }
-
-        if (curatedSamples.isNotEmpty() && !isSearching) {
-            CarouselSection(title = stringResource(R.string.explore_try_a_sample)) {
-                val state = rememberLazyListState()
-                LazyRow(
-                    state = state,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    // Edge padding so the first/last card has breathing room
-                    // and never sits half-cropped at the viewport edge — the
-                    // Pixel 9 audit (#1182) caught a screenshot where a card
-                    // appeared truncated mid-name purely because of zero-pad.
-                    contentPadding = PaddingValues(horizontal = 4.dp),
-                    // Snap to card boundaries on fling so the user never
-                    // releases scroll on a half-card.
-                    flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
-                ) {
-                    items(curatedSamples) { sample ->
-                        SampleCard(sample = sample, onClick = { onSampleClick(sample) })
-                    }
-                }
-            }
         }
 
         if (isSearching) {
@@ -450,20 +451,37 @@ private fun ExploreBody(
                     onModelClick = onModelClick,
                 )
             }
-        } else {
-            // One carousel per feed the selected source advertises. When a source
-            // is unreachable each empty FeedSection self-hides and the page falls
-            // back to the "Try a sample" carousel + the picker (switch sources) —
-            // a degraded source never blanks the tab (#2645). No red dev-style
-            // error banner: that was the v4.1.0 "horrible UI" complaint.
-            selectedSource.feedKinds.forEach { kind ->
-                val models = feedsByKind[kind].orEmpty()
-                FeedSection(
-                    title = feedTitle(kind),
-                    models = models,
-                    loading = loadingFeeds && models.isEmpty(),
-                    onModelClick = onModelClick,
-                )
+        } else if (!searchExpanded) {
+            val trending = feedsByKind[FeedKind.TRENDING]
+                ?: selectedSource.feedKinds.firstNotNullOfOrNull { kind ->
+                    feedsByKind[kind]?.takeIf { models -> models.isNotEmpty() }
+                }
+                ?: emptyList()
+            TrendingRail(models = trending, loading = loadingFeeds, onModelClick = onModelClick)
+
+            CompactBrowseRail(
+                sources = sources,
+                selectedSource = selectedSource,
+                onSelectSource = onSelectSource,
+                showAnimated = selectedSource.supportsAnimatedFilter,
+                animatedOnly = animatedOnly,
+                onToggleAnimated = onToggleAnimated,
+            )
+
+            if (curatedSamples.isNotEmpty()) {
+                CarouselSection(title = stringResource(R.string.explore_built_with_sceneview)) {
+                    val state = rememberLazyListState()
+                    LazyRow(
+                        state = state,
+                        horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+                        contentPadding = PaddingValues(horizontal = SceneViewTokens.Space.xs),
+                        flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
+                    ) {
+                        items(curatedSamples) { sample ->
+                            SampleCard(sample = sample, onClick = { onSampleClick(sample) })
+                        }
+                    }
+                }
             }
         }
 
@@ -475,7 +493,7 @@ private fun ExploreBody(
         // RecentSearchesState data layer is preserved for a future
         // search-focus dropdown (Google Search style).
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SceneViewTokens.Space.md))
     }
 }
 
@@ -487,13 +505,17 @@ private fun SearchField(
     onValueChange: (String) -> Unit,
     onSubmit: (String) -> Unit,
     sourceName: String,
-    apiKeyAvailable: Boolean = true,
+    onCollapse: () -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    val focusRequester = remember { FocusRequester() }
+    // Focus (and IME) only on first appearance — recompositions after a
+    // submitted search must not re-open the keyboard over the results.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.xs)) {
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
             placeholder = { Text(stringResource(R.string.explore_search_placeholder, sourceName)) },
             leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
             singleLine = true,
@@ -501,25 +523,127 @@ private fun SearchField(
             // the LaunchedEffect short-circuits in ExploreTabScreen.kt:165, so
             // disabling the input is honest UX rather than letting users type
             // queries that go into a black hole (#1909).
-            enabled = apiKeyAvailable,
-            shape = RoundedCornerShape(28.dp),
+            shape = RoundedCornerShape(SceneViewTokens.Radius.full),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(onSearch = { onSubmit(value) }),
-            trailingIcon = if (value.isNotEmpty()) {
-                {
+            trailingIcon = {
+                if (value.isNotEmpty()) {
                     IconButton(onClick = { onValueChange("") }) {
                         Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.explore_clear_search))
                     }
+                } else {
+                    IconButton(onClick = onCollapse) {
+                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.explore_clear_search))
+                    }
                 }
-            } else null,
+            },
         )
-        if (!apiKeyAvailable) {
+    }
+}
+
+@Composable
+private fun FloatingSearchPill(sourceName: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    val colors = SceneViewTokens.SpatialGalleryColor
+    val dark = isSystemInDarkTheme()
+    Surface(
+        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(SceneViewTokens.Radius.full),
+        color = if (dark) colors.glassSurfaceDark else colors.glassSurfaceLight,
+        border = BorderStroke(
+            colors.glassBorderWidth,
+            if (dark) colors.glassBorderDark else colors.glassBorderLight,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(SceneViewTokens.Space.md),
+            horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Filled.Search, contentDescription = null)
             Text(
-                text = stringResource(R.string.explore_sketchfab_search_hint),
-                style = MaterialTheme.typography.bodySmall,
+                text = stringResource(R.string.explore_search_placeholder, sourceName),
+                style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 16.dp),
             )
+        }
+    }
+}
+
+@Composable
+private fun TrendingRail(
+    models: List<GalleryModel>,
+    loading: Boolean,
+    onModelClick: (GalleryModel) -> Unit,
+) {
+    if (models.isEmpty() && !loading) return
+    CarouselSection(title = stringResource(R.string.explore_trending_in_3d)) {
+        if (models.isEmpty()) {
+            CircularProgressIndicator(modifier = Modifier.size(SceneViewTokens.Space.lg))
+        } else {
+            val state = rememberLazyListState()
+            LazyRow(
+                state = state,
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+                contentPadding = PaddingValues(horizontal = SceneViewTokens.Space.xs),
+                flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
+            ) {
+                items(models, key = { it.cardKey }) { model ->
+                    val width = if (model == models.first()) {
+                        SceneViewTokens.Layout.heroStageHeight
+                    } else {
+                        SceneViewTokens.Layout.heroStageHeight - SceneViewTokens.Space.x3l
+                    }
+                    FeaturedModelCard(
+                        model = model,
+                        onClick = { onModelClick(model) },
+                        modifier = Modifier.width(width),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompactBrowseRail(
+    sources: List<ModelSource>,
+    selectedSource: ModelSource,
+    onSelectSource: (ModelSource) -> Unit,
+    showAnimated: Boolean,
+    animatedOnly: Boolean,
+    onToggleAnimated: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
+        Text(
+            text = stringResource(R.string.explore_browse_by_source),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+        ) {
+            sources.forEach { source ->
+                FilterChip(
+                    selected = source.id == selectedSource.id,
+                    onClick = { onSelectSource(source) },
+                    label = { Text(source.id.displayName) },
+                )
+            }
+            if (showAnimated) {
+                FilterChip(
+                    selected = animatedOnly,
+                    onClick = onToggleAnimated,
+                    label = { Text(stringResource(R.string.explore_filter_animated)) },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Filled.AutoAwesome,
+                            contentDescription = null,
+                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                        )
+                    },
+                )
+            }
         }
     }
 }
@@ -561,14 +685,14 @@ private fun SketchfabDisabledBanner(keyRejected: Boolean = false) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable { showDialog = true },
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(SceneViewTokens.Radius.md),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = SceneViewTokens.Space.md, vertical = SceneViewTokens.Space.sm),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
         ) {
             Icon(
                 imageVector = Icons.Filled.Info,
@@ -623,7 +747,7 @@ private fun SketchfabDisabledBanner(keyRejected: Boolean = false) {
 
 @Composable
 private fun FiltersBar(animatedOnly: Boolean, onToggle: () -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
         FilterChip(
             selected = animatedOnly,
             onClick = onToggle,
@@ -656,7 +780,7 @@ private fun SourcePickerRow(
     onSelect: (ModelSource) -> Unit,
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
         modifier = Modifier.horizontalScroll(rememberScrollState()),
     ) {
         Text(
@@ -693,7 +817,7 @@ private fun CarouselSection(
     title: String,
     content: @Composable () -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge,
@@ -749,7 +873,7 @@ private fun FeedSection(
     // ghost sections stacking under each other in the offline path.
     if (models.isEmpty() && !loading) return
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -762,22 +886,31 @@ private fun FeedSection(
                 modifier = Modifier.weight(1f),
             )
             if (loading) {
-                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                CircularProgressIndicator(
+                    modifier = Modifier.size(SceneViewTokens.Space.lg),
+                    strokeWidth = SceneViewTokens.Space.xs,
+                )
             }
         }
         val state = rememberLazyListState()
         LazyRow(
             state = state,
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.md),
             // Edge padding so the first/last card has breathing room and never
             // sits half-cropped at the viewport edge (#1182).
-            contentPadding = PaddingValues(horizontal = 4.dp),
+            contentPadding = PaddingValues(horizontal = SceneViewTokens.Space.xs),
             // Snap to card boundaries on fling so the user never releases
             // scroll on a half-card mid-name.
             flingBehavior = rememberSnapFlingBehavior(lazyListState = state),
         ) {
             items(models, key = { it.cardKey }) { m ->
-                FeaturedModelCard(model = m, onClick = { onModelClick(m) })
+                FeaturedModelCard(
+                    model = m,
+                    onClick = { onModelClick(m) },
+                    modifier = Modifier.width(
+                        SceneViewTokens.Layout.heroStageHeight - SceneViewTokens.Space.x3l,
+                    ),
+                )
             }
         }
     }
@@ -786,60 +919,58 @@ private fun FeedSection(
 @Composable
 private fun SampleCard(sample: DemoEntry, onClick: () -> Unit) {
     val accent = demoCategoryAccent(sample.category)
-    androidx.compose.material3.Surface(
+    Box(
         modifier = Modifier
-            .width(168.dp)
-            .height(168.dp)
+            .width(SceneViewTokens.Layout.heroStageHeight - SceneViewTokens.Space.x3l * 3)
+            .aspectRatio(SceneViewTokens.Layout.mediaAspect)
+            .clip(RoundedCornerShape(SceneViewTokens.Radius.lg))
+            .background(
+                brush = androidx.compose.ui.graphics.Brush.linearGradient(
+                    colors = listOf(
+                        accent.copy(alpha = SceneViewTokens.SpatialGalleryColor.glassSurfaceLight.alpha),
+                        MaterialTheme.colorScheme.surfaceDim,
+                    ),
+                ),
+            )
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(20.dp),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        tonalElevation = 1.dp,
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(88.dp)
-                    .background(
-                        brush = androidx.compose.ui.graphics.Brush.linearGradient(
-                            colors = listOf(
-                                accent.copy(alpha = 0.32f),
-                                accent.copy(alpha = 0.14f),
-                            ),
+        Icon(
+            imageVector = sample.icon,
+            contentDescription = null,
+            tint = accent,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(SceneViewTokens.Space.x2l),
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .background(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            SceneViewTokens.SpatialGalleryColor.stageScrimStart,
+                            SceneViewTokens.SpatialGalleryColor.stageScrimEnd,
                         ),
                     ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = sample.icon,
-                    contentDescription = null,
-                    tint = accent,
-                    modifier = Modifier.size(36.dp),
                 )
-            }
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                Text(
-                    text = stringResource(sample.titleRes),
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                )
-                Text(
-                    text = stringResource(sample.subtitleRes),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    // Twin of the Samples-tab card: clip with an ellipsis rather
-                    // than mid-word. #3237
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+                .padding(SceneViewTokens.Space.sm),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.xs),
+        ) {
+            Text(
+                text = stringResource(sample.titleRes),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = androidx.compose.ui.graphics.Color.White,
+                maxLines = 1,
+            )
+            Text(
+                text = stringResource(sample.subtitleRes),
+                style = MaterialTheme.typography.bodySmall,
+                color = androidx.compose.ui.graphics.Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }
@@ -850,7 +981,7 @@ private fun SampleCard(sample: DemoEntry, onClick: () -> Unit) {
 @Composable
 private fun CategoriesSection(onCategoryClick: (SketchfabCategory) -> Unit) {
     val scrollState = rememberScrollState()
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
         Text(
             text = stringResource(R.string.explore_categories),
             style = MaterialTheme.typography.titleLarge,
@@ -863,16 +994,16 @@ private fun CategoriesSection(onCategoryClick: (SketchfabCategory) -> Unit) {
         // verticalScroll). Same compromise as the iOS demo.
         val all = SketchfabCategory.entries
         val rowSize = (all.size + 1) / 2
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
             Row(
                 modifier = Modifier.horizontalScroll(scrollState),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
             ) {
                 all.take(rowSize).forEach { CategoryChip(it, onCategoryClick) }
             }
             Row(
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
             ) {
                 all.drop(rowSize).forEach { CategoryChip(it, onCategoryClick) }
             }
@@ -884,10 +1015,10 @@ private fun CategoriesSection(onCategoryClick: (SketchfabCategory) -> Unit) {
 private fun CategoryChip(category: SketchfabCategory, onClick: (SketchfabCategory) -> Unit) {
     Box(
         modifier = Modifier
-            .clip(RoundedCornerShape(50))
+            .clip(RoundedCornerShape(SceneViewTokens.Radius.full))
             .background(MaterialTheme.colorScheme.tertiaryContainer)
             .clickable { onClick(category) }
-            .padding(horizontal = 14.dp, vertical = 10.dp),
+            .padding(horizontal = SceneViewTokens.Space.md, vertical = SceneViewTokens.Space.sm),
     ) {
         Text(
             text = category.displayName,
@@ -908,7 +1039,7 @@ private fun RecentSearchesSection(
     onClick: (String) -> Unit,
     onRemove: (String) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth(),
@@ -927,17 +1058,17 @@ private fun RecentSearchesSection(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(RoundedCornerShape(SceneViewTokens.Radius.md))
                     .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                     .clickable { onClick(query) }
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                    .padding(horizontal = SceneViewTokens.Space.md, vertical = SceneViewTokens.Space.sm),
             ) {
                 Icon(
                     Icons.Filled.History,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Spacer(Modifier.width(10.dp))
+                Spacer(Modifier.width(SceneViewTokens.Space.sm))
                 Text(
                     text = query,
                     style = MaterialTheme.typography.bodyMedium,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -396,7 +396,9 @@ private fun ExploreBody(
         } else {
             val hero = feedsByKind[FeedKind.TRENDING]?.firstOrNull()
                 ?: selectedSource.feedKinds.asSequence().flatMap { feedsByKind[it].orEmpty().asSequence() }.firstOrNull()
-            Box {
+            // The pill is anchored to the hero card, not the display: this Box lives
+            // inside the scrolled column, whose host applies the window insets.
+            Box(modifier = Modifier.fillMaxWidth()) {
                 if (hero != null) {
                     SpatialHero(model = hero, onViewIn3D = { onModelClick(hero) })
                 } else {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/FeaturedModelCard.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/FeaturedModelCard.kt
@@ -2,14 +2,15 @@ package io.github.sceneview.demo.ui.explore.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -20,111 +21,102 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
+import io.github.sceneview.demo.R
 import io.github.sceneview.demo.sources.GalleryModel
 import io.github.sceneview.demo.sources.formattedFaceCount
 import io.github.sceneview.demo.sources.preferredThumbnailUrl
 import io.github.sceneview.demo.sources.primaryTagDisplay
+import io.github.sceneview.demo.theme.SceneViewTokens
 
-/**
- * Horizontal-carousel card for a [GalleryModel] from any source (Sketchfab,
- * Icosa Gallery, Poly Haven). Mirrors the iOS `FeaturedModelCard`: 200×160
- * thumbnail, name, primary tag, poly count, and an "Animated" pill when
- * applicable.
- *
- * Tap → opens the [io.github.sceneview.demo.ui.explore.GalleryModelViewerScreen]
- * which renders the streamed GLB inside SceneView. The origin catalog's web
- * viewer is NEVER opened externally — the whole point of the demo is to show
- * off SceneView.
- */
+/** Media-first model tile. Metadata sits on the image instead of in an elevated container. */
 @Composable
 fun FeaturedModelCard(
     model: GalleryModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Box(
         modifier = modifier
-            .width(200.dp)
+            .aspectRatio(SceneViewTokens.Layout.mediaAspect)
+            .clip(RoundedCornerShape(SceneViewTokens.Radius.lg))
             .clickable(onClick = onClick),
     ) {
+        AsyncNetworkImage(
+            url = model.preferredThumbnailUrl(),
+            contentDescription = model.name,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
         Box(
             modifier = Modifier
-                .width(200.dp)
-                .height(160.dp)
-                .clip(RoundedCornerShape(20.dp)),
-        ) {
-            AsyncNetworkImage(
-                url = model.preferredThumbnailUrl(minWidth = 320, maxWidth = 640),
-                contentDescription = model.name,
-                modifier = Modifier.size(width = 200.dp, height = 160.dp),
-                contentScale = ContentScale.Crop,
-            )
-            if (model.isAnimated) {
-                AnimatedPill(modifier = Modifier.padding(8.dp))
-            }
-        }
-        Spacer(Modifier.height(8.dp))
-        Text(
-            text = model.name,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = 4.dp),
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            SceneViewTokens.SpatialGalleryColor.stageScrimStart,
+                            SceneViewTokens.SpatialGalleryColor.stageScrimEnd,
+                        ),
+                    ),
+                ),
         )
-        Spacer(Modifier.height(2.dp))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 4.dp),
-        ) {
-            Text(
-                text = model.primaryTagDisplay(),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (model.faceCount > 0) {
+        if (model.isAnimated) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(SceneViewTokens.Space.sm)
+                    .clip(RoundedCornerShape(SceneViewTokens.Radius.full))
+                    .background(MaterialTheme.colorScheme.tertiary)
+                    .padding(
+                        horizontal = SceneViewTokens.Space.sm,
+                        vertical = SceneViewTokens.Space.xs,
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.AutoAwesome,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiary,
+                    modifier = Modifier.size(SceneViewTokens.Space.md),
+                )
                 Text(
-                    text = " · ${model.formattedFaceCount()} polys",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    text = stringResource(R.string.explore_filter_animated),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiary,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun AnimatedPill(modifier: Modifier = Modifier) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .background(
-                color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.92f),
-                shape = RoundedCornerShape(50),
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(SceneViewTokens.Space.md),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.xs),
+        ) {
+            Text(
+                text = model.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = androidx.compose.ui.graphics.Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-    ) {
-        Icon(
-            imageVector = Icons.Filled.AutoAwesome,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onTertiary,
-            modifier = Modifier.size(12.dp),
-        )
-        Spacer(Modifier.width(4.dp))
-        Text(
-            text = "Animated",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onTertiary,
-            fontWeight = FontWeight.SemiBold,
-        )
+            Text(
+                text = buildString {
+                    append(model.primaryTagDisplay())
+                    if (model.faceCount > 0) append(" · ${model.formattedFaceCount()} polys")
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = androidx.compose.ui.graphics.Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/SpatialHero.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/SpatialHero.kt
@@ -23,8 +23,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import io.github.sceneview.demo.R
 import io.github.sceneview.demo.sources.GalleryModel
 import io.github.sceneview.demo.sources.preferredThumbnailUrl
 import io.github.sceneview.demo.theme.SceneViewTokens
@@ -84,7 +86,10 @@ fun SpatialHero(model: GalleryModel, onViewIn3D: () -> Unit, modifier: Modifier 
             Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
                 Button(onClick = onViewIn3D, shape = RoundedCornerShape(SceneViewTokens.Radius.full)) {
                     Icon(Icons.Filled.ViewInAr, contentDescription = null)
-                    Text("View in 3D", modifier = Modifier.padding(start = SceneViewTokens.Space.sm))
+                    Text(
+                        text = stringResource(R.string.explore_view_in_3d),
+                        modifier = Modifier.padding(start = SceneViewTokens.Space.sm),
+                    )
                 }
             }
         }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/SpatialHero.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/components/SpatialHero.kt
@@ -1,0 +1,92 @@
+package io.github.sceneview.demo.ui.explore.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ViewInAr
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import io.github.sceneview.demo.sources.GalleryModel
+import io.github.sceneview.demo.sources.preferredThumbnailUrl
+import io.github.sceneview.demo.theme.SceneViewTokens
+
+/** Static, media-led opening stage. Intentionally contains no SceneView/Filament rendering. */
+@Composable
+fun SpatialHero(model: GalleryModel, onViewIn3D: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(SceneViewTokens.Layout.heroStageHeight)
+            .clip(RoundedCornerShape(SceneViewTokens.Radius.xl))
+            .background(MaterialTheme.colorScheme.surfaceDim),
+    ) {
+        AsyncNetworkImage(
+            url = model.preferredThumbnailUrl(),
+            contentDescription = model.name,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            SceneViewTokens.SpatialGalleryColor.stageScrimStart,
+                            SceneViewTokens.SpatialGalleryColor.stageScrimEnd,
+                        ),
+                    ),
+                ),
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(SceneViewTokens.Space.lg),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+        ) {
+            Text(
+                text = model.sourceId.displayName,
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(SceneViewTokens.Radius.full))
+                    .background(SceneViewTokens.SpatialGalleryColor.glassSurfaceDark)
+                    .padding(horizontal = SceneViewTokens.Space.sm, vertical = SceneViewTokens.Space.xs),
+            )
+            Text(
+                text = model.name,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
+                Button(onClick = onViewIn3D, shape = RoundedCornerShape(SceneViewTokens.Radius.full)) {
+                    Icon(Icons.Filled.ViewInAr, contentDescription = null)
+                    Text("View in 3D", modifier = Modifier.padding(start = SceneViewTokens.Space.sm))
+                }
+            }
+        }
+    }
+}

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -23,27 +23,23 @@
     <string name="explore_play">Play animation</string>
     <string name="explore_animation_count">%d animations</string>
     <string name="explore_loading">Loading 3D model</string>
-    <string name="explore_heading">Explore</string>
     <string name="explore_search_placeholder">Search 3D models on %1$s</string>
     <string name="explore_filter_animated">Animated</string>
-    <string name="explore_try_a_sample">Try a sample</string>
-    <string name="explore_trending_models">Trending models</string>
     <string name="explore_trending_in_3d">Trending in 3D</string>
     <string name="explore_built_with_sceneview">Built with SceneView</string>
     <string name="explore_browse_by_source">Browse by source</string>
-    <string name="explore_staff_picks">Staff picks</string>
-    <string name="explore_recently_added">Recently added</string>
     <string name="explore_categories">Categories</string>
     <string name="explore_recent_searches">Recent searches</string>
     <string name="explore_clear">Clear</string>
     <string name="explore_clear_search">Clear search</string>
+    <string name="explore_close_search">Close search</string>
+    <string name="explore_view_in_3d">View in 3D</string>
     <string name="explore_remove_query">Remove %s</string>
     <string name="explore_search_results">Search results</string>
     <string name="explore_search_no_results">No results for "%s"</string>
     <string name="explore_search_loading">Searching…</string>
     <!-- Source picker chip row (#2645): label preceding the Sketchfab | Icosa
          Gallery | Poly Haven chips that let the user switch model catalog. -->
-    <string name="explore_source_label">Source</string>
     <!-- Defensive banner shown when SketchfabConfig.apiKey is null (#1909).
          End-user release builds with a missing or revoked secret would
          otherwise silently render an Explore tab without carousels and a
@@ -53,7 +49,6 @@
     <string name="explore_sketchfab_disabled_dialog_title">Sketchfab integration is off</string>
     <string name="explore_sketchfab_disabled_dialog_body">This build was published without a Sketchfab API key, so the Staff Picks, Most Liked and Recently Added carousels are hidden and search is disabled.\n\nThe curated samples and category grid below still work — they bundle local 3D models.\n\nIf you\'re building locally, add the line below to <b>local.properties</b> and rebuild:\n\n  sketchfab.api.key=&lt;your-token&gt;\n\nGrab a token at Sketchfab → Settings → Password &amp; API → API Token.</string>
     <string name="explore_sketchfab_disabled_dismiss">Got it</string>
-    <string name="explore_sketchfab_search_hint">Search needs a Sketchfab API key — see banner above.</string>
     <!-- Shown instead of the "key missing" copy when the key is present but the
          Sketchfab API rejected it with HTTP 401/403 — see issue #2095. -->
     <string name="explore_sketchfab_rejected_title">Sketchfab unavailable</string>

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -28,6 +28,9 @@
     <string name="explore_filter_animated">Animated</string>
     <string name="explore_try_a_sample">Try a sample</string>
     <string name="explore_trending_models">Trending models</string>
+    <string name="explore_trending_in_3d">Trending in 3D</string>
+    <string name="explore_built_with_sceneview">Built with SceneView</string>
+    <string name="explore_browse_by_source">Browse by source</string>
     <string name="explore_staff_picks">Staff picks</string>
     <string name="explore_recently_added">Recently added</string>
     <string name="explore_categories">Categories</string>


### PR DESCRIPTION
## What

Screen 1 of the demo-app UI/UX redesign: the Explore tab is rebuilt from scratch as a spatial gallery, designed natively against DESIGN.md and anchored on real reference apps (Sketchfab, Polycam, Reality Composer).

- **Hero stage** — a full-bleed featured-model card (`SpatialHero`) replaces the old list header, with a glass floating search pill anchored to the card.
- **Media-first rails** — trending models flow in an asymmetric rail; metadata sits on the image under a scrim instead of in elevated containers.
- **Compact source rail** — sources move into a chip rail instead of a full-width block.
- **Search state** — tapping the pill opens the keyboard immediately (FocusRequester) and shows a single, focused results layout (no duplicated browse sections).
- **Tokens** — new glass/scrim design tokens in DESIGN.md + `SceneViewTokens` (`SpatialGalleryColor`, `Layout.heroStageHeight`, `Layout.mediaAspect`), light + dark.

## QA

Emulator QA (reusable AR emulator, subagent-driven): light, dark and search states captured and verified — keyboard opens on pill tap, single browse section in search state, results render for a live query, clean logcat.

## Gates

`pre-push-check.sh`: 24/24 green (output quoted in the session). The one non-blocking warning (third-party CDN loads in HTML, 2 hits) predates this change.

Changelog fragment: `changelog.d/3242-explore-spatial-gallery-redesign.md` (category: Changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)