### PR TITLE
Derive the MCP Filament.js web version from gradle/libs.versions.toml

### DIFF
--- a/changelog.d/3173-filament-web-pin.md
+++ b/changelog.d/3173-filament-web-pin.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+The MCP server no longer names Filament.js 1.70.2 anywhere. That version was a
+hand-copied string in the web rendering guide and in the artifact generator, and it was
+wrong on both counts: it never matched the runtime vendored for `sceneview.js`
+(`filamentWebsite`, 1.70.1) and it was never published on npm, so the jsDelivr URL the
+generated 3D artifacts loaded (`filament@1.70.2/filament.js`) did not resolve.
+`generate-version.js` now reads `filamentWeb` and `filamentWebsite` from
+`gradle/libs.versions.toml` at build time; the artifact CDN URL uses the npm pin and the
+guide names the website runtime, so the next Filament bump propagates without a manual
+edit.

--- a/mcp/scripts/generate-version.js
+++ b/mcp/scripts/generate-version.js
@@ -76,6 +76,28 @@ if (!pubMatch) {
 }
 const flutterPubVersion = pubMatch[1];
 
+// The two WEB Filament runtimes, read from `gradle/libs.versions.toml` — the
+// single pin table CLAUDE.md designates for every Filament track. Both strings
+// used to be a hand-copied "1.70.2" in `artifact.ts` and `extra-guides.ts`, a
+// version that (a) was never published on npm, so the artifact CDN URL
+// 404'd, and (b) never matched the runtime vendored for the website. See #3173.
+//
+//   filamentWeb     — the npm `filament` package (sceneview-web / Kotlin-JS and
+//                     the jsDelivr CDN the generated artifacts load).
+//   filamentWebsite — the runtime vendored at website-static/js/filament/
+//                     that sceneview.js runs on.
+const versionsToml = readFileSync(resolve(mcpRoot, "..", "gradle", "libs.versions.toml"), "utf8");
+function readPin(name) {
+  const m = versionsToml.match(new RegExp(`^\\s*${name}\\s*=\\s*"([^"]+)"`, "m"));
+  if (!m) {
+    console.error(`[generate-version] FATAL: ${name} not found in ../gradle/libs.versions.toml`);
+    process.exit(1);
+  }
+  return m[1];
+}
+const filamentWebVersion = readPin("filamentWeb");
+const filamentWebsiteVersion = readPin("filamentWebsite");
+
 const outDir = resolve(mcpRoot, "src/generated");
 mkdirSync(outDir, { recursive: true });
 
@@ -92,14 +114,20 @@ const content =
   `// The pub.dev coordinate for \`flutter_sceneview\`, read from the plugin's\n` +
   `// README. Deliberately NOT LATEST_SCENEVIEW_RELEASE: pub.dev lags the SDK,\n` +
   `// and a caret range against an unpublished version cannot be resolved.\n` +
-  `export const LATEST_FLUTTER_PUB_RELEASE = "${flutterPubVersion}" as const;\n`;
+  `export const LATEST_FLUTTER_PUB_RELEASE = "${flutterPubVersion}" as const;\n` +
+  `// Web Filament runtimes, from ../gradle/libs.versions.toml (#3173).\n` +
+  `// FILAMENT_WEB_NPM_VERSION is the npm \`filament\` pin (CDN artifacts, Kotlin/JS);\n` +
+  `// FILAMENT_WEBSITE_VERSION is the runtime vendored for sceneview.js.\n` +
+  `export const FILAMENT_WEB_NPM_VERSION = "${filamentWebVersion}" as const;\n` +
+  `export const FILAMENT_WEBSITE_VERSION = "${filamentWebsiteVersion}" as const;\n`;
 
 writeFileSync(outPath, content, "utf8");
 // Log to stderr so we don't pollute stdout (npm pack --dry-run --json
 // pipes stdout through, and the package-files test parses that JSON).
 console.error(
   `[generate-version] wrote ${outPath} ` +
-    `(mcp=${version}, sdk=${sdkVersion}, flutter-pub=${flutterPubVersion})`
+    `(mcp=${version}, sdk=${sdkVersion}, flutter-pub=${flutterPubVersion}, ` +
+    `filament-web-npm=${filamentWebVersion}, filament-website=${filamentWebsiteVersion})`
 );
 
 // Keep the `android-ok` test fixture's SceneView pin in sync with the SDK

--- a/mcp/src/artifact.test.ts
+++ b/mcp/src/artifact.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { FILAMENT_WEB_NPM_VERSION } from "./generated/version.js";
 import {
   type ArtifactInput,
   formatArtifactResponse,
   generateArtifact,
   validateArtifactInput,
 } from "./artifact.js";
+import { FILAMENT_WEB_NPM_VERSION } from "./generated/version.js";
 
 // ─── validateArtifactInput ───────────────────────────────────────────────────
 
@@ -97,7 +97,9 @@ describe("generateArtifact — model-viewer (Filament.js)", () => {
 
   it("includes Filament.js CDN script", () => {
     const result = generateArtifact({ type: "model-viewer" });
-    expect(result.html).toContain(`cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`);
+    expect(result.html).toContain(
+      `cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`
+    );
   });
 
   it("does NOT include model-viewer web component", () => {
@@ -732,7 +734,9 @@ describe("Filament.js integration", () => {
   it("all 3D types use Filament.js CDN", () => {
     for (const type of ["model-viewer", "scene", "product-360"] as const) {
       const result = generateArtifact({ type });
-      expect(result.html).toContain(`cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`);
+      expect(result.html).toContain(
+        `cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`
+      );
     }
   });
 

--- a/mcp/src/artifact.test.ts
+++ b/mcp/src/artifact.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FILAMENT_WEB_NPM_VERSION } from "./generated/version.js";
 import {
   type ArtifactInput,
   formatArtifactResponse,
@@ -96,7 +97,7 @@ describe("generateArtifact — model-viewer (Filament.js)", () => {
 
   it("includes Filament.js CDN script", () => {
     const result = generateArtifact({ type: "model-viewer" });
-    expect(result.html).toContain("cdn.jsdelivr.net/npm/filament@1.70.2/filament.js");
+    expect(result.html).toContain(`cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`);
   });
 
   it("does NOT include model-viewer web component", () => {
@@ -731,7 +732,7 @@ describe("Filament.js integration", () => {
   it("all 3D types use Filament.js CDN", () => {
     for (const type of ["model-viewer", "scene", "product-360"] as const) {
       const result = generateArtifact({ type });
-      expect(result.html).toContain("cdn.jsdelivr.net/npm/filament@1.70.2/filament.js");
+      expect(result.html).toContain(`cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`);
     }
   });
 

--- a/mcp/src/artifact.ts
+++ b/mcp/src/artifact.ts
@@ -12,6 +12,8 @@
 //   - scene: multi-model 3D scene with lighting and environment (Filament.js)
 //   - product-360: product turntable with hotspot annotations (Filament.js)
 
+import { FILAMENT_WEB_NPM_VERSION } from "./generated/version.js";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type ArtifactType = "model-viewer" | "chart-3d" | "scene" | "product-360" | "geometry";
@@ -66,7 +68,9 @@ export interface ArtifactResult {
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const FILAMENT_CDN = "https://cdn.jsdelivr.net/npm/filament@1.70.2/filament.js";
+// The npm `filament` pin from gradle/libs.versions.toml (`filamentWeb`),
+// snapshotted at build time — never a hand-copied version (#3173).
+const FILAMENT_CDN = `https://cdn.jsdelivr.net/npm/filament@${FILAMENT_WEB_NPM_VERSION}/filament.js`;
 
 const DEFAULT_MODEL =
   "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb";

--- a/mcp/src/extra-guides.ts
+++ b/mcp/src/extra-guides.ts
@@ -4,7 +4,11 @@
  * Material, collision, model optimization, and web rendering guides.
  */
 
-import { LATEST_SCENEVIEW_RELEASE } from "./generated/version.js";
+import {
+  FILAMENT_WEB_NPM_VERSION,
+  FILAMENT_WEBSITE_VERSION,
+  LATEST_SCENEVIEW_RELEASE,
+} from "./generated/version.js";
 
 // ─── Material Guide ─────────────────────────────────────────────────────────
 
@@ -416,7 +420,7 @@ export const WEB_RENDERING_GUIDE = `# SceneView Web Rendering Guide (Filament.js
 
 ## Architecture
 
-SceneView Web uses **Filament.js v1.70.2** — Google's Filament engine compiled to WebAssembly. This is the **same PBR rendering engine** as SceneView Android, ensuring visual parity.
+SceneView Web uses **Filament.js v${FILAMENT_WEBSITE_VERSION}** (the runtime vendored with \`sceneview.js\`; the Kotlin/JS build pins the npm \`filament\` package at v${FILAMENT_WEB_NPM_VERSION}) — Google's Filament engine compiled to WebAssembly. This is the **same PBR rendering engine** as SceneView Android, ensuring visual parity.
 
 \`\`\`
 Browser → WebGL2 → Filament.js (WASM) → GPU
@@ -527,7 +531,7 @@ camera {
 
 | Feature | SceneView (Filament.js) | model-viewer |
 |---------|------------------------|--------------|
-| **Engine** | Filament v1.70.2 WASM | Filament WASM (same engine) |
+| **Engine** | Filament v${FILAMENT_WEBSITE_VERSION} WASM | Filament WASM (same engine) |
 | **Bundle size** | ~215KB JS + 3.3MB WASM | ~800 KB (subset) |
 | **Procedural geometry** | Yes (cubes, spheres, etc.) | No |
 | **Custom materials** | Yes (full Filament API) | Limited |

--- a/mcp/src/generated/version.ts
+++ b/mcp/src/generated/version.ts
@@ -11,3 +11,8 @@ export const LATEST_SCENEVIEW_RELEASE = "4.31.0" as const;
 // README. Deliberately NOT LATEST_SCENEVIEW_RELEASE: pub.dev lags the SDK,
 // and a caret range against an unpublished version cannot be resolved.
 export const LATEST_FLUTTER_PUB_RELEASE = "4.24.0" as const;
+// Web Filament runtimes, from ../gradle/libs.versions.toml (#3173).
+// FILAMENT_WEB_NPM_VERSION is the npm `filament` pin (CDN artifacts, Kotlin/JS);
+// FILAMENT_WEBSITE_VERSION is the runtime vendored for sceneview.js.
+export const FILAMENT_WEB_NPM_VERSION = "1.52.3" as const;
+export const FILAMENT_WEBSITE_VERSION = "1.70.1" as const;


### PR DESCRIPTION
## Summary

- The MCP web rendering guide and the 3D artifact generator hardcoded **Filament.js v1.70.2**, a version that matches none of the three Filament pins in `gradle/libs.versions.toml`. Worse, `filament@1.70.2` was never published on npm, so the jsDelivr URL in every generated `model-viewer` / `scene` / `product-360` artifact did not resolve.
- `mcp/scripts/generate-version.js` now reads `filamentWeb` and `filamentWebsite` from `gradle/libs.versions.toml` and emits `FILAMENT_WEB_NPM_VERSION` / `FILAMENT_WEBSITE_VERSION` into `src/generated/version.ts` (fails the build if either pin disappears).
- `artifact.ts` builds the CDN URL from the npm pin (`filament@1.52.3`, verified HTTP 200 on jsDelivr); `extra-guides.ts` names the website runtime (1.70.1) and the npm pin for the Kotlin/JS build.
- `artifact.test.ts` asserts against the generated constant, so a future bump cannot leave the test red or the string stale.

No non-generated file names `1.70.2` any more, except the historical notes in `CONTRIBUTING.md`, `RUNTIME.json` and `check-web-filamat-abi.sh` that describe the v4.1.0 incident.

Closes #3173

## Verification

- `cd mcp && npm test`: 83 files, 1965 tests passed.
- `npx tsc --noEmit` clean; biome reports nothing new on the touched files.
- `curl -I https://cdn.jsdelivr.net/npm/filament@1.52.3/filament.js` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)