### PR TITLE
Run the blocking render test on pull requests, and stop main from cancelling its own runs

### DIFF
--- a/.github/workflows/device-qa.yml
+++ b/.github/workflows/device-qa.yml
@@ -117,15 +117,25 @@ on:
   # the device-QA legs too — see #1324.
   workflow_call:
 
-# A Device QA run is ~50 min (emulator + Maestro). A `workflow_dispatch` run is
-# a deliberate release gate — keying its concurrency group on `github.run_id`
-# makes it unique so a later push to the same ref can never cancel it (#1665).
-# `push` (and the nightly `workflow_call`) runs share the `push` group, so a
-# stale push run is still auto-cancelled — desirable, no point burning a 50-min
-# emulator run on a superseded SHA.
+# A Device QA run is ~50 min (emulator + Maestro). Every run gets its own
+# concurrency group, keyed on `github.run_id`, so no run ever cancels another.
+#
+# #1665 did this for `workflow_dispatch` only (a deliberate release gate must
+# not be killed by a later push). `push` and the nightly `workflow_call` kept
+# sharing one `push` group with `cancel-in-progress: true`, on the theory that
+# a superseded SHA is not worth a 50-min emulator run. Measured (#2917): on a
+# busy main that theory cancelled ~half of all runs — 11 of 20 on 2026-07-27,
+# 7 of the last 30 at the time of this change — and a cancelled run reads as
+# "nothing happened", which is easy to mistake for "nothing was wrong". No
+# per-push Device QA had covered #2851 at all. There is no `pull_request`
+# trigger here, so nothing is left that benefits from cancellation; the
+# `device-qa.sh --ci` legs now queue per merge and each one reaches a
+# verdict. Cost: GitHub-hosted ubuntu minutes proportional to the merge rate
+# (the self-hosted Mac is only ever used by the `ios` leg, which never runs
+# on push).
 concurrency:
-  group: device-qa-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'push' }}
-  cancel-in-progress: true
+  group: device-qa-${{ github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/render-tests.yml
+++ b/.github/workflows/render-tests.yml
@@ -1,19 +1,42 @@
 name: Render Tests
 
 on:
-  # Render tests no longer run on PRs — they are non-blocking
-  # (`continue-on-error: true`), spin up a KVM-accelerated emulator
-  # + an iOS Simulator + Playwright web, and the screenshots they produce
-  # were rarely consulted by PR reviewers. The signal is still captured
-  # on every push to main, so post-merge regressions surface in the
-  # Actions tab without burning ~30 min × multiple PRs per day. Trigger
-  # manually via workflow_dispatch when you want to vet a feature branch.
+  # Two trigger tiers, split by what each one is allowed to cost (#3216):
   #
-  # Strictly path-gated (#1311, #1321): runs only when render-affecting
-  # source actually changes. SKIPPED on doc-only, CI-only (`.github/**`),
-  # and `mcp/`-only merges — none of those can change a rendered frame.
-  # squash-merge means `main` HEAD differs from every PR commit, so this
-  # main-push run still catches integration regressions a PR build can't.
+  # `pull_request` — runs ONLY the `android-library-render` job, and only
+  # when the PR touches something `:sceneview:connectedDebugAndroidTest` can
+  # see (the `paths:` list below). That job is the one blocking leg of this
+  # workflow; before #3216 it had no pre-merge run at all, so a PR that added
+  # or broke an androidTest merged on a green that never executed it, and the
+  # red surfaced on `main` attributed to whichever push came next. The demo
+  # screenshot, iOS and web jobs stay off PRs: they are advisory by design
+  # (`|| true` / `continue-on-error`), spin up a second emulator, a macOS
+  # Simulator and Playwright, and their screenshots were rarely consulted by
+  # reviewers. Each of those jobs carries `if: github.event_name !=
+  # 'pull_request'`. Fork PRs get no secrets, which is fine — the one PR job
+  # needs none.
+  #
+  # `push` to main — the full five-job run, strictly path-gated (#1311,
+  # #1321): runs only when render-affecting source actually changes. SKIPPED
+  # on doc-only, CI-only (`.github/**`), and `mcp/`-only merges — none of
+  # those can change a rendered frame. squash-merge means `main` HEAD differs
+  # from every PR commit, so this main-push run still catches integration
+  # regressions a PR build can't.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sceneview/**'
+      - 'sceneview-core/**'
+      - 'arsceneview/src/**'
+      - '.github/workflows/render-tests.yml'
+      - '.github/actions/setup-gradle/**'
+      # Same reasoning as the push list below: a dependency bump or a
+      # renderer-affecting module config change can break an instrumented
+      # test as surely as `src/**` can.
+      - 'gradle/**'
+      - 'build.gradle*'
+      - 'settings.gradle*'
+      - 'gradle.properties'
   push:
     branches: [main]
     paths:
@@ -35,9 +58,23 @@ on:
   # this render-test definition rather than duplicating it. See #1324.
   workflow_call:
 
+# Cancellation is allowed on pull requests only (#2917, #3216).
+#
+# On a PR the group is the PR ref, so a new push to the same PR supersedes
+# the previous run — the old SHA is never going to merge, no point finishing
+# it. Everywhere else (push to main, workflow_dispatch, the nightly
+# workflow_call) the group is `github.run_id`, which is unique per run, so
+# nothing ever cancels. The previous `group: render-tests-${{ github.ref }}`
+# + `cancel-in-progress: true` put EVERY push to main in one group: each
+# merge killed the run of the one before it, and over the last 30 main runs
+# 15 ended `cancelled` — the commit they were testing went untested and
+# nothing said so. Per-merge runs on main now queue instead of cancelling;
+# the cost is GitHub-hosted minutes proportional to the merge rate (the
+# jobs below are ubuntu-latest + one macos-latest leg, no self-hosted
+# runner), the gain is that every merge reaches a verdict.
 concurrency:
-  group: render-tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: render-tests-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -48,11 +85,15 @@ jobs:
     name: Android library render tests (emulator)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # SwiftShader emulator render tests are inherently flaky (JNI teardown
-    # races, GPU emulation timing).  Mark non-blocking so a spurious red X
-    # doesn't scare contributors — the workflow is already NOT a required
-    # status check.  Individual job status still visible in the Actions tab.
-    continue-on-error: true
+    # Non-blocking on push/nightly: SwiftShader emulator render tests are
+    # inherently flaky (JNI teardown races, GPU emulation timing), so a
+    # spurious red X on main is kept advisory — the workflow is NOT a required
+    # status check. On a pull request the job DOES report its own verdict
+    # (#3216): it is the only leg of this workflow that runs there, it is the
+    # one whose gradle invocation has no `|| true`, and it is the pre-merge
+    # run the PR author came for — a red it cannot show is a red nobody sees.
+    # Still not a required check, so a flake does not block a merge by itself.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
 
     # The 3-shard emulator matrix (#1119, PR #1145) was REVERTED to a single
     # job: the 5 render-test classes cleanly `assumeTrue`-skip on SwiftShader
@@ -119,6 +160,8 @@ jobs:
   # ── Android demo app screenshot capture ───────────────────────────────────
   android-demo-screenshots:
     name: Android demo app screenshots (emulator)
+    # Advisory leg — push/nightly/dispatch only, never on a PR (#3216).
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -231,6 +274,8 @@ jobs:
   # harvestable artifact instead).
   demo-render-goldens:
     name: Unified-demo render goldens (emulator)
+    # Advisory leg — push/nightly/dispatch only, never on a PR (#3216).
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     continue-on-error: true
@@ -293,6 +338,8 @@ jobs:
   # job becomes a real regression gate. See that dir's README for the flow.
   ar-demo-playback-screenshots:
     name: AR demo playback screenshots (emulator)
+    # Advisory leg — push/nightly/dispatch only, never on a PR (#3216).
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # AR emulator playback is inherently flaky (ARCore service init races,
@@ -377,6 +424,8 @@ jobs:
   # (main-push + nightly, non-blocking).
   ios-render:
     name: iOS screenshot tests (Simulator)
+    # Advisory leg — push/nightly/dispatch only, never on a PR (#3216).
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
     timeout-minutes: 40
 
@@ -482,6 +531,8 @@ jobs:
   # ── Web render tests ──────────────────────────────────────────────────────
   web-render:
     name: Web Playwright screenshot tests
+    # Advisory leg — push/nightly/dispatch only, never on a PR (#3216).
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # 30 min: the suite (53 tests, 1 worker) measures 13–17 min green on push
     # runs — 20 min left no headroom and the slower nightly runners timed the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,4 +60,6 @@ Full API reference: [`llms.txt`](./llms.txt).
 `.github/workflows/ci.yml` is the one PR workflow. Its `changes` job detects touched
 paths and gates every other job; `changes-verdict` ("Path filter completed") always runs
 and is the required check. Heavy suites (`render-tests.yml`, `device-qa.yml`) run
-nightly, not per PR. Details in [CONTRIBUTING.md](CONTRIBUTING.md).
+on push to `main` and nightly, never cancelling each other; the one per-PR
+exception is `render-tests.yml`'s `android-library-render` job, path-gated on
+`sceneview/**`, `sceneview-core/**` and the Gradle files (#3216). Details in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,9 @@ xcodebuild archive ... SV_ALLOW_MISSING_SECRETS=1
 tears down node trees 40 times per test and asserts engine state returns to
 baseline. It runs headless — no SwapChain, no `readPixels` — so unlike the
 `render` package it really executes on the CI emulator instead of skipping.
-It lands in `render-tests.yml`'s `continue-on-error` job, so a red run is an
+It lands in `render-tests.yml`'s `android-library-render` job. On a pull request
+that job reports its own verdict (a red job on the PR), but it is not a required
+check; on `main` and nightly it is `continue-on-error`, so a red run there is an
 advisory signal in the Actions tab, not a merge block.
 
 ```bash
@@ -325,9 +327,13 @@ correct. Specifically:
   docs-only PR runs none of them. (Before #1370 this was three separate
   workflows — `ci.yml`, `pr-check.yml`, `quality-gate.yml` — each with its
   own `changes` job; they are now one workflow with one path-detection job.)
-- **`render-tests.yml`** never runs on *any* pull request — it is push-to-main
-  + `workflow_dispatch` only — so docs-only PRs skip it for that reason rather
-  than via a path filter.
+- **`render-tests.yml`** has its own `pull_request` path filter: only a PR
+  touching `sceneview/**`, `sceneview-core/**`, `arsceneview/src/**` or the
+  Gradle build files runs it, and then only its `android-library-render` job
+  (`:sceneview:connectedDebugAndroidTest` on the emulator, #3216). The demo
+  screenshot, iOS and web legs are push-to-main + nightly + `workflow_dispatch`
+  only. A docs-only PR matches none of the paths, so the workflow does not
+  run at all.
 - The **`Path filter completed`** job (`changes-verdict` in `ci.yml`) runs
   on every PR whatever it touches, and it is the required check: it resolves
   green once path detection has run. That is how a docs-only PR stays
@@ -338,6 +344,19 @@ markdown change has accidentally invalidated an example referenced from
 runtime code), trigger the gates manually from the Actions tab —
 `Run workflow` on `ci.yml` / `render-tests.yml` accepts your PR's branch as
 input.
+
+### Heavy suites on `main`: every merge reaches a verdict
+
+`render-tests.yml` and `device-qa.yml` run on every (path-matched) push to
+`main`, and since #2917 / #3216 a later merge no longer cancels the run of
+the one before it: each run has its own concurrency group, so runs queue
+instead of being killed. Before that change roughly half of the runs on a
+busy `main` ended `cancelled` — neither pass nor fail — and the commit they
+were testing was never covered. The one place cancellation is still allowed
+is a pull request on `render-tests.yml`, where a new push to the same PR
+supersedes the previous SHA. The cost is GitHub-hosted minutes proportional
+to the merge rate; if the queue becomes a problem, the lever is the `paths:`
+filter on each workflow, not `cancel-in-progress`.
 
 ### Code style
 

--- a/changelog.d/3216-render-tests-on-pr.md
+++ b/changelog.d/3216-render-tests-on-pr.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+`render-tests.yml` now runs `:sceneview:connectedDebugAndroidTest` on a pull
+request, path-gated to `sceneview/**`, `sceneview-core/**`, `arsceneview/src/**`
+and the Gradle build files, so an instrumented test added or broken by a PR
+fails before the merge instead of on whichever push to `main` came next
+(#3216). The four advisory legs (demo screenshots, render goldens, AR playback,
+iOS, web) stay push-to-main + nightly only. On `main`, `render-tests.yml` and
+`device-qa.yml` no longer cancel the previous run on every merge — each run has
+its own concurrency group, so every merge reaches a verdict instead of the
+~50% that previously ended `cancelled` (#2917). Cancellation remains only for
+superseded pushes to the same pull request.


### PR DESCRIPTION
Closes #3216
Closes #2917

Both issues have the same root: the `on:` and `concurrency:` blocks of the two heavy workflows. `render-tests.yml` had no `pull_request` trigger, so its one blocking leg (`:sceneview:connectedDebugAndroidTest`) ran only after the merge; and both it and `device-qa.yml` keyed their concurrency group on `github.ref` with `cancel-in-progress: true`, so every merge to `main` killed the previous merge's run. Measured today: 15 of the last 30 `render-tests.yml` runs on `main` ended `cancelled`, 7 of the last 30 `device-qa.yml` runs.

## What changes

**`render-tests.yml`**
- New `pull_request` trigger, path-gated at the workflow level to `sceneview/**`, `sceneview-core/**`, `arsceneview/src/**`, the workflow itself, `setup-gradle`, and the Gradle build files. A PR that matches none of them does not start the workflow at all (zero runner cost), and since the workflow is not a required check nothing is "skipped → green".
- On a PR only `android-library-render` runs. The four advisory legs (demo screenshots, render goldens, AR playback, iOS, web) carry `if: github.event_name != 'pull_request'` — they are `|| true` / `continue-on-error` by design, cost a second emulator + a macOS Simulator + Playwright, and cannot fail a PR anyway.
- `android-library-render` is `continue-on-error: ${{ github.event_name != 'pull_request' }}`: on a PR the job reports its own red, because that is the whole point of running it there; on push/nightly it stays advisory as before (SwiftShader flake). It is still not a required check, so a flake cannot block a merge by itself.
- `concurrency.group` is the PR ref on `pull_request` (a new push to the same PR supersedes the old SHA) and `github.run_id` everywhere else; `cancel-in-progress` is true only on `pull_request`.

**`device-qa.yml`**
- `concurrency.group: device-qa-${{ github.run_id }}`, `cancel-in-progress: false`. #1665 had already done this for `workflow_dispatch`; it now applies to push and the nightly `workflow_call` too. No `pull_request` trigger is added — #2917 is about the verdict on `main`, and nothing in this workflow is cheap enough to justify a per-PR run.

**Docs**: CONTRIBUTING.md (docs-only PR section rewritten for the new trigger, new "Heavy suites on `main`" section, leak-churn paragraph), CLAUDE.md CI paragraph, changelog fragment.

## Tradeoff

Cancellation was a cost control, and removing it on `main` trades minutes for verdicts: each merge that matches the path filter now queues its own ~25 min `render-tests.yml` run (4 ubuntu jobs + 1 macos-latest job) and, when it matches `device-qa.yml`'s narrower filter, a ~50 min Device QA run. At the 14-merges-in-6-hours rate #2917 measured, that is a backlog that drains, not a run that is lost. All of these jobs are GitHub-hosted; the self-hosted Mac is only used by `device-qa.yml`'s `ios` leg, which never runs on push. If the queue becomes a problem, the lever is the `paths:` filter, not `cancel-in-progress`.

The per-PR cost is one `ubuntu-latest` emulator job (~20 min) on PRs that touch library source or Gradle config. `gradle/**` is in the filter on purpose (a `libs.versions.toml` bump is exactly what breaks an instrumented test), which means dependency-bump PRs pay it too.

## Validation

- `actionlint` on `render-tests.yml`, `device-qa.yml`, `nightly-ci.yml`: clean.
- `yaml.safe_load` on both workflows: parses.
- This PR touches `.github/workflows/render-tests.yml`, which is in the new `pull_request` path filter, so the `Android library render tests (emulator)` job should appear on this PR and the four advisory legs should not.
- Does not touch `ci.yml`, `check-test-suites-reachable.sh` or `pre-push-check.sh` — those are #3204's files and the web-leg line it reports (`render-tests.yml — cannot fail the build; does not run on pull requests`) stays true for the web leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
