### PR TITLE
Give the streetscape mesh the tangents and UV0 its lit material requires

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeGeometryNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeGeometryNode.kt
@@ -52,14 +52,46 @@ open class StreetscapeGeometryNode(
         engine = engine,
         primitiveType = PrimitiveType.TRIANGLES,
         vertexBuffer = VertexBuffer.Builder()
-            // Position + Normals + UV Coordinates
-            .bufferCount(1)
+            // POSITION + TANGENTS + UV0, one backing buffer each (#3215).
+            //
+            // ARCore ships positions only, but the lit materials this node is normally given
+            // (`opaque_colored` / `transparent_colored` from MaterialLoader.createColorInstance)
+            // require POSITION|TANGENTS|UV0 (MAT_REQA 0xB). Filament does not fail the
+            // mismatch — it logs `missing required attributes (0xb), declared=0x1` and shades
+            // the overlay with a constant fallback normal. So the node derives smooth
+            // per-vertex normals from the mesh once, at construction, and encodes them as
+            // tangent quaternions; UV0 is a zero buffer (no natural parameterisation, and the
+            // colored materials never sample it). See StreetscapeMeshAttributes.kt.
+            .bufferCount(BUFFER_COUNT)
             // Position Attribute (x, y, z)
-            .attribute(VertexAttribute.POSITION, 0, AttributeType.FLOAT3)
+            .attribute(VertexAttribute.POSITION, BUFFER_INDEX_POSITION, AttributeType.FLOAT3)
+            // Tangent frame quaternion (x, y, z, w) — Filament's per-vertex normal input.
+            // No `.normalized(TANGENTS)`: that flag is for integer formats, these are FLOAT4.
+            .attribute(
+                VertexAttribute.TANGENTS,
+                BUFFER_INDEX_TANGENT,
+                AttributeType.FLOAT4,
+                0,
+                STREETSCAPE_TANGENT_STRIDE
+            )
+            .attribute(
+                VertexAttribute.UV0,
+                BUFFER_INDEX_UV,
+                AttributeType.FLOAT2,
+                0,
+                STREETSCAPE_UV_STRIDE
+            )
             .vertexCount(streetscapeGeometry.mesh.vertexListSize)
             .build(engine)
             .apply {
-                setBufferAt(engine, 0, streetscapeGeometry.mesh.vertexList)
+                val mesh = streetscapeGeometry.mesh
+                setBufferAt(engine, BUFFER_INDEX_POSITION, mesh.vertexList)
+                setBufferAt(
+                    engine,
+                    BUFFER_INDEX_TANGENT,
+                    computeStreetscapeTangents(mesh.vertexList, mesh.indexList, mesh.vertexListSize)
+                )
+                setBufferAt(engine, BUFFER_INDEX_UV, zeroStreetscapeUvs(mesh.vertexListSize))
             },
         indexBuffer = IndexBuffer.Builder()
             .bufferType(IndexBuffer.Builder.IndexType.UINT)
@@ -108,5 +140,12 @@ open class StreetscapeGeometryNode(
         if (streetscapeGeometry.trackingState == TrackingState.TRACKING) {
             pose = streetscapeGeometry.meshPose
         }
+    }
+
+    private companion object {
+        const val BUFFER_INDEX_POSITION = 0
+        const val BUFFER_INDEX_TANGENT = 1
+        const val BUFFER_INDEX_UV = 2
+        const val BUFFER_COUNT = 3
     }
 }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeGeometryNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeGeometryNode.kt
@@ -141,11 +141,12 @@ open class StreetscapeGeometryNode(
             pose = streetscapeGeometry.meshPose
         }
     }
-
-    private companion object {
-        const val BUFFER_INDEX_POSITION = 0
-        const val BUFFER_INDEX_TANGENT = 1
-        const val BUFFER_INDEX_UV = 2
-        const val BUFFER_COUNT = 3
-    }
 }
+
+// Vertex buffer slots of a StreetscapeGeometryNode. File-private: a `const val` in a
+// `private companion object` still compiles to a public static field on the class and
+// trips apiCheck.
+private const val BUFFER_INDEX_POSITION = 0
+private const val BUFFER_INDEX_TANGENT = 1
+private const val BUFFER_INDEX_UV = 2
+private const val BUFFER_COUNT = 3

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeMeshAttributes.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/StreetscapeMeshAttributes.kt
@@ -1,0 +1,120 @@
+package io.github.sceneview.ar.node
+
+import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.cross
+import dev.romainguy.kotlin.math.dot
+import dev.romainguy.kotlin.math.normalize
+import io.github.sceneview.math.normalToTangent
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import java.nio.IntBuffer
+
+/**
+ * Per-vertex attribute derivation for [StreetscapeGeometryNode] (#3215).
+ *
+ * ARCore's Streetscape Geometry mesh ships positions and indices only. The lit materials the
+ * node is normally given (`opaque_colored` / `transparent_colored`, the output of
+ * `MaterialLoader.createColorInstance`) require POSITION|TANGENTS|UV0, and Filament does not
+ * fail a mismatch — it logs `missing required attributes (0xb), declared=0x1` and shades the
+ * building overlay against a constant fallback normal instead of its own surface.
+ *
+ * These helpers are pure JVM (no Filament, no ARCore) so they are unit-testable and so the
+ * work can be measured: it runs once per geometry, at node construction.
+ */
+
+/** Bytes per vertex of the TANGENTS attribute — an xyzw quaternion, FLOAT4. */
+internal const val STREETSCAPE_TANGENT_STRIDE = 4 * 4
+
+/** Bytes per vertex of the UV0 attribute — FLOAT2. */
+internal const val STREETSCAPE_UV_STRIDE = 2 * 4
+
+/**
+ * Normal assigned to a vertex no non-degenerate triangle references — +Y, matching the
+ * plane visualizers' flat fallback. Never decodes to a NaN frame.
+ */
+private val FALLBACK_NORMAL = Float3(0.0f, 1.0f, 0.0f)
+
+/**
+ * Builds the TANGENTS buffer for a triangle mesh from its positions and indices.
+ *
+ * Normals are **smooth, area-weighted**: every triangle's unnormalised face normal
+ * (`cross(b - a, c - a)`, whose length is twice the triangle area) is accumulated onto its three
+ * vertices, then each sum is normalised. Large faces therefore dominate a shared vertex, which
+ * is what a building façade meeting a terrain patch wants — there is no per-face split in the
+ * ARCore mesh, so a hard-edge reconstruction is not possible without duplicating vertices.
+ * Winding follows Filament's default (counter-clockwise front face).
+ *
+ * Each normal is then encoded as a tangent-frame quaternion via [normalToTangent], which is
+ * the only form Filament's vertex shader accepts (there is no NORMAL slot in
+ * `VertexBuffer.VertexAttribute`).
+ *
+ * @param positions `vertexCount * 3` floats, `xyz` per vertex. Read from position 0 regardless
+ *   of the buffer's current position; the buffer's position is left unchanged.
+ * @param indices `3 * triangleCount` vertex indices. Out-of-range or negative indices are
+ *   skipped rather than thrown — a malformed ARCore mesh must not crash the session.
+ * @return a direct, native-order buffer of `vertexCount * 16` bytes, position 0.
+ */
+internal fun computeStreetscapeTangents(
+    positions: FloatBuffer,
+    indices: IntBuffer,
+    vertexCount: Int,
+): ByteBuffer {
+    val pos = positions.duplicate().apply { rewind() }
+    val idx = indices.duplicate().apply { rewind() }
+
+    // Accumulate unnormalised face normals per vertex.
+    val nx = FloatArray(vertexCount)
+    val ny = FloatArray(vertexCount)
+    val nz = FloatArray(vertexCount)
+
+    val triangleCount = idx.limit() / 3
+    for (t in 0 until triangleCount) {
+        val ia = idx.get(t * 3)
+        val ib = idx.get(t * 3 + 1)
+        val ic = idx.get(t * 3 + 2)
+        if (ia !in 0 until vertexCount || ib !in 0 until vertexCount || ic !in 0 until vertexCount) {
+            continue
+        }
+        val a = vertexAt(pos, ia)
+        val b = vertexAt(pos, ib)
+        val c = vertexAt(pos, ic)
+        val n = cross(b - a, c - a)
+        nx[ia] += n.x; ny[ia] += n.y; nz[ia] += n.z
+        nx[ib] += n.x; ny[ib] += n.y; nz[ib] += n.z
+        nx[ic] += n.x; ny[ic] += n.y; nz[ic] += n.z
+    }
+
+    val out = ByteBuffer
+        .allocateDirect(vertexCount * STREETSCAPE_TANGENT_STRIDE)
+        .order(ByteOrder.nativeOrder())
+    val floats = out.asFloatBuffer()
+    for (v in 0 until vertexCount) {
+        val sum = Float3(nx[v], ny[v], nz[v])
+        val normal = if (dot(sum, sum) > 0.0f) normalize(sum) else FALLBACK_NORMAL
+        val q = normalToTangent(normal)
+        floats.put(q.x)
+        floats.put(q.y)
+        floats.put(q.z)
+        floats.put(q.w)
+    }
+    out.rewind()
+    return out
+}
+
+/**
+ * A zero-filled UV0 buffer of `vertexCount` FLOAT2 entries.
+ *
+ * Streetscape meshes have no natural parameterisation and the colored materials never sample
+ * a texture; the attribute only has to *exist* for Filament to stop reporting it missing. A
+ * newly allocated direct buffer is already zeroed, so no fill pass is needed.
+ */
+internal fun zeroStreetscapeUvs(vertexCount: Int): ByteBuffer = ByteBuffer
+    .allocateDirect(vertexCount * STREETSCAPE_UV_STRIDE)
+    .order(ByteOrder.nativeOrder())
+
+private fun vertexAt(positions: FloatBuffer, index: Int): Float3 = Float3(
+    positions.get(index * 3),
+    positions.get(index * 3 + 1),
+    positions.get(index * 3 + 2),
+)

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/StreetscapeMeshAttributesTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/StreetscapeMeshAttributesTest.kt
@@ -1,0 +1,251 @@
+package io.github.sceneview.ar.node
+
+import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.Quaternion
+import dev.romainguy.kotlin.math.dot
+import dev.romainguy.kotlin.math.normalize
+import dev.romainguy.kotlin.math.rotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import java.nio.IntBuffer
+
+/**
+ * [StreetscapeGeometryNode] vertex-attribute contract (#3215) — the same defect class as the
+ * plane visualizers' (#3213), on the one remaining `VertexBuffer.Builder` site that took a lit
+ * material with a POSITION-only mesh.
+ *
+ * Two halves:
+ *  1. **Contract** — the node's declared attribute set covers everything the colored materials
+ *     a caller gets from `MaterialLoader.createColorInstance` require (read from the committed
+ *     blobs' `MAT_REQA` chunk, so a material recompile that adds a requirement fails here).
+ *  2. **Derivation** — the tangent quaternions actually encode the mesh's own surface normal,
+ *     not a constant; and degenerate input never produces a NaN frame.
+ */
+class StreetscapeMeshAttributesTest {
+
+    // ── 1. Contract ───────────────────────────────────────────────────────────────────────────
+
+    private val nodeSource =
+        File("src/main/java/io/github/sceneview/ar/node/StreetscapeGeometryNode.kt")
+
+    /** The blobs `MaterialLoader.createColorInstance` resolves to, by alpha. They live in `:sceneview`. */
+    private val coloredMaterials = listOf("opaque_colored", "transparent_colored")
+
+    @Test
+    fun `the colored materials require TANGENTS and UV0 — the reason this node derives them`() {
+        coloredMaterials.forEach { material ->
+            assertEquals(
+                "$material.filamat is expected to require POSITION|TANGENTS|UV0 (0xB) — that " +
+                    "is WHY StreetscapeGeometryNode derives tangents. If the requirement " +
+                    "changed, revisit the node rather than relaxing this.",
+                POSITION_BIT or TANGENTS_BIT or UV0_BIT,
+                requiredAttributes(material)
+            )
+        }
+    }
+
+    @Test
+    fun `StreetscapeGeometryNode declares every attribute the colored materials require`() {
+        val declared = declaredAttributes(nodeSource)
+        assertTrue("Parsed no VertexAttribute out of ${nodeSource.absolutePath}", declared != 0)
+        coloredMaterials.forEach { material ->
+            val required = requiredAttributes(material)
+            val missing = required and declared.inv()
+            assertEquals(
+                "$material.filamat requires 0x${required.toString(16)} but " +
+                    "StreetscapeGeometryNode.kt declares only 0x${declared.toString(16)} — " +
+                    "missing 0x${missing.toString(16)}. Filament logs `missing required " +
+                    "attributes` and shades with a fallback normal instead of failing (#3215).",
+                0,
+                missing
+            )
+        }
+    }
+
+    @Test
+    fun `StreetscapeGeometryNode allocates and fills one backing buffer per attribute`() {
+        val source = stripComments(nodeSource.readText())
+        val attributeCount = Regex("""\.attribute\(""").findAll(source).count()
+        val bufferCount = Regex("""const\s+val\s+BUFFER_COUNT\s*=\s*(\d+)""")
+            .find(source)?.groupValues?.get(1)?.toInt()
+        assertNotNull("BUFFER_COUNT const not found in StreetscapeGeometryNode.kt", bufferCount)
+        assertEquals("one attribute, one buffer", attributeCount, bufferCount)
+        // A declared attribute whose buffer is never uploaded is the other half of the failure.
+        val uploads = Regex("""setBufferAt\(\s*engine,\s*BUFFER_INDEX_""").findAll(source).count()
+        assertEquals("every declared buffer must be uploaded", attributeCount, uploads)
+    }
+
+    // ── 2. Derivation ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a flat quad facing +Y encodes a +Y normal on every vertex`() {
+        // Two CCW triangles in the XZ plane, front face up (+Y).
+        val positions = floats(
+            0f, 0f, 0f,
+            0f, 0f, 1f,
+            1f, 0f, 1f,
+            1f, 0f, 0f,
+        )
+        val indices = ints(0, 1, 2, 0, 2, 3)
+
+        val tangents = computeStreetscapeTangents(positions, indices, vertexCount = 4)
+
+        assertEquals(4 * STREETSCAPE_TANGENT_STRIDE, tangents.remaining())
+        repeat(4) { v ->
+            assertNormalCloseTo(Float3(0f, 1f, 0f), decodedNormal(tangents, v), "vertex $v")
+        }
+    }
+
+    @Test
+    fun `a vertical facade encodes its own sideways normal, not a constant up`() {
+        // CCW when seen from +X: a wall in the YZ plane at x = 0 facing +X.
+        val positions = floats(
+            0f, 0f, 0f,
+            0f, 0f, -1f,
+            0f, 1f, -1f,
+        )
+        val indices = ints(0, 1, 2)
+
+        val tangents = computeStreetscapeTangents(positions, indices, vertexCount = 3)
+
+        repeat(3) { v ->
+            assertNormalCloseTo(Float3(1f, 0f, 0f), decodedNormal(tangents, v), "vertex $v")
+        }
+    }
+
+    @Test
+    fun `a shared vertex gets the area-weighted average of its faces`() {
+        // Vertex 0 is shared by a +Y face and a +X face of equal area: the smooth normal is the
+        // normalised (1, 1, 0) diagonal.
+        val positions = floats(
+            0f, 0f, 0f, // shared
+            0f, 0f, 1f,
+            1f, 0f, 1f, // +Y triangle: 0,1,2 (CCW from above)
+            0f, 0f, -1f,
+            0f, 1f, -1f, // +X triangle: 0,3,4 (CCW from +X)
+        )
+        val indices = ints(0, 1, 2, 0, 3, 4)
+
+        val tangents = computeStreetscapeTangents(positions, indices, vertexCount = 5)
+
+        assertNormalCloseTo(normalize(Float3(1f, 1f, 0f)), decodedNormal(tangents, 0), "shared vertex")
+    }
+
+    @Test
+    fun `unreferenced vertices and out-of-range indices fall back without NaN`() {
+        val positions = floats(
+            0f, 0f, 0f,
+            0f, 0f, 1f,
+            1f, 0f, 1f,
+            5f, 5f, 5f, // referenced by nothing
+        )
+        // Second triangle points past vertexCount and must be skipped, not thrown.
+        val indices = ints(0, 1, 2, 0, 1, 42)
+
+        val tangents = computeStreetscapeTangents(positions, indices, vertexCount = 4)
+
+        val floats = tangents.asFloatBuffer()
+        repeat(4 * 4) { i ->
+            assertTrue("component $i is NaN", !floats.get(i).isNaN())
+        }
+        assertNormalCloseTo(Float3(0f, 1f, 0f), decodedNormal(tangents, 3), "orphan vertex")
+    }
+
+    @Test
+    fun `the UV0 buffer is zero-filled with 8 bytes per vertex`() {
+        val uvs = zeroStreetscapeUvs(vertexCount = 7)
+        assertEquals(7 * STREETSCAPE_UV_STRIDE, uvs.remaining())
+        repeat(7 * 2) { i -> assertEquals(0f, uvs.asFloatBuffer().get(i)) }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private fun floats(vararg values: Float): FloatBuffer = ByteBuffer
+        .allocateDirect(values.size * 4).order(ByteOrder.nativeOrder())
+        .asFloatBuffer().put(values).apply { rewind() }
+
+    private fun ints(vararg values: Int): IntBuffer = ByteBuffer
+        .allocateDirect(values.size * 4).order(ByteOrder.nativeOrder())
+        .asIntBuffer().put(values).apply { rewind() }
+
+    /** The normal is the frame's +Z axis: rotate (0, 0, 1) by the stored quaternion. */
+    private fun decodedNormal(tangents: ByteBuffer, vertex: Int): Float3 {
+        val f = tangents.asFloatBuffer()
+        val q = Quaternion(f.get(vertex * 4), f.get(vertex * 4 + 1), f.get(vertex * 4 + 2), f.get(vertex * 4 + 3))
+        val m = rotation(q)
+        return Float3(m.z.x, m.z.y, m.z.z)
+    }
+
+    private fun assertNormalCloseTo(expected: Float3, actual: Float3, label: String) {
+        assertTrue(
+            "$label: expected normal $expected, decoded $actual",
+            dot(expected, actual) > 0.999f
+        )
+    }
+
+    private val attributeBits = mapOf(
+        "POSITION" to (1 shl 0), "TANGENTS" to (1 shl 1), "COLOR" to (1 shl 2),
+        "UV0" to (1 shl 3), "UV1" to (1 shl 4), "BONE_INDICES" to (1 shl 5),
+        "BONE_WEIGHTS" to (1 shl 6), "UNUSED" to (1 shl 7), "CUSTOM0" to (1 shl 8),
+        "CUSTOM1" to (1 shl 9), "CUSTOM2" to (1 shl 10), "CUSTOM3" to (1 shl 11),
+        "CUSTOM4" to (1 shl 12), "CUSTOM5" to (1 shl 13), "CUSTOM6" to (1 shl 14),
+        "CUSTOM7" to (1 shl 15)
+    )
+
+    /** Required-attribute bitmask of a committed `:sceneview` blob, from its `MAT_REQA` chunk. */
+    private fun requiredAttributes(material: String): Int {
+        val blob = File("../sceneview/src/main/assets/materials/$material.filamat")
+        assertTrue("Expected ${blob.absolutePath}", blob.exists())
+        val chunk = filamatChunk(blob.readBytes(), "MAT_REQA")
+        assertNotNull("$material.filamat has no MAT_REQA chunk", chunk)
+        return readUInt32LE(chunk!!, 0)
+    }
+
+    private fun declaredAttributes(source: File): Int {
+        assertTrue("Expected ${source.absolutePath}", source.exists())
+        return Regex("""VertexAttribute\.([A-Z0-9_]+)""")
+            .findAll(stripComments(source.readText()))
+            .fold(0) { mask, match ->
+                val bit = attributeBits[match.groupValues[1]]
+                assertNotNull("Unknown VertexAttribute `${match.groupValues[1]}`", bit)
+                mask or bit!!
+            }
+    }
+
+    private fun stripComments(source: String): String = source
+        .replace(Regex("""/\*[\s\S]*?\*/"""), "")
+        .replace(Regex("""//[^\n]*"""), "")
+
+    /** `[8-byte reversed tag][uint32 LE size][payload]` chunks — see PlaneVisualizerAttributeContractTest. */
+    private fun filamatChunk(bytes: ByteArray, tag: String): ByteArray? {
+        val tagBytes = tag.reversed().toByteArray(Charsets.US_ASCII)
+        var i = 0
+        while (i + 12 <= bytes.size) {
+            val size = readUInt32LE(bytes, i + 8)
+            if (size < 0 || i + 12 + size > bytes.size) return null
+            if (bytes.copyOfRange(i, i + 8).contentEquals(tagBytes)) {
+                return bytes.copyOfRange(i + 12, i + 12 + size)
+            }
+            i += 12 + size
+        }
+        return null
+    }
+
+    private fun readUInt32LE(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xFF) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 3].toInt() and 0xFF) shl 24)
+
+    private companion object {
+        const val POSITION_BIT = 1 shl 0
+        const val TANGENTS_BIT = 1 shl 1
+        const val UV0_BIT = 1 shl 3
+    }
+}

--- a/changelog.d/3215-streetscape-mesh-attributes.md
+++ b/changelog.d/3215-streetscape-mesh-attributes.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+`StreetscapeGeometryNode` now derives per-vertex normals (as tangent quaternions) and a UV0 slot for the ARCore mesh, so lit materials such as `rememberMaterialInstance(color = …)` shade buildings and terrain by their real surface instead of a fallback normal, and Filament no longer logs `missing required attributes (0xb), declared=0x1` for every geometry (#3215).


### PR DESCRIPTION
Closes #3215

## What

`StreetscapeGeometryNode` declared a POSITION-only `VertexBuffer`, while the material its one in-repo caller (`ARStreetscapeDemo`, `rememberMaterialInstance(materialLoader, color = …)`) resolves to — `opaque_colored` / `transparent_colored` — requires POSITION|TANGENTS|UV0 (`MAT_REQA` = `0xB`). Filament does not fail the mismatch; it logs `missing required attributes (0xb), declared=0x1` on every geometry and shades the building overlay against a constant fallback normal instead of its own surface.

The node now declares POSITION + TANGENTS + UV0 (one backing buffer each, matching `AugmentedFaceNode` and the plane visualizers):

- **TANGENTS** — smooth, area-weighted per-vertex normals derived once at construction from the ARCore positions + indices, encoded as tangent-frame quaternions via `normalToTangent` (the only normal form Filament's vertex shader accepts). Pure JVM, in the new `StreetscapeMeshAttributes.kt`.
- **UV0** — a zero-filled FLOAT2 buffer. Streetscape meshes have no natural parameterisation and the colored materials never sample a texture; the attribute only has to exist.

## Why this direction rather than an unlit material

The issue offers two fixes: derive normals (option 1) or document the node as POSITION-only and switch the demo to `rememberUnlitMaterialInstance` (option 2). Option 1 is the one chosen because:

- The node's `meshMaterialInstance` is a public parameter with a lit default path (`rememberMaterialInstance`) shown in the docs and the demo. Any user following the docs hits the same warning; fixing it in the demo alone leaves the SDK surface broken and contradicts the "AI emits working code on the first try" bar in CLAUDE.md.
- The demo deliberately asks for PBR (`metallic`, `roughness`, `reflectance`) so building façades and terrain read as lit surfaces; an unlit overlay gives that up.
- Unlike #3213's V1 plane (constant frame, one quaternion uploaded once), a streetscape mesh is arbitrary geometry, so the normals have to come from the mesh itself — exactly what the issue's recommendation says a "real fix" means. The cost is one linear pass per geometry at construction, on the main thread alongside the Filament buffer uploads it already did; no per-frame work is added (the mesh is static, only the pose updates).
- An unlit material still works: unlit shaders never read TANGENTS, and the extra buffers are harmless.

## How verified

- `./gradlew :arsceneview:compileDebugKotlin :samples:android-demo:compileDebugKotlin` — green.
- `./gradlew :arsceneview:testDebugUnitTest --tests io.github.sceneview.ar.node.StreetscapeMeshAttributesTest --tests io.github.sceneview.ar.PlaneVisualizerAttributeContractTest` — 8 + 5 tests, 0 failures.
  - Contract: both colored blobs' `MAT_REQA` read `0xB`; the node's declared set covers it; one buffer per attribute, every buffer uploaded.
  - Derivation: a flat +Y quad, a vertical +X façade and a shared vertex decode to their own geometric normal (area-weighted average for the shared one); orphan vertices and out-of-range indices fall back to +Y with no NaN; UV0 is zero-filled at 8 bytes/vertex.
- Not verified on device: Streetscape Geometry needs outdoor Geospatial/VPS coverage, which an emulator or indoor pass cannot provide (as the issue notes). The expected on-device signal is the `missing required attributes (0xb)` log line disappearing from the Streetscape demo and the overlay shading per façade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
