### PR TITLE
State the Apple platform floor once and check every copy against it

### DIFF
--- a/.claude/scripts/check-ios-floor.sh
+++ b/.claude/scripts/check-ios-floor.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# check-ios-floor.sh — drift gate for the Apple platform floor. Closes #3046.
+#
+# WHY THIS EXISTS
+# ---------------
+# `SceneViewSwift/Package.swift` is the only place the Apple deployment floor
+# is *enforced* (the compiler refuses a lower target). Every other statement of
+# it — the three CocoaPods podspecs, the root `Package.swift`, README badges,
+# the docs site, llms.txt, the MCP guides, the demo's About screen — is prose
+# that nothing compared to the manifest. The floor moved from iOS 17 to iOS 18
+# in #719 and eight surfaces kept saying 17 for months; `sync-versions.sh`
+# syncs the podspecs' *version* and their SceneViewSwift dependency floor, never
+# the *platform* floor, so it could not catch this.
+#
+# WHAT IT CHECKS (all hard-fail, no network, no toolchain)
+# --------------------------------------------------------
+#   1. Manifests: the root `Package.swift` declares the same iOS / macOS /
+#      visionOS floors as `SceneViewSwift/Package.swift`.
+#   2. Podspecs: every `s.platform = :ios, 'X'` / `s.platforms = { :ios => "X" }`
+#      equals the iOS floor.
+#   3. Docs: in a fixed list of user-facing files, every "iOS N+", "macOS N+"
+#      and "visionOS N+" *floor claim* names the floor's major version. The
+#      list is explicit so feature-level availability notes in code comments
+#      (`#available(iOS 17.0, *)`, "iOS 15+ only") and historical changelogs
+#      are never read as floor claims.
+#
+# Usage:  bash .claude/scripts/check-ios-floor.sh        (exit 0 = aligned)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ERRORS=0
+fail() { printf "${RED}FAIL${NC} %s\n" "$1"; ERRORS=$((ERRORS + 1)); }
+
+# ─── 1. Source of truth ─────────────────────────────────────────────────────
+MANIFEST="SceneViewSwift/Package.swift"
+floor_of() {
+    # .iOS("18.0") → 18.0 ; .visionOS(.v2) → 2 ; .macOS(.v10_15) → 10.15
+    local os="$1" file="$ROOT/$2" v
+    v=$(grep -oE "\.${os}\(\"[0-9]+(\.[0-9]+)*\"\)" "$file" | head -1 | grep -oE '[0-9]+(\.[0-9]+)*' || true)
+    if [ -z "$v" ]; then
+        v=$(grep -oE "\.${os}\(\.v[0-9]+(_[0-9]+)?\)" "$file" | head -1 | grep -oE 'v[0-9]+(_[0-9]+)?' | tr -d 'v' | tr '_' '.' || true)
+    fi
+    printf '%s' "$v"
+}
+IOS=$(floor_of iOS "$MANIFEST");         IOS_MAJOR=${IOS%%.*}
+MACOS=$(floor_of macOS "$MANIFEST");     MACOS_MAJOR=${MACOS%%.*}
+VISION=$(floor_of visionOS "$MANIFEST"); VISION_MAJOR=${VISION%%.*}
+for pair in "iOS:$IOS" "macOS:$MACOS" "visionOS:$VISION"; do
+    if [ -z "${pair#*:}" ]; then
+        printf "${RED}FATAL${NC} cannot read .%s(...) floor from %s\n" "${pair%%:*}" "$MANIFEST"
+        exit 2
+    fi
+done
+echo "Apple floor per $MANIFEST: iOS $IOS / macOS $MACOS / visionOS $VISION"
+
+# ─── 2. Root Package.swift ──────────────────────────────────────────────────
+# Only the major is compared: the sub-manifest spells `.visionOS("2.0")` while
+# the root uses the `.v2` enum, and both mean the same floor.
+for os in iOS macOS visionOS; do
+    want=$(floor_of "$os" "$MANIFEST"); got=$(floor_of "$os" Package.swift)
+    if [ "${got%%.*}" != "${want%%.*}" ]; then
+        fail "Package.swift declares .$os(${got:-?}) but $MANIFEST says $want"
+    fi
+done
+
+# ─── 3. Podspecs ────────────────────────────────────────────────────────────
+for spec in SceneViewSwift.podspec \
+            react-native/react-native-sceneview/react-native-sceneview.podspec \
+            flutter/sceneview_flutter/ios/flutter_sceneview.podspec; do
+    if [ ! -f "$ROOT/$spec" ]; then
+        fail "$spec is missing (listed in the podspec table of this script)"
+        continue
+    fi
+    got=$(grep -oE ":ios[[:space:]]*(,[[:space:]]*|=>[[:space:]]*)['\"][0-9]+(\.[0-9]+)*['\"]" "$ROOT/$spec" | grep -oE "[0-9]+(\.[0-9]+)*" | head -1 || true)
+    if [ -z "$got" ]; then
+        fail "$spec has no ':ios' platform line"
+    elif [ "$got" != "$IOS" ]; then
+        fail "$spec pins iOS $got but $MANIFEST says $IOS"
+    fi
+done
+
+# ─── 4. Prose floor claims ──────────────────────────────────────────────────
+# Only files whose "<OS> N+" is a *floor* statement. Add a file here when it
+# starts stating the minimum; never widen this to a repo-wide grep (code
+# comments and the changelog legitimately name older per-feature versions).
+DOC_FILES=(
+    README.md
+    SceneViewSwift/README.md
+    CONTRIBUTING.md
+    llms.txt
+    website-static/.well-known/llms.txt
+    website-static/docs.html
+    docs/docs/platforms.md
+    docs/docs/quickstart-ios.md
+    docs/docs/samples-ios.md
+    docs/docs/structured-data.json
+    .github/copilot-instructions.md
+    mcp/src/guides.ts
+    mcp/src/platform-setup.ts
+    mcp/src/tools/handler.ts
+    SceneViewSwift/Examples/SceneViewDemo/SceneViewDemo/Views/AboutView.swift
+)
+# Per-feature availability notes that are NOT floor claims — keep this list
+# short and justified. Matched as fixed substrings of the offending line.
+ALLOW=(
+    "Safari iOS"            # WebXR browser support matrix in llms.txt
+    "iOS 15+"               # ARKit per-feature notes (scene reconstruction, etc.)
+)
+CLAIM_RE="(iOS|macOS|visionOS) \(?[0-9]+(\.[0-9]+)?\+"
+for f in "${DOC_FILES[@]}"; do
+    if [ ! -f "$ROOT/$f" ]; then
+        fail "$f is missing (listed in DOC_FILES of this script)"
+        continue
+    fi
+    while IFS= read -r hit; do
+        [ -n "$hit" ] || continue
+        line=${hit%%:*}; rest=${hit#*:}
+        skip=0
+        for a in "${ALLOW[@]}"; do
+            case "$rest" in *"$a"*) skip=1 ;; esac
+        done
+        [ "$skip" = 1 ] && continue
+        for claim in $(printf '%s' "$rest" | grep -oE "$CLAIM_RE" | tr ' ' '_'); do
+            os=${claim%%_*}; num=${claim#*_}; num=${num#\(}; num=${num%+}; major=${num%%.*}
+            case "$os" in
+                iOS)      want=$IOS_MAJOR ;;
+                macOS)    want=$MACOS_MAJOR ;;
+                visionOS) want=$VISION_MAJOR ;;
+            esac
+            if [ "$major" != "$want" ]; then
+                fail "$f:$line says '$(printf '%s' "$claim" | tr '_' ' ')' but the floor is $os $want+"
+            fi
+        done
+    done <<EOT
+$(grep -nE "$CLAIM_RE" "$ROOT/$f" || true)
+EOT
+done
+
+if [ "$ERRORS" -eq 0 ]; then
+    printf "${GREEN}Apple platform floor is consistent${NC} (iOS %s / macOS %s / visionOS %s across manifests, podspecs and docs)\n" "$IOS" "$MACOS" "$VISION"
+    exit 0
+fi
+printf "${RED}%d drift(s)${NC} — the floor is declared once, in %s; fix the listed files to match it.\n" "$ERRORS" "$MANIFEST"
+exit 1

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ fun MyARScreen() {
 1. SPM: `https://github.com/sceneview/sceneview.git` (from: "4.31.0")`
 2. Use `SceneView` for 3D, `ARSceneView` for AR (SwiftUI views)
 3. Load models: `try await ModelNode.load("models/car.usdz")` — async
-4. Minimum: iOS 17+, macOS 14+, visionOS 1+
+4. Minimum: iOS 18+, macOS 15+, visionOS 2+
 
 ## Node types (26+)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing! This guide covers everything you need 
 
 - **JDK 17** (for Android/KMP modules)
 - **Android Studio** (latest stable recommended)
-- **Xcode 15+** (for SceneViewSwift / iOS work only)
+- **Xcode 16+** (for SceneViewSwift / iOS work only — Swift 6 and the iOS 18 floor)
 - Optional but recommended: Google's [`android` CLI](https://developer.android.com/tools/agents/android-cli)
   for agent-driven QA. Bootstrap in one shot:
   ```bash
@@ -182,6 +182,17 @@ for full API context in any chat:
 5. **Keep commits clean.** Squash fixups before requesting review.
 
 Contributions to any part of the project are welcome — Android (`sceneview/`, `arsceneview/`), iOS (`SceneViewSwift/`), shared KMP core (`sceneview-core/`), samples, documentation, or the MCP server.
+
+### Changing the Apple platform floor
+
+`SceneViewSwift/Package.swift` is the only *enforced* statement of the iOS / macOS /
+visionOS minimum; the three podspecs, the root `Package.swift`, the README badges, the
+docs site, `llms.txt`, the MCP guides and the demo's About screen all repeat it as prose.
+When you move the floor, run
+[`.claude/scripts/check-ios-floor.sh`](.claude/scripts/check-ios-floor.sh) — it reads
+the manifest and lists every podspec and doc line that still names the old version
+(exit 1 on drift). It runs offline in under a second; nothing in CI runs it for you
+(#3046).
 
 ### Adding a demo to `samples/android-demo`
 

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     platforms: [
         .iOS("18.0"),
         .macOS("15.0"),
-        .visionOS(.v1)
+        .visionOS(.v2)
     ],
     products: [
         .library(

--- a/SceneViewSwift/Examples/SceneViewDemo/SceneViewDemo/Views/AboutView.swift
+++ b/SceneViewSwift/Examples/SceneViewDemo/SceneViewDemo/Views/AboutView.swift
@@ -18,7 +18,7 @@ struct AboutView: View {
                 // SDK info
                 Section {
                     LabeledContent("Version", value: marketingVersion)
-                    LabeledContent("Platform", value: "iOS 17+ / visionOS 1+")
+                    LabeledContent("Platform", value: "iOS 18+ / visionOS 2+")
                     LabeledContent("Engine", value: "RealityKit + ARKit")
                     LabeledContent("License", value: "Apache 2.0")
                 } header: {

--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -4,7 +4,7 @@
 
 ![iOS 18+](https://img.shields.io/badge/iOS-18%2B-blue)
 ![macOS 15+](https://img.shields.io/badge/macOS-15%2B-blue)
-![visionOS 1+](https://img.shields.io/badge/visionOS-1%2B-blue)
+![visionOS 2+](https://img.shields.io/badge/visionOS-2%2B-blue)
 
 ## Installation
 

--- a/changelog.d/3046-ios-floor.md
+++ b/changelog.d/3046-ios-floor.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+Every statement of the Apple platform floor now matches `SceneViewSwift/Package.swift`
+(iOS 18 / macOS 15 / visionOS 2). The floor moved in #719 but `llms.txt` on the website,
+`docs.html`, `structured-data.json`, the Copilot instructions, the MCP setup guides, the
+demo's About screen and the visionOS badges kept promising iOS 17 / macOS 14 /
+visionOS 1, and two pages still asked for Xcode 15 although Swift 6 and the iOS 18 target
+need Xcode 16. The root `Package.swift` also declared `.visionOS(.v1)` for a target whose
+light and shadow APIs need visionOS 2. A new `.claude/scripts/check-ios-floor.sh` compares
+the podspecs, both manifests and the user-facing docs against the sub-manifest and exits 1
+on drift.

--- a/docs/docs/platforms.md
+++ b/docs/docs/platforms.md
@@ -53,7 +53,7 @@ SceneViewSwift provides a native SwiftUI library powered by RealityKit and ARKit
 
 - **3D**: `SceneView { }` with ModelNode, GeometryNode, LightNode, and more
 - **AR**: `ARSceneView()` with plane detection and tap-to-place (iOS only)
-- **Min versions**: iOS 18+, macOS 15+, visionOS 1+
+- **Min versions**: iOS 18+, macOS 15+, visionOS 2+
 - **Install**: `.package(url: "https://github.com/sceneview/sceneview.git", from: "4.31.0")`
 
 [:octicons-arrow-right-24: Apple Quickstart](quickstart-ios.md)

--- a/docs/docs/quickstart-ios.md
+++ b/docs/docs/quickstart-ios.md
@@ -15,8 +15,8 @@ description: "Set up SceneViewSwift in your Xcode project in 10 minutes. Build a
 
 ## Prerequisites
 
-- **Xcode 15** or newer
-- An Apple device or simulator running **iOS 18+**, **macOS 15+**, or **visionOS 1+**
+- **Xcode 16** or newer
+- An Apple device or simulator running **iOS 18+**, **macOS 15+**, or **visionOS 2+**
 - Basic familiarity with Swift and SwiftUI
 
 ---

--- a/docs/docs/samples-ios.md
+++ b/docs/docs/samples-ios.md
@@ -208,7 +208,7 @@ struct ARTapToPlaceSample: View {
 
 ### 3D samples
 
-3D samples run on iOS 18+, macOS 15+, and visionOS 1+. They work in both the Simulator and on physical devices.
+3D samples run on iOS 18+, macOS 15+, and visionOS 2+. They work in both the Simulator and on physical devices.
 
 ### AR samples
 

--- a/docs/docs/structured-data.json
+++ b/docs/docs/structured-data.json
@@ -92,7 +92,7 @@
     "url": "https://sceneview.github.io",
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "3D Rendering & Augmented Reality SDK",
-    "operatingSystem": "Android 7.0+ (API 24), iOS 17+",
+    "operatingSystem": "Android 7.0+ (API 24), iOS 18+",
     "softwareVersion": "4.31.0",
     "datePublished": "2021-06-01",
     "dateModified": "2026-03-27",
@@ -184,7 +184,7 @@
     "runtimePlatform": ["Android", "iOS", "macOS", "visionOS"],
     "softwareRequirements": [
       "Android SDK API 24+ (Android)",
-      "iOS 17+ (iOS)",
+      "iOS 18+ (iOS)",
       "Kotlin 2.1.21",
       "Jetpack Compose (Android)",
       "SwiftUI (iOS)",
@@ -279,7 +279,7 @@
         "name": "What platforms does SceneView support?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "SceneView supports Android (API 24+) with Jetpack Compose, Filament, and ARCore, and iOS (17+) with SwiftUI, RealityKit, and ARKit. A shared Kotlin Multiplatform core (sceneview-core) provides cross-platform math, collision, animation, and geometry. SceneView also provides an MCP server for AI assistant integration."
+          "text": "SceneView supports Android (API 24+) with Jetpack Compose, Filament, and ARCore, and iOS (18+) with SwiftUI, RealityKit, and ARKit. A shared Kotlin Multiplatform core (sceneview-core) provides cross-platform math, collision, animation, and geometry. SceneView also provides an MCP server for AI assistant integration."
         }
       },
       {

--- a/docs/docs/visionos-spatial.md
+++ b/docs/docs/visionos-spatial.md
@@ -1,6 +1,6 @@
 # visionOS Spatial Computing
 
-SceneViewSwift supports visionOS 1+ via RealityKit. This page documents the spatial
+SceneViewSwift supports visionOS 2+ via RealityKit. This page documents the spatial
 computing features available on Apple Vision Pro and how SceneViewSwift will integrate
 them.
 

--- a/mcp/src/debug-issue.ts
+++ b/mcp/src/debug-issue.ts
@@ -555,7 +555,7 @@ SceneView(
 
 ### SPM Package Resolution Fails
 
-- Require Xcode 15.0+ (iOS 17 / visionOS targets).
+- Require Xcode 16.0+ (iOS 18 / visionOS 2 targets, Swift 6).
 - Clean: Xcode > Product > Clean Build Folder.
 - Reset packages: File > Packages > Reset Package Caches.
 - URL must be exactly: \`https://github.com/sceneview/sceneview\`

--- a/mcp/src/guides.ts
+++ b/mcp/src/guides.ts
@@ -40,7 +40,7 @@ KMP shares **logic**, not **rendering**. Each platform uses its native renderer.
 
 ## Apple — Alpha (SceneViewSwift)
 
-- **3D + AR** in SwiftUI via RealityKit — iOS 17+ / macOS 14+ / visionOS 1+
+- **3D + AR** in SwiftUI via RealityKit — iOS 18+ / macOS 15+ / visionOS 2+
 - Node types: ModelNode, AnchorNode, GeometryNode, LightNode, CameraNode, ImageNode, VideoNode, PhysicsNode, AugmentedImageNode
 - PBR material system with textures
 - Swift Package Manager distribution
@@ -331,7 +331,7 @@ export const TROUBLESHOOTING_GUIDE = `# SceneView Troubleshooting Guide
 
 ### SPM Package Resolution Fails
 **Fix:**
-- Ensure Xcode 15.0+ (required for iOS 17 / visionOS targets).
+- Ensure Xcode 16.0+ (required for the iOS 18 / visionOS 2 targets and Swift 6).
 - Clean derived data: Xcode → Product → Clean Build Folder, then File → Packages → Reset Package Caches.
 - Check the URL is exactly: \`https://github.com/sceneview/sceneview\`
 
@@ -366,7 +366,7 @@ Without this entry, the app will crash on camera access.
 
 ## 3. Minimum Platform
 
-AR requires **iOS 17.0+**. ARKit is not available on macOS or visionOS via \`ARSceneView\` (visionOS uses \`ARKitSession\` directly).
+AR requires **iOS 18.0+**. ARKit is not available on macOS or visionOS via \`ARSceneView\` (visionOS uses \`ARKitSession\` directly).
 
 ## 4. Basic AR Template
 

--- a/mcp/src/tools/handler.ts
+++ b/mcp/src/tools/handler.ts
@@ -466,7 +466,7 @@ export async function dispatchTool(
                 ``,
                 `### 2. Minimum Platform`,
                 ``,
-                `AR requires **iOS 17.0+** (ARKit + RealityKit). macOS and visionOS use different AR APIs.`,
+                `AR requires **iOS 18.0+** (ARKit + RealityKit). macOS and visionOS use different AR APIs.`,
                 ``,
                 `### 3. Info.plist — Camera Permission`,
                 ``,

--- a/website-static/.well-known/llms.txt
+++ b/website-static/.well-known/llms.txt
@@ -6,7 +6,7 @@ SceneView is a declarative 3D and AR SDK for Android (Jetpack Compose, Filament,
 - 3D only: `io.github.sceneview:sceneview:4.31.0`
 - AR + 3D: `io.github.sceneview:arsceneview:4.31.0`
 
-**Apple (iOS 17+ / macOS 14+ / visionOS 1+) — Swift Package:**
+**Apple (iOS 18+ / macOS 15+ / visionOS 2+) — Swift Package:**
 - `https://github.com/sceneview/sceneview.git` (from: "4.31.0"))
 
 **Min SDK:** 24 | **Target SDK:** 36 | **Kotlin:** 2.4.10 | **Compose BOM compatible**
@@ -2781,7 +2781,7 @@ All geometry shares the PBR material pipeline — supports `color` (base color f
 
 ## SceneViewSwift (iOS / macOS / visionOS)
 
-Renderer: **RealityKit**. Requires iOS 17+ / macOS 14+ / visionOS 1+.
+Renderer: **RealityKit**. Requires iOS 18+ / macOS 15+ / visionOS 2+.
 
 SPM dependency (Package.swift or Xcode):
 ```swift

--- a/website-static/docs.html
+++ b/website-static/docs.html
@@ -352,7 +352,7 @@
               <img src="assets/brand/apple.svg" alt="" class="docs-card__icon-img">
             </div>
             <h3 class="docs-card__title">iOS / macOS / visionOS (SwiftUI)</h3>
-            <p class="docs-card__text">Swift Package with RealityKit renderer. SceneView and ARSceneView for iOS 17+, macOS 14+, visionOS 1+.</p>
+            <p class="docs-card__text">Swift Package with RealityKit renderer. SceneView and ARSceneView for iOS 18+, macOS 15+, visionOS 2+.</p>
           </a>
 
           <a href="https://github.com/sceneview/sceneview/tree/main/sceneview-web" class="docs-card reveal" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary

- `SceneViewSwift/Package.swift` has required **iOS 18 / macOS 15 / visionOS 2** since #719, but eight user-facing surfaces still said iOS 17 / macOS 14 / visionOS 1: `website-static/.well-known/llms.txt` (x2), `website-static/docs.html`, `docs/docs/structured-data.json` (x3), `.github/copilot-instructions.md`, the demo's `AboutView.swift`, plus the MCP guides (`guides.ts`, `tools/handler.ts`, `debug-issue.ts`). All of them now read the real floor.
- Two Xcode floors were stale as well: `CONTRIBUTING.md` and `docs/docs/quickstart-ios.md` asked for Xcode 15; Swift 6 and the iOS 18 target need Xcode 16.
- visionOS: the sub-manifest pins `.visionOS("2.0")` (RealityKit lights and per-entity shadows are `@available(visionOS 2.0, *)`, #1366), but the root `Package.swift` declared `.visionOS(.v1)` and the README badge, `platforms.md`, `quickstart-ios.md`, `samples-ios.md` and `visionos-spatial.md` said 1+. Aligned to 2 so the repo has one answer. Flagging this explicitly since it is the one non-prose change.
- New `.claude/scripts/check-ios-floor.sh`: reads the floor from `SceneViewSwift/Package.swift`, then compares the root manifest, the three podspecs (`SceneViewSwift.podspec`, React Native, Flutter) and a fixed list of docs; exits 1 on any `iOS N+` / `macOS N+` / `visionOS N+` claim with a different major. Offline, no toolchain. The doc list is explicit so per-feature notes (`#available(iOS 17.0, *)`, ARKit "iOS 15+") and the historical changelog are never read as floor claims.
- `ci.yml` has no step that runs the sibling `check-*.sh` scripts, so this one is documented in CONTRIBUTING.md (new "Changing the Apple platform floor" section) rather than wired into a job.

Closes #3046

## Verification

- `bash .claude/scripts/check-ios-floor.sh` → exit 0 on this branch; on `origin/main` (edits stashed) it reports 27 drifts and exits 1.
- `cd mcp && npx vitest run`: 83 files, 1965 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)