### PR TITLE
fix(android-demo): frame the custom-geometry Shape sub-mode at its intended distance (#2937)

### DIFF
--- a/changelog.d/2937-custom-geometry-shape-orbit.md
+++ b/changelog.d/2937-custom-geometry-shape-orbit.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **android-demo**: the *Shape Extrude* sub-mode of `custom-geometry` no longer clips its triangle, star and hexagon on a portrait phone. It paired `orbitHomePosition = (0, 0, 1.5)` with a target at `z = -1`, which reads as a 2.5 m camera but — with `autoCenterContent` putting the shape on the origin — framed from 1.5 m. The distance is now derived from the frustum in `ShapeFraming` and pinned by a JVM test, as #2923 did for the geometry demo (#2937).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomGeometryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomGeometryDemo.kt
@@ -30,11 +30,11 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.demos.internal.ShapeFraming
 import io.github.sceneview.demo.initialDemoMode
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.rememberPausableHeroYaw
 import io.github.sceneview.math.Position
-import io.github.sceneview.math.Position2
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberEngine
@@ -42,9 +42,6 @@ import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.sample.rememberMaterialInstance
 import io.github.sceneview.sample.ui.LabeledSlider
 import java.util.Locale
-import kotlin.math.PI
-import kotlin.math.cos
-import kotlin.math.sin
 
 /**
  * Unified "Custom Geometry" demo — consolidates the retired `custom-mesh` and
@@ -228,36 +225,6 @@ private fun ShapeSection(
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
-    val trianglePath = remember {
-        listOf(
-            Position2(0f, 0.5f),
-            Position2(-0.5f, -0.3f),
-            Position2(0.5f, -0.3f)
-        )
-    }
-
-    val starPath = remember {
-        buildList {
-            val outerR = 0.5f
-            val innerR = 0.2f
-            for (i in 0 until 10) {
-                val angle = (i * 36f - 90f) * (PI.toFloat() / 180f)
-                val r = if (i % 2 == 0) outerR else innerR
-                add(Position2(cos(angle) * r, sin(angle) * r))
-            }
-        }
-    }
-
-    val hexagonPath = remember {
-        buildList {
-            val r = 0.4f
-            for (i in 0 until 6) {
-                val angle = (i * 60f) * (PI.toFloat() / 180f)
-                add(Position2(cos(angle) * r, sin(angle) * r))
-            }
-        }
-    }
-
     val triangleMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Primary)
     val starMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Accent)
     val hexagonMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.TintLight)
@@ -266,11 +233,9 @@ private fun ShapeSection(
         "Star" to starMaterial,
         "Hexagon" to hexagonMaterial,
     )
-    val shapePaths = mapOf(
-        "Triangle" to trianglePath,
-        "Star" to starPath,
-        "Hexagon" to hexagonPath,
-    )
+    // Outlines live in ShapeFraming so the framing test measures the vertices actually
+    // extruded, not a copy of them (#2937).
+    val shapePaths = ShapeFraming.paths
 
     val firstFrame = rememberFirstFrameState()
 
@@ -300,16 +265,24 @@ private fun ShapeSection(
             onFrame = firstFrame.onFrame,
             engine = engine,
             materialLoader = materialLoader,
+            // The orbit distance is the LENGTH of `orbitHomePosition`, not its distance to
+            // `targetPosition`: `autoCenterContent = true` (the default, kept here) moves the
+            // shape onto the world origin and Filament takes the vector verbatim as the eye
+            // (#2930). The previous `(0, 0, 1.5)` / target `(0, 0, -1)` pairing therefore put
+            // the camera 1.5 m out — not the 2.5 m it read as — and clipped the 1 m-wide
+            // outlines on both sides of a portrait frame (#2937). ShapeFraming derives the
+            // distance from the frustum and a unit test pins the margin, as #2923 did for the
+            // geometry demo.
             cameraManipulator = rememberCameraManipulator(
-                orbitHomePosition = Position(0f, 0f, 1.5f),
-                targetPosition = Position(0f, 0f, -1f),
+                orbitHomePosition = ShapeFraming.orbitHomeOffset(ShapeFraming.CAMERA_DISTANCE),
+                targetPosition = Position(0f, 0f, ShapeFraming.TARGET_Z),
             ),
         ) {
             key(selectedShape) {
                 ShapeNode(
                     polygonPath = shapePaths.getValue(selectedShape),
                     materialInstance = shapeMaterials.getValue(selectedShape),
-                    position = Position(y = 0f, z = -1f)
+                    position = Position(y = 0f, z = ShapeFraming.TARGET_Z)
                 )
             }
         }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/ShapeFraming.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/ShapeFraming.kt
@@ -1,0 +1,127 @@
+package io.github.sceneview.demo.demos.internal
+
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.Position2
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Outlines + framing arithmetic for the *Shape Extrude* sub-mode of
+ * [io.github.sceneview.demo.demos.CustomGeometryDemo].
+ *
+ * The sub-mode used to pair `orbitHomePosition = (0, 0, 1.5)` with `targetPosition = (0, 0, -1)`
+ * and a shape authored at `z = -1` — which reads as "a camera 2.5 m from the subject". It is
+ * not: the orbit distance is the **length** of `orbitHomePosition`, because `SceneView`'s
+ * default `autoCenterContent = true` moves the shape onto the world origin and Filament takes
+ * the vector verbatim as the eye (see `rememberCameraManipulator`'s KDoc, #2930, and
+ * [GeometryLayout]'s orbit-distance note, #2873). The camera was therefore 1.5 m out — 40 %
+ * closer than intended — and a 1 m-wide outline on a portrait frame that is only ~0.68 m wide
+ * at that distance was clipped on both sides
+ * ([#2937](https://github.com/sceneview/sceneview/issues/2937)).
+ *
+ * Same cure as #2923: the distance is a named constant, [orbitHomeOffset] returns a vector
+ * whose length *is* that distance, and `ShapeFramingTest` asserts the widest outline clears a
+ * phone-portrait frame through the same frustum relation [GeometryLayout] uses
+ * (`halfHeight = distance · 12 / focalLength`). The outlines themselves live here too, so the
+ * test measures the vertices the demo actually extrudes rather than a copy of them.
+ *
+ * **Precondition:** the sub-mode keeps `autoCenterContent` at its default. With it off the
+ * distance would become `|orbitHomePosition − contentCentre|` and [CAMERA_DISTANCE] would need
+ * re-deriving.
+ */
+internal object ShapeFraming {
+
+    /** Depth the shape is authored at, and the camera's orbit target. */
+    const val TARGET_Z = -1f
+
+    /**
+     * Camera-to-shape distance, in metres.
+     *
+     * Chosen so the widest outline fills ~73 % of the frame width at
+     * [GeometryLayout.PHONE_PORTRAIT_ASPECT] — readable at thumbnail size, with a visible margin
+     * on every side — and still clears the frame at [GeometryLayout.NARROWEST_EXPECTED_ASPECT].
+     * `ShapeFramingTest` pins the margin this value actually delivers.
+     */
+    const val CAMERA_DISTANCE = 3f
+
+    /** Triangle outline: apex up, 1 m wide, 0.8 m tall. */
+    val trianglePath: List<Position2> = listOf(
+        Position2(0f, 0.5f),
+        Position2(-0.5f, -0.3f),
+        Position2(0.5f, -0.3f),
+    )
+
+    /** Five-point star outline, outer radius 0.5 m, inner radius 0.2 m, one point up. */
+    val starPath: List<Position2> = buildList {
+        val outerR = 0.5f
+        val innerR = 0.2f
+        for (i in 0 until 10) {
+            val angle = (i * 36f - 90f) * (PI.toFloat() / 180f)
+            val r = if (i % 2 == 0) outerR else innerR
+            add(Position2(cos(angle) * r, sin(angle) * r))
+        }
+    }
+
+    /** Regular hexagon outline, circumradius 0.4 m, one vertex on +X. */
+    val hexagonPath: List<Position2> = buildList {
+        val r = 0.4f
+        for (i in 0 until 6) {
+            val angle = (i * 60f) * (PI.toFloat() / 180f)
+            add(Position2(cos(angle) * r, sin(angle) * r))
+        }
+    }
+
+    /** Every outline the sub-mode offers, keyed by its chip label. */
+    val paths: Map<String, List<Position2>> = mapOf(
+        "Triangle" to trianglePath,
+        "Star" to starPath,
+        "Hexagon" to hexagonPath,
+    )
+
+    /**
+     * Orbit offset to pass as `orbitHomePosition`, for a camera [distance] metres from the
+     * shape: a vector of length exactly [distance], straight down the view axis. The shape is a
+     * flat extrusion facing +Z, so unlike [GeometryLayout.orbitHomeOffset] there is no elevation
+     * — a tilt would only foreshorten it.
+     *
+     * @param distance Camera-to-shape distance in metres. Must be `> 0`.
+     */
+    fun orbitHomeOffset(distance: Float): Position {
+        require(distance > 0f) { "distance must be > 0, was $distance" }
+        return Position(x = 0f, y = 0f, z = distance)
+    }
+
+    /**
+     * Widest half-extent of an [outline] about its bounding-box centre, in metres. The shape
+     * does not spin, so this is a plain vertex maximum — and it is taken about the box centre,
+     * not the authored origin, because that is where `autoCenterContent` puts it.
+     */
+    fun halfWidth(outline: List<Position2>): Float = halfExtent(outline.map { it.x })
+
+    /** Tallest half-extent of an [outline] about its bounding-box centre — see [halfWidth]. */
+    fun halfHeight(outline: List<Position2>): Float = halfExtent(outline.map { it.y })
+
+    /** Widest half-extent across every outline in [paths]. */
+    val halfWidth: Float get() = paths.values.maxOf(::halfWidth)
+
+    /** Tallest half-extent across every outline in [paths]. */
+    val halfHeight: Float get() = paths.values.maxOf(::halfHeight)
+
+    /**
+     * Fraction of the frame **width** the widest outline occupies at [distance] on an [aspect]
+     * viewport — `1.0` touches both edges, above `1.0` is clipped.
+     */
+    fun horizontalFillRatio(distance: Float, aspect: Float): Float =
+        halfWidth / GeometryLayout.frameHalfWidth(distance, aspect)
+
+    /** Fraction of the frame **height** the tallest outline occupies at [distance]. */
+    fun verticalFillRatio(distance: Float): Float =
+        halfHeight / GeometryLayout.frameHalfHeight(distance)
+
+    private fun halfExtent(coordinates: List<Float>): Float {
+        require(coordinates.isNotEmpty()) { "an outline needs at least one vertex" }
+        return abs(coordinates.max() - coordinates.min()) * 0.5f
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/ShapeFramingTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/ShapeFramingTest.kt
@@ -1,0 +1,74 @@
+package io.github.sceneview.demo.demos.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.sqrt
+
+/**
+ * JVM tests for [ShapeFraming] — the framing arithmetic behind the *Shape Extrude* sub-mode of
+ * [io.github.sceneview.demo.demos.CustomGeometryDemo].
+ *
+ * Same reason [GeometryLayoutTest] exists: the defect guarded against
+ * ([#2937](https://github.com/sceneview/sceneview/issues/2937)) is a *number* — an outline wider
+ * than the frame it is viewed in — which compiles, renders and passes every blank-frame guard.
+ */
+class ShapeFramingTest {
+
+    private val portraitFillCeiling = 0.80f
+    private val worstCaseFillCeiling = 0.92f
+
+    @Test
+    fun `outline extents are measured from the vertices the demo extrudes`() {
+        // Triangle: 1 m wide, apex at 0.5, base at -0.3.
+        assertEquals(0.5f, ShapeFraming.halfWidth(ShapeFraming.trianglePath), 1e-5f)
+        assertEquals(0.4f, ShapeFraming.halfHeight(ShapeFraming.trianglePath), 1e-5f)
+        // Hexagon with a vertex on +X: circumradius wide, apothem tall.
+        assertEquals(0.4f, ShapeFraming.halfWidth(ShapeFraming.hexagonPath), 1e-5f)
+        assertEquals(0.4f * sqrt(3f) / 2f, ShapeFraming.halfHeight(ShapeFraming.hexagonPath), 1e-5f)
+        // The triangle is the widest outline, so it is the one the distance is derived for.
+        assertEquals(0.5f, ShapeFraming.halfWidth, 1e-5f)
+    }
+
+    @Test
+    fun `the old framing really was clipped`() {
+        // orbitHomePosition = (0, 0, 1.5) → 1.5 m out, not the 2.5 m the target suggested.
+        val fill = ShapeFraming.horizontalFillRatio(1.5f, GeometryLayout.PHONE_PORTRAIT_ASPECT)
+        assertTrue("expected the 1.5 m framing to clip, it fills $fill", fill > 1f)
+    }
+
+    @Test
+    fun `orbit home offset has the requested length and no elevation`() {
+        val offset = ShapeFraming.orbitHomeOffset(ShapeFraming.CAMERA_DISTANCE)
+        val length = sqrt(offset.x * offset.x + offset.y * offset.y + offset.z * offset.z)
+        assertEquals(ShapeFraming.CAMERA_DISTANCE, length, 1e-5f)
+        assertEquals(0f, offset.y, 0f)
+    }
+
+    @Test
+    fun `widest outline fits a phone-portrait frame with visible margin at the default distance`() {
+        val fill = ShapeFraming.horizontalFillRatio(
+            ShapeFraming.CAMERA_DISTANCE,
+            GeometryLayout.PHONE_PORTRAIT_ASPECT,
+        )
+        assertTrue("outline fills $fill of the frame width — clipped", fill < 1f)
+        assertTrue("outline fills $fill of the frame width — no visible margin", fill < portraitFillCeiling)
+        assertTrue("outline fills only $fill of the frame width — too small to read", fill > 0.6f)
+    }
+
+    @Test
+    fun `widest outline still clears the narrowest frame it could be rendered in`() {
+        val fill = ShapeFraming.horizontalFillRatio(
+            ShapeFraming.CAMERA_DISTANCE,
+            GeometryLayout.NARROWEST_EXPECTED_ASPECT,
+        )
+        assertTrue("outline fills $fill of the worst-case frame width — clipped", fill < 1f)
+        assertTrue("outline fills $fill of the worst-case frame width — margin too thin", fill < worstCaseFillCeiling)
+    }
+
+    @Test
+    fun `tallest outline is nowhere near the vertical limit`() {
+        val fill = ShapeFraming.verticalFillRatio(ShapeFraming.CAMERA_DISTANCE)
+        assertTrue("outline fills $fill of the frame height", fill < 0.5f)
+    }
+}


### PR DESCRIPTION
Closes #2937

## What

The *Shape Extrude* sub-mode of `custom-geometry` paired `orbitHomePosition = (0, 0, 1.5)` with `targetPosition = (0, 0, -1)` and a shape authored at `z = -1` — which reads as a 2.5 m camera. Per the `rememberCameraManipulator` semantics documented by #2930, the orbit distance is the **length** of `orbitHomePosition`: `autoCenterContent` (default, kept) moves the shape onto the origin and Filament takes the vector verbatim as the eye. The camera was 1.5 m out; at that distance the measured phone-portrait frame is ~0.68 m wide and the 1 m-wide triangle/star were clipped on both sides — the same misreading #2873 / #2923 fixed in the geometry demo.

## How

Same cure as #2923, with this section's own extents:

- `demos/internal/ShapeFraming.kt` owns the three outlines, `TARGET_Z`, a `CAMERA_DISTANCE = 3 m` derived from the frustum relation (`halfHeight = distance · 12 / focalLength`, reusing `GeometryLayout.frameHalfWidth/Height`), and `orbitHomeOffset(distance)` returning a vector whose length *is* the distance.
- `CustomGeometryDemo.ShapeSection` reads its outlines and framing from it; the call-site comment states the `|orbitHomePosition|` semantics so the next reader does not re-derive the mistake.
- `ShapeFramingTest` (JVM) pins the fit: 73 % horizontal fill at `PHONE_PORTRAIT_ASPECT`, 86 % at `NARROWEST_EXPECTED_ASPECT`, < 50 % vertical, and a regression case proving the old 1.5 m framing exceeds 100 %.

Not done here: the `orbitHomePosition` rename / `orbitRadius` overload — that is #2932, an API question; this PR only fixes the call site.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin` — OK
- `./gradlew :samples:android-demo:testDebugUnitTest --tests '*ShapeFramingTest*' --tests '*GeometryLayoutTest*'` — 6/6 + existing pass
- No device capture (no emulator in this session); the issue asked to measure before fixing — the measurement here is the same frustum arithmetic that reproduced on-device pixels to within 1.5 % in #2923. A portrait capture of the sub-mode would be a good addition before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
