### PR TITLE
Give the iOS ReflectionProbesDemo probe an environment so its intensity slider works

### DIFF
--- a/changelog.d/3158-ios-reflection-probe-env.md
+++ b/changelog.d/3158-ios-reflection-probe-env.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+iOS demo: `ReflectionProbesDemo` now loads the selected environment into its `ReflectionProbeNode` via `environmentTexture(_:)` and points the metallic sphere and cubes at the probe, so the probe actually carries an `ImageBasedLightComponent` and the Intensity slider visibly changes the reflections instead of rebuilding an identical scene (#3158).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		ED794E60A009AF57DE2B2861 /* MovableLightDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E3457CB732DF2AE71757CC /* MovableLightDemo.swift */; };
 		F00000000000000000000003 /* AppStoreUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000002 /* AppStoreUpdaterTests.swift */; };
 		F00000000000000000000077 /* LabeledSliderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000076 /* LabeledSliderTests.swift */; };
+		A20000000000000000003159 /* ReflectionProbesDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000003158 /* ReflectionProbesDemoTests.swift */; };
 		F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000060 /* SketchfabService+Tests.swift */; };
 		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
 		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
@@ -216,6 +217,7 @@
 		F10000000000000000000002 /* SceneViewDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneViewDemoUITests.swift; path = SceneViewDemoUITests/SceneViewDemoUITests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000002 /* AppStoreUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreUpdaterTests.swift; path = SceneViewDemoTests/AppStoreUpdaterTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000076 /* LabeledSliderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LabeledSliderTests.swift; path = SceneViewDemoTests/LabeledSliderTests.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000003158 /* ReflectionProbesDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReflectionProbesDemoTests.swift; path = SceneViewDemoTests/ReflectionProbesDemoTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000060 /* SketchfabService+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabService+Tests.swift"; path = "SceneViewDemo/Services/SketchfabService+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabAssetResolver+Tests.swift"; path = "SceneViewDemo/Services/SketchfabAssetResolver+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000072 /* DemoRegistryGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoRegistryGuardTests.swift; path = SceneViewDemoTests/DemoRegistryGuardTests.swift; sourceTree = SOURCE_ROOT; };
@@ -427,6 +429,7 @@
 			children = (
 				F00000000000000000000002 /* AppStoreUpdaterTests.swift */,
 				F00000000000000000000076 /* LabeledSliderTests.swift */,
+				A20000000000000000003158 /* ReflectionProbesDemoTests.swift */,
 				F00000000000000000000060 /* SketchfabService+Tests.swift */,
 				F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */,
 				F00000000000000000000072 /* DemoRegistryGuardTests.swift */,
@@ -985,6 +988,7 @@
 			files = (
 				F00000000000000000000003 /* AppStoreUpdaterTests.swift in Sources */,
 				F00000000000000000000077 /* LabeledSliderTests.swift in Sources */,
+				A20000000000000000003159 /* ReflectionProbesDemoTests.swift in Sources */,
 				F00000000000000000000061 /* SketchfabService+Tests.swift in Sources */,
 				F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */,
 				F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ReflectionProbesDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ReflectionProbesDemo.swift
@@ -17,6 +17,9 @@ struct ReflectionProbesDemo: View {
     @State private var selectedEnvironment: ProbeEnvironment = .sunset
     @State private var intensity: Double = 1.0
     @State private var showSphere: Bool = true
+    /// The selected environment, loaded once per selection and handed to the
+    /// probe as its reflection texture. `nil` until the load lands (#3158).
+    @State private var probeEnvironment: EnvironmentResource?
 
     var body: some View {
         ZStack {
@@ -32,6 +35,10 @@ struct ReflectionProbesDemo: View {
         .demoSettingsSheet {
             settingsContent
         }
+        .task(id: selectedEnvironment) {
+            probeEnvironment = nil
+            probeEnvironment = try? await selectedEnvironment.sceneEnvironment.load()
+        }
     }
 
     // MARK: - Scene
@@ -43,15 +50,50 @@ struct ReflectionProbesDemo: View {
         }
         .cameraControls(.orbit)
         .environment(selectedEnvironment.sceneEnvironment)
-        .id("\(selectedEnvironment.id)-\(showSphere)-\(String(format: "%.2f", intensity))")
+        // The key also flips when the probe texture finishes loading: keyed on
+        // the picker alone the scene would already sit at its final key while
+        // `probeEnvironment` is still `nil`, and the probe would stay empty.
+        .id("\(selectedEnvironment.id)-\(showSphere)-\(String(format: "%.2f", intensity))-\(probeEnvironment != nil)")
         .ignoresSafeArea()
+    }
+
+    /// Builds the demo's probe: a 4 m box at the origin carrying the selected
+    /// environment as its reflection texture.
+    ///
+    /// `ReflectionProbeNode.intensity` only reaches RealityKit through the
+    /// `ImageBasedLightComponent` that `environmentTexture(_:)` installs — a
+    /// probe without a texture is an empty `Entity`, and the intensity slider
+    /// driving it is inert (#3158). Static and internal so
+    /// `ReflectionProbesDemoTests` can pin that the demo path installs the
+    /// component.
+    @MainActor
+    static func makeProbe(intensity: Float, environment: EnvironmentResource?) -> ReflectionProbeNode {
+        let probe = ReflectionProbeNode.box(size: [4, 4, 4], intensity: intensity)
+        probe.entity.position = .zero
+        if let environment {
+            probe.environmentTexture(environment)
+        }
+        return probe
+    }
+
+    /// Points a reflective entity at the probe instead of the scene's global IBL.
+    ///
+    /// RealityKit resolves `ImageBasedLightReceiverComponent` per entity: the
+    /// receiver `environmentTexture(_:)` sets lives on the probe entity itself,
+    /// so the geometry that should *show* the probe needs its own receiver
+    /// targeting the probe — otherwise it keeps reflecting the global
+    /// environment and the probe contributes nothing (#3158).
+    @MainActor
+    static func attach(_ entity: Entity, to probe: ReflectionProbeNode) {
+        entity.components.set(
+            ImageBasedLightReceiverComponent(imageBasedLight: probe.entity)
+        )
     }
 
     @MainActor
     private func buildScene(root: Entity) {
         // Centre box probe
-        let probe = ReflectionProbeNode.box(size: [4, 4, 4], intensity: Float(intensity))
-        probe.entity.position = .zero
+        let probe = Self.makeProbe(intensity: Float(intensity), environment: probeEnvironment)
         root.addChild(probe.entity)
 
         if showSphere {
@@ -61,6 +103,7 @@ struct ReflectionProbesDemo: View {
                 material: .pbr(color: .white, metallic: 0.9, roughness: 0.05)
             )
             sphere.entity.position = .init(x: 0, y: 0, z: -1.5)
+            Self.attach(sphere.entity, to: probe)
             root.addChild(sphere.entity)
         }
 
@@ -77,6 +120,7 @@ struct ReflectionProbesDemo: View {
                 material: .pbr(color: .white, metallic: metals[i], roughness: 0.1)
             )
             cube.entity.position = pos
+            Self.attach(cube.entity, to: probe)
             root.addChild(cube.entity)
         }
 

--- a/samples/ios-demo/SceneViewDemoTests/ReflectionProbesDemoTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/ReflectionProbesDemoTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import RealityKit
+
+@testable import SceneViewDemo
+@testable import SceneViewSwift
+
+/// Pins that the probe built through the demo path actually carries an IBL.
+///
+/// `ReflectionProbeNode.intensity` only reaches RealityKit through the
+/// `ImageBasedLightComponent` that `environmentTexture(_:)` installs. The demo
+/// used to build the probe without a texture, so the Intensity slider rebuilt
+/// an identical scene on every step (#3158).
+@MainActor
+final class ReflectionProbesDemoTests: XCTestCase {
+
+    func testDemoProbeCarriesAnImageBasedLightAtTheSliderIntensity() async throws {
+        let environment = try await Self.makeEnvironmentResource(named: "demo-probe")
+        let probe = ReflectionProbesDemo.makeProbe(intensity: 2.0, environment: environment)
+
+        let ibl = try XCTUnwrap(probe.entity.components[ImageBasedLightComponent.self])
+        // Linear multiplier 2.0 → RealityKit exponent 1 (#2956).
+        XCTAssertEqual(ibl.intensityExponent, 1.0, accuracy: 1e-6)
+        XCTAssertNotNil(probe.entity.components[ImageBasedLightReceiverComponent.self])
+    }
+
+    func testDemoProbeWithoutALoadedEnvironmentHasNoLightYet() {
+        // Before the async load lands the probe is still an empty entity; the
+        // view key flips once `probeEnvironment` is set so the scene rebuilds.
+        let probe = ReflectionProbesDemo.makeProbe(intensity: 1.0, environment: nil)
+        XCTAssertNil(probe.entity.components[ImageBasedLightComponent.self])
+    }
+
+    func testReflectiveGeometryReceivesTheProbeNotTheGlobalIBL() async throws {
+        let environment = try await Self.makeEnvironmentResource(named: "demo-probe-receiver")
+        let probe = ReflectionProbesDemo.makeProbe(intensity: 1.0, environment: environment)
+        let sphere = Entity()
+
+        ReflectionProbesDemo.attach(sphere, to: probe)
+
+        let receiver = try XCTUnwrap(sphere.components[ImageBasedLightReceiverComponent.self])
+        XCTAssertTrue(receiver.imageBasedLight === probe.entity)
+    }
+
+    /// A flat gray equirectangular image is enough to build a real
+    /// `EnvironmentResource` headlessly — same trick as `ReflectionProbeNodeTests`.
+    private static func makeEnvironmentResource(named name: String) async throws -> EnvironmentResource {
+        let width = 64, height = 32
+        let colorSpace = try XCTUnwrap(CGColorSpace(name: CGColorSpace.linearSRGB))
+        let context = try XCTUnwrap(
+            CGContext(
+                data: nil, width: width, height: height,
+                bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        )
+        context.setFillColor(CGColor(srgbRed: 0.5, green: 0.5, blue: 0.5, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = try XCTUnwrap(context.makeImage())
+        return try await EnvironmentResource(equirectangular: image, withName: name)
+    }
+}


### PR DESCRIPTION
Closes #3158

## Root cause

`ReflectionProbesDemo.buildScene` built `ReflectionProbeNode.box(size:intensity:)` and never called `environmentTexture(_:)`. `ReflectionProbeNode.intensity` only reaches RealityKit through the `ImageBasedLightComponent` that `environmentTexture(_:)` installs, so the probe was an empty `Entity`: the metallic sphere and cubes reflected the *global* scene IBL, and the Intensity slider (wired into the view `.id()`) rebuilt a pixel-identical scene on every step.

## Fix

- The selected environment is loaded once per selection (`SceneEnvironment.load()`) into `@State`, and handed to the probe through a new static `ReflectionProbesDemo.makeProbe(intensity:environment:)` that calls `environmentTexture(_:)`.
- The sphere and the three cubes get their own `ImageBasedLightReceiverComponent(imageBasedLight: probe.entity)` (`ReflectionProbesDemo.attach(_:to:)`), so they reflect the probe rather than the global IBL — RealityKit resolves receivers per entity, and the receiver `environmentTexture(_:)` sets only lives on the probe itself.
- The `.id()` key also flips when the texture finishes loading, so the scene rebuilds once the probe is populated instead of staying empty.
- New `samples/ios-demo/SceneViewDemoTests/ReflectionProbesDemoTests.swift` (registered in the pbxproj) pins that a probe built through the demo path carries the IBL component at the slider's linear intensity (2.0 → exponent 1, #2956), that it has none before the load lands, and that the reflective geometry's receiver targets the probe.

Slider span `0.1…3.0` (linear) kept: at 3.0 the reflections blow out toward white without clipping the rest of the frame, and 0.1 reads as a clearly dimmed sphere — a sensible demo range.

## Evidence (iOS 26.3 Simulator, iPhone 17 Pro)

- Before, intensity 1.0: sunset sky, grey-blue metallic sphere and cubes reflecting the global IBL.
- After, intensity 1.0: identical frame — the probe carries the same environment, `1.0` is a true no-op.
- After, intensity 3.0: the sphere and cubes brighten sharply (reflections toward white) while the sky background is unchanged — the probe, not the global IBL, now drives the geometry, and the slider is visibly live.
- `ReflectionProbesDemoTests`: 3 tests, 0 failures, run on the simulator via `xcodebuild test -only-testing:SceneViewDemoTests/ReflectionProbesDemoTests`.

No SDK (`SceneViewSwift/`) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
