### PR TITLE
iOS demos: rebuild scene content with contentID instead of re-creating the SceneView (#3020)

### DIFF
--- a/changelog.d/3020-ios-demos-content-id.md
+++ b/changelog.d/3020-ios-demos-content-id.md
@@ -1,0 +1,17 @@
+<!-- category: Fixed -->
+**iOS demo app**: 17 more `SceneView` call sites stop re-creating the
+`RealityView` with SwiftUI's `.id(_:)` — the pattern that intermittently
+leaves the viewport black on iOS 26 Simulator (#3008). Each scene now stays
+mounted for its whole lifetime and swaps or rebuilds its content in place via
+`SceneView.contentID(_:)`: the Explore viewer and gallery (4 sites), Materials,
+Environment, Lighting, Fog, Dynamic Sky, Movable Light, Gesture Editing, Video
+Texture, Collision, Shape Extrude, Physics, Double Pendulum, the AR Placement
+Reticle preview and the Depth Collider simulator fallback. Continuous
+parameters — fog density, time of day, light intensity, marker visibility,
+auto-rotation, the HDR environment — are applied to the live scene instead of
+rebuilding it per slider tick. Materials and Environment also keep the scene
+mounted while their model loads (spinner in an overlay). The Video Texture
+demo's Loop toggle now actually replaces the previous quad and pauses its
+player. The three `ARSceneView` re-keys (AR tab, AR Lighting, AR Instant
+Placement) are left as they are: `ARSceneView` has no `contentID`, and there
+the re-key means "restart the AR session". (#3020)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/CollisionHitTestDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/CollisionHitTestDemo.swift
@@ -66,7 +66,10 @@ struct CollisionHitTestDemo: View {
             }
             .cameraControls(.orbit)
             .environment(.studio)
-            .id(sceneKey)
+            // Reset rebuilds the shapes under the same `RealityView`; a
+            // `.id(_:)` re-key would discard the renderer and intermittently
+            // leave the viewport black on iOS 26 Simulator (#3008).
+            .contentID(sceneKey)
             .ignoresSafeArea()
             .background(Color.black)
 
@@ -82,7 +85,7 @@ struct CollisionHitTestDemo: View {
                     Spacer()
                     Button {
                         highlightedIndices.removeAll()
-                        sceneKey = UUID()  // force scene rebuild to reset materials
+                        sceneKey = UUID()  // rebuild the content to reset materials
                         #if os(iOS)
                         SceneViewHaptic.shared.medium()
                         #endif

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/DoublePendulumDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/DoublePendulumDemo.swift
@@ -174,7 +174,10 @@ struct DoublePendulumDemo: View {
             }
             .environment(.studio)
             .cameraControls(.orbit)
-            .id(generation)
+            // Reset rebuilds the links in place and restarts the tick on the
+            // new entities; the `RealityView` itself is never re-created
+            // (a `.id(_:)` re-key intermittently left it black, #3008).
+            .contentID(generation)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/DynamicSkyDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/DynamicSkyDemo.swift
@@ -7,6 +7,10 @@ struct DynamicSkyDemo: View {
     @State private var timeOfDay: Float = 12
     @State private var heroNode: ModelNode?
     @State private var heroLoadFailed = false
+    /// The sun currently in the scene. The time-of-day slider re-aims it in
+    /// place (`DynamicSkyNode.time(_:)` writes the new sun state onto the
+    /// same entity) instead of rebuilding the scene per slider tick.
+    @State private var skyNode: DynamicSkyNode?
     @AppStorage(DeepLinkRouter.qaModeDefaultsKey) private var qaMode: Bool = false
 
     /// Framing margin, mirroring `ModelViewerDemo`'s split for the same reason:
@@ -102,6 +106,7 @@ struct DynamicSkyDemo: View {
                 // Dynamic sky light
                 let sky = DynamicSkyNode(timeOfDay: timeOfDay, turbidity: 3, sunIntensity: 1500)
                 root.addChild(sky.entity)
+                DispatchQueue.main.async { skyNode = sky }
             }
             .environment(skyEnvironment)
             .cameraControls(.orbit)
@@ -111,14 +116,21 @@ struct DynamicSkyDemo: View {
             // where the sky fills most of the frame (#2896).
             .cameraOrbit(elevation: .pi / 15)
             .framingMargin(qaMode ? Self.captureFramingMargin : 0.95)
-            // `heroNode != nil` is part of the key so a scene built before the
-            // async load lands picks the model up on the next rebuild — same
-            // idiom as `PlacementReticlePreviewScene` / `GestureEditingDemo`.
-            // Without it the first build wins and the helmet never appears.
-            .id("sky-\(Int(timeOfDay * 10))-\(skyEnvironment.name)-\(heroNode != nil)")
+            // The content is rebuilt exactly once, when the helmet lands: the
+            // key goes `nil` -> "hero" so a scene built before the async load
+            // picks the model up (same idiom as `GestureEditingDemo`). The
+            // time of day and the matching HDR are continuous parameters and
+            // are applied reactively — the sun below, the environment by
+            // `SceneView` itself. Keying the whole view on them with `.id(_:)`
+            // re-created the `RealityView` per slider tick and intermittently
+            // left it black on iOS 26 Simulator (#3008).
+            .contentID(heroNode == nil ? nil : "hero")
             .ignoresSafeArea()
         }
         .background(Color.black)
+        .onChange(of: timeOfDay) { _, newValue in
+            skyNode = skyNode?.time(newValue)
+        }
         // On the ZStack, not inside the SceneView modifier chain: `.task`
         // erases to `some View`, and `.environment` / `.cameraControls` /
         // `.cameraOrbit` are SceneView-specific, so inserting it mid-chain

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/EnvironmentDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/EnvironmentDemo.swift
@@ -33,21 +33,24 @@ struct EnvironmentDemo: View {
     @ViewBuilder
     private var content: some View {
         ZStack {
-            if let loadedNode {
-                SceneView { root in
-                    loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
-                    root.addChild(loadedNode.entity)
-                }
-                .environment(selectedEnvironment)
-                .cameraControls(.orbit)
-                .autoRotate(speed: 0.15)
-                .ignoresSafeArea()
-                // Re-mount the RealityView when the environment changes so the new
-                // EnvironmentResource is applied cleanly. A `.id` keyed on the
-                // environment name is simpler than patching ImageBasedLightComponent
-                // in place and avoids any cached-resource aliasing edge cases.
-                .id("environment-\(selectedEnvironment.name)")
-            } else {
+            // One `RealityView` for the whole demo. The environment switch is
+            // applied reactively by `SceneView` (it diffs the HDR resource
+            // against the one on screen), so the content only has to be built
+            // once the model lands — `.contentID(_:)` goes `nil` -> "loaded"
+            // then. Re-mounting the view with `.id(_:)` on every environment
+            // change intermittently left it black on iOS 26 Simulator (#3008).
+            SceneView { root in
+                guard let loadedNode else { return }
+                loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
+                root.addChild(loadedNode.entity)
+            }
+            .environment(selectedEnvironment)
+            .cameraControls(.orbit)
+            .autoRotate(speed: 0.15)
+            .contentID(loadedNode == nil ? nil : "loaded")
+            .ignoresSafeArea()
+
+            if loadedNode == nil {
                 VStack(spacing: 12) {
                     ProgressView()
                         .tint(.white)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/FogDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/FogDemo.swift
@@ -10,6 +10,10 @@ import SceneViewSwift
 struct FogDemo: View {
     @State private var fogMode: Int = 0
     @State private var density: Float = 0.3
+    /// The fog volume currently in the scene. The density slider writes to it
+    /// directly (`FogNode.density` rebuilds the material in place) instead of
+    /// rebuilding the forest on every slider tick.
+    @State private var fogNode: FogNode?
 
     private let modeNames = ["Linear", "Exponential"]
     private let modeIcons = ["line.diagonal", "waveform"]
@@ -58,12 +62,22 @@ struct FogDemo: View {
                 }
                 fog.entity.position = .init(x: 0, y: 0, z: -2)
                 root.addChild(fog.entity)
+                DispatchQueue.main.async { fogNode = fog }
             }
             .cameraControls(.orbit)
-            .id("fog-\(fogMode)-\(Int(density * 100))")
+            // Only the mode rebuilds the content (a linear and an exponential
+            // fog are different nodes), under the same `RealityView`. Density
+            // is a continuous parameter and is applied reactively below — it
+            // used to be part of a `.id(_:)` key, which re-created the whole
+            // view per slider tick and intermittently left it black on iOS 26
+            // Simulator (#3008).
+            .contentID(fogMode)
             .ignoresSafeArea()
         }
         .background(Color.black)
+        .onChange(of: density) { _, newValue in
+            fogNode?.density = newValue
+        }
     }
 
     @ViewBuilder

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/GestureEditingDemo.swift
@@ -84,15 +84,18 @@ struct GestureEditingDemo: View {
             floor.entity.position = SIMD3(0, -0.45, -2)
             root.addChild(floor.entity)
         }
-        // .cameraControls must precede .id — .id wraps to some View which loses the modifier.
         .cameraControls(isEditable ? .none : .orbit)
         // The loaded subject is the bundled Ferrari F40 — a PBR USDZ with
         // metallic paint — and with no IBL it has nothing to reflect while
         // the user drags/pinches/rotates it. Same `.studio` preset as
-        // ModelViewerDemo (#2114); must also precede .id (see above).
+        // ModelViewerDemo (#2114).
         .environment(.studio)
-        // Don't include isEditable in the id — camera mode changes without scene rebuild.
-        .id("gesture-\(loadedModel != nil)")
+        // The scene stays mounted while the model loads and the content is
+        // rebuilt in place once it lands — never re-keyed with `.id(_:)`,
+        // which discards the `RealityView` and intermittently leaves it black
+        // on iOS 26 Simulator (#3008). `isEditable` is deliberately not part
+        // of the key: the camera mode changes without a content rebuild.
+        .contentID(loadedModel == nil ? nil : "loaded")
         .ignoresSafeArea()
     }
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/LightTypesDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/LightTypesDemo.swift
@@ -56,7 +56,10 @@ struct LightingDemo: View {
                 }
             }
             .cameraControls(.orbit)
-            .id("light-\(selectedLight)")
+            // Swap the light inside the scene that is already rendering. A
+            // SceneView re-created with `.id(_:)` intermittently comes back
+            // rendering nothing on iOS 26 Simulator, permanently (#3008).
+            .contentID(selectedLight)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
@@ -63,8 +63,16 @@ struct MaterialsDemo: View {
 
     @ViewBuilder
     private var sceneView: some View {
-        if let loadedNode {
+        ZStack {
+            // The scene stays mounted for the whole demo — never wrapped in
+            // `if let loadedNode` and never re-keyed with `.id(_:)`. Both
+            // discard the `RealityView`, and a re-created one intermittently
+            // renders nothing at all on iOS 26 Simulator (#3008).
+            // `.contentID(_:)` swaps the model inside the scene that is
+            // already rendering; the key is `nil` while loading so it also
+            // changes when the load lands (same shape as AnimationDemo).
             SceneView { root in
+                guard let loadedNode else { return }
                 loadedNode.entity.position = .init(x: 0, y: 0, z: -1.5)
                 root.addChild(loadedNode.entity)
             }
@@ -78,25 +86,34 @@ struct MaterialsDemo: View {
             // curated models render as flat silhouettes — the demo hides its own
             // subject. Same `.studio` preset ModelViewerDemo uses (#2114).
             .environment(.studio)
+            .contentID(loadedContentKey)
             .ignoresSafeArea()
-            .id("materials-\(selectedSlug?.uid ?? "none")")
-        } else {
-            VStack(spacing: 12) {
-                ProgressView()
-                    .tint(.white)
-                if let loadError {
-                    Text(loadError)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 24)
-                } else {
-                    Text("Streaming material…")
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.7))
+
+            if loadedNode == nil {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .tint(.white)
+                    if let loadError {
+                        Text(loadError)
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 24)
+                    } else {
+                        Text("Streaming material…")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
                 }
             }
         }
+    }
+
+    /// What the content closure currently builds: `nil` while the selected
+    /// material is streaming, its slug once the model is in hand.
+    private var loadedContentKey: String? {
+        guard loadedNode != nil else { return nil }
+        return selectedSlug?.uid ?? "none"
     }
 
     private var controls: some View {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MovableLightDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MovableLightDemo.swift
@@ -27,9 +27,10 @@ struct MovableLightDemo: View {
     @State private var loadedModel: ModelNode?
     @State private var isLoading: Bool = true
     @State private var loadError: String?
-    // Hold references to the live entities so drag gestures can mutate their
-    // position directly (avoids `.id()`-based scene rebuild at every pixel of
-    // drag, which froze the rendering 200-400 ms per frame).
+    // Hold references to the live entities so drag gestures and the controls
+    // sheet can mutate them directly. The scene content is built once the
+    // model lands and never rebuilt afterwards: position, intensity and
+    // marker visibility are all in-place writes.
     @State private var lightEntityRef: Entity?
     @State private var markerEntityRef: Entity?
 
@@ -109,24 +110,24 @@ struct MovableLightDemo: View {
                 DispatchQueue.main.async { lightEntityRef = userLight.entity }
 
                 // Yellow unlit marker sphere — unlit so it always reads as
-                // self-emissive regardless of where *the* light is.
-                if showLightSource {
-                    let marker = GeometryNode.sphere(
-                        radius: 0.05,
-                        material: .unlit(color: .yellow)
-                    )
-                    marker.entity.position = lightPosition
-                    root.addChild(marker.entity)
-                    DispatchQueue.main.async { markerEntityRef = marker.entity }
-                } else {
-                    DispatchQueue.main.async { markerEntityRef = nil }
-                }
+                // self-emissive regardless of where *the* light is. Always in
+                // the scene; the toggle flips `isEnabled` in place.
+                let marker = GeometryNode.sphere(
+                    radius: 0.05,
+                    material: .unlit(color: .yellow)
+                )
+                marker.entity.position = lightPosition
+                marker.entity.isEnabled = showLightSource
+                root.addChild(marker.entity)
+                DispatchQueue.main.async { markerEntityRef = marker.entity }
             }
-            // Identity only depends on inputs that need a real rebuild (model
-            // load, intensity, marker visibility). Azimuth/elevation drive a
-            // direct entity mutation below, so they MUST stay out of `.id`
-            // — including them caused a full SceneView teardown per drag pixel.
-            .id("movable-\(intensity)-\(showLightSource)-\(loadedModel != nil)")
+            // The only content change is the model landing: the key goes
+            // `nil` -> "loaded" and the closure re-runs under the same
+            // `RealityView`. Intensity and marker visibility are applied to
+            // the live entities below; they used to re-key the whole view
+            // with `.id(_:)`, which re-created the renderer per slider tick
+            // and intermittently left it black on iOS 26 Simulator (#3008).
+            .contentID(loadedModel == nil ? nil : "loaded")
             .ignoresSafeArea()
 
             // Transparent overlay that captures drag gestures *before* SceneView
@@ -194,6 +195,12 @@ struct MovableLightDemo: View {
         .background(Color.black)
         .task {
             await loadFerrari()
+        }
+        .onChange(of: intensity) { _, newValue in
+            lightEntityRef?.components[PointLightComponent.self]?.intensity = newValue
+        }
+        .onChange(of: showLightSource) { _, newValue in
+            markerEntityRef?.isEnabled = newValue
         }
     }
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
@@ -72,7 +72,12 @@ struct PhysicsDemo: View {
             }
             .cameraControls(.orbit)
             .environment(.studio) // parity with android-demo IBL fix (#2114)
-            .id(sceneKey)
+            // Reset / Drop rebuild the floor and bodies under the same
+            // `RealityView` — removing the content root restarts the physics
+            // simulation without discarding the renderer, which a `.id(_:)`
+            // re-key did and which intermittently left the viewport black on
+            // iOS 26 Simulator (#3008).
+            .contentID(sceneKey)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthColliderScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/ArDepthColliderScene.swift
@@ -298,7 +298,9 @@ struct ARDepthColliderDemo: View {
         }
         .cameraControls(.orbit)
         .environment(.studio) // parity with android-demo IBL fix (#2114), mirrors PhysicsDemo
-        .id(simSceneKey)
+        // Drop / Reset rebuild the balls under the same `RealityView` instead
+        // of re-keying the view with `.id(_:)` (#3008, mirrors PhysicsDemo).
+        .contentID(simSceneKey)
         .background(Color.black)
     }
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementReticlePreviewScene.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/Scenes/PlacementReticlePreviewScene.swift
@@ -71,8 +71,13 @@ struct PlacementReticlePreviewDemo: View {
 
     var body: some View {
         ZStack {
+            // `.contentID(_:)` rebuilds the reticle / placed diorama under the
+            // same `RealityView`; a `.id(_:)` re-key discarded the renderer and
+            // intermittently left it black on iOS 26 Simulator (#3008). The
+            // `.environment` / `.renderQuality` changes that ride on `placed`
+            // are applied reactively by `SceneView` itself.
             configuredSceneView
-                .id(sceneKey)
+                .contentID(sceneKey)
                 .background(placed ? Color.black : Self.reticleBackdrop)
                 .ignoresSafeArea()
 
@@ -212,8 +217,8 @@ struct PlacementReticlePreviewDemo: View {
     /// `placed` toggle only needs to reference it afterwards, no reload per
     /// toggle. Bumps `sceneKey` on completion so a scene built before the
     /// load finished (user flips to "placed" before the async load lands)
-    /// picks the model up on the next rebuild — same idiom as
-    /// `GestureEditingDemo`'s `.id("gesture-\(loadedModel != nil)")`.
+    /// picks the model up on the next content rebuild — same idiom as
+    /// `GestureEditingDemo`'s `.contentID(loadedModel == nil ? nil : "loaded")`.
     @MainActor
     private func loadHelmetIfNeeded() async {
         guard helmetNode == nil, !helmetLoadFailed else { return }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ShapeExtrudeDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ShapeExtrudeDemo.swift
@@ -37,7 +37,10 @@ struct ShapeExtrudeDemo: View {
             }
             .cameraControls(.orbit)
             .environment(.studio)
-            .id(sceneKey)
+            // Every control rebuilds the shape in place under the same
+            // `RealityView` — never re-key the view with `.id(_:)`, which
+            // intermittently leaves the scene black on iOS 26 Simulator (#3008).
+            .contentID(sceneKey)
             .ignoresSafeArea()
 
             VStack {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/VideoTextureDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/VideoTextureDemo.swift
@@ -48,7 +48,12 @@ struct VideoTextureDemo: View {
             }
         }
         .cameraControls(.orbit)
-        .id("video-\(videoNode != nil)")
+        // Keyed on the node instance, not on `videoNode != nil`: the Loop
+        // toggle builds a fresh `VideoNode`, and the content has to be rebuilt
+        // around the new one so the previous quad is removed. Rebuilt in place
+        // under the same `RealityView` — a `.id(_:)` re-key intermittently
+        // left the viewport black on iOS 26 Simulator (#3008).
+        .contentID(videoNode.map { ObjectIdentifier($0.entity) })
         .ignoresSafeArea()
     }
 
@@ -114,6 +119,9 @@ struct VideoTextureDemo: View {
     // MARK: - Helpers
 
     private func buildVideoNode() {
+        // The previous node is about to leave the scene — stop its player so
+        // it does not keep playing audio from a detached entity.
+        videoNode?.pause()
         let node = VideoNode.load("sample", width: 2.4, height: 1.35, loop: isLooping)
         node.entity.position = SIMD3(0, 0.3, -3)
         node.muted(isMuted)

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
@@ -1350,31 +1350,24 @@ struct ModelViewerScreen: View {
 
     // MARK: - Scene
 
-    @ViewBuilder
     private var sceneView: some View {
-        // qa_mode freezes auto-rotation for deterministic QA screenshots.
-        if autoRotate && !qaMode {
-            SceneView { root in
-                if let loadedModel {
-                    loadedModel.entity.position = .zero
-                    root.addChild(loadedModel.entity)
-                }
-            }
-            .environment(selectedEnvironment)
-            .cameraControls(.orbit)
-            .autoRotate(speed: 0.4)
-            .id("viewer-auto-\(loadedModel != nil)-\(selectedEnvironment.name)")
-        } else {
-            SceneView { root in
-                if let loadedModel {
-                    loadedModel.entity.position = .zero
-                    root.addChild(loadedModel.entity)
-                }
-            }
-            .environment(selectedEnvironment)
-            .cameraControls(.orbit)
-            .id("viewer-manual-\(loadedModel != nil)-\(selectedEnvironment.name)")
+        // One `SceneView` for the viewer's lifetime. The model is swapped in
+        // with `.contentID(_:)` once it lands, the environment and the
+        // auto-rotation are reactive modifiers — `SceneView` diffs them in
+        // place. The previous `if autoRotate { ... } else { ... }` plus
+        // `.id(_:)` keys re-created the `RealityView` on every change, which
+        // intermittently leaves it black on iOS 26 Simulator (#3008).
+        // qa_mode freezes auto-rotation for deterministic QA screenshots
+        // (speed 0 starts no rotation loop at all).
+        SceneView { root in
+            guard let loadedModel else { return }
+            loadedModel.entity.position = .zero
+            root.addChild(loadedModel.entity)
         }
+        .environment(selectedEnvironment)
+        .cameraControls(.orbit)
+        .autoRotate(speed: autoRotate && !qaMode ? 0.4 : 0)
+        .contentID(loadedModel == nil ? nil : "loaded")
     }
 
     // MARK: - Controls
@@ -1778,30 +1771,19 @@ struct GalleryModelViewerScreen: View {
         isLoading = false
     }
 
-    @ViewBuilder
     private var sceneView: some View {
-        if autoRotate && !qaMode {
-            SceneView { root in
-                if let loadedNode {
-                    loadedNode.entity.position = .zero
-                    root.addChild(loadedNode.entity)
-                }
-            }
-            .environment(selectedEnvironment)
-            .cameraControls(.orbit)
-            .autoRotate(speed: 0.4)
-            .id("gallery-auto-\(loadedNode != nil)-\(selectedEnvironment.name)")
-        } else {
-            SceneView { root in
-                if let loadedNode {
-                    loadedNode.entity.position = .zero
-                    root.addChild(loadedNode.entity)
-                }
-            }
-            .environment(selectedEnvironment)
-            .cameraControls(.orbit)
-            .id("gallery-manual-\(loadedNode != nil)-\(selectedEnvironment.name)")
+        // Same shape as the bundled viewer above: one `SceneView`, the model
+        // swapped in via `.contentID(_:)`, environment and auto-rotation
+        // applied reactively instead of re-keying the view (#3008).
+        SceneView { root in
+            guard let loadedNode else { return }
+            loadedNode.entity.position = .zero
+            root.addChild(loadedNode.entity)
         }
+        .environment(selectedEnvironment)
+        .cameraControls(.orbit)
+        .autoRotate(speed: autoRotate && !qaMode ? 0.4 : 0)
+        .contentID(loadedNode == nil ? nil : "loaded")
     }
 
     /// Cinematic vignette — costs ~0 GPU and lifts the model in the centre.


### PR DESCRIPTION
Closes #3020

A `SceneView` re-created by SwiftUI's `.id(_:)` intermittently renders nothing at all on iOS 26 Simulator and never recovers (#3008). #3019 shipped `SceneView.contentID(_:)` and moved three pilot demos onto it. This PR moves every remaining non-AR `SceneView` re-key in the iOS demo app onto the same pattern: one `RealityView` for the scene's lifetime, content swapped or rebuilt in place, on the same triggers as before.

## Migrated (17 call sites, 16 files)

**Model swaps** — scene stays mounted while loading, key goes `nil` → value when the load lands (the #3019 shape):
- `ExploreTab` ×4 (bundled viewer + gallery, auto/manual branches) — the two `if autoRotate { … } else { … }` branches per scene were themselves a re-mount; merged into one `SceneView` driven by the reactive `.autoRotate(speed:)` (0 under `qa_mode`)
- `MaterialsDemo`, `EnvironmentDemo` — also stop unmounting the scene while loading (spinner in an overlay)
- `GestureEditingDemo`, `VideoTextureDemo` — Video now keys on the node instance so the Loop toggle actually replaces the previous quad and pauses its player (before, the old key `videoNode != nil` never changed, so the old quad stayed)

**Whole-scene resets** — the existing `sceneKey` / `generation` state now feeds `contentID`; removing the content root restarts the simulation without discarding the renderer:
- `CollisionHitTestDemo`, `ShapeExtrudeDemo`, `PhysicsDemo`, `DoublePendulumDemo`, `LightTypesDemo`, `PlacementReticlePreviewScene`, `ArDepthColliderScene` (simulator fallback scene)

**Continuous parameters** — applied to the live scene instead of rebuilding per slider tick (the issue's category b):
- `FogDemo`: density → `FogNode.density` (material rebuilt in place); only the mode rebuilds content
- `DynamicSkyDemo`: time of day → `DynamicSkyNode.time(_:)` on the live sun; the matching HDR is diffed by `SceneView`'s own environment task; content rebuilds once, when the helmet lands
- `MovableLightDemo`: intensity → `PointLightComponent.intensity`, marker visibility → `isEnabled` (marker always in the scene); content rebuilds once, when the model lands
- `EnvironmentDemo` / `ExploreTab`: the HDR switch is no longer part of any key — `SceneView` already diffs `sceneEnvironment` reactively (its task clears the skybox before the await precisely for the studio → night switch)

## Left alone (4 sites)
- `ARTab` (`.id(arViewID)`), `ARLightingDemo` (`.id(mode)`), `ARInstantPlacementDemo` (`.id("instant-placement-…")`): all `ARSceneView`, which has no `contentID`, and there the re-key means "restart the AR session" — device-only code paths (`#if !targetEnvironment(simulator)`). Needs the API shape the issue's category c asks for; not faked here.
- `ReflectionProbesDemo`: in flight in #3257, which extends its `.id()` key — left untouched to avoid a conflict. It stays on the list for a follow-up after #3257 merges.

## Verification
- Built `SceneViewDemo` for a dedicated simulator clone (`sv-agent-3020`, iPhone 17 Pro, iOS 26.3), then smoke-ran 7 migrated demos via `-demo <id>` and screenshotted each: Materials (iridescent beetle + studio skybox), Dynamic Sky (helmet against outdoor HDR), Movable Light (F40 on the floor, marker visible), Physics (cubes resting on the floor, studio HDR), Environment (hovercar in the studio HDR), Fog (forest disc with fog), Double Pendulum (links + brass pivot). None black or empty.
- `SceneViewDemoTests` run on the same simulator (result in the checks / final comment).
- Not exercised by hand: slider / toggle interactions on the simulator (no UI automation available in this session). The reactive paths rely on existing public setters (`FogNode.density`, `DynamicSkyNode.time`, `PointLightComponent.intensity`, `Entity.isEnabled`) and on `SceneView`'s existing environment / auto-rotate diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
