### PR TITLE
Declare the MCP gateway widget on tools/list, not only on tool results

### DIFF
--- a/changelog.d/3192-widget-tools-list.md
+++ b/changelog.d/3192-widget-tools-list.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+
+- **The hosted MCP gateway now declares its 3D-viewer widget in `tools/list`, not only on tool results ([#3192](https://github.com/sceneview/sceneview/issues/3192)).** `_meta.ui.resourceUri` rode on the result of `view_3d_model` alone, so a host deciding from the tool list whether a tool has a UI — the MCP Apps convention — never learned the widget existed. The declaration now carries the same `ui://widget/3d-viewer.html` pointer; non-widget tools gain no `_meta`.

--- a/mcp-gateway/src/mcp/transport.ts
+++ b/mcp-gateway/src/mcp/transport.ts
@@ -352,9 +352,20 @@ function handleResourcesRead(req: JsonRpcRequest): unknown {
   return { contents: [resource] };
 }
 
-/** Returns the full list of multiplexed tool definitions. */
+/**
+ * Returns the full list of multiplexed tool definitions.
+ *
+ * Widget-bearing tools carry `_meta.ui.resourceUri` on the DECLARATION as
+ * well as on the result (see `handleToolsCall`): a host that decides from
+ * `tools/list` whether a tool has a UI never sees a result first, so a
+ * pointer that only rides on results is invisible to it (#3192).
+ */
 function handleToolsList(): unknown {
-  return { tools: getAllTools() };
+  const tools = getAllTools().map((def) => {
+    const widgetUri = widgetResourceFor(def.name);
+    return widgetUri ? { ...def, _meta: { ui: { resourceUri: widgetUri } } } : def;
+  });
+  return { tools };
 }
 
 /** Validates params and dispatches a `tools/call` to the registry. */
@@ -390,9 +401,10 @@ async function handleToolsCall(
 
   const result = await registryDispatch(toolName, args, ctx.dispatchContext);
 
-  // Widget tools attach `_meta.ui.resourceUri` so OpenAI-Apps-aware clients
-  // know to fetch the bundled HTML widget and render it inline. Other
-  // clients ignore the unknown `_meta` keys and just see the text content.
+  // Widget tools attach `_meta.ui.resourceUri` so MCP-Apps-aware clients
+  // know to fetch the bundled HTML widget and render it inline. The same
+  // pointer is on the tool declaration (`handleToolsList`). Other clients
+  // ignore the unknown `_meta` keys and just see the text content.
   const widgetUri = widgetResourceFor(toolName);
   if (widgetUri) {
     // Narrow through `unknown` to avoid the strict-overlap check on

--- a/mcp-gateway/src/mcp/widget-tools.ts
+++ b/mcp-gateway/src/mcp/widget-tools.ts
@@ -82,8 +82,9 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
 
 /**
  * Marker the gateway transport looks for to attach the widget pointer
- * (`_meta.ui.resourceUri`) on the JSON-RPC tool result. Kept here so the
- * tool definition and the marker live next to each other.
+ * (`_meta.ui.resourceUri`) on both the `tools/list` declaration and the
+ * JSON-RPC tool result. Kept here so the tool definition and the marker
+ * live next to each other.
  */
 export const WIDGET_TOOL_RESOURCE: Record<string, string> = {
   view_3d_model: "ui://widget/3d-viewer.html",

--- a/mcp-gateway/src/mcp/widgets.ts
+++ b/mcp-gateway/src/mcp/widgets.ts
@@ -8,9 +8,10 @@
  *    (e.g. `ui://widget/3d-viewer.html`) and the canonical mime type
  *    `text/html;profile=mcp-app`. ChatGPT fetches it via `resources/read`
  *    when a tool result references the URI.
- * 2. A tool result attaches `_meta.ui.resourceUri` pointing at the widget
- *    URI plus a `structuredContent` JSON payload that the widget reads
- *    from the MCP Apps bridge (postMessage).
+ * 2. The tool declaration in `tools/list` AND each tool result attach
+ *    `_meta.ui.resourceUri` pointing at the widget URI; the result adds a
+ *    `structuredContent` JSON payload that the widget reads from the MCP
+ *    Apps bridge (postMessage).
  * 3. The widget runs inside the iframe, reads `window.openai?.structuredContent`
  *    (set by the host), and renders accordingly.
  *

--- a/mcp-gateway/test/transport.test.ts
+++ b/mcp-gateway/test/transport.test.ts
@@ -87,6 +87,23 @@ describe("transport: tools/list", () => {
     expect(names.has("list_samples")).toBe(true);
     expect(names.has("get_sample")).toBe(true);
   });
+
+  it("declares the widget pointer on the tool itself, not only on results", async () => {
+    const kv = new MockKv();
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+      { kv: kv.asKv() },
+    );
+    const body = await asJsonRpc(res);
+    const result = body.result as {
+      tools: { name: string; _meta?: { ui?: { resourceUri?: string } } }[];
+    };
+    const widget = result.tools.find((t) => t.name === "view_3d_model");
+    expect(widget?._meta?.ui?.resourceUri).toBe("ui://widget/3d-viewer.html");
+    // A host deciding from tools/list must not see phantom widgets either.
+    const plain = result.tools.find((t) => t.name === "list_samples");
+    expect(plain?._meta).toBeUndefined();
+  });
 });
 
 describe("transport: tools/call", () => {


### PR DESCRIPTION
## Summary

Part of #3192 (workstream 4a).

`_meta.ui.resourceUri` rode only on the **result** of `view_3d_model` (`transport.ts` `handleToolsCall`). A host that decides from `tools/list` whether a tool has a UI — the MCP Apps convention — never sees a result first, so the 67-tool list carried zero widget pointers and the 3D viewer was invisible to it.

- `handleToolsList` now attaches `_meta.ui.resourceUri` (`ui://widget/3d-viewer.html`) to the declaration of every widget-bearing tool, using the same `widgetResourceFor` marker the result path uses.
- Non-widget tools gain no `_meta` (asserted by the test).
- Comments in `widgets.ts` / `widget-tools.ts` updated to describe both carriers.

Deliberately **not** bundled, per the issue thread: the protocol-version bump (4b) and `outputSchema` on tool declarations. The mimeType stays `text/html;profile=mcp-app` (not a defect).

## Testing done

- `mcp-gateway`: `npx tsc --noEmit` clean; `npx vitest run` 17 files, **188 tests passed** (one new: the pointer is on `view_3d_model` and absent on `list_samples`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
