### PR TITLE
fix(ios-demo): honour scaleToUnits in AR placement and credit the model on screen (#2966)

### DIFF
--- a/changelog.d/2966-ios-ar-placement-scale-credit.md
+++ b/changelog.d/2966-ios-ar-placement-scale-credit.md
@@ -1,0 +1,6 @@
+<!-- category: Fixed -->
+iOS demo: the AR placement demos now place each streamed slug at its own `scaleToUnits`
+(a coffee mug at 0.10 m, a floor lamp at 1.55 m) instead of a hardcoded 0.3 m, and the
+attribution caption under every streamed-slug picker credits the model actually on screen —
+the bundled fallback's own name, author and licence on a keyless build (including CC-BY-NC
+fallbacks), the Sketchfab author only when the stream really loaded (#2966).

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		593E4FADBA93AF1190A3A67E /* SketchfabModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C214F8F9A1B35560E551895 /* SketchfabModels.swift */; };
 		95BE47B4B9B828745697FB4B /* SketchfabConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77142EC848C995EDE06546D /* SketchfabConfig.swift */; };
 		A10000000000000000002960 /* AssetSourceProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002960 /* AssetSourceProbe.swift */; };
+		A10000000000000000002966 /* BundledAssetCredits.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002966 /* BundledAssetCredits.swift */; };
 		A10000010000000000000001 /* SceneViewDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000001 /* SceneViewDemoApp.swift */; };
 		A10000010000000000000002 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000002 /* Assets.xcassets */; };
 		B4A94ABD8B5DA5F4E4CE4834 /* SketchfabService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFA4BE9A50A8347603AA10E /* SketchfabService.swift */; };
@@ -123,6 +124,7 @@
 		C10000000000000000000060 /* AppStoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000060 /* AppStoreUpdater.swift */; };
 		C10000000000000000000061 /* UpdateBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000061 /* UpdateBanner.swift */; };
 		A10000000000000000002961 /* AssetSourcePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002961 /* AssetSourcePill.swift */; };
+		A10000000000000000002967 /* AssetCreditLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002967 /* AssetCreditLine.swift */; };
 		A10000000000000000002963 /* LabeledSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002963 /* LabeledSlider.swift */; };
 		D10000000000000000000001 /* game_boy_classic.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D20000000000000000000001 /* game_boy_classic.usdz */; };
 		D10000000000000000000002 /* tree_scene.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D20000000000000000000002 /* tree_scene.usdz */; };
@@ -171,6 +173,7 @@
 		F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */; };
 		F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000072 /* DemoRegistryGuardTests.swift */; };
 		A10000000000000000002962 /* AssetSourceProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002962 /* AssetSourceProbeTests.swift */; };
+		A10000000000000000002968 /* BundledAssetCreditsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000002968 /* BundledAssetCreditsTests.swift */; };
 		F00000000000000000000075 /* BundledAssetPrimBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */; };
 		491E5281694990528BA8402A /* PlacementReticlePreviewScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082ADF6A2C2D1C4D7C316F93 /* PlacementReticlePreviewScene.swift */; };
 		FF2214F77B752E9AB93A66B1 /* WallPlacementScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1767394F8DE920AA4961C04 /* WallPlacementScene.swift */; };
@@ -222,6 +225,7 @@
 		F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SketchfabAssetResolver+Tests.swift"; path = "SceneViewDemo/Services/SketchfabAssetResolver+Tests.swift"; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000072 /* DemoRegistryGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoRegistryGuardTests.swift; path = SceneViewDemoTests/DemoRegistryGuardTests.swift; sourceTree = SOURCE_ROOT; };
 		A20000000000000000002962 /* AssetSourceProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourceProbeTests.swift; path = SceneViewDemoTests/AssetSourceProbeTests.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002968 /* BundledAssetCreditsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BundledAssetCreditsTests.swift; path = SceneViewDemoTests/BundledAssetCreditsTests.swift; sourceTree = SOURCE_ROOT; };
 		F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BundledAssetPrimBudgetTests.swift; path = SceneViewDemoTests/BundledAssetPrimBudgetTests.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000002 /* DemoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoItem.swift; sourceTree = "<group>"; };
 		C20000000000000000000003 /* ExploreTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreTab.swift; sourceTree = "<group>"; };
@@ -283,6 +287,7 @@
 		C20000000000000000000060 /* AppStoreUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreUpdater.swift; path = SceneViewDemo/Services/AppStoreUpdater.swift; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000061 /* UpdateBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UpdateBanner.swift; path = SceneViewDemo/Views/Components/UpdateBanner.swift; sourceTree = SOURCE_ROOT; };
 		A20000000000000000002961 /* AssetSourcePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourcePill.swift; path = SceneViewDemo/Views/Components/AssetSourcePill.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002967 /* AssetCreditLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetCreditLine.swift; path = SceneViewDemo/Views/Components/AssetCreditLine.swift; sourceTree = SOURCE_ROOT; };
 		A20000000000000000002963 /* LabeledSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LabeledSlider.swift; path = SceneViewDemo/Views/Components/LabeledSlider.swift; sourceTree = SOURCE_ROOT; };
 		D20000000000000000000001 /* game_boy_classic.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = game_boy_classic.usdz; sourceTree = "<group>"; };
 		D20000000000000000000002 /* tree_scene.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = tree_scene.usdz; sourceTree = "<group>"; };
@@ -317,6 +322,7 @@
 		2C26CC8CC5834E15CDD1F062 /* khronos_damaged_helmet.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = khronos_damaged_helmet.usdz; sourceTree = "<group>"; };
 		D77142EC848C995EDE06546D /* SketchfabConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SketchfabConfig.swift; path = SceneViewDemo/Services/SketchfabConfig.swift; sourceTree = SOURCE_ROOT; };
 		A20000000000000000002960 /* AssetSourceProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetSourceProbe.swift; path = SceneViewDemo/Services/AssetSourceProbe.swift; sourceTree = SOURCE_ROOT; };
+		A20000000000000000002966 /* BundledAssetCredits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BundledAssetCredits.swift; path = SceneViewDemo/Services/BundledAssetCredits.swift; sourceTree = SOURCE_ROOT; };
 		E20000000000000000000001 /* studio.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = studio.hdr; sourceTree = "<group>"; };
 		E20000000000000000000002 /* outdoor_cloudy.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = outdoor_cloudy.hdr; sourceTree = "<group>"; };
 		E20000000000000000000003 /* sunset.hdr */ = {isa = PBXFileReference; lastKnownFileType = file; path = sunset.hdr; sourceTree = "<group>"; };
@@ -411,6 +417,7 @@
 				5FA64989921B8BD7A9F30B31 /* ComingSoonScreen.swift */,
 				D77142EC848C995EDE06546D /* SketchfabConfig.swift */,
 				A20000000000000000002960 /* AssetSourceProbe.swift */,
+				A20000000000000000002966 /* BundledAssetCredits.swift */,
 				6C214F8F9A1B35560E551895 /* SketchfabModels.swift */,
 				8FFA4BE9A50A8347603AA10E /* SketchfabService.swift */,
 				E11525101A2B40A19EAECE6700000001 /* SketchfabSlug.swift */,
@@ -434,6 +441,7 @@
 				F00000000000000000000070 /* SketchfabAssetResolver+Tests.swift */,
 				F00000000000000000000072 /* DemoRegistryGuardTests.swift */,
 				A20000000000000000002962 /* AssetSourceProbeTests.swift */,
+				A20000000000000000002968 /* BundledAssetCreditsTests.swift */,
 				F00000000000000000000074 /* BundledAssetPrimBudgetTests.swift */,
 			);
 			path = SceneViewDemoTests;
@@ -496,6 +504,7 @@
 				C20000000000000000000050 /* DemoSheet.swift */,
 				C20000000000000000000061 /* UpdateBanner.swift */,
 				A20000000000000000002961 /* AssetSourcePill.swift */,
+				A20000000000000000002967 /* AssetCreditLine.swift */,
 				A20000000000000000002963 /* LabeledSlider.swift */,
 			);
 			path = Components;
@@ -890,6 +899,7 @@
 				0C0448E495F77BF795D1C647 /* ComingSoonScreen.swift in Sources */,
 				95BE47B4B9B828745697FB4B /* SketchfabConfig.swift in Sources */,
 				A10000000000000000002960 /* AssetSourceProbe.swift in Sources */,
+				A10000000000000000002966 /* BundledAssetCredits.swift in Sources */,
 				593E4FADBA93AF1190A3A67E /* SketchfabModels.swift in Sources */,
 				B4A94ABD8B5DA5F4E4CE4834 /* SketchfabService.swift in Sources */,
 				E11525001A2B40A19EAECE6700000001 /* SketchfabSlug.swift in Sources */,
@@ -930,6 +940,7 @@
 				C10000000000000000000060 /* AppStoreUpdater.swift in Sources */,
 				C10000000000000000000061 /* UpdateBanner.swift in Sources */,
 				A10000000000000000002961 /* AssetSourcePill.swift in Sources */,
+				A10000000000000000002967 /* AssetCreditLine.swift in Sources */,
 				A10000000000000000002963 /* LabeledSlider.swift in Sources */,
 				7E28E9DEA941B656301CDA67 /* DemoScene.swift in Sources */,
 				F962AD205078EAFC5201865B /* AnimationScene.swift in Sources */,
@@ -993,6 +1004,7 @@
 				F00000000000000000000071 /* SketchfabAssetResolver+Tests.swift in Sources */,
 				F00000000000000000000073 /* DemoRegistryGuardTests.swift in Sources */,
 				A10000000000000000002962 /* AssetSourceProbeTests.swift in Sources */,
+				A10000000000000000002968 /* BundledAssetCreditsTests.swift in Sources */,
 				F00000000000000000000075 /* BundledAssetPrimBudgetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/samples/ios-demo/SceneViewDemo/Services/BundledAssetCredits.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/BundledAssetCredits.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Attribution for one USDZ shipped inside the app bundle
+/// (`samples/ios-demo/SceneViewDemo/Models/`).
+///
+/// Mirrors the matching entry of `assets/catalog.json` — the single source the
+/// generated `assets/CREDITS.md` is built from. Keep the three fields verbatim
+/// with the catalog; the table below is the only place the running app can
+/// read them from, since the catalog itself is not bundled.
+struct BundledAssetCredit: Hashable, Sendable {
+    /// Human-readable asset name (`catalog.json` `name`).
+    let name: String
+    /// Original author, exactly as the catalog credits them.
+    let author: String
+    /// Short licence label shown on screen — `"CC-BY 4.0"`, `"CC-BY-NC 4.0"`,
+    /// `"CC-BY-NC-SA 4.0"`. Not every bundled model is CC-BY, so the caption
+    /// must print this rather than assume the registry's streamed licence.
+    let license: String
+}
+
+/// Per-file attribution for the bundled USDZ set, keyed on the same
+/// bundle-relative path `SketchfabSlug.fallbackBundledPath` declares.
+///
+/// **Why this exists (#2966).** Every demo that streams a `SketchfabSlug`
+/// captions the model `by <slug.author> · CC-BY 4.0`. On a keyless build — the
+/// default local build *and* the App Store build — the resolver hands back the
+/// bundled fallback instead, which is a different model by a different author,
+/// sometimes under a different licence. The caption is an attribution surface,
+/// so it has to credit whatever is actually on screen. `AssetCreditLine` reads
+/// this table whenever `AssetSourceProbe` measured a fallback.
+///
+/// `BundledAssetCreditsTests` pins that every fallback the registry can hand
+/// out has a row here, so a new `fallbackBundledPath` cannot ship uncredited.
+enum BundledAssetCredits {
+
+    /// Attribution for a bundle-relative path such as `Models/khronos_fox.usdz`,
+    /// or `nil` when the file is not a known bundled asset.
+    static func credit(forBundledPath path: String) -> BundledAssetCredit? {
+        byPath[path]
+    }
+
+    /// Attribution for the bundled asset a slug falls back to.
+    static func fallbackCredit(for slug: SketchfabSlug) -> BundledAssetCredit? {
+        credit(forBundledPath: slug.fallbackBundledPath)
+    }
+
+    /// One row per file under `Models/`, in `catalog.json` order.
+    static let byPath: [String: BundledAssetCredit] = [
+        "Models/game_boy_classic.usdz": .init(name: "Game Boy Classic", author: "JonhyOliver", license: "CC-BY 4.0"),
+        "Models/tree_scene.usdz": .init(name: "Low Poly Tree Scene", author: "mateustorresg", license: "CC-BY 4.0"),
+        "Models/khronos_toy_car.usdz": .init(name: "Toy Car", author: "KhronosGroup", license: "CC-BY 4.0"),
+        "Models/red_car.usdz": .init(name: "A Red Car", author: "SerjogaSan", license: "CC-BY 4.0"),
+        "Models/animated_butterfly.usdz": .init(name: "Animated Flying Fluttering Butterfly Loop", author: "LasquetiSpice", license: "CC-BY 4.0"),
+        "Models/retro_piano.usdz": .init(name: "Retro Piano", author: "DailyArt", license: "CC-BY-NC 4.0"),
+        "Models/phoenix_bird.usdz": .init(name: "Phoenix Bird", author: "NORBERTO-3D", license: "CC-BY 4.0"),
+        "Models/cyberpunk_car.usdz": .init(name: "Cyberpunk Car", author: "4d_Bob", license: "CC-BY 4.0"),
+        "Models/fantasy_book.usdz": .init(name: "Medieval Fantasy Book", author: "Pixel", license: "CC-BY 4.0"),
+        "Models/mosquito_amber.usdz": .init(name: "Mosquito in Amber", author: "Loïc Norgeot", license: "CC-BY 4.0"),
+        "Models/ship_in_clouds.usdz": .init(name: "Ship in Clouds", author: "Bastien Genbrugge", license: "CC-BY 4.0"),
+        "Models/cyberpunk_hovercar.usdz": .init(name: "Cyberpunk Hovercar", author: "Karol Miklas", license: "CC-BY 4.0"),
+        "Models/cyberpunk_character.usdz": .init(name: "Cyberpunk Character", author: "Esk", license: "CC-BY 4.0"),
+        "Models/porsche_911.usdz": .init(name: "FREE 1975 Porsche 911 (930) Turbo", author: "Karol Miklas", license: "CC-BY 4.0"),
+        "Models/black_dragon.usdz": .init(name: "Black Dragon with Idle Animation", author: "Arturs J", license: "CC-BY 4.0"),
+        "Models/fiat_punto.usdz": .init(name: "1995 Fiat Punto GT", author: "Karol Miklas", license: "CC-BY 4.0"),
+        "Models/shelby_cobra.usdz": .init(name: "1965 AC Shelby Cobra 427", author: "vecarz", license: "CC-BY-NC-SA 4.0"),
+        "Models/audi_tt.usdz": .init(name: "2007 Audi TT Coupe", author: "Ddiaz Design", license: "CC-BY-NC-SA 4.0"),
+        "Models/earthquake_california.usdz": .init(name: "August 7, 2024 M5.2 Earthquake in California", author: "Kyle", license: "CC-BY 4.0"),
+        "Models/lamborghini_countach.usdz": .init(name: "2021 Lamborghini Countach LPI 800-4", author: "Lexyc16", license: "CC-BY-NC 4.0"),
+        "Models/nike_air_jordan.usdz": .init(name: "Nike Air Jordan", author: "Ar41k", license: "CC-BY 4.0"),
+        "Models/ferrari_f40.usdz": .init(name: "Ferrari F40", author: "Black Snow", license: "CC-BY 4.0"),
+        "Models/porsche_911_turbo.usdz": .init(name: "1975 Porsche 911 (930) Turbo", author: "Lionsharp Studios", license: "CC-BY 4.0"),
+        "Models/ps5_dualsense.usdz": .init(name: "PlayStation 5 DualSense", author: "AHarmlessPotato", license: "CC-BY 4.0"),
+        "Models/tesla_cybertruck.usdz": .init(name: "Tesla Cybertruck", author: "hashikemu", license: "CC-BY 4.0"),
+        "Models/mercedes_a45_amg.usdz": .init(name: "Mercedes-Benz A45 AMG 2018", author: "Lexyc16", license: "CC-BY-NC 4.0"),
+        "Models/nintendo_switch.usdz": .init(name: "Nintendo Switch Diorama", author: "Mikkel Garde Blaase", license: "CC-BY-NC 4.0"),
+        "Models/bmw_m3_e30.usdz": .init(name: "BMW M3 Coupe (E30) 1986", author: "Lexyc16", license: "CC-BY-NC 4.0"),
+        "Models/khronos_damaged_helmet.usdz": .init(name: "Damaged Helmet", author: "KhronosGroup (theblueturtle_)", license: "CC-BY 4.0"),
+        "Models/khronos_fox.usdz": .init(name: "Fox", author: "PixelMannen, tomkranis", license: "CC-BY 4.0"),
+        "Models/khronos_lantern.usdz": .init(name: "Lantern", author: "Microsoft", license: "CC-BY 4.0"),
+    ]
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Components/AssetCreditLine.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Components/AssetCreditLine.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// The attribution caption under a streamed-slug picker — credits **the model
+/// that is actually on screen**, not the one the slug would stream (#2966).
+///
+/// Before this view every demo printed `by <slug.author> · CC-BY 4.0`
+/// unconditionally. On a keyless build the resolver hands back the bundled
+/// fallback, so the App Store build captioned a Khronos Damaged Helmet
+/// "by ChubbyPanda". The caption is an attribution surface, so it now follows
+/// the same measured verdict the `AssetSourcePill` uses:
+///
+///  - ``AssetSourceState/streamed`` → the slug's Sketchfab author, CC-BY 4.0
+///    (the only licence the streamed registry admits).
+///  - ``AssetSourceState/bundled`` → the fallback's own name, author and
+///    licence from `BundledAssetCredits` — which is not always CC-BY.
+///  - ``AssetSourceState/streaming`` → nothing is on screen yet, so no byline.
+struct AssetCreditLine: View {
+    let slug: SketchfabSlug
+    let source: AssetSourceState
+    /// Text colour — `.secondary` on a sheet, a translucent white when the
+    /// caption floats over the scene (Scene Gallery, Materials).
+    var style: AnyShapeStyle = AnyShapeStyle(.secondary)
+
+    /// The caption text, or `nil` while nothing is on screen. A pure function
+    /// so `AssetCreditLineTests` can pin all three branches without SwiftUI.
+    static func text(slug: SketchfabSlug, source: AssetSourceState) -> String? {
+        switch source {
+        case .streaming:
+            return nil
+        case .streamed:
+            return "by \(slug.author) · CC-BY 4.0"
+        case .bundled:
+            guard let credit = BundledAssetCredits.fallbackCredit(for: slug) else {
+                // Unknown bundled file: say so rather than borrow the streamed
+                // author. `BundledAssetCreditsTests` keeps this branch unreachable
+                // for the shipped registry.
+                return "Offline stand-in · uncredited bundled asset"
+            }
+            return "Offline stand-in: \(credit.name) by \(credit.author) · \(credit.license)"
+        }
+    }
+
+    var body: some View {
+        if let text = Self.text(slug: slug, source: source) {
+            Text(text)
+                .font(.caption2)
+                .foregroundStyle(style)
+                .accessibilityIdentifier("assetCreditLine")
+        }
+    }
+}

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
@@ -134,9 +134,10 @@ struct ARInstantPlacementDemo: View {
             let node: ModelNode
             if let slug = selectedSlug, let url = armedURL {
                 node = try await ModelNode.load(contentsOf: url)
-                _ = node.scaleToUnits(0.3)
+                // Honour the slug's real-world size hint, as ARPlacementDemo
+                // does — the bundled cycle alone is normalised to 0.3 m (#2966).
+                _ = node.scaleToUnits(slug.scaleToUnits)
                 _ = node.centerOrigin()
-                _ = slug
             } else {
                 let entry = Self.bundledCycle[cycleIndex % Self.bundledCycle.count]
                 cycleIndex += 1
@@ -216,9 +217,8 @@ struct ARInstantPlacementDemo: View {
                         .font(.caption2)
                         .foregroundStyle(.green)
                 }
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Same rule as ARPlacementDemo: credit what is on screen (#2966).
+                AssetCreditLine(slug: slug, source: assetSource ?? .streaming)
             }
 
             Button(role: .destructive) {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
@@ -150,9 +150,11 @@ struct ARPlacementDemo: View {
         do {
             let url: URL
             let displayName: String
+            let scaleToUnits: Float
             if let slug = selectedSlug, let resolved = armedURL {
                 url = resolved
                 displayName = slug.displayName
+                scaleToUnits = slug.scaleToUnits
             } else {
                 // Bundled cycle — round-robin through the five bundled entries.
                 let entry = Self.bundledCycle[cycleIndex % Self.bundledCycle.count]
@@ -171,7 +173,11 @@ struct ARPlacementDemo: View {
                 return
             }
             let node = try await ModelNode.load(contentsOf: url)
-            _ = node.scaleToUnits(0.3)
+            // The slug's real-world size hint is the point of the picker: a
+            // coffee mug at 0.10 m and a floor lamp at 1.55 m, not both at the
+            // bundled cycle's 0.3 m (#2966). Applies to the fallback too — it
+            // stands in at the size the label claims.
+            _ = node.scaleToUnits(scaleToUnits)
             _ = node.centerOrigin()
             let anchor = AnchorNode.world(position: worldPosition)
             anchor.add(node.entity)
@@ -242,9 +248,10 @@ struct ARPlacementDemo: View {
                         .font(.caption2)
                         .foregroundStyle(.green)
                 }
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Credits whatever is actually on screen — the fallback's own
+                // author and licence in keyless mode, never the streamed one
+                // next to a bundled stand-in (#2966).
+                AssetCreditLine(slug: slug, source: assetSource ?? .streaming)
             } else {
                 Text("Next tap places: \(Self.bundledCycle[cycleIndex % Self.bundledCycle.count].displayName)")
                     .font(.caption2)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
@@ -288,9 +288,9 @@ struct AnimationDemo: View {
                 .foregroundStyle(.secondary)
 
             if let slug = selectedSubject.streamedSlug {
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Credits the model actually on screen — streamed author or the
+                // bundled fallback's own author and licence (#2966).
+                AssetCreditLine(slug: slug, source: assetSource ?? .streaming)
             }
         }
     }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
@@ -135,9 +135,10 @@ struct MaterialsDemo: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.85))
                 }
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.white.opacity(0.75))
+                // Credits the model actually on screen — streamed author or the
+                // bundled fallback's own author and licence (#2966).
+                AssetCreditLine(slug: slug, source: assetSource,
+                                style: AnyShapeStyle(.white.opacity(0.75)))
             }
         }
         .padding(.vertical, 12)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
@@ -246,9 +246,9 @@ struct PhysicsDemo: View {
                         .font(.caption2)
                         .foregroundStyle(.orange)
                 }
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Credits the model actually on screen — streamed author or the
+                // bundled fallback's own author and licence (#2966).
+                AssetCreditLine(slug: slug, source: assetSource ?? .streaming)
             } else {
                 Text("Drop count capped at 20 on RealityKit — beyond that the simulation lags.")
                     .font(.caption2)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
@@ -144,9 +144,10 @@ struct SceneGalleryDemo: View {
                 // CC-BY 4.0 attribution lives inline so it's always visible
                 // without a tap. The Credits sheet (Stage 3) carries the full
                 // attribution + Sketchfab page link.
-                Text("by \(slug.author) · CC-BY 4.0")
-                    .font(.caption2)
-                    .foregroundStyle(.white.opacity(0.75))
+                // Credits the model actually on screen — streamed author or the
+                // bundled fallback's own author and licence (#2966).
+                AssetCreditLine(slug: slug, source: assetSource,
+                                style: AnyShapeStyle(.white.opacity(0.75)))
             }
         }
         .padding(.vertical, 12)

--- a/samples/ios-demo/SceneViewDemoTests/BundledAssetCreditsTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/BundledAssetCreditsTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+// Deliberately NOT wrapped in `#if DEBUG` — see BundledAssetPrimBudgetTests for
+// why: `ENABLE_TESTABILITY` is Debug-only, so a Release test run must fail to
+// COMPILE rather than silently compile to an empty, green file.
+@testable import SceneViewDemo
+
+/// Pins the attribution surface for keyless builds (#2966).
+///
+/// Every demo that streams a `SketchfabSlug` captions it with an author. On a
+/// keyless build the bundled fallback is what renders, so the caption has to
+/// credit the fallback instead. These tests keep the two halves in step: the
+/// registry cannot hand out a fallback the credit table does not know, and the
+/// caption cannot borrow the streamed author when the probe measured a
+/// fallback.
+final class BundledAssetCreditsTests: XCTestCase {
+
+    /// The host app's bundle — where the resolver looks for a fallback.
+    private var bundle: Bundle { .main }
+
+    /// A fallback without a credit row would render uncredited on every
+    /// App Store build — which is the #2966 defect in its licence-edge form.
+    func testEveryDeclaredFallbackHasACredit() {
+        let declared = Set(SampleAssets.all.map(\.fallbackBundledPath))
+        XCTAssertFalse(declared.isEmpty, "SampleAssets declared no fallbacks")
+        for path in declared.sorted() {
+            let credit = BundledAssetCredits.credit(forBundledPath: path)
+            XCTAssertNotNil(credit, "\(path) has no row in BundledAssetCredits")
+            XCTAssertFalse(credit?.author.isEmpty ?? true, "\(path) credit has no author")
+            XCTAssertFalse(credit?.license.isEmpty ?? true, "\(path) credit has no licence")
+        }
+    }
+
+    /// The other direction: a credit row must name a file that ships. A stale
+    /// row is harmless today but would let a typo in a future
+    /// `fallbackBundledPath` pass the test above against the wrong asset.
+    func testEveryCreditNamesAShippedAsset() throws {
+        for path in BundledAssetCredits.byPath.keys.sorted() {
+            let file = (path as NSString).lastPathComponent
+            let name = (file as NSString).deletingPathExtension
+            let ext = (file as NSString).pathExtension
+            let components = path.split(separator: "/").dropLast()
+            let subdirectory = components.isEmpty ? nil : components.joined(separator: "/")
+            let url = bundle.url(forResource: name, withExtension: ext, subdirectory: subdirectory)
+                ?? bundle.url(forResource: name, withExtension: ext)
+            XCTAssertNotNil(url, "BundledAssetCredits names \(path), which is not in the app bundle")
+        }
+    }
+
+    // MARK: - Caption
+
+    private var monstera: SketchfabSlug {
+        try! XCTUnwrap(SampleAssets.all.first { $0.displayName == "Potted Monstera" })
+    }
+
+    func testStreamedCaptionCreditsTheSketchfabAuthor() {
+        XCTAssertEqual(
+            AssetCreditLine.text(slug: monstera, source: .streamed),
+            "by ChubbyPanda · CC-BY 4.0"
+        )
+    }
+
+    /// The App Store shape: the helmet is on screen, so the helmet is credited
+    /// and the streamed author is nowhere in the caption.
+    func testBundledCaptionCreditsTheFallbackNotTheStreamedAuthor() throws {
+        let text = try XCTUnwrap(AssetCreditLine.text(slug: monstera, source: .bundled))
+        XCTAssertTrue(text.hasPrefix("Offline stand-in:"), text)
+        XCTAssertTrue(text.contains("Damaged Helmet"), text)
+        XCTAssertTrue(text.contains("KhronosGroup"), text)
+        XCTAssertFalse(text.contains("ChubbyPanda"), "streamed author leaked into the fallback caption: \(text)")
+    }
+
+    /// `retro_piano` is CC-BY-NC, so the caption must print the fallback's own
+    /// licence rather than the registry's blanket "CC-BY 4.0".
+    func testBundledCaptionPrintsTheFallbackLicence() throws {
+        let mug = try XCTUnwrap(SampleAssets.all.first { $0.displayName == "Coffee Mug" })
+        let text = try XCTUnwrap(AssetCreditLine.text(slug: mug, source: .bundled))
+        XCTAssertTrue(text.contains("CC-BY-NC 4.0"), text)
+        XCTAssertFalse(text.contains("FrenchBaguette"), text)
+    }
+
+    func testStreamingHasNoCaption() {
+        XCTAssertNil(AssetCreditLine.text(slug: monstera, source: .streaming))
+    }
+}


### PR DESCRIPTION
Closes #2966

## What

1. **`scaleToUnits` is honoured.** `ARPlacementDemo` and `ARInstantPlacementDemo` placed every streamed slug at a hardcoded 0.3 m. They now apply `slug.scaleToUnits` (coffee mug 0.10 m, floor lamp 1.55 m), the same way `SceneGalleryDemo` / `MaterialsDemo` already did. The "Bundled cycle" keeps its 0.3 m normalisation — those five models are not slugs.
2. **The caption credits what is on screen.** `by <slug.author> · CC-BY 4.0` was printed even when the resolver had returned the bundled fallback, so the App Store (keyless) build captioned a Khronos Damaged Helmet "by ChubbyPanda". New `AssetCreditLine` follows the same measured `AssetSourceProbe` verdict as the pill:
   - streamed → `by <author> · CC-BY 4.0`
   - bundled → `Offline stand-in: <name> by <author> · <licence>` from a new `BundledAssetCredits` table mirroring `assets/catalog.json` (retro_piano is CC-BY-NC — the licence is printed, not assumed)
   - streaming → no byline
   
   Wired into all six demos that had the old line (AR Placement, AR Instant Placement, Animation, Materials, Physics, Scene Gallery).

## Tests

`BundledAssetCreditsTests` (6 cases): every declared fallback has a credit, every credit names a shipped asset, and the three caption branches. `AssetSourceProbeTests` / `BundledAssetPrimBudgetTests` still green.

## Verified

Keyless build on an iOS 26.3 simulator clone, AR Placement → settings sheet → "Potted Monstera": pill reads "Offline model", caption reads "Offline stand-in: Damaged Helmet by KhronosGroup (theblueturtle_) · CC-BY 4.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)