### PR TITLE
fix(ios-demo): label semantically incompatible keyless fallbacks as placeholders (#2960)

### DIFF
--- a/changelog.d/2960-ios-fallback-slugs.md
+++ b/changelog.d/2960-ios-fallback-slugs.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+iOS demo: every curated Sketchfab slug now declares whether its bundled keyless fallback is
+the same subject as its label or a stand-in (`SketchfabSlug.fallbackRole`). The 16 slugs whose
+fallback is a different subject — no vase, mug, crate, table, sofa, camera, statue or plant is
+bundled — show "Offline placeholder" in the asset-source pill instead of "Offline model", so a
+keyless build no longer renders a confident wrong subject; a reviewed allowlist test pins every
+subject-match claim (#2960).

--- a/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SampleAssets.swift
@@ -30,8 +30,11 @@ import Foundation
 ///  3. Eyeball a realistic `scaleToUnits` — the bounds sanity check in
 ///     `SketchfabAssetResolver.boundsAreSane(_:slug:)` rejects values outside
 ///     `[0.05 m, 5 m]`.
-///  4. Pick an existing bundled fallback that visually resembles the streamed
-///     model.
+///  4. Pick an existing bundled fallback that IS the same kind of thing as the
+///     streamed model, or declare `fallbackRole: .placeholder` so the pill says
+///     "Offline placeholder" instead of pretending (#2960). Every
+///     `.subjectMatch` must be added to the reviewed allowlist in
+///     `BundledAssetPrimBudgetTests.testEveryFallbackIsASubjectMatchOrADeclaredPlaceholder`.
 enum SampleAssets {
 
     /// All curated entries flattened into a single list.
@@ -89,6 +92,8 @@ enum SampleAssets {
             author: "rigsters",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/retro_piano.usdz",
+            // Offline placeholder (#2960): no statue is bundled; a piano keeps the gallery picker working.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.85,
             hasBakedAnimation: false,
             category: "gallery",
@@ -134,6 +139,8 @@ enum SampleAssets {
             author: "MartijnVaes",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/game_boy_classic.usdz",
+            // Offline placeholder (#2960): a Game Boy is a retro gadget, not a camera.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.20,
             hasBakedAnimation: false,
             category: "gallery",
@@ -220,6 +227,8 @@ enum SampleAssets {
             // tree_scene islands instead of a scene (#2355). A small furniture-
             // like prop (1.8 MB retro_piano) reads as the foreground bench.
             fallbackBundledPath: "Models/retro_piano.usdz",
+            // Offline placeholder (#2960): deliberate bench-slot stand-in, see above — still not a tree.
+            fallbackRole: .placeholder,
             scaleToUnits: 1.80,
             hasBakedAnimation: false,
             category: "park",
@@ -234,6 +243,8 @@ enum SampleAssets {
             // slot — a small animated creature (3.1 MB animated_butterfly).
             // Distinct silhouette from the tree backdrop (#2355).
             fallbackBundledPath: "Models/animated_butterfly.usdz",
+            // Offline placeholder (#2960): deliberate dog-slot stand-in — a butterfly is not a tree.
+            fallbackRole: .placeholder,
             scaleToUnits: 2.60,
             hasBakedAnimation: false,
             category: "park",
@@ -251,6 +262,8 @@ enum SampleAssets {
             // loaded the same heavy 14 MB tree_scene). Distinct silhouette
             // (#2355).
             fallbackBundledPath: "Models/phoenix_bird.usdz",
+            // Offline placeholder (#2960): deliberate bird-slot stand-in — a phoenix is not a tree.
+            fallbackRole: .placeholder,
             scaleToUnits: 2.30,
             hasBakedAnimation: false,
             category: "park",
@@ -264,6 +277,8 @@ enum SampleAssets {
             author: "FrenchBaguette",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/retro_piano.usdz",
+            // Offline placeholder (#2960): no mug is bundled; the piano only keeps something placeable.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.10,
             hasBakedAnimation: false,
             category: "ar_placement",
@@ -278,6 +293,8 @@ enum SampleAssets {
             // object stands in rather than a mislabelled real object; the
             // previous tree_scene read as an actual potted plant (#2940).
             fallbackBundledPath: "Models/khronos_damaged_helmet.usdz",
+            // Offline placeholder (#2960): no plant is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.45,
             hasBakedAnimation: false,
             category: "ar_placement",
@@ -289,6 +306,8 @@ enum SampleAssets {
             author: "jeandiz",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/game_boy_classic.usdz",
+            // Offline placeholder (#2960): no crate is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.60,
             hasBakedAnimation: false,
             category: "ar_placement",
@@ -306,6 +325,8 @@ enum SampleAssets {
             // NB: both placement demos place at a hardcoded `scaleToUnits(0.3)`
             // and never read the value below, so pick for silhouette, not size.
             fallbackBundledPath: "Models/khronos_toy_car.usdz",
+            // Offline placeholder (#2960): no table is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.60,
             hasBakedAnimation: false,
             category: "ar_placement",
@@ -338,6 +359,8 @@ enum SampleAssets {
             // bundled, so the last unclaimed Khronos reference object stands in
             // rather than a mislabelled real object (#2355).
             fallbackBundledPath: "Models/khronos_fox.usdz",
+            // Offline placeholder (#2960): no frame is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.40,
             hasBakedAnimation: false,
             category: "ar_placement",
@@ -351,6 +374,8 @@ enum SampleAssets {
             author: "apariciosilva3D",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/fantasy_book.usdz",
+            // Offline placeholder (#2960): no pottery is bundled; the book keeps a rigid body to drop.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.30,
             hasBakedAnimation: false,
             category: "physics",
@@ -362,6 +387,8 @@ enum SampleAssets {
             author: "niver_mk",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/fantasy_book.usdz",
+            // Offline placeholder (#2960): no barrel is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.50,
             hasBakedAnimation: false,
             category: "physics",
@@ -373,6 +400,8 @@ enum SampleAssets {
             author: "local.yany",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/fantasy_book.usdz",
+            // Offline placeholder (#2960): no pottery is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.45,
             hasBakedAnimation: false,
             category: "physics",
@@ -384,6 +413,8 @@ enum SampleAssets {
             author: "skodvirr",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/fantasy_book.usdz",
+            // Offline placeholder (#2960): no pottery is bundled.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.35,
             hasBakedAnimation: false,
             category: "physics",
@@ -408,6 +439,8 @@ enum SampleAssets {
             author: "Antrea",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/mosquito_amber.usdz",
+            // Offline placeholder (#2960): amber is translucent, but it is not a decanter.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.35,
             hasBakedAnimation: false,
             category: "materials",
@@ -419,6 +452,8 @@ enum SampleAssets {
             author: "klava88",
             licenseURL: URL(string: "https://creativecommons.org/licenses/by/4.0/")!,
             fallbackBundledPath: "Models/mosquito_amber.usdz",
+            // Offline placeholder (#2960): no furniture is bundled; a mosquito in amber is not a sofa.
+            fallbackRole: .placeholder,
             scaleToUnits: 0.90,
             hasBakedAnimation: false,
             category: "materials",

--- a/samples/ios-demo/SceneViewDemo/Services/SketchfabSlug.swift
+++ b/samples/ios-demo/SceneViewDemo/Services/SketchfabSlug.swift
@@ -22,6 +22,29 @@ import Foundation
 /// Mirrors the Android scaffold (`SketchfabSlug.kt`) — keep both in sync when
 /// adding fields.
 struct SketchfabSlug: Hashable, Sendable {
+    /// What the bundled fallback IS relative to the label it renders under
+    /// (#2960).
+    ///
+    /// The defect #2940 named is "a fallback whose subject is semantically
+    /// incompatible with the label it renders under" — a book under
+    /// "Wine Barrel", a piano under "Coffee Mug". The bundled set has no vase,
+    /// mug, crate, table, sofa or statue, so most of those cannot be re-pointed
+    /// without shipping a new binary. Until then the demo must *say* it is
+    /// showing a placeholder rather than pretend: the asset-source pill reads
+    /// "Offline placeholder" instead of "Offline model" for a ``placeholder``
+    /// slug. `BundledAssetPrimBudgetTests` pins every ``subjectMatch`` claim to
+    /// a reviewed allowlist, so a new slug cannot claim a match by default.
+    enum FallbackRole: Hashable, Sendable {
+        /// The fallback is the same kind of thing as the label — a fox for a
+        /// fox, a lantern for a lamp, a butterfly for a butterfly, an animated
+        /// humanoid for a walking robot.
+        case subjectMatch
+        /// The fallback is a different subject that only keeps the demo's
+        /// *mechanism* working (something to place, drop, light, animate).
+        /// The UI must label it as a placeholder.
+        case placeholder
+    }
+
     /// The Sketchfab model uid (matches the path segment in
     /// `sketchfab.com/3d-models/<slug>-<uid>`). Always the unique identifier
     /// — never trust the `<slug>` portion which authors can edit.
@@ -43,6 +66,10 @@ struct SketchfabSlug: Hashable, Sendable {
     /// Bundle-relative path to the offline fallback (`Models/<file>.usdz`).
     /// Used by `SketchfabAssetResolver.fallbackBundle(for:)`.
     let fallbackBundledPath: String
+
+    /// Whether `fallbackBundledPath` is the same subject as the label or a
+    /// declared stand-in. See ``FallbackRole``.
+    let fallbackRole: FallbackRole
 
     /// Expected post-load bounding-sphere radius in metres. Out-of-range
     /// values trigger the resolver's fallback.
@@ -78,6 +105,7 @@ struct SketchfabSlug: Hashable, Sendable {
         author: String,
         licenseURL: URL,
         fallbackBundledPath: String,
+        fallbackRole: FallbackRole = .subjectMatch,
         scaleToUnits: Float,
         hasBakedAnimation: Bool,
         category: String,
@@ -108,6 +136,7 @@ struct SketchfabSlug: Hashable, Sendable {
         self.author = author
         self.licenseURL = licenseURL
         self.fallbackBundledPath = fallbackBundledPath
+        self.fallbackRole = fallbackRole
         self.scaleToUnits = scaleToUnits
         self.hasBakedAnimation = hasBakedAnimation
         self.category = category

--- a/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Components/AssetSourcePill.swift
@@ -16,14 +16,22 @@ import SwiftUI
 /// two demo apps read the same in screenshots and QA transcripts.
 struct AssetSourcePill: View {
     let state: AssetSourceState
+    /// `true` when the slug on screen declares `fallbackRole == .placeholder`
+    /// — its bundled stand-in is a different subject than the label (#2960).
+    /// Only changes the ``AssetSourceState/bundled`` wording: a streamed model
+    /// is never a placeholder, whatever its fallback would have been.
+    var isPlaceholder: Bool = false
 
-    private var label: String {
+    /// The pill copy. Static so the tests can pin it without SwiftUI.
+    static func label(state: AssetSourceState, isPlaceholder: Bool) -> String {
         switch state {
         case .streamed: return "Streamed (cached)"
         case .streaming: return "Streaming…"
-        case .bundled: return "Offline model"
+        case .bundled: return isPlaceholder ? "Offline placeholder" : "Offline model"
         }
     }
+
+    private var label: String { Self.label(state: state, isPlaceholder: isPlaceholder) }
 
     private var tint: Color {
         switch state {
@@ -75,10 +83,10 @@ extension View {
     /// taking the scene's `RealityView` with it. That is the same teardown
     /// `.contentID(_:)` exists to avoid, and it was measured re-creating the
     /// scene on exactly the first subject change and no other (#3008).
-    func assetSourcePill(_ state: AssetSourceState?) -> some View {
+    func assetSourcePill(_ state: AssetSourceState?, placeholder: Bool = false) -> some View {
         overlay(alignment: .topTrailing) {
             if let state {
-                AssetSourcePill(state: state)
+                AssetSourcePill(state: state, isPlaceholder: placeholder)
                     .padding(.top, 12)
                     .padding(.trailing, 16)
             }
@@ -91,6 +99,7 @@ extension View {
         AssetSourcePill(state: .streamed)
         AssetSourcePill(state: .streaming)
         AssetSourcePill(state: .bundled)
+        AssetSourcePill(state: .bundled, isPlaceholder: true)
     }
     .padding()
     .background(Color.black)

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARInstantPlacementDemo.swift
@@ -110,7 +110,8 @@ struct ARInstantPlacementDemo: View {
                 if let assetSource {
                     HStack {
                         Spacer()
-                        AssetSourcePill(state: assetSource)
+                        AssetSourcePill(state: assetSource,
+                                        isPlaceholder: selectedSlug?.fallbackRole == .placeholder)
                     }
                     .padding(.horizontal, 16)
                 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
@@ -106,7 +106,8 @@ struct ARPlacementDemo: View {
                 if let assetSource {
                     HStack {
                         Spacer()
-                        AssetSourcePill(state: assetSource)
+                        AssetSourcePill(state: assetSource,
+                                        isPlaceholder: selectedSlug?.fallbackRole == .placeholder)
                     }
                     .padding(.horizontal, 16)
                 }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/AnimationDemo.swift
@@ -112,7 +112,8 @@ struct AnimationDemo: View {
 
     var body: some View {
         sceneContent
-            .assetSourcePill(assetSource)
+            .assetSourcePill(assetSource,
+                             placeholder: selectedSubject.streamedSlug?.fallbackRole == .placeholder)
             .demoSettingsSheet {
                 controlsSheet
             }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MaterialsDemo.swift
@@ -51,7 +51,8 @@ struct MaterialsDemo: View {
                 controls
             }
         }
-        .assetSourcePill(assetSource)
+        .assetSourcePill(assetSource,
+                         placeholder: selectedSlug?.fallbackRole == .placeholder)
         .background(Color.black)
         .task(id: selectedSlug?.uid) {
             await loadSelectedSlug()

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/MultiModelDemo.swift
@@ -133,7 +133,12 @@ struct MultiModelDemo: View {
 
     var body: some View {
         sceneContent
-            .assetSourcePill(assetSource)
+            .assetSourcePill(
+                assetSource,
+                // Three of the four park stand-ins are not trees (#2960); the
+                // whole-scene verdict says so.
+                placeholder: Self.slots.compactMap(\.slug).contains { $0.fallbackRole == .placeholder }
+            )
             .demoSettingsSheet { controlsSheet }
             .task {
                 _ = await SketchfabAssetResolver.shared.prefetchAll(category: "park")

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/PhysicsDemo.swift
@@ -54,7 +54,8 @@ struct PhysicsDemo: View {
 
     var body: some View {
         sceneContent
-            .assetSourcePill(assetSource)
+            .assetSourcePill(assetSource,
+                         placeholder: selectedSlug?.fallbackRole == .placeholder)
             .demoSettingsSheet { controlsSheet }
             .task {
                 _ = await SketchfabAssetResolver.shared.prefetchAll(category: "physics")

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/SceneGalleryDemo.swift
@@ -53,7 +53,8 @@ struct SceneGalleryDemo: View {
                 controls
             }
         }
-        .assetSourcePill(assetSource)
+        .assetSourcePill(assetSource,
+                         placeholder: selectedSlug?.fallbackRole == .placeholder)
         .background(Color.black)
         .task(id: selectedSlug?.uid) {
             await loadSelectedSlug()

--- a/samples/ios-demo/SceneViewDemoTests/BundledAssetPrimBudgetTests.swift
+++ b/samples/ios-demo/SceneViewDemoTests/BundledAssetPrimBudgetTests.swift
@@ -185,4 +185,57 @@ final class BundledAssetPrimBudgetTests: XCTestCase {
             }
         }
     }
+
+    /// #2960's rule: every slug's fallback is either the same kind of thing as
+    /// its label, or the slug declares `fallbackRole: .placeholder` so the pill
+    /// reads "Offline placeholder" instead of pretending.
+    ///
+    /// `.subjectMatch` is the init default, so a new slug would claim a match
+    /// by omission. This allowlist is what stops that: a `.subjectMatch` slug
+    /// that is not listed here fails, and listing one is a reviewed claim that
+    /// the bundled asset really is a fox for a fox, a lantern for a lamp.
+    func testEveryFallbackIsASubjectMatchOrADeclaredPlaceholder() {
+        let reviewedSubjectMatches: Set<String> = [
+            // solar — a butterfly for a butterfly
+            "Fantasy Butterfly", "Fluttering Butterfly", "Animated Butterfly", "Animated Butterflies",
+            // gallery
+            "PBR Low-Poly Fox",      // khronos_fox
+            "Desk Lamp",             // khronos_lantern
+            // animation — an animated humanoid for a robot / mech (#3007)
+            "Retro TV Robot", "Catfish Mech", "Walking Robot", "Enforcer Mk1",
+            // park — the one tree_scene consumer that IS trees
+            "Oak Trees",
+            // ar_placement
+            "Floor Lamp",            // khronos_lantern
+            // materials — an insect scan for an insect scan
+            "Iridescent Beetle",     // mosquito_amber
+        ]
+        for slug in SampleAssets.all {
+            switch slug.fallbackRole {
+            case .placeholder:
+                XCTAssertFalse(
+                    reviewedSubjectMatches.contains(slug.displayName),
+                    "\"\(slug.displayName)\" is declared a placeholder but is also on " +
+                    "the reviewed subject-match allowlist — pick one"
+                )
+            case .subjectMatch:
+                XCTAssertTrue(
+                    reviewedSubjectMatches.contains(slug.displayName),
+                    "\"\(slug.displayName)\" claims its fallback \(slug.fallbackBundledPath) " +
+                    "is the same subject as its label, but nobody reviewed that claim. " +
+                    "Either add it to the allowlist above (if it really is) or declare " +
+                    "`fallbackRole: .placeholder` in SampleAssets (#2960)."
+                )
+            }
+        }
+    }
+
+    /// The placeholder flag has to reach the screen, or it is just metadata.
+    func testPillSaysPlaceholderOnlyForABundledPlaceholder() {
+        XCTAssertEqual(AssetSourcePill.label(state: .bundled, isPlaceholder: true), "Offline placeholder")
+        XCTAssertEqual(AssetSourcePill.label(state: .bundled, isPlaceholder: false), "Offline model")
+        // A model that actually streamed is never a placeholder.
+        XCTAssertEqual(AssetSourcePill.label(state: .streamed, isPlaceholder: true), "Streamed (cached)")
+        XCTAssertEqual(AssetSourcePill.label(state: .streaming, isPlaceholder: true), "Streaming…")
+    }
 }


### PR DESCRIPTION
Closes #2960

## The rule, applied to the remaining slugs

#3007 re-pointed the four slugs that had a matching bundled asset (fox, lantern, humanoid ×2) and left the rest open because each needs a new binary: the bundled set has no vase, mug, crate, table, sofa, camera, statue or plant. This PR applies the #2940 rule to everything else without adding binaries: **a fallback is either the same subject as its label, or the demo says "offline placeholder" explicitly.**

- `SketchfabSlug.fallbackRole` — `.subjectMatch` / `.placeholder`.
- 16 slugs declare `.placeholder`, each with the reason inline in `SampleAssets.swift`: Nile, Vintage Camera, the three deliberate park role stand-ins (bench / dog / bird), the five `ar_placement` stand-ins, the four `physics` pottery slugs, Crystal Glass Decanter, Cushioned Sofa.
- 13 remain `.subjectMatch`: the four butterflies, Fox, Desk Lamp, Floor Lamp, the four animated-humanoid robots/mechs, Oak Trees, Iridescent Beetle (an insect scan for an insect scan).
- `AssetSourcePill` reads **"Offline placeholder"** for a bundled placeholder and keeps "Offline model" for a subject match. All eight streaming demos pass the role through (Multi-Model as a whole-scene verdict; Orbital AR's butterflies are all matches).

No `fallbackBundledPath` moved — nothing bundled fits any of the sixteen better than what they use today, and `ar_placement` stays pairwise distinct (#2973's test still green).

## Tests

- `testEveryFallbackIsASubjectMatchOrADeclaredPlaceholder` — reviewed allowlist of the 13 matches; `.subjectMatch` is the init default, so a new slug that is not on the list fails instead of silently claiming a match.
- `testPillSaysPlaceholderOnlyForABundledPlaceholder` — a streamed model is never a placeholder.

## Verified (keyless, iOS 26.3 simulator clone)

Physics "Decorated Vase", Scene Gallery "Nile (Classical Statue)" (a piano) and Materials "Crystal Glass Decanter" (mosquito in amber) all read **Offline placeholder**; Materials "Iridescent Beetle" still reads **Offline model**.

Independent of #3280 (#2966), which makes the *caption* under the same pickers credit the fallback's own author and licence; both apply cleanly on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)