### PR TITLE
Credit every bundled asset in the iOS and web demos, generated from the catalog

### DIFF
--- a/.claude/scripts/generate-credits.py
+++ b/.claude/scripts/generate-credits.py
@@ -28,6 +28,9 @@ and fails on any this script does not name.
 
   assets/CREDITS.md                                GENERATED (full catalog)
   samples/android-demo/src/main/assets/CREDITS.md  GENERATED (bundled scope)
+  samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json
+                                                   GENERATED (bundled scope, JSON, #3214)
+  samples/web-demo/site/credits.json               GENERATED (bundled scope, JSON, #3214)
   assets/audio/CREDITS.md                          SOURCE    (hand-written)
   samples/ios-demo/SceneViewDemo/Audio/CREDITS.md  MIRROR    (of the above)
   samples/web-demo/site/audio/CREDITS.md           MIRROR    (of the above)
@@ -127,6 +130,37 @@ BUNDLED_SCOPES = [
         # the generated CREDITS.md itself lives here and would otherwise
         # demand a credit line for itself.
         "ignore_suffixes": (".md",),
+        "format": "markdown",
+    },
+    # ── JSON scopes (#3214) ──────────────────────────────────────────────────
+    # The iOS and web demos cannot show a Markdown file to a user, so their
+    # credits are a machine-readable JSON rendered by the app at runtime:
+    # `CreditsSheet.swift` (About → Credits) and the web demo's Credits tab.
+    # Same catalogue, same classification, same gate — a bundled file nobody
+    # declared fails here exactly as it does for the APK.
+    #
+    # `subdirs` restricts the scan to the folders that are actually copied
+    # into the artefact: `SceneViewDemo/` also holds Swift sources, xcassets
+    # and xcconfig files, `site/` holds index.html and the Kotlin/JS bundle.
+    {
+        "id": "ios-demo",
+        "assets_dir": "samples/ios-demo/SceneViewDemo",
+        "subdirs": ("Models", "Environments", "Audio", "Resources", "Videos"),
+        "out": "samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json",
+        "title": "Bundled Asset Credits — SceneView iOS demo",
+        "artefact": "the App Store build",
+        "ignore_suffixes": (".md", ".json"),
+        "format": "json",
+    },
+    {
+        "id": "web-demo",
+        "assets_dir": "samples/web-demo/site",
+        "subdirs": ("models", "environments", "audio"),
+        "out": "samples/web-demo/site/credits.json",
+        "title": "Bundled Asset Credits — SceneView web demo",
+        "artefact": "the sceneview.github.io/web-demo deploy",
+        "ignore_suffixes": (".md", ".json"),
+        "format": "json",
     },
 ]
 
@@ -150,49 +184,58 @@ MIRRORS = {
 # ships to a user and therefore needs a line in the CREDITS they receive.
 # Declaring them here (rather than staying silent) is what lets the coverage
 # check below treat "a bundled file I have never heard of" as an error.
-# Keys are paths relative to the scope's assets_dir.
+# Keys are basenames, not scope-relative paths: the same `bell.wav` ships as
+# `audio/bell.wav` in the APK, `Audio/bell.wav` in the .app and `audio/bell.wav`
+# on the web, and one declaration must cover all three (#3214).
 NON_CATALOG_BUNDLED = {
-    "audio/bell.wav": {
+    "bell.wav": {
         "name": "bell.wav",
         "author": "SceneView project",
         "license": "CC0-1.0",
         "sourceUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
         "note": "Generated locally with ffmpeg (880 Hz sine, 0.6 s) — see `assets/audio/CREDITS.md`",
     },
-    "augmented_images/qrcode.png": {
+    "qrcode.png": {
         "name": "qrcode.png",
         "author": "SceneView project",
         "license": "Apache-2.0",
         "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
         "note": "QR-like reference pattern drawn for `ARImageDemo`",
     },
-    "textures/sceneview_logo.png": {
+    "sceneview_logo.png": {
         "name": "sceneview_logo.png",
         "author": "SceneView project",
         "license": "Apache-2.0",
         "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
         "note": "SceneView brand mark, exported from `branding/exports/logo/logo-1024.png`",
     },
-    "videos/sample.mp4": {
+    "sample.mp4": {
         "name": "sample.mp4",
         "author": "SceneView project",
         "license": "Apache-2.0",
         "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
         "note": "Generated with ffmpeg — 10 s / 1280×720 / H.264 brand animation for `TwoDInThreeDDemo`",
     },
-    "splats/rainbow_sphere.ply": {
+    "rainbow_sphere.ply": {
         "name": "rainbow_sphere.ply",
         "author": "SceneView project",
         "license": "Apache-2.0",
         "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
         "note": "Generated procedurally by `tools/generate-splat-sphere.py`",
     },
-    "mediapipe/pose_landmarker_lite.task": {
+    "pose_landmarker_lite.task": {
         "name": "MediaPipe Pose Landmarker (lite)",
         "author": "Google LLC",
         "license": "Apache-2.0",
         "sourceUrl": "https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker",
         "note": "On-device pose model bundle used by `ARBodyTrackerDemo`",
+    },
+    "neutral_ibl.ktx": {
+        "name": "Neutral IBL (Filament default environment)",
+        "author": "Google LLC — Filament",
+        "license": "Apache-2.0",
+        "sourceUrl": "https://github.com/google/filament/tree/main/third_party/environments",
+        "note": "Prefiltered KTX environment shipped with Filament, used by the web demo as its default lighting",
     },
 }
 
@@ -212,21 +255,12 @@ SOURCE_BLANKET_LICENSE = {
     },
 }
 
-# ─── Deliberately NOT handled here, and why ───────────────────────────────────
-# Named so that a reader does not have to guess whether the omission is a
-# decision or an oversight.
-#
-#   samples/ios-demo  — bundles 31 catalogue assets (24 CC-BY .usdz models) and
-#   samples/web-demo    12 respectively, and NEITHER ships a bundled-model
-#                       CREDITS file at all; each has only the audio mirror
-#                       above. Generating one is not the missing piece — the
-#                       iOS copy would also need adding to the Xcode Resources
-#                       build phase (`project.pbxproj` lists Audio/CREDITS.md
-#                       as a file reference only, so it is not in the .app),
-#                       and the web copy needs a link from `site/index.html`.
-#                       That is a shipped-surface change, not a gate change.
-#                       Measured and filed separately rather than smuggled in
-#                       here. See #2941 for the numbers.
+# ─── Scopes that used to be missing ──────────────────────────────────────────
+# Until #3214 the iOS and web demos shipped 31 and 12 catalogue assets with no
+# bundled-model credits at all (only the audio mirror above). They are now the
+# two JSON scopes in BUNDLED_SCOPES: the iOS copy is in the Xcode Resources
+# build phase and rendered by `CreditsSheet.swift`; the web copy sits next to
+# `site/index.html` and feeds the Credits tab.
 
 
 def repo_relative(p: Path) -> str:
@@ -275,6 +309,11 @@ def catalog_by_basename() -> dict[str, dict]:
         f = e.get("file")
         if f:
             index.setdefault(Path(f).name, e)
+            # The iOS demo bundles the same Poly Haven maps under their
+            # catalogue id (`studio.hdr`), without the `_2k` resolution
+            # suffix the catalogue file carries (`studio_2k.hdr`) — #3214.
+            if e.get("id"):
+                index.setdefault(f"{e['id']}{Path(f).suffix}", e)
     return index
 
 
@@ -433,14 +472,16 @@ def scan_bundled(scope: dict) -> list[Path]:
     base = ROOT / scope["assets_dir"]
     if not base.is_dir():
         return []
+    roots = [base / d for d in scope.get("subdirs", ())] or [base]
+    out_abs = ROOT / scope["out"]
     out: list[Path] = []
-    for p in sorted(base.rglob("*")):
+    for p in sorted(q for r in roots if r.is_dir() for q in r.rglob("*")):
         if not p.is_file():
             continue
         rel = p.relative_to(base).as_posix()
         if any(part.startswith(".") for part in rel.split("/")):
             continue
-        if rel == Path(scope["out"]).name:
+        if p == out_abs:
             continue
         if p.suffix in scope["ignore_suffixes"]:
             continue
@@ -465,7 +506,7 @@ def classify_bundled(scope: dict, index: dict[str, dict]) -> tuple[list, list, l
     for p in scan_bundled(scope):
         rel = p.relative_to(base).as_posix()
         size = p.stat().st_size
-        declared = NON_CATALOG_BUNDLED.get(rel)
+        declared = NON_CATALOG_BUNDLED.get(p.name)
         if declared is not None:
             credited.append((rel, declared, size))
             continue
@@ -578,6 +619,66 @@ def render_bundled_credits(scope: dict, index: dict[str, dict]) -> tuple[str, li
     return "\n".join(lines) + "\n", uncredited
 
 
+def render_bundled_credits_json(scope: dict, index: dict[str, dict]) -> tuple[str, list[str]]:
+    """Machine-readable twin of `render_bundled_credits` (#3214).
+
+    Consumed at runtime by the iOS demo (`CreditsSheet.swift`) and the web
+    demo (Credits tab). Sections follow KIND_ORDER; blanket-licensed assets are
+    folded into their kind with the source's published license and site URL,
+    so a client needs no knowledge of SOURCE_BLANKET_LICENSE to show a
+    complete "by author — license" line. Keys are stable API: renaming one
+    breaks a shipped app, so add, never rename.
+    """
+    credited, blanket, uncredited = classify_bundled(scope, index)
+
+    by_kind: dict[str, list[dict]] = defaultdict(list)
+    for rel, entry, size in credited:
+        lic = (entry.get("license") or "").strip()
+        by_kind[_kind(rel)].append({
+            "file": rel,
+            "name": entry.get("name") or entry.get("id") or Path(rel).name,
+            "author": (entry.get("author") or "").strip(),
+            "license": lic,
+            "licenseUrl": license_url(lic),
+            "sourceUrl": (entry.get("sourceUrl") or "").strip(),
+            "size": size,
+            "note": (entry.get("note") or "").strip(),
+        })
+    for rel, entry, size in blanket:
+        meta = SOURCE_BLANKET_LICENSE[(entry.get("source") or "").lower()]
+        by_kind[_kind(rel)].append({
+            "file": rel,
+            "name": entry.get("name") or entry.get("id") or Path(rel).name,
+            "author": (entry.get("author") or "").strip() or meta["label"],
+            "license": meta["license"],
+            "licenseUrl": meta["licenseUrl"],
+            "sourceUrl": meta["siteUrl"],
+            "size": size,
+            "note": f"{meta['label']} publishes its whole library under {meta['license']}",
+        })
+
+    sections = []
+    for kind in KIND_ORDER:
+        items = sorted(by_kind.get(kind, []), key=lambda a: a["file"])
+        if items:
+            sections.append({"title": kind, "assets": items})
+
+    doc = {
+        "_comment": (
+            "GENERATED FILE — DO NOT EDIT BY HAND. Generated from assets/catalog.json "
+            f"and the contents of {scope['assets_dir']} by "
+            ".claude/scripts/generate-credits.py; `--check` fails on drift."
+        ),
+        "scope": scope["id"],
+        "title": scope["title"],
+        "artefact": scope["artefact"],
+        "source": "assets/catalog.json",
+        "total": len(credited) + len(blanket),
+        "sections": sections,
+    }
+    return json.dumps(doc, indent=2, ensure_ascii=False) + "\n", uncredited
+
+
 def main() -> int:
     # Reject unknown arguments instead of falling through to the write path.
     # `--chekc` must NOT silently regenerate the file and exit 0: that turns
@@ -603,7 +704,10 @@ def main() -> int:
 
     uncredited_all: list[tuple[str, list[str]]] = []
     for scope in BUNDLED_SCOPES:
-        content, uncredited = render_bundled_credits(scope, index)
+        if scope.get("format") == "json":
+            content, uncredited = render_bundled_credits_json(scope, index)
+        else:
+            content, uncredited = render_bundled_credits(scope, index)
         outputs.append((ROOT / scope["out"], content))
         if uncredited:
             uncredited_all.append((scope["id"], uncredited))

--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,9 @@ samples/ios-demo/SceneViewDemo/Views/Demos/GeneratedScenes.swift
 # ── MkDocs ────────────────────────────────────────────────
 docs/.cache/
 docs/site/
-site/
+# Anchored to the root: `samples/web-demo/site/` is a tracked source tree,
+# not a build output, and an unanchored `site/` hid new files there (#3214).
+/site/
 
 # `docs/docs/llms.txt` is a byte-for-byte mirror of the root `llms.txt`,
 # served by mkdocs at `/docs/llms.txt` (issue #899). Committing the mirror

--- a/changelog.d/3214-demo-asset-credits.md
+++ b/changelog.d/3214-demo-asset-credits.md
@@ -1,0 +1,11 @@
+<!-- category: Added -->
+<!-- breaking: false -->
+The iOS and web demos now credit every bundled third-party asset where a user can see it,
+as the Android demo already did. `generate-credits.py` gained two JSON scopes next to the
+Markdown ones — `samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json` (41 assets)
+and `samples/web-demo/site/credits.json` (15 assets) — generated from `assets/catalog.json`
+and gated by the same `--check`, so a bundled file nobody declared fails the gate on every
+platform. The iOS About → Credits sheet lists the bundled models, HDR environments and media
+("by author — license", tap to open the source) above the streamed Sketchfab models it
+already showed; the web demo gets a Credits tab (`#credits` deep link) rendered from
+`credits.json` at runtime.

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		C100000000000000000000F1 /* ARAugmentedFacesDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000F1 /* ARAugmentedFacesDemo.swift */; };
 		C100000000000000000000F2 /* ARDepthOcclusionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000F2 /* ARDepthOcclusionDemo.swift */; };
 		E500000000000000000000F3 /* qrcode.png in Resources */ = {isa = PBXBuildFile; fileRef = E600000000000000000000F3 /* qrcode.png */; };
+		E500000000000000000000F4 /* BundledCredits.json in Resources */ = {isa = PBXBuildFile; fileRef = E600000000000000000000F4 /* BundledCredits.json */; };
 		C100000000000000000000D0 /* ShapeExtrudeDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D0 /* ShapeExtrudeDemo.swift */; };
 		C100000000000000000000D1 /* ReflectionProbesDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D1 /* ReflectionProbesDemo.swift */; };
 		C100000000000000000000D2 /* VideoTextureDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000D2 /* VideoTextureDemo.swift */; };
@@ -269,6 +270,7 @@
 		C200000000000000000000F6 /* ARPlaneNodeDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPlaneNodeDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000F7 /* ARPointCloudDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARPointCloudDemo.swift; sourceTree = "<group>"; };
 		E600000000000000000000F3 /* qrcode.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = qrcode.png; sourceTree = "<group>"; };
+		E600000000000000000000F4 /* BundledCredits.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BundledCredits.json; sourceTree = "<group>"; };
 		C200000000000000000000D0 /* ShapeExtrudeDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeExtrudeDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000D1 /* ReflectionProbesDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionProbesDemo.swift; sourceTree = "<group>"; };
 		C200000000000000000000D2 /* VideoTextureDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTextureDemo.swift; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 			isa = PBXGroup;
 			children = (
 				E600000000000000000000F3 /* qrcode.png */,
+				E600000000000000000000F4 /* BundledCredits.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -761,6 +764,7 @@
 				A10000010000000000000002 /* Assets.xcassets in Resources */,
 				F50000000000000000000001 /* bell.wav in Resources */,
 				E500000000000000000000F3 /* qrcode.png in Resources */,
+				E500000000000000000000F4 /* BundledCredits.json in Resources */,
 				E500000000000000000000D3 /* sample.mp4 in Resources */,
 				D10000000000000000000001 /* game_boy_classic.usdz in Resources */,
 				D10000000000000000000002 /* tree_scene.usdz in Resources */,

--- a/samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json
+++ b/samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json
@@ -1,0 +1,435 @@
+{
+  "_comment": "GENERATED FILE — DO NOT EDIT BY HAND. Generated from assets/catalog.json and the contents of samples/ios-demo/SceneViewDemo by .claude/scripts/generate-credits.py; `--check` fails on drift.",
+  "scope": "ios-demo",
+  "title": "Bundled Asset Credits — SceneView iOS demo",
+  "artefact": "the App Store build",
+  "source": "assets/catalog.json",
+  "total": 41,
+  "sections": [
+    {
+      "title": "3D models",
+      "assets": [
+        {
+          "file": "Models/animated_butterfly.usdz",
+          "name": "Animated Flying Fluttering Butterfly Loop",
+          "author": "LasquetiSpice",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/animated-flying-fluttering-butterfly-loop-80f8d9a6dadc411e89ca366cb0cfb0d9",
+          "size": 3228959,
+          "note": ""
+        },
+        {
+          "file": "Models/audi_tt.usdz",
+          "name": "2007 Audi TT Coupe",
+          "author": "Ddiaz Design",
+          "license": "CC-BY-NC-SA-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/2007-audi-tt-coupe-b548ef872a8b4164a700e5b8cdb85a14",
+          "size": 6817323,
+          "note": ""
+        },
+        {
+          "file": "Models/black_dragon.usdz",
+          "name": "Black Dragon with Idle Animation",
+          "author": "Arturs J",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/black-dragon-with-idle-animation-fb0053a2e59b43868e934c239bf4eb36",
+          "size": 16031277,
+          "note": ""
+        },
+        {
+          "file": "Models/bmw_m3_e30.usdz",
+          "name": "BMW M3 Coupe (E30) 1986",
+          "author": "Lexyc16",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/bmw-m3-coupe-e30-1986-8fa21fe97a6042a2a09e0b09fd546b91",
+          "size": 9669385,
+          "note": ""
+        },
+        {
+          "file": "Models/cyberpunk_car.usdz",
+          "name": "Cyberpunk Car",
+          "author": "4d_Bob",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/cyberpunk-car-b4301ff99d214d16a7a43708a5866bf0",
+          "size": 2928603,
+          "note": ""
+        },
+        {
+          "file": "Models/cyberpunk_character.usdz",
+          "name": "Cyberpunk Character",
+          "author": "Esk",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/cyberpunk-character-019f4b3fd3c74ed0bc6c8dbe9cd50d51",
+          "size": 8152320,
+          "note": ""
+        },
+        {
+          "file": "Models/cyberpunk_hovercar.usdz",
+          "name": "Cyberpunk Hovercar",
+          "author": "Karol Miklas",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/free-cyberpunk-hovercar-3205b1075bb44ffc826bce0c2a04d74c",
+          "size": 3699910,
+          "note": ""
+        },
+        {
+          "file": "Models/earthquake_california.usdz",
+          "name": "August 7, 2024 M5.2 Earthquake in California",
+          "author": "Kyle",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/august-7-2024-m52-earthquake-in-california-9c38a08933154e128bb550246285f9e4",
+          "size": 25335648,
+          "note": ""
+        },
+        {
+          "file": "Models/fantasy_book.usdz",
+          "name": "Medieval Fantasy Book",
+          "author": "Pixel",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/medieval-fantasy-book-06d5a80a04fc4c5ab552759e9a97d91a",
+          "size": 3214600,
+          "note": ""
+        },
+        {
+          "file": "Models/ferrari_f40.usdz",
+          "name": "Ferrari F40",
+          "author": "Black Snow",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/ferrari-f40-52a66c41cfcd4f999fb1b1c49bf24d70",
+          "size": 4264019,
+          "note": ""
+        },
+        {
+          "file": "Models/fiat_punto.usdz",
+          "name": "1995 Fiat Punto GT",
+          "author": "Karol Miklas",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/free-1995-fiat-punto-gt-48db6facb4b64e99b60f36b8c01185e1",
+          "size": 3028932,
+          "note": ""
+        },
+        {
+          "file": "Models/game_boy_classic.usdz",
+          "name": "Game Boy Classic",
+          "author": "JonhyOliver",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/game-boy-classic-0ae80019e6f046168923286d7e628f6f",
+          "size": 5431874,
+          "note": ""
+        },
+        {
+          "file": "Models/khronos_damaged_helmet.usdz",
+          "name": "Damaged Helmet",
+          "author": "KhronosGroup (theblueturtle_)",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DamagedHelmet",
+          "size": 4191290,
+          "note": ""
+        },
+        {
+          "file": "Models/khronos_fox.usdz",
+          "name": "Fox",
+          "author": "PixelMannen (model), tomkranis (rigging & animation)",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/Fox",
+          "size": 139880,
+          "note": ""
+        },
+        {
+          "file": "Models/khronos_lantern.usdz",
+          "name": "Lantern",
+          "author": "Microsoft",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/Lantern",
+          "size": 9356255,
+          "note": ""
+        },
+        {
+          "file": "Models/khronos_toy_car.usdz",
+          "name": "Toy Car",
+          "author": "KhronosGroup",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/ToyCar",
+          "size": 9171863,
+          "note": ""
+        },
+        {
+          "file": "Models/lamborghini_countach.usdz",
+          "name": "2021 Lamborghini Countach LPI 800-4",
+          "author": "Lexyc16",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/2021-lamborghini-countach-lpi-800-4-d76b94884432422b966d1a7f8815afb5",
+          "size": 8965293,
+          "note": ""
+        },
+        {
+          "file": "Models/mercedes_a45_amg.usdz",
+          "name": "Mercedes-Benz A45 AMG 2018",
+          "author": "Lexyc16",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/mercedes-benz-a45-amg-2018-9482f251f9c34a6e91d7777db5934cfc",
+          "size": 9050162,
+          "note": ""
+        },
+        {
+          "file": "Models/mosquito_amber.usdz",
+          "name": "Mosquito in Amber",
+          "author": "Loïc Norgeot",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/mosquito-in-amber-53a61d58c09b4d2ab30e269aa3e22078",
+          "size": 3683955,
+          "note": ""
+        },
+        {
+          "file": "Models/nike_air_jordan.usdz",
+          "name": "Nike Air Jordan",
+          "author": "Ar41k",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/nike-air-jordan-fd462c530d974f33a523d88a7562f1cf",
+          "size": 10820512,
+          "note": ""
+        },
+        {
+          "file": "Models/nintendo_switch.usdz",
+          "name": "Nintendo Switch Diorama",
+          "author": "Mikkel Garde Blaase",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/nintendo-switch-diorama-7bafb356e4f34695954da8fa6cd640b4",
+          "size": 846974,
+          "note": ""
+        },
+        {
+          "file": "Models/phoenix_bird.usdz",
+          "name": "Phoenix Bird",
+          "author": "NORBERTO-3D",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/phoenix-bird-844ba0cf144a413ea92c779f18912042",
+          "size": 1162886,
+          "note": ""
+        },
+        {
+          "file": "Models/porsche_911.usdz",
+          "name": "FREE 1975 Porsche 911 (930) Turbo",
+          "author": "Karol Miklas",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/free-1975-porsche-911-930-turbo-8568d9d14a994b9cae59499f0dbed21e",
+          "size": 12351092,
+          "note": ""
+        },
+        {
+          "file": "Models/porsche_911_turbo.usdz",
+          "name": "1975 Porsche 911 (930) Turbo",
+          "author": "Lionsharp Studios",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/free-1975-porsche-911-930-turbo-8568d9d14a994b9cae59499f0dbed21e",
+          "size": 12351092,
+          "note": ""
+        },
+        {
+          "file": "Models/ps5_dualsense.usdz",
+          "name": "PlayStation 5 DualSense",
+          "author": "AHarmlessPotato",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/playstation-5-dualsense-878c1f882808477ab81c2fe86d5a3936",
+          "size": 3297630,
+          "note": ""
+        },
+        {
+          "file": "Models/red_car.usdz",
+          "name": "A Red Car",
+          "author": "SerjogaSan",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://www.fab.com/listings/c86be43c-3923-4c98-b752-40bedb121239",
+          "size": 241457,
+          "note": ""
+        },
+        {
+          "file": "Models/retro_piano.usdz",
+          "name": "Retro Piano",
+          "author": "DailyArt",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/retro-piano-fd4971cd71564319aa2132266d208185",
+          "size": 1926166,
+          "note": ""
+        },
+        {
+          "file": "Models/shelby_cobra.usdz",
+          "name": "1965 AC Shelby Cobra 427",
+          "author": "vecarz",
+          "license": "CC-BY-NC-SA-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/1965-ac-shelby-cobra-427-wwwvecarzcom-3e9c994c428b44f087d64e738428886c",
+          "size": 5121065,
+          "note": ""
+        },
+        {
+          "file": "Models/ship_in_clouds.usdz",
+          "name": "Ship in Clouds",
+          "author": "Bastien Genbrugge",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/ship-in-clouds-c475323dc7f24e26ba2009c08c8e1941",
+          "size": 6727605,
+          "note": ""
+        },
+        {
+          "file": "Models/tesla_cybertruck.usdz",
+          "name": "Tesla Cybertruck",
+          "author": "hashikemu",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/tesla-cybertruck-657e71b3e2ad468196668e9c9df708fb",
+          "size": 4343008,
+          "note": ""
+        },
+        {
+          "file": "Models/tree_scene.usdz",
+          "name": "Low Poly Tree Scene",
+          "author": "mateustorresg (modified by SceneView — grass-tuft prims removed)",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/low-poly-tree-scene-free-89daa5e21f0d4f08a59dba0d566e88bd",
+          "size": 14146523,
+          "note": ""
+        }
+      ]
+    },
+    {
+      "title": "HDR environments",
+      "assets": [
+        {
+          "file": "Environments/autumn_field.hdr",
+          "name": "Autumn Field",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 4374736,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        },
+        {
+          "file": "Environments/night_sky.hdr",
+          "name": "Night Sky (Dikhololo Night)",
+          "author": "Greg Zaal",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "sourceUrl": "https://polyhaven.com/a/dikhololo_night",
+          "size": 7050455,
+          "note": ""
+        },
+        {
+          "file": "Environments/outdoor_cloudy.hdr",
+          "name": "Outdoor Cloudy",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 6480797,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        },
+        {
+          "file": "Environments/rooftop_night.hdr",
+          "name": "Rooftop Night",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 6509158,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        },
+        {
+          "file": "Environments/studio.hdr",
+          "name": "Studio",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 6470014,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        },
+        {
+          "file": "Environments/studio_warm.hdr",
+          "name": "Studio Warm",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 5930381,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        },
+        {
+          "file": "Environments/sunset.hdr",
+          "name": "Sunset",
+          "author": "Poly Haven",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://polyhaven.com/license",
+          "sourceUrl": "https://polyhaven.com",
+          "size": 4344656,
+          "note": "Poly Haven publishes its whole library under CC0-1.0"
+        }
+      ]
+    },
+    {
+      "title": "Other bundled assets",
+      "assets": [
+        {
+          "file": "Audio/bell.wav",
+          "name": "bell.wav",
+          "author": "SceneView project",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "sourceUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "size": 26538,
+          "note": "Generated locally with ffmpeg (880 Hz sine, 0.6 s) — see `assets/audio/CREDITS.md`"
+        },
+        {
+          "file": "Resources/qrcode.png",
+          "name": "qrcode.png",
+          "author": "SceneView project",
+          "license": "Apache-2.0",
+          "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
+          "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
+          "size": 2006,
+          "note": "QR-like reference pattern drawn for `ARImageDemo`"
+        },
+        {
+          "file": "Videos/sample.mp4",
+          "name": "sample.mp4",
+          "author": "SceneView project",
+          "license": "Apache-2.0",
+          "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
+          "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
+          "size": 529360,
+          "note": "Generated with ffmpeg — 10 s / 1280×720 / H.264 brand animation for `TwoDInThreeDDemo`"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/ios-demo/SceneViewDemo/Views/CreditsSheet.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/CreditsSheet.swift
@@ -1,66 +1,42 @@
 import SwiftUI
 
-/// Sheet presented from the About tab listing every streamed Sketchfab model
-/// the iOS demo app may load, grouped by `SketchfabSlug.category`. Each row
-/// shows the display name, author, license and links to the original
-/// Sketchfab page.
+/// Sheet presented from the About tab crediting every third-party 3D asset
+/// the iOS demo app ships or streams (#1152 Stage 3, #3214).
 ///
-/// **Why this exists.** CC-BY 4.0 — the only Sketchfab license `SampleAssets`
-/// accepts — requires *visible* attribution in the redistributed artefact.
-/// Without this sheet, shipping the streamed models would violate the license.
-/// Mirrors the Android `CreditsSheet.kt` 1:1 (#1152 Stage 3).
+/// **Why this exists.** CC-BY 4.0 — the license on most of the catalogue —
+/// requires *visible* attribution in the redistributed artefact. The App Store
+/// build carries 31 `.usdz` models, 7 HDR environments and a few first-party
+/// media files, and until #3214 none of them was credited anywhere a user
+/// could see. Mirrors the Android `CreditsSheet.kt`.
 ///
-/// Bundled (non-streamed) assets are credited in the project-level
-/// `assets/CREDITS.md`, which is GENERATED from `assets/catalog.json` — never
-/// hand-edit it. That file is a repository artefact and is NOT copied into the
-/// .app: `project.pbxproj` carries `Audio/CREDITS.md` as a file reference only,
-/// not in the Resources build phase, so unlike the Android demo this target
-/// ships no bundled-asset credits of its own. Measured under #2941 and tracked
-/// separately; the gate there covers the repository copies.
+/// Two sources, one sheet:
+///  - **Bundled** — `Resources/BundledCredits.json`, GENERATED from
+///    `assets/catalog.json` by `.claude/scripts/generate-credits.py` and gated
+///    by its `--check` mode. Never hand-edit it; re-run the script after
+///    adding, removing or renaming a bundled asset.
+///  - **Streamed** — `SampleAssets.all`, the curated Sketchfab slugs the demos
+///    download on demand.
 struct CreditsSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    private let orderedCategories = [
-        "solar", "gallery", "animation", "park",
-        "ar_placement", "physics", "materials",
-    ]
+    private let bundled = BundledCredits.load()
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text("Every model below is streamed from Sketchfab under CC-BY 4.0. Tap a row to open the original page.")
+                    Text("SceneView is Apache 2.0. The 3D models, environments and media below keep the license granted by their authors — tap a row to open the original page.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
 
-                    let groups = Dictionary(grouping: SampleAssets.all) { $0.category }
-                    let knownOrder = orderedCategories.filter { groups[$0] != nil }
-                    let remaining = Array(groups.keys).filter { !orderedCategories.contains($0) }.sorted()
-
-                    ForEach(knownOrder + remaining, id: \.self) { category in
-                        if let slugs = groups[category], !slugs.isEmpty {
-                            Text(label(for: category))
-                                .font(.headline)
-                                .foregroundStyle(.tint)
-                                .padding(.top, 4)
-
-                            VStack(spacing: 8) {
-                                ForEach(slugs, id: \.uid) { slug in
-                                    creditsRow(for: slug)
-                                }
-                            }
-                        }
-                    }
-
-                    Text("Bundled (offline) models are credited in the project's assets/CREDITS.md.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 8)
+                    bundledSection
+                    streamedSection
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
             }
-            .navigationTitle("Streamed model credits")
+            .background(SceneViewTheme.surfaceGrouped)
+            .navigationTitle("Credits")
             .navigationBarTitleInline()
             .toolbar {
                 #if os(iOS)
@@ -76,41 +52,148 @@ struct CreditsSheet: View {
         }
     }
 
+    // MARK: - Bundled (generated JSON)
+
     @ViewBuilder
-    private func creditsRow(for slug: SketchfabSlug) -> some View {
-        Link(destination: slug.sketchfabURL) {
-            HStack(spacing: 12) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(Color.accentColor.opacity(0.15))
-                    Image(systemName: "globe")
-                        .font(.title3)
-                        .foregroundStyle(.tint)
+    private var bundledSection: some View {
+        switch bundled {
+        case .success(let credits):
+            sectionHeader("Bundled in this app — \(credits.total) assets")
+            ForEach(credits.sections, id: \.title) { section in
+                Text(section.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+                VStack(spacing: 8) {
+                    ForEach(section.assets, id: \.file) { asset in
+                        creditsRow(
+                            icon: Self.icon(for: section.title),
+                            title: asset.name,
+                            subtitle: "by \(asset.author) — \(asset.license)",
+                            url: URL(string: asset.sourceUrl)
+                        )
+                    }
                 }
-                .frame(width: 40, height: 40)
-                .accessibilityHidden(true)
+            }
+        case .failure(let error):
+            sectionHeader("Bundled in this app")
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+                Text("Bundled asset credits are unavailable in this build (\(error.localizedDescription)). The full list lives in the project's assets/CREDITS.md.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(slug.displayName)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.primary)
-                    Text("by \(slug.author) — CC-BY 4.0")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+    // MARK: - Streamed (Sketchfab)
+
+    private let orderedCategories = [
+        "solar", "gallery", "animation", "park",
+        "ar_placement", "physics", "materials",
+    ]
+
+    @ViewBuilder
+    private var streamedSection: some View {
+        sectionHeader("Streamed from Sketchfab — \(SampleAssets.all.count) models")
+            .padding(.top, 8)
+        Text("Downloaded on demand, all CC-BY 4.0.")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+
+        let groups = Dictionary(grouping: SampleAssets.all) { $0.category }
+        let knownOrder = orderedCategories.filter { groups[$0] != nil }
+        let remaining = Array(groups.keys).filter { !orderedCategories.contains($0) }.sorted()
+
+        ForEach(knownOrder + remaining, id: \.self) { category in
+            if let slugs = groups[category], !slugs.isEmpty {
+                Text(label(for: category))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+
+                VStack(spacing: 8) {
+                    ForEach(slugs, id: \.uid) { slug in
+                        creditsRow(
+                            icon: "globe",
+                            title: slug.displayName,
+                            subtitle: "by \(slug.author) — CC-BY 4.0",
+                            url: slug.sketchfabURL
+                        )
+                    }
                 }
+            }
+        }
+    }
 
-                Spacer(minLength: 4)
+    // MARK: - Building blocks
 
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.headline)
+            .foregroundStyle(.tint)
+            .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private func creditsRow(icon: String, title: String, subtitle: String, url: URL?) -> some View {
+        if let url {
+            Link(destination: url) { rowContent(icon: icon, title: title, subtitle: subtitle, opensLink: true) }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(title), \(subtitle). Opens \(url.host ?? "link").")
+        } else {
+            rowContent(icon: icon, title: title, subtitle: subtitle, opensLink: false)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(title), \(subtitle).")
+        }
+    }
+
+    private func rowContent(icon: String, title: String, subtitle: String, opensLink: Bool) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.15))
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundStyle(.tint)
+            }
+            .frame(width: 40, height: 40)
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 4)
+
+            if opensLink {
                 Image(systemName: "arrow.up.right")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(slug.displayName) by \(slug.author), CC-BY 4.0. Opens Sketchfab.")
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private static func icon(for sectionTitle: String) -> String {
+        switch sectionTitle {
+        case "3D models": return "cube"
+        case "HDR environments": return "sun.max"
+        default: return "doc"
+        }
     }
 
     private func label(for category: String) -> String {
@@ -123,6 +206,57 @@ struct CreditsSheet: View {
         case "physics": return "Physics"
         case "materials": return "Materials"
         default: return category.capitalized
+        }
+    }
+}
+
+// MARK: - BundledCredits.json
+
+/// Decoded shape of `Resources/BundledCredits.json`. Keys are the stable API
+/// of `generate-credits.py`'s JSON scopes: the script adds keys but never
+/// renames them, so optional fields here only ever grow.
+struct BundledCredits: Decodable {
+    struct Section: Decodable {
+        let title: String
+        let assets: [Asset]
+    }
+
+    struct Asset: Decodable {
+        let file: String
+        let name: String
+        let author: String
+        let license: String
+        let licenseUrl: String
+        let sourceUrl: String
+        let size: Int
+        let note: String
+    }
+
+    let scope: String
+    let total: Int
+    let sections: [Section]
+
+    enum LoadError: LocalizedError {
+        case missing
+
+        var errorDescription: String? {
+            switch self {
+            case .missing: return "BundledCredits.json is not in the bundle"
+            }
+        }
+    }
+
+    /// Reads the generated JSON from the main bundle. A missing or malformed
+    /// file is reported, not fatal: the sheet still shows the streamed credits.
+    static func load(bundle: Bundle = .main) -> Result<BundledCredits, Error> {
+        guard let url = bundle.url(forResource: "BundledCredits", withExtension: "json") else {
+            return .failure(LoadError.missing)
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return .success(try JSONDecoder().decode(BundledCredits.self, from: data))
+        } catch {
+            return .failure(error)
         }
     }
 }

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/AboutTab.swift
@@ -11,7 +11,8 @@ struct AboutTab: View {
     }()
 
     // #1152 Stage 3 — Credits sheet (CC-BY attribution for every streamed
-    // Sketchfab model in `SampleAssets`).
+    // Sketchfab model in `SampleAssets`); #3214 — bundled assets too, from
+    // the generated `BundledCredits.json`.
     @State private var showCreditsSheet = false
 
     var body: some View {
@@ -129,7 +130,7 @@ struct AboutTab: View {
                 icon: "person.2.fill",
                 iconColor: .teal,
                 title: "Credits",
-                subtitle: "Authors & CC-BY attribution for every streamed Sketchfab model",
+                subtitle: "Authors & licenses for every bundled and streamed 3D asset",
                 trailing: .chevron,
                 action: { showCreditsSheet = true }
             )

--- a/samples/web-demo/site/credits.json
+++ b/samples/web-demo/site/credits.json
@@ -1,0 +1,175 @@
+{
+  "_comment": "GENERATED FILE — DO NOT EDIT BY HAND. Generated from assets/catalog.json and the contents of samples/web-demo/site by .claude/scripts/generate-credits.py; `--check` fails on drift.",
+  "scope": "web-demo",
+  "title": "Bundled Asset Credits — SceneView web demo",
+  "artefact": "the sceneview.github.io/web-demo deploy",
+  "source": "assets/catalog.json",
+  "total": 15,
+  "sections": [
+    {
+      "title": "3D models",
+      "assets": [
+        {
+          "file": "models/animated_butterfly.glb",
+          "name": "Animated Flying Fluttering Butterfly Loop",
+          "author": "LasquetiSpice",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/animated-flying-fluttering-butterfly-loop-80f8d9a6dadc411e89ca366cb0cfb0d9",
+          "size": 4062652,
+          "note": ""
+        },
+        {
+          "file": "models/animated_dragon.glb",
+          "name": "Animated Dragon Three Motion Loops",
+          "author": "LasquetiSpice",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/animated-dragon-three-motion-loops-eca98cf6cd084c1596cecf716e110c29",
+          "size": 8377076,
+          "note": ""
+        },
+        {
+          "file": "models/bmw_m3_e30.glb",
+          "name": "BMW M3 Coupe (E30) 1986",
+          "author": "Lexyc16",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/bmw-m3-coupe-e30-1986-8fa21fe97a6042a2a09e0b09fd546b91",
+          "size": 10306960,
+          "note": ""
+        },
+        {
+          "file": "models/chronograph_watch.glb",
+          "name": "Chronograph Watch (web demo)",
+          "author": "KhronosGroup",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/ChronographWatch",
+          "size": 7446368,
+          "note": ""
+        },
+        {
+          "file": "models/cyberpunk_character.glb",
+          "name": "Cyberpunk Character",
+          "author": "Esk",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/cyberpunk-character-019f4b3fd3c74ed0bc6c8dbe9cd50d51",
+          "size": 7685048,
+          "note": ""
+        },
+        {
+          "file": "models/ferrari_f40.glb",
+          "name": "Ferrari F40",
+          "author": "Black Snow",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/ferrari-f40-52a66c41cfcd4f999fb1b1c49bf24d70",
+          "size": 8058920,
+          "note": ""
+        },
+        {
+          "file": "models/game_boy_classic.glb",
+          "name": "Game Boy Classic",
+          "author": "JonhyOliver",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/game-boy-classic-0ae80019e6f046168923286d7e628f6f",
+          "size": 2866976,
+          "note": ""
+        },
+        {
+          "file": "models/khronos_damaged_helmet.glb",
+          "name": "Damaged Helmet",
+          "author": "KhronosGroup (theblueturtle_)",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DamagedHelmet",
+          "size": 3773916,
+          "note": ""
+        },
+        {
+          "file": "models/nintendo_switch.glb",
+          "name": "Nintendo Switch Diorama",
+          "author": "Mikkel Garde Blaase",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/nintendo-switch-diorama-7bafb356e4f34695954da8fa6cd640b4",
+          "size": 769040,
+          "note": ""
+        },
+        {
+          "file": "models/phoenix_bird.glb",
+          "name": "Phoenix Bird",
+          "author": "NORBERTO-3D",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/phoenix-bird-844ba0cf144a413ea92c779f18912042",
+          "size": 1630364,
+          "note": ""
+        },
+        {
+          "file": "models/retro_piano.glb",
+          "name": "Retro Piano",
+          "author": "DailyArt",
+          "license": "CC-BY-NC-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+          "sourceUrl": "https://sketchfab.com/3d-models/retro-piano-fd4971cd71564319aa2132266d208185",
+          "size": 4184316,
+          "note": ""
+        },
+        {
+          "file": "models/sheen_chair.glb",
+          "name": "Sheen Chair (web demo)",
+          "author": "KhronosGroup",
+          "license": "CC-BY-4.0",
+          "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+          "sourceUrl": "https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/SheenChair",
+          "size": 4125648,
+          "note": ""
+        },
+        {
+          "file": "models/splats/rainbow_sphere.ply",
+          "name": "rainbow_sphere.ply",
+          "author": "SceneView project",
+          "license": "Apache-2.0",
+          "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
+          "sourceUrl": "https://github.com/sceneview/sceneview/blob/main/LICENSE",
+          "size": 448451,
+          "note": "Generated procedurally by `tools/generate-splat-sphere.py`"
+        }
+      ]
+    },
+    {
+      "title": "HDR environments",
+      "assets": [
+        {
+          "file": "environments/neutral_ibl.ktx",
+          "name": "Neutral IBL (Filament default environment)",
+          "author": "Google LLC — Filament",
+          "license": "Apache-2.0",
+          "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
+          "sourceUrl": "https://github.com/google/filament/tree/main/third_party/environments",
+          "size": 2095464,
+          "note": "Prefiltered KTX environment shipped with Filament, used by the web demo as its default lighting"
+        }
+      ]
+    },
+    {
+      "title": "Other bundled assets",
+      "assets": [
+        {
+          "file": "audio/bell.wav",
+          "name": "bell.wav",
+          "author": "SceneView project",
+          "license": "CC0-1.0",
+          "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "sourceUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+          "size": 26538,
+          "note": "Generated locally with ffmpeg (880 Hz sine, 0.6 s) — see `assets/audio/CREDITS.md`"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/web-demo/site/index.html
+++ b/samples/web-demo/site/index.html
@@ -647,9 +647,57 @@
             color: var(--sv-blue-light);
         }
 
+        /* Credits panel (#3214) — rendered from credits.json, generated from assets/catalog.json */
+        .credits-panel {
+            left: 20px; top: 110px; bottom: 80px;
+            width: 360px;
+            flex-direction: column; gap: 10px;
+            overflow-y: auto;
+        }
+        .credits-intro {
+            font-size: 12px; line-height: 1.5;
+            color: var(--sv-text-dim);
+            background: var(--sv-glass);
+            backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+            border: 1px solid var(--sv-border);
+            border-radius: var(--sv-radius);
+            padding: 12px 14px;
+        }
+        .credits-intro a { color: var(--sv-blue-light); text-decoration: none; font-weight: 500; }
+        .credits-intro a:hover { text-decoration: underline; }
+        .credits-section-title {
+            font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+            color: var(--sv-text-faint);
+            margin: 6px 4px 0;
+        }
+        .credit-card {
+            display: flex; align-items: center; gap: 12px;
+            background: var(--sv-glass);
+            backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+            border: 1px solid var(--sv-border);
+            border-radius: var(--sv-radius);
+            padding: 10px 12px;
+            color: inherit; text-decoration: none;
+            transition: border-color 0.2s;
+        }
+        a.credit-card:hover { border-color: var(--sv-border-hover); }
+        .credit-icon {
+            flex: 0 0 36px; height: 36px;
+            display: flex; align-items: center; justify-content: center;
+            border-radius: var(--sv-radius-sm);
+            background: rgba(0, 91, 193, 0.2);
+            color: var(--sv-blue-light);
+            font-size: 16px;
+        }
+        .credit-body { min-width: 0; flex: 1; }
+        .credit-title { font-size: 13px; font-weight: 600; color: var(--sv-text); }
+        .credit-meta { font-size: 11.5px; color: var(--sv-text-dim); margin-top: 2px; }
+        .credit-meta .credit-license { color: var(--sv-green-light); }
+        .credit-ext { color: var(--sv-text-faint); font-size: 12px; flex: 0 0 auto; }
+
         /* ---- Responsive ---- */
         @media (max-width: 768px) {
-            .search-panel, .geometry-panel {
+            .search-panel, .geometry-panel, .credits-panel {
                 left: 10px; right: 10px; top: auto; bottom: 70px;
                 width: auto; max-height: 45vh;
             }
@@ -713,6 +761,7 @@
         <button class="tab-btn" data-tab="physics">Physics</button>
         <button class="tab-btn" data-tab="audio">Spatial Audio</button>
         <button class="tab-btn" data-tab="settings">Settings</button>
+        <button class="tab-btn" data-tab="credits">Credits</button>
     </nav>
 
     <!-- Models panel -->
@@ -957,6 +1006,18 @@
         </p>
     </div>
 
+    <!-- Credits panel (#3214) — every bundled third-party asset with its author
+         and license. Rendered at runtime from `credits.json`, which is GENERATED
+         from `assets/catalog.json` by `.claude/scripts/generate-credits.py`. -->
+    <div id="panel-credits" class="panel credits-panel">
+        <div class="credits-intro">
+            SceneView is Apache 2.0. The 3D models, environments and media bundled in this
+            demo keep the license granted by their authors — click a card to open the
+            original page. <a href="https://github.com/sceneview/sceneview/blob/main/assets/catalog.json" target="_blank" rel="noopener">Generated from assets/catalog.json</a>.
+        </div>
+        <div id="credits-list"></div>
+    </div>
+
     <!-- Settings panel -->
     <div id="panel-settings" class="panel env-panel">
         <div class="env-card">
@@ -1122,10 +1183,14 @@
         var hash = (location.hash || '').replace('#', '').toLowerCase();
         if (hash === 'double-pendulum' || hash === 'physics') {
           pendingDeepLink = 'physics';
+        } else if (hash === 'credits') {
+          // #3214 — linkable attribution page (README, store listings).
+          pendingDeepLink = 'credits';
         }
         window.addEventListener('hashchange', function() {
           var h = (location.hash || '').replace('#', '').toLowerCase();
           if (h === 'double-pendulum' || h === 'physics') switchTab('physics');
+          if (h === 'credits') switchTab('credits');
         });
       }
 
@@ -1208,6 +1273,96 @@
           });
       }
 
+      // ---- Credits (#3214) ----
+      // `credits.json` sits next to this file and is generated from
+      // `assets/catalog.json`; fetched once, on first visit to the tab.
+
+      var creditsLoaded = false;
+
+      function creditIcon(sectionTitle) {
+        if (sectionTitle === '3D models') return '\u25A3';        // ▣ model
+        if (sectionTitle === 'HDR environments') return '\u2600'; // ☀ lighting
+        return '\u2691';                                          // ⚑ other
+      }
+
+      function sectionLabel(title) {
+        if (title === '3D models') return '3D Models';
+        if (title === 'HDR environments') return 'HDR Environments';
+        return title;
+      }
+
+      function renderCredits(doc) {
+        var list = document.getElementById('credits-list');
+        list.textContent = '';
+        var frag = document.createDocumentFragment();
+        (doc.sections || []).forEach(function(section) {
+          var h = document.createElement('div');
+          h.className = 'credits-section-title';
+          h.textContent = sectionLabel(section.title) + ' (' + section.assets.length + ')';
+          frag.appendChild(h);
+          section.assets.forEach(function(asset) {
+            var card = document.createElement(asset.sourceUrl ? 'a' : 'div');
+            card.className = 'credit-card';
+            if (asset.sourceUrl) {
+              card.href = asset.sourceUrl;
+              card.target = '_blank';
+              card.rel = 'noopener';
+              card.title = asset.file;
+            }
+            var icon = document.createElement('span');
+            icon.className = 'credit-icon';
+            icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = creditIcon(section.title);
+            var body = document.createElement('div');
+            body.className = 'credit-body';
+            var title = document.createElement('div');
+            title.className = 'credit-title';
+            title.textContent = asset.name;
+            var meta = document.createElement('div');
+            meta.className = 'credit-meta';
+            meta.appendChild(document.createTextNode('by ' + asset.author + ' \u2014 '));
+            var lic = document.createElement('span');
+            lic.className = 'credit-license';
+            lic.textContent = asset.license;
+            meta.appendChild(lic);
+            body.appendChild(title);
+            body.appendChild(meta);
+            card.appendChild(icon);
+            card.appendChild(body);
+            if (asset.sourceUrl) {
+              var ext = document.createElement('span');
+              ext.className = 'credit-ext';
+              ext.setAttribute('aria-hidden', 'true');
+              ext.textContent = '\u2197';
+              card.appendChild(ext);
+            }
+            frag.appendChild(card);
+          });
+        });
+        list.appendChild(frag);
+      }
+
+      function loadCredits() {
+        if (creditsLoaded) return;
+        creditsLoaded = true;
+        fetch('credits.json', { cache: 'no-cache' })
+          .then(function(r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.json();
+          })
+          .then(renderCredits)
+          .catch(function(err) {
+            creditsLoaded = false;
+            var list = document.getElementById('credits-list');
+            list.textContent = '';
+            var msg = document.createElement('div');
+            msg.className = 'credits-intro';
+            msg.textContent = 'Credits could not be loaded (' + err.message + '). The full list lives in assets/CREDITS.md on GitHub.';
+            list.appendChild(msg);
+            console.warn('credits.json unavailable:', err);
+          });
+      }
+
       // ---- Tab navigation ----
 
       function setupTabs() {
@@ -1229,7 +1384,7 @@
           var btn = buttons[i];
           btn.classList.toggle('active', btn.getAttribute('data-tab') === tab);
         }
-        var panels = ['models', 'geometry', 'lighting', 'animation', 'text', 'environment', 'physics', 'audio', 'settings'];
+        var panels = ['models', 'geometry', 'lighting', 'animation', 'text', 'environment', 'physics', 'audio', 'settings', 'credits'];
         panels.forEach(function(p) {
           var panel = document.getElementById('panel-' + p);
           if (panel) {
@@ -1243,8 +1398,9 @@
         // Adjust controls-info position — left-anchored panels push it right.
         var sidePanel = (tab === 'models' || tab === 'geometry' || tab === 'physics' ||
                          tab === 'lighting' || tab === 'animation' || tab === 'text' ||
-                         tab === 'audio');
+                         tab === 'audio' || tab === 'credits');
         controlsInfo.style.left = sidePanel ? '380px' : '20px';
+        if (tab === 'credits') loadCredits();
         // The Double Pendulum runs its own physics scene; entering or leaving
         // the Physics tab swaps the scene in/out so it never lingers behind
         // the model viewer.


### PR DESCRIPTION
Closes #3214

## Why

The Android demo ships a generated `CREDITS.md` inside the APK. The iOS demo (31 catalogue `.usdz` models, 7 HDRs) and the web demo (12 GLBs + a splat) shipped their CC-BY assets with no credits surface a user could reach. CC-BY 4.0 §3a requires visible attribution in the redistributed artefact.

## What

**Single source, one generator.** `.claude/scripts/generate-credits.py` gains two JSON bundled scopes next to the Markdown one:

| File | Assets | Consumer |
|---|---|---|
| `samples/ios-demo/SceneViewDemo/Resources/BundledCredits.json` | 41 (31 models, 7 HDR, 3 media) | `CreditsSheet.swift` |
| `samples/web-demo/site/credits.json` | 15 (13 models, 1 IBL, 1 audio) | Credits tab |

Same classification and the same `UNCREDITED` gate as the APK scope; `--check` now fails on drift of either JSON. `NON_CATALOG_BUNDLED` is keyed by basename so one declaration covers every platform; the environment index also matches the iOS `<id>.hdr` names; `neutral_ibl.ktx` (Filament, Apache-2.0) is declared. Existing Markdown outputs are byte-identical.

**iOS** — About → "Credits" card ("Authors & licenses for every bundled and streamed 3D asset") opens a sheet titled Credits: intro, "Bundled in this app — 41 assets" with 3D models / HDR environments / Other bundled assets sections, then "Streamed from Sketchfab". Rows are icon / title / "by author — license", tap opens the source. A fallback card is shown if the JSON is missing. JSON added to the Xcode Resources build phase.

**Web** — new "Credits" tab (`button[data-tab="credits"]`, `#panel-credits`, `#credits` deep link) rendered from `credits.json` at runtime: "3D Models (13)", "HDR Environments (1)", "Other bundled assets (1)", one `.credit-card` per asset, intro + "Generated from assets/catalog.json" link. DESIGN.md tokens via the site's existing variables.

**Housekeeping** — `.gitignore`'s MkDocs `site/` rule is anchored to `/site/`; unanchored it hid new files under `samples/web-demo/site/`.

## Verification

- `python3 .claude/scripts/generate-credits.py --check` → all six outputs in sync.
- Web: served `site/`, opened the Credits tab in Chrome — 15 cards, three section headers, zero console errors (screenshot reviewed).
- iOS: built `SceneViewDemo` for a throwaway `iPhone 17 Pro` / iOS 26.3 simulator clone, opened About → Credits — sheet shows "Bundled in this app — 41 assets" with the generated rows (screenshot reviewed). Clone and DerivedData deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
