### PR TITLE
Close the three sceneview-compose follow-ups left open by #3026

### DIFF
--- a/.claude/scripts/setup-self-hosted-runner.sh
+++ b/.claude/scripts/setup-self-hosted-runner.sh
@@ -34,6 +34,25 @@
 #   verbatim from the `self-hosted-runner` skill, or from
 #   .github/workflows/bridge-ios-compile.yml, which holds the rationale.
 #
+# MACHINE HYGIENE (#3051) — what this script does and does not isolate
+#   The runner is a LaunchAgent in the login user's GUI domain, so a job runs
+#   as that user and inherits its filesystem. What the installer isolates:
+#     - GRADLE_USER_HOME points at ~/sceneview-runner/gradle-home, so CI and
+#       interactive builds never share a cache (a poisoned-cache red is then
+#       attributable to the run that wrote it).
+#   What it deliberately does NOT do, because each is a machine-level decision
+#   the maintainer takes once, outside any script:
+#     - run the runner under a dedicated non-admin macOS user (the installer
+#       needs `gh auth` to mint the registration token, but the *runner* does
+#       not — register from the admin account, then move the LaunchAgent);
+#     - keep `gh` logins and SSH keys out of that user's environment — a
+#       runner never needs to push;
+#     - audit what ~/sceneview-runner/ can read outside itself.
+#   Fork PRs never reach this machine regardless: the workflow expression
+#   routes them to a hosted runner, and the repository's fork-PR approval
+#   policy is `all_external_contributors` (verified 2026-08-22 via
+#   `gh api repos/sceneview/sceneview/actions/permissions/fork-pr-contributor-approval`).
+#
 # USAGE
 #   bash .claude/scripts/setup-self-hosted-runner.sh             # install
 #   bash .claude/scripts/setup-self-hosted-runner.sh --check     # status
@@ -46,6 +65,11 @@ REPO="sceneview/sceneview"
 RUNNER_VERSION="2.334.0"   # baseline; the runner auto-updates after first connect
 RUNNER_LABEL="sceneview-mac"
 RUNNER_HOME="${HOME}/sceneview-runner"
+# CI gets its own Gradle home (#3051): the runner shares the login user's filesystem, and
+# with the default ~/.gradle an interactive build and a CI build read and write the same
+# dependency/distribution cache. A poisoned or half-written cache then produces a red run
+# nothing in the PR explains. Costs one cold download per dependency, once.
+RUNNER_GRADLE_HOME="${RUNNER_HOME}/gradle-home"
 RUNNER_HOME_V2_LEGACY="${HOME}/Library/Application Support/sceneview-runner"
 RUNNER_NAME="sceneview-mac-$(hostname -s)"
 
@@ -255,6 +279,7 @@ cat > "${RUNNER_PLIST}" <<PLIST
   <dict>
     <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key><string>${HOME}</string>
+    <key>GRADLE_USER_HOME</key><string>${RUNNER_GRADLE_HOME}</string>
   </dict>
 </dict>
 </plist>

--- a/changelog.d/3051-compose-followups.md
+++ b/changelog.d/3051-compose-followups.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+A model created while its load was being cancelled no longer leaks. `ModelLoader.loadModel`
+and `loadInstancedModel` hop to the main thread to build the Filament asset, and
+`withContext` drops that result when the caller is cancelled mid-hop — which is exactly
+what `SceneViewer` does on every source swap. The asset is now destroyed on that path, and
+a model cancelled during resource loading is freed instead of sitting in the loader until
+`destroy()`. `SceneViewerError`'s constructor is public, so an app can unit-test its
+`onError` handler without a renderer. The self-hosted runner installer gives CI its own
+`GRADLE_USER_HOME`.

--- a/docs/docs/compose-multiplatform.md
+++ b/docs/docs/compose-multiplatform.md
@@ -95,6 +95,13 @@ refused to parse a buffer) for the suspending `loadModelInstance` (which returns
 the same input). Reporting only exceptions would have made every malformed model fail
 silently — a fix for one defect quietly creating another.
 
+`SceneViewerError` has a public constructor (#3051). The type reaches apps through
+`onError`, so an app must be able to build one to unit-test whatever it renders on
+failure — a retry button should not need a real renderer and a real failed load. The
+constructor was `internal` at merge to keep the door open for extra fields; that door
+stays open through defaulted parameters, which is the usual additive path and costs
+callers nothing.
+
 ## Hard guardrails
 
 These are load-bearing. Breaking one turns a bounded, reversible module into a

--- a/sceneview-compose/api/android/sceneview-compose.api
+++ b/sceneview-compose/api/android/sceneview-compose.api
@@ -137,6 +137,8 @@ public final class io/github/sceneview/compose/ModelSource$Url : io/github/scene
 
 public final class io/github/sceneview/compose/SceneViewerError {
 	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCause ()Ljava/lang/Throwable;
 	public final fun getMessage ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;

--- a/sceneview-compose/api/desktop/sceneview-compose.api
+++ b/sceneview-compose/api/desktop/sceneview-compose.api
@@ -137,6 +137,8 @@ public final class io/github/sceneview/compose/ModelSource$Url : io/github/scene
 
 public final class io/github/sceneview/compose/SceneViewerError {
 	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCause ()Ljava/lang/Throwable;
 	public final fun getMessage ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;

--- a/sceneview-compose/src/commonMain/kotlin/io/github/sceneview/compose/SceneViewerError.kt
+++ b/sceneview-compose/src/commonMain/kotlin/io/github/sceneview/compose/SceneViewerError.kt
@@ -12,6 +12,12 @@ package io.github.sceneview.compose
  * platform log under the `SceneViewer` tag, exactly as before; nothing throws, and the
  * viewport keeps rendering.
  *
+ * The constructor is public so an app can unit-test its own handler — a retry button
+ * rendered from `onError` should not need a real renderer and a real failed load to be
+ * exercised (#3051). Build one with any `message` and an optional `cause`; the fields
+ * are the whole contract, and any future addition will carry a default so existing call
+ * sites keep compiling.
+ *
  * @property message what failed, in English, naming the source — e.g.
  *   `loading asset 'models/helmet.glb'`. Intended for logs and bug reports, not for
  *   display to end users: it is not localised and its wording is not part of the API
@@ -20,7 +26,7 @@ package io.github.sceneview.compose
  *   platform reported a failure without one — a loader returning "no model" rather than
  *   throwing, or an error forwarded from a non-Kotlin renderer.
  */
-public class SceneViewerError internal constructor(
+public class SceneViewerError(
     public val message: String,
     public val cause: Throwable? = null,
 ) {

--- a/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/SceneViewerErrorTest.kt
+++ b/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/SceneViewerErrorTest.kt
@@ -1,0 +1,39 @@
+package io.github.sceneview.compose
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * An app's `onError` handler must be testable without a renderer (#3051): this file is
+ * the proof that the type reaching it can be built from app code, in common code, with
+ * nothing but a message.
+ */
+class SceneViewerErrorTest {
+
+    @Test
+    fun app_code_can_construct_one_with_a_message_only() {
+        val error = SceneViewerError("loading asset 'models/helmet.glb'")
+        assertEquals("loading asset 'models/helmet.glb'", error.message)
+        assertNull(error.cause)
+        assertEquals("SceneViewerError(loading asset 'models/helmet.glb')", error.toString())
+    }
+
+    @Test
+    fun cause_is_carried_through() {
+        val cause = IllegalStateException("boom")
+        val error = SceneViewerError("downloading https://x/m.glb", cause)
+        assertSame(cause, error.cause)
+        assertEquals("SceneViewerError(downloading https://x/m.glb, cause=$cause)", error.toString())
+    }
+
+    @Test
+    fun a_handler_can_be_exercised_without_a_renderer() {
+        var retryShown = false
+        val onError: (SceneViewerError) -> Unit = { retryShown = true }
+        onError(SceneViewerError("parsing 12 in-memory bytes"))
+        assertTrue(retryShown)
+    }
+}

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -17,9 +17,12 @@ import io.github.sceneview.model.ModelInstance
 import io.github.sceneview.safeDestroyModel
 import io.github.sceneview.utils.loadFileBuffer
 import io.github.sceneview.utils.readBuffer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -141,12 +144,14 @@ class ModelLoader(
     ): Model? = context.loadFileBuffer(fileLocation)?.let { buffer ->
         // Transcoding decodes and re-encodes images: keep it off the main thread.
         val source = withContext(Dispatchers.Default) { buffer.transcodeWebPTextures() }
-        val model = withContext(Dispatchers.Main) {
+        val model = createOrDestroyOnCancel(::destroyModel) {
             assetLoader.createAsset(source)
         } ?: return@let null
         models += model
-        loadResourcesSuspended(model) { resourceFileName: String ->
-            context.loadFileBuffer(resourceResolver(resourceFileName))
+        destroyOnCancel(model, ::destroyModel) {
+            loadResourcesSuspended(model) { resourceFileName: String ->
+                context.loadFileBuffer(resourceResolver(resourceFileName))
+            }
         }
         model
     }
@@ -373,12 +378,14 @@ class ModelLoader(
     ): List<ModelInstance> = context.loadFileBuffer(fileLocation)?.let { buffer ->
         val instances = arrayOfNulls<ModelInstance>(count)
         val source = withContext(Dispatchers.Default) { buffer.transcodeWebPTextures() }
-        val model = withContext(Dispatchers.Main) {
+        val model = createOrDestroyOnCancel(::destroyModel) {
             assetLoader.createInstancedAsset(source, instances)
         } ?: throw IllegalArgumentException("Failed to parse glTF model from buffer")
         models += model
-        loadResourcesSuspended(model) { resourceFileName: String ->
-            context.loadFileBuffer(resourceResolver(resourceFileName))
+        destroyOnCancel(model, ::destroyModel) {
+            loadResourcesSuspended(model) { resourceFileName: String ->
+                context.loadFileBuffer(resourceResolver(resourceFileName))
+            }
         }
         instances.filterNotNull()
     } ?: listOf()
@@ -501,6 +508,59 @@ class ModelLoader(
     companion object {
         fun getFolderPath(baseFileName: String, resourceFileName: String) =
             "${baseFileName.substringBeforeLast("/")}/$resourceFileName"
+    }
+}
+
+/**
+ * Runs [create] on [dispatcher] and returns its result — unless the caller was cancelled
+ * in the meantime, in which case the result is handed to [destroy] before the
+ * [CancellationException] propagates.
+ *
+ * This closes the window described in #3051: `withContext` delivers its result through
+ * a cancellable resume, so a coroutine cancelled while the main-thread block is running
+ * (or while the hop back is queued) resumes with [CancellationException] and the value
+ * the block returned is dropped on the floor. For a Filament asset that value is a live
+ * GPU-side model nothing else references — `rememberModelInstance` in `sceneview-compose`
+ * swaps sources by cancelling the producer, which is exactly this sequence. The block
+ * itself never starts once the caller is cancelled, so [created] is either unset or
+ * holds the one value that would otherwise leak.
+ *
+ * The dispatcher is a parameter only so the mechanism can be pinned in a JVM unit test;
+ * production callers leave it on [Dispatchers.Main], the Filament JNI contract.
+ */
+internal suspend fun <T : Any> createOrDestroyOnCancel(
+    destroy: (T) -> Unit,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    create: () -> T?,
+): T? {
+    var created: T? = null
+    try {
+        return withContext(dispatcher) { create()?.also { created = it } }
+    } catch (cancellation: CancellationException) {
+        created?.let { withContext(NonCancellable + dispatcher) { destroy(it) } }
+        throw cancellation
+    }
+}
+
+/**
+ * Runs [block] and, if it is cancelled, destroys [created] — the model a load has
+ * already built but not yet returned to the caller — before rethrowing.
+ *
+ * Resource loading suspends once per external buffer; a source swap that lands there
+ * would otherwise leave the half-loaded model in [ModelLoader]'s list until the loader
+ * is destroyed, with no caller holding a handle to free it earlier.
+ */
+internal suspend fun <T : Any> destroyOnCancel(
+    created: T,
+    destroy: (T) -> Unit,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    block: suspend () -> Unit,
+) {
+    try {
+        block()
+    } catch (cancellation: CancellationException) {
+        withContext(NonCancellable + dispatcher) { destroy(created) }
+        throw cancellation
     }
 }
 

--- a/sceneview/src/test/java/io/github/sceneview/loaders/ModelLoaderCancellationTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/loaders/ModelLoaderCancellationTest.kt
@@ -1,0 +1,156 @@
+package io.github.sceneview.loaders
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression contract for #3051 item 1 — a model created on the main thread but never
+ * returned to a caller cancelled mid-flight must still be destroyed.
+ *
+ * A real `ModelLoader` needs a Filament `Engine`, so what is exercised here is the helper
+ * `loadModel` / `loadInstancedModel` route their creation through, on a single-thread
+ * dispatcher standing in for `Dispatchers.Main`. The first test is the premise, measured:
+ * `withContext` discards its block's result when the caller is cancelled while the block
+ * runs. Without that fact the helper would be dead code.
+ */
+class ModelLoaderCancellationTest {
+
+    private val executor = Executors.newSingleThreadExecutor()
+    private val main = executor.asCoroutineDispatcher()
+
+    @After
+    fun tearDown() {
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun `premise - a bare withContext drops the value created before cancellation`() = runBlocking {
+        val blockEntered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        var created: String? = null
+        var returned: String? = null
+
+        val job = launch(Dispatchers.Default) {
+            returned = withContext(main) {
+                blockEntered.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                "model".also { created = it }
+            }
+        }
+        assertTrue(blockEntered.await(5, TimeUnit.SECONDS))
+        job.cancel()
+        release.countDown()
+        job.join()
+
+        assertEquals("The block did finish and did build the value", "model", created)
+        assertNull("The caller never sees the value — this is the leak window", returned)
+    }
+
+    @Test
+    fun `createOrDestroyOnCancel destroys the value the cancelled caller never received`() =
+        runBlocking {
+            val destroyed = mutableListOf<String>()
+            val blockEntered = CountDownLatch(1)
+            val release = CountDownLatch(1)
+            var returned: String? = null
+            var cancelled = false
+
+            val job = launch(Dispatchers.Default) {
+                try {
+                    returned = createOrDestroyOnCancel(destroy = { destroyed += it }, dispatcher = main) {
+                        blockEntered.countDown()
+                        release.await(5, TimeUnit.SECONDS)
+                        "model"
+                    }
+                } catch (e: CancellationException) {
+                    cancelled = true
+                    throw e
+                }
+            }
+            assertTrue(blockEntered.await(5, TimeUnit.SECONDS))
+            job.cancel()
+            release.countDown()
+            job.join()
+
+            assertTrue("CancellationException must still propagate", cancelled)
+            assertNull(returned)
+            assertEquals(listOf("model"), destroyed)
+        }
+
+    @Test
+    fun `createOrDestroyOnCancel returns the value and destroys nothing when not cancelled`() =
+        runBlocking {
+            val destroyed = mutableListOf<String>()
+            val returned = createOrDestroyOnCancel(destroy = { destroyed += it }, dispatcher = main) {
+                "model"
+            }
+            assertEquals("model", returned)
+            assertTrue(destroyed.isEmpty())
+        }
+
+    @Test
+    fun `createOrDestroyOnCancel passes a null result through untouched`() = runBlocking {
+        val destroyed = mutableListOf<String>()
+        val returned = createOrDestroyOnCancel<String>(destroy = { destroyed += it }, dispatcher = main) {
+            null
+        }
+        assertNull(returned)
+        assertTrue(destroyed.isEmpty())
+    }
+
+    @Test
+    fun `createOrDestroyOnCancel destroys nothing when cancelled before the block ran`() =
+        runBlocking {
+            val destroyed = mutableListOf<String>()
+            var blockRan = false
+            val job = launch(Dispatchers.Default, start = CoroutineStart.LAZY) {
+                createOrDestroyOnCancel(destroy = { destroyed += it }, dispatcher = main) {
+                    blockRan = true
+                    "model"
+                }
+            }
+            job.cancel()
+            job.join()
+            assertFalse(blockRan)
+            assertTrue(destroyed.isEmpty())
+        }
+
+    @Test
+    fun `destroyOnCancel frees a created model when resource loading is cancelled`() =
+        runBlocking {
+            val destroyed = mutableListOf<String>()
+            val entered = CountDownLatch(1)
+            val job = launch(Dispatchers.Default) {
+                destroyOnCancel("model", destroy = { destroyed += it }, dispatcher = main) {
+                    entered.countDown()
+                    delay(10_000)
+                }
+            }
+            assertTrue(entered.await(5, TimeUnit.SECONDS))
+            job.cancel()
+            job.join()
+            assertEquals(listOf("model"), destroyed)
+        }
+
+    @Test
+    fun `destroyOnCancel leaves a model alone when resource loading completes`() = runBlocking {
+        val destroyed = mutableListOf<String>()
+        destroyOnCancel("model", destroy = { destroyed += it }, dispatcher = main) { }
+        assertTrue(destroyed.isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #3051

Each of the three follow-ups was re-checked against `origin/main` (`d08082411b`) before
anything was written. Two were real and are fixed here; the third was half done already
and gets the half a script can own.

### 1 — Model leak when a source swap cancels a load mid-flight: confirmed, fixed in `ModelLoader`

The issue placed any real window inside `ModelLoader.loadModelInstance`, around its
`withContext(Dispatchers.Main)` hop — and that is where it is. `withContext` delivers its
result through a cancellable resume: when the caller is cancelled while the main-thread
block runs (or while the hop back is queued), the caller resumes with
`CancellationException` and **the value the block returned is dropped**. For
`assetLoader.createAsset(source)` that value is a live GPU-side model held by nothing but
the loader's internal list, so it survives until `ModelLoader.destroy()`. `SceneViewer`
swaps sources by cancelling the `produceState` producer, which is exactly this sequence.

The premise is measured, not argued: the first test in `ModelLoaderCancellationTest`
drives a bare `withContext` on a single-thread stand-in for Main, cancels the caller while
the block runs, and asserts the block finished *and* the caller got `null`.

Fix, in `sceneview/` (not `sceneview-compose`, as the issue predicted):

- `createOrDestroyOnCancel` wraps the main-thread creation, captures the created value from
  inside the block, and on `CancellationException` destroys it under `NonCancellable + Main`
  before rethrowing. The block never starts once the caller is cancelled, so the capture is
  either unset or the one value that would otherwise leak.
- `destroyOnCancel` covers the second window: `loadResourcesSuspended` suspends once per
  external buffer, and a cancellation there left the model in `models` with no caller able
  to free it earlier than `destroy()`.
- Both `loadModel` and `loadInstancedModel` use them. `destroyModel` already removes from
  `models`, so there is no double-free on the `clear()` path.

No public API change in `:sceneview` (the helpers are `internal`; the dispatcher parameter
exists only so a JVM test can pin the mechanism). `orReport` in `sceneview-compose` still
rethrows `CancellationException`, unchanged.

### 2 — `SceneViewerError`'s `internal` constructor: made public (additive)

Still `internal` on main. The option taken is the middle one from the issue: a public
constructor taking exactly `message` and an optional `cause`. The "keep the door open"
argument for `internal` is preserved by the usual additive path — any future field carries
a default — so the constructor costs nothing and apps can unit-test their `onError`
handler without a renderer. KDoc and `docs/docs/compose-multiplatform.md` now say so.

`apiDump` regenerated for both `android` and `desktop` dumps (two added lines each, the
constructor and its synthetic defaults overload); `apiCheck` green. A new
`SceneViewerErrorTest` in `commonTest` constructs one from common code and runs a handler
against it.

### 3 — Machine hygiene for the self-hosted runner: the click is already done, the script now owns its half

The item the issue called the single highest-value one is already in place:
`gh api repos/sceneview/sceneview/actions/permissions/fork-pr-contributor-approval` →
`{"approval_policy":"all_external_contributors"}`. Nothing to do there.

Of the four machine-level points, one is a script concern and is implemented: the runner
LaunchAgent now sets `GRADLE_USER_HOME=~/sceneview-runner/gradle-home`, so CI and
interactive work never share a Gradle cache and a poisoned-cache red is attributable. The
other three (dedicated non-admin user, no `gh`/SSH in its environment, auditing what
`~/sceneview-runner/` can read) are decisions a maintainer takes once on the machine, not
things an installer should silently do to a daily driver; they are now written into the
script header as the explicit remaining list, with the reason the installer cannot do the
user switch itself (it needs `gh auth` for the registration token; the runner does not).
This is a change to what `setup-self-hosted-runner.sh` will install on its *next* run — it
has not been re-run on `sceneview-mac` from this branch.

### Verification

All local, no device, no emulator (`df -h /` → 18 Gi free before building):

- `./gradlew --no-daemon --no-configuration-cache :sceneview-compose:apiDump` then
  `:sceneview-compose:apiCheck :sceneview-compose:compileReleaseKotlinAndroid
  :sceneview-compose:compileKotlinDesktop :sceneview-compose:desktopTest
  :sceneview-compose:testReleaseUnitTest :sceneview:compileReleaseKotlin
  :sceneview:testDebugUnitTest --tests 'io.github.sceneview.loaders.*'` → green.
- `ModelLoaderCancellationTest`: 7 tests, 0 failures, 0 skipped (premise + fix in both
  directions + the cancelled-before-start and not-cancelled cases).
- `SceneViewerErrorTest`: 3 tests, 0 failures, on both desktop and android unit-test targets.
- `:sceneview-compose:detekt :sceneview:detekt` → 0 findings.
- `bash -n .claude/scripts/setup-self-hosted-runner.sh` OK; `check-sceneview-skill.sh` passes.
- iOS targets not compiled locally; the only iOS-facing change is the constructor visibility,
  whose existing call site `SceneViewerError(message)` in `SceneViewer.ios.kt` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
