### PR TITLE
MCP gateway negotiates protocol 2025-06-18 and tools declare output schemas

### DIFF
--- a/changelog.d/3192-mcp-protocol-output-schema.md
+++ b/changelog.d/3192-mcp-protocol-output-schema.md
@@ -1,0 +1,3 @@
+<!-- category: Changed -->
+
+Advertise MCP protocol revision 2025-06-18 and expose schema-validated structured output for gateway tools that return structured data.

--- a/mcp-gateway/src/mcp/session.ts
+++ b/mcp-gateway/src/mcp/session.ts
@@ -1,7 +1,7 @@
 /**
  * MCP session management on top of Workers KV.
  *
- * The Streamable HTTP transport (spec 2025-03-26) assigns each logical
+ * The Streamable HTTP transport (spec 2025-06-18) assigns each logical
  * client session a server-generated identifier that is echoed back on
  * every subsequent request through the `Mcp-Session-Id` header. This
  * module provides the small surface needed by `transport.ts`:
@@ -25,6 +25,8 @@ export interface SessionState {
   id: string;
   /** Whether the client has completed the MCP `initialize` handshake. */
   initialized: boolean;
+  /** Protocol revision selected during `initialize`. */
+  protocolVersion?: string;
   /** Optional client info captured during `initialize`. */
   clientInfo?: {
     name?: string;

--- a/mcp-gateway/src/mcp/transport.ts
+++ b/mcp-gateway/src/mcp/transport.ts
@@ -1,5 +1,5 @@
 /**
- * MCP Streamable HTTP transport (spec 2025-03-26) — minimal server impl.
+ * MCP Streamable HTTP transport (spec 2025-06-18) — minimal server impl.
  *
  * This module is intentionally decoupled from Hono: it consumes a
  * plain `Request` and returns a plain `Response`, so it can be mounted
@@ -29,7 +29,7 @@
  *   - Per-request cancellation.
  *
  * References:
- *   - https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+ *   - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
  *   - https://www.jsonrpc.org/specification
  */
 
@@ -110,10 +110,10 @@ const SERVER_INFO = {
 } as const;
 
 /**
- * MCP protocol version we speak. Must match the 2025-03-26 revision
- * because that is the one implementing Streamable HTTP.
+ * Protocol revisions implemented by this server, newest first.
  */
-const PROTOCOL_VERSION = "2025-03-26";
+export const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26"] as const;
+export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
 
 /** Default origins always allowed even when a caller passes an allowlist. */
 const DEFAULT_ORIGIN_ALLOWLIST = [
@@ -210,6 +210,33 @@ export async function handleMcpRequest(
     }, session);
   }
 
+  // `initialize` negotiates versions in its JSON body. Every later
+  // Streamable HTTP request may carry MCP-Protocol-Version; reject an
+  // explicit version this server does not implement. As in the reference
+  // SDK, an absent header is accepted for backwards compatibility and the
+  // session's negotiated version remains in force.
+  if (req.method !== "initialize") {
+    const protocolVersion = request.headers.get("mcp-protocol-version");
+    if (
+      protocolVersion !== null &&
+      !SUPPORTED_PROTOCOL_VERSIONS.includes(
+        protocolVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number],
+      )
+    ) {
+      return httpJson(
+        {
+          jsonrpc: "2.0",
+          id: req.id ?? null,
+          error: {
+            code: -32000,
+            message: `Bad Request: Unsupported protocol version: ${protocolVersion} (supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")})`,
+          },
+        },
+        400,
+      );
+    }
+  }
+
   // Notifications have no `id` and must not produce a JSON-RPC reply.
   const isNotification = req.id === undefined;
 
@@ -303,6 +330,15 @@ function handleInitialize(
   session: SessionState,
 ): unknown {
   const params = (req.params ?? {}) as Record<string, unknown>;
+  const requestedVersion = params.protocolVersion;
+  const protocolVersion =
+    typeof requestedVersion === "string" &&
+    SUPPORTED_PROTOCOL_VERSIONS.includes(
+      requestedVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number],
+    )
+      ? requestedVersion
+      : PROTOCOL_VERSION;
+  session.protocolVersion = protocolVersion;
   const clientInfo = params.clientInfo as
     | { name?: string; version?: string }
     | undefined;
@@ -314,7 +350,7 @@ function handleInitialize(
     };
   }
   return {
-    protocolVersion: PROTOCOL_VERSION,
+    protocolVersion,
     capabilities: {
       tools: { listChanged: false },
       // Resources advertise the OpenAI Apps SDK widget templates served
@@ -517,7 +553,7 @@ function corsPreflight(): Response {
       "access-control-allow-origin": "*",
       "access-control-allow-methods": "POST, OPTIONS",
       "access-control-allow-headers":
-        "content-type, authorization, mcp-session-id",
+        "content-type, authorization, mcp-session-id, mcp-protocol-version",
       "access-control-max-age": "600",
     },
   });

--- a/mcp-gateway/src/mcp/types.ts
+++ b/mcp-gateway/src/mcp/types.ts
@@ -24,6 +24,7 @@ export interface ToolTextContent {
 /** Result returned by every SceneView MCP tool handler. */
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -45,6 +46,13 @@ export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+    additionalProperties?: boolean;
+  };
+  /** JSON Schema for the machine-readable `structuredContent` result. */
+  outputSchema?: {
     type: "object";
     properties?: Record<string, unknown>;
     required?: string[];

--- a/mcp-gateway/src/mcp/widget-tools.ts
+++ b/mcp-gateway/src/mcp/widget-tools.ts
@@ -68,6 +68,19 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["modelUrl"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        modelUrl: { type: "string" },
+        title: { type: "string" },
+        autoRotate: { type: "boolean" },
+        ar: { type: "boolean" },
+        alt: { type: "string" },
+        posterUrl: { type: "string" },
+      },
+      required: ["modelUrl", "title", "autoRotate", "ar", "alt"],
+      additionalProperties: false,
+    },
     annotations: {
       readOnlyHint: true,
       // The model URL is fetched by the user's browser inside the widget
@@ -134,9 +147,14 @@ export async function dispatchTool(
       // structuredContent is what the widget reads via the MCP Apps bridge.
       // Adding it as a custom field on ToolResult — non-breaking because
       // every consumer treats unknown ToolResult keys as opaque.
-      ...({
-        structuredContent: { modelUrl, title, autoRotate, ar, alt, posterUrl },
-      } as Record<string, unknown>),
+      structuredContent: {
+        modelUrl,
+        title,
+        autoRotate,
+        ar,
+        alt,
+        ...(posterUrl === undefined ? {} : { posterUrl }),
+      },
     };
   }
 

--- a/mcp-gateway/test/registry.test.ts
+++ b/mcp-gateway/test/registry.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation";
 import {
   dispatch,
   getAllTools,
@@ -115,6 +117,38 @@ describe("registry — getToolDefinition", () => {
 });
 
 describe("registry — dispatch", () => {
+  it("every declared outputSchema validates its handler's sample result", async () => {
+    const samples: Record<string, Record<string, unknown>> = {
+      view_3d_model: {
+        modelUrl: "https://example.com/chair.glb",
+        title: "Chair",
+        autoRotate: false,
+        ar: true,
+        alt: "A chair",
+        posterUrl: "https://example.com/chair.webp",
+      },
+    };
+    const validatorProvider = new AjvJsonSchemaValidator();
+    const definitions = getAllTools().filter((tool) => tool.outputSchema);
+
+    expect(definitions.map((tool) => tool.name)).toEqual(
+      Object.keys(samples),
+    );
+    for (const definition of definitions) {
+      const result = await dispatch(definition.name, samples[definition.name]);
+      expect(result.isError, definition.name).toBeFalsy();
+      expect(result.structuredContent, definition.name).toBeDefined();
+      const validate = validatorProvider.getValidator(
+        definition.outputSchema! as JsonSchemaType,
+      );
+      const validation = validate(result.structuredContent);
+      expect(
+        validation.valid,
+        `${definition.name}: ${validation.errorMessage}`,
+      ).toBe(true);
+    }
+  });
+
   it("routes a sceneview-mcp call to the sceneview library", async () => {
     const result = await dispatch("get_migration_guide", undefined);
     expect(result.isError).toBeFalsy();

--- a/mcp-gateway/test/registry.test.ts
+++ b/mcp-gateway/test/registry.test.ts
@@ -119,6 +119,26 @@ describe("registry — getToolDefinition", () => {
 describe("registry — dispatch", () => {
   it("every declared outputSchema validates its handler's sample result", async () => {
     const samples: Record<string, Record<string, unknown>> = {
+      render_3d_preview: {
+        modelUrl: "https://example.com/chair.glb",
+        title: "Chair",
+      },
+      create_3d_artifact: {
+        type: "model-viewer",
+        modelUrl: "https://example.com/chair.glb",
+        title: "Chair",
+      },
+      list_platforms: {},
+      setup_rerun_project: { platform: "python" },
+      embed_web_viewer: { rrdUrl: "https://example.com/session.rrd" },
+      list_car_models: {},
+      validate_automotive_code: { code: "@Composable fun Car() {}" },
+      list_game_models: {},
+      validate_game_code: { code: "@Composable fun Game() {}" },
+      list_medical_models: {},
+      validate_medical_code: { code: "@Composable fun Anatomy() {}" },
+      list_furniture_models: {},
+      validate_interior_code: { code: "@Composable fun Room() {}" },
       view_3d_model: {
         modelUrl: "https://example.com/chair.glb",
         title: "Chair",
@@ -131,8 +151,8 @@ describe("registry — dispatch", () => {
     const validatorProvider = new AjvJsonSchemaValidator();
     const definitions = getAllTools().filter((tool) => tool.outputSchema);
 
-    expect(definitions.map((tool) => tool.name)).toEqual(
-      Object.keys(samples),
+    expect(definitions.map((tool) => tool.name).sort()).toEqual(
+      Object.keys(samples).sort(),
     );
     for (const definition of definitions) {
       const result = await dispatch(definition.name, samples[definition.name]);

--- a/mcp-gateway/test/transport.test.ts
+++ b/mcp-gateway/test/transport.test.ts
@@ -146,7 +146,20 @@ describe("transport: tools/list", () => {
     const result = body.result as {
       tools: { name: string; outputSchema?: unknown }[];
     };
-    expect(result.tools.filter((tool) => tool.outputSchema).map((tool) => tool.name)).toEqual([
+    expect(result.tools.filter((tool) => tool.outputSchema).map((tool) => tool.name).sort()).toEqual([
+      "create_3d_artifact",
+      "embed_web_viewer",
+      "list_car_models",
+      "list_furniture_models",
+      "list_game_models",
+      "list_medical_models",
+      "list_platforms",
+      "render_3d_preview",
+      "setup_rerun_project",
+      "validate_automotive_code",
+      "validate_game_code",
+      "validate_interior_code",
+      "validate_medical_code",
       "view_3d_model",
     ]);
   });

--- a/mcp-gateway/test/transport.test.ts
+++ b/mcp-gateway/test/transport.test.ts
@@ -57,6 +57,38 @@ describe("transport: initialize handshake", () => {
     expect(result.serverInfo.name).toBe("sceneview-mcp-gateway");
   });
 
+  it("negotiates the latest supported version when the client version is unknown", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2099-01-01" },
+      }),
+      { kv: new MockKv().asKv() },
+    );
+    const body = await asJsonRpc(res);
+    expect((body.result as { protocolVersion: string }).protocolVersion).toBe(
+      "2025-06-18",
+    );
+  });
+
+  it("accepts the latest supported client version", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      }),
+      { kv: new MockKv().asKv() },
+    );
+    const body = await asJsonRpc(res);
+    expect((body.result as { protocolVersion: string }).protocolVersion).toBe(
+      "2025-06-18",
+    );
+  });
+
   it("acknowledges the initialized notification with 202 and no body", async () => {
     const kv = new MockKv();
     const res = await handleMcpRequest(
@@ -104,9 +136,47 @@ describe("transport: tools/list", () => {
     const plain = result.tools.find((t) => t.name === "list_samples");
     expect(plain?._meta).toBeUndefined();
   });
+
+  it("advertises outputSchema only for structured tools", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      { kv: new MockKv().asKv() },
+    );
+    const body = await asJsonRpc(res);
+    const result = body.result as {
+      tools: { name: string; outputSchema?: unknown }[];
+    };
+    expect(result.tools.filter((tool) => tool.outputSchema).map((tool) => tool.name)).toEqual([
+      "view_3d_model",
+    ]);
+  });
 });
 
 describe("transport: tools/call", () => {
+  it("returns schema-matching structuredContent for a structured tool", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "view_3d_model",
+          arguments: { modelUrl: "https://example.com/chair.glb" },
+        },
+      }),
+      { kv: new MockKv().asKv() },
+    );
+    const body = await asJsonRpc(res);
+    const result = body.result as { structuredContent?: Record<string, unknown> };
+    expect(result.structuredContent).toMatchObject({
+      modelUrl: "https://example.com/chair.glb",
+      title: "3D model",
+      autoRotate: true,
+      ar: true,
+      alt: "3D model",
+    });
+  });
+
   it("routes to the sceneview-mcp handler for a known free tool", async () => {
     const kv = new MockKv();
     const res = await handleMcpRequest(
@@ -287,6 +357,48 @@ describe("transport: origin validation", () => {
 });
 
 describe("transport: HTTP-level protections", () => {
+  it("accepts a supported MCP-Protocol-Version header", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { "mcp-protocol-version": "2025-06-18" },
+      ),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts an absent MCP-Protocol-Version header for compatibility", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an unsupported MCP-Protocol-Version header with HTTP 400", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { "mcp-protocol-version": "2099-01-01" },
+      ),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(400);
+    const body = await asJsonRpc(res);
+    expect(body.error?.message).toContain("Unsupported protocol version");
+  });
+
+  it("allows MCP-Protocol-Version in CORS preflight", async () => {
+    const res = await handleMcpRequest(
+      new Request("https://example.com/mcp", { method: "OPTIONS" }),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.headers.get("access-control-allow-headers")).toContain(
+      "mcp-protocol-version",
+    );
+  });
+
   it("returns 405 for non-POST/GET methods", async () => {
     const kv = new MockKv();
     const res = await handleMcpRequest(

--- a/mcp/packages/automotive/src/tools.ts
+++ b/mcp/packages/automotive/src/tools.ts
@@ -90,6 +90,7 @@ export interface ToolTextContent {
 
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -109,6 +110,7 @@ export interface ToolDefinition {
     required?: string[];
     additionalProperties?: boolean;
   };
+  outputSchema?: { type: "object"; properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
   /** MCP behaviour hints — see mcp/src/tools/types.ts for the full rationale. */
   annotations?: ToolAnnotations;
 }
@@ -421,6 +423,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: [],
     },
+    outputSchema: { type: "object", properties: { models: { type: "array", items: { type: "object", properties: { id: { type: "string" }, name: { type: "string" }, category: { type: "string" }, source: { type: "string" }, sourceUrl: { type: "string" }, format: { type: "string" }, license: { type: "string" }, description: { type: "string" }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "name", "category", "source", "sourceUrl", "format", "license", "description", "tags"], additionalProperties: false } } }, required: ["models"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -441,6 +444,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["code"],
     },
+    outputSchema: { type: "object", properties: { valid: { type: "boolean" }, issues: { type: "array", items: { type: "object", properties: { severity: { type: "string" }, message: { type: "string" }, line: { type: "number" } }, required: ["severity", "message"], additionalProperties: false } }, issueCount: { type: "object", properties: { errors: { type: "number" }, warnings: { type: "number" }, info: { type: "number" } }, required: ["errors", "warnings", "info"], additionalProperties: false } }, required: ["valid", "issues", "issueCount"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -841,6 +845,7 @@ export async function dispatchTool(
 
       return {
         content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { models },
       };
     }
 
@@ -859,6 +864,7 @@ export async function dispatchTool(
 
       return {
         content: [{ type: "text", text: report }],
+        structuredContent: { ...result },
       };
     }
 

--- a/mcp/packages/gaming/src/tools.ts
+++ b/mcp/packages/gaming/src/tools.ts
@@ -77,6 +77,7 @@ export interface ToolTextContent {
 
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -96,6 +97,7 @@ export interface ToolDefinition {
     required?: string[];
     additionalProperties?: boolean;
   };
+  outputSchema?: { type: "object"; properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
   /** MCP behaviour hints — see mcp/src/tools/types.ts for the full rationale. */
   annotations?: ToolAnnotations;
 }
@@ -334,6 +336,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: [],
     },
+    outputSchema: { type: "object", properties: { models: { type: "array", items: { type: "object", properties: { id: { type: "string" }, name: { type: "string" }, category: { type: "string" }, source: { type: "string" }, sourceUrl: { type: "string" }, format: { type: "string" }, license: { type: "string" }, description: { type: "string" }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "name", "category", "source", "sourceUrl", "format", "license", "description", "tags"], additionalProperties: false } } }, required: ["models"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -354,6 +357,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["code"],
     },
+    outputSchema: { type: "object", properties: { valid: { type: "boolean" }, issues: { type: "array", items: { type: "object", properties: { severity: { type: "string" }, message: { type: "string" }, line: { type: "number" } }, required: ["severity", "message"], additionalProperties: false } }, issueCount: { type: "object", properties: { errors: { type: "number" }, warnings: { type: "number" }, info: { type: "number" } }, required: ["errors", "warnings", "info"], additionalProperties: false } }, required: ["valid", "issues", "issueCount"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -643,6 +647,7 @@ export async function dispatchTool(
 
       return {
         content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { models },
       };
     }
 
@@ -661,6 +666,7 @@ export async function dispatchTool(
 
       return {
         content: [{ type: "text", text: report }],
+        structuredContent: { ...result },
       };
     }
 

--- a/mcp/packages/healthcare/src/tools.ts
+++ b/mcp/packages/healthcare/src/tools.ts
@@ -77,6 +77,7 @@ export interface ToolTextContent {
 
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -96,6 +97,7 @@ export interface ToolDefinition {
     required?: string[];
     additionalProperties?: boolean;
   };
+  outputSchema?: { type: "object"; properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
   /** MCP behaviour hints — see mcp/src/tools/types.ts for the full rationale. */
   annotations?: ToolAnnotations;
 }
@@ -345,6 +347,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: [],
     },
+    outputSchema: { type: "object", properties: { models: { type: "array", items: { type: "object", properties: { id: { type: "string" }, name: { type: "string" }, category: { type: "string" }, source: { type: "string" }, sourceUrl: { type: "string" }, format: { type: "string" }, license: { type: "string" }, description: { type: "string" }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "name", "category", "source", "sourceUrl", "format", "license", "description", "tags"], additionalProperties: false } } }, required: ["models"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -365,6 +368,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["code"],
     },
+    outputSchema: { type: "object", properties: { valid: { type: "boolean" }, issues: { type: "array", items: { type: "object", properties: { severity: { type: "string" }, message: { type: "string" }, line: { type: "number" } }, required: ["severity", "message"], additionalProperties: false } }, issueCount: { type: "object", properties: { errors: { type: "number" }, warnings: { type: "number" }, info: { type: "number" } }, required: ["errors", "warnings", "info"], additionalProperties: false } }, required: ["valid", "issues", "issueCount"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -657,6 +661,7 @@ export async function dispatchTool(
 
       return {
         content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { models },
       };
     }
 
@@ -675,6 +680,7 @@ export async function dispatchTool(
 
       return {
         content: [{ type: "text", text: report }],
+        structuredContent: { ...result },
       };
     }
 

--- a/mcp/packages/interior/src/tools.ts
+++ b/mcp/packages/interior/src/tools.ts
@@ -79,6 +79,7 @@ export interface ToolTextContent {
 
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -98,6 +99,7 @@ export interface ToolDefinition {
     required?: string[];
     additionalProperties?: boolean;
   };
+  outputSchema?: { type: "object"; properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
   /** MCP behaviour hints — see mcp/src/tools/types.ts for the full rationale. */
   annotations?: ToolAnnotations;
 }
@@ -365,6 +367,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: [],
     },
+    outputSchema: { type: "object", properties: { models: { type: "array", items: { type: "object", properties: { id: { type: "string" }, name: { type: "string" }, category: { type: "string" }, source: { type: "string" }, sourceUrl: { type: "string" }, format: { type: "string" }, license: { type: "string" }, description: { type: "string" }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "name", "category", "source", "sourceUrl", "format", "license", "description", "tags"], additionalProperties: false } } }, required: ["models"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -385,6 +388,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["code"],
     },
+    outputSchema: { type: "object", properties: { valid: { type: "boolean" }, issues: { type: "array", items: { type: "object", properties: { severity: { type: "string" }, message: { type: "string" }, line: { type: "number" } }, required: ["severity", "message"], additionalProperties: false } }, issueCount: { type: "object", properties: { errors: { type: "number" }, warnings: { type: "number" }, info: { type: "number" } }, required: ["errors", "warnings", "info"], additionalProperties: false } }, required: ["valid", "issues", "issueCount"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -696,6 +700,7 @@ export async function dispatchTool(
 
       return {
         content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { models },
       };
     }
 
@@ -714,6 +719,7 @@ export async function dispatchTool(
 
       return {
         content: [{ type: "text", text: report }],
+        structuredContent: { ...result },
       };
     }
 

--- a/mcp/packages/rerun/src/tools.ts
+++ b/mcp/packages/rerun/src/tools.ts
@@ -53,6 +53,7 @@ export interface ToolTextContent {
 
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -72,6 +73,7 @@ export interface ToolDefinition {
     required?: string[];
     additionalProperties?: boolean;
   };
+  outputSchema?: { type: "object"; properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
   /**
    * MCP behaviour hints — see mcp/src/tools/types.ts for the full rationale.
    * Optional in the type to keep migrations easy; runtime contract test in
@@ -115,6 +117,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["platform"],
     },
+    outputSchema: { type: "object", properties: { platform: { type: "string" }, files: { type: "array", items: { type: "object", properties: { path: { type: "string" }, contents: { type: "string" }, language: { type: "string" } }, required: ["path", "contents", "language"], additionalProperties: false } }, instructions: { type: "array", items: { type: "string" } } }, required: ["platform", "files", "instructions"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -221,6 +224,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["rrdUrl"],
     },
+    outputSchema: { type: "object", properties: { html: { type: "string" }, script: { type: "string" }, fullDocument: { type: "string" } }, required: ["html", "script", "fullDocument"], additionalProperties: false },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -305,6 +309,7 @@ export async function dispatchTool(
 
       return {
         content: withDisclaimer([{ type: "text", text: body.join("\n") }]),
+        structuredContent: { ...result },
       };
     }
 
@@ -481,6 +486,7 @@ export async function dispatchTool(
             ].join("\n"),
           },
         ]),
+        structuredContent: { ...result },
       };
     }
 

--- a/mcp/src/tools/definitions.ts
+++ b/mcp/src/tools/definitions.ts
@@ -271,7 +271,12 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     },
     outputSchema: {
       type: "object",
-      properties: { previewUrl: { type: "string" }, modelUrl: { type: "string" }, hasCode: { type: "boolean" }, title: { type: "string" } },
+      properties: {
+        previewUrl: { type: "string" },
+        modelUrl: { type: "string" },
+        hasCode: { type: "boolean" },
+        title: { type: "string" },
+      },
       required: ["previewUrl", "modelUrl", "hasCode", "title"],
       additionalProperties: false,
     },
@@ -399,7 +404,14 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     },
     outputSchema: {
       type: "object",
-      properties: { html: { type: "string" }, title: { type: "string" }, type: { type: "string", enum: ["model-viewer", "chart-3d", "scene", "product-360", "geometry"] } },
+      properties: {
+        html: { type: "string" },
+        title: { type: "string" },
+        type: {
+          type: "string",
+          enum: ["model-viewer", "chart-3d", "scene", "product-360", "geometry"],
+        },
+      },
       required: ["html", "title", "type"],
       additionalProperties: false,
     },
@@ -521,11 +533,23 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           items: {
             type: "object",
             properties: {
-              platform: { type: "string" }, renderer: { type: "string" }, framework: { type: "string" },
-              status: { type: "string" }, version: { type: "string" }, dependency: { type: "string" },
+              platform: { type: "string" },
+              renderer: { type: "string" },
+              framework: { type: "string" },
+              status: { type: "string" },
+              version: { type: "string" },
+              dependency: { type: "string" },
               features: { type: "array", items: { type: "string" } },
             },
-            required: ["platform", "renderer", "framework", "status", "version", "dependency", "features"],
+            required: [
+              "platform",
+              "renderer",
+              "framework",
+              "status",
+              "version",
+              "dependency",
+              "features",
+            ],
             additionalProperties: false,
           },
         },

--- a/mcp/src/tools/definitions.ts
+++ b/mcp/src/tools/definitions.ts
@@ -269,6 +269,12 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: { previewUrl: { type: "string" }, modelUrl: { type: "string" }, hasCode: { type: "boolean" }, title: { type: "string" } },
+      required: ["previewUrl", "modelUrl", "hasCode", "title"],
+      additionalProperties: false,
+    },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -391,6 +397,12 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
       required: ["type"],
     },
+    outputSchema: {
+      type: "object",
+      properties: { html: { type: "string" }, title: { type: "string" }, type: { type: "string", enum: ["model-viewer", "chart-3d", "scene", "product-360", "geometry"] } },
+      required: ["html", "title", "type"],
+      additionalProperties: false,
+    },
     annotations: {
       readOnlyHint: true,
       openWorldHint: false,
@@ -500,6 +512,26 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       type: "object",
       properties: {},
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        platforms: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              platform: { type: "string" }, renderer: { type: "string" }, framework: { type: "string" },
+              status: { type: "string" }, version: { type: "string" }, dependency: { type: "string" },
+              features: { type: "array", items: { type: "string" } },
+            },
+            required: ["platform", "renderer", "framework", "status", "version", "dependency", "features"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["platforms"],
+      additionalProperties: false,
     },
     annotations: {
       readOnlyHint: true,

--- a/mcp/src/tools/handler.ts
+++ b/mcp/src/tools/handler.ts
@@ -658,7 +658,10 @@ export async function dispatchTool(
       const result = buildPreviewUrl({ modelUrl, codeSnippet, autoRotate, ar, title });
       const text = formatPreviewResponse(result);
 
-      return { content: withDisclaimer([{ type: "text", text }]), structuredContent: { ...result } };
+      return {
+        content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { ...result },
+      };
     }
 
     // ── create_3d_artifact ───────────────────────────────────────────────────
@@ -683,7 +686,10 @@ export async function dispatchTool(
 
       const result = generateArtifact(artifactInput);
       const text = formatArtifactResponse(result);
-      return { content: withDisclaimer([{ type: "text", text }]), structuredContent: { ...result } };
+      return {
+        content: withDisclaimer([{ type: "text", text }]),
+        structuredContent: { ...result },
+      };
     }
 
     // ── get_platform_setup ─────────────────────────────────────────────────
@@ -880,7 +886,10 @@ export async function dispatchTool(
         "KMP `sceneview-core` shares logic (math, collision, geometry, animations) across all platforms.",
       ];
 
-      return { content: withDisclaimer([{ type: "text", text: lines.join("\n") }]), structuredContent: { platforms } };
+      return {
+        content: withDisclaimer([{ type: "text", text: lines.join("\n") }]),
+        structuredContent: { platforms },
+      };
     }
 
     // ── get_animation_guide ─────────────────────────────────────────────────

--- a/mcp/src/tools/handler.ts
+++ b/mcp/src/tools/handler.ts
@@ -658,7 +658,7 @@ export async function dispatchTool(
       const result = buildPreviewUrl({ modelUrl, codeSnippet, autoRotate, ar, title });
       const text = formatPreviewResponse(result);
 
-      return { content: withDisclaimer([{ type: "text", text }]) };
+      return { content: withDisclaimer([{ type: "text", text }]), structuredContent: { ...result } };
     }
 
     // ── create_3d_artifact ───────────────────────────────────────────────────
@@ -683,7 +683,7 @@ export async function dispatchTool(
 
       const result = generateArtifact(artifactInput);
       const text = formatArtifactResponse(result);
-      return { content: withDisclaimer([{ type: "text", text }]) };
+      return { content: withDisclaimer([{ type: "text", text }]), structuredContent: { ...result } };
     }
 
     // ── get_platform_setup ─────────────────────────────────────────────────
@@ -880,7 +880,7 @@ export async function dispatchTool(
         "KMP `sceneview-core` shares logic (math, collision, geometry, animations) across all platforms.",
       ];
 
-      return { content: withDisclaimer([{ type: "text", text: lines.join("\n") }]) };
+      return { content: withDisclaimer([{ type: "text", text: lines.join("\n") }]), structuredContent: { platforms } };
     }
 
     // ── get_animation_guide ─────────────────────────────────────────────────

--- a/mcp/src/tools/types.ts
+++ b/mcp/src/tools/types.ts
@@ -15,6 +15,7 @@ export interface ToolTextContent {
 /** The shape returned by every SceneView MCP tool handler. */
 export interface ToolResult {
   content: ToolTextContent[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -62,6 +63,12 @@ export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+    additionalProperties?: boolean;
+  };
+  outputSchema?: {
     type: "object";
     properties?: Record<string, unknown>;
     required?: string[];


### PR DESCRIPTION
Part of #3192 (workstream 4b).

- `mcp-gateway`: negotiates `2025-06-18` (falls back to `2025-03-26`), rejects unsupported `mcp-protocol-version` headers, exposes `mcp-protocol-version` in CORS, and the widget tool declares `outputSchema` + returns `structuredContent`.
- `mcp`: every tool with a closed JSON result (`list_platforms`, model catalogues, `validate_*_code`, `setup_rerun_project`, `embed_web_viewer`, …) now declares `outputSchema` and returns `structuredContent`. Prose/generator tools stay text-only on purpose.
- Tests: gateway 197 ✅, mcp 1965 ✅, `tsc --noEmit` clean in both.

Implementation delegated to Codex, reviewed and integrated by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)