### PR TITLE
Document Codex delegation as an orchestration lever and stop pinning the session model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "model": "opus",
   "permissions": {
     "defaultMode": "bypassPermissions"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,12 @@ Full API reference: [`llms.txt`](./llms.txt).
   `<!-- category: Fixed -->` tag. `CHANGELOG.md` is generated — never hand-edit it, same
   for `gpt/knowledge-*.md` and every `CREDITS.md` (licence compliance).
 - **Public surfaces are English only** — commit messages and PR bodies included.
-- **Delegate to Codex by default** — Codex bills the ChatGPT plan, a quota separate
-  from Claude's. Always `.claude/scripts/codex-delegate.sh`, never a raw `codex`, never
-  an OpenAI API key. Default routing: exploration/audit → `ask` · second opinion on a
-  diff → `review` · mechanical implementation → `implement --new-worktree`. Decisions,
-  integration, commits, merges and releases stay with Claude.
+- **Codex is a delegation lever, not a rule** — it bills the ChatGPT plan, a quota
+  separate from Claude's. The orchestrating session picks its delegate per task: Codex
+  (`ask` · `review` · `implement --new-worktree`) for well-scoped mechanical work or an
+  independent second opinion, Claude subagents when judgment or integration quality
+  matters. Always `.claude/scripts/codex-delegate.sh`, never a raw `codex`, never an
+  OpenAI API key. Commits, merges and releases stay with the lead session.
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,11 @@ Full API reference: [`llms.txt`](./llms.txt).
   `<!-- category: Fixed -->` tag. `CHANGELOG.md` is generated — never hand-edit it, same
   for `gpt/knowledge-*.md` and every `CREDITS.md` (licence compliance).
 - **Public surfaces are English only** — commit messages and PR bodies included.
-- **Codex bills the ChatGPT plan**: always `.claude/scripts/codex-delegate.sh`, never a
-  raw `codex`, never an OpenAI API key.
+- **Delegate to Codex by default** — Codex bills the ChatGPT plan, a quota separate
+  from Claude's. Always `.claude/scripts/codex-delegate.sh`, never a raw `codex`, never
+  an OpenAI API key. Default routing: exploration/audit → `ask` · second opinion on a
+  diff → `review` · mechanical implementation → `implement --new-worktree`. Decisions,
+  integration, commits, merges and releases stay with Claude.
 
 ## CI
 

--- a/changelog.d/3290-codex-delegation-default.md
+++ b/changelog.d/3290-codex-delegation-default.md
@@ -1,6 +1,6 @@
 <!-- category: Changed -->
 <!-- breaking: false -->
-Codex delegation is now the standing default for delegable agent work (exploration,
-diff reviews, mechanical implementation) instead of a temporary quota measure, and
-`.claude/settings.json` no longer pins the session model, so each session inherits the
-developer's own model choice (#3290).
+Codex delegation is now documented as a standing orchestration lever (exploration,
+diff reviews, mechanical implementation) at the lead session's discretion instead of a
+temporary quota measure, and `.claude/settings.json` no longer pins the session model,
+so each session inherits the developer's own model choice (#3290).

--- a/changelog.d/3290-codex-delegation-default.md
+++ b/changelog.d/3290-codex-delegation-default.md
@@ -1,0 +1,6 @@
+<!-- category: Changed -->
+<!-- breaking: false -->
+Codex delegation is now the standing default for delegable agent work (exploration,
+diff reviews, mechanical implementation) instead of a temporary quota measure, and
+`.claude/settings.json` no longer pins the session model, so each session inherits the
+developer's own model choice (#3290).


### PR DESCRIPTION
## What

- `CLAUDE.md`: the Codex bullet becomes a standing convention, phrased as a lever, not a mandate — the orchestrating session picks its delegate per task: Codex (`ask` / `review` / `implement --new-worktree`) for well-scoped mechanical work or an independent second opinion, Claude subagents when judgment or integration quality matters. The hard rules are unchanged: always `.claude/scripts/codex-delegate.sh`, never a raw `codex`, never an OpenAI API key; commits, merges and releases stay with the lead session.
- `.claude/settings.json`: drop the `"model": "opus"` pin so each session inherits the developer's own model choice instead of being forced onto Opus by a versioned file.

## Why

The Codex routing was introduced on 2026-08-18 as a one-week quota measure and proved useful (the ChatGPT-plan reservoir sits at 4% of its weekly window). But measurement shows the main session's context — not subagent choice — dominates cost, so a hard "delegate by default" rule would constrain the orchestrating session for little gain and possible quality loss. The convention keeps the lever documented and leaves the routing decision to the session. The model pin predates the current model lineup and had to be manually overridden every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)