### PR TITLE
ML object label stops crashing and body tracker draws its detections

### DIFF
--- a/changelog.d/3266-body-tracker.md
+++ b/changelog.d/3266-body-tracker.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+- **android-demo**: `ar-body-tracker` now actually detects a body. The CPU camera image ARCore
+  hands back is in raw sensor (landscape) orientation regardless of the device's display
+  orientation, but the demo's YUV→bitmap conversion never corrected for it — on a portrait
+  phone, MediaPipe's pose model was handed a person lying sideways and almost never found one.
+  `PoseLandmarker.detect` is now called with an `ImageProcessingOptions` rotation hint (the same
+  rotation-degrees mapping `ar-ml-object-label`'s ML Kit pipeline already used), so the model
+  sees an upright frame and the existing 2D skeleton overlay — plus the "point the camera at a
+  person" hint shown while nothing is tracked — now actually render the detection (#3266).

--- a/changelog.d/3268-ml-object-label.md
+++ b/changelog.d/3268-ml-object-label.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **android-demo**: `ar-ml-object-label` no longer crashes after a handful of detections. The
+  ML Kit success listener runs on the main thread while ARCore's `Session`/`Frame` belong to
+  the render thread — the listener was calling `frame.hitTest` on a `Frame` reference that was
+  already several updates stale by the time a ~30–80 ms detector pass completed, a cross-thread
+  access to ARCore's non-thread-safe native session. Anchor creation now happens back on the
+  render thread, in `onSessionUpdated`, against that frame's own current `Frame`. The demo also
+  now explains, once a label is anchored, that ML Kit's bundled detector classifies only five
+  broad categories (Home good, Fashion good, Food, Place, Plant) — so an indoor scene landing
+  almost entirely on "Home good" reads as expected behaviour, not a bug (#3268).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/CameraImageRotation.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/CameraImageRotation.kt
@@ -1,0 +1,46 @@
+package io.github.sceneview.demo.common
+
+import android.content.Context
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
+
+/**
+ * Maps a `Surface.ROTATION_*` display-rotation constant to the number of degrees ARCore's CPU
+ * camera image (delivered in the device's natural sensor orientation) must be rotated to appear
+ * upright on the current display.
+ *
+ * Shared by every demo that feeds [io.github.sceneview.ar.arcore.cameraImage] into an
+ * off-device vision pipeline — ML Kit's `InputImage.fromMediaImage(image, rotationDegrees)` and
+ * MediaPipe's `ImageProcessingOptions.setRotationDegrees(rotationDegrees)` both use this exact
+ * convention (clockwise degrees to apply to the buffer to make it upright).
+ *
+ * ARCore's back-camera sensor orientation on Android phones is 90°, so a
+ * `Surface.ROTATION_0` (portrait, the common case) needs 90° of correction. Kept as a pure
+ * function — separate from [displayRotationDegrees] — so it is unit-testable without a real
+ * [android.view.Display].
+ */
+internal fun rotationDegreesForDisplayRotation(displayRotation: Int): Int = when (displayRotation) {
+    Surface.ROTATION_0 -> 90
+    Surface.ROTATION_90 -> 0
+    Surface.ROTATION_180 -> 270
+    Surface.ROTATION_270 -> 180
+    else -> 90
+}
+
+/**
+ * Degrees of clockwise rotation to apply to the ARCore CPU camera image so it appears upright
+ * on [context]'s current display. See [rotationDegreesForDisplayRotation].
+ *
+ * `Context.display` was added in API 30; falls back to the deprecated
+ * `WindowManager.defaultDisplay` on API 28–29.
+ */
+internal fun displayRotationDegrees(context: Context): Int {
+    val displayRotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        context.display.rotation
+    } else {
+        @Suppress("DEPRECATION")
+        (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
+    }
+    return rotationDegreesForDisplayRotation(displayRotation)
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
@@ -40,6 +40,7 @@ import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
 import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.tasks.core.BaseOptions
+import com.google.mediapipe.tasks.vision.core.ImageProcessingOptions
 import com.google.mediapipe.tasks.vision.core.RunningMode
 import com.google.mediapipe.tasks.vision.poselandmarker.PoseLandmarker
 import io.github.sceneview.ar.ARSceneView
@@ -50,6 +51,7 @@ import io.github.sceneview.ar.body.SKELETON_BONES
 import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.displayRotationDegrees
 import io.github.sceneview.demo.common.trackingFailureMessage
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.rememberEngine
@@ -79,9 +81,23 @@ import java.io.ByteArrayOutputStream
  *  1. Each AR frame, pull the CPU camera image via [io.github.sceneview.ar.arcore.cameraImage].
  *  2. Throttle to ~6 fps (the landmarker costs ~30–60 ms/frame) and convert the YUV image to
  *     an ARGB [Bitmap].
- *  3. Run [PoseLandmarker.detect] (`RunningMode.IMAGE`), adapt the result into
- *     [BodyPose.RawLandmark]s and build a [BodyPose].
+ *  3. Run [PoseLandmarker.detect] (`RunningMode.IMAGE`) with an [ImageProcessingOptions]
+ *     rotation hint (#3266 — see below), adapt the result into [BodyPose.RawLandmark]s and
+ *     build a [BodyPose].
  *  4. Draw the [SKELETON_BONES] topology over the viewport with a Compose [Canvas].
+ *
+ * **Rotation (#3266).** [io.github.sceneview.ar.arcore.cameraImage] hands back the CPU image in
+ * ARCore's raw sensor orientation — landscape, regardless of the device's current display
+ * orientation (see that accessor's kdoc: "ML Kit: `InputImage.fromMediaImage(image,
+ * rotationDegrees)`", the same caveat applies here). [toBitmap] does a byte-for-byte YUV→ARGB
+ * conversion with no rotation applied, so on a portrait phone the bitmap handed to the
+ * landmarker showed a person lying sideways. MediaPipe's pose model is not rotation-invariant —
+ * fed a 90°-off frame it almost never found a body, which is why the demo "did nothing" no
+ * matter how a person stood in front of the camera. The fix passes the same
+ * [io.github.sceneview.demo.common.displayRotationDegrees] used by `ar-ml-object-label`'s ML
+ * Kit pipeline as an [ImageProcessingOptions] rotation hint to [PoseLandmarker.detect] — that
+ * lets MediaPipe correct for the rotation internally (landmarks come back already normalised to
+ * the upright, on-screen orientation) instead of physically rotating the bitmap.
  *
  * ### Model asset
  *
@@ -260,7 +276,14 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
                         runCatching {
                             val bitmap = image.toBitmap()
                             val mpImage = BitmapImageBuilder(bitmap).build()
-                            val result = landmarker.detect(mpImage)
+                            // #3266: the bitmap is still in ARCore's raw sensor orientation —
+                            // tell MediaPipe how to rotate it internally so the pose model
+                            // sees an upright person instead of one lying sideways. See the
+                            // "Rotation (#3266)" note on the file kdoc.
+                            val imageProcessingOptions = ImageProcessingOptions.builder()
+                                .setRotationDegrees(displayRotationDegrees(context))
+                                .build()
+                            val result = landmarker.detect(mpImage, imageProcessingOptions)
                             // First (and only — numPoses=1) pose, adapted to the
                             // renderer-agnostic RawLandmark shape so BodyPose stays
                             // free of any MediaPipe dependency.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemo.kt
@@ -5,6 +5,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -41,6 +42,7 @@ import io.github.sceneview.ar.arcore.cameraImage
 import io.github.sceneview.ar.arcore.position
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.displayRotationDegrees
 import io.github.sceneview.demo.common.trackingFailureMessage
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.math.Position
@@ -151,6 +153,24 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
     // per frame (saves ~2–4 ms of canvas work per detector pass).
     val labelBitmaps = remember { mutableMapOf<String, Bitmap>() }
 
+    // Result of the most recent completed ML Kit pass, waiting to be turned into anchors.
+    // `onSessionUpdated` runs on the render thread that owns the ARCore session (see
+    // ARRecordInterpreter's kdoc); `detector.process`'s listeners run on the main thread
+    // (the Play Services Tasks default when no Executor is given). Anchor creation needs
+    // `frame.hitTest`, an ARCore `Frame`/`Session` call — and ARCore's session state is not
+    // thread-safe, nor is a `Frame` reference still valid once the render thread has moved on
+    // to later frames, which it always has by the time a ~30–80 ms TFLite pass completes. Doing
+    // the hit-test from the async listener against the `Frame` captured at dispatch time was a
+    // cross-thread, stale-frame access to ARCore's native session — the root cause of the
+    // reported post-launch crash (#3268): it surfaced once enough detector passes had run for
+    // the timing skew between "frame captured" and "hit-test executed" to hit the race.
+    // The fix: the listener only stashes the raw ML Kit results here; the actual hit-test runs
+    // below, back on the render thread, against that frame's own *current* `frame` — always
+    // fresh, always on the right thread.
+    val pendingDetection = remember {
+        java.util.concurrent.atomic.AtomicReference<PendingDetection?>(null)
+    }
+
     // Status banner text — "Warming up…" / "Aim at an object" / detection count.
     // trackingFailureMessage returns String? — fall back to the status-banner res if
     // the reason resolves to no specific message.
@@ -179,12 +199,28 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
                 color = Color.Black.copy(alpha = 0.4f),
                 modifier = Modifier.padding(horizontal = 16.dp),
             ) {
-                Text(
-                    text = statusText,
-                    color = Color.White,
-                    style = MaterialTheme.typography.bodyMedium,
+                Column(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                )
+                ) {
+                    Text(
+                        text = statusText,
+                        color = Color.White,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    // The bundled ML Kit detector classifies five broad categories (Home
+                    // good, Fashion good, Food, Place, Plant) rather than specific object
+                    // names — indoor scenes land on "Home good" for almost everything, which
+                    // reads as "the demo only ever detects one thing" if unexplained (#3268).
+                    // Shown only once something is anchored so the warm-up / aim prompts stay
+                    // uncluttered.
+                    if (detections.isNotEmpty()) {
+                        Text(
+                            text = stringResource(R.string.demo_ar_ml_explainer),
+                            color = Color.White.copy(alpha = 0.75f),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
             }
         },
     ) {
@@ -213,6 +249,19 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
                     cameraPosition[0] = camPose.x
                     cameraPosition[1] = camPose.y
                     cameraPosition[2] = camPose.z
+
+                    // Turn the previous detector pass's results into anchors now, on the
+                    // render thread, against *this* frame — see `pendingDetection` above.
+                    pendingDetection.getAndSet(null)?.let { pending ->
+                        updateAnchorsFromDetections(
+                            frame = frame,
+                            results = pending.results,
+                            imageW = pending.imageW,
+                            imageH = pending.imageH,
+                            detections = detections,
+                            labelBitmaps = labelBitmaps,
+                        )
+                    }
 
                     if (!isTracking) return@ARSceneView
 
@@ -257,25 +306,7 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
                     // prevent, because nothing in the UI would say so.
                     var dispatched = false
                     try {
-                        // `Context.display` was added in API 30; fall back to the
-                        // deprecated `WindowManager.defaultDisplay` on API 28–29.
-                        val displayRotation = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                            context.display.rotation
-                        } else {
-                            @Suppress("DEPRECATION")
-                            (context.getSystemService(android.content.Context.WINDOW_SERVICE)
-                                    as android.view.WindowManager).defaultDisplay.rotation
-                        }
-                        val rotationDegrees = when (displayRotation) {
-                            // ARCore CPU image is delivered with the device's natural-orientation
-                            // axis. ML Kit needs degrees of rotation from upright. ARCore's
-                            // back-camera sensor orientation on Android phones is 90° → match.
-                            android.view.Surface.ROTATION_0 -> 90
-                            android.view.Surface.ROTATION_90 -> 0
-                            android.view.Surface.ROTATION_180 -> 270
-                            android.view.Surface.ROTATION_270 -> 180
-                            else -> 90
-                        }
+                        val rotationDegrees = displayRotationDegrees(context)
 
                         // Hand the image to ML Kit. `InputImage.fromMediaImage` retains a
                         // reference until the task completes, so we close `cameraImage` in
@@ -289,13 +320,11 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
                         detector.process(input)
                             .addOnSuccessListener { results ->
                                 try {
-                                    updateAnchorsFromDetections(
-                                        frame = frame,
-                                        results = results,
-                                        imageW = imageW,
-                                        imageH = imageH,
-                                        detections = detections,
-                                        labelBitmaps = labelBitmaps,
+                                    // Stash for `onSessionUpdated` to turn into anchors against
+                                    // the *next* current frame — never hit-test here (see
+                                    // `pendingDetection` above for why).
+                                    pendingDetection.set(
+                                        PendingDetection(results, imageW, imageH)
                                     )
                                     // Once anything is anchored, the status text switches to
                                     // the live "N objects detected" count (see `statusText`
@@ -400,11 +429,22 @@ private data class DetectionAnchor(
 )
 
 /**
+ * One completed-but-not-yet-anchored ML Kit detector pass, captured off the render thread.
+ * `imageW`/`imageH` travel with the results because they describe the CPU image *that pass*
+ * ran against, not necessarily the current frame's.
+ */
+private data class PendingDetection(
+    val results: List<DetectedObject>,
+    val imageW: Int,
+    val imageH: Int,
+)
+
+/**
  * Buckets a 0..1 ML Kit confidence into a stable percentage step so the label-bitmap cache
  * key changes only every [step] percent. Without bucketing, every sub-percent confidence
  * jitter between detector passes would invalidate the cache and re-rasterise the bitmap.
  */
-private fun confidenceBucketPercent(confidence: Float, step: Int = 5): Int {
+internal fun confidenceBucketPercent(confidence: Float, step: Int = 5): Int {
     val pct = (confidence.coerceIn(0f, 1f) * 100f).toInt()
     return (pct / step) * step
 }

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_ml_object_label.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_ml_object_label.xml
@@ -7,7 +7,7 @@
 <resources>
     <string name="demo_ar_ml_title">ML Kit Object Labels</string>
     <string name="demo_ar_ml_subtitle">ML Kit object detection with 3D labels anchored on real-world hits</string>
-    <string name="demo_ar_ml_explainer">Aim the device at a recognisable object (a chair, a plant, a book). ML Kit\'s bundled detector classifies the CPU camera image and we anchor a 3D label at the hit-tested world position.</string>
+    <string name="demo_ar_ml_explainer">ML Kit\'s bundled model classifies 5 broad categories (Home good, Fashion good, Food, Place, Plant) — indoors, most objects land on \"Home good\". That\'s expected, not a bug.</string>
     <string name="demo_ar_ml_status_warming">Warming up — waiting for camera image…</string>
     <string name="demo_ar_ml_status_aim">Aim at a recognisable object</string>
     <plurals name="demo_ar_ml_status_detected">

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/common/CameraImageRotationTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/common/CameraImageRotationTest.kt
@@ -1,0 +1,43 @@
+package io.github.sceneview.demo.common
+
+import android.view.Surface
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the `Surface.ROTATION_*` -> rotation-degrees mapping shared by
+ * `ar-ml-object-label` (ML Kit) and `ar-body-tracker` (MediaPipe) to correct ARCore's raw
+ * sensor-orientation CPU camera image before feeding it into either vision pipeline.
+ *
+ * `ar-body-tracker` shipped without this correction (#3266): its bitmap conversion never
+ * accounted for rotation, so a person standing upright in front of the camera appeared
+ * sideways to the pose model, which almost never found a body. This mapping is the fix, so
+ * every rotation case is pinned here.
+ */
+class CameraImageRotationTest {
+
+    @Test
+    fun `ROTATION_0 (portrait) needs 90 degrees of correction`() {
+        assertEquals(90, rotationDegreesForDisplayRotation(Surface.ROTATION_0))
+    }
+
+    @Test
+    fun `ROTATION_90 needs no correction`() {
+        assertEquals(0, rotationDegreesForDisplayRotation(Surface.ROTATION_90))
+    }
+
+    @Test
+    fun `ROTATION_180 needs 270 degrees of correction`() {
+        assertEquals(270, rotationDegreesForDisplayRotation(Surface.ROTATION_180))
+    }
+
+    @Test
+    fun `ROTATION_270 needs 180 degrees of correction`() {
+        assertEquals(180, rotationDegreesForDisplayRotation(Surface.ROTATION_270))
+    }
+
+    @Test
+    fun `unknown rotation values fall back to the portrait correction`() {
+        assertEquals(90, rotationDegreesForDisplayRotation(-1))
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemoTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemoTest.kt
@@ -1,0 +1,37 @@
+package io.github.sceneview.demo.demos
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [confidenceBucketPercent] — the bucketing that keeps the `ar-ml-object-label`
+ * label-bitmap cache from re-rasterising on every sub-percent confidence jitter between detector
+ * passes.
+ */
+class ARMLObjectLabelDemoTest {
+
+    @Test
+    fun `buckets down to the nearest 5 percent step by default`() {
+        assertEquals(80, confidenceBucketPercent(0.84f))
+        assertEquals(85, confidenceBucketPercent(0.85f))
+        assertEquals(85, confidenceBucketPercent(0.89f))
+    }
+
+    @Test
+    fun `0 and 1 confidence map to their own buckets`() {
+        assertEquals(0, confidenceBucketPercent(0f))
+        assertEquals(100, confidenceBucketPercent(1f))
+    }
+
+    @Test
+    fun `out-of-range confidence is coerced into 0 to 1 before bucketing`() {
+        assertEquals(0, confidenceBucketPercent(-0.5f))
+        assertEquals(100, confidenceBucketPercent(1.5f))
+    }
+
+    @Test
+    fun `custom step size changes the bucket width`() {
+        assertEquals(70, confidenceBucketPercent(0.73f, step = 10))
+        assertEquals(75, confidenceBucketPercent(0.79f, step = 25))
+    }
+}


### PR DESCRIPTION
Closes #3268, closes #3266

## Root causes

**#3268 — `ar-ml-object-label` crash after a handful of detections.**
`onSessionUpdated` runs on the render thread that owns the ARCore session. The ML Kit
`ObjectDetector` success listener runs on the main thread (the Play Services `Task` default when
no `Executor` is given). That listener was calling `frame.hitTest(...)` against the `Frame`
captured at dispatch time — but by the time a ~30–80 ms TFLite pass completes, the render thread
has already moved several frames on. That's a cross-thread, stale-frame access to ARCore's
non-thread-safe native session, and it crashed once enough detector passes had run for the
timing skew to hit the race — matching the "crash after 5[ detections]" report. Fix: the async
listener now only stashes the raw ML Kit results; the hit-test that turns them into anchors runs
back on the render thread, in `onSessionUpdated`, against that frame's own *current* `Frame`.

Also addressed the "only Home goods" half of the report: ML Kit's bundled object detector
classifies just five broad categories (`Home good`, `Fashion good`, `Food`, `Place`, `Plant`), so
an indoor scene landing almost entirely on "Home good" is expected model behaviour, not a bug.
The demo now surfaces that explanation in its status overlay once a label is anchored, instead of
silently leaving the user to conclude the demo only recognises one thing.

**#3266 — `ar-body-tracker` never detects anything.**
`Frame.cameraImage()` (documented on the accessor) hands back the CPU image in ARCore's raw
sensor orientation — landscape, regardless of the device's current display orientation. The
sibling ML Kit demo already corrects for this by computing `rotationDegrees` and passing it into
`InputImage.fromMediaImage`. `ar-body-tracker`'s YUV→bitmap conversion did no such correction, so
on a portrait phone MediaPipe's `PoseLandmarker` was handed a person lying sideways — and its pose
model is not rotation-invariant, so it almost never found a body. Fix: `PoseLandmarker.detect` now
takes an `ImageProcessingOptions` rotation hint built from the same rotation-degrees mapping,
extracted into a shared `demo/common/CameraImageRotation.kt` helper so both demos stay in sync.
The existing 2D skeleton overlay and "aim at a person" status hint were already correctly wired —
they just had nothing to draw.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin :samples:android-demo:testDebugUnitTest --no-daemon --no-configuration-cache` — green, including the new `CameraImageRotationTest` and `ARMLObjectLabelDemoTest` (pure-JVM coverage for the rotation mapping and confidence-bucketing logic).
- **Device/emulator QA is pending** — this session did not use any physical device or emulator (owned by other agents). The threading/staleness fix and the rotation fix are both reasoned from ARCore/ML Kit/MediaPipe's documented thread and coordinate-space contracts, but neither crash reproduction nor on-device pose detection has been visually confirmed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)