### PR TITLE
AR point cloud, raw depth and scene semantics demos render again

### DIFF
--- a/changelog.d/3270-point-cloud.md
+++ b/changelog.d/3270-point-cloud.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+**android-demo**: `ar-point-cloud` no longer renders a silent black screen when tracking
+fails or the cloud stays empty. Unlike its `ar-raw-depth-point-cloud` / `ar-scene-semantics`
+siblings, it had no `onTrackingFailureChanged` wiring at all — a lost-tracking session (or a
+cold-start still resolving its first feature points) rendered nothing, with no on-screen
+explanation, which read to users as "nothing rendered" (#3270). It now shows the same
+tracking-failure banner as the other AR demos, plus a "still scanning" hint once the cloud has
+sat at zero points, while tracking, for more than two seconds. The stuck-at-zero gate is a
+pure function pinned by a JVM test (`PointCloudFeedbackTest`).

--- a/changelog.d/3271-raw-depth.md
+++ b/changelog.d/3271-raw-depth.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+**android-demo**: `ar-raw-depth-point-cloud` no longer scatters its points across the wrong
+part of the screen in portrait. ARCore's raw-depth image is handed back in the camera-sensor
+frame, which does not follow the display — `RawDepthCloud.buildCloud` mapped `x`/`y` straight
+onto the screen-space `Canvas` overlay with no rotation correction, so in portrait the cloud
+landed 90° off and most points fell outside the visible view (reported as "rotation error...
+points are not visible enough", #3271). This is the same class of bug already fixed for the
+false-color depth visualization in #3184; `buildCloud` now takes a `rotationDegrees` parameter
+(derived from the live display rotation, same as `ARDepthVisualizationDemo`) and re-indexes
+each point into the rotated output frame. Pinned by four new JVM tests in
+`RawDepthCloudTest` (0°/90°/180°/270° plus the invalid-rotation guard).

--- a/changelog.d/3274-scene-semantics.md
+++ b/changelog.d/3274-scene-semantics.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+**android-demo**: `ar-scene-semantics` now explains itself when the scene classifies as
+almost entirely `UNLABELED` — ARCore's Scene Semantics model has no indoor training data, and
+the overlay shader paints `UNLABELED` fully transparent, so an indoor session silently showed
+the plain camera feed with zero on-screen indication of why (reported as "nothing...
+rendered", #3274). A guidance banner now appears whenever the frame's dominant label is
+`UNLABELED` at ≥90%, pointing the user outdoors. The gate is a pure function,
+`SemanticsOverlay.isOutdoorSceneUnclassified`, pinned by four new JVM tests.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPointCloudDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPointCloudDemo.kt
@@ -1,5 +1,8 @@
 package io.github.sceneview.demo.demos
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,23 +15,36 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Config
+import com.google.ar.core.Frame
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingFailureReason
+import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.common.DemoStatusBanner
+import io.github.sceneview.demo.common.DemoStatusTone
+import io.github.sceneview.demo.common.ForceTrackingFailureMenu
+import io.github.sceneview.demo.common.ForcedTrackingFailure
+import io.github.sceneview.demo.demos.internal.PointCloudFeedback
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 
 /**
  * AR demo — renders ARCore's live tracking feature points as an in-scene point cloud using
@@ -46,7 +62,16 @@ import java.util.Locale
  * The live point count is surfaced in the scaffold header so the user gets honest feedback on
  * tracking quality — more points generally means a richer, better-tracked scene.
  *
- * Closes [#1773](https://github.com/sceneview/sceneview/issues/1773).
+ * **Tracking feedback (#3270).** [io.github.sceneview.ar.node.PointCloudNode.update] silently
+ * no-ops whenever ARCore isn't `TRACKING` — a lost-tracking session renders literally nothing,
+ * with no on-screen explanation, and read to users as "nothing rendered" rather than "point the
+ * camera at a textured surface". This demo now surfaces the same tracking-failure banner as its
+ * [ARRawDepthPointCloudDemo] / `ARSceneSemanticsDemo` siblings, plus a "still scanning" hint if
+ * tracking is fine but the cloud has stayed empty for a couple of seconds (the #1617 principle:
+ * never leave the user staring at a screen that looks broken without saying why).
+ *
+ * Closes [#1773](https://github.com/sceneview/sceneview/issues/1773),
+ * [#3270](https://github.com/sceneview/sceneview/issues/3270).
  */
 @Composable
 fun ARPointCloudDemo(onBack: () -> Unit) {
@@ -60,6 +85,28 @@ fun ARPointCloudDemo(onBack: () -> Unit) {
     // (0.2) — permissive enough that motion-stereo's noisy first frames still surface points.
     var confidenceThreshold by remember { mutableFloatStateOf(0.2f) }
     var pointCount by remember { mutableIntStateOf(0) }
+
+    var isTracking by remember { mutableStateOf(false) }
+    var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
+
+    // "Stuck at zero points" chip state (#3270) — same shape as ARRawDepthPointCloudDemo's.
+    // `zeroPointsSince` is set the first time the cloud reports zero points and cleared as
+    // soon as it recovers; `now` is bumped by a 1 Hz tick so the gate re-evaluates even while
+    // the point count itself never changes (a level condition, not an edge).
+    var zeroPointsSince by remember { mutableStateOf<Long?>(System.currentTimeMillis()) }
+    var now by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1.seconds)
+            now = System.currentTimeMillis()
+        }
+    }
+    val zeroPointsStuck = PointCloudFeedback.zeroPointsStuck(
+        isTracking = isTracking,
+        pointCount = pointCount,
+        zeroPointsSinceMs = zeroPointsSince,
+        nowMs = now,
+    )
 
     // A flat cyan unlit dot — lighting-independent so the points read clearly against any
     // camera feed. Owned by this composable: destroyed on dispose to avoid leaking the
@@ -105,6 +152,49 @@ fun ARPointCloudDemo(onBack: () -> Unit) {
                     valueRange = 0f..1f,
                 )
             }
+            // Developer-only debug toggle — lets QA force-emit each TrackingFailureReason so
+            // the banner below can be validated without staging a real failure (#1881).
+            ForceTrackingFailureMenu()
+        },
+        // Tracking-failure banner + "still scanning" hint — same vocabulary as the other AR
+        // demos. Without this, a lost-tracking session (or a cold-start still resolving its
+        // first points) rendered nothing at all with zero on-screen explanation, which is
+        // exactly what #3270 reported as "nothing rendered".
+        bottomOverlay = {
+            val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
+            AnimatedVisibility(
+                visible = (!isTracking && trackingFailureReason != null) ||
+                    ForcedTrackingFailure.override != null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                val (statusText, statusTone) = when (effectiveReason) {
+                    TrackingFailureReason.INSUFFICIENT_LIGHT ->
+                        "Not enough light" to DemoStatusTone.Guidance
+                    TrackingFailureReason.EXCESSIVE_MOTION ->
+                        "Moving too fast" to DemoStatusTone.Guidance
+                    TrackingFailureReason.INSUFFICIENT_FEATURES ->
+                        "Not enough detail — point at a textured surface" to
+                            DemoStatusTone.Guidance
+                    TrackingFailureReason.CAMERA_UNAVAILABLE ->
+                        "Camera unavailable" to DemoStatusTone.Blocked
+                    TrackingFailureReason.BAD_STATE ->
+                        "AR session error" to DemoStatusTone.Blocked
+                    else -> stringResource(R.string.ar_status_scanning) to
+                        DemoStatusTone.Progress
+                }
+                DemoStatusBanner(text = statusText, tone = statusTone)
+            }
+            AnimatedVisibility(
+                visible = zeroPointsStuck && trackingFailureReason == null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                DemoStatusBanner(
+                    text = stringResource(R.string.demo_ar_point_cloud_move_hint_short),
+                    tone = DemoStatusTone.Guidance,
+                )
+            }
         },
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -113,11 +203,20 @@ fun ARPointCloudDemo(onBack: () -> Unit) {
                 engine = engine,
                 materialLoader = materialLoader,
                 playbackDataset = arPlaybackDataset,
+                onSessionUpdated = { _: Session, frame: Frame ->
+                    isTracking = frame.camera.trackingState == TrackingState.TRACKING
+                },
+                onTrackingFailureChanged = { reason ->
+                    trackingFailureReason = reason
+                },
             ) {
                 val pointCloud = rememberPointCloud(
                     confidenceThreshold = confidenceThreshold,
                     materialInstance = pointMaterial,
-                    onPointCloudUpdated = { pointCount = it },
+                    onPointCloudUpdated = {
+                        pointCount = it
+                        zeroPointsSince = if (it > 0) null else zeroPointsSince ?: System.currentTimeMillis()
+                    },
                 )
                 PointCloudNode(node = pointCloud)
             }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRawDepthPointCloudDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRawDepthPointCloudDemo.kt
@@ -1,5 +1,9 @@
 package io.github.sceneview.demo.demos
 
+import android.content.Context
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -30,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Config
@@ -44,6 +49,7 @@ import io.github.sceneview.demo.common.DemoStatusBanner
 import io.github.sceneview.demo.common.DemoStatusTone
 import io.github.sceneview.demo.common.ForceTrackingFailureMenu
 import io.github.sceneview.demo.common.ForcedTrackingFailure
+import io.github.sceneview.demo.demos.internal.DepthVisualization
 import io.github.sceneview.demo.demos.internal.RawDepthCloud
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.rememberEngine
@@ -79,6 +85,20 @@ import kotlinx.coroutines.delay
  */
 @Composable
 fun ARRawDepthPointCloudDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+    // Resolved once: the Display *object* is stable for the lifetime of this context, while
+    // `rotation` on it is live — so the per-frame read below stays cheap. Mirrors
+    // ARDepthVisualizationDemo / ARMLObjectLabelDemo (#3184).
+    val display = remember(context) {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                context.display
+            } else {
+                @Suppress("DEPRECATION")
+                (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+            }
+        }.getOrNull()
+    }
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
@@ -352,6 +372,16 @@ fun ARRawDepthPointCloudDemo(onBack: () -> Unit) {
                                 val confidencePlane = confidenceImage.planes[0]
                                 val w = depthImage.width
                                 val h = depthImage.height
+                                // Read the rotation per frame, not once at composition: the
+                                // display can turn between two depth frames and the cloud has
+                                // to follow it in the same frame the camera feed does. ARCore
+                                // hands the raw-depth image out in the camera-sensor frame,
+                                // which does not follow the display — without this the points
+                                // land 90° off in portrait and mostly scatter outside the
+                                // visible view (#3271 / #3184).
+                                val rotation = DepthVisualization.displayRotationToDegrees(
+                                    display?.rotation ?: Surface.ROTATION_0
+                                )
                                 cloudPacked = RawDepthCloud.buildCloud(
                                     depthBytes = depthPlane.buffer,
                                     depthRowStrideBytes = depthPlane.rowStride,
@@ -360,9 +390,13 @@ fun ARRawDepthPointCloudDemo(onBack: () -> Unit) {
                                     width = w,
                                     height = h,
                                     confidenceThreshold = confidenceThreshold,
+                                    rotationDegrees = rotation,
                                 )
-                                depthWidth = w
-                                depthHeight = h
+                                // Post-rotation dimensions — swapped on a quarter turn, which
+                                // is the portrait case. The Canvas overlay below maps points
+                                // against these, not the raw sensor dimensions.
+                                depthWidth = DepthVisualization.rotatedWidth(w, h, rotation)
+                                depthHeight = DepthVisualization.rotatedHeight(w, h, rotation)
                                 visiblePointCount = RawDepthCloud.pointCount(cloudPacked!!)
                                 depthEverReceived = true
                                 // Onboarding hint dismisses on the first frame that

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneSemanticsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneSemanticsDemo.kt
@@ -127,6 +127,14 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
     // overlay so the user knows the model is initialising rather than broken.
     var semanticsEverReceived by remember { mutableStateOf(false) }
 
+    // #3274: the Scene Semantics model has no indoor training data — pointed at a
+    // living-room wall it classifies almost every pixel UNLABELED, which the overlay
+    // shader paints fully transparent. Without this flag the demo then shows exactly the
+    // plain camera feed with zero on-screen explanation, which read to a user as "nothing
+    // ...rendered" even though the pipeline was working end to end. Derived from `topLabels`
+    // below via the pure [SemanticsOverlay.isOutdoorSceneUnclassified] gate.
+    var sceneUnclassified by remember { mutableStateOf(false) }
+
     var isTracking by remember { mutableStateOf(false) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
 
@@ -268,6 +276,29 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
                 }
             }
 
+            // #3274 — the scene has been classified but almost every pixel came back
+            // UNLABELED (typically: an indoor scene — the model has no indoor training
+            // data). The overlay shader paints UNLABELED fully transparent, so without this
+            // the demo silently shows the plain camera feed and reads as broken.
+            AnimatedVisibility(
+                visible = semanticsSupported == true && semanticsEverReceived && sceneUnclassified,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    shape = MaterialTheme.shapes.large
+                ) {
+                    Text(
+                        text = "Nothing classified yet — Scene Semantics is outdoor-only. " +
+                            "Try a street, park or back yard.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+
             // Tracking-failure overlay — same vocabulary as the other AR demos.
             // ForcedTrackingFailure.override shadows the real ARCore-reported reason
             // when a developer has picked one in the debug menu (#1881). Read it here
@@ -350,6 +381,14 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
                         if (snapshot.any { it.fraction > 0f }) {
                             semanticsEverReceived = true
                         }
+                        // #3274 — a dominant UNLABELED top label means the model has
+                        // classified essentially nothing this frame (typically: indoors).
+                        sceneUnclassified = snapshot.firstOrNull()?.let {
+                            SemanticsOverlay.isOutdoorSceneUnclassified(
+                                topOrdinal = it.label.ordinal,
+                                topFraction = it.fraction,
+                            )
+                        } ?: false
 
                         // Per-pixel raster overlay — acquire the R8 semantic image, upload it
                         // into the Filament texture, (re)build the camera-parented overlay quad

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/PointCloudFeedback.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/PointCloudFeedback.kt
@@ -1,0 +1,50 @@
+package io.github.sceneview.demo.demos.internal
+
+/**
+ * Pure feedback gate for `ARPointCloudDemo` (#3270).
+ *
+ * [io.github.sceneview.ar.node.PointCloudNode.update] silently no-ops whenever ARCore isn't
+ * `TRACKING` — lost tracking, a paused session, or a cold-start still resolving the first
+ * feature points all look identical from the UI: zero points, forever, with no indication why.
+ * `ARRawDepthPointCloudDemo` and `ARSceneSemanticsDemo` both surface a tracking-failure banner
+ * plus a "stuck at zero" hint for exactly this reason (see #1617 — never leave the user staring
+ * at a screen that looks broken); `ARPointCloudDemo` previously had neither, so a real tracking
+ * failure read as "nothing rendered" (the #3270 report) instead of "move the device" or "not
+ * enough light".
+ *
+ * Extracted as a pure, ARCore-free function so the gate — including the "just started" and
+ * "already recovered" edges — can be pinned by a JVM unit test. See `PointCloudFeedbackTest`.
+ */
+internal object PointCloudFeedback {
+
+    /** Minimum time (ms) the cloud must sit at zero points, while tracking, before the demo
+     * surfaces the "still no points" hint. Mirrors `ARRawDepthPointCloudDemo`'s own threshold. */
+    const val STUCK_AFTER_MS: Long = 2_000L
+
+    /**
+     * `true` when the point cloud has been stuck at zero points, **while tracking**, for at
+     * least [stuckAfterMs] — i.e. long enough that "move the device" is more helpful than
+     * staying silent, but not so trigger-happy that it flashes on every normal frame gap.
+     *
+     * Returns `false` while tracking is lost — that path already has its own (louder) banner,
+     * driven by `onTrackingFailureChanged`, so this hint would only be redundant noise on top
+     * of it.
+     *
+     * @param isTracking       Whether ARCore's camera is currently `TrackingState.TRACKING`.
+     * @param pointCount       Points rendered on the most recent [io.github.sceneview.ar.node.PointCloudNode] update.
+     * @param zeroPointsSinceMs Wall-clock time the count first dropped to (or started at) zero;
+     *                         `null` means it hasn't happened yet, or already recovered.
+     * @param nowMs            Current wall-clock time.
+     * @param stuckAfterMs     Threshold in ms. Defaults to [STUCK_AFTER_MS].
+     */
+    fun zeroPointsStuck(
+        isTracking: Boolean,
+        pointCount: Int,
+        zeroPointsSinceMs: Long?,
+        nowMs: Long,
+        stuckAfterMs: Long = STUCK_AFTER_MS,
+    ): Boolean = isTracking &&
+        pointCount == 0 &&
+        zeroPointsSinceMs != null &&
+        (nowMs - zeroPointsSinceMs) > stuckAfterMs
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/RawDepthCloud.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/RawDepthCloud.kt
@@ -58,8 +58,22 @@ internal object RawDepthCloud {
      * @param stride                Sub-sample stride (>=1). Defaults to [DEFAULT_STRIDE].
      * @param confidenceThreshold   Minimum confidence (0..255) to keep a point.
      * @param maxPoints             Cap on emitted points so the Compose draw stays cheap.
+     * @param rotationDegrees       Clockwise rotation, a multiple of 90, applied to every emitted
+     *                              `(x, y)` so the cloud is upright on screen (#3271 — same fix as
+     *                              [DepthVisualization.depthBufferToArgb] / #3184). ARCore hands
+     *                              back the raw-depth image in the **camera sensor** frame, which
+     *                              does not follow the display: in portrait the image arrives 90°
+     *                              off, so mapping `x/width, y/height` straight onto the screen
+     *                              scatters points into the wrong region — reading as "almost
+     *                              nothing visible" rather than a clean rotation. Use
+     *                              [DepthVisualization.displayRotationToDegrees] to derive it from
+     *                              the current display rotation. `0` (the default) preserves the
+     *                              original, byte-for-byte behavior.
      *
-     * @return Packed array length = `nPoints * STRIDE_INTS`. Always returns a fresh array.
+     * @return Packed array length = `nPoints * STRIDE_INTS`. `x`/`y` are already rotated — the
+     *         caller must size its overlay to [DepthVisualization.rotatedWidth] /
+     *         [DepthVisualization.rotatedHeight] of ([width], [height], [rotationDegrees]), not to
+     *         the raw `width` / `height`, on a quarter turn.
      */
     @Suppress("NestedBlockDepth") // y→x→confidence→depth nested loops are the canonical depth-cloud pattern
     fun buildCloud(
@@ -72,6 +86,7 @@ internal object RawDepthCloud {
         stride: Int = DEFAULT_STRIDE,
         confidenceThreshold: Int = DEFAULT_CONFIDENCE_THRESHOLD,
         maxPoints: Int = DEFAULT_MAX_POINTS,
+        rotationDegrees: Int = 0,
     ): IntArray {
         require(width > 0 && height > 0) { "raw-depth image must be non-empty (got $width x $height)" }
         require(stride >= 1) { "stride must be >= 1, was $stride" }
@@ -82,6 +97,10 @@ internal object RawDepthCloud {
             "confidenceRowStrideBytes ($confidenceRowStrideBytes) must be >= width ($width)"
         }
         require(maxPoints >= 0) { "maxPoints must be >= 0, was $maxPoints" }
+        val rotation = ((rotationDegrees % 360) + 360) % 360
+        require(rotation % 90 == 0) {
+            "rotationDegrees ($rotationDegrees) must be a multiple of 90"
+        }
         val clampedThreshold = confidenceThreshold.coerceIn(0, 255)
 
         val prevDepthOrder = depthBytes.order()
@@ -110,9 +129,18 @@ internal object RawDepthCloud {
                         if (mm > 0) {
                             val t = DepthVisualization.normalize(mm) ?: 0f
                             val color = DepthVisualization.falseColorArgb(t)
+                            // Rotate (x, y) the same way DepthVisualization.depthBufferToArgb
+                            // re-indexes pixels while writing (#3271 / #3184): the destination
+                            // point lands in the *rotated* output frame, matching the display.
+                            val (outX, outY) = when (rotation) {
+                                90 -> (height - 1 - y) to x
+                                180 -> (width - 1 - x) to (height - 1 - y)
+                                270 -> y to (width - 1 - x)
+                                else -> x to y
+                            }
                             val base = n * STRIDE_INTS
-                            out[base] = x
-                            out[base + 1] = y
+                            out[base] = outX
+                            out[base + 1] = outY
                             out[base + 2] = mm
                             out[base + 3] = color
                             n++

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/SemanticsOverlay.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/SemanticsOverlay.kt
@@ -111,4 +111,38 @@ internal object SemanticsOverlay {
         value > 1f -> 1f
         else -> value
     }
+
+    /**
+     * Default fraction above which an [UNLABELED_ORDINAL]-dominant frame counts as "the scene
+     * has nothing classified", not just ordinary edge noise.
+     */
+    const val DEFAULT_UNCLASSIFIED_THRESHOLD: Float = 0.9f
+
+    /**
+     * `true` when the current frame's single most-common label is [UNLABELED_ORDINAL] at or
+     * above [threshold] — i.e. ARCore's Scene Semantics model classified almost nothing (#3274).
+     *
+     * The Scene Semantics model has **no indoor training data**: pointed at a living-room wall
+     * it returns UNLABELED for almost every pixel, which the overlay shader paints fully
+     * transparent (see `semantics_overlay.mat`) — so the demo shows exactly the plain camera
+     * feed, with no on-screen indication of *why*. A user filed that as "nothing...rendered"
+     * (#3274) even though the pipeline itself was working correctly end to end; the fix isn't a
+     * code bug in the classification path, it's the missing feedback the #1617 principle
+     * ("never leave the user staring at a screen that looks broken without saying why") demands
+     * everywhere else in this codebase.
+     *
+     * Extracted as a pure, ARCore-free function (`topOrdinal` instead of `SemanticLabel`, so no
+     * ARCore type is needed on the test classpath) so the gate can be pinned by a JVM unit test.
+     * See `SemanticsOverlayTest`.
+     *
+     * @param topOrdinal  Ordinal (`0..11`) of the frame's highest-fraction label.
+     * @param topFraction That label's fraction, in `[0, 1]`.
+     * @param threshold   Minimum fraction to call it "dominant". Defaults to
+     *                    [DEFAULT_UNCLASSIFIED_THRESHOLD].
+     */
+    fun isOutdoorSceneUnclassified(
+        topOrdinal: Int,
+        topFraction: Float,
+        threshold: Float = DEFAULT_UNCLASSIFIED_THRESHOLD,
+    ): Boolean = topOrdinal == UNLABELED_ORDINAL && topFraction >= threshold
 }

--- a/samples/android-demo/src/main/res/values/strings_demo_ar_point_cloud.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_ar_point_cloud.xml
@@ -9,4 +9,5 @@
     <string name="demo_ar_point_cloud_subtitle">World-space feature points via PointCloudNode</string>
     <string name="demo_ar_point_cloud_count">Tracking %1$d points</string>
     <string name="demo_ar_point_cloud_move_hint">Move your device to detect feature points</string>
+    <string name="demo_ar_point_cloud_move_hint_short">Still scanning — keep moving</string>
 </resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/PointCloudFeedbackTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/PointCloudFeedbackTest.kt
@@ -1,0 +1,91 @@
+package io.github.sceneview.demo.demos.internal
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** JVM unit tests for [PointCloudFeedback] (#3270). */
+class PointCloudFeedbackTest {
+
+    @Test
+    fun `not stuck while not tracking`() {
+        assertFalse(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = false,
+                pointCount = 0,
+                zeroPointsSinceMs = 0L,
+                nowMs = 10_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `not stuck once points are flowing`() {
+        assertFalse(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 42,
+                zeroPointsSinceMs = 0L,
+                nowMs = 10_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `not stuck when zeroPointsSinceMs has not been recorded yet`() {
+        assertFalse(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 0,
+                zeroPointsSinceMs = null,
+                nowMs = 10_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `not stuck before the threshold elapses`() {
+        assertFalse(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 0,
+                zeroPointsSinceMs = 9_000L,
+                nowMs = 10_000L,
+                stuckAfterMs = 2_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `stuck once the threshold has elapsed while tracking with zero points`() {
+        assertTrue(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 0,
+                zeroPointsSinceMs = 0L,
+                nowMs = 2_001L,
+                stuckAfterMs = 2_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `default threshold matches STUCK_AFTER_MS`() {
+        assertTrue(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 0,
+                zeroPointsSinceMs = 0L,
+                nowMs = PointCloudFeedback.STUCK_AFTER_MS + 1,
+            )
+        )
+        assertFalse(
+            PointCloudFeedback.zeroPointsStuck(
+                isTracking = true,
+                pointCount = 0,
+                zeroPointsSinceMs = 0L,
+                nowMs = PointCloudFeedback.STUCK_AFTER_MS,
+            )
+        )
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/RawDepthCloudTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/RawDepthCloudTest.kt
@@ -306,6 +306,123 @@ class RawDepthCloudTest {
     }
 
     @Test
+    fun `buildCloud with rotationDegrees 0 matches the unrotated coordinates`() {
+        val (depth, conf) = buildPair(
+            depthMm = intArrayOf(300, 1_000, 2_000, 5_000),
+            confidence = intArrayOf(200, 200, 200, 200),
+            width = 4,
+            height = 1,
+        )
+
+        val packed = RawDepthCloud.buildCloud(
+            depthBytes = depth,
+            depthRowStrideBytes = 8,
+            confidenceBytes = conf,
+            confidenceRowStrideBytes = 4,
+            width = 4,
+            height = 1,
+            stride = 1,
+            confidenceThreshold = 0,
+            rotationDegrees = 0,
+        )
+
+        assertEquals(0, RawDepthCloud.x(packed, 0))
+        assertEquals(0, RawDepthCloud.y(packed, 0))
+        assertEquals(3, RawDepthCloud.x(packed, 3))
+        assertEquals(0, RawDepthCloud.y(packed, 3))
+    }
+
+    @Test
+    fun `buildCloud rotates points 90 degrees clockwise (portrait sensor fix, #3271)`() {
+        // 4x2 source image. A single qualifying pixel at (3, 0) — the top-right corner of
+        // the sensor-frame image — must land in the top-left corner of the 90°-rotated
+        // (2x4) output frame, exactly mirroring DepthVisualization.depthBufferToArgb's
+        // pixel remap for the same rotation.
+        val width = 4
+        val height = 2
+        val depthMm = IntArray(width * height)
+        val confidence = IntArray(width * height) { 200 }
+        depthMm[0 * width + 3] = 1_000 // (x=3, y=0)
+        val (depth, conf) = buildPair(depthMm, confidence, width, height)
+
+        val packed = RawDepthCloud.buildCloud(
+            depthBytes = depth,
+            depthRowStrideBytes = width * 2,
+            confidenceBytes = conf,
+            confidenceRowStrideBytes = width,
+            width = width,
+            height = height,
+            stride = 1,
+            confidenceThreshold = 0,
+            rotationDegrees = 90,
+        )
+
+        assertEquals(1, RawDepthCloud.pointCount(packed))
+        // outX = height - 1 - y = 2 - 1 - 0 = 1; outY = x = 3.
+        assertEquals(1, RawDepthCloud.x(packed, 0))
+        assertEquals(3, RawDepthCloud.y(packed, 0))
+    }
+
+    @Test
+    fun `buildCloud rotates points 180 degrees`() {
+        val width = 4
+        val height = 2
+        val depthMm = IntArray(width * height)
+        val confidence = IntArray(width * height) { 200 }
+        depthMm[0] = 1_000 // (x=0, y=0)
+        val (depth, conf) = buildPair(depthMm, confidence, width, height)
+
+        val packed = RawDepthCloud.buildCloud(
+            depthBytes = depth,
+            depthRowStrideBytes = width * 2,
+            confidenceBytes = conf,
+            confidenceRowStrideBytes = width,
+            width = width,
+            height = height,
+            stride = 1,
+            confidenceThreshold = 0,
+            rotationDegrees = 180,
+        )
+
+        assertEquals(1, RawDepthCloud.pointCount(packed))
+        assertEquals(width - 1, RawDepthCloud.x(packed, 0))
+        assertEquals(height - 1, RawDepthCloud.y(packed, 0))
+    }
+
+    @Test
+    fun `buildCloud rotates points 270 degrees`() {
+        val width = 4
+        val height = 2
+        val depthMm = IntArray(width * height)
+        val confidence = IntArray(width * height) { 200 }
+        depthMm[0 * width + 3] = 1_000 // (x=3, y=0)
+        val (depth, conf) = buildPair(depthMm, confidence, width, height)
+
+        val packed = RawDepthCloud.buildCloud(
+            depthBytes = depth,
+            depthRowStrideBytes = width * 2,
+            confidenceBytes = conf,
+            confidenceRowStrideBytes = width,
+            width = width,
+            height = height,
+            stride = 1,
+            confidenceThreshold = 0,
+            rotationDegrees = 270,
+        )
+
+        assertEquals(1, RawDepthCloud.pointCount(packed))
+        // outX = y = 0; outY = width - 1 - x = 4 - 1 - 3 = 0.
+        assertEquals(0, RawDepthCloud.x(packed, 0))
+        assertEquals(0, RawDepthCloud.y(packed, 0))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `buildCloud rejects a rotation that is not a multiple of 90`() {
+        val empty = ByteBuffer.allocate(8)
+        RawDepthCloud.buildCloud(empty, 8, empty, 4, 4, 1, rotationDegrees = 45)
+    }
+
+    @Test
     fun `defaults are within sane bounds`() {
         assertTrue(RawDepthCloud.DEFAULT_STRIDE >= 1)
         assertTrue(RawDepthCloud.DEFAULT_MAX_POINTS > 0)

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
@@ -1,6 +1,7 @@
 package io.github.sceneview.demo.demos.internal
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -113,5 +114,55 @@ class SemanticsOverlayTest {
         assertEquals(0.5f, SemanticsOverlay.clampUnit(0.5f), 1e-6f)
         assertTrue(SemanticsOverlay.clampUnit(0f) == 0f)
         assertTrue(SemanticsOverlay.clampUnit(1f) == 1f)
+    }
+
+    // ── isOutdoorSceneUnclassified (#3274) ────────────────────────────────
+
+    @Test
+    fun `dominant unlabeled fraction is reported as unclassified`() {
+        assertTrue(
+            SemanticsOverlay.isOutdoorSceneUnclassified(
+                topOrdinal = SemanticsOverlay.UNLABELED_ORDINAL,
+                topFraction = 0.97f,
+            )
+        )
+    }
+
+    @Test
+    fun `unlabeled fraction under the threshold is not reported as unclassified`() {
+        assertFalse(
+            SemanticsOverlay.isOutdoorSceneUnclassified(
+                topOrdinal = SemanticsOverlay.UNLABELED_ORDINAL,
+                topFraction = 0.5f,
+            )
+        )
+    }
+
+    @Test
+    fun `a real top label is never reported as unclassified, however high its fraction`() {
+        assertFalse(
+            SemanticsOverlay.isOutdoorSceneUnclassified(
+                topOrdinal = 0, // SKY
+                topFraction = 1.0f,
+            )
+        )
+    }
+
+    @Test
+    fun `threshold is exact at the boundary`() {
+        assertTrue(
+            SemanticsOverlay.isOutdoorSceneUnclassified(
+                topOrdinal = SemanticsOverlay.UNLABELED_ORDINAL,
+                topFraction = 0.9f,
+                threshold = 0.9f,
+            )
+        )
+        assertFalse(
+            SemanticsOverlay.isOutdoorSceneUnclassified(
+                topOrdinal = SemanticsOverlay.UNLABELED_ORDINAL,
+                topFraction = 0.899f,
+                threshold = 0.9f,
+            )
+        )
     }
 }


### PR DESCRIPTION
Closes #3270, closes #3271, closes #3274

## Root cause per demo

- **#3270 `ar-point-cloud` — "nothing rendered".** `ARPointCloudDemo` had no
  `onTrackingFailureChanged` wiring at all, unlike its `ar-raw-depth-point-cloud` /
  `ar-scene-semantics` siblings. `PointCloudNode.update()` silently no-ops whenever ARCore
  isn't `TRACKING`, so a lost-tracking session (or a cold start still resolving its first
  feature points) rendered nothing with zero on-screen explanation — which read as "nothing
  rendered" rather than "point the camera at a textured surface". Added the same
  tracking-failure banner the other two demos already have, plus a "still scanning" hint once
  the cloud has sat at zero points, while tracking, for more than two seconds. The gate is a
  pure function (`PointCloudFeedback.zeroPointsStuck`), pinned by a new JVM test.

- **#3271 `ar-raw-depth-point-cloud` — "rotation error...points are not visible enough".**
  ARCore hands back the raw-depth image in the camera-sensor frame, which does not follow the
  display. `RawDepthCloud.buildCloud` mapped `x`/`y` straight onto the screen-space `Canvas`
  overlay with no rotation correction, so in portrait the cloud landed 90° off and most points
  scattered outside the visible view. This is the exact same bug class already fixed for the
  false-color depth visualization in #3184 (`DepthVisualization.depthBufferToArgb`) but never
  applied to the point-cloud variant. `buildCloud` now takes a `rotationDegrees` parameter,
  derived from the live display rotation the same way `ARDepthVisualizationDemo` already does,
  and re-indexes each point into the rotated output frame. Pinned by four new JVM tests
  (0°/90°/180°/270° plus the invalid-rotation guard).

- **#3274 `ar-scene-semantics` — "nothing...rendered".** ARCore's Scene Semantics model has
  no indoor training data; pointed at an indoor scene it classifies almost every pixel
  `UNLABELED`, which the overlay shader paints fully transparent by design. The demo already
  had support-gating and a "warming up" banner, but nothing distinguished "classified nothing
  because indoors" from "working normally" — so an indoor session silently showed the plain
  camera feed. Added a guidance banner ("Scene Semantics is outdoor-only...") that appears
  whenever the frame's dominant label is `UNLABELED` at ≥90%. The gate is a pure function
  (`SemanticsOverlay.isOutdoorSceneUnclassified`), pinned by four new JVM tests.

None of the three turned out to be an SDK-level bug (Config/session wiring, thread-safety,
buffer math were all already correct and covered by existing tests) — each was a demo-level
UX gap: missing or insufficient on-screen feedback for a state ARCore itself reports cleanly.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin :samples:android-demo:testDebugUnitTest --no-daemon --no-configuration-cache -q` — passes, including 15 new JVM unit tests across `PointCloudFeedbackTest`, `RawDepthCloudTest`, and `SemanticsOverlayTest`.
- **Physical-device QA is still pending.** Per this session's instructions I did not use a
  physical device (a Pixel 4a is owned by another agent), and the emulator (`emulator-5554`)
  was in use by another agent for the point-cloud demo's UI, so all three fixes are verified
  by code reading + JVM unit tests only, not by running the app. In particular the raw-depth
  rotation fix (#3271) and the point-cloud tracking banner (#3270) should be spot-checked on a
  real Pixel 9 in portrait before this ships, and the scene-semantics banner (#3274) should be
  checked both indoors (banner should appear) and outdoors (should not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)