### PR TITLE
Readable AR instructions overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,6 +71,8 @@ Glassmorphism adds depth and layering to surfaces that float over content (nav, 
 | `stage-scrim-end` | rgba(0,0,0,0.90) | rgba(0,0,0,0.90) | Spatial Gallery media scrim end |
 | `glass-surface` | rgba(255,255,255,0.72) | rgba(255,255,255,0.05) | Floating Spatial Gallery controls |
 | `glass-border` | 1px rgba(255,255,255,0.08) | 1px rgba(255,255,255,0.08) | Floating control outline |
+| `ar-scrim` | rgba(0,0,0,0.94) | rgba(0,0,0,0.88) | AR coaching overlay ground, over the camera feed |
+| `ar-scrim-border` | 1px rgba(255,255,255,0.16) | 1px rgba(255,255,255,0.10) | AR coaching overlay hairline |
 
 ### Text
 
@@ -79,6 +81,8 @@ Glassmorphism adds depth and layering to surfaces that float over content (nav, 
 | `on-surface` | #1a1a2e | #f3f4f6 | Primary text |
 | `on-surface-dim` | #3d4654 | #9ca3af | Secondary text |
 | `on-surface-faint` | #5c6370 | #6b7280 | Tertiary text, captions |
+| `on-ar-scrim` | #ffffff | #ffffff | AR coaching overlay text — white in both themes, the ground is the camera |
+| `on-ar-scrim-dim` | rgba(255,255,255,0.72) | rgba(255,255,255,0.72) | AR coaching overlay secondary text |
 
 ### Borders
 
@@ -331,6 +335,29 @@ Glassmorphism layer system for surfaces that float over content. Apply with rest
 - Padding: `space-md`
 - Border: 1px solid rgba(255,255,255,0.05)
 - Font size: `text-xs` (0.85rem)
+
+### AR Coaching Overlay
+
+The one instruction surface shown over a live camera feed (`DemoStatusBanner` on Android).
+
+- Ground: `ar-scrim` — a near-opaque dark pill, **not** a brand-coloured one. The
+  background it must beat is an arbitrary camera frame, not an app surface, so the
+  ground does not flip with the theme; only its opacity does (light mode is used
+  outdoors more often, so it is a touch more opaque).
+- Text: `on-ar-scrim`, `text-body` at `weight-medium`, max 3 lines, one short sentence.
+- Border: `ar-scrim-border`, shadow `shadow-lg` — separates the pill from a busy frame.
+- Radius: `radius-lg`; padding 16px horizontal, 12px vertical; max width 480px.
+- Leading indicator, 20px, one per severity:
+
+| Severity | Indicator | Accent |
+|---|---|---|
+| Progress | Indeterminate spinner | `primary` (dark value #a4c1ff) |
+| Guidance | Gesture / move-device icon | `warning` |
+| Blocked | Error icon | #ffb4ab (dark-scheme error) |
+
+- Accents are the **dark-scheme** values in both themes: they are read on `ar-scrim`.
+- Motion: enters with fade + 8px rise (`duration-medium`, `ease-expressive`), leaves
+  with fade + fall (`duration-short`). Nothing to say → nothing on screen.
 
 ### Tabs
 - Padding: 10px 20px

--- a/changelog.d/3265-ar-instructions.md
+++ b/changelog.d/3265-ar-instructions.md
@@ -1,0 +1,7 @@
+<!-- category: Changed -->
+The in-AR instructions overlay shared by every AR demo (`DemoStatusBanner`) is now a
+dark-scrim coaching pill — white 16 sp text, a leading spinner or severity icon, a
+hairline border and a soft lift — instead of a flat brand-coloured capsule with 14 sp
+text, which was hard to read over a live camera feed. Passing `null` or a blank string
+now animates the pill out, so a demo whose step is done hides it without extra code
+(#3265).

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoStatusBanner.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoStatusBanner.kt
@@ -1,20 +1,47 @@
 package io.github.sceneview.demo.common
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.ScreenRotationAlt
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.demo.DemoBottomOverlayScope
+import io.github.sceneview.demo.theme.SceneViewTokens
 
 /**
  * How loud a [DemoStatusBanner] should be.
@@ -24,6 +51,9 @@ import io.github.sceneview.demo.DemoBottomOverlayScope
  * `surface` elsewhere — with the result that the same severity looked different
  * from one demo to the next, and "ARCore is initialising" (normal, transient) got
  * the same red as "no API key configured" (broken, needs the user to act).
+ *
+ * Since #3265 the tone no longer picks the pill's *background* — it picks the
+ * leading indicator and its accent. See [DemoStatusBanner].
  */
 enum class DemoStatusTone {
     /** Normal, transient state: initialising, scanning, waiting for a lock. */
@@ -39,8 +69,20 @@ enum class DemoStatusTone {
 /** Test tag for the shared banner, so a UI test can assert on it by contract. */
 const val DEMO_STATUS_BANNER_TAG = "demo-status-banner"
 
+/** Vertical padding inside the pill — half of `space-lg`, the one value not on the scale. */
+private val PILL_VERTICAL_PADDING = 12.dp
+
+/** Gap between the leading indicator and the sentence. */
+private val PILL_ICON_GAP = 12.dp
+
+/** Leading icon / spinner box. Big enough to read at arm's length, small enough to stay a hint. */
+private val PILL_INDICATOR_SIZE = 20.dp
+
+/** Lift over a busy camera frame — the hairline border alone is not separation enough. */
+private val PILL_ELEVATION = 8.dp
+
 /**
- * The one status banner shape for the demo app.
+ * The one status banner shape for the demo app — the AR coaching overlay.
  *
  * Only callable inside `DemoScaffold(bottomOverlay = …)`, because the receiver is
  * what carries the geometry it cannot otherwise know: how much room the Settings
@@ -61,26 +103,91 @@ const val DEMO_STATUS_BANNER_TAG = "demo-status-banner"
  * composable is not a style helper — it is the thing that makes the geometry a
  * demo author cannot get wrong, because they never write it.
  *
- * @param text the complete sentence to show. Banners say what is happening and
- *   what to do about it; they are not labels.
+ * ## Why the pill is a dark scrim and not brand blue (#3265)
+ *
+ * It used to paint itself in `primary` / `tertiary` / `error` at 92 % alpha, one
+ * flat colour per tone, with 14 sp body text on top. Over a live camera feed that
+ * is the wrong ground twice over: mid-tone brand colours sit close to a lot of
+ * real-world luminance (blue on sky, purple on a lit wall), and letting the tone
+ * pick the *background* meant the most common state — "scanning", the one every
+ * AR demo shows on launch — was the hardest to read, in the largest area of
+ * colour, for the least reason.
+ *
+ * The shape every shipping AR app converges on instead (ARKit's coaching overlay,
+ * ARCore's coaching card, Polycam's capture hints) is the one this now uses: a
+ * dark near-opaque scrim, white text, and the severity carried by a small leading
+ * indicator rather than by 300 dp² of colour. `ar-scrim` in `DESIGN.md` is that
+ * ground, and it deliberately does **not** flip with the app theme — the thing
+ * behind it is a camera frame, not a `surface`; only its opacity moves (light
+ * mode is used outdoors more often, where the frame is brightest). Text is
+ * `on-ar-scrim` white at `text-body` / `weight-medium`, ≈ 19:1 against the
+ * scrim, where the old 14 sp on a mid-tone container failed WCAG AA outdoors
+ * even at 92 % alpha.
+ *
+ * ## Nothing to say means nothing on screen
+ *
+ * [text] is nullable, and a null or blank string animates the pill *out* instead
+ * of leaving an empty capsule floating over the scene. A demo whose step is done
+ * therefore auto-hides by passing `null` — no per-demo `AnimatedVisibility`
+ * needed, though the demos that already wrap this in one keep working unchanged,
+ * which is why the parameter list is otherwise identical to the old one.
+ *
+ * @param text the complete sentence to show, or `null`/blank to hide the banner.
+ *   Banners say what is happening and what to do about it; they are not labels.
+ *   Keep them short — the pill holds three lines and truncates past that.
+ * @param tone the severity, which picks the leading indicator and its accent.
+ * @param icon overrides the tone's default leading icon. A `Progress` banner with
+ *   no override shows an indeterminate spinner rather than an icon.
  */
 @Composable
 fun DemoBottomOverlayScope.DemoStatusBanner(
-    text: String,
+    text: String?,
     tone: DemoStatusTone = DemoStatusTone.Progress,
     modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
 ) {
-    val scheme = MaterialTheme.colorScheme
-    val container: Color = when (tone) {
-        DemoStatusTone.Progress -> scheme.primary
-        DemoStatusTone.Guidance -> scheme.tertiary
-        DemoStatusTone.Blocked -> scheme.error
+    val visible = !text.isNullOrBlank()
+
+    // Hold the last real sentence for the length of the exit animation: reading
+    // `text` straight through would blank the pill's content on the same frame the
+    // fade starts, and the user would watch an empty capsule slide away.
+    var lastText by remember { mutableStateOf(text.orEmpty()) }
+    var lastTone by remember { mutableStateOf(tone) }
+    var lastIcon by remember { mutableStateOf(icon) }
+    if (visible) {
+        lastText = text!!
+        lastTone = tone
+        lastIcon = icon
     }
-    val content: Color = when (tone) {
-        DemoStatusTone.Progress -> scheme.onPrimary
-        DemoStatusTone.Guidance -> scheme.onTertiary
-        DemoStatusTone.Blocked -> scheme.onError
+
+    // Read the *theme's* darkness, not the system's: `SceneViewDemoTheme` takes an
+    // explicit `darkTheme` flag (previews and the in-app theme override both set it),
+    // and `isSystemInDarkTheme()` would ignore that and answer for the OS.
+    val dark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val scrim = if (dark) {
+        SceneViewTokens.ArOverlay.scrimDark
+    } else {
+        SceneViewTokens.ArOverlay.scrimLight
     }
+    val borderColor = if (dark) {
+        SceneViewTokens.ArOverlay.borderDark
+    } else {
+        SceneViewTokens.ArOverlay.borderLight
+    }
+    val accent: Color = when (lastTone) {
+        DemoStatusTone.Progress -> SceneViewTokens.ArOverlay.accentProgress
+        DemoStatusTone.Guidance -> SceneViewTokens.ArOverlay.accentGuidance
+        DemoStatusTone.Blocked -> SceneViewTokens.ArOverlay.accentBlocked
+    }
+    val leadingIcon: ImageVector? = lastIcon ?: when (lastTone) {
+        // Progress has no icon on purpose: the spinner *is* the indicator, and it
+        // says "still working" in a way no static glyph does.
+        DemoStatusTone.Progress -> null
+        DemoStatusTone.Guidance -> Icons.Rounded.ScreenRotationAlt
+        DemoStatusTone.Blocked -> Icons.Rounded.ErrorOutline
+    }
+    val shape = RoundedCornerShape(SceneViewTokens.Radius.lg)
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -97,22 +204,86 @@ fun DemoBottomOverlayScope.DemoStatusBanner(
             .padding(end = settingsFabReservedSpace),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = content,
-            textAlign = TextAlign.Center,
-            modifier = modifier
-                .background(
-                    // 0.92f rather than the 0.85f the demos had settled on: these
-                    // banners are read over a live camera feed, and at 0.85 the
-                    // highest-contrast text in the app was still failing WCAG AA
-                    // against a bright outdoor scene showing through.
-                    color = container.copy(alpha = 0.92f),
-                    shape = RoundedCornerShape(24.dp),
+        // Fully qualified: the receiver is a `ColumnScope`, whose `AnimatedVisibility`
+        // extension would win resolution here and animate the wrong axis.
+        androidx.compose.animation.AnimatedVisibility(
+            visible = visible,
+            // Rise on entry, fall on exit, both with `ease-expressive`: the pill
+            // belongs to the bottom band it comes from. The exit is the shorter of
+            // the two — a message that no longer applies should get out of the way.
+            enter = fadeIn(
+                animationSpec = tween(
+                    durationMillis = SceneViewTokens.Duration.mediumMillis,
+                    easing = SceneViewTokens.Ease.expressive,
+                ),
+            ) + slideInVertically(
+                animationSpec = tween(
+                    durationMillis = SceneViewTokens.Duration.mediumMillis,
+                    easing = SceneViewTokens.Ease.expressive,
+                ),
+                initialOffsetY = { it / 3 },
+            ),
+            exit = fadeOut(
+                animationSpec = tween(
+                    durationMillis = SceneViewTokens.Duration.shortMillis,
+                    easing = SceneViewTokens.Ease.expressive,
+                ),
+            ) + slideOutVertically(
+                animationSpec = tween(
+                    durationMillis = SceneViewTokens.Duration.shortMillis,
+                    easing = SceneViewTokens.Ease.expressive,
+                ),
+                targetOffsetY = { it / 3 },
+            ),
+        ) {
+            Row(
+                modifier = modifier
+                    .padding(horizontal = SceneViewTokens.Space.md)
+                    .widthIn(max = SceneViewTokens.ArOverlay.maxWidth)
+                    // Shadow before background so the lift is cast by the pill's
+                    // shape rather than clipped inside it.
+                    .shadow(elevation = PILL_ELEVATION, shape = shape, clip = false)
+                    .background(color = scrim, shape = shape)
+                    .border(
+                        width = SceneViewTokens.ArOverlay.borderWidth,
+                        color = borderColor,
+                        shape = shape,
+                    )
+                    .padding(
+                        horizontal = SceneViewTokens.Space.md,
+                        vertical = PILL_VERTICAL_PADDING,
+                    )
+                    // TalkBack should announce a coaching change without the user
+                    // going looking for it — that is the whole point of the surface.
+                    .semantics { liveRegion = LiveRegionMode.Polite }
+                    .testTag(DEMO_STATUS_BANNER_TAG),
+                horizontalArrangement = Arrangement.spacedBy(PILL_ICON_GAP),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (leadingIcon != null) {
+                    Icon(
+                        imageVector = leadingIcon,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.size(PILL_INDICATOR_SIZE),
+                    )
+                } else {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(PILL_INDICATOR_SIZE),
+                        color = accent,
+                        strokeWidth = 2.dp,
+                    )
+                }
+                Text(
+                    text = lastText,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.Medium,
+                    ),
+                    color = SceneViewTokens.ArOverlay.onScrim,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
                 )
-                .padding(horizontal = 20.dp, vertical = 10.dp)
-                .testTag(DEMO_STATUS_BANNER_TAG),
-        )
+            }
+        }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoStatusBannerPreviews.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/DemoStatusBannerPreviews.kt
@@ -1,0 +1,98 @@
+package io.github.sceneview.demo.common
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.sceneview.demo.DemoBottomOverlayScope
+import io.github.sceneview.demo.theme.SceneViewDemoTheme
+import io.github.sceneview.demo.theme.SceneViewTokens
+
+/**
+ * `@Preview` coverage for the AR coaching overlay, [DemoStatusBanner] (#3265).
+ *
+ * The background is deliberately the hardest case rather than a flat grey: a bright
+ * overexposed sky at the top fading to a dark interior at the bottom, which is what
+ * a phone actually points at when it is being told to "move around slowly". A pill
+ * that stays readable across that gradient is readable over a camera feed.
+ *
+ * All three tones are shown at once, in the order a demo escalates through them.
+ */
+@Composable
+private fun CameraFeedStandIn(content: @Composable DemoBottomOverlayScope.() -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0xFFEDF3FF), // blown-out sky
+                        Color(0xFFB8A88C), // sunlit wall
+                        Color(0xFF2B2620), // shadowed interior
+                    )
+                )
+            ),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = SceneViewTokens.Space.lg),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // `settingsFabReservedSpace` stands in at the value a demo with a
+            // Settings FAB reports, so the preview shows the real off-centre band.
+            DemoBottomOverlayScope(this, 104.dp).content()
+        }
+    }
+}
+
+@Composable
+private fun DemoBottomOverlayScope.AllTones() {
+    DemoStatusBanner(
+        text = "Move your phone slowly to scan the surface",
+        tone = DemoStatusTone.Progress,
+    )
+    DemoStatusBanner(
+        text = "Too dark — turn on a light or move somewhere brighter",
+        tone = DemoStatusTone.Guidance,
+    )
+    DemoStatusBanner(
+        text = "No ARCore Cloud API key — Geospatial features stay off until one is set",
+        tone = DemoStatusTone.Blocked,
+    )
+}
+
+@Preview(name = "AR status banner — light", showBackground = true, widthDp = 411, heightDp = 500)
+@Composable
+private fun DemoStatusBannerLightPreview() {
+    SceneViewDemoTheme(darkTheme = false, dynamicColor = false) {
+        CameraFeedStandIn { AllTones() }
+    }
+}
+
+@Preview(
+    name = "AR status banner — dark",
+    showBackground = true,
+    widthDp = 411,
+    heightDp = 500,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun DemoStatusBannerDarkPreview() {
+    SceneViewDemoTheme(darkTheme = true, dynamicColor = false) {
+        CameraFeedStandIn { AllTones() }
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
@@ -30,6 +30,37 @@ object SceneViewTokens {
         val glassBorderWidth = 1.dp
     }
 
+    /**
+     * `DESIGN.md` — AR coaching overlay colours (`ar-scrim`, `on-ar-scrim`, …).
+     *
+     * These do **not** flip with the app theme the way a surface token does: the
+     * ground behind an AR overlay is an arbitrary camera frame, so the pill stays
+     * a dark scrim with white text in both themes, and only its opacity moves
+     * (light mode is used outdoors more often, where the frame is brightest).
+     * The accents are the dark-scheme values of the Material roles for the same
+     * reason — they are read on black, never on `surface`.
+     */
+    object ArOverlay {
+        val scrimLight = Color(0xF0000000)
+        val scrimDark = Color(0xE0000000)
+        val onScrim = Color(0xFFFFFFFF)
+        val borderLight = Color(0x29FFFFFF)
+        val borderDark = Color(0x1AFFFFFF)
+        val borderWidth = 1.dp
+
+        /** Transient work in progress — spinner accent. `primary` (dark value). */
+        val accentProgress = Color(0xFFA4C1FF)
+
+        /** Waiting on the user to move the phone — `warning`. */
+        val accentGuidance = Color(0xFFF59E0B)
+
+        /** Broken until something changes — dark-scheme `error`. */
+        val accentBlocked = Color(0xFFFFB4AB)
+
+        /** Widest a coaching pill may grow — a long line stays one readable column. */
+        val maxWidth = 480.dp
+    }
+
     /** `DESIGN.md` — Spacing scale (`space-*`). */
     object Space {
         val xs = 4.dp


### PR DESCRIPTION
Closes #3265

## Why

The in-AR instructions overlay every AR demo shares (`DemoStatusBanner`) painted itself
in `primary` / `tertiary` / `error` at 92 % alpha with 14 sp body text. Over a live
camera feed that is the wrong ground twice over: mid-tone brand colours sit close to a
lot of real-world luminance (blue on sky, purple on a lit wall), and letting the severity
pick the *background* made the most common state — "scanning", shown by every AR demo on
launch — the hardest to read, in the largest area of colour, for the least reason.

## What it is now

The shape shipping AR apps converge on (ARKit's coaching overlay, ARCore's coaching card,
Polycam's capture hints):

- **Dark scrim pill**, `radius-lg`, max 480 dp wide, hairline border, 8 dp lift so it
  separates from a busy frame.
- **White 16 sp medium text** (`on-ar-scrim`, ≈ 19:1 contrast), three lines max, then
  ellipsis — short sentences by construction.
- **Severity in a 20 dp leading indicator**, not in 300 dp² of colour: an indeterminate
  spinner for `Progress`, a move-device icon for `Guidance`, an error icon for `Blocked`,
  each in an accent picked to be read on black.
- **The ground does not flip with the app theme** — what is behind it is a camera frame,
  not a `surface`. Only its opacity moves (light 0.94, dark 0.88), which is the one thing
  the ambient theme is evidence about.
- **Motion**: rises with a fade over `duration-medium` on entry, falls over
  `duration-short` on exit, both `ease-expressive`.
- **Auto-hide**: `text` is now nullable — `null` or blank animates the pill out instead
  of leaving an empty capsule over the scene, so a demo hides a finished step by passing
  `null`. Demos that already wrap it in their own `AnimatedVisibility` keep working.
- **Accessibility**: the pill is a polite live region, so TalkBack announces a coaching
  change instead of waiting to be found.

`ar-scrim`, `ar-scrim-border`, `on-ar-scrim` and an "AR Coaching Overlay" component
section are new in `DESIGN.md`, mirrored one-for-one in `SceneViewTokens.ArOverlay` —
nothing in the composable is a hand-picked colour.

## Compatibility

The parameter list is otherwise identical (`text`, `tone`, `modifier`, plus an optional
`icon` override), so **all 20 AR demos get the new overlay with no per-demo edit** and no
shim: only the nullability of `text` changed, which is source-compatible for every
existing call.

## Verification

- `./gradlew :samples:android-demo:compileDebugKotlin` — green.
- `./gradlew :samples:android-demo:verifyRoborazziDebug` — green; no existing golden
  covers this composable, and the module's unit tests (incl. `DemoScaffoldBottomBandTest`,
  which pins the bottom-band geometry this overlay lives in) still pass.
- New `@Preview`s (light + dark) render all three tones over a sky-to-shadow gradient —
  the hardest legibility case, brighter and darker than most camera frames.
- On the AR emulator (`emulator-5554`, Pixel 7a, never a personal device): `ar-streetscape`
  (Blocked tone) and `ar-plane-renderer-v2` (Progress tone) captured in light and dark
  (`cmd uimode night yes|no`), overlay legible and clear of the FAB / action-bar band in
  both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
