### PR TITLE
iOS parity: complete the SplatNode doc-honesty fix (#2768)

### DIFF
--- a/changelog.d/2768-splatnode-ios-parity-doc.md
+++ b/changelog.d/2768-splatnode-ios-parity-doc.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+`llms.txt`'s "Android-only — no port planned or pending" table was missing `SplatNode` /
+`SplatCloud` / `rememberSplatCloud` (3D Gaussian Splatting) — an AI generating
+SceneViewSwift code for splat content got no signal the capability doesn't exist on iOS.
+The row now matches the one already added to `cheatsheet-ios.md`. The demo-catalog parity
+ledger (`parity-manifest.yml`) also pointed its `splat-preview` gap at #2768, which
+explicitly parks the RealityKit port as a maintainer decision rather than owning the
+implementation — it now points at #2646 (item 2 of its scope), which does own it (#2768).

--- a/llms.txt
+++ b/llms.txt
@@ -5884,6 +5884,7 @@ These symbols do not exist on iOS (no `@available(*, deprecated)` factory — th
 | `SurfaceType.texture` | RealityKit always renders to `MTKView` | N/A — no port needed |
 | `StreetscapeGeometry` | ARGeoTrackingConfiguration exists but no mesh equivalent | iOS-skip with doc warning |
 | `TerrainAnchor / RooftopAnchor` | `ARGeoAnchor` only does ground; rooftop has no ARKit equivalent | iOS-skip with doc warning |
+| `SplatNode` / `SplatCloud` / `rememberSplatCloud` — 3D Gaussian Splatting (`splat-preview` demo, #2646) | No first-party RealityKit Gaussian-splat primitive; would need a custom Metal render path or a mesh-impostor approximation | iOS-skip — Android-only today, absent from every SceneViewSwift surface. Needs-decision on a future custom-Metal or impostor-mesh port (#2768). |
 
 ### Approximated — iOS implements via different mechanism
 

--- a/parity-manifest.yml
+++ b/parity-manifest.yml
@@ -364,7 +364,9 @@ demos:
     androidStatus: Working
     iosStatus: android-only
     reason: >-
-      No iOS screen — blocked on an iOS SplatNode renderer (#2768). Its
+      No iOS screen — blocked on an iOS SplatNode renderer, tracked as
+      item 2 of #2646 (#2768 documents the gap but explicitly parks the
+      port as a maintainer decision, not an implementation owner). Its
       coming-soon Scene stub was deleted in #3231.
   - id: video-recording
     androidStatus: Working


### PR DESCRIPTION
## Summary

- Adds the missing `SplatNode` / `SplatCloud` / `rememberSplatCloud` row to `llms.txt`'s "Android-only — no port planned or pending" table, matching the equivalent row already shipped to `cheatsheet-ios.md` in #2812. Before this, an AI generating SceneViewSwift code from `llms.txt` alone got no signal that 3D Gaussian Splatting doesn't exist on iOS — the exact "silently missing" failure mode #2768 reported.
- Fixes an ownership pointer in `parity-manifest.yml`: the `splat-preview` row's `reason` cited #2768 as the blocker, but #2768 explicitly parks the RealityKit port as a maintainer "needs-decision" rather than owning the implementation. #2646 (item 2 of its scope) is the issue that owns "iOS `SplatNode` on RealityKit". The row now points there, so closing #2768 doesn't silently orphan the port (flagged in #2768's own triage comment).

## Option taken

#2768 is labeled `documentation` and its own body frames the fix in two boxes: "Now (docs, trivial)" — restore honesty — and "Later (product decision)" — whether to port Gaussian Splatting to RealityKit at all, explicitly "fine to park as `needs-decision`". This PR completes box 1 only (documentation), which is what the issue asks this PR to own. Implementing SplatNode on RealityKit is tracked separately as item 2 of #2646's scope and is a much larger, unstarted body of work (no first-party RealityKit splat primitive; needs a custom Metal path or mesh-impostor approximation) — well outside a documentation PR.

The cheatsheet-ios.md half of box 1 already shipped in #2812 (2026-07-20); this PR closes the remaining gap the triage comment identified: the `llms.txt` row and the ownership-pointer conflict in `parity-manifest.yml`.

## Test plan

- [x] `bash .claude/scripts/check-sceneview-skill.sh` — passes (frontmatter, API identifiers, demo refs all green)
- [x] Manual read-through of the new `llms.txt` row against the existing `cheatsheet-ios.md` row for consistent wording
- [x] `changelog.d/2768-splatnode-ios-parity-doc.md` added with `<!-- category: Fixed -->`

Fixes #2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)