### PR TITLE
feat(web): port centerOrigin to sceneview-web + shared cross-platform golden vectors

### DIFF
--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ModelNodeTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ModelNodeTests.swift
@@ -543,5 +543,85 @@ final class ModelNodeTests: XCTestCase {
             .centerOrigin(normalized: SIMD3(0, -1, 0))
         XCTAssertNotNil(node.entity.model)
     }
+
+    // MARK: - Cross-platform golden-vector table (#2763)
+    //
+    // Same expected translations as Kotlin `centerOriginGoldenVectors`
+    // (`sceneview-core/src/commonTest/kotlin/io/github/sceneview/math/CenterOriginGoldenVectorsTest.kt`,
+    // shared by Android and Web since both compile that KMP module) — the
+    // Rerun-precedent pattern (`RerunWireFormatTest.kt` /
+    // `RerunWireFormatTests.swift`): identical expected values duplicated in
+    // each platform's own suite so a numeric divergence fails locally, on
+    // its own platform, with no shared runtime dependency.
+    //
+    // This overload has no separate `scale` parameter — RealityKit's
+    // `visualBounds` already reports SCALED world-space extents (see the
+    // `centerOrigin(normalized:)` doc comment above) — so a Kotlin vector's
+    // `(center, halfExtent, scale)` is folded into this overload's
+    // `(center: center*scale, extents: 2*halfExtent*scale)` before calling.
+    // The resulting `expected` translations are unchanged by that folding
+    // (verified algebraically: `-(c*s + o*h*s) == -(c*s + o*(2*h*s)/2)`),
+    // so the numbers below are literally the same as the Kotlin table's.
+
+    func testGoldenVectorCenteredPullsOffPivotAabbCenterOntoOrigin() {
+        // Kotlin: center=(1,2,1), halfExtent=(1,2,1), scale=0.5, origin=(0,0,0).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(0.5, 1, 0.5), extents: SIMD3(1, 2, 1), origin: .zero
+        )
+        XCTAssertEqual(t.x, -0.5, accuracy: 1e-6)
+        XCTAssertEqual(t.y, -1, accuracy: 1e-6)
+        XCTAssertEqual(t.z, -0.5, accuracy: 1e-6)
+    }
+
+    func testGoldenVectorBottomAlignedSitsModelOnNodeOrigin() {
+        // Kotlin: center=(1,2,1), halfExtent=(1,2,1), scale=0.5, origin=(0,-1,0).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(0.5, 1, 0.5), extents: SIMD3(1, 2, 1), origin: SIMD3(0, -1, 0)
+        )
+        XCTAssertEqual(t.x, -0.5, accuracy: 1e-6)
+        XCTAssertEqual(t.y, 0, accuracy: 1e-6)
+        XCTAssertEqual(t.z, -0.5, accuracy: 1e-6)
+    }
+
+    func testGoldenVectorTopAlignedHangsModelFromNodeOrigin() {
+        // Kotlin: center=(1,2,1), halfExtent=(1,2,1), scale=0.5, origin=(0,1,0).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(0.5, 1, 0.5), extents: SIMD3(1, 2, 1), origin: SIMD3(0, 1, 0)
+        )
+        XCTAssertEqual(t.x, -0.5, accuracy: 1e-6)
+        XCTAssertEqual(t.y, -2, accuracy: 1e-6)
+        XCTAssertEqual(t.z, -0.5, accuracy: 1e-6)
+    }
+
+    func testGoldenVectorLeftTopAligned() {
+        // Kotlin: center=(1,2,1), halfExtent=(1,2,1), scale=0.5, origin=(-1,1,0).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(0.5, 1, 0.5), extents: SIMD3(1, 2, 1), origin: SIMD3(-1, 1, 0)
+        )
+        XCTAssertEqual(t.x, 0, accuracy: 1e-6)
+        XCTAssertEqual(t.y, -2, accuracy: 1e-6)
+        XCTAssertEqual(t.z, -0.5, accuracy: 1e-6)
+    }
+
+    func testGoldenVectorOffCenterAabbUnitScaleGeneralOrigin() {
+        // Kotlin: center=(-2,0.5,3), halfExtent=(0.5,1.5,2), scale=1, origin=(1,-1,-1).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(-2, 0.5, 3), extents: SIMD3(1, 3, 4), origin: SIMD3(1, -1, -1)
+        )
+        XCTAssertEqual(t.x, 1.5, accuracy: 1e-6)
+        XCTAssertEqual(t.y, 1, accuracy: 1e-6)
+        XCTAssertEqual(t.z, -1, accuracy: 1e-6)
+    }
+
+    func testGoldenVectorCenteredAabbNonUniformScaleGeneralOrigin() {
+        // Kotlin: center=(0,0,0), halfExtent=(2,3,4), scale=(2,0.5,1), origin=(1,1,-1).
+        // swift_center = center*scale = (0,0,0); swift_extents = 2*halfExtent*scale = (8,3,8).
+        let t = ModelNode.centerOriginTranslation(
+            center: SIMD3(0, 0, 0), extents: SIMD3(8, 3, 8), origin: SIMD3(1, 1, -1)
+        )
+        XCTAssertEqual(t.x, -4, accuracy: 1e-6)
+        XCTAssertEqual(t.y, -1.5, accuracy: 1e-6)
+        XCTAssertEqual(t.z, 4, accuracy: 1e-6)
+    }
 }
 #endif

--- a/changelog.d/2763-web-center-origin.md
+++ b/changelog.d/2763-web-center-origin.md
@@ -1,0 +1,13 @@
+<!-- category: Added -->
+`centerOrigin` reaches full cross-platform parity (#2763). `sceneview-web` gains
+`NodeHandle.centerOrigin(originX, originY, originZ)` — aligns the AABB point selected by a
+normalized origin (`-1..1` per axis, `0` = bounding-box center) with the node origin, typed
+in `sceneview-web.d.ts`. It calls the exact same `-(center + origin * halfExtent) * scale`
+formula as Android's `ModelNode.centerOrigin(Position)`, now extracted into a shared
+`sceneview-core` KMP function (`io.github.sceneview.math.centerOriginTranslation`) both
+platforms compile — Android and Web literally share one code path and cannot numerically
+diverge. A `centerOriginGoldenVectors` table pins that formula in `sceneview-core`'s
+`commonTest`, which runs unmodified on both the JVM (`android`) and JS (Karma) targets; the
+same expected values are duplicated in `SceneViewSwift`'s `ModelNodeTests` (RealityKit has no
+dependency on the KMP module, so it reimplements the math natively), following the
+`RerunWireFormatTest` cross-suite precedent. `llms.txt` documents the parity.

--- a/llms.txt
+++ b/llms.txt
@@ -515,7 +515,9 @@ ModelNode class properties (available via `apply` block):
 - `stopAnimation(index: Int)`, `stopAnimation(name: String)`
 - `setAnimationSpeed(index: Int, speed: Float)`
 - `scaleToUnitCube(units: Float = 1.0f)`
-- `centerOrigin(origin: Position = Position(0f, 0f, 0f))`
+- `centerOrigin(origin: Position = Position(0f, 0f, 0f))` — cross-platform parity: iOS
+  `ModelNode.centerOrigin(normalized:)`, Web `NodeHandle.centerOrigin(x, y, z)` (#2763),
+  identical `-(center + origin * halfExtent) * scale` formula on all three.
 - `onFrameError: ((Exception) -> Unit)?` — callback for frame errors (default: logs via Log.e)
 
 ### LightNode — light source
@@ -5763,6 +5765,7 @@ There are two `centerOrigin` overloads:
 - **`centerOrigin(_ target:)`** — absolute: moves the model so its visual-bounds **centre** sits at the supplied model-space point (in metres). Pass `.zero` to center on the origin — the equivalent of Kotlin `ModelNode(centerOrigin = Position(0,0,0))`. The target is an **absolute** point, so `SIMD3(0, -1, 0)` puts the bounds centre 1 m below the origin (it does NOT bottom-align).
 - **`centerOrigin(normalized origin:)`** — Android parity (#2632): `origin` is a **normalized** AABB coordinate (`-1..1` per axis, `0` = box centre, `±1` = box faces), and the selected AABB point is aligned with the node origin via `-(center + origin * extents/2)`. `centerOrigin(normalized: SIMD3(0, -1, 0))` bottom-aligns like Android's `Position(0, -1, 0)` (the model sits on the origin); `.zero` is identical to `centerOrigin(.zero)`. Prefer this overload when porting an Android grounding snippet (on an unpositioned entity) — it replaces the former manual grounding workaround `centerOrigin(SIMD3(0, bounds.extents.y / 2, 0))`.
   - **Apply before positioning.** Unlike Android's `centerOrigin` (which composes additively — `position += translation`, independent of the current position), this reads the entity's **world** visual-bounds, so it does not compose with a previously-set position: call it on an unpositioned, unparented entity (load → scaleToUnits → centerOrigin, before `.position(_:)` or anchoring), and a later `.position(_:)` replaces the grounding offset.
+  - **Web parity (#2763):** `sceneview-web`'s `NodeHandle.centerOrigin(x, y, z)` composes additively like Android (not like this iOS overload) since it wraps the same `sceneview-core` KMP formula Android calls — see the Web section's `centerOrigin` entry.
 
 ### iOS: GeometryNode
 
@@ -6169,9 +6172,19 @@ being closed incrementally (issue #2024, v5 milestone):
   `sv.addSphereNode(radius)` / `sv.addLightNode(type)` / `sv.addModelNode(url)`, keep the
   returned handle, and **address it after `create()`** — `setPosition` / `setRotation`
   (Euler degrees) / `setScale` / `setScaleUniform` / `setVisible` / `addChild` /
-  `removeChild` / `getWorldPosition` / `destroy`. This is the thing the builder DSL could
-  never do: mutate content imperatively after the scene is built. It is a **minimal first
-  slice** — no gestures, no collision, no transform object; those are additive later.
+  `removeChild` / `getWorldPosition` / `centerOrigin` / `destroy`. This is the thing the
+  builder DSL could never do: mutate content imperatively after the scene is built. It is
+  a **minimal first slice** — no gestures, no collision, no transform object; those are
+  additive later.
+- **`centerOrigin(originX, originY, originZ)` — Android/iOS parity (#2763).** Aligns the
+  AABB point selected by the normalized origin (`-1..1` per axis, `0` = AABB center) with
+  the node origin, using the exact `-(center + origin * halfExtent) * scale` formula
+  Android's `ModelNode.centerOrigin(Position)` uses (both compile the same
+  `sceneview-core` KMP function, so the two platforms cannot numerically diverge — pinned
+  by the `centerOriginGoldenVectors` table). `(0, -1, 0)` bottom-aligns; `(0, 1, 0)` hangs
+  the model from the origin. A no-op on a non-model handle, or before the model has
+  finished loading. Composes additively with the current position — call it once, right
+  after `sv.addModelNode(url)` resolves.
 
 The builder DSL below stays fully supported and is the simplest path for a static scene;
 `NodeHandle` is the additive imperative surface for scenes that mutate at runtime.
@@ -6188,6 +6201,7 @@ The builder DSL below stays fully supported and is the simplest path for a stati
 | Parent / child hierarchy | `node.parent = other` / `node.childNodes` | `handle.addChild(child)` / `handle.removeChild(child)` (exported since slice 3); builder-DSL content stays flat |
 | Per-content transform | `node.position` / `node.rotation` / `node.scale` (mutable, reactive) | builder `*Config` sets it once (not re-mutable); a `NodeHandle` IS re-mutable via `setPosition` / `setRotation` / `setScale` |
 | Transform inheritance | composed parent→child via Filament `TransformManager` | composed for `NodeHandle` parent/child (Filament `TransformManager`, same as Android); builder-DSL flat content is a world-space leaf |
+| Center a model on its bounding box | `ModelNode(centerOrigin = Position(...))` / iOS `centerOrigin(normalized:)` | `handle.centerOrigin(originX, originY, originZ)` (#2763, model-node handles only) — same formula as Android/iOS |
 
 **Correct Web code** — the builder DSL (simplest for a static scene):
 
@@ -6213,6 +6227,7 @@ sceneview.createViewer("canvas").then(function (sv) {
 
   sv.addModelNode("models/helmet.glb").then(function (model) {
     model.setRotation(0, 45, 0);             // Euler degrees
+    model.centerOrigin(0, -1, 0);            // bottom-align — same formula as Android/iOS (#2763)
     model.addChild(cube);                    // re-parent — cube now follows the model
   });
 

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -1060,6 +1060,10 @@ public final class io/github/sceneview/math/MathKt {
 	public static final fun toVector3 (Ldev/romainguy/kotlin/math/Float3;)Lio/github/sceneview/collision/Vector3;
 }
 
+public final class io/github/sceneview/math/ModelCenteringKt {
+	public static final fun centerOriginTranslation (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;)Ldev/romainguy/kotlin/math/Float3;
+}
+
 public final class io/github/sceneview/math/Noise {
 	public static final field INSTANCE Lio/github/sceneview/math/Noise;
 	public final fun fbm2D (FFIFF)F

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/ModelCentering.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/math/ModelCentering.kt
@@ -1,0 +1,28 @@
+package io.github.sceneview.math
+
+/**
+ * Computes the `centerOrigin` translation: the offset that moves the point of a model's
+ * bounding box selected by [origin] (normalized AABB coordinates, `-1..1` per axis, `0` = AABB
+ * center) onto the node's local origin.
+ *
+ * The anchor point in unscaled model space is `center + origin * halfExtent`; negating it and
+ * applying the node [scale] yields the parent-space translation that cancels it out. Using the
+ * AABB [center] (not just the extents) makes the alignment correct for assets whose bounding
+ * box is not authored centered on their pivot.
+ *
+ * **Single cross-platform source of truth (issue #2763).** Both `sceneview` (Android,
+ * `ModelNode.centerOrigin`) and `sceneview-web` (Kotlin/JS, `ModelNode.centerOrigin`) call this
+ * exact function — since `sceneview-core` compiles to both the `android` (JVM) and `js` KMP
+ * targets, the two platforms share one code path and cannot numerically diverge. The
+ * `centerOriginGoldenVectors` table in `sceneview-core`'s `commonTest` pins this formula on both
+ * targets from a single Kotlin source. `SceneViewSwift` (RealityKit) has no dependency on this
+ * KMP module and reimplements the same math natively in `ModelNode.centerOriginTranslation(
+ * center:extents:origin:)` — its `ModelNodeTests.swift` duplicates the identical numeric table
+ * so a divergence there is caught too.
+ */
+fun centerOriginTranslation(
+    center: Position,
+    halfExtent: Size,
+    scale: Scale,
+    origin: Position
+): Position = -(center + origin * halfExtent) * scale

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/math/CenterOriginGoldenVectorsTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/math/CenterOriginGoldenVectorsTest.kt
@@ -1,0 +1,104 @@
+package io.github.sceneview.math
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Golden-vector table for [centerOriginTranslation] (issue #2763).
+ *
+ * `{center, halfExtent, scale, origin} -> expected translation`. Because this file lives in
+ * `sceneview-core`'s `commonTest`, it compiles and runs unmodified against BOTH the `android`
+ * (JVM) and `js` (Karma/browser) KMP targets — a single Kotlin source proving Android and Web
+ * compute identical `centerOrigin` offsets, closing the "no shared truth" gap called out in
+ * #2763.
+ *
+ * `SceneViewSwift` cannot consume this KMP module (RealityKit has no dependency on
+ * `sceneview-core`), so it reimplements the formula natively and duplicates this exact table as
+ * literals in `ModelNodeTests.swift` — the same "expected string identical across suites"
+ * pattern proven by `RerunWireFormatTest.kt` / `RerunWireFormatTests.swift`. A numeric
+ * regression on ANY of the three platforms must fail that platform's suite (mutation-tested
+ * manually per #2763's "Done" checklist: flipping the formula's sign turns every vector below
+ * red).
+ *
+ * Android's existing `ModelNodeCenterOriginFormulaTest` (`sceneview` module) pins the first
+ * three vectors below (`centered` / `bottom` / `top`) against the same fixture AABB — this table
+ * is the superset, adding an off-pivot AABB and a non-uniform scale.
+ */
+class CenterOriginGoldenVectorsTest {
+
+    private data class Vector(
+        val name: String,
+        val center: Position,
+        val halfExtent: Size,
+        val scale: Scale,
+        val origin: Position,
+        val expected: Position,
+    )
+
+    /**
+     * `center = (1,2,1)`, `halfExtent = (1,2,1)` is a deliberately **non-centered** AABB
+     * (`min = (0,0,0)`, `max = (2,4,2)`) — `center != 0` is the discriminant that catches a
+     * formula which forgets to consult the AABB center. `scale = 0.5` mirrors
+     * `scaleToUnitCube(2f)` on a `maxExtent = 4` asset.
+     */
+    private val vectors = listOf(
+        Vector(
+            name = "centered — origin (0,0,0) pulls the off-pivot AABB center onto the node origin",
+            center = Position(1f, 2f, 1f),
+            halfExtent = Size(1f, 2f, 1f),
+            scale = Scale(0.5f),
+            origin = Position(0f, 0f, 0f),
+            expected = Position(-0.5f, -1f, -0.5f),
+        ),
+        Vector(
+            name = "bottom-aligned — origin (0,-1,0) sits the model on the node origin",
+            center = Position(1f, 2f, 1f),
+            halfExtent = Size(1f, 2f, 1f),
+            scale = Scale(0.5f),
+            origin = Position(0f, -1f, 0f),
+            expected = Position(-0.5f, 0f, -0.5f),
+        ),
+        Vector(
+            name = "top-aligned — origin (0,1,0) hangs the model from the node origin",
+            center = Position(1f, 2f, 1f),
+            halfExtent = Size(1f, 2f, 1f),
+            scale = Scale(0.5f),
+            origin = Position(0f, 1f, 0f),
+            expected = Position(-0.5f, -2f, -0.5f),
+        ),
+        Vector(
+            name = "left | top aligned — origin (-1,1,0)",
+            center = Position(1f, 2f, 1f),
+            halfExtent = Size(1f, 2f, 1f),
+            scale = Scale(0.5f),
+            origin = Position(-1f, 1f, 0f),
+            expected = Position(0f, -2f, -0.5f),
+        ),
+        Vector(
+            name = "off-center AABB, unit scale, general origin",
+            center = Position(-2f, 0.5f, 3f),
+            halfExtent = Size(0.5f, 1.5f, 2f),
+            scale = Scale(1f),
+            origin = Position(1f, -1f, -1f),
+            expected = Position(1.5f, 1f, -1f),
+        ),
+        Vector(
+            name = "centered AABB, non-uniform scale, general origin",
+            center = Position(0f, 0f, 0f),
+            halfExtent = Size(2f, 3f, 4f),
+            scale = Scale(2f, 0.5f, 1f),
+            origin = Position(1f, 1f, -1f),
+            expected = Position(-4f, -1.5f, 4f),
+        ),
+    )
+
+    @Test
+    fun centerOriginTranslationMatchesTheGoldenVectorTable() {
+        for (v in vectors) {
+            val actual = centerOriginTranslation(v.center, v.halfExtent, v.scale, v.origin)
+            assertEquals(v.expected.x, actual.x, 1e-6f, "${v.name} (x)")
+            assertEquals(v.expected.y, actual.y, 1e-6f, "${v.name} (y)")
+            assertEquals(v.expected.z, actual.z, 1e-6f, "${v.name} (z)")
+        }
+    }
+}

--- a/sceneview-web/sceneview-web.d.ts
+++ b/sceneview-web/sceneview-web.d.ts
@@ -66,6 +66,15 @@ export interface NodeHandle {
   /** Uniform local scale on all three axes — the common case. */
   setScaleUniform(s: number): void;
 
+  /** Align the AABB point selected by a **normalized** origin with the node
+   *  origin — Android `ModelNode.centerOrigin(Position)` parity (#2763).
+   *  `0` = bounding-box center, `±1` = bounding-box faces, per axis;
+   *  `(0, -1, 0)` bottom-aligns, `(0, 1, 0)` hangs the model from the origin.
+   *  Composes additively with the current position. A no-op for a handle
+   *  that does not wrap a model node, or whose model hasn't finished
+   *  loading yet. */
+  centerOrigin(originX: number, originY: number, originZ: number): void;
+
   /** Show/hide the node's renderable content. For a model/geometry node this
    *  adds/removes its asset entities from the scene, so it actually
    *  disappears/reappears. An empty pivot node only flips the stored flag. */

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/NodeHandle.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/NodeHandle.kt
@@ -3,7 +3,9 @@ package io.github.sceneview.web
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.math.Scale
+import io.github.sceneview.web.nodes.ModelNode
 import io.github.sceneview.web.nodes.Node
+import io.github.sceneview.web.nodes.centerOrigin
 
 /**
  * The viewer-side callbacks a [NodeHandle] fires on mutation — the seam between
@@ -89,6 +91,26 @@ class NodeHandle internal constructor(
     @JsName("setScaleUniform")
     fun setScaleUniform(s: Double) {
         node.scale = Scale(s.toFloat())
+        viewer.requestRender()
+    }
+
+    /**
+     * Aligns the AABB point selected by a **normalized** origin with the node origin — Android
+     * `ModelNode.centerOrigin(Position)` parity, exported for plain JS (#2763). `0` = bounding-box
+     * center, `±1` = bounding-box faces, per axis; `(0, -1, 0)` bottom-aligns, `(0, 1, 0)` hangs
+     * the model from the origin. Composes additively with the current position — apply it once,
+     * typically right after `sv.addModelNode(url)` resolves.
+     *
+     * A no-op for a handle that does not wrap a
+     * [io.github.sceneview.web.nodes.ModelNode] (e.g. a pivot, geometry, or light node handle) or
+     * whose model hasn't finished loading yet — same "nothing to align against" contract as the
+     * underlying Kotlin `ModelNode.centerOrigin`.
+     */
+    @JsName("centerOrigin")
+    fun centerOrigin(originX: Double, originY: Double, originZ: Double) {
+        (node as? ModelNode)?.centerOrigin(
+            Position(originX.toFloat(), originY.toFloat(), originZ.toFloat())
+        )
         viewer.requestRender()
     }
 

--- a/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/ModelNode.kt
+++ b/sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/nodes/ModelNode.kt
@@ -1,5 +1,7 @@
 package io.github.sceneview.web.nodes
 
+import io.github.sceneview.math.Position
+import io.github.sceneview.math.centerOriginTranslation
 import io.github.sceneview.web.bindings.Engine
 import io.github.sceneview.web.bindings.Entity
 import io.github.sceneview.web.bindings.EntityManager
@@ -42,4 +44,44 @@ class ModelNode internal constructor(
      */
     var asset: FilamentAsset? = null
         internal set
+}
+
+/**
+ * Aligns the AABB point selected by a **normalized** [origin] with the node origin — the web
+ * mirror of Android `ModelNode.centerOrigin(Position)` (issue #2763).
+ *
+ * `origin` is a point of the model's bounding box in normalized AABB coordinates —
+ * `0` = bounding-box center, `±1` = bounding-box faces, per axis. Translates the node by
+ * `-(center + origin * halfExtent) * scale` (the shared `sceneview-core`
+ * [centerOriginTranslation] — identical formula to Android, pinned by the
+ * `centerOriginGoldenVectors` table) so the selected AABB point lands exactly on the node's
+ * local origin, whatever the asset's authored pivot. Composes **additively** with the current
+ * [Node.position], mirroring Android's contract: applying it more than once keeps shifting the
+ * node, apply it once (typically right after load).
+ *
+ * - `Position(0f, 0f, 0f)` (default) — the bounding-box center lands on the node origin (true
+ *   centering, even for models whose authored pivot is off-center).
+ * - `Position(0f, -1f, 0f)` — center horizontal, bottom aligned: the model sits on the node
+ *   origin.
+ * - `Position(-1f, 1f, 0f)` — left | top aligned.
+ *
+ * A no-op while [ModelNode.asset] hasn't finished loading yet — `getBoundingBox()` is not
+ * readable until then (#1597), so there is nothing to align against.
+ */
+fun ModelNode.centerOrigin(origin: Position = Position(x = 0f, y = 0f, z = 0f)) {
+    val box = asset?.getBoundingBox() ?: return
+    val min: dynamic = box.min
+    val max: dynamic = box.max
+    fun component(v: dynamic, i: Int) = (v[i] as Number).toFloat()
+    val center = Position(
+        (component(min, 0) + component(max, 0)) / 2f,
+        (component(min, 1) + component(max, 1)) / 2f,
+        (component(min, 2) + component(max, 2)) / 2f,
+    )
+    val halfExtent = Position(
+        (component(max, 0) - component(min, 0)) / 2f,
+        (component(max, 1) - component(min, 1)) / 2f,
+        (component(max, 2) - component(min, 2)) / 2f,
+    )
+    position += centerOriginTranslation(center, halfExtent, scale, origin)
 }

--- a/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/ModelNode.kt
@@ -719,12 +719,15 @@ inline fun <reified T : MaterialInstance> List<T>.getOrNull(name: String): T? =
  * AABB [center] (not just the extents) makes the alignment correct for assets whose bounding
  * box is not authored centered on their pivot.
  *
- * Pure math, extracted so the formula is JVM-unit-testable without a Filament `Engine`
- * (see `ModelNodeCenterOriginFormulaTest`), mirroring the `resolveModelNodePosition` precedent.
+ * Delegates to the shared `sceneview-core` [io.github.sceneview.math.centerOriginTranslation] —
+ * `sceneview-web`'s `ModelNode.centerOrigin` calls the exact same KMP function (issue #2763), so
+ * Android and Web cannot numerically diverge: a formula bug here fails on both platforms'
+ * suites at once (`centerOriginGoldenVectors` in `sceneview-core` commonTest, plus this module's
+ * own `ModelNodeCenterOriginFormulaTest`, mirroring the `resolveModelNodePosition` precedent).
  */
 internal fun centerOriginTranslation(
     center: Float3,
     halfExtent: Float3,
     scale: Scale,
     origin: Position
-): Position = -(center + origin * halfExtent) * scale
+): Position = io.github.sceneview.math.centerOriginTranslation(center, halfExtent, scale, origin)


### PR DESCRIPTION
## Summary

- Extracts Android's `centerOrigin` formula (`-(center + origin * halfExtent) * scale`) into a shared `sceneview-core` KMP function (`io.github.sceneview.math.centerOriginTranslation`), compiled for both the `android` (JVM) and `js` targets.
- Ports `centerOrigin` to `sceneview-web`: `ModelNode.centerOrigin(origin)` (Kotlin/JS) and `NodeHandle.centerOrigin(originX, originY, originZ)` (the `@JsExport` surface, typed in `sceneview-web.d.ts`, verified by `.claude/scripts/check-web-dts.sh`).
- Android's `ModelNode.kt` now delegates its internal `centerOriginTranslation` to the shared core function instead of duplicating the formula — Android and Web literally share one code path and cannot numerically diverge.
- Adds a golden-vector table (`sceneview-core`'s `CenterOriginGoldenVectorsTest`, in `commonTest`) that runs unmodified on both the JVM and JS (Karma) targets from a single Kotlin source.
- `SceneViewSwift` has no dependency on the KMP module (RealityKit reimplements the formula natively), so `ModelNodeTests.swift` duplicates the identical expected values as literals — the same pattern already proven by `RerunWireFormatTest.kt` / `RerunWireFormatTests.swift`.
- Documents the new export in `llms.txt` (Web `NodeHandle` table + bullet list + example, plus cross-references from the Android/iOS `centerOrigin` docs).

Closes #2763.

## Test plan

- [x] `sceneview-core:androidTest` (JVM target) — `CenterOriginGoldenVectorsTest` passes (827 tests total in the module, 0 failures).
- [x] `sceneview-core:jsBrowserTest` (Karma/Chrome headless) — `CenterOriginGoldenVectorsTest` passes (841 tests total, 0 failures).
- [x] `sceneview-web:jsBrowserTest` — full suite passes (271 tests, 0 failures) after the `ModelNode`/`NodeHandle` additions.
- [x] `sceneview:testDebugUnitTest` — existing `ModelNodeCenterOriginFormulaTest` / `ModelNodeCenterOriginTest` still pass against the delegated formula.
- [x] `swift test --filter ModelNodeTests` (SceneViewSwift package) — 58 tests pass, including the 6 new golden-vector tests.
- [x] Mutation test: flipped the sign in both the Kotlin shared formula and the Swift formula — confirmed every golden-vector test (Kotlin JVM, Kotlin JS, Swift) goes red, then reverted and confirmed green again.
- [x] `bash .claude/scripts/check-web-dts.sh` — `sceneview-web.d.ts` in sync with the Kotlin/JS surface.
- [x] `:sceneview:detekt` and `:sceneview-core:detekt` (the CI-gated tasks) — clean.
- [x] No `.filamat` / Filament version pins touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)