### PR TITLE
feat(ios-demo): add a -camera_distance launch arg for screenshot/QA framing

### DIFF
--- a/changelog.d/2785-ios-camera-distance-arg.md
+++ b/changelog.d/2785-ios-camera-distance-arg.md
@@ -1,0 +1,7 @@
+<!-- category: Added -->
+The iOS demo host now accepts a `-camera_distance <float>` launch argument, matching
+Android's `camera_distance` intent extra (#2652): `DeepLinkRouter.validateCameraDistance`
+applies the identical `0.05...100` clamp on both platforms. `ModelViewerDemo` — the demo
+used by the App Store screenshot pipeline — threads the validated value into its
+`.framingMargin(_:)` override, taking precedence over both the interactive and `qa_mode`
+defaults, so a tight store frame no longer needs Android-only tooling (#2785).

--- a/samples/ios-demo/SceneViewDemo/DeepLinkRouter.swift
+++ b/samples/ios-demo/SceneViewDemo/DeepLinkRouter.swift
@@ -28,6 +28,15 @@ import Foundation
 /// Example: `sceneview://demo/animation?qa_mode=1`
 /// The parsed result is stored in `UserDefaults` under the key `"qa_mode"`
 /// so any demo can read it via `@AppStorage("qa_mode")`.
+///
+/// ### Camera distance
+///
+/// The `-camera_distance <float>` launch argument (parsed in
+/// `SceneViewDemoApp`) lets the App Store screenshot pipeline frame the hero
+/// demo tighter than the interactive auto-fit default — mirrors Android's
+/// `camera_distance` intent extra (`DeepLinkRouter.kt`,
+/// `coerceCameraDistanceExtra`, #2652). [validateCameraDistance] applies the
+/// identical clamp so both platforms accept the same value range (#2785).
 enum DeepLinkRouter {
 
     /// Custom URL scheme registered in `Info.plist > CFBundleURLTypes`.
@@ -51,6 +60,34 @@ enum DeepLinkRouter {
     /// `UserDefaults` key written when `?qa_mode=1` is present in the URL.
     /// Read via `@AppStorage("qa_mode") var qaMode: Bool` in any demo view.
     static let qaModeDefaultsKey: String = "qa_mode"
+
+    /// Smallest accepted camera-distance / framing value. Matches Android's
+    /// `DeepLinkRouter.CAMERA_DISTANCE_MIN` exactly, so a value rejected on
+    /// one platform is rejected on the other — see [validateCameraDistance].
+    static let cameraDistanceMin: Float = 0.05
+
+    /// Largest accepted camera-distance / framing value. Matches Android's
+    /// `DeepLinkRouter.CAMERA_DISTANCE_MAX` exactly.
+    static let cameraDistanceMax: Float = 100
+
+    /// `UserDefaults` key written when a valid `-camera_distance <float>`
+    /// launch argument is parsed (`SceneViewDemoApp`). Read via
+    /// `@AppStorage("camera_distance") var cameraDistanceRaw: Double = 0` in
+    /// any demo view — `0` (the default) means "no override": it is outside
+    /// `[cameraDistanceMin, cameraDistanceMax]`, so it is never a value
+    /// [validateCameraDistance] would accept. `AppStorage` has no native
+    /// `Optional<Double>` support, hence the sentinel (mirrors Android's
+    /// nullable `DemoSettings.cameraDistance`, which needs no such trick).
+    static let cameraDistanceDefaultsKey: String = "camera_distance"
+
+    /// Validates an already-parsed camera-distance value against the
+    /// accepted range. Mirrors Android's `DeepLinkRouter.validateCameraDistance`
+    /// exactly: returns [value] iff it is non-nil, finite, and within
+    /// `[cameraDistanceMin, cameraDistanceMax]`; otherwise `nil`. Never throws.
+    static func validateCameraDistance(_ value: Float?) -> Float? {
+        guard let value, value.isFinite else { return nil }
+        return (value >= cameraDistanceMin && value <= cameraDistanceMax) ? value : nil
+    }
 
     /// Parses the URL and returns the validated demo id, or `nil`.
     /// As a side-effect, writes `UserDefaults["qa_mode"]` when the

--- a/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
+++ b/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
@@ -41,6 +41,21 @@ struct SceneViewDemoApp: App {
            qIdx + 1 < args.count, args[qIdx + 1] == "1" {
             UserDefaults.standard.set(true, forKey: DeepLinkRouter.qaModeDefaultsKey)
         }
+        // Propagate `-camera_distance <float>` so the App Store screenshot
+        // pipeline can frame the hero demo tighter than the interactive
+        // auto-fit default — mirrors Android's `camera_distance` intent
+        // extra (#2652) and its dual-ingress precedence (extra beats deep
+        // link). Unlike the Android Bundle extra, `CommandLine.arguments`
+        // has no typed-value channel — every launch arg, from `xcrun simctl
+        // launch` or Xcode's own scheme arguments, arrives as a `String` —
+        // so there is no `Number` case to mirror here, just `Float.init?`.
+        // [DeepLinkRouter.validateCameraDistance] applies the identical
+        // clamp as Android either way: absent, unparseable, non-finite, or
+        // out-of-range all leave the sentinel `0` (== "no override"). #2785.
+        if let dIdx = args.firstIndex(of: "-camera_distance"), dIdx + 1 < args.count,
+           let distance = DeepLinkRouter.validateCameraDistance(Float(args[dIdx + 1])) {
+            UserDefaults.standard.set(Double(distance), forKey: DeepLinkRouter.cameraDistanceDefaultsKey)
+        }
         return DemoDeepLinkRegistry.allowedIds.contains(id) ? id : nil
     }()
 

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -75,6 +75,25 @@ struct ModelViewerDemo: View {
     /// same demo produced different poses AND different HDRI backdrops (#2896).
     @AppStorage(DeepLinkRouter.qaModeDefaultsKey) private var qaMode: Bool = false
 
+    /// Raw `-camera_distance <float>` launch-arg override, written by
+    /// `SceneViewDemoApp` into `UserDefaults` (#2785). `0` is the "unset"
+    /// sentinel — see `DeepLinkRouter.cameraDistanceDefaultsKey`.
+    @AppStorage(DeepLinkRouter.cameraDistanceDefaultsKey) private var cameraDistanceRaw: Double = 0
+
+    /// Validated `-camera_distance` override, or `nil` when absent — mirrors
+    /// Android's nullable `DemoSettings.cameraDistance`. Threaded into
+    /// ``sceneView``'s `.framingMargin(_:)` in place of the demo's own
+    /// interactive / `qa_mode` defaults, the same "explicit override wins
+    /// over auto-fit" precedence Android's `rememberHeroOrbitCameraManipulator`
+    /// applies to `radius` (`DemoHelpers.kt`, #1571). Note `.framingMargin(_:)`
+    /// itself clamps to `0.2...10` (`SceneView.swift`) — narrower than
+    /// `DeepLinkRouter`'s accepted `0.05...100`, since it is a fit-margin
+    /// multiplier, not the absolute-metre distance Android's `radius` is;
+    /// callers targeting a store-tight frame want small values (< 1) anyway.
+    private var cameraDistanceOverride: Float? {
+        cameraDistanceRaw > 0 ? Float(cameraDistanceRaw) : nil
+    }
+
     var body: some View {
         ZStack {
             sceneView
@@ -135,7 +154,11 @@ struct ModelViewerDemo: View {
             // value was the reason the store frame read as a small subject
             // adrift in empty backdrop: the hero's bounding sphere is set by
             // its display plinth, not by the car (#2896).
-            .framingMargin(qaMode ? Self.captureFramingMargin : 0.95)
+            //
+            // `cameraDistanceOverride` — the `-camera_distance <float>` launch
+            // arg (#2785) — wins over both when present, same as Android's
+            // `DemoSettings.cameraDistance` beating its own `radius` default.
+            .framingMargin(cameraDistanceOverride ?? (qaMode ? Self.captureFramingMargin : 0.95))
             .contentID(loadedNode == nil ? nil : loadCount)
             .ignoresSafeArea()
 

--- a/samples/ios-demo/appstore-screenshots/README.md
+++ b/samples/ios-demo/appstore-screenshots/README.md
@@ -167,13 +167,15 @@ slice of HDRI behind it changed every run.
 >   `dynamic-sky` with no sky at all. `SceneEnvironment.load()` now falls back to
 >   ImageIO. A `[SceneViewSwift] Failed to load environment '…'` line in the
 >   console means this regressed.
-> - iOS has no `camera_distance` launch argument (Android's framing lever,
->   tracked for iOS in #2785). The scenes instead carry their own framing via
->   `.framingMargin(_:)` / `.cameraOrbit(azimuth:elevation:)`. `model-viewer`
->   frames tighter under `qa_mode` than it does interactively: its bounding
->   sphere is set by the hero's display plinth rather than by the car, and the
->   looser interactive value — needed so an auto-rotating model does not clip at
->   its broadside — left the subject small in a mostly-empty frame.
+> - `model-viewer` frames tighter under `qa_mode` than it does interactively:
+>   its bounding sphere is set by the hero's display plinth rather than by the
+>   car, and the looser interactive value — needed so an auto-rotating model
+>   does not clip at its broadside — left the subject small in a mostly-empty
+>   frame. Since #2785, iOS also accepts a `-camera_distance <float>` launch
+>   argument (Android's framing lever, `DeepLinkRouter.validateCameraDistance`
+>   range `0.05...100`) that overrides both `.framingMargin(_:)` defaults on
+>   `model-viewer` — pass it explicitly for an even tighter store frame instead
+>   of relying on the `qa_mode` capture-margin constant.
 
 ## How to regenerate
 


### PR DESCRIPTION
## Summary

- Adds a `-camera_distance <float>` launch argument to the iOS demo host, mirroring Android's `camera_distance` intent extra (`DeepLinkRouter.coerceCameraDistanceExtra`, #2652) so the App Store screenshot pipeline can frame the hero demo tightly instead of relying only on auto-fit.
- `DeepLinkRouter.validateCameraDistance` applies the exact same `0.05...100` clamp Android's `DeepLinkRouter.CAMERA_DISTANCE_MIN`/`MAX` use, so a value rejected on one platform is rejected on the other.
- `SceneViewDemoApp` parses `-camera_distance` the same way it already parses `-qa_mode`, writing the validated value into `UserDefaults`. `CommandLine.arguments` has no typed-value channel (unlike Android's `Bundle` extra, which arrives as `Number` or `String` depending on the launcher/Maestro), so every launch arg here is a `String` — a single `Float.init?` covers every sender.
- `ModelViewerDemo` — the demo captured for the App Store screenshot set — reads the override and threads it into its existing `.framingMargin(_:)` call in place of the interactive/`qa_mode` defaults, the same "explicit override wins over auto-fit" precedence Android's `rememberHeroOrbitCameraManipulator` applies to its `radius` parameter (#1571).
- Updates `appstore-screenshots/README.md`'s caveat note, which previously said iOS had no such argument and pointed at this issue.

## Test plan

- [x] `xcodebuild -scheme SceneViewDemo -destination 'generic/platform=iOS Simulator' -configuration Debug build` — **BUILD SUCCEEDED**, no new warnings.
- [ ] Manual device-QA: launch with `xcrun simctl launch <udid> io.github.sceneview.demo -demo model-viewer -camera_distance 0.6` and confirm a tighter frame than the default.

Fixes #2785

🤖 Generated with [Claude Code](https://claude.com/claude-code)