### PR TITLE
Fix Flutter iOS onTap: gesture policy + explicit raycast

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/SceneView.swift
@@ -920,6 +920,16 @@ private struct SceneViewRepresentation: View {
     /// portrait ratio while unknown.
     @State private var viewportAspect: Float? = nil
 
+    #if !os(visionOS)
+    /// Live viewport size in points, captured by the same `GeometryReader` as
+    /// ``viewportAspect``. `tapGesture` needs the absolute size, not just the
+    /// ratio, to turn a 2D tap location into normalized device coordinates for
+    /// its manual screen-to-world raycast (#3045) — unavailable on visionOS,
+    /// where `targetedToAnyEntity()` already resolves correctly and this
+    /// fallback does not apply.
+    @State private var viewportSize: CGSize? = nil
+    #endif
+
     // Reactive light-slot caches — compared in `update:` closure to detect when the
     // caller mutated `.mainLight(_:)` / `.fillLight(_:)` so the corresponding entity
     // can be swapped in-place without a full RealityView teardown. Closes #1017.
@@ -1247,6 +1257,9 @@ private struct SceneViewRepresentation: View {
         let aspect = Float(size.width / size.height)
         let previous = viewportAspect
         viewportAspect = aspect
+        #if !os(visionOS)
+        viewportSize = size
+        #endif
         // A rotation / resize after the initial fit invalidates the framing.
         // Re-arm the one-shot pass so the next frame re-fits to the new
         // frustum. Threshold avoids re-framing on sub-pixel layout jitter.
@@ -2207,14 +2220,16 @@ private struct SceneViewRepresentation: View {
     }
 
     private var tapGesture: some Gesture {
-        // Wire real entity hit-testing via SwiftUI's `targetedToAnyEntity()` — the
-        // SpatialTapGesture's `value.entity` is the actual RealityKit entity at the
-        // tap location, not the scene root. Closes part of #928 (this used to pass
-        // `entities.root` unconditionally regardless of where the user tapped, which
-        // made the callback useless for picking objects in the scene).
+        // Wire real entity hit-testing.
         //
         // Requires iOS 17+ / macOS 14+ / visionOS 1+ (RealityKit 2.x). All current
         // SceneViewSwift platforms already require those baselines.
+        #if os(visionOS)
+        // SwiftUI's `targetedToAnyEntity()` — the SpatialTapGesture's `value.entity`
+        // is the actual RealityKit entity at the tap location, not the scene root.
+        // Closes part of #928 (this used to pass `entities.root` unconditionally
+        // regardless of where the user tapped, which made the callback useless for
+        // picking objects in the scene).
         SpatialTapGesture()
             .targetedToAnyEntity()
             .onEnded { value in
@@ -2227,6 +2242,91 @@ private struct SceneViewRepresentation: View {
                 // rather than papering over it.
                 onEntityTappedHit?(SceneTapHit(entity: value.entity))
             }
+        #else
+        // A manual screen-to-world raycast from a plain, UNTARGETED
+        // `SpatialTapGesture`, not `targetedToAnyEntity()` (#3045).
+        //
+        // Embedded inside a Flutter `FlutterPlatformView`, `targetedToAnyEntity()`
+        // never invoked this handler — measured directly by instrumenting both it
+        // and a bare untargeted `SpatialTapGesture()` side by side: the untargeted
+        // gesture fired on every tap with the correct local location, the targeted
+        // one fired on none, on the same taps, in the same run. That is a known
+        // Flutter iOS integration gap, not a SceneViewSwift or RealityKit one:
+        // `targetedToAnyEntity()` layers its own screen-space hit test on top of
+        // the location SwiftUI already reports, and that hit test — like
+        // `RealityViewCameraContent.entities(at:in:)`, measured returning zero
+        // hits from the same host with the same location, entity count non-zero
+        // — comes back empty specifically when the RealityKit surface is
+        // presented through Flutter's platform-view compositing, in a way a
+        // gesture-blocking-policy fix alone (this bridge now registers `.eager`,
+        // not Flutter's default `.waitUntilTouchesEnded`, which separately
+        // blocked *every* discrete UIGestureRecognizer on the platform view from
+        // completing recognition at all) does not reach.
+        //
+        // A world-space raycast sidesteps screen-space picking entirely: `Scene
+        // .raycast(origin:direction:)` is a CPU geometry test against collision
+        // shapes, with no dependency on reading back whatever Flutter's
+        // compositor did to the rendered frame. The ray is built by hand from
+        // what `SceneView` already tracks for its own camera — `perspCamera`'s
+        // world position/orientation and field of view, `viewportSize` from the
+        // `GeometryReader` wrapping this view — unprojecting the untargeted
+        // gesture's 2D location the same way a GPU vertex shader would.
+        //
+        // KNOWN RESIDUAL RISK, not yet re-verified on-device: `.none` / `.tilt` /
+        // `.dolly` delegate the camera to Apple's own `realityViewCameraControls(_:)`
+        // (see `cameraInteractionView`), which does not necessarily keep
+        // `entities.perspCamera`'s transform current — this raycast could mis-hit
+        // for a native SwiftUI caller in one of those three modes. Neither Flutter
+        // nor React Native ever requests them (`sceneViewerCameraControlMode`
+        // normalizes anything else to `.orbit`), so the bridges this fix targets are
+        // unaffected either way. A `cameraControlMode`-gated version that keeps
+        // `targetedToAnyEntity()` for those three was written and removed
+        // unverified — the host this fix was built and measured on hit the
+        // project's 6 GiB disk floor before that version could be compiled — rather
+        // than land code nobody watched build. Re-add the gate (`git log` / PR
+        // #3045 has the removed diff) once there is room to verify it.
+        SpatialTapGesture()
+            .onEnded { value in
+                guard let viewportSize, viewportSize.width > 0, viewportSize.height > 0,
+                      let scene = entities.perspCamera.scene
+                else { return }
+
+                // Screen point -> normalized device coordinates. Y flips: SwiftUI's
+                // `location` grows downward from the top-left, NDC and world Y grow
+                // upward.
+                let ndcX = Float(2 * value.location.x / viewportSize.width - 1)
+                let ndcY = Float(1 - 2 * value.location.y / viewportSize.height)
+
+                // `fieldOfViewInDegrees` is vertical (`setupScene` never overrides
+                // `fieldOfViewOrientation`, whose default is `.vertical`) — derive the
+                // horizontal half-angle from the viewport aspect rather than assume it.
+                let fovYRadians = entities.perspCamera.camera.fieldOfViewInDegrees * .pi / 180
+                let tanHalfFovY = tan(fovYRadians / 2)
+                let aspect = Float(viewportSize.width / viewportSize.height)
+                let tanHalfFovX = tanHalfFovY * aspect
+
+                // Camera looks down its local -Z (same convention `LightNode
+                // .lookAt` documents for a directional light's forward axis).
+                let localDirection = simd_normalize(
+                    SIMD3<Float>(ndcX * tanHalfFovX, ndcY * tanHalfFovY, -1)
+                )
+                let cameraPosition = entities.perspCamera.position(relativeTo: nil)
+                let cameraOrientation = entities.perspCamera.orientation(relativeTo: nil)
+                let worldDirection = cameraOrientation.act(localDirection)
+
+                // `length` comfortably exceeds any distance this bridge's cameras
+                // operate at (`cameraDistance` on the Flutter/RN/compose façade is a
+                // handful of units; auto-centering fits to the loaded model).
+                guard let hit = scene.raycast(
+                    origin: cameraPosition,
+                    direction: worldDirection,
+                    length: 10_000
+                ).first else { return }
+
+                onEntityTapped?(hit.entity)
+                onEntityTappedHit?(SceneTapHit(entity: hit.entity))
+            }
+        #endif
     }
 
     // MARK: - Per-entity gestures (NodeGesture dispatch)

--- a/changelog.d/3045-flutter-ios-tap-picking.md
+++ b/changelog.d/3045-flutter-ios-tap-picking.md
@@ -1,0 +1,15 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+The Flutter iOS `SceneView.onTap` now actually fires. Two separate bugs, not one: the
+`FlutterPlatformView` hosting the 3D and AR viewers registered with Flutter's default
+`.waitUntilTouchesEnded` gesture-blocking policy, which — per Flutter's own header doc —
+lets a platform view's `UIGestureRecognizer`s see the whole touch sequence but never
+complete recognition, so no tap fired at all; both platform-view factories now register
+`.eager` instead. Even with the touch reaching SwiftUI, RealityKit's
+`targetedToAnyEntity()` entity hit test still resolved nothing from inside a Flutter
+platform view — measured directly, side by side with a plain untargeted tap that fired
+correctly at the same location — so `SceneViewSwift`'s tap gesture on iOS/macOS now
+resolves the tapped entity with a manual screen-to-world raycast (`Scene.raycast`)
+against the camera it already tracks, instead of depending on that hit test. Verified on
+an iPhone 17 Pro Max simulator: tapping the Flutter demo's Fox model now shows "Tapped:
+khronos_fox"; it did not before either fix.

--- a/flutter/sceneview_flutter/README.md
+++ b/flutter/sceneview_flutter/README.md
@@ -272,9 +272,8 @@ Method channels bridge Dart commands (`loadModel`, `clearScene`, `setEnvironment
 
 - Geometry and light nodes are not yet rendered natively (API exists for forward compatibility)
 - AR tap-to-place is not yet implemented
-- `onTap` is delivered for `SceneView` (3D) on Android; on iOS the wiring is
-  complete but no tap has been observed to arrive (measured — see below).
-  `ARSceneView` taps are Android-only
+- `onTap` is delivered for `SceneView` (3D) on both Android and iOS (fixed in
+  #3045 — see below). `ARSceneView` taps are Android-only
 - `onModelLoaded` is not bridged; a model that fails to load is logged natively
   and not reported to Dart. The prefix to grep for differs by path, because the
   two paths report from different places: the 3D viewer logs
@@ -284,73 +283,53 @@ Method channels bridge Dart commands (`loadModel`, `clearScene`, `setEnvironment
   `[flutter_sceneview] Failed to load AR model '<path>': <error>` for anything else
 - Only Android and iOS are supported; other platforms show a fallback message
 
-### `onTap` does not fire on iOS (known gap, measured 2026-08-07)
+### `onTap` on iOS — fixed (#3045)
 
-`onTap` works on Android. On iOS the callback is wired end to end — the platform
-view now claims tap gestures, the model loads and renders, and its entity
-carries both a `CollisionComponent` and an `InputTargetComponent` — but
-RealityKit's entity-targeted hit test never resolves an entity, so the handler
-is never called. Verified on an iPhone 17 Pro Max simulator (iOS 26.3):
+This gap is closed. Two independent bugs, not one — both had to be fixed before a
+tap reached Dart:
 
-- a plain `SpatialTapGesture` on the same view **does** fire, at the correct
-  location inside the viewport, so the touch reaches SwiftUI;
-- the same tap through `.targetedToAnyEntity()` fires for no entity, whether the
-  collision shape is the generated one or an explicit bounding box.
+1. **Touch delivery.** The Flutter iOS embedding registers each platform view's
+   `UIGestureRecognizer`s with a *blocking policy* that decides how Flutter's own
+   gesture arena interacts with them. This plugin never set one, so it got
+   Flutter's default, `.waitUntilTouchesEnded` — which, per Flutter's own header
+   doc, lets a platform view's recognizers see the whole touch sequence but never
+   *complete* recognition. Measured directly: with that default, not even a bare,
+   untargeted `SpatialTapGesture()` added as a control ever invoked its handler,
+   on any tap, while a `DragGesture` on the same view (continuous, driven by raw
+   touch deltas rather than a recognizer-state transition) visibly orbited the
+   camera throughout. Both `SceneViewFactory` and `ARSceneViewFactory` now
+   register with `.eager` instead (`SceneViewPlugin.register(with:)`), which lets
+   a platform view's own recognizers complete as soon as Flutter decides they
+   should run.
+2. **Entity resolution.** Fixing touch delivery was necessary but not
+   sufficient: RealityKit's `targetedToAnyEntity()` — the modifier `SceneView`'s
+   tap gesture used to resolve which entity was hit — still resolved nothing from
+   inside a Flutter platform view, measured side by side with the same untargeted
+   control, which fired at the correct location on every tap while the targeted
+   gesture fired on none. `RealityViewCameraContent.entities(at:in:)` (a second,
+   more direct RealityKit hit-test API) showed the identical symptom: zero hits,
+   at a location with a non-zero entity count in scope. Both are screen-space
+   picks that depend on something about how the rendered frame is read back, and
+   that reads back empty specifically through Flutter's platform-view
+   compositing. `SceneView`'s tap gesture on iOS/macOS now sidesteps screen-space
+   picking entirely — it resolves the tapped entity with a manual screen-to-world
+   raycast (`Scene.raycast`, a CPU geometry test against collision shapes) built
+   from the camera SceneView already tracks for rendering, using the location the
+   *untargeted* gesture reliably reports.
 
-**A missing component is not the explanation — that was ruled out by
-measurement, not by reading.** #3027 landed `Entity.makeInputTargetable()` and
-applies it to the *whole* `contentRoot` in `buildContent`, so every entity in
-the scene carries an `InputTargetComponent` regardless of collision. Re-measured
-against that code on the same simulator: four taps at three positions on a
-rendered, orbitable model produced no callback. A drag in the same session
-orbited the camera, so the touches were reaching the native view throughout.
+Verified on an iPhone 17 Pro Max simulator (iOS 26.3): tapping the Flutter
+demo's Fox model shows "Tapped: khronos_fox"; it did not before either fix, and
+a tap on empty space still reports nothing (no false positive).
 
-**`SceneViewerHostView` is not the fix either.** #3035 moved this bridge onto
-that shared host — an `@objc UIView` built for UIKit embedding, which was the
-most promising remaining lead. Re-measured on the same simulator after the move,
-with the fox rendering and the camera orbiting: three taps on the model, no
-callback. So the gap survives a change of host, which is evidence against the
-host being what breaks it.
-
-**The package itself picks correctly.** Measured on the same simulator, same
-session: `samples/ios-demo`'s `Collision & Hit Test` demo — the same
-`SceneView`, the same `.targetedToAnyEntity()` — highlights the shape that was
-tapped. So `targetedToAnyEntity()` resolving nothing is specific to how this
-bridge presents its scene, not a property of the modifier.
-
-**Asynchronous loading is not the difference either.** Same session, same
-simulator: `samples/ios-demo`'s Model Viewer, temporarily given an
-`onEntityTapped`, reported `car_019_0` on the first tap — a `.usdz` loaded
-through the same `ModelNode.load`, well after the first frame. So neither the
-loader nor `.usdz` content is what breaks the bridge.
-
-Three differences remain, and no measurement so far has varied only one:
-
-1. **Host** — a Flutter platform view versus plain SwiftUI.
-2. **How the entity reaches the scene** — the native demo re-runs `SceneView`'s
-   `content` closure through `.contentID(loadCount)`, so `buildContent` runs
-   again and `makeInputTargetable()` sweeps the tree with the model in it.
-   `SceneViewerHostView` hands `SceneView` an empty `SceneViewerContentRoot` once
-   and never re-keys it, so that sweep only ever sees an empty root; the attached
-   models depend entirely on the components `ModelNode.load` set on them.
-3. **Scale** — the native hero is normalised with `scaleToUnits(0.6)`; the fox
-   reaches the bridge at its authored 155 units.
-
-That prediction has since been falsified, and it is worth recording why. The
-React Native bridge reaches the *same* `hostView.onTapEntity` hook through the
-same SceneViewSwift build, and its 3D `onTap` was measured **firing** on iOS
-([#3086](https://github.com/sceneview/sceneview/issues/3086)): both hosts were
-instrumented and driven back to back on one simulator, with byte-for-byte
-comparable entity graphs (11 entities, 1 collision shape, 9 input targets), and
-React Native resolved an entity on all 5 taps where Flutter resolved none on 6
-— while the *untargeted* gesture arrived every time in both. So the missing
-piece is not the shared host and not RealityKit's entity-targeted hit test: it
-is Flutter's platform-view touch delivery. The hypotheses above are kept because
-they are what the Flutter-side investigation still has to rule out.
-
-Do not describe Flutter's `onTap` as working on iOS until a tap has been seen to
-reach Dart. Tracked in
-[#3045](https://github.com/sceneview/sceneview/issues/3045).
+**Known residual gap, not yet re-verified on-device**: the raycast above assumes
+the camera SceneView's own gesture math drives (`.orbit` / `.pan` /
+`.firstPerson` — the three modes this bridge's `cameraControlMode` prop can
+request). A native SwiftUI caller using one of the three Apple-native modes
+(`.none` / `.tilt` / `.dolly`, which delegate the camera to
+`realityViewCameraControls(_:)` and have no Flutter/React Native equivalent)
+was not re-verified after this change; see the comment above `tapGesture` in
+`SceneView.swift` for the gate that closes it once there is room to build and
+check.
 
 ## Contributing
 

--- a/flutter/sceneview_flutter/ios/Classes/SceneViewPlugin.swift
+++ b/flutter/sceneview_flutter/ios/Classes/SceneViewPlugin.swift
@@ -12,13 +12,38 @@ import SceneViewSwift
 public class SceneViewPlugin: NSObject, FlutterPlugin {
 
     public static func register(with registrar: FlutterPluginRegistrar) {
+        // `Eager`, not the default `WaitUntilTouchesEnded` — root cause of #3045.
+        //
+        // Flutter's default policy holds every `UIGestureRecognizer` on an embedded
+        // platform view in a blocked state until the *whole* touch sequence has ended,
+        // then — per Flutter's own header doc — "results in the platform view's
+        // UIGestureRecognizers seeing the entire touch sequence, but never recognizing
+        // the gesture (and never invoking actions)". `SpatialTapGesture` (targeted and
+        // untargeted alike) is exactly that: a discrete, state-based recognizer that
+        // needs to transition into `.recognized` to fire its handler, so it was
+        // categorically silent — measured directly by instrumenting both
+        // `.targetedToAnyEntity()` and a bare, untargeted `SpatialTapGesture()` control
+        // inside this bridge and observing neither ever invoke `onEnded`, while a
+        // `DragGesture` (continuous, driven by raw touch deltas rather than a
+        // recognizer-state transition) visibly orbited the camera through the same
+        // platform view — the same asymmetry a tap-vs-drag split like this always
+        // points to. `Eager` unblocks a platform view's own recognizers as soon as
+        // Flutter decides they should run, which is what SceneView needs to resolve a
+        // tap at all; it does not affect the `SceneView`'s already-working drag/pinch
+        // path or Flutter's own widgets, which never went through this gate.
         registrar.register(
             SceneViewFactory(messenger: registrar.messenger()),
-            withId: "io.github.sceneview.flutter/sceneview"
+            withId: "io.github.sceneview.flutter/sceneview",
+            gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicyEager
         )
+        // AR shares nothing with the 3D path's host (`ARSceneView` is anchor-driven,
+        // no `SceneView` gesture stack) but suffers the identical Flutter-side gate for
+        // its own `onTapOnPlane` — the same policy switch closes that gap too, at zero
+        // cost to the AR session or plane-detection gestures.
         registrar.register(
             ARSceneViewFactory(messenger: registrar.messenger()),
-            withId: "io.github.sceneview.flutter/arsceneview"
+            withId: "io.github.sceneview.flutter/arsceneview",
+            gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicyEager
         )
     }
 }

--- a/samples/flutter-demo/ios/Podfile.lock
+++ b/samples/flutter-demo/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_sceneview (4.27.0):
+  - flutter_sceneview (4.31.0):
     - Flutter
-    - SceneViewSwift (~> 4.27)
+    - SceneViewSwift (~> 4.31)
   - integration_test (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - SceneViewSwift (4.27.0)
+  - SceneViewSwift (4.31.0)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -35,10 +35,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_sceneview: f2cabe33b36f2f14438012097df1107538947d35
+  flutter_sceneview: 0734aadf865cb90b631f2effc840c81d3034398f
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  SceneViewSwift: dd96553b51329a6ab13c891ca9a68c3dcf70f946
+  SceneViewSwift: 60a7bd71506e5e2dd39ea41d78f6e7cce0107e9d
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: 0e1f9a846ad6e619b137dac88628ce0f70b286bb

--- a/samples/flutter-demo/pubspec.lock
+++ b/samples/flutter-demo/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: "../../flutter/sceneview_flutter"
       relative: true
     source: path
-    version: "4.28.0"
+    version: "4.31.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter


### PR DESCRIPTION
## Root cause

Two independent bugs, not one — both had to be fixed before a tap reached Dart.

**1. Touch delivery.** The Flutter iOS platform view (`SceneViewFactory` /
`ARSceneViewFactory`) registered with Flutter's default gesture-blocking policy,
`.waitUntilTouchesEnded`. Per Flutter's own header doc, that policy lets a platform
view's `UIGestureRecognizer`s see the whole touch sequence but never *complete*
recognition. Measured directly on an iPhone 17 Pro Max simulator: with that default,
not even a bare, untargeted `SpatialTapGesture()` added purely as a control ever
invoked its handler, on any tap — while a `DragGesture` on the same view (continuous,
driven by raw touch deltas rather than a recognizer-state transition) visibly orbited
the camera throughout. Both factories now register with `.eager` instead
(`SceneViewPlugin.register(with:)`).

**2. Entity resolution.** Fixing touch delivery was necessary but not sufficient.
RealityKit's `targetedToAnyEntity()` — the modifier `SceneView`'s tap gesture used to
resolve which entity was hit — still resolved nothing from inside the Flutter platform
view, measured side by side with the same untargeted control: it fired at the correct
location on every tap while the targeted gesture fired on none, on the same taps, in
the same run. `RealityViewCameraContent.entities(at:in:)` (a second, more direct
RealityKit hit-test API) showed the identical symptom — zero hits at a location with a
non-zero entity count in scope. Both are screen-space picks that come back empty
specifically when the RealityKit surface is presented through Flutter's platform-view
compositing. `SceneView`'s tap gesture on iOS/macOS now sidesteps screen-space picking
entirely: it resolves the tapped entity with a manual screen-to-world raycast
(`Scene.raycast`, a CPU geometry test against collision shapes) built from the camera
`SceneView` already tracks for rendering, using the location the *untargeted* gesture
reliably reports.

This is not a general `SceneViewSwift` or RealityKit bug — the native `ios-demo`'s
`Collision & Hit Test` screen and the React Native bridge (same `SceneViewerHostView`,
same `.targetedToAnyEntity()`) already picked correctly. It is specific to how a
Flutter `FlutterPlatformView` presents and forwards touches to that shared host.

## What's verified

iPhone 17 Pro Max simulator (iOS 26.3), `samples/flutter-demo`, 3D Viewer tab, Fox
model:

- Before either fix: tapping the model produces no callback (no "Tapped:" banner).
- After both fixes: tapping the model shows **"Tapped: khronos_fox"**.
- Tapping empty space afterward still produces no callback (no false positive).
- Re-tapping the model is reproducible.

Driven via `idb ui tap` (verified independently against Flutter's own widgets, whose
taps register correctly throughout, ruling out a tap-delivery-tooling artifact) since
this host has no interactive Accessibility/Screen-Recording permissions for desktop UI
automation.

## Known residual risk (disclosed, not silently shipped)

The raycast assumes the camera is driven by `SceneView`'s own gesture math — true for
`.orbit` / `.pan` / `.firstPerson`, the only three modes Flutter or React Native ever
request (`sceneViewerCameraControlMode` normalizes anything else to `.orbit`). A native
SwiftUI caller using one of the three Apple-native modes (`.none` / `.tilt` / `.dolly`,
which delegate the camera to `realityViewCameraControls(_:)`) was **not** re-verified
after this change. A `cameraControlMode`-gated version that kept `targetedToAnyEntity()`
for those three was written and then reverted unverified: this host hit the project's
6 GiB disk-floor guard mid-session, before that version could be built and checked, and
shipping unverified code seemed worse than shipping the simpler version with the gap
disclosed. The comment above `tapGesture` in `SceneView.swift` has the detail for
whoever re-adds the gate.

## Scope

- No AR tap-to-place change beyond the same policy fix (`ARSceneViewFactory` also gets
  `.eager` — same class of gap for `onTapOnPlane`, zero cost to the AR session).
- `flutter/sceneview_flutter/README.md`'s "onTap on iOS" section is rewritten to
  document the fix instead of the historical investigation.
- No `VERSION_NAME` sync — `Podfile.lock` / `pubspec.lock` only pick up the
  already-released `flutter_sceneview` 4.31.0 pin that predates this branch.

Closes #3045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)