### PR TITLE
ci: provision JDK 22 for the desktop-demo toolchain

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -17,11 +17,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up JDK ${{ inputs.java-version }}
+    # `:samples:desktop-demo` (filament-kmp desktop renderer, FFM-based, #2540)
+    # pins `jvmToolchain(22)`. Gradle configures every included subproject on
+    # any `./gradlew` invocation from root, so every job needs a JDK 22
+    # locally installed for toolchain auto-detection — auto-download isn't
+    # configured (no foojay resolver) and shouldn't be, to avoid a network
+    # dependency in CI. Installed first so `inputs.java-version` stays last
+    # and keeps owning JAVA_HOME (the JDK that actually runs Gradle).
+    - name: Set up JDK 22 + ${{ inputs.java-version }}
       uses: actions/setup-java@v5
       with:
         distribution: ${{ inputs.java-distribution }}
-        java-version: ${{ inputs.java-version }}
+        java-version: |
+          22
+          ${{ inputs.java-version }}
 
     # Build-cache-aware Gradle setup. Replaces the lightweight
     # `cache: gradle` shortcut on setup-java (wrapper + deps only) with the


### PR DESCRIPTION
## Cause

PR #3243 (desktop `SceneViewer` via filament-kmp, #2540) adds a `jvmToolchain(22)` pin to `samples/desktop-demo` (filament-kmp's FFM dependency needs JDK 22+). Gradle configures every included subproject on any root `./gradlew` invocation, so that pin gets evaluated on *every* CI job — including ones that never touch desktop-demo (Lint, Doc snippets, KMP native iOS, API compatibility, ...). CI runners only have the job's own JDK (17/21) installed and toolchain auto-download isn't configured, so each job fails identically:

```
ToolchainProvisioningException: Cannot find a Java installation ... languageVersion=22 ...
Toolchain download repositories have not been configured.
```

`main`'s own CI is currently green, confirming this is a CI-provisioning gap surfaced by #3243, not application code.

## Fix

Install JDK 22 alongside each job's existing JDK in the one shared `.github/actions/setup-gradle/action.yml` composite action (used by every Gradle-invoking job in `ci.yml` and `snippets-check.yml`), so Gradle's built-in toolchain auto-detection finds it locally. The job's own JDK (17/21) stays last in the `java-version` list, so it keeps owning `JAVA_HOME` (the JDK that actually runs Gradle) — this only adds JDK 22 as an available toolchain candidate, no foojay-resolver / network-download dependency added.

## Effect

Once this lands on `main`, PR #3243's CI re-run picks it up automatically via GitHub's auto-computed `pull/3243/merge` ref (head + latest `main`) — no contact with the external contributor's fork required.

## Local validation

All run against #3243's branch rebased onto current `main` (clean, zero conflicts):

- [x] `./gradlew :sceneview-core:compileKotlinMetadata :sceneview:assembleRelease apiCheck` — BUILD SUCCESSFUL
- [x] `./gradlew :sceneview:lintDebug :arsceneview:lintDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :sceneview-core:compileKotlinIosArm64 :sceneview-core:compileKotlinIosSimulatorArm64 :sceneview-core:compileKotlinIosX64 :sceneview-compose:compileKotlinIosArm64 :sceneview-compose:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- [x] `./gradlew :sceneview-core:jsMainClasses :sceneview-web:jsMainClasses` — BUILD SUCCESSFUL
- [x] `./gradlew :snippets-check:compileDebugKotlin` — BUILD SUCCESSFUL (156 snippets)
- [x] `./gradlew :samples:desktop-demo:compileKotlinDesktop :sceneview-compose:desktopTest` — BUILD SUCCESSFUL
- [x] `./gradlew :sceneview-compose:iosSimulatorArm64Test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)