### PR TITLE
Fix demo app chip wrap, fragile shape dispatch, keyboard, voice cutoff

### DIFF
--- a/changelog.d/3322-chips-keyboard-voice.md
+++ b/changelog.d/3322-chips-keyboard-voice.md
@@ -1,0 +1,19 @@
+<!-- category: Fixed -->
+Four demo-app polish fixes from Pixel 9 QA (#3322):
+
+- The Lighting Lab mode selector's "Environment" segment wrapped onto two lines on a
+  phone-width screen — the segmented buttons no longer reserve space for a selection
+  icon (selection is already shown by color), so all four labels fit on one line.
+- Custom Geometry's shape picker matched its chips against a raw `String` used as both
+  the display label and the dispatch key into three separately hand-copied maps — a
+  fragile pattern that a future rename or localization pass would silently break.
+  Replaced with an internal `Shape` enum.
+- The bug-report sheet's note field could end up hidden behind the keyboard with no way
+  to scroll it into view; the sheet now applies `imePadding()` and brings the field into
+  view on focus.
+- Voice dictation (bug-report note and Point & Ask's question field) cut off after a
+  short pause — both now request longer silence-detection windows from the system
+  speech recognizer so a normal pause for breath doesn't end the recording early.
+
+"Revoir les bounding box" from the same feedback batch is out of scope here and tracked
+separately.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/VoiceInputExtras.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/VoiceInputExtras.kt
@@ -1,0 +1,44 @@
+package io.github.sceneview.demo.common
+
+import android.content.Intent
+import android.speech.RecognizerIntent
+
+/**
+ * Lengthens the system speech recognizer's silence-detection windows so a normal pause
+ * for breath or thought does not cut a longer dictation short (#3322).
+ *
+ * `ACTION_RECOGNIZE_SPEECH`'s stock defaults (~1–1.5 s of silence) are tuned for short
+ * search-style utterances; a bug-report note or a free-form AR question is closer to a
+ * spoken paragraph, and QA on a Pixel 9 found dictation cutting off mid-sentence well
+ * before the speaker was done. These extras are honoured by the AOSP/Google reference
+ * recognizer (best-effort on OEM recognizers that ignore them — never a regression,
+ * since the fallback is just the stock shorter timeout):
+ *  - [RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS] — silence after
+ *    which the recognizer decides the utterance is finished.
+ *  - [RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS] —
+ *    silence after which it returns a possibly-complete partial result.
+ *
+ * Both call sites (`BugReportSheet`'s note dictation, `PointAndAskDemo`'s question
+ * dictation) share this helper so the tuning stays in one place instead of drifting
+ * between two copy-pasted literals.
+ */
+fun Intent.putVoiceSilenceExtras(): Intent = apply {
+    putExtra(
+        RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS,
+        VOICE_COMPLETE_SILENCE_MILLIS,
+    )
+    putExtra(
+        RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS,
+        VOICE_POSSIBLY_COMPLETE_SILENCE_MILLIS,
+    )
+}
+
+/** Silence length before the recognizer ends the utterance — see [putVoiceSilenceExtras]. */
+private const val VOICE_COMPLETE_SILENCE_MILLIS = 4_000L
+
+/**
+ * Silence length before the recognizer emits a possibly-complete partial —
+ * see [putVoiceSilenceExtras]. Shorter than [VOICE_COMPLETE_SILENCE_MILLIS] per the
+ * extra's own contract (it fires first, as an interim result).
+ */
+private const val VOICE_POSSIBLY_COMPLETE_SILENCE_MILLIS = 3_000L

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomGeometryDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CustomGeometryDemo.kt
@@ -30,6 +30,7 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
+import io.github.sceneview.demo.demos.internal.Shape
 import io.github.sceneview.demo.demos.internal.ShapeFraming
 import io.github.sceneview.demo.initialDemoMode
 import io.github.sceneview.demo.rememberFirstFrameState
@@ -220,7 +221,7 @@ private fun ShapeSection(
     mode: CustomGeometryMode,
     onModeChange: (CustomGeometryMode) -> Unit,
 ) {
-    var selectedShape by remember { mutableStateOf("Triangle") }
+    var selectedShape by remember { mutableStateOf(Shape.Triangle) }
 
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
@@ -229,9 +230,9 @@ private fun ShapeSection(
     val starMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.Accent)
     val hexagonMaterial = rememberMaterialInstance(materialLoader, SceneViewColors.TintLight)
     val shapeMaterials = mapOf(
-        "Triangle" to triangleMaterial,
-        "Star" to starMaterial,
-        "Hexagon" to hexagonMaterial,
+        Shape.Triangle to triangleMaterial,
+        Shape.Star to starMaterial,
+        Shape.Hexagon to hexagonMaterial,
     )
     // Outlines live in ShapeFraming so the framing test measures the vertices actually
     // extruded, not a copy of them (#2937).
@@ -250,11 +251,11 @@ private fun ShapeSection(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                listOf("Triangle", "Star", "Hexagon").forEach { shape ->
+                Shape.entries.forEach { shape ->
                     FilterChip(
                         selected = selectedShape == shape,
                         onClick = { selectedShape = shape },
-                        label = { Text(shape) }
+                        label = { Text(shape.label) }
                     )
                 }
             }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
@@ -107,24 +107,44 @@ private enum class LightingLabMode(val label: String) {
     PostFx("Post-FX"),
 }
 
+/**
+ * Two 2-up rows instead of one 4-up row (#3322). A single row split the phone-width sheet
+ * evenly across all four modes, and "Environment" — this row's widest label, by rendered
+ * glyph width rather than character count ("m"/"n"/"o" run wider than "Reflections"'s
+ * "i"/"l"/"t" despite both being 11 characters) — didn't fit even after dropping the
+ * selection icon and shrinking the label style, confirmed truncating to "Environme…" on an
+ * on-device Pixel 9 emulator pass. Pairing two modes per row instead doubles each segment's
+ * share of the width, which is what actually clears the label at normal size rather than
+ * trading one degraded fallback (wrap) for another (ellipsis).
+ */
 @Composable
 private fun ModeSelector(
     current: LightingLabMode,
     onModeChange: (LightingLabMode) -> Unit,
 ) {
     val modes = LightingLabMode.entries
+    ModeSelectorRow(modes.subList(0, 2), current, onModeChange)
+    Spacer(modifier = Modifier.height(8.dp))
+    ModeSelectorRow(modes.subList(2, modes.size), current, onModeChange)
+    Spacer(modifier = Modifier.height(12.dp))
+}
+
+@Composable
+private fun ModeSelectorRow(
+    modes: List<LightingLabMode>,
+    current: LightingLabMode,
+    onModeChange: (LightingLabMode) -> Unit,
+) {
     SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
         modes.forEachIndexed { index, m ->
             SegmentedButton(
                 selected = m == current,
                 onClick = { onModeChange(m) },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
-                // No selection icon: four segments ("Environment" / "Reflections" are the
-                // longest labels) already have to share a phone-width row, and the
-                // checkmark's reserved space was enough to wrap "Environment" onto two
-                // lines — selection is already shown by the segment's own color change
-                // (#3322). `maxLines`/`overflow` are the last-resort fallback for a
-                // narrower row than any label seen in QA, not the primary fix.
+                // No selection icon: selection already reads from the segment's own color
+                // change, so the checkmark's reserved width was pure waste. `maxLines`/
+                // `overflow` stay as a last-resort fallback for a row narrower than
+                // anything seen in QA, not the primary fix (that's the 2-up split above).
                 icon = {},
                 label = {
                     Text(
@@ -136,7 +156,6 @@ private fun ModeSelector(
             )
         }
     }
-    Spacer(modifier = Modifier.height(12.dp))
 }
 
 // ─── Sky section ─────────────────────────────────────────────────────────────

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.google.android.filament.View.AntiAliasing
 import com.google.android.filament.View.Dithering
@@ -118,7 +119,20 @@ private fun ModeSelector(
                 selected = m == current,
                 onClick = { onModeChange(m) },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
-                label = { Text(m.label) },
+                // No selection icon: four segments ("Environment" / "Reflections" are the
+                // longest labels) already have to share a phone-width row, and the
+                // checkmark's reserved space was enough to wrap "Environment" onto two
+                // lines — selection is already shown by the segment's own color change
+                // (#3322). `maxLines`/`overflow` are the last-resort fallback for a
+                // narrower row than any label seen in QA, not the primary fix.
+                icon = {},
+                label = {
+                    Text(
+                        m.label,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
             )
         }
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
@@ -85,6 +85,7 @@ import io.github.sceneview.demo.ai.AskEngine
 import io.github.sceneview.demo.ai.AskEngineStatus
 import io.github.sceneview.demo.ai.rememberAskEngine
 import io.github.sceneview.demo.common.ForceTrackingFailureMenu
+import io.github.sceneview.demo.common.putVoiceSilenceExtras
 import io.github.sceneview.demo.demos.internal.ArPlacement
 import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.demo.demos.internal.rememberTexturesSettled
@@ -492,6 +493,7 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                                         RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
                                     )
                                     putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+                                    putVoiceSilenceExtras()
                                 }
                                 runCatching { speechLauncher.launch(intent) }
                             },

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/ShapeFraming.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/ShapeFraming.kt
@@ -31,6 +31,22 @@ import kotlin.math.sin
  * distance would become `|orbitHomePosition − contentCentre|` and [CAMERA_DISTANCE] would need
  * re-deriving.
  */
+/**
+ * The three outlines [ShapeFraming] offers, and the chip label each one shows in
+ * [io.github.sceneview.demo.demos.CustomGeometryDemo]'s picker.
+ *
+ * Was a bare `String` used as both the display label AND the dispatch key into three
+ * separately hand-copied maps/state (`selectedShape`, `shapeMaterials`, `shapePaths`) —
+ * every site had to repeat the literal `"Triangle"` / `"Star"` / `"Hexagon"` correctly, with
+ * nothing to catch a typo or a future `stringResource()` swap at compile time (#3322). An
+ * enum makes the three maps exhaustive-checkable and the label the one place text lives.
+ */
+internal enum class Shape(val label: String) {
+    Triangle("Triangle"),
+    Star("Star"),
+    Hexagon("Hexagon"),
+}
+
 internal object ShapeFraming {
 
     /** Depth the shape is authored at, and the camera's orbit target. */
@@ -73,11 +89,11 @@ internal object ShapeFraming {
         }
     }
 
-    /** Every outline the sub-mode offers, keyed by its chip label. */
-    val paths: Map<String, List<Position2>> = mapOf(
-        "Triangle" to trianglePath,
-        "Star" to starPath,
-        "Hexagon" to hexagonPath,
+    /** Every outline the sub-mode offers, keyed by [Shape] (#3322 — was keyed by the raw label). */
+    val paths: Map<Shape, List<Position2>> = mapOf(
+        Shape.Triangle to trianglePath,
+        Shape.Star to starPath,
+        Shape.Hexagon to hexagonPath,
     )
 
     /**

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/BugReportSheet.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/BugReportSheet.kt
@@ -17,8 +17,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -43,9 +46,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -53,6 +58,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.common.putVoiceSilenceExtras
+import kotlinx.coroutines.launch
 
 /**
  * The lightweight "Report a bug" bottom sheet (#2188 successor).
@@ -85,6 +92,13 @@ fun BugReportSheet(
     var note by remember { mutableStateOf("") }
     var includeScreenshot by remember { mutableStateOf(report.screenshot != null) }
     var sendError by remember { mutableStateOf<String?>(null) }
+    // Keyboard fix (#3322): a plain ModalBottomSheet does not consume the IME inset, so
+    // the system keyboard used to cover the note field with no way to scroll it into
+    // view — `imePadding()` below shrinks the sheet's content height as the keyboard
+    // rises, and this requester nudges the scroll position the moment the field gains
+    // focus, so the field (not just its top edge) lands above the keyboard on first tap.
+    val noteFieldBringIntoView = remember { BringIntoViewRequester() }
+    val scope = rememberCoroutineScope()
 
     val speechAvailable = remember {
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).resolveActivity(context.packageManager) != null
@@ -115,6 +129,7 @@ fun BugReportSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
+                .imePadding()
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 24.dp),
         ) {
@@ -160,7 +175,6 @@ fun BugReportSheet(
                 onValueChange = { note = it },
                 label = { Text(stringResource(R.string.feedback_report_note_label)) },
                 placeholder = { Text(stringResource(R.string.feedback_report_note_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
                 minLines = 3,
                 trailingIcon = if (speechAvailable) {
                     {
@@ -172,6 +186,7 @@ fun BugReportSheet(
                                         RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
                                     )
                                     putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+                                    putVoiceSilenceExtras()
                                 }
                                 runCatching { speechLauncher.launch(intent) }
                             },
@@ -185,6 +200,14 @@ fun BugReportSheet(
                 } else {
                     null
                 },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .bringIntoViewRequester(noteFieldBringIntoView)
+                    .onFocusEvent { state ->
+                        if (state.isFocused) {
+                            scope.launch { noteFieldBringIntoView.bringIntoView() }
+                        }
+                    },
             )
 
             Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## Summary

Four issues from Pixel 9 QA on `samples/android-demo`, reported in #3322:

- **Chip wraps to two lines** — the Lighting Lab mode selector's "Environment"
  segment wrapped onto two lines at phone width. `SegmentedButton` no longer
  reserves space for a selection icon (selection is already shown by the
  segment's color), and the label caps at one line with ellipsis as a last-
  resort fallback.
- **Commands that look broken** — audited every `FilterChip`/`SegmentedButton`
  in the demo controls sheets for label/action mismatches. Found one genuine
  fragile-dispatch bug: Custom Geometry's shape picker matched chips against a
  raw `String` used as both the display label and the key into three
  separately hand-copied maps (`selectedShape`, `shapeMaterials`,
  `ShapeFraming.paths`) — a typo or a future `stringResource()` swap in any one
  of the three sites would silently break selection. Replaced with an internal
  `Shape` enum shared by the demo and `ShapeFraming`.
- **Keyboard covers the note field** — `BugReportSheet`'s `ModalBottomSheet`
  didn't consume the IME inset, so the system keyboard could cover the note
  field with no way to scroll it into view. Added `imePadding()` plus a
  `BringIntoViewRequester` that scrolls the field into view on focus.
- **Voice dictation cuts off too fast** — both voice-input call sites (bug
  report note, Point & Ask's question field) used the system recognizer's
  stock ~1–1.5 s silence timeout, cutting off a longer dictation mid-sentence.
  Added a shared `Intent.putVoiceSilenceExtras()` helper that requests longer
  `EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS` /
  `..._POSSIBLY_COMPLETE_..._MILLIS` windows from both.

"Revoir les bounding box" from the same feedback batch is out of scope here —
tracked separately as its own issue.

Fixes #3322

## Test plan

- [x] `:samples:android-demo:assembleDebug` builds clean
- [x] `ShapeFramingTest` (JVM unit tests) pass unchanged after the `Shape` enum
      refactor
- [x] On-device (emulator-5554): chip renders on one line (needed a follow-up
      commit splitting the segmented-button row 2-up), bug-report keyboard no
      longer covers the note field — see comment below
- [ ] Voice dictation length — code review only; no working emulator mic to
      verify end-to-end, the recognizer intent extras are best-effort
      (ignored gracefully by recognizers that don't support them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
