### PR TITLE
Fix AR ML object-label anchors hit-testing the wrong screen point

### DIFF
--- a/changelog.d/3337-ar-ml-object-label-bbox-hittest.md
+++ b/changelog.d/3337-ar-ml-object-label-bbox-hittest.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+- **AR object-label detections now anchor on the actual object, not a fixed corner of the
+  screen ([#3337](https://github.com/sceneview/sceneview/issues/3337), follow-up from
+  [#3322](https://github.com/sceneview/sceneview/issues/3322)).**
+  `ARMLObjectLabelDemo` maps each ML Kit detection's bounding-box centre — reported in CPU
+  image pixel space — to a screen-space point for `Frame.hitTest`. That mapping scaled the
+  centre onto a hardcoded 1000×1000 square instead of the AR surface's real pixel size. On
+  a tall portrait phone (e.g. a Pixel 9 at 1080×2424) that square only spans the top ~41% of
+  the screen, so any object detected in the lower half of the camera frame hit-tested
+  against the wrong point and its label landed off the object. The demo now measures its
+  real surface size via Compose layout and scales against that instead.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemo.kt
@@ -24,8 +24,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Anchor
 import com.google.ar.core.Config
@@ -135,6 +137,11 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
     val detections = remember { mutableStateListOf<DetectionAnchor>() }
     var statusBannerRes by remember { mutableIntStateOf(R.string.demo_ar_ml_status_warming) }
 
+    // Real pixel size of the AR surface, measured by Compose layout — see
+    // `updateAnchorsFromDetections`'s `displayW`/`displayH` doc for why this replaced a
+    // hardcoded 1000×1000 square (#3337). Zero until the first layout pass.
+    var viewSize by remember { mutableStateOf(IntSize.Zero) }
+
     // Detector throttle — minimum gap between detector runs so we don't starve the
     // renderer. ~6 fps is plenty for "label what's in front of me".
     val lastDetectMs = remember { longArrayOf(0L) }
@@ -224,7 +231,7 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
             }
         },
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().onSizeChanged { viewSize = it }) {
             ARSceneView(
                 modifier = Modifier.fillMaxSize(),
                 engine = engine,
@@ -258,6 +265,8 @@ fun ARMLObjectLabelDemo(onBack: () -> Unit) {
                             results = pending.results,
                             imageW = pending.imageW,
                             imageH = pending.imageH,
+                            displayW = viewSize.width,
+                            displayH = viewSize.height,
                             detections = detections,
                             labelBitmaps = labelBitmaps,
                         )
@@ -450,6 +459,30 @@ internal fun confidenceBucketPercent(confidence: Float, step: Int = 5): Int {
 }
 
 /**
+ * Maps a detection's bounding-box centre, in **CPU image pixel space** (`imageW × imageH`),
+ * to the equivalent point in **AR surface pixel space** (`displayW × displayH`) — the
+ * coordinate space `Frame.hitTest` expects.
+ *
+ * Pure fraction-preserving scale: the fraction of the image the centre sits at (x/imageW,
+ * y/imageH) is applied to the real display size. [displayW]/[displayH] MUST be the AR
+ * surface's actual pixel size (see [updateAnchorsFromDetections] doc) — a fixed square
+ * placeholder here was the root cause of #3337's mislocated bounding-box anchors on tall
+ * portrait phones.
+ */
+internal fun bboxCentreToScreenPoint(
+    cx: Int,
+    cy: Int,
+    imageW: Int,
+    imageH: Int,
+    displayW: Int,
+    displayH: Int,
+): Pair<Float, Float> {
+    val xFraction = cx.toFloat() / imageW.coerceAtLeast(1)
+    val yFraction = cy.toFloat() / imageH.coerceAtLeast(1)
+    return (xFraction * displayW) to (yFraction * displayH)
+}
+
+/**
  * Reconciles the current detection set with the latest ML Kit results.
  *
  * Strategy:
@@ -463,18 +496,33 @@ internal fun confidenceBucketPercent(confidence: Float, step: Int = 5): Int {
  * Bbox centre is mapped from the **CPU image coordinate space** (`imageW × imageH`) to
  * the display coordinate space via the active `frame`'s coords transform — ARCore's
  * `frame.transformCoordinates2d` would be the right tool, but for V1 we approximate by
- * scaling from the image space to the framebuffer via the camera's display geometry.
- * Detector throttle (#kDetectIntervalMs) keeps the cost bounded.
+ * scaling the bbox centre's fraction of the image to the same fraction of [displayW] ×
+ * [displayH]. Detector throttle (#kDetectIntervalMs) keeps the cost bounded.
+ *
+ * [displayW]/[displayH] MUST be the AR surface's actual pixel size — the same size ARCore's
+ * `Session.setDisplayGeometry` was configured with — because `Frame.hitTest` interprets its
+ * arguments as screen-space pixels on that surface. An earlier version hardcoded a 1000×1000
+ * square here ("arbitrary; hitTest takes screen-space pixels"): on a real phone's tall
+ * portrait aspect (e.g. a Pixel 9 at 1080×2424) that square only spans the top ~41% of the
+ * screen, so any object detected in the lower half of the frame hit-tested against the WRONG
+ * point and its label anchor landed off the object — the "bounding box" mislocation reported
+ * on-device in #3322/#3337.
  */
 private fun updateAnchorsFromDetections(
     frame: Frame,
     results: List<DetectedObject>,
     imageW: Int,
     imageH: Int,
+    displayW: Int,
+    displayH: Int,
     detections: SnapshotStateList<DetectionAnchor>,
     labelBitmaps: MutableMap<String, Bitmap>,
 ) {
     if (results.isEmpty()) return
+    // No layout pass yet (first frame or two after the composable enters) — the surface's
+    // real pixel size isn't known, so a hit-test would be meaningless. Skip this pass; the
+    // next one retries once `onSizeChanged` has fired.
+    if (displayW <= 0 || displayH <= 0) return
 
     // Build category keys from this frame's detections.
     val newKeys = mutableSetOf<String>()
@@ -495,18 +543,10 @@ private fun updateAnchorsFromDetections(
         // same aspect under the default camera config — scaling the centre to the
         // frame's hit-test surface as a proportion of width/height is the safest
         // approximation without bringing in the (deprecated) transformCoordinates3d API.
-        val xFraction = cx.toFloat() / imageW.coerceAtLeast(1)
-        val yFraction = cy.toFloat() / imageH.coerceAtLeast(1)
+        val (screenX, screenY) = bboxCentreToScreenPoint(cx, cy, imageW, imageH, displayW, displayH)
 
-        // Use frame.camera.imageIntrinsics + projection? Simpler: skip the screen-space
-        // mapping and use a centred hit-test for V1 — every detection appears near scene
-        // centre. The user is meant to aim the device AT the object, so centre is already
-        // close to the truth for a single detection. For multi-detection, the labels stack
-        // tightly at scene centre — acceptable V1 UX, improvable in a follow-up.
-        val displayW = 1000f // arbitrary; hitTest takes screen-space pixels
-        val displayH = 1000f
         val hits = runCatching {
-            frame.hitTest(xFraction * displayW, yFraction * displayH)
+            frame.hitTest(screenX, screenY)
         }.getOrNull().orEmpty()
         val hit = hits.firstOrNull { it.distance in 0.1f..5.0f } ?: continue
 

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemoTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARMLObjectLabelDemoTest.kt
@@ -35,3 +35,42 @@ class ARMLObjectLabelDemoTest {
         assertEquals(75, confidenceBucketPercent(0.79f, step = 25))
     }
 }
+
+/**
+ * Pure-JVM tests for [bboxCentreToScreenPoint] — the CPU-image-space → AR-surface-space
+ * mapping fed into `Frame.hitTest` (#3337). Before this fix the caller passed a hardcoded
+ * 1000×1000 square instead of the real surface size, so on a tall portrait phone (e.g. a
+ * Pixel 9 at 1080×2424) a detection in the lower half of the frame hit-tested against the
+ * wrong point on screen and its label anchor landed off the object.
+ */
+class BboxCentreToScreenPointTest {
+
+    @Test
+    fun `centre of the image maps to centre of the display`() {
+        val (x, y) = bboxCentreToScreenPoint(
+            cx = 320, cy = 240, imageW = 640, imageH = 480, displayW = 1080, displayH = 2424,
+        )
+        assertEquals(540f, x, 0.01f)
+        assertEquals(1212f, y, 0.01f)
+    }
+
+    @Test
+    fun `a detection in the lower half of a tall portrait display lands past a 1000px square`() {
+        // Regression for #3337: the old hardcoded 1000x1000 square could never produce a
+        // y beyond 1000px, silently clamping every lower-half detection onto the wrong point
+        // on a 2424px-tall real display.
+        val (_, y) = bboxCentreToScreenPoint(
+            cx = 320, cy = 400, imageW = 640, imageH = 480, displayW = 1080, displayH = 2424,
+        )
+        assert(y > 1000f) { "expected y > 1000f (past the old hardcoded square), was $y" }
+    }
+
+    @Test
+    fun `zero-size image dimensions are coerced instead of dividing by zero`() {
+        val (x, y) = bboxCentreToScreenPoint(
+            cx = 10, cy = 10, imageW = 0, imageH = 0, displayW = 1080, displayH = 2424,
+        )
+        assertEquals(10f * 1080f, x, 0.01f)
+        assertEquals(10f * 2424f, y, 0.01f)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #3337 ("[Demo app] Review bounding boxes") was deferred from #3322's dictated Pixel 9
report ("revoir les bounding box") with no further context. Scoped it against every
bounding-box surface in the demo app and the libraries it exercises (posted the audit as an
[issue comment](https://github.com/sceneview/sceneview/issues/3337#issuecomment-5426556538)
before opening this PR):

- Model-viewer camera auto-fit framing — no visible issue.
- Collision/selection hit-test highlighting — no drawn wireframe, tap targets matched shapes.
- Point & Ask's answer anchor — not bbox-driven.
- **`ARMLObjectLabelDemo`** — the one screen with a literal ML **bounding box** driving a
  visible result. Found the bug: it hit-tested each ML Kit detection's bbox centre against a
  **hardcoded 1000×1000 square** instead of the AR surface's real pixel size. On a tall
  portrait phone (the reporting Pixel 9 is 1080×2424) that square only covers the top ~41% of
  the screen, so objects detected in the lower half hit-tested against the wrong point and
  their labels landed away from the object.

## Fix

- Measure the AR surface's real pixel size via Compose's `onSizeChanged` and thread it into
  `updateAnchorsFromDetections` as `displayW`/`displayH`, replacing the hardcoded square.
- Extracted the pure coordinate mapping into `bboxCentreToScreenPoint(cx, cy, imageW, imageH,
  displayW, displayH)` for testability.
- Guard against acting on a size-0 surface before the first Compose layout pass.

## Test plan

- [x] New JVM unit tests for `bboxCentreToScreenPoint`, including a regression case showing a
      lower-half-of-screen detection lands past the old hardcoded 1000px square on a
      1080×2424-style display — 7/7 tests pass (`ARMLObjectLabelDemoTest` +
      `BboxCentreToScreenPointTest`).
- [x] `:samples:android-demo:assembleDebug` builds clean.
- [ ] On-device: `ARMLObjectLabelDemo` is AR-only (ARCore), which the shared `emulator-5554`
      cannot exercise (no ARCore support there). Logic/JVM-verified only — pending Thomas's
      go-ahead to validate on the AR-capable Pixel 9 that reported this.

Fixes #3337

🤖 Generated with [Claude Code](https://claude.com/claude-code)
