### PR TITLE
fix(tools): read the Sketchfab API token from the environment

### DIFF
--- a/changelog.d/sketchfab-token-env.md
+++ b/changelog.d/sketchfab-token-env.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+`tools/download-assets.sh` no longer embeds a Sketchfab API token; it now requires `SKETCHFAB_API_KEY` from the environment.

--- a/tools/download-assets.sh
+++ b/tools/download-assets.sh
@@ -3,7 +3,11 @@
 # Usage: bash tools/download-assets.sh
 set -e
 
-API_KEY="[REDACTED-API-KEY]"
+API_KEY="${SKETCHFAB_API_KEY:-}"
+if [ -z "$API_KEY" ]; then
+    echo "SKETCHFAB_API_KEY is not set. Get a token from https://sketchfab.com/settings/password and export it." >&2
+    exit 1
+fi
 MODELS_DIR="samples/android-demo/src/main/assets/models"
 ENV_DIR="samples/android-demo/src/main/assets/environments"
 


### PR DESCRIPTION
`tools/download-assets.sh` has carried a live Sketchfab API token in cleartext since 2026-03-21 (`3c905cd20`), in a public repository. This PR removes it from the tree: the script now reads `SKETCHFAB_API_KEY` from the environment and fails fast with instructions when it is missing.

**This does not remediate the exposure** — the token remains in git history and must be revoked/rotated at https://sketchfab.com/settings/password. Flagged to the maintainer separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)