### PR TITLE
fix: widen pub.dev publish verification budget to match its own propagation window

### DIFF
--- a/.claude/scripts/verify-published-version.sh
+++ b/.claude/scripts/verify-published-version.sh
@@ -68,10 +68,19 @@ VERSION="$3"
 [ -n "$PACKAGE" ] || usage
 [ -n "$VERSION" ] || usage
 
-# Per-registry defaults. npm and pub.dev are near-immediate; Central is not.
+# Per-registry defaults. npm is near-immediate; Central and pub.dev are not.
 case "$REGISTRY" in
     npm)   DEF_ATTEMPTS=5;  DEF_DELAY=20 ;;
-    pub)   DEF_ATTEMPTS=5;  DEF_DELAY=20 ;;
+    # 20 × 30s = 10 min. NOT a guess: pub.dev's own upload response says so
+    # verbatim — "it may take up-to 10 minutes before the new version is
+    # available" — yet the previous budget here was 5 × 20s = 100s, ~6x short
+    # of the bound pub.dev itself documents. v4.33.0 hit exactly that gap:
+    # the publish step's own log shows the server's "Successfully uploaded"
+    # message, the version was live on pub.dev minutes later, and the job
+    # still went red because verification gave up first (#3011/#3021 follow-up).
+    # v4.32.0 came within one retry of the same false red (FOUND on attempt
+    # 3/5, ~60s from the end of a 100s budget) — this was not a one-off.
+    pub)   DEF_ATTEMPTS=20; DEF_DELAY=30 ;;
     # 20 × 45s = 15 min, against the ~30 min OSSRH lag measured at v4.26.0.
     # Short of the worst case on purpose: the shared deadline, not this
     # number, is what keeps four artifacts inside one job timeout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -665,7 +665,12 @@ jobs:
   pub-publish:
     name: Publish flutter_sceneview to pub.dev
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 20, not 15: the verify step below now budgets up to 10 min for pub.dev's
+    # own documented propagation window ("it may take up-to 10 minutes"), on
+    # top of ~1-2 min for checkout/flutter-action/dry-run/publish. 15 min left
+    # no margin and was itself part of why v4.33.0 went red on a publish that
+    # had actually landed.
+    timeout-minutes: 20
     needs: [breaking-change-guard]
     permissions:
       contents: read

--- a/changelog.d/3011-pubdev-verify-propagation-budget.md
+++ b/changelog.d/3011-pubdev-verify-propagation-budget.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+<!-- RELEASE NOTE (maintainer-only):
+     v4.33.0's "Publish flutter_sceneview to pub.dev" job went red with
+     "NOT ON REGISTRY: flutter_sceneview 4.33.0 is absent after a green
+     publish" even though the publish had actually succeeded — pub.dev's own
+     upload response says "it may take up-to 10 minutes before the new
+     version is available," but the post-publish verification (#3013,
+     #3021) only retried for 100s (5 x 20s) before failing the job. v4.32.0
+     nearly hit the same false red, landing on attempt 3/5. The package was
+     never at risk — this only fixed the CI signal, not pub.dev credentials
+     or trust. -->
+- **pub.dev publish verification no longer false-reds on its own documented propagation delay.** `.claude/scripts/verify-published-version.sh`'s `pub` budget grew from 5x20s (100s) to 20x30s (10 min), matching the window pub.dev's own upload response states; `release.yml`'s `pub-publish` job timeout grew from 15 to 20 minutes to give that budget room.


### PR DESCRIPTION
## Summary

- Run 33004369060 (tag v4.33.0) reported `NOT ON REGISTRY: flutter_sceneview 4.33.0 is absent after a green publish` even though the publish had actually succeeded — pub.dev now serves `4.33.0` as `latest` (confirmed at https://pub.dev/api/packages/flutter_sceneview).
- pub.dev's own upload response says *"it may take up-to 10 minutes before the new version is available"*, but `.claude/scripts/verify-published-version.sh`'s `pub` retry budget was 5 attempts x 20s = 100s — about 6x short of the window pub.dev itself documents. The previous release (v4.32.0, run 32605221478) nearly hit the same false red, only landing on attempt 3/5 (~60s before the old budget ran out).
- Widen the `pub` budget to 20 x 30s = 10 minutes (matching pub.dev's stated bound), and bump `pub-publish`'s job `timeout-minutes` from 15 to 20 so the wider verification budget has room alongside checkout/flutter-action/dry-run/publish.
- This only fixes the CI signal. It does not touch pub.dev credentials, trust configuration, or the publish mechanism — those were confirmed working; see diagnosis in #3011.

## Diagnosis (for context)

Full investigation posted as a comment on #3011, comparing this run against v4.32.0 (success) and v4.31.0 (genuine failure, unrelated cause: "publishing from github is not enabled" on pub.dev's side, since fixed).

## Test plan

- [ ] `bash -n .claude/scripts/verify-published-version.sh` (done locally, passes)
- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`, done locally, passes)
- [ ] Next tagged release exercises the real `pub-publish` job end to end and should go green without the false red

🤖 Generated with [Claude Code](https://claude.com/claude-code)