### PR TITLE
fix(ar): restore the isEditable gate on AnchorNode move gestures

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AnchorNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AnchorNode.kt
@@ -87,7 +87,14 @@ open class AnchorNode(
             updateVisibility()
         }
 
+    /**
+     * Whether the anchor can be moved by drag gestures.
+     *
+     * Like every editable flag, it is gated by [isEditable]: a move gesture detaches and
+     * re-creates the anchor only when both [isEditable] and this flag are `true`.
+     */
     override var isPositionEditable = true
+        get() = isEditable && field
 
     override var isVisible
         get() = super.isVisible && (trackingState in visibleTrackingStates || isMoving)

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/PoseNode.kt
@@ -126,7 +126,10 @@ open class PoseNode(
     internal var frameUpdatedAnchors: Set<com.google.ar.core.Anchor>? = null
 
     // Rotation edition is disabled by default because retrieved from the pose.
+    // The custom getter keeps [Node]'s `isEditable &&` gate, which a plain field
+    // override would silently drop.
     override var isRotationEditable = false
+        get() = isEditable && field
 
     override var isVisible
         get() = super.isVisible &&

--- a/arsceneview/src/test/java/io/github/sceneview/ar/AnchorNodeEditableGateContractTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/AnchorNodeEditableGateContractTest.kt
@@ -1,0 +1,89 @@
+package io.github.sceneview.ar
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source contract for the `isEditable` gate on AR node editable flags.
+ *
+ * ## What broke
+ *
+ * [Node][io.github.sceneview.node.Node] declares every `is*Editable` flag with a custom
+ * getter — `get() = isEditable && field` — so no gesture edits a node unless the caller
+ * opted in with `isEditable = true`. [io.github.sceneview.ar.node.AnchorNode] overrode
+ * `isPositionEditable` as a **plain field** (`override var isPositionEditable = true`),
+ * which replaces the getter and silently drops the gate: every `AnchorNode` answered move
+ * gestures even with `isEditable = false`. `onMoveBegin` then detached the anchor and
+ * `onMoveEnd` re-anchored it, so a stray drag on a non-editable placed model detached its
+ * anchor mid-session — on the ar-instant-placement rig this raced the demo's lost-anchor
+ * reconciliation (#1184) and killed placed models with ARCore "already removed/detached"
+ * warning bursts.
+ *
+ * ## Why a source contract rather than a behavioral test
+ *
+ * The behavioral half of the gate is already pinned by `NodeGestureTest`
+ * (`isPositionEditable_requiresIsEditable`, androidTest) on a live `Node`. What cannot be
+ * tested behaviorally here is the *subclass override*: constructing an `AnchorNode`
+ * requires a real ARCore [com.google.ar.core.Anchor] (final, native-backed, only issued by
+ * a tracking `Session`), which neither a JVM test nor a plain emulator instrumentation
+ * test can produce. The defect, however, is a build-time fact — an override either
+ * re-declares the gate or it does not — so this test reads it from the source of truth,
+ * the same idiom as `PlaneVisualizerAttributeContractTest`.
+ *
+ * It generalises: any `override var is*Editable` added to an AR node source file without
+ * re-declaring `get() = isEditable && field` fails here, except overrides of `isEditable`
+ * itself (the gate variable, plain by design — see `LightNode` / `CameraNode`).
+ */
+class AnchorNodeEditableGateContractTest {
+
+    /** JVM tests run with the module directory as CWD. */
+    private val nodeSources = File("src/main/java/io/github/sceneview/ar/node")
+        .listFiles { file -> file.extension == "kt" }!!
+        .associate { it.name to it.readText() }
+
+    /** Matches a plain-field editable-flag override NOT followed by the gating getter. */
+    private val overrideRegex =
+        Regex("""override\s+var\s+(is(?:Position|Rotation|Scale)Editable)[^\n]*\n(\s*get\(\)\s*=\s*isEditable\s*&&\s*field)?""")
+
+    @Test
+    fun `every editable flag override keeps the isEditable gate`() {
+        val ungated = nodeSources.flatMap { (name, source) ->
+            overrideRegex.findAll(source)
+                .filter { it.groupValues[2].isEmpty() }
+                .map { "$name: ${it.groupValues[1]}" }
+        }
+        assertTrue(
+            "Editable-flag override(s) drop Node's `get() = isEditable && field` gate " +
+                "(a plain `override var` replaces the custom getter): $ungated",
+            ungated.isEmpty()
+        )
+    }
+
+    @Test
+    fun `AnchorNode declares the gated isPositionEditable override`() {
+        // The generic scan above passes vacuously if the override is deleted outright;
+        // this pins that AnchorNode still opts position editing in, gated.
+        val anchorNode = nodeSources.getValue("AnchorNode.kt")
+        assertTrue(
+            "AnchorNode.kt must override isPositionEditable with the isEditable gate",
+            Regex("""override\s+var\s+isPositionEditable\s*=\s*true\s*\n\s*get\(\)\s*=\s*isEditable\s*&&\s*field""")
+                .containsMatchIn(anchorNode)
+        )
+    }
+
+    @Test
+    fun `AnchorNode move handlers stay guarded by isPositionEditable`() {
+        // The gate only protects the anchor if onMoveBegin/onMoveEnd consult it before
+        // detaching/re-creating the anchor.
+        val anchorNode = nodeSources.getValue("AnchorNode.kt")
+        for (handler in listOf("onMoveBegin", "onMoveEnd")) {
+            val body = anchorNode.substringAfter("override fun $handler")
+                .substringBefore("override fun")
+            assertTrue(
+                "AnchorNode.$handler must guard anchor detach/re-anchor with isPositionEditable",
+                "if (isPositionEditable)" in body
+            )
+        }
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/AnchorNodeEditableGateContractTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/AnchorNodeEditableGateContractTest.kt
@@ -43,8 +43,10 @@ class AnchorNodeEditableGateContractTest {
         .associate { it.name to it.readText() }
 
     /** Matches a plain-field editable-flag override NOT followed by the gating getter. */
-    private val overrideRegex =
-        Regex("""override\s+var\s+(is(?:Position|Rotation|Scale)Editable)[^\n]*\n(\s*get\(\)\s*=\s*isEditable\s*&&\s*field)?""")
+    private val overrideRegex = Regex(
+        """override\s+var\s+(is(?:Position|Rotation|Scale)Editable)[^\n]*\n""" +
+            """(\s*get\(\)\s*=\s*isEditable\s*&&\s*field)?"""
+    )
 
     @Test
     fun `every editable flag override keeps the isEditable gate`() {

--- a/changelog.d/3357-anchornode-iseditable-gate.md
+++ b/changelog.d/3357-anchornode-iseditable-gate.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+<!-- breaking -->
+- **`AnchorNode` no longer answers move gestures unless `isEditable = true`.** Its
+  `isPositionEditable` override was a plain field that silently dropped `Node`'s
+  `isEditable &&` gate, so a drag on any anchored node detached and re-created its anchor
+  even with editing off — observed as ARCore "already removed/detached" bursts killing
+  placed models in the ar-instant-placement demo. `PoseNode.isRotationEditable` carried
+  the same ungated override and is fixed the same way. **Behavior change:** code that
+  relied on anchors being draggable by default must now opt in with `isEditable = true`
+  on the `AnchorNode` (the demo placement helper now does exactly that).

--- a/changelog.d/3359-anchornode-iseditable-gate.md
+++ b/changelog.d/3359-anchornode-iseditable-gate.md
@@ -1,6 +1,6 @@
 <!-- category: Fixed -->
 <!-- breaking -->
-- **`AnchorNode` no longer answers move gestures unless `isEditable = true`.** Its
+- **`AnchorNode` no longer answers move gestures unless `isEditable = true` ([#3359](https://github.com/sceneview/sceneview/pull/3359)).** Its
   `isPositionEditable` override was a plain field that silently dropped `Node`'s
   `isEditable &&` gate, so a drag on any anchored node detached and re-created its anchor
   even with editing off — observed as ARCore "already removed/detached" bursts killing

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementNodes.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementNodes.kt
@@ -78,6 +78,10 @@ internal fun ARSceneScope.PlacedModelNode(
         anchor = placed.anchor,
         visibleTrackingStates = ArPlacement.ANCHORED_VISIBLE_STATES,
         apply = {
+            // The anchor drag below only works while the node is editable: every
+            // `is*Editable` flag — `isPositionEditable` included — is gated by
+            // `isEditable`, which defaults to false.
+            isEditable = true
             // Constrain the drag to the same surfaces a tap would accept, so "where can I
             // put this?" has one answer whether the user taps or drags (#1883 / #3326).
             moveHitTest = { frame, event ->


### PR DESCRIPTION
## Summary

`AnchorNode` overrode `isPositionEditable` as a plain field (`override var isPositionEditable = true`), which replaces `Node`'s custom getter `get() = isEditable && field` and silently drops the gate: **every AnchorNode answered move gestures even with `isEditable = false`**. `onMoveBegin` then detached the anchor and `onMoveEnd` re-anchored it, so a stray drag on a non-editable placed model detached its anchor mid-session — on the Pixel 4a rig this raced the ar-instant-placement demo's lost-anchor reconciliation (#1184) and killed placed models with ARCore "Remove/detach called on an anchor that was already removed/detached" warning bursts. #3357 worked around the race demo-side; this PR restores the SDK gate itself.

## Changes

- **`AnchorNode.isPositionEditable`** keeps its `true` default but re-declares the gating getter, so a move gesture detaches/re-creates the anchor only when `isEditable` is also `true`.
- **`PoseNode.isRotationEditable`** had the same ungated plain-field override (`= false`) and is fixed the same way.
- **Demo audit**: the only sample that deliberately relies on anchor dragging is the shared placement helper (`PlacedModelNode`, #3326) — it now opts in with `isEditable = true`. Every other demo sets `isEditable` only on the model child; their anchors were never meant to be draggable.
- **`AnchorNodeEditableGateContractTest`** (JVM) pins the override shape from source and generalises to any future `is*Editable` override in the AR node package. A behavioral test is not constructible: an `AnchorNode` requires a native ARCore `Anchor` only a tracking session can issue; the base gate's behavior is already covered by `NodeGestureTest` (androidTest).
- Changelog fragment declared `<!-- breaking -->` — behavior change, ships as a minor bump per policy.

## Test plan

- `:arsceneview:testDebugUnitTest` — green (new contract test included; verified it fails when the gate is removed).
- `:samples:android-demo:compileDebugKotlin` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)