### PR TITLE
fix(tools): remove the remaining hardcoded Sketchfab token from download-asset-by-uid.sh

### DIFF
--- a/changelog.d/sketchfab-token-env-uid.md
+++ b/changelog.d/sketchfab-token-env-uid.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+`tools/download-asset-by-uid.sh` no longer embeds a Sketchfab API token; it now requires `SKETCHFAB_API_KEY` from the environment (companion of the `download-assets.sh` fix).

--- a/tools/download-asset-by-uid.sh
+++ b/tools/download-asset-by-uid.sh
@@ -3,7 +3,11 @@
 # Usage: bash tools/download-asset-by-uid.sh <uid> <filename_without_extension>
 set -e
 
-API_KEY="[REDACTED-API-KEY]"
+API_KEY="${SKETCHFAB_API_KEY:-}"
+if [ -z "$API_KEY" ]; then
+    echo "SKETCHFAB_API_KEY is not set. Get a token from https://sketchfab.com/settings/password and export it." >&2
+    exit 1
+fi
 MODELS_DIR="samples/android-demo/src/main/assets/models"
 
 uid=$1


### PR DESCRIPTION
Companion of #3354, which fixed `download-assets.sh` but missed its sibling: `tools/download-asset-by-uid.sh` line 6 still carries the same cleartext Sketchfab token on `main` today. Both scripts have exposed it since 2026-03-21 (`e11eb12c2`, originally under `scripts/`).

Same fix: read `SKETCHFAB_API_KEY` from the environment, fail fast with instructions when missing.

**Revocation at https://sketchfab.com/settings/password remains mandatory** — the token stays readable in public git history regardless of this PR. Coordination note: if the same token is used by the AR Model Viewer Cloudflare worker (`SKETCHFAB_TOKEN` secret), the new token must be set there in the same operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)