### PR TITLE
fix(ci): tag the release in-run so a GITHUB_TOKEN auto-merge cannot skip it

### DIFF
--- a/.claude/scripts/tag-release.sh
+++ b/.claude/scripts/tag-release.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tag-release.sh — tag a merged release-fast bump commit and launch release.yml.
+#
+# WHY THIS IS A SCRIPT AND NOT A WORKFLOW STEP (#3358)
+# ---------------------------------------------------
+# Two different callers need the exact same three decisions (is this a release
+# commit? does it agree with gradle.properties? is it already tagged?):
+#
+#   1. `release-fast.yml`'s `tag` job — the primary path. It waits for its own
+#      release PR to merge and then tags, because the auto-merge is performed
+#      with the default `GITHUB_TOKEN` and GitHub suppresses workflow events for
+#      pushes made with that token: the merge push emits NO `push` event, so a
+#      workflow that only listens for one can never see the release land.
+#   2. `tag-release.yml` — the `on: push: branches: [main]` safety net that DOES
+#      fire when a human merges the release PR (a human merge is a real push
+#      event), plus a manual `workflow_dispatch` recovery handle.
+#
+# Both paths are idempotent and race-safe: whoever gets there first creates the
+# tag, the other one sees it and exits 0. Duplicating this logic in two YAML
+# `run:` blocks is how the two copies drift, so it lives here once.
+#
+# USAGE
+#   tag-release.sh [<commit-ish>]     # default: HEAD
+#
+# Requires: git (full history / the commit fetched), `gh` authenticated with a
+# token carrying `contents: write` and `actions: write`.
+set -euo pipefail
+
+REF="${1:-HEAD}"
+
+SUBJECT=$(git log -1 --pretty=%s "$REF")
+
+# Squash-merge subject = the release-fast PR title, optionally + " (#N)".
+# A hand-written commit that merely mentions "release:" does not match and does
+# nothing — this shape is the only authorisation to tag.
+V=$(printf '%s\n' "$SUBJECT" \
+  | sed -n 's/^release: \([0-9][0-9.]*\) — version bump + changelog collate\( (#[0-9]*)\)\{0,1\}$/\1/p')
+
+if [ -z "$V" ]; then
+  echo "Not a release commit ($SUBJECT) — nothing to do."
+  exit 0
+fi
+
+PROP=$(git show "$REF:gradle.properties" | grep '^VERSION_NAME=' | cut -d= -f2)
+if [ "$PROP" != "$V" ]; then
+  echo "::error::commit says $V but VERSION_NAME=$PROP — refusing to tag"
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/v$V" >/dev/null 2>&1; then
+  echo "v$V already exists locally — nothing to do."
+  exit 0
+fi
+# The other caller may have tagged since this checkout was made. Ask the remote,
+# never `git push --force` a tag: an existing tag is a success, not a conflict.
+if git ls-remote --exit-code --tags origin "refs/tags/v$V" >/dev/null 2>&1; then
+  echo "v$V already exists on origin — nothing to do."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git tag -a "v$V" "$REF" -m "SceneView $V"
+
+# A concurrent tagger can still win between the check above and this push.
+# `git push` refuses to clobber an existing tag, so a failure here is only fatal
+# if the tag still does not exist afterwards.
+if ! git push origin "v$V"; then
+  if git ls-remote --exit-code --tags origin "refs/tags/v$V" >/dev/null 2>&1; then
+    echo "v$V was tagged concurrently — nothing to do."
+    exit 0
+  fi
+  echo "::error::failed to push tag v$V"
+  exit 1
+fi
+
+echo "Tagged v$V — dispatching release.yml on the tag ref."
+# The tag was pushed with GITHUB_TOKEN, so release.yml's `on: push: tags:`
+# trigger will NOT fire (same suppression as above). release.yml accepts
+# workflow_dispatch, and running it on the tag ref is equivalent.
+gh workflow run release.yml --ref "v$V"

--- a/.github/workflows/release-fast.yml
+++ b/.github/workflows/release-fast.yml
@@ -4,8 +4,8 @@
 #
 #   dispatch(version) ─▶ web device-QA gate (BLOCKING) ─▶ bump via the now-complete
 #   sync-versions.sh --fix (M7b, 0 residuals) ─▶ changelog collate ─▶ release PR
-#   with auto-merge ─▶ [tag-release.yml] tags the merge commit and dispatches
-#   release.yml on the tag ref.
+#   with auto-merge ─▶ this workflow's own `tag` job waits for that PR to merge,
+#   tags the merge commit and dispatches release.yml on the tag ref.
 #
 # WHY PR-then-tag and not a direct push: main is protected by required status
 # checks (ci.yml job names) with no push restrictions but no GITHUB_TOKEN
@@ -13,11 +13,33 @@
 # can, which is exactly what the manual recipe did). The PR path keeps the
 # required checks honest AND gives the bump diff a reviewable surface for free.
 #
-# WHY the companion tag workflow: a tag created here with GITHUB_TOKEN would
-# NOT trigger release.yml (GitHub suppresses workflow-to-workflow events for
-# the default token). tag-release.yml therefore creates the tag at merge time
-# and explicitly dispatches release.yml on the tag ref (release.yml already
-# accepts workflow_dispatch).
+# WHY THIS WORKFLOW TAGS ITSELF INSTEAD OF HANDING OFF (#3358): GitHub emits NO
+# workflow events for anything done with the default `GITHUB_TOKEN`. That bites
+# twice on this pipeline, one step apart:
+#
+#   * the auto-MERGE of the release PR is performed with GITHUB_TOKEN, so the
+#     resulting push to main fires no `push` event — a companion workflow keyed
+#     on `on: push: branches: [main]` never runs. This is exactly how v4.33.0
+#     shipped a bumped-but-untagged main with nothing red anywhere (#3358);
+#   * the TAG this pipeline pushes is likewise GITHUB_TOKEN-made, so release.yml's
+#     `on: push: tags:` trigger would not fire either.
+#
+# The fix for the first is to stop depending on the event chain at all: the `tag`
+# job below belongs to THIS run, waits for the PR it just opened to merge, and
+# tags the merge commit directly. If the merge never happens, that job fails red
+# instead of the release evaporating in silence. The fix for the second is
+# unchanged — an explicit `gh workflow run release.yml --ref v$V` (release.yml
+# already accepts workflow_dispatch, which is equivalent to the tag-push path).
+#
+# A PAT/App token for the merge was the other candidate. Rejected: it makes the
+# release depend on a credential that expires silently and fails back into the
+# exact same invisible half-release, and it widens the blast radius of the one
+# job allowed to write to main. Owning the tag in-run needs no secret at all.
+#
+# tag-release.yml survives as a safety net for the human-merge path (a human
+# merge IS a real push event) and as a manual `workflow_dispatch` recovery
+# handle. Both callers share `.claude/scripts/tag-release.sh`, which is
+# idempotent — whoever tags first wins, the other exits 0.
 name: Release fast
 
 on:
@@ -45,6 +67,8 @@ jobs:
     name: QA gate + bump PR (${{ inputs.version }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      branch: ${{ steps.open_pr.outputs.branch }}
     # Shell-injection hardening: the version input reaches shell ONLY via this
     # env var (never ${{ }} inside run: bodies) — env interpolation is inert,
     # and the regex validation below rejects anything but 4.x.y anyway.
@@ -112,11 +136,13 @@ jobs:
         run: bash .claude/scripts/collate-changelog.sh "$RELEASE_VERSION"
 
       - name: Open release PR (auto-merge)
+        id: open_pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           V="$RELEASE_VERSION"
           BRANCH="release/v$V"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -128,9 +154,79 @@ jobs:
           git add -A
           git reset -q -- device-qa-report.json device-qa-artifacts ar-qa-summary.json web-qa-summary.json
           git commit -m "release: $V — version bump + changelog collate" \
-            -m "Automated by release-fast.yml (web QA verdict gated, sync-versions 0 mismatch). Merging this PR tags v$V via tag-release.yml, which dispatches release.yml on the tag."
+            -m "Automated by release-fast.yml (web QA verdict gated, sync-versions 0 mismatch). Merging this PR tags v$V from the same release-fast run, which dispatches release.yml on the tag."
           git push origin "$BRANCH"
           gh pr create --title "release: $V — version bump + changelog collate" \
-            --body "One-click release pipeline (release-fast.yml). Web device-QA gate passed (or explicitly skipped: \`${{ inputs.skip_web_qa }}\`); sync-versions 0 mismatch; changelog collated. **Merging this PR tags \`v$V\`** (tag-release.yml) and launches release.yml." \
+            --body "One-click release pipeline (release-fast.yml). Web device-QA gate passed (or explicitly skipped: \`${{ inputs.skip_web_qa }}\`); sync-versions 0 mismatch; changelog collated. **Merging this PR tags \`v$V\`** (the \`tag\` job of this same release-fast run) and launches release.yml." \
             --base main --head "$BRANCH"
           gh pr merge "$BRANCH" --squash --auto
+
+  # The release is NOT done when the PR is open — it is done when the tag exists.
+  # This job owns that gap end to end (#3358): it waits for its own PR to merge
+  # and tags the merge commit, instead of handing off to a `push`-triggered
+  # workflow that a GITHUB_TOKEN auto-merge never wakes up.
+  tag:
+    name: Await merge + tag v${{ inputs.version }}
+    needs: checkpoint
+    runs-on: ubuntu-latest
+    # Long by design: this spans the release PR's full required-check suite.
+    # Timing out is the POINT of the job — a release PR that never merges must
+    # end in a red run, which is precisely what #3358 lacked.
+    timeout-minutes: 180
+    # Job-level permissions REPLACE the workflow-level block, so restate what is
+    # needed: `contents` to push the tag, `actions` to dispatch release.yml.
+    permissions:
+      contents: write
+      actions: write
+      pull-requests: read
+    env:
+      RELEASE_BRANCH: ${{ needs.checkpoint.outputs.branch }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Wait for the release PR to merge
+        id: wait
+        run: |
+          # 340 × 30 s ≈ 170 min, inside the 180-min job timeout so the wait
+          # ends with a named error rather than an opaque cancellation.
+          for _ in $(seq 1 340); do
+            # A transient API blip must cost one poll, not the whole release:
+            # `|| true` keeps `bash -e` from killing the wait, and an empty
+            # answer simply falls through to the next iteration.
+            STATUS=$(gh pr view "$RELEASE_BRANCH" --json state,mergeCommit \
+              -q '.state + " " + (.mergeCommit.oid // "")' || true)
+            STATE=${STATUS%% *}
+            OID=${STATUS#* }
+            case "$STATE" in
+              MERGED)
+                # Never fall back to "HEAD" on a blank oid: HEAD here is still
+                # the PRE-merge main this job checked out, and tagging that
+                # would tag the wrong commit.
+                [ -n "$OID" ] || { echo "::error::PR reports MERGED with no merge commit oid"; exit 1; }
+                echo "PR merged as $OID."
+                echo "oid=$OID" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              CLOSED)
+                echo "::error::release PR $RELEASE_BRANCH was closed without merging — no tag, no release"
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "::error::release PR $RELEASE_BRANCH still not merged after ~170 min — check its required checks, then re-run tag-release.yml manually once it lands"
+          exit 1
+
+      # Same hardening rule as the checkpoint job: the commit id reaches the
+      # shell through an env var only, never `${{ }}` inside a `run:` body.
+      - name: Tag the merge commit and dispatch release.yml
+        env:
+          MERGE_OID: ${{ steps.wait.outputs.oid }}
+        run: |
+          git fetch --tags origin main
+          bash .claude/scripts/tag-release.sh "$MERGE_OID"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,24 +1,29 @@
-# tag-release.yml — companion of release-fast.yml (M7c).
+# tag-release.yml — safety net + manual handle for the release-fast tag step.
 #
-# When a release-fast bump PR merges to main (squash commit titled
-# "release: X.Y.Z — …"), this workflow creates the annotated tag vX.Y.Z on the
-# merge commit and explicitly dispatches release.yml on the tag ref.
+# The PRIMARY tagger is now release-fast.yml's own `tag` job (#3358): it waits
+# for the release PR it opened to merge and tags the merge commit itself. That
+# removes the event chain entirely, because the auto-merge is performed with the
+# default `GITHUB_TOKEN` and GitHub emits NO workflow events for pushes made
+# with that token — this workflow's `on: push` trigger simply never fired for an
+# auto-merged release PR, and v4.33.0 sat bumped-but-untagged until a human
+# noticed.
 #
-# The explicit dispatch exists because GitHub suppresses workflow-to-workflow
-# events for the default GITHUB_TOKEN: a tag pushed here would never fire
-# release.yml's `on: push: tags:` trigger by itself. release.yml already
-# accepts workflow_dispatch, and running it on the tag ref is equivalent to
-# the tag-push path.
+# This workflow remains for the two cases release-fast cannot cover:
+#   * a HUMAN merges the release PR (a human merge IS a real push event, and it
+#     may land after release-fast's waiting job has already timed out);
+#   * `workflow_dispatch` — a manual recovery handle when a release did land
+#     untagged for any other reason.
 #
-# Safety: fires ONLY on main pushes whose HEAD commit subject matches the
-# release-fast commit shape AND whose version matches gradle.properties —
-# a hand-written commit that merely says "release:" without the bump does
-# nothing. Existing tags are never moved.
+# The decision logic lives in `.claude/scripts/tag-release.sh`, shared with
+# release-fast so the two callers cannot drift. It is idempotent: it fires ONLY
+# on a HEAD commit matching the release-fast commit shape whose version matches
+# gradle.properties, and an already-existing tag is a no-op, never a move.
 name: Tag release
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -38,17 +43,4 @@ jobs:
       - name: Detect release commit and tag
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          SUBJECT=$(git log -1 --pretty=%s)
-          # Squash-merge subject = the PR title + " (#N)": match that shape.
-          V=$(echo "$SUBJECT" | sed -n 's/^release: \([0-9][0-9.]*\) — version bump + changelog collate\( (#[0-9]*)\)\{0,1\}$/\1/p')
-          [ -z "$V" ] && { echo "Not a release commit — nothing to do."; exit 0; }
-          PROP=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
-          [ "$PROP" != "$V" ] && { echo "::error::commit says $V but VERSION_NAME=$PROP — refusing to tag"; exit 1; }
-          git rev-parse "v$V" >/dev/null 2>&1 && { echo "v$V already exists — nothing to do."; exit 0; }
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$V" -m "SceneView $V"
-          git push origin "v$V"
-          echo "Tagged v$V — dispatching release.yml on the tag ref."
-          gh workflow run release.yml --ref "v$V"
+        run: bash .claude/scripts/tag-release.sh

--- a/changelog.d/3358-tag-release-github-token.md
+++ b/changelog.d/3358-tag-release-github-token.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+- **A release whose PR auto-merges is now always tagged ([#3361](https://github.com/sceneview/sceneview/pull/3361)).** GitHub
+  emits no workflow events for pushes made with the default `GITHUB_TOKEN`, so when
+  `release-fast.yml`'s release PR auto-merged, the merge produced no `push` event and the
+  `push`-triggered `Tag release` workflow never ran: v4.33.0 sat on `main` with
+  `VERSION_NAME` bumped, no tag, no publications and nothing red anywhere until a human
+  noticed. `release-fast.yml` now owns the tag in the same run — a `tag` job waits for the
+  PR it opened to merge, tags the merge commit and dispatches `release.yml` — so the
+  release no longer depends on an event chain, and a PR that never merges ends in a red
+  run instead of a silent half-release. `tag-release.yml` remains as the human-merge
+  safety net and a manual recovery handle; both callers share the idempotent
+  `.claude/scripts/tag-release.sh`.


### PR DESCRIPTION
Fixes #3358

## The failure

GitHub emits **no workflow events for anything done with the default `GITHUB_TOKEN`**. That suppression bites the release pipeline twice, one step apart:

1. `release-fast.yml` enables auto-merge on its release PR with `GITHUB_TOKEN`, so the eventual merge push to `main` fires **no `push` event** — and `tag-release.yml` listens for exactly that. On v4.33.0 the PR merged at 17:38 UTC, `Tag release` never ran, and `main` sat with `VERSION_NAME` bumped, no tag, no publications, and **nothing red anywhere** until a human noticed.
2. The tag itself is `GITHUB_TOKEN`-made, so `release.yml`'s `on: push: tags:` would not fire either. That half was already handled by an explicit `gh workflow run release.yml --ref v$V`; the half one step earlier was not.

## The fix: remove the event chain, don't patch it

`release-fast.yml` gains a `tag` job **in the same run**. It waits for the PR it just opened to merge (polling `gh pr view`, ~170 min inside a 180-min timeout), then tags the merge commit and dispatches `release.yml`. The release no longer depends on an event firing, and — just as important — **a release PR that never merges now ends in a red run** instead of evaporating silently. That visibility is the actual bug #3358 reports.

`tag-release.yml` survives, reduced to what it is genuinely good for: the **human-merge path** (a human merge *is* a real push event, and may land after the waiting job timed out) and a manual `workflow_dispatch` **recovery handle** for a release that landed untagged for any other reason.

Both callers now share `.claude/scripts/tag-release.sh` — one copy of the three decisions (is this a release commit? does it agree with `gradle.properties`? is it already tagged?), because two YAML `run:` blocks holding the same logic is how they drift. The script is idempotent and race-safe: it checks the tag locally *and* on the remote, treats a concurrent tagger's push as success rather than conflict, and never moves an existing tag. Whoever tags first wins; the other exits 0 without a second `release.yml` dispatch.

## Why not the other options

| Option | Verdict |
|---|---|
| **PAT / App token for the merge** (`PERSONAL_TOKEN` already exists in the repo) | Rejected. It makes every release depend on a credential that expires **silently**, failing back into the exact same invisible half-release this issue is about — and it widens the blast radius of the one job allowed to write to `main`. Owning the tag in-run needs no secret at all. |
| **`workflow_run`** | Does not apply. `workflow_run` chains off a workflow *that ran*; here the problem is that **nothing ran** on the merge push. |
| **Scheduled watchdog** (option 3 in the issue) | Alerting after the fact, not a fix — and a cron job whose only job is to notice a rare failure is itself unverifiable between releases. Superseded by the run turning red at the moment of failure. |

## Verification

No release workflow was run — this PR touches workflow files only, and a real dispatch would deploy.

- `actionlint` clean on both modified workflows.
- `bash -n` clean on the new script; the release-commit subject regex is byte-identical to the one it replaces and was re-tested against the merged/unmerged/decoy subject shapes.
- Permissions: the new `tag` job declares its own block (job-level `permissions` *replace* the workflow-level one) with `contents: write` to push the tag and `actions: write` to dispatch `release.yml`.
- Shell-injection hardening kept: the merge commit id reaches the shell through an env var, never `${{ }}` inside a `run:` body.
- Concurrency checked: `release-fast.yml` uses group `release-pipeline`, `release.yml` uses group `release` — the dispatched release cannot queue behind the run that dispatched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
