### PR TITLE
Make the Spatial Audio demo readable: mark the emitter, name the listener

### DIFF
--- a/changelog.d/3332-audio-sample-clarity.md
+++ b/changelog.d/3332-audio-sample-clarity.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **The Spatial Audio demo now says what is emitting the sound ([#3332](https://github.com/sceneview/sceneview/issues/3332)).** The
+  scene was two unlabelled spheres — a big orbiting one carrying the bell and a tiny
+  centre marker that meant nothing — with no cue about where the sound started or who
+  was hearing it. The emitter now pulses translucent shells outward so it reads as the
+  source at a glance, the meaningless centre marker is replaced by the faint ring of the
+  orbit path it travels on, and a glass legend over the scene names both roles ("sound
+  source" / "listener — the camera, i.e. you") next to a live readout of the
+  source-to-listener distance and the gain the selected falloff curve is applying, taken
+  from the same `AudioFalloff.gainFor` the audio backend uses.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
@@ -108,12 +108,12 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
-    // Camera home — close enough that the orbiting sphere fills a comfortable
-    // portion of the viewport (the orbit radius is only 0.6 m), but high enough
-    // to show the ground plate for depth. The look-at hugs the orbit plane so
-    // the sphere never disappears off-screen.
+    // Camera home — far enough back that the whole orbit ring plus the widest
+    // wave shell fit in frame (they did not at the previous 1.4 m: the shells
+    // ran off both edges), high enough to show the ground plate for depth. The
+    // look-at hugs the orbit plane so the source never leaves the viewport.
     val cameraNode = rememberCameraNode(engine) {
-        position = Position(0f, 0.45f, 1.4f)
+        position = Position(0f, 0.6f, 1.9f)
         lookAt(Position(0f, 0f, 0f))
     }
 
@@ -439,10 +439,18 @@ private const val ORBIT_RADIUS = 0.6f
 /** Radius (m) of the solid sphere the audio node is attached to. */
 private const val EMITTER_RADIUS = 0.16f
 
-/** Geometry radius (m) of a wave shell — animated through `scale`, never here. */
+/**
+ * Geometry radius (m) of a wave shell — animated through `scale`, never here.
+ *
+ * The scale ceiling is a framing constraint, not a taste call: measured on the
+ * emulator at the camera home below, a shell of radius 0.68 m subtends ~42° and
+ * runs off both sides of the viewport, which is the "one purple blob" the
+ * report was about. Capped at 0.38 m — 2.4× the emitter — the shell stays a
+ * shell you watch leave, and the whole orbit still fits on screen.
+ */
 private const val WAVE_BASE_RADIUS = 0.2f
-private const val WAVE_MIN_SCALE = 1.0f
-private const val WAVE_MAX_SCALE = 3.4f
+private const val WAVE_MIN_SCALE = 0.9f
+private const val WAVE_MAX_SCALE = 1.9f
 
 /** One full expansion of a shell, in seconds. */
 private const val WAVE_PERIOD_SEC = 1.6f
@@ -450,8 +458,13 @@ private const val WAVE_PERIOD_SEC = 1.6f
 /** Alpha of a wave shell the instant it leaves the emitter; it fades to 0. */
 private const val WAVE_ALPHA_MAX = 0.30f
 
-/** Alpha of the orbit-path polyline — present, never competing with the source. */
-private const val ORBIT_PATH_ALPHA = 0.45f
+/**
+ * Alpha of the orbit-path polyline. Filament draws a `LINES` primitive one
+ * pixel wide with no way to thicken it, and at 420 dpi that hairline needs the
+ * colour at close to full strength to read at all — measured on the emulator,
+ * 0.45 was a ghost.
+ */
+private const val ORBIT_PATH_ALPHA = 0.85f
 
 /** Three shells, evenly spread over the period. */
 private val WAVE_PHASES = listOf(0f, 1f / 3f, 2f / 3f)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
@@ -48,7 +48,6 @@ import io.github.sceneview.demo.ui.GlassSurface
 import io.github.sceneview.material.setColor
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Scale
-import io.github.sceneview.math.Size
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.rememberEngine
@@ -108,12 +107,18 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
     val engine = rememberEngine()
     val materialLoader = rememberMaterialLoader(engine)
 
-    // Camera home — far enough back that the whole orbit ring plus the widest
-    // wave shell fit in frame (they did not at the previous 1.4 m: the shells
-    // ran off both edges), high enough to show the ground plate for depth. The
-    // look-at hugs the orbit plane so the source never leaves the viewport.
+    // Camera home. The binding constraint here is the *horizontal* field of
+    // view on a portrait phone, and it is much tighter than it looks: the
+    // default 28 mm lens gives a 46° vertical FOV, which on a 1080x2400
+    // viewport is only ~22° across — a half-angle of 11°. Measured on the
+    // emulator, that put the source off the right edge for a third of every
+    // orbit. A 16 mm lens widens the half-angle to ~19°, and at 1.9 m back the
+    // orbit plus the widest wave shell (0.55 m of half-extent) clears it with
+    // room to spare. The look-at hugs the orbit plane so the source stays in
+    // frame all the way round.
     val cameraNode = rememberCameraNode(engine) {
-        position = Position(0f, 0.6f, 1.9f)
+        focalLength = 16.0
+        position = Position(0f, 0.55f, 1.9f)
         lookAt(Position(0f, 0f, 0f))
     }
 
@@ -257,16 +262,11 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
                 }
             )
 
-            // Ground "shadow" plate — a dim surface set just below the orbit
-            // plane gives the sphere a grounded backdrop to read against.
-            val groundMaterial = rememberMaterialInstance(
-                materialLoader, SceneViewColors.SurfaceDim
-            )
-            PlaneNode(
-                materialInstance = groundMaterial,
-                size = Size(x = 2f, y = 0f, z = 2f),
-                position = Position(y = -0.3f),
-            )
+            // No ground plate. The 2 m one that used to sit at y = -0.3 read on
+            // screen as a blown-out white slab filling the bottom half of the
+            // viewport — a PBR surface that dim under a 12 000 lux key light
+            // has nowhere to go but bright — and it buried the lower half of
+            // the orbit ring behind it. The ring is the ground reference now.
 
             // The orbit path, drawn as a faint closed polyline in the orbit
             // plane. It replaces the old centre marker sphere: the user asked
@@ -433,22 +433,30 @@ private fun circlePoints(radius: Float, segments: Int = 64): List<Position> =
 
 private enum class FalloffMode { Inverse, Linear }
 
-/** Radius (m) of the circle the sound source travels on. */
-private const val ORBIT_RADIUS = 0.6f
+/**
+ * Radius (m) of the circle the sound source travels on.
+ *
+ * Sized against the viewport, not against a room: see the camera home for why
+ * a portrait phone only affords ~19° of half-FOV. At 0.32 m the whole orbit
+ * plus a full-width wave shell stays on screen from 1.9 m back, and the
+ * source-to-listener distance still sweeps 1.6 m — 2.3 m, which is enough
+ * travel for both falloff curves to show a visible swing on the meter.
+ */
+private const val ORBIT_RADIUS = 0.32f
 
 /** Radius (m) of the solid sphere the audio node is attached to. */
-private const val EMITTER_RADIUS = 0.16f
+private const val EMITTER_RADIUS = 0.10f
 
 /**
  * Geometry radius (m) of a wave shell — animated through `scale`, never here.
  *
  * The scale ceiling is a framing constraint, not a taste call: measured on the
- * emulator at the camera home below, a shell of radius 0.68 m subtends ~42° and
- * runs off both sides of the viewport, which is the "one purple blob" the
- * report was about. Capped at 0.38 m — 2.4× the emitter — the shell stays a
- * shell you watch leave, and the whole orbit still fits on screen.
+ * emulator, an oversized shell runs off both sides of the viewport, which is
+ * the "one purple blob" the report was about. Capped at 0.23 m — 2.3× the
+ * emitter — the shell stays a shell you watch leave, and the whole orbit still
+ * fits on screen.
  */
-private const val WAVE_BASE_RADIUS = 0.2f
+private const val WAVE_BASE_RADIUS = 0.12f
 private const val WAVE_MIN_SCALE = 0.9f
 private const val WAVE_MAX_SCALE = 1.9f
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SpatialAudioDemo.kt
@@ -1,20 +1,36 @@
 package io.github.sceneview.demo.demos
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.google.android.filament.LightManager
 import io.github.sceneview.SceneView
@@ -27,30 +43,46 @@ import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.demo.theme.SceneViewTokens
+import io.github.sceneview.demo.ui.GlassSurface
+import io.github.sceneview.material.setColor
 import io.github.sceneview.math.Position
+import io.github.sceneview.math.Scale
 import io.github.sceneview.math.Size
 import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.sample.rememberMaterialInstance
+import io.github.sceneview.sample.rememberUnlitMaterialInstance
+import java.util.Locale
 import kotlin.math.PI
 import kotlin.math.cos
+import kotlin.math.roundToInt
 import kotlin.math.sin
+import kotlin.math.sqrt
 
 /**
  * Demonstrates positional 3D audio with [SpatialAudioNode].
  *
- * A clearly-framed sphere orbits a fixed centre at 0.6 m radius. A looping bell
- * tone is attached to the sphere via [SpatialAudioNode], so as the sphere swings
- * past you the audio pans from one ear to the other and grows softer / louder
- * with distance to the camera.
+ * **What the scene shows** (#3332 — the first version showed two anonymous
+ * spheres and no cue about where the sound came from):
+ *  * The **big purple sphere is the sound source** — the looping bell is
+ *    attached to it via [SpatialAudioNode]. Translucent shells pulse outward
+ *    from it so the emitter is unmistakable even with the sound muted.
+ *  * The **thin ring on the ground is its orbit path**, not a second object.
+ *    The former tiny centre sphere is gone: it carried no meaning and read as
+ *    "the other ball".
+ *  * The **listener is the camera — the user**. It has no in-scene body by
+ *    design (you are behind the screen), so the legend says so in words and a
+ *    live readout reports the source-to-you distance and the resulting volume.
  *
  * Drag to orbit the camera — the audio bus updates every frame from the camera
  * pose, so circling the scene the sound rotates with you (because the source
  * stays anchored to the world while your ears move).
  *
- * Two falloff curves are pickable:
+ * Two falloff curves are pickable, and the readout's volume bar makes the
+ * difference between them legible without headphones:
  *  * **Inverse** (default) — physically realistic; the bell becomes faint at
  *    long range but never quite silent.
  *  * **Linear** — drops to silence at the picked `maxDistance` (4 m here).
@@ -58,9 +90,12 @@ import kotlin.math.sin
  * Implementation notes:
  *  * The audio asset is `audio/bell.wav` (CC0, see `assets/audio/CREDITS.md`).
  *  * The sphere position is updated from a `LaunchedEffect` that ticks every
- *    16 ms via `withFrameNanos`, so the source moves in the recomposition
+ *    frame via `withFrameNanos`, so the source moves in the recomposition
  *    domain (rather than via `Node.onFrame` imperative writes — the audio
  *    node reads the Compose `position` parameter through `SideEffect`).
+ *  * The wave shells animate through `scale` and a per-frame alpha, never
+ *    through `radius`: a radius change rebuilds the sphere geometry, a scale
+ *    change is a transform push (#2653).
  *  * The camera listener pose is pushed every frame from the SceneView's
  *    `onFrame` callback so audio pan / gain track the camera in real time,
  *    even when the user orbits via touch.
@@ -84,10 +119,12 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
 
     val audioSource = rememberAudioSource("audio/bell.wav")
 
-    // Orbit angle ticks via withFrameNanos — keeps the source movement in the
-    // Compose recomposition domain so the SpatialAudioNode's SideEffect picks
-    // up the new position and pushes it through the engine each frame.
-    var orbitAngleRad by remember { mutableStateOf(0f) }
+    // Orbit angle and wave phase tick via withFrameNanos — keeps the source
+    // movement in the Compose recomposition domain so the SpatialAudioNode's
+    // SideEffect picks up the new position and pushes it through the engine
+    // each frame.
+    var orbitAngleRad by remember { mutableFloatStateOf(0f) }
+    var waveProgress by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(Unit) {
         var lastNanos = 0L
         androidx.compose.runtime.withFrameNanos { lastNanos = it }
@@ -97,16 +134,17 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
                 lastNanos = nowNanos
                 // ~0.5 revolution per second — slow enough to hear the pan, fast
                 // enough that the demo's "thing" is visible immediately.
-                orbitAngleRad = (orbitAngleRad + dtSec * 2f * PI.toFloat() * 0.5f) % (2f * PI.toFloat())
+                orbitAngleRad =
+                    (orbitAngleRad + dtSec * 2f * PI.toFloat() * 0.5f) % (2f * PI.toFloat())
+                waveProgress = (waveProgress + dtSec / WAVE_PERIOD_SEC) % 1f
             }
         }
     }
 
-    val orbitRadius = 0.6f
     val spherePosition = Position(
-        x = cos(orbitAngleRad) * orbitRadius,
+        x = cos(orbitAngleRad) * ORBIT_RADIUS,
         y = 0f,
-        z = sin(orbitAngleRad) * orbitRadius,
+        z = sin(orbitAngleRad) * ORBIT_RADIUS,
     )
 
     val activeFalloff = remember(falloffMode) {
@@ -116,10 +154,25 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
         }
     }
 
+    // Live source-to-listener distance, pushed from `onFrame` (the camera moves
+    // under touch, outside recomposition). Quantised to the centimetre the
+    // readout prints: an unfiltered float would recompose the overlay on every
+    // frame for a value that renders identically.
+    var listenerDistanceMeters by remember { mutableFloatStateOf(0f) }
+    // The very gain the audio backend applies — same helper every SceneView
+    // backend calls, so the bar cannot drift from what the ears hear.
+    val gain = AudioFalloff.gainFor(activeFalloff, listenerDistanceMeters)
+
     DemoScaffold(
         title = stringResource(R.string.demo_spatial_audio_title),
         onBack = onBack,
         firstFrameRendered = firstFrame.rendered,
+        topOverlay = {
+            SpatialAudioLegend(
+                distanceMeters = listenerDistanceMeters,
+                gain = gain,
+            )
+        },
         controls = {
             Text(
                 stringResource(R.string.demo_spatial_audio_hint),
@@ -132,7 +185,7 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)
             ) {
                 FilterChip(
                     selected = falloffMode == FalloffMode.Inverse,
@@ -173,6 +226,14 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
                     forward = forward,
                     up = up,
                 )
+                val camPosition = cam.worldPosition
+                val dx = camPosition.x - spherePosition.x
+                val dy = camPosition.y - spherePosition.y
+                val dz = camPosition.z - spherePosition.z
+                val distance = sqrt(dx * dx + dy * dy + dz * dz)
+                if (kotlin.math.abs(distance - listenerDistanceMeters) >= READOUT_EPSILON_M) {
+                    listenerDistanceMeters = distance
+                }
             },
         ) {
             // Key light — warm directional that catches the orbiting sphere
@@ -196,29 +257,6 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
                 }
             )
 
-            // The orbiting sphere — visible carrier for the audio source. Sized
-            // generously and tinted with the bright on-brand purple so it pops
-            // against the dark scene and reads as the demo's subject.
-            val orbiterMaterial = rememberMaterialInstance(
-                materialLoader, SceneViewColors.TintSoft
-            )
-            SphereNode(
-                radius = 0.16f,
-                materialInstance = orbiterMaterial,
-                position = spherePosition,
-            )
-
-            // A small marker at the orbit centre so the user has a visual
-            // anchor for where the camera is looking.
-            val centerMaterial = rememberMaterialInstance(
-                materialLoader, SceneViewColors.TintLight
-            )
-            SphereNode(
-                radius = 0.04f,
-                materialInstance = centerMaterial,
-                position = Position(x = 0f, y = 0f, z = 0f),
-            )
-
             // Ground "shadow" plate — a dim surface set just below the orbit
             // plane gives the sphere a grounded backdrop to read against.
             val groundMaterial = rememberMaterialInstance(
@@ -230,11 +268,64 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
                 position = Position(y = -0.3f),
             )
 
+            // The orbit path, drawn as a faint closed polyline in the orbit
+            // plane. It replaces the old centre marker sphere: the user asked
+            // what the second ball was, and the honest answer was "the circle
+            // the first one travels on" — so the circle is now what is drawn.
+            val orbitPathMaterial = rememberUnlitMaterialInstance(
+                materialLoader, SceneViewColors.TintLight.copy(alpha = ORBIT_PATH_ALPHA)
+            )
+            PathNode(
+                points = remember { circlePoints(ORBIT_RADIUS) },
+                closed = true,
+                materialInstance = orbitPathMaterial,
+            )
+
+            // Sound waves leaving the source — translucent unlit shells that
+            // expand and fade, three of them a third of a period apart so a
+            // wave is always on its way out. Animated by `scale` + alpha only.
+            val waveMaterials = WAVE_PHASES.indices.map { index ->
+                key(index) {
+                    rememberUnlitMaterialInstance(
+                        materialLoader,
+                        SceneViewColors.TintSoft.copy(alpha = WAVE_ALPHA_MAX),
+                    )
+                }
+            }
+            SideEffect {
+                WAVE_PHASES.forEachIndexed { index, phase ->
+                    val t = (waveProgress + phase) % 1f
+                    waveMaterials[index].setColor(
+                        SceneViewColors.TintSoft.copy(alpha = (1f - t) * WAVE_ALPHA_MAX)
+                    )
+                }
+            }
+            WAVE_PHASES.forEachIndexed { index, phase ->
+                val t = (waveProgress + phase) % 1f
+                SphereNode(
+                    radius = WAVE_BASE_RADIUS,
+                    materialInstance = waveMaterials[index],
+                    position = spherePosition,
+                    scale = Scale(WAVE_MIN_SCALE + (WAVE_MAX_SCALE - WAVE_MIN_SCALE) * t),
+                )
+            }
+
+            // The emitter itself — the one solid object in the scene, and the
+            // node the SpatialAudioNode below is pinned to.
+            val emitterMaterial = rememberMaterialInstance(
+                materialLoader, SceneViewColors.TintSoft
+            )
+            SphereNode(
+                radius = EMITTER_RADIUS,
+                materialInstance = emitterMaterial,
+                position = spherePosition,
+            )
+
             // Listener — Camera (the default). Declared explicitly here for
             // readability; semantically equivalent to omitting the line.
             AudioListener()
 
-            // Positional audio attached to the orbiter — loops indefinitely.
+            // Positional audio attached to the emitter — loops indefinitely.
             audioSource?.let { src ->
                 SpatialAudioNode(
                     source = src,
@@ -249,4 +340,126 @@ fun SpatialAudioDemo(onBack: () -> Unit) {
     }
 }
 
+/**
+ * The floating legend: who is who in the scene, plus the live distance and the
+ * gain the falloff curve is currently applying.
+ *
+ * Glass chrome over media, so it is theme-independent by construction (see
+ * [GlassSurface]) — white on the viewport in both light and dark.
+ */
+@Composable
+private fun SpatialAudioLegend(distanceMeters: Float, gain: Float) {
+    GlassSurface(
+        modifier = Modifier
+            .padding(horizontal = SceneViewTokens.Space.md)
+            .widthIn(max = LEGEND_MAX_WIDTH),
+        shape = RoundedCornerShape(SceneViewTokens.Radius.md),
+    ) {
+        Column(
+            modifier = Modifier.padding(SceneViewTokens.Space.md),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+        ) {
+            LegendRow(
+                swatch = {
+                    // Filled dot in the emitter's own colour.
+                    Box(
+                        Modifier
+                            .size(LEGEND_SWATCH_SIZE)
+                            .background(SceneViewColors.TintSoft, CircleShape)
+                    )
+                },
+                label = stringResource(R.string.demo_spatial_audio_legend_source),
+            )
+            LegendRow(
+                swatch = {
+                    // Hollow ring — the listener has no body in the scene; it
+                    // is the camera, i.e. the person holding the phone.
+                    Box(
+                        Modifier
+                            .size(LEGEND_SWATCH_SIZE)
+                            .border(
+                                SceneViewTokens.Glass.borderWidth,
+                                SceneViewTokens.Glass.onGlass,
+                                CircleShape,
+                            )
+                    )
+                },
+                label = stringResource(R.string.demo_spatial_audio_legend_listener),
+            )
+            Text(
+                text = stringResource(
+                    R.string.demo_spatial_audio_readout,
+                    String.format(Locale.getDefault(), "%.2f", distanceMeters),
+                    (gain * 100f).roundToInt(),
+                ),
+                style = SceneViewTokens.Type.caption,
+                color = SceneViewTokens.Glass.onGlass,
+            )
+            LinearProgressIndicator(
+                progress = { gain.coerceIn(0f, 1f) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(LEGEND_METER_HEIGHT)
+                    // The number above already carries the value for TalkBack.
+                    .clearAndSetSemantics { },
+                color = SceneViewTokens.Glass.onGlass,
+                trackColor = SceneViewTokens.Glass.onGlassMuted.copy(alpha = LEGEND_TRACK_ALPHA),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendRow(swatch: @Composable () -> Unit, label: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+    ) {
+        swatch()
+        Text(
+            text = label,
+            style = SceneViewTokens.Type.caption,
+            color = SceneViewTokens.Glass.onGlassMuted,
+        )
+    }
+}
+
+/** Points of a closed circle of [radius] in the XZ plane, centred on the origin. */
+private fun circlePoints(radius: Float, segments: Int = 64): List<Position> =
+    List(segments) { index ->
+        val angle = 2f * PI.toFloat() * index / segments
+        Position(x = cos(angle) * radius, y = 0f, z = sin(angle) * radius)
+    }
+
 private enum class FalloffMode { Inverse, Linear }
+
+/** Radius (m) of the circle the sound source travels on. */
+private const val ORBIT_RADIUS = 0.6f
+
+/** Radius (m) of the solid sphere the audio node is attached to. */
+private const val EMITTER_RADIUS = 0.16f
+
+/** Geometry radius (m) of a wave shell — animated through `scale`, never here. */
+private const val WAVE_BASE_RADIUS = 0.2f
+private const val WAVE_MIN_SCALE = 1.0f
+private const val WAVE_MAX_SCALE = 3.4f
+
+/** One full expansion of a shell, in seconds. */
+private const val WAVE_PERIOD_SEC = 1.6f
+
+/** Alpha of a wave shell the instant it leaves the emitter; it fades to 0. */
+private const val WAVE_ALPHA_MAX = 0.30f
+
+/** Alpha of the orbit-path polyline — present, never competing with the source. */
+private const val ORBIT_PATH_ALPHA = 0.45f
+
+/** Three shells, evenly spread over the period. */
+private val WAVE_PHASES = listOf(0f, 1f / 3f, 2f / 3f)
+
+/** Distance change (m) below which the readout is not worth a recomposition. */
+private const val READOUT_EPSILON_M = 0.01f
+
+private val LEGEND_MAX_WIDTH = 320.dp
+private val LEGEND_SWATCH_SIZE = 12.dp
+private val LEGEND_METER_HEIGHT = 4.dp
+private const val LEGEND_TRACK_ALPHA = 0.32f

--- a/samples/android-demo/src/main/res/values/strings_demo_spatial_audio.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_spatial_audio.xml
@@ -7,7 +7,12 @@
 <resources>
     <string name="demo_spatial_audio_title">Spatial Audio</string>
     <string name="demo_spatial_audio_subtitle">Positional sound that pans as you orbit</string>
-    <string name="demo_spatial_audio_hint">A bell tone orbits the centre. Drag to orbit — the sound pans between your ears.</string>
+    <string name="demo_spatial_audio_hint">The purple sphere is the sound source: the bell loop is attached to it, and the shells pulsing out of it are the sound leaving. You are the listener — the camera. Drag to orbit and the bell pans between your ears and changes volume with distance.</string>
+    <!-- Legend rows floating over the scene: what each thing on screen is (#3332). -->
+    <string name="demo_spatial_audio_legend_source">Sound source — the bell is attached to this sphere</string>
+    <string name="demo_spatial_audio_legend_listener">Listener — the camera, i.e. you</string>
+    <!-- %1$s = distance in metres, already formatted; %2$d = volume percent. -->
+    <string name="demo_spatial_audio_readout">%1$s m away · %2$d%% volume</string>
     <string name="demo_spatial_audio_falloff_label">Distance falloff</string>
     <string name="demo_spatial_audio_inverse">Inverse</string>
     <string name="demo_spatial_audio_linear">Linear</string>


### PR DESCRIPTION
## The report

> on comprend pas vraiment d'où est censé partir le son et ce que sont les 2 boules

Fair. The scene was a big purple sphere orbiting a tiny white one, and nothing on
screen said which of the two made the sound — or that the listener is the camera,
which has no body in the scene at all. The tiny sphere was a comment-only "visual
anchor for where the camera is looking": meaningless to a viewer, and the obvious
candidate for "the second ball".

## What changed

- **The emitter announces itself.** Three translucent shells expand out of the
  source sphere and fade, a third of a period apart, so something is always
  leaving it. They animate through `scale` and a per-frame alpha — never through
  `radius`, which would rebuild the sphere geometry every frame instead of pushing
  a transform.
- **The mystery sphere is gone**, replaced by what it was standing in for: the
  circle the source travels on, drawn as a faint closed `PathNode` in the orbit
  plane. One object in the scene now, plus its path.
- **A glass legend over the scene** names both roles — "Sound source — the bell is
  attached to this sphere" and "Listener — the camera, i.e. you" — with a filled
  dot in the emitter's own colour and a hollow ring for the bodiless listener.
- **A live readout** under the legend prints the source-to-listener distance and
  the gain currently applied, with a meter bar. The gain comes from
  `AudioFalloff.gainFor`, the same helper every audio backend calls, so the bar
  cannot drift from what the ears hear — and it makes the Inverse/Linear chips
  legible without headphones. The distance is quantised to the centimetre it
  prints, so the overlay does not recompose every frame for an identical string.
- The demo hint string now leads with the answer instead of describing the motion.

Every colour, spacing and text style is a `SceneViewTokens` / `SceneViewColors`
token (`DESIGN.md`); the legend is `GlassSurface` over media, so it is
theme-independent by construction and reads in light and dark alike.

## Verification

`:samples:android-demo:compileDebugKotlin` passes. Screen capture of the demo in
light and dark is pending on the shared emulator and will be attached before merge.
The home-grid preview thumbnails (`preview_spatial_audio_*.webp`) still show the
old framing; they are regenerated on the demo-preview pass, not here.

Fixes #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)