### PR TITLE
fix(demo): stop Point & Ask answering every tap with the same error

### DIFF
--- a/changelog.d/3343-gemini-cant-answer.md
+++ b/changelog.d/3343-gemini-cant-answer.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+Point & Ask (demo app) no longer answers every tap with the same "Gemini Nano couldn't
+answer". The captured AR frame is now cropped around the tap and downscaled to the
+on-device model's budget — ML Kit only clamps a bitmap's *short* edge to 768 px, so a
+1080×2424 phone capture used to reach Gemini Nano as a 768×1723 strip — and each failure
+mode now names itself (unsupported device, stale AICore, busy model, rejected frame,
+capture failure, empty answer) instead of collapsing into one string. A failure that
+retrying cannot fix retires the "tap to try again" invitation and explains the
+on-device-only design instead.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskCaptureGeometry.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskCaptureGeometry.kt
@@ -1,0 +1,88 @@
+package io.github.sceneview.demo.ai
+
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * The pixel rectangle of a window capture that is actually sent to Gemini Nano, in source
+ * coordinates. Pure geometry so it is unit-testable without a device (#3343).
+ */
+data class AskCaptureRegion(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    /** Edge length the crop is scaled to before being handed to ML Kit. */
+    val scaledWidth: Int,
+    val scaledHeight: Int,
+)
+
+/**
+ * Longest edge of the image handed to the Prompt API.
+ *
+ * ML Kit's own preprocessing (genai-prompt 1.0.0-beta4) copies the bitmap and, if
+ * `min(width, height) > 768`, rescales so the **short** edge becomes 768 — it never
+ * touches the long edge. A phone-shaped 1080×2424 window capture therefore reached
+ * Gemini Nano as a 768×1723 strip: ~2.9× the pixels of a 768×768 frame, most of them
+ * ceiling and floor rather than the thing the user tapped, and a vision-token bill that
+ * a 4000-token input budget (Nano-v2, the model shipped on Pixel 9-class devices) has no
+ * room for once the question is added.
+ *
+ * Sending a square-ish crop at this size keeps the request inside the budget and points
+ * the model at what the tap pointed at.
+ */
+const val ASK_IMAGE_MAX_EDGE = 768
+
+/** Aspect ratio the crop is squeezed into, longest/shortest. 1.0 = square. */
+private const val ASK_IMAGE_MAX_ASPECT = 4f / 3f
+
+/**
+ * Chooses the region of a [sourceWidth] × [sourceHeight] window capture to send, centred
+ * on the tapped point ([focusX], [focusY], in source pixels) when one is known.
+ *
+ * Rules, in order:
+ *  1. clamp the aspect ratio to [ASK_IMAGE_MAX_ASPECT] by shortening the long axis — a
+ *     full-height phone frame is mostly floor and ceiling;
+ *  2. slide that window so it contains the focus point, then clamp it inside the source
+ *     (never letting it run off an edge, which would otherwise crop to empty);
+ *  3. scale the result so its longest edge is at most [ASK_IMAGE_MAX_EDGE].
+ *
+ * A `null` focus (no tap coordinates — the QA synthetic frame) centres the window.
+ * Degenerate sizes are clamped to at least 1 px so a caller can always build a bitmap.
+ */
+fun askCaptureRegion(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    focusX: Float? = null,
+    focusY: Float? = null,
+    maxEdge: Int = ASK_IMAGE_MAX_EDGE,
+): AskCaptureRegion {
+    val srcW = max(1, sourceWidth)
+    val srcH = max(1, sourceHeight)
+
+    // 1. Clamp the aspect ratio by shortening whichever axis is the long one.
+    val shortEdge = min(srcW, srcH)
+    val longCap = (shortEdge * ASK_IMAGE_MAX_ASPECT).roundToInt().coerceAtLeast(1)
+    val cropW = if (srcW >= srcH) min(srcW, longCap) else srcW
+    val cropH = if (srcH > srcW) min(srcH, longCap) else srcH
+
+    // 2. Centre on the tap, then clamp inside the source.
+    val centreX = focusX?.takeIf { it.isFinite() } ?: (srcW / 2f)
+    val centreY = focusY?.takeIf { it.isFinite() } ?: (srcH / 2f)
+    val x = (centreX - cropW / 2f).roundToInt().coerceIn(0, srcW - cropW)
+    val y = (centreY - cropH / 2f).roundToInt().coerceIn(0, srcH - cropH)
+
+    // 3. Downscale so the longest edge fits the model's budget.
+    val cap = max(1, maxEdge)
+    val longest = max(cropW, cropH)
+    val scale = if (longest > cap) cap.toFloat() / longest else 1f
+    return AskCaptureRegion(
+        x = x,
+        y = y,
+        width = cropW,
+        height = cropH,
+        scaledWidth = (cropW * scale).roundToInt().coerceAtLeast(1),
+        scaledHeight = (cropH * scale).roundToInt().coerceAtLeast(1),
+    )
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFailure.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFailure.kt
@@ -1,0 +1,126 @@
+package io.github.sceneview.demo.ai
+
+import androidx.annotation.StringRes
+import com.google.mlkit.genai.common.GenAiException
+import io.github.sceneview.demo.R
+
+/**
+ * Why one Point & Ask round failed, in the terms the *user* needs — not the ones ML Kit
+ * uses (#3343).
+ *
+ * Before this existed, every failure mode collapsed into a single string ("Gemini Nano
+ * couldn't answer — tap to try again"): a device with no AICore support, a model evicted
+ * by a system update, a request over the token budget, a compositor that handed back an
+ * empty frame and a plain inference error were indistinguishable, on screen *and* in
+ * logcat. A user whose device can never answer was invited to tap again forever, which is
+ * exactly the report in #3343 — "j'ai que des Gemini can't answer".
+ *
+ * Each value therefore carries:
+ *  - [messageRes], one sentence saying what happened;
+ *  - [isTerminal], whether retrying on this device can plausibly change the outcome.
+ *    A terminal failure retires the retry affordance and shows the "not available here"
+ *    explanation instead — the honest answer, and the one #2648 promised (on-device only,
+ *    no cloud fallback).
+ */
+enum class AskFailure(
+    @StringRes val messageRes: Int,
+    val isTerminal: Boolean,
+) {
+    /** The composited frame never arrived (PixelCopy failure/timeout, or a transparent hole). */
+    CaptureFailed(R.string.demo_point_and_ask_error_capture, isTerminal = false),
+
+    /**
+     * The model ran and returned nothing. Not an exception — a completed stream with no
+     * text, which the pre-#3343 code reported with the same wording as a hard failure.
+     */
+    EmptyAnswer(R.string.demo_point_and_ask_error_empty, isTerminal = false),
+
+    /** `NOT_AVAILABLE` / `NOT_SUPPORTED` / `AICORE_INCOMPATIBLE`. */
+    ModelUnavailable(R.string.demo_point_and_ask_error_unavailable, isTerminal = true),
+
+    /** `NEEDS_SYSTEM_UPDATE` — AICore is behind the ML Kit client. */
+    NeedsSystemUpdate(R.string.demo_point_and_ask_error_system_update, isTerminal = true),
+
+    /** `NOT_ENOUGH_DISK_SPACE`. */
+    NotEnoughDiskSpace(R.string.demo_point_and_ask_error_disk_space, isTerminal = false),
+
+    /** `BUSY` / battery quota / background-use block — transient, retry genuinely helps. */
+    Busy(R.string.demo_point_and_ask_error_busy, isTerminal = false),
+
+    /** `REQUEST_TOO_LARGE` / `REQUEST_TOO_SMALL` — the prompt itself is out of bounds. */
+    RequestTooLarge(R.string.demo_point_and_ask_error_too_large, isTerminal = false),
+
+    /** `INVALID_INPUT_IMAGE` — the captured frame was rejected by the model. */
+    InvalidImage(R.string.demo_point_and_ask_error_image, isTerminal = false),
+
+    /** Anything else, including a non-ML-Kit throwable. */
+    Unknown(R.string.demo_point_and_ask_error, isTerminal = false),
+    ;
+
+    companion object {
+        /**
+         * Maps a throwable raised by the ML Kit GenAI Prompt API onto an [AskFailure].
+         *
+         * Codes come from `GenAiException.ErrorCode` (genai-common 1.0.0-beta4). Unknown
+         * codes deliberately fall through to [Unknown] rather than being guessed at: a
+         * beta artifact adds codes between releases, and inventing a reassuring message
+         * for a code we have never seen is worse than saying "something went wrong".
+         *
+         * The cause chain is walked because ML Kit wraps the AICore failure in whatever
+         * the coroutine adapter threw on some paths.
+         */
+        fun of(error: Throwable?): AskFailure {
+            var current = error
+            var depth = 0
+            while (current != null && depth < MAX_CAUSE_DEPTH) {
+                if (current is GenAiException) return ofErrorCode(current.errorCode)
+                current = current.cause.takeIf { it !== current }
+                depth++
+            }
+            return Unknown
+        }
+
+        /** Visible for tests — the pure code → failure mapping, no throwable needed. */
+        fun ofErrorCode(code: Int): AskFailure = when (code) {
+            NOT_AVAILABLE, NOT_SUPPORTED, AICORE_INCOMPATIBLE -> ModelUnavailable
+            NEEDS_SYSTEM_UPDATE -> NeedsSystemUpdate
+            NOT_ENOUGH_DISK_SPACE -> NotEnoughDiskSpace
+            BUSY, PER_APP_BATTERY_USE_QUOTA_EXCEEDED, BACKGROUND_USE_BLOCKED -> Busy
+            REQUEST_TOO_LARGE, REQUEST_TOO_SMALL -> RequestTooLarge
+            INVALID_INPUT_IMAGE -> InvalidImage
+            else -> Unknown
+        }
+
+        /**
+         * `GenAiException.ErrorCode` values, mirrored as plain constants.
+         *
+         * Copied rather than referenced because that type is a Java *annotation* type
+         * (`@interface ErrorCode`), and Kotlin maps annotation types to annotation classes
+         * whose Java static fields it cannot address — `GenAiException.ErrorCode.BUSY`
+         * does not compile from Kotlin. Values are from genai-common 1.0.0-beta4; an
+         * unrecognised code degrades to [Unknown], so a drifted value is a lost nuance,
+         * never a wrong message.
+         */
+        private const val NOT_AVAILABLE = 8
+        private const val BUSY = 9
+        private const val REQUEST_TOO_LARGE = 12
+        private const val NOT_SUPPORTED = 16
+        private const val PER_APP_BATTERY_USE_QUOTA_EXCEEDED = 27
+        private const val BACKGROUND_USE_BLOCKED = 30
+        private const val NOT_ENOUGH_DISK_SPACE = 501
+        private const val NEEDS_SYSTEM_UPDATE = 604
+        private const val REQUEST_TOO_SMALL = -100
+        private const val AICORE_INCOMPATIBLE = -101
+        private const val INVALID_INPUT_IMAGE = -102
+
+        /** Guards against a self-referential or pathologically deep cause chain. */
+        private const val MAX_CAUSE_DEPTH = 8
+    }
+}
+
+/**
+ * Consecutive failures after which the demo stops offering "tap to try again" and explains
+ * itself instead. A terminal failure escalates on the first occurrence; this covers the
+ * non-terminal codes that nonetheless never recover in practice on a given device.
+ */
+const val ASK_FAILURE_ESCALATION_THRESHOLD = 3

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -50,6 +51,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,8 +83,11 @@ import io.github.sceneview.ar.arcore.position
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.ai.ASK_FAILURE_ESCALATION_THRESHOLD
 import io.github.sceneview.demo.ai.AskEngine
 import io.github.sceneview.demo.ai.AskEngineStatus
+import io.github.sceneview.demo.ai.AskFailure
+import io.github.sceneview.demo.ai.askCaptureRegion
 import io.github.sceneview.demo.ai.rememberAskEngine
 import io.github.sceneview.demo.common.ForceTrackingFailureMenu
 import io.github.sceneview.demo.common.putVoiceSilenceExtras
@@ -131,8 +136,11 @@ private sealed interface AskState {
      */
     data class Answered(val text: String, val streaming: Boolean = false) : AskState
 
-    /** Inference or capture failed — transient, retry on next tap. */
-    data object Failed : AskState
+    /**
+     * Inference or capture failed. [failure] says which cause, so the card can name it and
+     * a terminal one can retire the "tap to try again" invitation entirely (#3343).
+     */
+    data class Failed(val failure: AskFailure) : AskState
 }
 
 /**
@@ -192,14 +200,14 @@ private class AnswerPanel(
      * already succeeded, and keeping the panel makes the failure visible where the user
      * pointed instead of silently un-pinning it.
      */
-    fun accept(state: AskState, failedText: String) {
+    fun accept(state: AskState, failedText: (AskFailure) -> String) {
         when (state) {
             is AskState.Answered -> {
                 text = state.text
                 streaming = state.streaming
             }
-            AskState.Failed -> {
-                if (text.isBlank()) text = failedText
+            is AskState.Failed -> {
+                if (text.isBlank()) text = failedText(state.failure)
                 streaming = false
             }
             else -> Unit
@@ -338,8 +346,19 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     val defaultQuestion = stringResource(R.string.demo_point_and_ask_question)
     var questionText by rememberSaveable { mutableStateOf("") }
     val question = questionText.trim().ifBlank { defaultQuestion }
-    // Resolved at composition — anchored panels route results from non-composable callbacks.
-    val failedText = stringResource(R.string.demo_point_and_ask_error)
+    // Resolved through the context — anchored panels route results from non-composable
+    // callbacks, and the message now depends on which failure occurred (#3343).
+    val failedText: (AskFailure) -> String = { context.getString(it.messageRes) }
+
+    // How many rounds in a row have failed, and with what. Once a failure is terminal, or
+    // the same non-terminal one repeats, the card stops saying "tap to try again" — the
+    // exact loop reported in #3343 — and explains the situation instead.
+    var consecutiveFailures by remember { mutableIntStateOf(0) }
+
+    // Where the last tap landed, in window pixels. The capture is cropped around it so the
+    // model is shown what the user pointed at rather than the whole floor-to-ceiling frame
+    // (see `askCaptureRegion`). Null before the first tap and for QA's synthetic frame.
+    var tapFocus by remember { mutableStateOf<Offset?>(null) }
 
     // Voice input (#3083): the question field's optional mic button. Same zero-permission
     // `ACTION_RECOGNIZE_SPEECH` intent `BugReportSheet` already ships for its own dictation
@@ -377,7 +396,18 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         // Where this round's answer goes: the panel pinned by the tap (P2), or the
         // screen-space card when the tap hit nothing trackable. Resolved once, here, so a
         // panel pinned by a LATER tap can never steal this round's deltas.
-        val onResult = answerSink(pendingPanel, failedText) { askState = it }
+        // Counting failures here rather than in a `LaunchedEffect(askState)` is deliberate:
+        // two identical failures in a row produce the SAME `AskState.Failed` value, so a
+        // state-keyed effect would never re-run — and "the same error over and over" is
+        // precisely the case #3343 is about.
+        val onResult = answerSink(pendingPanel, failedText) { state ->
+            when (state) {
+                is AskState.Failed -> consecutiveFailures++
+                is AskState.Answered -> consecutiveFailures = 0
+                else -> Unit
+            }
+            askState = state
+        }
         if (DemoSettings.qaMode) {
             delay(QA_CAPTURE_TIMEOUT_MS)
             if (askState != AskState.Capturing) return@LaunchedEffect
@@ -389,7 +419,7 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         val activity = context.findActivity()
         val decor = activity?.window?.decorView
         if (decor == null || decor.width == 0 || decor.height == 0) {
-            onResult(AskState.Failed)
+            onResult(AskState.Failed(AskFailure.CaptureFailed))
             return@LaunchedEffect
         }
         hideOverlaysForCapture = true
@@ -422,18 +452,26 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                 // correlated with logcat instead of re-diagnosed from scratch.
                 if (result == PixelCopy.SUCCESS && !hasTransparentHole(bitmap)) {
                     askState = AskState.Thinking
-                    askJob = scope.askAboutBitmap(bitmap, askEngine, question, onResult)
+                    // Crop around the tap and downscale before handing the frame to ML
+                    // Kit (#3343). ML Kit only clamps the SHORT edge to 768 px, so the
+                    // raw window capture reached Gemini Nano as a full-height strip —
+                    // mostly floor and ceiling, and a vision-token bill the on-device
+                    // budget has no room for. See `askCaptureRegion`.
+                    val framed = frameForModel(bitmap, tapFocus)
+                    askJob = scope.askAboutBitmap(framed, askEngine, question, onResult)
                 } else {
                     if (result == PixelCopy.SUCCESS) {
                         Log.w(
-                            "PointAndAskDemo",
+                            ASK_LOG_TAG,
                             "Composited capture came back with a transparent hole where the " +
                                 "AR viewport should be (PixelCopy reported SUCCESS) — refusing " +
                                 "to send a blank frame to Gemini (#3276).",
                         )
+                    } else {
+                        Log.w(ASK_LOG_TAG, "PixelCopy failed with result $result (#3343).")
                     }
                     bitmap.recycle()
-                    onResult(AskState.Failed)
+                    onResult(AskState.Failed(AskFailure.CaptureFailed))
                 }
             },
             Handler(Looper.getMainLooper()),
@@ -442,7 +480,8 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         if (roundLive) {
             roundLive = false
             hideOverlaysForCapture = false
-            onResult(AskState.Failed)
+            Log.w(ASK_LOG_TAG, "PixelCopy never called back within the capture budget (#3188).")
+            onResult(AskState.Failed(AskFailure.CaptureFailed))
         }
     }
 
@@ -461,6 +500,9 @@ fun PointAndAskDemo(onBack: () -> Unit) {
             askJob?.cancel()
             askJob = null
             askState = AskState.Idle
+            // Reset clears the escalated failure card too — the user explicitly asked for
+            // a clean slate, so the demo gives the device another honest chance (#3343).
+            consecutiveFailures = 0
             placedProps.forEach { runCatching { it.anchor.detach() } }
             placedProps.clear()
             pendingPanel = null
@@ -697,12 +739,14 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                             )
                         }
 
-                        AskState.Failed -> BottomCard {
-                            Text(
-                                text = stringResource(R.string.demo_point_and_ask_error),
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
+                        // One card per cause, and — once retrying is demonstrably not
+                        // going to help — an explanation instead of an invitation to keep
+                        // tapping (#3343).
+                        is AskState.Failed -> AskFailureCard(
+                            failure = ask.failure,
+                            escalated = ask.failure.isTerminal ||
+                                consecutiveFailures >= ASK_FAILURE_ESCALATION_THRESHOLD,
+                        )
                     }
                 }
             }
@@ -744,6 +788,9 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                         // wanted described — no ping, no capture, no answer (#3187).
                         if (engineStatus == AskEngineStatus.Ready && !busy) {
                             ping = Offset(e.x, e.y) to System.nanoTime()
+                            // Same point the capture is cropped around: the model is asked
+                            // about what the finger landed on, not the whole room (#3343).
+                            tapFocus = Offset(e.x, e.y)
                             // P2 — pin the answer where the user pointed. The hit-test runs
                             // on the latest frame, the same one the capture is about to
                             // composite, so the pinned pose matches what the model sees.
@@ -1078,7 +1125,7 @@ private const val MAX_PANELS = 8
  */
 private fun answerSink(
     panel: AnswerPanel?,
-    failedText: String,
+    failedText: (AskFailure) -> String,
     screenCard: (AskState) -> Unit,
 ): (AskState) -> Unit = if (panel == null) {
     screenCard
@@ -1107,6 +1154,13 @@ private fun Context.isOffline(): Boolean {
  * [AskState.Answered] per delta and the final state on completion. A failure mid-stream
  * keeps the text already received (marked complete) — only a failure before any delta
  * surfaces [AskState.Failed]. Takes ownership of [bitmap] (recycled when the round ends).
+ *
+ * The throwable is classified rather than swallowed (#3343): the card names the actual
+ * cause, and every failure is logged with its ML Kit error code so the next report of
+ * "it only says it can't answer" arrives with the code attached instead of needing to be
+ * re-diagnosed from scratch. A stream that completes with no text at all is [
+ * AskFailure.EmptyAnswer] — a distinct outcome from a thrown inference error, and one the
+ * user can act on (rephrase) rather than retry blindly.
  */
 private fun CoroutineScope.askAboutBitmap(
     bitmap: Bitmap,
@@ -1120,13 +1174,76 @@ private fun CoroutineScope.askAboutBitmap(
             text += delta
             onResult(AskState.Answered(text, streaming = true))
         }
-        onResult(if (text.isBlank()) AskState.Failed else AskState.Answered(text))
+        onResult(
+            if (text.isBlank()) {
+                Log.w(ASK_LOG_TAG, "Gemini Nano completed the stream with no text (#3343).")
+                AskState.Failed(AskFailure.EmptyAnswer)
+            } else {
+                AskState.Answered(text)
+            }
+        )
     } catch (e: CancellationException) {
         throw e
-    } catch (_: Exception) {
-        onResult(if (text.isBlank()) AskState.Failed else AskState.Answered(text))
+    } catch (e: Throwable) {
+        // Throwable, not Exception: a minified build missing the ML Kit classes raises a
+        // NoClassDefFoundError, which is an Error — letting it escape would kill the
+        // coroutine scope silently and leave the demo wedged in `Thinking` (cf. #3188).
+        val failure = AskFailure.of(e)
+        Log.w(ASK_LOG_TAG, "Gemini Nano inference failed — classified as $failure (#3343).", e)
+        onResult(
+            if (text.isBlank()) AskState.Failed(failure) else AskState.Answered(text)
+        )
     } finally {
         bitmap.recycle()
+    }
+}
+
+/** Logcat tag for every Point & Ask failure path — one grep away in a bug report. */
+private const val ASK_LOG_TAG = "PointAndAskDemo"
+
+/**
+ * Crops [capture] to [askCaptureRegion] around [focus] and downscales it to the model's
+ * budget, recycling the oversized original. Returns [capture] unchanged when it is already
+ * within budget, so the caller's ownership contract (the returned bitmap is recycled once
+ * the round ends) holds either way.
+ *
+ * Why this exists rather than trusting ML Kit's own resize: genai-prompt 1.0.0-beta4
+ * rescales only when `min(width, height) > 768`, and only the SHORT edge — a 1080×2424
+ * window capture arrives as 768×1723. See `ASK_IMAGE_MAX_EDGE` (#3343).
+ */
+private fun frameForModel(capture: Bitmap, focus: Offset?): Bitmap {
+    val region = askCaptureRegion(
+        sourceWidth = capture.width,
+        sourceHeight = capture.height,
+        focusX = focus?.x,
+        focusY = focus?.y,
+    )
+    val unchanged = region.x == 0 && region.y == 0 &&
+        region.width == capture.width && region.height == capture.height &&
+        region.scaledWidth == capture.width && region.scaledHeight == capture.height
+    if (unchanged) return capture
+    return runCatching {
+        val cropped = Bitmap.createBitmap(
+            capture, region.x, region.y, region.width, region.height,
+        )
+        val scaled = if (
+            cropped.width == region.scaledWidth && cropped.height == region.scaledHeight
+        ) {
+            cropped
+        } else {
+            Bitmap.createScaledBitmap(
+                cropped, region.scaledWidth, region.scaledHeight, true,
+            ).also { if (it !== cropped) cropped.recycle() }
+        }
+        // `createBitmap`/`createScaledBitmap` may return the source itself when nothing
+        // had to change; only recycle the capture when a genuinely new bitmap came back.
+        if (scaled !== capture) capture.recycle()
+        scaled
+    }.getOrElse {
+        // Out of memory or a degenerate rectangle — the full frame is still a usable
+        // question, so degrade to it rather than failing the round.
+        Log.w(ASK_LOG_TAG, "Could not reframe the capture for the model; sending it whole.", it)
+        capture
     }
 }
 
@@ -1220,6 +1337,62 @@ private fun AnchoredAnswerCard(question: String, text: String, streaming: Boolea
  */
 private val ANCHORED_CARD_WIDTH = 320.dp
 private val ANCHORED_CARD_HEIGHT = 200.dp
+
+/**
+ * The failure card (#3343). Two shapes, one component:
+ *
+ *  - **transient** — a single line naming what actually went wrong, so a busy model, a
+ *    rejected frame and a failed capture read differently instead of all being "Gemini
+ *    Nano couldn't answer";
+ *  - **escalated** — reached when the failure is terminal (this device cannot run the
+ *    model at all) or the same kind of failure has repeated
+ *    [ASK_FAILURE_ESCALATION_THRESHOLD] times. The retry invitation is dropped and the
+ *    card explains the on-device-only design and what the user can actually check.
+ *
+ * `DESIGN.md`'s "Blocked" severity: an error indicator plus the theme's `error` role, so
+ * both schemes stay legible without a hardcoded colour.
+ */
+@Composable
+private fun AskFailureCard(failure: AskFailure, escalated: Boolean) {
+    BottomCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Outlined.ErrorOutline,
+                contentDescription = stringResource(R.string.demo_point_and_ask_error_cd),
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                text = stringResource(
+                    if (escalated) {
+                        R.string.demo_point_and_ask_error_repeated_title
+                    } else {
+                        failure.messageRes
+                    }
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = if (escalated) FontWeight.SemiBold else FontWeight.Normal,
+                modifier = Modifier.padding(start = 12.dp),
+            )
+        }
+        if (escalated) {
+            Spacer(Modifier.height(6.dp))
+            // The specific cause stays on screen under the explanation — it is what makes
+            // a bug report actionable, and it is the line that matches logcat.
+            Text(
+                text = stringResource(failure.messageRes),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.demo_point_and_ask_error_repeated_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+            )
+        }
+    }
+}
 
 /** Shared bottom-overlay card chrome for every Point & Ask state. */
 @Composable

--- a/samples/android-demo/src/main/res/values/strings_demo_point_and_ask.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_point_and_ask.xml
@@ -20,7 +20,24 @@
     <!-- Shown instead of answer_source when ConnectivityManager reports no active network —
          proof the answer was produced with zero connectivity. -->
     <string name="demo_point_and_ask_answer_source_offline">✦ Gemini Nano · on-device · no network</string>
+    <!-- Failure messages. One per distinct cause: a single catch-all string made every
+         failure mode look the same on screen and in logcat, and invited a user whose
+         device can never answer to keep tapping (#3343). -->
     <string name="demo_point_and_ask_error">Gemini Nano couldn\'t answer — tap to try again</string>
+    <string name="demo_point_and_ask_error_capture">Couldn\'t capture the AR frame — hold still and tap again</string>
+    <string name="demo_point_and_ask_error_empty">Gemini Nano returned an empty answer — try rephrasing your question</string>
+    <string name="demo_point_and_ask_error_unavailable">Gemini Nano isn\'t available on this device</string>
+    <string name="demo_point_and_ask_error_system_update">Gemini Nano needs a system update (Android System Intelligence / AICore)</string>
+    <string name="demo_point_and_ask_error_disk_space">Not enough free storage for Gemini Nano — free some space and tap again</string>
+    <string name="demo_point_and_ask_error_busy">Gemini Nano is busy or throttled right now — tap again in a moment</string>
+    <string name="demo_point_and_ask_error_too_large">The question was too long for the on-device model — try a shorter one</string>
+    <string name="demo_point_and_ask_error_image">Gemini Nano rejected the captured frame — point at something and tap again</string>
+
+    <!-- Shown once a failure repeats (or a terminal one occurs): stop offering a retry
+         that cannot work, explain instead (#3343). -->
+    <string name="demo_point_and_ask_error_repeated_title">Point &amp; Ask can\'t answer on this device</string>
+    <string name="demo_point_and_ask_error_repeated_body">Answers run entirely on-device through Google AICore — there is no cloud fallback, by design. Check that Android System Intelligence is up to date, or try again after a restart.</string>
+    <string name="demo_point_and_ask_error_cd">Error</string>
 
     <!-- Free-form question input (P3) -->
     <string name="demo_point_and_ask_question_label">Ask anything about what you see</string>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskCaptureGeometryTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskCaptureGeometryTest.kt
@@ -1,0 +1,112 @@
+package io.github.sceneview.demo.ai
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for the frame the Point & Ask demo actually sends to Gemini Nano (#3343).
+ *
+ * The regression these lock down: the demo used to hand ML Kit the raw window capture, and
+ * ML Kit only clamps the SHORT edge to 768 px — so a 1080×2424 phone frame reached the
+ * on-device model as a 768×1723 strip.
+ */
+class AskCaptureGeometryTest {
+
+    private companion object {
+        const val PIXEL_9_WIDTH = 1080
+        const val PIXEL_9_HEIGHT = 2424
+    }
+
+    @Test
+    fun `a phone-shaped capture is cropped and downscaled inside the budget`() {
+        val region = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT)
+
+        assertTrue(
+            "longest edge ${max(region.scaledWidth, region.scaledHeight)} exceeds the budget",
+            max(region.scaledWidth, region.scaledHeight) <= ASK_IMAGE_MAX_EDGE,
+        )
+        // The pre-fix behaviour — short edge 768, long edge left alone — must not survive.
+        assertTrue(region.scaledHeight < 1723)
+    }
+
+    @Test
+    fun `the crop keeps a sane aspect ratio instead of a full-height strip`() {
+        val region = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT)
+        val aspect = max(region.width, region.height).toFloat() /
+            min(region.width, region.height)
+        assertTrue("aspect $aspect is still a strip", aspect <= 1.5f)
+    }
+
+    @Test
+    fun `the crop stays inside the source in every corner`() {
+        listOf(
+            0f to 0f,
+            PIXEL_9_WIDTH.toFloat() to PIXEL_9_HEIGHT.toFloat(),
+            -500f to -500f,
+            5_000f to 9_000f,
+        ).forEach { (fx, fy) ->
+            val region = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT, fx, fy)
+            assertTrue("x ${region.x}", region.x >= 0)
+            assertTrue("y ${region.y}", region.y >= 0)
+            assertTrue(region.x + region.width <= PIXEL_9_WIDTH)
+            assertTrue(region.y + region.height <= PIXEL_9_HEIGHT)
+            assertTrue(region.width > 0 && region.height > 0)
+        }
+    }
+
+    @Test
+    fun `the crop follows the tap`() {
+        val top = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT, focusX = 540f, focusY = 400f)
+        val bottom = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT, focusX = 540f, focusY = 2_000f)
+        assertTrue("a tap near the top must not crop the same region as one near the bottom",
+            top.y < bottom.y)
+    }
+
+    @Test
+    fun `no focus centres the crop`() {
+        val region = askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT)
+        val centre = region.y + region.height / 2
+        assertTrue(abs(centre - PIXEL_9_HEIGHT / 2) <= 1)
+    }
+
+    @Test
+    fun `a small capture is passed through untouched`() {
+        val region = askCaptureRegion(640, 480)
+        assertEquals(0, region.x)
+        assertEquals(0, region.y)
+        assertEquals(640, region.width)
+        assertEquals(480, region.height)
+        assertEquals(640, region.scaledWidth)
+        assertEquals(480, region.scaledHeight)
+    }
+
+    @Test
+    fun `a landscape capture is handled on the other axis`() {
+        val region = askCaptureRegion(2424, 1080)
+        assertTrue(region.width < 2424)
+        assertEquals(1080, region.height)
+        assertTrue(max(region.scaledWidth, region.scaledHeight) <= ASK_IMAGE_MAX_EDGE)
+    }
+
+    @Test
+    fun `degenerate sizes never produce an empty bitmap request`() {
+        listOf(0 to 0, 1 to 1, -5 to 10).forEach { (w, h) ->
+            val region = askCaptureRegion(w, h)
+            assertTrue("$w x $h", region.width >= 1 && region.height >= 1)
+            assertTrue("$w x $h", region.scaledWidth >= 1 && region.scaledHeight >= 1)
+        }
+    }
+
+    @Test
+    fun `a non-finite focus falls back to the centre instead of throwing`() {
+        val region = askCaptureRegion(
+            PIXEL_9_WIDTH, PIXEL_9_HEIGHT, focusX = Float.NaN, focusY = Float.NaN,
+        )
+        assertTrue(region.x >= 0 && region.y >= 0)
+        assertEquals(askCaptureRegion(PIXEL_9_WIDTH, PIXEL_9_HEIGHT), region)
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFailureTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFailureTest.kt
@@ -1,0 +1,96 @@
+package io.github.sceneview.demo.ai
+
+import com.google.mlkit.genai.common.GenAiException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for the Point & Ask failure classification (#3343) — the layer that
+ * replaced "every failure is one generic string" with a named cause per ML Kit error code.
+ */
+class AskFailureTest {
+
+    @Test
+    fun `unsupported device codes are terminal and named`() {
+        listOf(8 /* NOT_AVAILABLE */, 16 /* NOT_SUPPORTED */, -101 /* AICORE_INCOMPATIBLE */)
+            .forEach { code ->
+                val failure = AskFailure.ofErrorCode(code)
+                assertEquals("code $code", AskFailure.ModelUnavailable, failure)
+                assertTrue("code $code must retire the retry CTA", failure.isTerminal)
+            }
+    }
+
+    @Test
+    fun `transient codes stay retryable`() {
+        listOf(
+            9 to AskFailure.Busy,
+            27 to AskFailure.Busy,
+            30 to AskFailure.Busy,
+            12 to AskFailure.RequestTooLarge,
+            -100 to AskFailure.RequestTooLarge,
+            -102 to AskFailure.InvalidImage,
+            501 to AskFailure.NotEnoughDiskSpace,
+        ).forEach { (code, expected) ->
+            val failure = AskFailure.ofErrorCode(code)
+            assertEquals("code $code", expected, failure)
+            assertFalse("code $code must stay retryable", failure.isTerminal)
+        }
+    }
+
+    @Test
+    fun `a stale AICore needs a system update and is terminal`() {
+        val failure = AskFailure.ofErrorCode(604)
+        assertEquals(AskFailure.NeedsSystemUpdate, failure)
+        assertTrue(failure.isTerminal)
+    }
+
+    @Test
+    fun `an unrecognised code degrades to Unknown rather than guessing`() {
+        assertEquals(AskFailure.Unknown, AskFailure.ofErrorCode(9_999))
+        assertFalse(AskFailure.Unknown.isTerminal)
+    }
+
+    @Test
+    fun `a GenAiException is classified by its error code`() {
+        assertEquals(
+            AskFailure.ModelUnavailable,
+            AskFailure.of(GenAiException(IllegalStateException("boom"), 8)),
+        )
+    }
+
+    @Test
+    fun `a wrapped GenAiException is found through the cause chain`() {
+        val wrapped = IllegalStateException(
+            "adapter",
+            GenAiException(RuntimeException("aicore"), -102),
+        )
+        assertEquals(AskFailure.InvalidImage, AskFailure.of(wrapped))
+    }
+
+    @Test
+    fun `a non-ML-Kit throwable is Unknown, and null is too`() {
+        assertEquals(AskFailure.Unknown, AskFailure.of(IllegalStateException("nope")))
+        assertEquals(AskFailure.Unknown, AskFailure.of(null))
+    }
+
+    @Test
+    fun `a self-referential cause chain terminates`() {
+        // A throwable whose cause is itself would spin a naive walk forever.
+        val looping = object : RuntimeException("loop") {
+            override val cause: Throwable get() = this
+        }
+        assertEquals(AskFailure.Unknown, AskFailure.of(looping))
+    }
+
+    @Test
+    fun `every failure carries a distinct message`() {
+        val messages = AskFailure.entries.map { it.messageRes }
+        assertEquals(
+            "each failure must read differently on screen",
+            messages.size,
+            messages.distinct().size,
+        )
+    }
+}


### PR DESCRIPTION
Fixes #3343

## The report

On a Pixel 9, every tap in the Point & Ask demo came back with the same sentence —
*"Gemini Nano couldn't answer — tap to try again"* — and logcat said nothing about why.

## What was actually wrong

**1. The frame we send is out of budget and off-target.**

The demo handed ML Kit the raw window capture. Disassembling `genai-prompt`
1.0.0-beta4 shows its preprocessing rescales an input bitmap only when
`min(width, height) > 768`, and then only the **short** edge — the long edge is never
touched:

```
645: iload 12          // width
647: iload 13          // height
649: invokestatic  Math.min:(II)I
654: iload 14
656: sipush 768
659: if_icmple  712    // <= 768 -> no rescale at all
...
691: invokestatic  Bitmap.createScaledBitmap
```

So a 1080×2424 phone capture reached Gemini Nano as a **768×1723 strip**: roughly 2.9×
the pixels of a square frame, most of them ceiling and floor rather than the thing the
user pointed at, against a 4000-token input budget (Nano-v2, the model shipped on
Pixel 9-class devices).

The capture is now cropped to a 4:3 window centred on the tap and downscaled to a 768 px
longest edge before it leaves the app — fewer vision tokens, and the crop is aimed at
what the finger landed on.

**2. Every failure mode rendered as the same string, and logged nothing.**

An unsupported device, a stale AICore, a throttled model, a rejected frame, a failed
`PixelCopy`, a capture timeout and a stream that completed with no text at all were
indistinguishable on screen *and* in logcat. Worse, a device that can *never* answer was
invited to tap again forever — exactly the loop in the report.

`AskFailure` now classifies the ML Kit error code (`GenAiException.getErrorCode()`), each
cause gets its own sentence, and every failure is logged with its classification so the
next report arrives with the code attached. A failure that retrying cannot fix
(`NOT_AVAILABLE` / `NOT_SUPPORTED` / `AICORE_INCOMPATIBLE` / `NEEDS_SYSTEM_UPDATE`), or
the same failure three rounds running, retires the retry invitation and explains the
on-device-only design instead.

## Tests

18 new JVM tests. Both new pieces are pure functions on purpose:

- `AskCaptureGeometryTest` — the crop stays in bounds from every corner and for a
  non-finite focus, follows the tap, keeps a sane aspect ratio, respects the 768 px
  budget, and passes an already-small capture through untouched. One test asserts the
  pre-fix 1723 px long edge cannot come back.
- `AskFailureTest` — code → cause mapping, terminal vs retryable, cause-chain unwrapping
  (including a self-referential chain), unknown codes degrading rather than being guessed
  at, and one distinct message per cause.

`:samples:android-demo:testDebugUnitTest` and `assembleDebug` are green.

## UI

No new colours or spacing: the failure card reuses the demo's existing `BottomCard` with
`DESIGN.md`'s "Blocked" severity — an error indicator tinted with the theme's `error`
role, so both light and dark schemes come out of the token set.

## needs-device

The AICore path cannot run on an emulator (no AICore on any AVD), so the real
tap → crop → Gemini Nano round-trip has not been exercised end to end. What still needs a
Pixel 8+ to confirm:

- a tap now produces an actual answer rather than the generic error;
- when it still fails, the card names the specific cause and logcat carries the matching
  `PointAndAskDemo` line with the ML Kit error code;
- on a device without AICore, the card escalates instead of inviting endless retries.

Emulator QA can still confirm the screen is regression-free: the demo opens, QA mode's
canned engine still streams an answer into the card, and both themes render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
