### PR TITLE
fix(mcp): answer server/discover instead of -32601 (#3349)

### DIFF
--- a/changelog.d/3349-mcp-server-discover.md
+++ b/changelog.d/3349-mcp-server-discover.md
@@ -1,0 +1,15 @@
+<!-- category: Fixed -->
+<!-- RELEASE NOTE (maintainer-only):
+     `@hasmcp/mcp-spec-test` 0.1.1 reported `sceneview-mcp` as "not conformant —
+     6 requirements violated" against MCP 2026-07-28, with 22 further cases
+     unverified, because `server/discover` answered `-32601 Method not found`.
+     The issue's premise that the server *advertises* 2026-07-28 turned out to
+     be wrong — nothing in `mcp/` ever named that revision; the report's
+     "supported 2026-07-28, 2025-11-25" header is the suite's own vendored
+     schema window. Bumping the SDK was not an option either:
+     `@modelcontextprotocol/sdk` 1.30.0, the newest release, tops out at
+     2025-11-25 and ships no `server/discover` at all. So the handler is
+     hand-rolled and advertises exactly what the SDK can serve, read from
+     `SUPPORTED_PROTOCOL_VERSIONS` rather than hardcoded. `mcp/` stays on its
+     own version track (4.0.16 -> 4.1.0); publishing to npm remains manual. -->
+- **`sceneview-mcp` answers `server/discover` (MCP 2026-07-28) instead of `-32601 Method not found`.** A 2026-07-28-aware client now learns in one handshake-free round trip which revisions the server actually serves, plus its identity, capabilities and cache hints (`ttlMs`, `cacheScope`), rather than being left to guess after a "method not found". Against `@hasmcp/mcp-spec-test` 0.1.1 the 2026-07-28 run goes from 8 passed / 6 failed / 22 not verified to 14 passed / 0 failed, and 2025-11-25 stays at 0 failures.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sceneview-mcp",
-  "version": "4.0.16",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sceneview-mcp",
-      "version": "4.0.16",
+      "version": "4.1.0",
       "funding": [
         {
           "type": "github",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sceneview-mcp",
-  "version": "4.0.16",
+  "version": "4.1.0",
   "mcpName": "io.github.sceneview/mcp",
   "description": "MCP server for SceneView — cross-platform 3D & AR SDK for Android and iOS. Give Claude the full SceneView SDK so it writes correct, compilable code.",
   "keywords": [

--- a/mcp/src/discover.test.ts
+++ b/mcp/src/discover.test.ts
@@ -1,0 +1,83 @@
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import {
+  buildDiscoverResult,
+  DISCOVER_METHOD,
+  DISCOVER_TTL_MS,
+  DiscoverRequestSchema,
+  SERVER_CAPABILITIES,
+  SERVER_INFO,
+} from "./discover.js";
+import { PACKAGE_VERSION } from "./generated/version.js";
+
+// The conformance suite (@hasmcp/mcp-spec-test) checks these five fields on the
+// `server/discover` result; `serverInfo` is expected on top of them. Keep this
+// list in sync with `spec/2026-07-28/schema.json` → `DiscoverResult.required`.
+const REQUIRED_FIELDS = ["cacheScope", "capabilities", "resultType", "supportedVersions", "ttlMs"];
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("server/discover request schema", () => {
+  it("accepts a version-less, session-less request", () => {
+    const parsed = DiscoverRequestSchema.parse({
+      method: DISCOVER_METHOD,
+      params: {},
+    });
+    expect(parsed.method).toBe("server/discover");
+  });
+
+  it("rejects any other method (so the SDK routes on the literal)", () => {
+    expect(() => DiscoverRequestSchema.parse({ method: "server/discovery", params: {} })).toThrow();
+  });
+});
+
+describe("buildDiscoverResult", () => {
+  it("carries every field the 2026-07-28 schema requires", () => {
+    const result = buildDiscoverResult();
+    for (const field of REQUIRED_FIELDS) {
+      expect(result, `missing required field: ${field}`).toHaveProperty(field);
+    }
+    expect(result.resultType).toBe("complete");
+  });
+
+  it("advertises only revisions the SDK can actually serve", () => {
+    const result = buildDiscoverResult();
+    expect(result.supportedVersions.length).toBeGreaterThan(0);
+    expect(result.supportedVersions).toEqual([...SUPPORTED_PROTOCOL_VERSIONS]);
+    for (const version of result.supportedVersions) {
+      expect(version).toMatch(ISO_DATE);
+    }
+  });
+
+  it("returns a copy, so a caller cannot mutate the SDK constant", () => {
+    const result = buildDiscoverResult();
+    result.supportedVersions.push("1999-01-01");
+    expect(buildDiscoverResult().supportedVersions).toEqual([...SUPPORTED_PROTOCOL_VERSIONS]);
+  });
+
+  it("gives usable cache hints", () => {
+    const result = buildDiscoverResult();
+    expect(result.cacheScope).toBe("public");
+    expect(result.ttlMs).toBe(DISCOVER_TTL_MS);
+    expect(result.ttlMs).toBeGreaterThan(0);
+  });
+
+  it("stays stable across calls, as anything cacheable must", () => {
+    expect(buildDiscoverResult()).toEqual(buildDiscoverResult());
+  });
+
+  it("reports the same identity and capabilities as the handshake", () => {
+    const result = buildDiscoverResult();
+    // `index.ts` builds the `Server` from these very constants, so equality
+    // here is what proves discover and `initialize` cannot drift apart.
+    expect(result.serverInfo).toEqual({ ...SERVER_INFO });
+    expect(result.serverInfo).toEqual({ name: "sceneview-mcp", version: PACKAGE_VERSION });
+    expect(result.capabilities).toEqual({ ...SERVER_CAPABILITIES });
+    expect(result.capabilities).toHaveProperty("tools");
+    expect(result.capabilities).toHaveProperty("resources");
+  });
+
+  it("includes instructions that point at the API resource", () => {
+    expect(buildDiscoverResult().instructions).toContain("sceneview://api");
+  });
+});

--- a/mcp/src/discover.ts
+++ b/mcp/src/discover.ts
@@ -1,0 +1,113 @@
+/**
+ * `server/discover` — handshake-free discovery (MCP 2026-07-28).
+ *
+ * The 2026-07-28 revision introduced `server/discover`: one request a client
+ * MAY send **before** `initialize`, with no session and no negotiated version,
+ * which answers "who are you, what can you do, and which protocol revisions
+ * can you actually serve?". It is a `CacheableResult`, so the answer carries
+ * its own cache hints (`ttlMs`, `cacheScope`) and must stay stable inside that
+ * TTL.
+ *
+ * Two things are worth stating plainly, because they drove the design here
+ * (see issue #3349):
+ *
+ *  1. **We do not serve 2026-07-28.** `@modelcontextprotocol/sdk` 1.30.0 — the
+ *     newest published release — tops out at `2025-11-25`
+ *     (`SUPPORTED_PROTOCOL_VERSIONS`) and ships no `server/discover` at all.
+ *     So `supportedVersions` below is read straight from the SDK rather than
+ *     hardcoded: it advertises exactly what the handshake will really settle
+ *     on, never a revision we cannot honour. Announcing a revision we don't
+ *     serve would be the actual bug.
+ *
+ *  2. **Answering it anyway is still correct and useful.** `server/discover`
+ *     is how a 2026-07-28-aware client learns, in one round trip, that this
+ *     server speaks `2025-11-25` — the alternative is a `-32601 Method not
+ *     found` that tells the client nothing and leaves it guessing. The method
+ *     is cheap, purely informational, and requires no SDK upgrade.
+ *
+ * TODO(#3349): when `@modelcontextprotocol/sdk` ships 2026-07-28 support
+ * (result envelope with `resultType`, per-request `_meta` version negotiation,
+ * `subscriptions/listen`), bump the SDK and drop `SUPPORTED_PROTOCOL_VERSIONS`
+ * here for whatever the new release exposes. This file needs no other change:
+ * the advertised list is derived, not written down.
+ */
+
+import { RequestSchema, SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { PACKAGE_VERSION } from "./generated/version.js";
+
+/** JSON-RPC method name defined by MCP 2026-07-28. */
+export const DISCOVER_METHOD = "server/discover";
+
+/**
+ * Zod schema for the incoming request, in the shape the SDK's
+ * `setRequestHandler` expects (a `method` literal it can route on).
+ */
+export const DiscoverRequestSchema = RequestSchema.extend({
+  method: z.literal(DISCOVER_METHOD),
+});
+
+/**
+ * Server capabilities, declared once and shared between the `Server`
+ * constructor and `server/discover` so the two can never drift apart.
+ */
+export const SERVER_CAPABILITIES = { resources: {}, tools: {} } as const;
+
+/** Server identity, likewise shared with the `Server` constructor. */
+export const SERVER_INFO = { name: "sceneview-mcp", version: PACKAGE_VERSION } as const;
+
+/**
+ * How long a client may cache the discover answer. Everything in it —
+ * identity, capabilities, the SDK's revision list — is fixed at build time and
+ * cannot change while the process lives, so an hour is conservative rather
+ * than optimistic.
+ */
+export const DISCOVER_TTL_MS = 3_600_000;
+
+/**
+ * Natural-language guidance, mirrored from the package description. Kept short
+ * on purpose: per the spec it should not duplicate tool descriptions.
+ */
+const DISCOVER_INSTRUCTIONS =
+  "SceneView MCP — the full SceneView SDK (Android/Compose + Filament, iOS/SwiftUI + RealityKit, AR via ARCore/ARKit) " +
+  "as tools and resources, so an AI writes correct, compilable SceneView code. Read the `sceneview://api` resource " +
+  "before writing any SceneView code.";
+
+export interface DiscoverResult {
+  // The SDK types a request handler's return as an open JSON-RPC result, so the
+  // index signature is what lets this shape be returned from one directly.
+  [key: string]: unknown;
+  resultType: "complete";
+  ttlMs: number;
+  cacheScope: "public" | "private";
+  supportedVersions: string[];
+  capabilities: Record<string, unknown>;
+  serverInfo: { name: string; version: string };
+  instructions: string;
+}
+
+/**
+ * Builds the `DiscoverResult`.
+ *
+ * Every field is derived from a build-time constant, which is what makes the
+ * result stable across calls inside its TTL — a requirement, since a client
+ * that caches for `ttlMs` would otherwise be handed a moving target.
+ *
+ * `cacheScope` is `"public"`: nothing here is user-specific. The payload is
+ * identical whether or not a Pro API key is configured (the key only affects
+ * how individual tool *calls* are routed, never identity or capabilities), so
+ * a shared proxy may serve one cached copy to everyone.
+ */
+export function buildDiscoverResult(): DiscoverResult {
+  return {
+    resultType: "complete",
+    ttlMs: DISCOVER_TTL_MS,
+    cacheScope: "public",
+    // Copied so a caller mutating the array cannot corrupt the SDK's constant
+    // — and so two successive calls stay `deepEqual` rather than aliased.
+    supportedVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+    capabilities: { ...SERVER_CAPABILITIES },
+    serverInfo: { ...SERVER_INFO },
+    instructions: DISCOVER_INSTRUCTIONS,
+  };
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -23,6 +23,12 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import {
+  buildDiscoverResult,
+  DiscoverRequestSchema,
+  SERVER_CAPABILITIES,
+  SERVER_INFO,
+} from "./discover.js";
 import { DEMO_WITH_SETTINGS_EXAMPLE, SKETCHFAB_STREAMING_EXAMPLE } from "./examples.js";
 import { LATEST_SCENEVIEW_RELEASE, PACKAGE_VERSION } from "./generated/version.js";
 import { fetchKnownIssues } from "./issues.js";
@@ -53,10 +59,19 @@ function logStartupBanner(): void {
 
 logStartupBanner();
 
-const server = new Server(
-  { name: "sceneview-mcp", version: PACKAGE_VERSION },
-  { capabilities: { resources: {}, tools: {} } }
-);
+// `SERVER_INFO` / `SERVER_CAPABILITIES` live in `./discover.ts` so the
+// handshake and `server/discover` answer the identity/capability question the
+// same way, from one source.
+const server = new Server({ ...SERVER_INFO }, { capabilities: { ...SERVER_CAPABILITIES } });
+
+// ─── server/discover (MCP 2026-07-28) ────────────────────────────────────────
+//
+// Handshake-free discovery: answered before `initialize`, with no session and
+// no negotiated version. The SDK routes on the method literal and imposes no
+// pre-initialization gate, so registering the handler is enough. See
+// `./discover.ts` for why we answer a 2026-07-28 method while serving
+// 2025-11-25 (issue #3349).
+server.setRequestHandler(DiscoverRequestSchema, async () => buildDiscoverResult());
 
 // ─── Telemetry (anonymous, opt-out via SCENEVIEW_TELEMETRY=0) ────────────────
 //


### PR DESCRIPTION
Fixes #3349

## What the investigation found

Two premises in the issue did not survive contact with the code, and both changed the fix:

1. **The server never advertised `2026-07-28`.** Grepping `mcp/` (`src/`, `scripts/`, `server.json`, `mcpize.yaml`, `package.json`, `packages/`) finds neither revision date anywhere. The report's `supported 2026-07-28, 2025-11-25` header comes from the suite's *own* vendored schema window (`lib/env.mjs` derives it from the `spec/<date>/` directories it ships, window of 2) — it is not the target's advertisement. So option (b) of the brief, "cleanly remove 2026-07-28 from the advertised revisions", had nothing to remove.
2. **An SDK bump does not deliver `server/discover`.** `@modelcontextprotocol/sdk` 1.30.0 is the newest published release; it already is what the lockfile resolves. Its `LATEST_PROTOCOL_VERSION` is `2025-11-25`, and `server/discover` appears nowhere in its `dist`. The preferred "clean SDK bump" path is simply not available yet.

## Chosen option: (a), honestly scoped

`server/discover` is implemented by hand in `mcp/src/discover.ts` on the existing SDK. It is answered **before `initialize`**, with no session and no negotiated version — the SDK routes on the method literal and imposes no pre-initialization gate, so registering the handler is enough.

The result is a `CacheableResult` carrying `resultType`, `ttlMs`, `cacheScope`, `capabilities`, `serverInfo` and `instructions`, and it is stable inside its TTL (every field is a build-time constant, copied on the way out).

The part that mattered most: **`supportedVersions` is read from the SDK's `SUPPORTED_PROTOCOL_VERSIONS`, never hardcoded.** This server does not serve `2026-07-28` and says so plainly — it advertises exactly the revisions the handshake will really settle on. Announcing a revision we cannot honour would be the actual bug. Answering the method anyway is still correct and useful: it is how a 2026-07-28-aware client learns in one round trip that we speak `2025-11-25`, where a `-32601` tells it nothing.

`SERVER_INFO` / `SERVER_CAPABILITIES` moved next to the handler and now feed the `Server` constructor too, so `initialize` and `server/discover` answer the identity/capability question from one source and cannot drift.

A `TODO(#3349)` documents the path to full 2026-07-28 support (result envelope with `resultType`, per-request `_meta` version negotiation, `subscriptions/listen`) once the SDK ships it. Because the advertised list is derived, that upgrade needs no edit in this file.

## Verdicts — `@hasmcp/mcp-spec-test` 0.1.1 against the locally built server

Run as `npx -y @hasmcp/mcp-spec-test@0.1.1 -c "node mcp/dist/index.js" --spec-version <rev>`, against `mcp/dist` built from this branch — not the published npm package.

| Revision | Before | After |
|---|---|---|
| `2026-07-28` | 8 passed, **6 failed**, 22 not verified (36 cases) — *"not conformant — 6 requirements violated"* | **14 passed, 0 failed**, 22 not verified (36 cases) — *"conformant on what could be checked"* |
| `2025-11-25` | 17 passed, 0 failed, 3 not verified, 1 recommended not met (20 cases) | **17 passed, 0 failed**, 3 not verified, 1 recommended not met — unchanged, no regression |

All seven `server/discover` cases now pass, including *"is answered without a session or handshake"*, *"advertises the versions the server can serve"*, *"is a CacheableResult with usable cache hints"* and *"is stable across calls within its own TTL"*.

The 22 still-unverified cases are **explicit, informative skips** rather than collateral from a `-32601`. Each now says why:

```
target does not advertise 2026-07-28; it offers
["2025-11-25","2025-06-18","2025-03-26","2024-11-05","2024-10-07"]
```

That is the honest answer, and it is the one the suite is designed to receive: a server that cannot serve a revision should say which ones it can.

## Tests

`mcp/src/discover.test.ts` — 9 cases: schema routes only on the exact method literal; every field the 2026-07-28 schema requires is present; `supportedVersions` matches the SDK's list and is all ISO-date-shaped; the result is copied so a caller cannot mutate the SDK constant; cache hints are usable; two calls are deep-equal; identity and capabilities equal the constants the `Server` is built from.

Full suite: **1975 passed / 84 files**. `biome check` clean on the touched files.

## Versioning

`mcp/` is an independent version track — untouched by `VERSION_NAME`. Bumped `4.0.16` → `4.1.0` (minor: a new method, no behaviour change for existing clients).

**Publication to npm is deliberately not done here and remains Thomas's call.** This PR delivers code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
