### PR TITLE
fix(demo): pin the web deep link to its host, and stop claiming debug builds verify

### DIFF
--- a/changelog.d/3366-intent-filter-host.md
+++ b/changelog.d/3366-intent-filter-host.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+- **The demo app's web deep link can no longer be widened into a link hijacker
+  ([#3366](https://github.com/sceneview/sceneview/issues/3366)).** The HTTPS
+  intent-filter was already scoped to `sceneview.github.io/open`, matching
+  `DeepLinkRouter.extractCandidate`, and never shipped host-less — but nothing in
+  the build said so, so dropping `android:host` would have silently made the demo a
+  candidate for *every* https link on the device. A new pure-JVM guard
+  (`DeepLinkManifestScopeTest`) reads the scope back out of the manifest and pins it
+  to the router's own constants, so the two layers can only move together. The
+  manifest and `website-static/.well-known/README.md` also stopped claiming that
+  App-Links verify on debug builds: `assembleDebug` is signed with the default
+  `~/.android/debug.keystore`, which is not — and cannot be — listed in
+  `assetlinks.json`, so an unverified domain on a debug install is expected, and
+  `sceneview://demo/<id>` is the deep-link channel for QA.

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -129,13 +129,33 @@
 
             <!--
                 Verified App-Link over HTTPS — pairs with
-                `website-static/.well-known/assetlinks.json`, which lists
-                both the Play App Signing SHA-256 and the local upload key
-                so verification succeeds for Play Store installs AND for
-                local `adb install` / `assembleDebug` builds.
-                Verify on a phone via `adb shell pm get-app-links
-                io.github.sceneview.demo` (expected: "sceneview.github.io:
-                verified"); `pm verify-app-links` re-runs verification.
+                `website-static/.well-known/assetlinks.json`, which lists the
+                Play App Signing SHA-256 and the upload key.
+
+                Scope, deliberately narrow (#3366): host `sceneview.github.io`
+                AND path prefix `/open`. Never widen this to a bare
+                `<data android:scheme="https" />` — a host-less https filter
+                makes the demo a candidate for every https link on the device
+                and it can win the chooser, stealing links (and taps) from
+                unrelated apps. `DeepLinkRouter.extractCandidate` applies the
+                same host + path check in code, so both layers must be
+                widened together or not at all.
+
+                Verification is expected to SUCCEED only for builds signed
+                with one of the two fingerprints in assetlinks.json (Play
+                Store installs, and local installs of a release build signed
+                with the upload keystore). `assembleDebug` is signed with the
+                default `~/.android/debug.keystore`, which is NOT listed, so
+                a debug install always reports an unverified domain — that is
+                normal, not a regression. The custom `sceneview://demo/<id>`
+                scheme above is the deep-link channel for debug/QA builds.
+
+                Check the state with `adb shell pm get-app-links
+                io.github.sceneview.demo`. To exercise the https link on a
+                debug build, opt the domain in by hand with
+                `pm set-app-links-user-selection` — the exact command, and the
+                expected output per build type, are in
+                website-static/.well-known/README.md.
             -->
             <intent-filter android:label="Open in SceneView" android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/DeepLinkManifestScopeTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/DeepLinkManifestScopeTest.kt
@@ -1,0 +1,106 @@
+package io.github.sceneview.demo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pins the *scope* of the demo app's web deep-link intent-filter (#3366).
+ *
+ * A `<data android:scheme="https" />` with no `android:host` makes the app a
+ * candidate for **every** https link on the device: it joins the "Open with"
+ * chooser for unrelated sites, and can win it outright once a user has tapped
+ * "Always". On a shared QA emulator that looks exactly like the demo stealing
+ * another app's taps, and there is nothing in the build that would say so —
+ * a missing attribute is not a lint error, and no instrumentation test asserts
+ * on the resolver table.
+ *
+ * `DeepLinkRouter.extractCandidate` applies the same host + path check in
+ * code, so a widened manifest would not even reach a demo screen: it would
+ * intercept the link and drop it. The two layers must move together or not at
+ * all, which is why this test reads its expectations from the router's own
+ * constants rather than repeating the literals.
+ *
+ * Plain JUnit on purpose: the assertion is about the manifest *source*, so it
+ * needs no Android runtime, no Robolectric shadow and no device — and it fails
+ * on the widening itself, not on a resolver behaviour that only reproduces once
+ * a second app is installed.
+ */
+class DeepLinkManifestScopeTest {
+
+    private val dataElement = Regex("""<data\b[^>]*>""")
+    private val xmlComment = Regex("""<!--.*?-->""", RegexOption.DOT_MATCHES_ALL)
+
+    private fun attribute(element: String, name: String): String? =
+        Regex("""android:$name\s*=\s*"([^"]*)"""").find(element)?.groupValues?.get(1)
+
+    @Test
+    fun `every web scheme in the manifest is bound to a host and a path prefix`() {
+        val manifest = manifestSource()
+        val webData = dataElement.findAll(manifest)
+            .map { it.value }
+            .filter { attribute(it, "scheme") in setOf("http", "https") }
+            .toList()
+
+        assertTrue(
+            "The demo declares no http/https <data> element any more. If the App-Link " +
+                "was removed on purpose, delete this test; otherwise the deep link is broken.",
+            webData.isNotEmpty(),
+        )
+
+        webData.forEach { element ->
+            assertEquals(
+                "A web <data> element must be scoped to the site that hosts " +
+                    "assetlinks.json — never a bare scheme (#3366): $element",
+                DeepLinkRouter.HOST_HTTPS,
+                attribute(element, "host"),
+            )
+            assertEquals(
+                "A web <data> element must be scoped to the deep-link path, matching " +
+                    "DeepLinkRouter.PATH_HTTPS (#3366): $element",
+                DeepLinkRouter.PATH_HTTPS,
+                attribute(element, "pathPrefix"),
+            )
+        }
+    }
+
+    @Test
+    fun `the custom scheme filter stays bound to the router's scheme and host`() {
+        val manifest = manifestSource()
+        val custom = dataElement.findAll(manifest)
+            .map { it.value }
+            .filter { attribute(it, "scheme") == DeepLinkRouter.SCHEME_CUSTOM }
+            .toList()
+
+        assertEquals(
+            "Expected exactly one ${DeepLinkRouter.SCHEME_CUSTOM}:// <data> element",
+            1,
+            custom.size,
+        )
+        assertEquals(
+            "The custom-scheme filter must match DeepLinkRouter.HOST_CUSTOM",
+            DeepLinkRouter.HOST_CUSTOM,
+            attribute(custom.single(), "host"),
+        )
+    }
+
+    /**
+     * The manifest with its XML comments stripped — the comment above the filter
+     * quotes the very `<data android:scheme="https" />` shape this test forbids,
+     * and a scanner that reads comments would fail on the documentation of the rule.
+     *
+     * The Gradle test task's working directory is the module directory; the search
+     * walks up so the test also passes when a runner starts it from the repo root.
+     */
+    private fun manifestSource(): String {
+        val relative = "samples/android-demo/src/main/AndroidManifest.xml"
+        var dir: File? = File("").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, relative)
+            if (candidate.isFile) return xmlComment.replace(candidate.readText(), "")
+            dir = dir.parentFile
+        }
+        throw AssertionError("Could not locate $relative from ${File("").absolutePath}")
+    }
+}

--- a/website-static/.well-known/README.md
+++ b/website-static/.well-known/README.md
@@ -18,9 +18,18 @@ URLs. Two `sha256_cert_fingerprints` are listed:
    App signing][playconsole] under "App signing key certificate".
 2. **`5E:59:9D:AA:62:74:BC:DF:…:6D:8C`** — the **upload key** of
    `samples/android-demo` (alias `sceneview`, see
-   `project_play_store_signing.md`). Lets App-Links verify on local
-   debug builds installed via `adb install` / `assembleDebug` so
-   developers don't see different behaviour from real users.
+   `project_play_store_signing.md`). Lets App-Links verify on a
+   **release** build signed with that upload keystore and installed
+   locally via `adb install`, so the pre-upload artifact behaves like
+   the Play Store one.
+
+   It does **not** cover `assembleDebug`: `samples/android-demo/build.gradle`
+   declares no `debug` signing config, so debug builds are signed with the
+   default `~/.android/debug.keystore`
+   (`D8:C9:77:2C:F3:23:CA:49:…:B0:ED:D5` on a stock SDK install, and
+   different on every developer machine that generated its own). A debug
+   install therefore **never** verifies — see the expected-output note
+   below.
 
 Both are public artifacts of public certificates — the **private** keys
 are not in this file (they live in `~/sceneview-upload.jks` for the
@@ -30,12 +39,33 @@ upload key, and on Google's signing service for the App Signing key).
 
 The HTTPS intent-filter in `samples/android-demo/src/main/AndroidManifest.xml`
 already has `android:autoVerify="true"` so the OS fetches this file at
-install time. Verify on a phone with:
+install time. That filter is scoped to host `sceneview.github.io` **and**
+path prefix `/open` — it must never be widened to a bare
+`<data android:scheme="https" />`, which would make the demo a candidate
+for every https link on the device (#3366).
+
+Verify on a phone with:
 
 ```bash
 adb shell pm verify-app-links --re-verify io.github.sceneview.demo
 adb shell pm get-app-links io.github.sceneview.demo
-# Expected output: "sceneview.github.io: verified"
+```
+
+Expected output depends on how the APK was signed:
+
+| Build | `get-app-links` |
+|---|---|
+| Play Store install, or release APK signed with the upload keystore | `sceneview.github.io: verified` |
+| `assembleDebug` / `installDebug` (default debug keystore) | unverified — `Domain verification state: sceneview.github.io: 1024` |
+
+The debug row is **expected**, not a regression: the debug keystore is not
+listed above and cannot be, since it differs per machine. Use the custom
+`sceneview://demo/<id>` scheme for debug/QA deep links, or opt the domain
+in by hand for one device:
+
+```bash
+adb shell pm set-app-links-user-selection --user 0 \
+  --package io.github.sceneview.demo true sceneview.github.io
 ```
 
 ## `apple-app-site-association` — iOS Universal Links


### PR DESCRIPTION
## The report, and what the code says

#3366 reports that `samples/android-demo` declares a `VIEW` intent-filter on scheme
`https` **without** a host, so the demo offers itself for unrelated https links and
hijacked another app's taps on the shared QA emulator.

The filter is not host-less, and never was:

```xml
<data android:scheme="https" android:host="sceneview.github.io" android:pathPrefix="/open" />
```

- It is the only `scheme="https"` in any non-generated `AndroidManifest.xml` in the repo.
- `git log -p --follow` shows the `<data>` line was born with the host restriction.
- The APK installed on the QA emulator (versionName 4.33.0) carries it too — its
  resolver entry reads `Authority: "sceneview.github.io": -1`,
  `Path: PatternMatcher{PREFIX: /open}`.
- `pm resolve-activity -a VIEW -d "https://example.com/foo"` resolves to Chrome's
  `IntentDispatcher` alone, with and without `BROWSABLE`. The demo is already absent.

The hijack was most plausibly a concurrent QA session launching the demo on the shared
emulator — the resolution data says the demo cannot win an unrelated https link.

## What this PR fixes instead

**Nothing guarded the scope.** Deleting `android:host` is not a lint error, and no test
inspects the resolver table, so the exact regression #3366 describes could land silently
— and it would not even reach a demo screen: `DeepLinkRouter.extractCandidate` applies
the same host + path check in code and would intercept the link, then drop it.

`DeepLinkManifestScopeTest` reads the scope back out of the manifest source and pins it
to `DeepLinkRouter`'s own constants, so the manifest and the router can only move
together. Plain JUnit — no Robolectric, no device: the assertion is about the manifest,
and it fails on the widening itself rather than on a resolver behaviour that only
reproduces once a second app is installed.

**The documentation was wrong.** The manifest comment and
`website-static/.well-known/README.md` both promised `sceneview.github.io: verified`
after `pm verify-app-links`. `assembleDebug` is signed with the default
`~/.android/debug.keystore` (`samples/android-demo/build.gradle` declares no `debug`
signing config), that fingerprint is not in `assetlinks.json` and cannot be — it differs
per machine — so a debug install always reports domain state `1024`. Verified on the
emulator: the installed APK's fingerprint is exactly the stock debug keystore's, and
`get-app-links` shows `Disabled: sceneview.github.io`. Anyone following the doc read
that as a regression. The expected output is now stated per build type, with the manual
`pm set-app-links-user-selection` opt-in for exercising the https link on a debug build.

## `android:autoVerify` — kept

`curl https://sceneview.github.io/.well-known/assetlinks.json` → HTTP 200,
`Content-Type: application/json`, listing `io.github.sceneview.demo` with both the Play
App Signing and upload-key SHA-256 fingerprints. The prerequisite holds for the builds
users actually install, so autoVerify stays on; it is only debug installs that cannot
verify, and those have `sceneview://demo/<id>`.

## Verification

- `:samples:android-demo:testDebugUnitTest --tests DeepLinkManifestScopeTest --tests DeepLinkRouterTest` — 41 tests, green.
- The new guard was proven to bite: its first run failed on a bare
  `<data android:scheme="https" />` quoted inside the manifest comment, which is why it
  strips XML comments before scanning.
- No QA script or Maestro flow sends an https `VIEW` intent to the demo, so nothing
  downstream needed adapting.

Fixes #3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
