### PR TITLE
Merge the demo's two settings surfaces into one sheet

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -329,15 +329,27 @@ themed surface — so it is theme-independent and uses the "Button glass" row.
 
 | Token | Value | Usage |
 |---|---|---|
-| `glass-surface` (over media) | rgba(255,255,255,0.08) | Back button, identity pill, overflow button, dock |
+| `glass-surface` (over media) | rgba(255,255,255,0.08) | Back button, identity pill, dock |
 | `glass-border` | 1px rgba(255,255,255,0.08) | Outline of every glass element |
 | `on-glass` | #ffffff | Icons and labels on glass |
 | `on-glass-muted` | rgba(255,255,255,0.72) | Secondary label on glass |
-| `glass-icon-button` | 44dp visual, 48dp touch target | Back / overflow |
+| `chrome-scrim` | rgba(0,0,0,0.60) → transparent | Ground under the chrome bands |
+| `glass-icon-button` | 44dp visual, 48dp touch target | Back |
 | `glass-pill` | 36dp high, 14dp horizontal padding | Identity pill |
 
 - **No blur on Android.** A `SurfaceView` cannot be sampled by a Compose render
   effect, so glass over the scene is fill + border only. Do not emulate blur.
+- **The chrome bands sit on `chrome-scrim`.** White on media reads only when the
+  media is dark, and a demo scene can be any brightness — a near-white studio
+  erases an 8 % white fill and white glyphs alike. The top band (160dp) and the
+  bottom band (220dp minimum) each carry a vertical scrim, flat for the 55 %
+  nearest the screen edge and fading to transparent, so the chrome never depends
+  on what the scene happens to render behind it. The top scrim fades with the
+  chrome; the bottom one grows to the measured overlay band and outlives the
+  fade, because a status pill or legend stays on screen after a scene tap has
+  hidden the dock.
+- **There is no overflow menu.** Reset, Send feedback and QA mode live in the
+  settings sheet the dock's Controls item opens — one settings surface, not two.
 
 ### Floating Dock (Android demo)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -344,10 +344,11 @@ themed surface — so it is theme-independent and uses the "Button glass" row.
   erases an 8 % white fill and white glyphs alike. The top band (160dp) and the
   bottom band (220dp minimum) each carry a vertical scrim, flat for the 55 %
   nearest the screen edge and fading to transparent, so the chrome never depends
-  on what the scene happens to render behind it. The top scrim fades with the
-  chrome; the bottom one grows to the measured overlay band and outlives the
-  fade, because a status pill or legend stays on screen after a scene tap has
-  hidden the dock.
+  on what the scene happens to render behind it. Both are drawn under the
+  overlay slots, so they tint the scene and never a demo's own overlay card. The
+  top scrim fades with the chrome; the bottom one grows to the measured overlay
+  band and outlives the fade, because a status pill or legend stays on screen
+  after a scene tap has hidden the dock.
 - **There is no overflow menu.** Reset, Send feedback and QA mode live in the
   settings sheet the dock's Controls item opens — one settings surface, not two.
 

--- a/changelog.d/3328-settings-tabs-merge.md
+++ b/changelog.d/3328-settings-tabs-merge.md
@@ -1,0 +1,8 @@
+<!-- category: Changed -->
+Android demo: the two settings surfaces are now one. The overflow menu is gone and
+its actions — Reset demo, Send feedback, QA mode — moved into the settings sheet the
+dock's Controls item opens, below the demo's own controls. The sheet's own settings
+reset stays pinned in the header, and the per-demo reset it used to be confusable
+with is now labelled "Reset demo". The chrome also carries its own scrim, so the
+back arrow, the identity pill, the dock and a demo's status pill stay legible over a
+light scene instead of disappearing into it.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -36,26 +36,22 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Feedback
-import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.material.icons.outlined.Science
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -64,6 +60,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.Switch
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SheetState
@@ -85,6 +82,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -158,17 +157,18 @@ data class DockItem(
  * **Top row** (16 dp margins): back glass button (contentDescription
  * "Navigate back" — Maestro's per-demo liveness gate taps it) · identity pill
  * with the demo [title] and the optional [assetSource] suffix · the QA pill
- * (`" QA ×"`, unchanged — the rendering suite keys on it) · overflow glass
- * button opening a menu with Reset ([onReset]), Reset settings
- * ([onResetSettings]), Feedback and the QA-mode toggle.
+ * (`" QA ×"`, unchanged — the rendering suite keys on it). The overflow "⋮"
+ * menu that used to end this row is gone (#3328): its actions moved into the
+ * settings sheet, so there is one settings surface instead of two.
  *
  * **Dock** (bottom-centre, [HorizontalFloatingToolbar]): up to four [dock]
- * items, the auto-appended *Controls* item when [controls] is non-null (it
- * carries `SETTINGS_FAB` + "Demo settings", so `DemoInteractionTest` opens the
- * same sheet it always did), and an optional [dockAccent] rendered as a filled
- * primary button — the AR action. Hidden entirely when there is nothing to put
- * in it. [SETTINGS_FAB_RESERVED_SPACE] names the band it occupies; the
- * `bottomOverlay` slot stacks **above** that band, measured from the real dock.
+ * items, the always-appended *Controls* item (it carries `SETTINGS_FAB` +
+ * "Demo settings", so `DemoInteractionTest` opens the same sheet it always
+ * did), and an optional [dockAccent] rendered as a filled primary button — the
+ * AR action. Always present, since the Controls item is now the only way to
+ * Reset, send feedback or toggle QA mode. [SETTINGS_FAB_RESERVED_SPACE] names
+ * the band it occupies; the `bottomOverlay` slot stacks **above** that band,
+ * measured from the real dock.
  *
  * **Chrome toggle**: a tap on the scene — observed in the `Initial` pointer
  * pass without consuming, so the 3D view keeps every drag, tap and pinch —
@@ -184,11 +184,13 @@ data class DockItem(
  * viewport. AR demos pass `null` on purpose: their viewport is the live camera
  * feed (#1361).
  *
- * **Controls sheet**: `controls != null` → a [ModalBottomSheet] on the theme's
- * `surfaceContainer` with a 28 dp top radius, opened from the dock's Controls
- * item at the detent this demo was last left at (#2084, persisted per demo via
- * [DemoSheetDetentStore]). [onResetSettings] adds a "Reset" text button in the
- * sheet header. [peekHeader] — a short live status such as "3 anchors placed"
+ * **Settings sheet** (the single settings surface, #3328): a [ModalBottomSheet]
+ * on the theme's `surfaceContainer` with a 28 dp top radius, opened from the
+ * dock's Controls item at the detent this demo was last left at (#2084,
+ * persisted per demo via [DemoSheetDetentStore]). It stacks the demo's own
+ * [controls], then — behind a divider — Reset ([onReset]), Send feedback and
+ * the QA-mode toggle. [onResetSettings] adds a "Reset" text button pinned in
+ * the sheet header. [peekHeader] — a short live status such as "3 anchors placed"
  * — is rendered as a glass status pill at the top of the bottom band; the old
  * peek chip it used to label is gone.
  *
@@ -245,7 +247,26 @@ fun DemoScaffold(
     val chromeVisible = chromeToggled || touchExploration || DemoSettings.qaMode
 
     var settingsExpanded by rememberSaveable { mutableStateOf(false) }
-    val hasDock = dock.isNotEmpty() || dockAccent != null || controls != null
+    // The dock always carries the Controls item now (#3328): the settings sheet is the
+    // single settings surface, so it must exist even on a demo with no own controls —
+    // Reset, Feedback and QA mode live in it.
+    val hasDock = true
+
+    // Reset + its snackbar confirmation, hoisted out of the chrome: the sheet is the
+    // only caller since the overflow menu was folded into it.
+    val onResetConfirmed: (() -> Unit)? = onReset?.let { reset ->
+        {
+            haptic.medium()
+            reset()
+            resetScope.launch {
+                snackbarHostState.currentSnackbarData?.dismiss()
+                snackbarHostState.showSnackbar(
+                    message = resetConfirmation,
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
 
     Scaffold(
         // Edge-to-edge: the scene owns every pixel; the chrome applies the insets.
@@ -316,6 +337,39 @@ fun DemoScaffold(
                 )
             }
 
+            // Ground for everything that lives at the bottom of the scene (#3328):
+            // the dock band and, when a demo reserves one, the whole bottom-overlay
+            // stack above it. It lives here rather than inside the chrome for two
+            // reasons: it is drawn *before* the overlays and the chrome, so it tints
+            // the scene and never the glass sitting on it; and it outlives the
+            // chrome's fade, because a status pill stays on screen after a scene tap
+            // has hidden the dock. Sized to the measured band so a pill a demo lifted
+            // clear of the dock still lands on the scrim.
+            val bottomBand = maxOf(
+                SceneViewTokens.Glass.scrimBottomHeight,
+                dockClearance + bottomOverlayBand,
+            )
+            AnimatedVisibility(
+                visible = chromeVisible || bottomOverlay != null || peekHeader != null,
+                enter = fadeIn(SceneViewTokens.Motion.fade()),
+                exit = fadeOut(SceneViewTokens.Motion.fade()),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(bottomBand)
+                        .background(
+                            Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                1f - SceneViewTokens.Glass.scrimPlateau to
+                                    SceneViewTokens.Glass.scrim,
+                                1f to SceneViewTokens.Glass.scrim,
+                            )
+                        ),
+                )
+            }
+
             // Top band: the demo's own overlays below the identity row, then the
             // chrome on top so scaffold controls always win the z-order.
             if (topOverlay != null) {
@@ -340,42 +394,27 @@ fun DemoScaffold(
                 title = title,
                 assetSource = assetSource,
                 onBack = onBack,
-                onReset = onReset?.let { reset ->
-                    {
-                        haptic.medium()
-                        reset()
-                        resetScope.launch {
-                            snackbarHostState.currentSnackbarData?.dismiss()
-                            snackbarHostState.showSnackbar(
-                                message = resetConfirmation,
-                                duration = SnackbarDuration.Short,
-                            )
-                        }
-                    }
-                },
-                onResetSettings = onResetSettings,
                 haptic = haptic,
                 dock = dock,
                 dockAccent = dockAccent,
-                controlsItem = if (controls != null) {
-                    DockItem(
-                        icon = Icons.Outlined.Tune,
-                        label = stringResource(R.string.demo_settings_fab_cd),
-                        onClick = {
-                            haptic.selection()
-                            settingsExpanded = true
-                        },
-                    )
-                } else null,
+                controlsItem = DockItem(
+                    icon = Icons.Outlined.Tune,
+                    label = stringResource(R.string.demo_settings_fab_cd),
+                    onClick = {
+                        haptic.selection()
+                        settingsExpanded = true
+                    },
+                ),
                 onIdentityRowHeight = { identityRowPx = maxOf(identityRowPx, it) },
                 onDockBandHeight = { dockBandPx = maxOf(dockBandPx, it) },
             )
 
-            if (controls != null && settingsExpanded) {
+            if (settingsExpanded) {
                 DemoSettingsSheet(
                     demoTitle = title,
                     controlsContent = controls,
                     haptic = haptic,
+                    onReset = onResetConfirmed,
                     onResetSettings = onResetSettings,
                     onDismissed = { settingsExpanded = false },
                 )
@@ -440,8 +479,6 @@ private fun BoxScope.DemoChrome(
     title: String,
     assetSource: AssetSourceState?,
     onBack: () -> Unit,
-    onReset: (() -> Unit)?,
-    onResetSettings: (() -> Unit)?,
     haptic: SceneViewHaptic,
     dock: List<DockItem>,
     dockAccent: DockItem?,
@@ -456,12 +493,26 @@ private fun BoxScope.DemoChrome(
         modifier = Modifier.matchParentSize(),
     ) {
         Box(Modifier.fillMaxSize()) {
+            // The chrome's own ground (#3328). Drawn first, inside the fade, so it
+            // comes and goes with the glass it exists to make legible, and behind it
+            // so nothing is tinted twice. Not touchable: it is `Box` with no input.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(SceneViewTokens.Glass.scrimTopHeight)
+                    .background(
+                        Brush.verticalGradient(
+                            0f to SceneViewTokens.Glass.scrim,
+                            SceneViewTokens.Glass.scrimPlateau to SceneViewTokens.Glass.scrim,
+                            1f to Color.Transparent,
+                        )
+                    ),
+            )
             DemoIdentityRow(
                 title = title,
                 assetSource = assetSource,
                 onBack = onBack,
-                onReset = onReset,
-                onResetSettings = onResetSettings,
                 haptic = haptic,
                 onHeightChanged = onIdentityRowHeight,
             )
@@ -486,8 +537,6 @@ private fun BoxScope.DemoIdentityRow(
     title: String,
     assetSource: AssetSourceState?,
     onBack: () -> Unit,
-    onReset: (() -> Unit)?,
-    onResetSettings: (() -> Unit)?,
     haptic: SceneViewHaptic,
     onHeightChanged: (Int) -> Unit,
 ) {
@@ -555,7 +604,7 @@ private fun BoxScope.DemoIdentityRow(
         }
         if (DemoSettings.qaMode) {
             // Tappable QA pill: tap to disable — a single-tap escape hatch for a
-            // user who toggled QA mode from the overflow menu by accident (#951).
+            // user who toggled QA mode from the settings sheet by accident (#951).
             // Text is exactly `" QA ×"`: the rendering suite keys on it.
             GlassPill(
                 modifier = Modifier
@@ -575,99 +624,6 @@ private fun BoxScope.DemoIdentityRow(
                     maxLines = 1,
                 )
             }
-        }
-        DemoOverflowMenu(
-            onReset = onReset,
-            onResetSettings = onResetSettings,
-            haptic = haptic,
-        )
-    }
-}
-
-/**
- * Overflow glass button + [DropdownMenu]. Feedback keeps `FEEDBACK_ACTION` and
- * raises [io.github.sceneview.demo.feedback.FeedbackOpenRequest] exactly as the
- * former top-bar action did (#1930); Reset keeps `RESET_ACTION` (#1966). The
- * QA-mode toggle moved here from the long-press on the deleted peek chip.
- *
- * `wrapContentSize(Alignment.TopEnd)` on the anchor [Box] is the documented
- * Compose fix for a menu anchored to a button flush against the trailing edge
- * of the screen (AndroidX b/168594123, "DropdownMenu is positioned strangely
- * for toggles up against the edge of the screen") — exactly this button's
- * position, last in the identity row on every demo screen. Without it the
- * `DropdownMenu` opened detached from the glass button it belongs to (#3323).
- */
-@Composable
-private fun DemoOverflowMenu(
-    onReset: (() -> Unit)?,
-    onResetSettings: (() -> Unit)?,
-    haptic: SceneViewHaptic,
-) {
-    var open by remember { mutableStateOf(false) }
-    Box(modifier = Modifier.wrapContentSize(Alignment.TopEnd)) {
-        GlassIconButton(
-            icon = Icons.Filled.MoreVert,
-            contentDescription = stringResource(R.string.demo_menu_cd),
-            onClick = { open = true },
-            modifier = Modifier.testTag(DemoScaffoldTestTags.OVERFLOW_MENU),
-        )
-        DropdownMenu(
-            expanded = open,
-            onDismissRequest = { open = false },
-            shape = RoundedCornerShape(SceneViewTokens.Radius.md),
-            containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        ) {
-            if (onReset != null) {
-                val resetCd = stringResource(R.string.demo_reset_cd)
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.demo_settings_reset)) },
-                    leadingIcon = { Icon(Icons.Filled.Refresh, contentDescription = null) },
-                    onClick = {
-                        open = false
-                        onReset()
-                    },
-                    modifier = Modifier
-                        .semantics { contentDescription = resetCd }
-                        .testTag(DemoScaffoldTestTags.RESET_ACTION),
-                )
-            }
-            if (onResetSettings != null) {
-                val resetSettingsCd = stringResource(R.string.demo_settings_reset_cd)
-                DropdownMenuItem(
-                    text = { Text(resetSettingsCd) },
-                    leadingIcon = { Icon(Icons.Outlined.RestartAlt, contentDescription = null) },
-                    onClick = {
-                        open = false
-                        haptic.selection()
-                        onResetSettings()
-                    },
-                )
-            }
-            val feedbackCd = stringResource(R.string.feedback_action_cd)
-            DropdownMenuItem(
-                text = { Text(feedbackCd) },
-                leadingIcon = { Icon(Icons.Outlined.Feedback, contentDescription = null) },
-                onClick = {
-                    open = false
-                    haptic.selection()
-                    io.github.sceneview.demo.feedback.FeedbackOpenRequest.request()
-                },
-                modifier = Modifier
-                    .semantics { contentDescription = feedbackCd }
-                    .testTag(DemoScaffoldTestTags.FEEDBACK_ACTION),
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.demo_menu_qa_mode)) },
-                leadingIcon = { Icon(Icons.Outlined.Science, contentDescription = null) },
-                trailingIcon = if (DemoSettings.qaMode) {
-                    { Text("✓", style = MaterialTheme.typography.labelLarge) }
-                } else null,
-                onClick = {
-                    open = false
-                    haptic.medium()
-                    DemoSettings.qaMode = !DemoSettings.qaMode
-                },
-            )
         }
     }
 }
@@ -886,9 +842,10 @@ object DemoScaffoldTestTags {
     const val SETTINGS_FAB = "demo-settings-fab"
     const val SETTINGS_SHEET = "demo-settings-sheet"
     const val SETTINGS_RESET = "demo-settings-reset"
+    /** Rows in the settings sheet's actions section — the overflow menu's heirs (#3328). */
     const val RESET_ACTION = "demo-reset-action"
     const val FEEDBACK_ACTION = "demo-feedback-action"
-    const val OVERFLOW_MENU = "demo-overflow-menu"
+    const val QA_MODE_ACTION = "demo-qa-mode-action"
     const val QA_PILL = "demo-qa-pill"
     /** The identity pill, tagged only when it carries an asset-source suffix. */
     const val ASSET_SOURCE_CHIP = "demo-asset-source-chip"
@@ -1049,7 +1006,14 @@ private fun BoxScope.DemoTopOverlay(
 }
 
 /**
- * The controls [ModalBottomSheet], opened from the dock's Controls item.
+ * The one settings surface, opened from the dock's Controls item.
+ *
+ * There used to be two (#3328): this sheet for the demo's own controls, and a
+ * top-right overflow [androidx.compose.material3.DropdownMenu] carrying Reset,
+ * Reset settings, Send feedback and QA mode — with "Reset settings" present in
+ * both. The menu is gone; its four actions live here, below the demo controls,
+ * behind a divider. That is why [controlsContent] is nullable: a demo with no
+ * controls of its own still needs the sheet for the app-level actions.
  *
  * Follows the app theme (`surfaceContainer`, 28 dp top radius) — it is a
  * themed surface, unlike the glass chrome over the media.
@@ -1062,8 +1026,9 @@ private fun BoxScope.DemoTopOverlay(
 @Composable
 private fun DemoSettingsSheet(
     demoTitle: String,
-    controlsContent: @Composable ColumnScope.() -> Unit,
+    controlsContent: (@Composable ColumnScope.() -> Unit)?,
     haptic: SceneViewHaptic,
+    onReset: (() -> Unit)?,
     onResetSettings: (() -> Unit)?,
     onDismissed: () -> Unit,
 ) {
@@ -1132,13 +1097,65 @@ private fun DemoSettingsSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
-                .padding(
-                    start = SceneViewTokens.Space.md,
-                    end = SceneViewTokens.Space.md,
-                    bottom = SceneViewTokens.Space.lg,
-                ),
-            content = controlsContent,
-        )
+                .padding(bottom = SceneViewTokens.Space.lg),
+        ) {
+            if (controlsContent != null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = SceneViewTokens.Space.md),
+                    content = controlsContent,
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(
+                        horizontal = SceneViewTokens.Space.md,
+                        vertical = SceneViewTokens.Space.md,
+                    ),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
+
+            // The former overflow-menu actions (#3328), in the order they had there.
+            if (onReset != null) {
+                val resetCd = stringResource(R.string.demo_reset_cd)
+                SheetActionRow(
+                    icon = Icons.Filled.Refresh,
+                    label = stringResource(R.string.demo_reset_action),
+                    contentDescription = resetCd,
+                    onClick = onReset,
+                    modifier = Modifier.testTag(DemoScaffoldTestTags.RESET_ACTION),
+                )
+            }
+            val feedbackCd = stringResource(R.string.feedback_action_cd)
+            SheetActionRow(
+                icon = Icons.Outlined.Feedback,
+                label = feedbackCd,
+                contentDescription = feedbackCd,
+                onClick = {
+                    haptic.selection()
+                    io.github.sceneview.demo.feedback.FeedbackOpenRequest.request()
+                },
+                modifier = Modifier.testTag(DemoScaffoldTestTags.FEEDBACK_ACTION),
+            )
+            SheetActionRow(
+                icon = Icons.Outlined.Science,
+                label = stringResource(R.string.demo_menu_qa_mode),
+                contentDescription = stringResource(R.string.demo_menu_qa_mode),
+                onClick = {
+                    haptic.medium()
+                    DemoSettings.qaMode = !DemoSettings.qaMode
+                },
+                modifier = Modifier.testTag(DemoScaffoldTestTags.QA_MODE_ACTION),
+                trailing = {
+                    // Decorative: the whole row is the toggle, so the switch must not
+                    // take a second focus stop for TalkBack.
+                    Switch(
+                        checked = DemoSettings.qaMode,
+                        onCheckedChange = null,
+                    )
+                },
+            )
+        }
     }
 
     // The `SheetState` starts at `Hidden` and animates open, so this effect fires
@@ -1178,5 +1195,47 @@ private fun DemoSettingsSheet(
                 }
             }
         }
+    }
+}
+
+/**
+ * One app-level action inside the settings sheet: leading icon, label, optional
+ * trailing control. A full-width tap target — the whole row is the affordance,
+ * so a trailing [Switch] stays decorative (`onCheckedChange = null`) instead of
+ * competing for the same gesture and doubling the accessibility focus stops.
+ */
+@Composable
+private fun SheetActionRow(
+    icon: ImageVector,
+    label: String,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .semantics { this.contentDescription = contentDescription }
+            .padding(
+                horizontal = SceneViewTokens.Space.md,
+                vertical = SceneViewTokens.Space.sm,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.md),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        trailing?.invoke()
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -2,7 +2,9 @@
 
 package io.github.sceneview.demo
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -69,6 +71,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -92,6 +95,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -102,6 +106,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
 import io.github.sceneview.demo.theme.SceneViewTokens
 import io.github.sceneview.demo.ui.GlassIconButton
 import io.github.sceneview.demo.ui.GlassPill
@@ -246,11 +251,25 @@ fun DemoScaffold(
     var chromeToggled by rememberSaveable { mutableStateOf(true) }
     val chromeVisible = chromeToggled || touchExploration || DemoSettings.qaMode
 
+    // The top scrim (#3328) puts a 60 %-black ground under the status bar, so in light
+    // mode the system icons — clock, wifi, battery — turn dark-on-dark and disappear.
+    // They used to read because they sat on whatever the scene rendered. Force the
+    // light (white) icon set while the scrim is up, and restore whatever the theme had
+    // when the chrome hides or the demo is left; capturing the previous value rather
+    // than deducing it keeps this correct in both themes and under edge-to-edge.
+    val view = LocalView.current
+    DisposableEffect(view, chromeVisible) {
+        val window = generateSequence(view.context) { (it as? ContextWrapper)?.baseContext }
+            .filterIsInstance<Activity>()
+            .firstOrNull()
+            ?.window
+        val controller = window?.let { WindowCompat.getInsetsController(it, view) }
+        val previous = controller?.isAppearanceLightStatusBars
+        if (chromeVisible) controller?.isAppearanceLightStatusBars = false
+        onDispose { if (previous != null) controller?.isAppearanceLightStatusBars = previous }
+    }
+
     var settingsExpanded by rememberSaveable { mutableStateOf(false) }
-    // The dock always carries the Controls item now (#3328): the settings sheet is the
-    // single settings surface, so it must exist even on a demo with no own controls —
-    // Reset, Feedback and QA mode live in it.
-    val hasDock = true
 
     // Reset + its snackbar confirmation, hoisted out of the chrome: the sheet is the
     // only caller since the overflow menu was folded into it.
@@ -300,8 +319,11 @@ fun DemoScaffold(
 
         // Room the dock band takes at the bottom — the same floor-or-measured
         // value `bottomOverlay` clears, shared with the snackbar below so both
-        // float above the dock instead of behind or through it (#3325).
-        val dockClearance = if (hasDock) maxOf(SETTINGS_FAB_RESERVED_SPACE, dockBand) else 0.dp
+        // float above the dock instead of behind or through it (#3325). The dock
+        // always exists now (#3328): it carries the Controls item that opens the
+        // one settings surface, even on a demo with no controls of its own, so
+        // the clearance is unconditional.
+        val dockClearance = maxOf(SETTINGS_FAB_RESERVED_SPACE, dockBand)
 
         // `consumeWindowInsets(padding)` gives this Box's whole subtree ONE inset
         // reference frame (#3237). With `contentWindowInsets = 0` the padding is
@@ -334,6 +356,33 @@ fun DemoScaffold(
                     firstFrameRendered = firstFrameRendered,
                     previewRes = previewRes,
                     onRetry = onReset,
+                )
+            }
+
+            // Ground for the identity row (#3328). Like the bottom band below, it is
+            // drawn here rather than inside the chrome so it tints the *scene* and
+            // never the glass — or the demo's own top overlay, which a scrim drawn
+            // inside the chrome greys out, because the chrome is composed after the
+            // overlay slots. It still fades with the chrome, which is the only thing
+            // standing on it.
+            AnimatedVisibility(
+                visible = chromeVisible,
+                enter = fadeIn(SceneViewTokens.Motion.fade()),
+                exit = fadeOut(SceneViewTokens.Motion.fade()),
+                modifier = Modifier.align(Alignment.TopCenter),
+            ) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(SceneViewTokens.Glass.scrimTopHeight)
+                        .background(
+                            Brush.verticalGradient(
+                                0f to SceneViewTokens.Glass.scrim,
+                                SceneViewTokens.Glass.scrimPlateau to
+                                    SceneViewTokens.Glass.scrim,
+                                1f to Color.Transparent,
+                            )
+                        ),
                 )
             }
 
@@ -493,22 +542,6 @@ private fun BoxScope.DemoChrome(
         modifier = Modifier.matchParentSize(),
     ) {
         Box(Modifier.fillMaxSize()) {
-            // The chrome's own ground (#3328). Drawn first, inside the fade, so it
-            // comes and goes with the glass it exists to make legible, and behind it
-            // so nothing is tinted twice. Not touchable: it is `Box` with no input.
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth()
-                    .height(SceneViewTokens.Glass.scrimTopHeight)
-                    .background(
-                        Brush.verticalGradient(
-                            0f to SceneViewTokens.Glass.scrim,
-                            SceneViewTokens.Glass.scrimPlateau to SceneViewTokens.Glass.scrim,
-                            1f to Color.Transparent,
-                        )
-                    ),
-            )
             DemoIdentityRow(
                 title = title,
                 assetSource = assetSource,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ContactShadowPreviewDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ContactShadowPreviewDemo.kt
@@ -237,8 +237,10 @@ fun ContactShadowPreviewDemo(onBack: () -> Unit) {
             if (shadowVisible) R.string.contact_shadow_peek_on
             else R.string.contact_shadow_peek_off
         ),
+        // One reset, offered once: this demo has no settings-only state to restore apart from
+        // what `resetAll` already covers, so wiring `onResetSettings` to the same lambda would
+        // put the very same action twice in the merged sheet (#3328).
         onReset = resetAll,
-        onResetSettings = resetAll,
         // The wall TV's live A/B, hosted by the scaffold's top band so it sits in the TV's
         // half of the frame — see [WallShadowBeat] for why this is an on-screen control and
         // not a settings-sheet row. The slot owns the gutter and the inset, so the beat

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/theme/SceneViewTokens.kt
@@ -67,6 +67,33 @@ object SceneViewTokens {
         val pillHeight = 36.dp
         /** `GlassPill` horizontal content padding. */
         val pillPaddingHorizontal = 14.dp
+
+        /**
+         * `chrome-scrim` — the wash the chrome bands sit on.
+         *
+         * White on media only reads when the media is dark, and a Filament scene is
+         * whatever the demo authored: the contact-shadow studio is a near-white room,
+         * where an 8 % white fill and white glyphs disappear entirely. The chrome
+         * therefore carries its own ground, the same transparent-to-black media scrim
+         * the Spatial Gallery puts under white copy. 60 % black takes a white
+         * background down to ~5.6:1 against white text, so the band reads on the
+         * brightest scene the demos ship and stays unobtrusive on the darkest.
+         */
+        val scrim = Color(0x99000000)
+        /** Height of the top scrim: the identity row, its gutter and the status bar. */
+        val scrimTopHeight = 160.dp
+        /**
+         * Floor for the bottom scrim: enough for the dock band alone. The scaffold
+         * grows it to the measured `dockClearance + bottomOverlayBand` whenever a
+         * demo stacks a status pill or a legend above the dock, so the ground always
+         * reaches the topmost thing standing on it.
+         */
+        val scrimBottomHeight = 220.dp
+        /**
+         * Where the scrim stops being flat and starts fading out, as a fraction of its
+         * height measured from the screen edge. The chrome sits inside the flat part.
+         */
+        const val scrimPlateau = 0.55f
     }
 
     /**

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -286,8 +286,7 @@
     <string name="demo_source_streamed">Streamed</string>
     <string name="demo_source_streaming">Streaming</string>
     <string name="demo_source_bundled">Offline</string>
-    <!-- Overflow menu + stalled-load card (DemoScaffold). -->
-    <string name="demo_menu_cd">More options</string>
+    <!-- Settings-sheet actions + stalled-load card (DemoScaffold). -->
     <string name="demo_menu_qa_mode">QA mode</string>
     <string name="demo_loading_stalled_title">Still loading…</string>
     <string name="demo_loading_stalled_body">The scene has not rendered a frame yet.</string>
@@ -298,6 +297,12 @@
     <string name="demo_settings_reset">Reset</string>
     <string name="demo_settings_reset_cd">Reset demo settings to defaults</string>
     <!-- Predictable per-demo reset action (#1966) -->
+    <!--
+        Labelled "Reset demo", not "Reset": since #3328 it sits in the same sheet as the
+        header's settings-scoped "Reset", and two identically-labelled buttons doing
+        different things is exactly the confusion the merge set out to remove.
+    -->
+    <string name="demo_reset_action">Reset demo</string>
     <string name="demo_reset_cd">Reset this demo to its initial state</string>
     <string name="demo_reset_done">Demo reset — ready to try again</string>
     <string name="about_star_on_github">Star on GitHub</string>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoScaffoldBottomBandTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoScaffoldBottomBandTest.kt
@@ -104,10 +104,14 @@ class DemoScaffoldBottomBandTest {
     }
 
     @Test
-    fun bottomOverlay_usesTheWholeBottomEdge_whenThereIsNoDock() {
-        // No `controls`, no `dock`, no accent → no dock is composed at all, and the
-        // overlay must reach the bottom of the scene area instead of reserving a
-        // band for chrome that does not exist.
+    fun bareDemo_stillGetsTheDock_andTheOverlayClearsIt() {
+        // Before #3328 a demo with no `controls`, no `dock` and no accent composed
+        // no dock at all, and the overlay ran to the bottom of the scene. The
+        // settings sheet is now the single settings surface — Reset, Send feedback
+        // and QA mode live in it — so the dock always carries the Controls item
+        // that opens it, on every demo. The invariant that replaces "no dock" is
+        // therefore: the bare demo still has a dock, and the overlay still clears
+        // it rather than running underneath.
         composeRule.setContent {
             ScaledDensity(1.0f) {
                 SceneViewDemoTheme(darkTheme = false) {
@@ -129,13 +133,23 @@ class DemoScaffoldBottomBandTest {
             }
         }
         composeRule.waitForIdle()
-        composeRule.onNodeWithTag(DemoScaffoldTestTags.DOCK).assertDoesNotExist()
+        composeRule.onNodeWithTag(DemoScaffoldTestTags.SETTINGS_FAB)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals("Demo settings")
+        val dock = composeRule.onNodeWithTag(DemoScaffoldTestTags.DOCK)
+            .getUnclippedBoundsInRoot()
         val overlay = composeRule.onNodeWithTag(OVERLAY_PROBE).getUnclippedBoundsInRoot()
         val scene = composeRule.onNodeWithTag(SCENE_PROBE).getUnclippedBoundsInRoot()
         assertTrue(
-            "without a dock the overlay ends at ${overlay.bottom} while the scene ends at " +
-                "${scene.bottom} — a band is being reserved for chrome that is not there.",
-            overlay.bottom >= scene.bottom - 1.dp,
+            "a demo with no controls of its own still gets the dock, but its overlay ends " +
+                "at ${overlay.bottom} while the dock starts at ${dock.top}.",
+            overlay.bottom <= dock.top,
+        )
+        assertTrue(
+            "the overlay ends at ${overlay.bottom}, ${dock.top - overlay.bottom} above the " +
+                "dock at ${dock.top} on a scene ending at ${scene.bottom} — the reserve " +
+                "should be the dock band and a gutter, not a second empty band.",
+            dock.top - overlay.bottom < 48.dp,
         )
     }
 


### PR DESCRIPTION
Two reports, same feedback dictated twice: the demo had **two settings surfaces** — the
controls sheet behind the FAB and an overflow "⋮" menu carrying Reset, Send feedback and
QA mode — and the chrome around them read as "vraiment moyen".

## One settings surface

- The overflow menu and its glass "⋮" button are gone. `DemoOverflowMenu`, the
  `demo_menu_cd` string and the `OVERFLOW_MENU` test tag with them.
- The dock now **always** carries a Controls item (`Tune`), on every demo, even one with
  no controls of its own — it is the single entry point to settings.
- `DemoSettingsSheet` is that surface: a pinned header (title + a settings-scoped Reset)
  over a scrolling body — the demo's own controls, a divider, then **Reset demo**,
  **Send feedback**, **QA mode**.
- `SETTINGS_FAB` still tags the Controls item and still answers to
  `By.desc("Demo settings")`, so `DemoInteractionTest` and `ARDepthOcclusionToggleTest`
  keep resolving it.

## Chrome that reads over any scene

- Both scrims are drawn in the scaffold Box **above the overlay slots**, not inside
  `DemoChrome`. Composition order in a Box is draw order, and a scrim composed with the
  chrome drew over a demo's own overlay card and greyed it. They now tint the scene and
  nothing else.
- The top scrim fades with the chrome. The bottom band grows from its
  `scrimBottomHeight` floor to `dockClearance + bottomOverlayBand`, so a status pill and
  a legend both land on ground instead of half off it, and it outlives the chrome fade
  because the overlays do.
- That new ground under the status bar made the light theme's dark system icons
  invisible. The scaffold forces the light icon set while the chrome is up and restores
  the previous appearance on dispose — captured, not deduced, so it is correct in both
  themes.
- `DESIGN.md` records the `chrome-scrim` token, where the two bands are drawn, and that
  there is no overflow menu.

## Test contract

`DemoScaffoldBottomBandTest.bottomOverlay_usesTheWholeBottomEdge_whenThereIsNoDock`
asserted a case this design removes — with the Controls item always in the dock, "no
dock" no longer exists. It is replaced by the invariant the new design *does* guarantee
at the bottom edge: a bare demo still gets the dock, its overlay clears it rather than
running underneath, and the reserve is the dock band plus a gutter, not a second empty
band. The assertion was rewritten, not weakened.

## Verified on screen

`emulator-5554`, `contact-shadow-preview` (a `bottomOverlayReservesScene` demo), **light
and dark**: status-bar icons legible over the scrim in both, the "Wall TV" top overlay
card bright and untinted, the "Grounded vs floating" pill, the Contact shadow / No shadow
legend and the dock all grounded on the bottom band, and the merged sheet showing
controls → divider → Reset demo / Send feedback / QA mode. Module unit tests green.

## Known follow-up, not in this PR

In the settings sheet the *Shadow intensity* slider shows `100%` with its thumb short of
the track end. It predates this PR and belongs to the slider's own range, not the chrome.

Fixes #3328
Fixes #3330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
