### PR TITLE
fix(ar): surface an explicit state when ARCore cannot start a session

### DIFF
--- a/arsceneview/api/arsceneview.api
+++ b/arsceneview/api/arsceneview.api
@@ -58,9 +58,11 @@ public final class io/github/sceneview/ar/ARCore {
 	public final fun create (Landroid/content/Context;Ljava/util/Set;)V
 	public final fun createSession (Landroid/content/Context;)V
 	public final fun destroy ()V
+	public final fun getArCoreAvailability ()Lio/github/sceneview/ar/ARCoreAvailability;
 	public final fun getCheckAvailability ()Z
 	public final fun getCheckCameraPermission ()Z
 	public final fun getFeatures ()Ljava/util/Set;
+	public final fun getOnARCoreAvailability ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnArSessionFailed ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnCameraPermissionDenied ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnSessionConfigChanged ()Lkotlin/jvm/functions/Function2;
@@ -75,13 +77,50 @@ public final class io/github/sceneview/ar/ARCore {
 	public final fun pause ()V
 	public final fun resume (Landroid/content/Context;)V
 	public final fun resume (Landroid/content/Context;Lio/github/sceneview/ar/ARPermissionHandler;)V
+	public final fun retryARCoreAvailability (Lio/github/sceneview/ar/ARPermissionHandler;)V
+	public static synthetic fun retryARCoreAvailability$default (Lio/github/sceneview/ar/ARCore;Lio/github/sceneview/ar/ARPermissionHandler;ILjava/lang/Object;)V
 	public final fun retryCameraPermission (Lio/github/sceneview/ar/ARPermissionHandler;)V
 	public static synthetic fun retryCameraPermission$default (Lio/github/sceneview/ar/ARCore;Lio/github/sceneview/ar/ARPermissionHandler;ILjava/lang/Object;)V
+	public final fun retrySession (Landroid/content/Context;)V
+	public static synthetic fun retrySession$default (Lio/github/sceneview/ar/ARCore;Landroid/content/Context;ILjava/lang/Object;)V
 	public final fun setCheckAvailability (Z)V
 	public final fun setCheckCameraPermission (Z)V
 	public final fun setFeatures (Ljava/util/Set;)V
+	public final fun setOnARCoreAvailability (Lkotlin/jvm/functions/Function1;)V
 	public final fun setOnCameraPermissionDenied (Lkotlin/jvm/functions/Function1;)V
 	public final fun setPermissionHandler (Lio/github/sceneview/ar/ARPermissionHandler;)V
+}
+
+public final class io/github/sceneview/ar/ARCoreAvailability : java/lang/Enum {
+	public static final field CheckFailed Lio/github/sceneview/ar/ARCoreAvailability;
+	public static final field NeedsUpdate Lio/github/sceneview/ar/ARCoreAvailability;
+	public static final field NotInstalled Lio/github/sceneview/ar/ARCoreAvailability;
+	public static final field SessionFailed Lio/github/sceneview/ar/ARCoreAvailability;
+	public static final field Unsupported Lio/github/sceneview/ar/ARCoreAvailability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/sceneview/ar/ARCoreAvailability;
+	public static fun values ()[Lio/github/sceneview/ar/ARCoreAvailability;
+}
+
+public final class io/github/sceneview/ar/ARCoreAvailabilityOverlayKt {
+	public static final fun ARCoreAvailabilityOverlay (Landroidx/compose/foundation/layout/BoxScope;Lio/github/sceneview/ar/ARCoreAvailabilityState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun isActionable (Lio/github/sceneview/ar/ARCoreAvailability;)Z
+	public static final fun toARCoreAvailability (Lcom/google/ar/core/ArCoreApk$Availability;)Lio/github/sceneview/ar/ARCoreAvailability;
+	public static final fun toARCoreAvailability (Ljava/lang/Throwable;)Lio/github/sceneview/ar/ARCoreAvailability;
+}
+
+public final class io/github/sceneview/ar/ARCoreAvailabilityOverlayTags {
+	public static final field $stable I
+	public static final field ACTION Ljava/lang/String;
+	public static final field CARD Ljava/lang/String;
+	public static final field INSTANCE Lio/github/sceneview/ar/ARCoreAvailabilityOverlayTags;
+}
+
+public final class io/github/sceneview/ar/ARCoreAvailabilityState {
+	public static final field $stable I
+	public fun <init> (Lio/github/sceneview/ar/ARCoreAvailability;Lkotlin/jvm/functions/Function0;)V
+	public final fun getAvailability ()Lio/github/sceneview/ar/ARCoreAvailability;
+	public final fun getRetry ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class io/github/sceneview/ar/ARCoreKt {
@@ -119,7 +158,7 @@ public abstract interface class io/github/sceneview/ar/ARPermissionHandler {
 
 public final class io/github/sceneview/ar/ARSceneKt {
 	public static final fun ARScene (Landroidx/compose/ui/Modifier;Lio/github/sceneview/SurfaceType;Lcom/google/android/filament/Engine;Lio/github/sceneview/loaders/ModelLoader;Lio/github/sceneview/loaders/MaterialLoader;Lio/github/sceneview/loaders/EnvironmentLoader;Ljava/util/Set;Ljava/io/File;Lkotlin/jvm/functions/Function1;Lcom/google/ar/core/Config$FlashMode;Lkotlin/jvm/functions/Function2;ZLio/github/sceneview/ar/scene/PlaneRendererBase$Version;Lio/github/sceneview/ar/camera/ARCameraStream;Lcom/google/android/filament/View;ZLcom/google/android/filament/Renderer;Lcom/google/android/filament/Scene;Lio/github/sceneview/environment/Environment;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/ar/node/ARCameraNode;Ljava/lang/Float;Lio/github/sceneview/collision/CollisionSystem;Lio/github/sceneview/node/ViewNode$WindowManager;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lio/github/sceneview/gesture/GestureDetector$OnGestureListener;Lkotlin/jvm/functions/Function2;Lio/github/sceneview/ar/ARPermissionHandler;Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIIIII)V
-	public static final fun ARSceneView (Landroidx/compose/ui/Modifier;Lio/github/sceneview/SurfaceType;Lcom/google/android/filament/Engine;Lio/github/sceneview/loaders/ModelLoader;Lio/github/sceneview/loaders/MaterialLoader;Lio/github/sceneview/loaders/EnvironmentLoader;Ljava/util/Set;Ljava/io/File;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lcom/google/ar/core/Config$FlashMode;Lcom/google/ar/core/Config$PlaneFindingMode;Lcom/google/ar/core/Config$DepthMode;Lcom/google/ar/core/Config$InstantPlacementMode;Lcom/google/ar/core/Config$GeospatialMode;Lcom/google/ar/core/Config$StreetscapeGeometryMode;Lcom/google/ar/core/Config$CloudAnchorMode;Lcom/google/ar/core/Config$AugmentedFaceMode;Lcom/google/ar/core/Config$ImageStabilizationMode;Lcom/google/ar/core/Config$SemanticMode;Lcom/google/ar/core/Config$UpdateMode;Lcom/google/ar/core/Config$FocusMode;Lkotlin/jvm/functions/Function2;ZLio/github/sceneview/ar/scene/PlaneRendererBase$Version;Lio/github/sceneview/ar/scene/SceneUnderstanding;Lio/github/sceneview/ar/camera/ARCameraStream;Lcom/google/android/filament/View;Lio/github/sceneview/RenderQuality;ZLcom/google/android/filament/Renderer;Lcom/google/android/filament/Scene;Lio/github/sceneview/environment/Environment;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/ar/node/ARCameraNode;Ljava/lang/Float;Lio/github/sceneview/collision/CollisionSystem;Lio/github/sceneview/node/ViewNode$WindowManager;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lio/github/sceneview/utils/SurfaceMirrorer;Lio/github/sceneview/gesture/GestureDetector$OnGestureListener;Lkotlin/jvm/functions/Function2;Lio/github/sceneview/ar/ARPermissionHandler;Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIIIIIII)V
+	public static final fun ARSceneView (Landroidx/compose/ui/Modifier;Lio/github/sceneview/SurfaceType;Lcom/google/android/filament/Engine;Lio/github/sceneview/loaders/ModelLoader;Lio/github/sceneview/loaders/MaterialLoader;Lio/github/sceneview/loaders/EnvironmentLoader;Ljava/util/Set;Ljava/io/File;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lcom/google/ar/core/Config$FlashMode;Lcom/google/ar/core/Config$PlaneFindingMode;Lcom/google/ar/core/Config$DepthMode;Lcom/google/ar/core/Config$InstantPlacementMode;Lcom/google/ar/core/Config$GeospatialMode;Lcom/google/ar/core/Config$StreetscapeGeometryMode;Lcom/google/ar/core/Config$CloudAnchorMode;Lcom/google/ar/core/Config$AugmentedFaceMode;Lcom/google/ar/core/Config$ImageStabilizationMode;Lcom/google/ar/core/Config$SemanticMode;Lcom/google/ar/core/Config$UpdateMode;Lcom/google/ar/core/Config$FocusMode;Lkotlin/jvm/functions/Function2;ZLio/github/sceneview/ar/scene/PlaneRendererBase$Version;Lio/github/sceneview/ar/scene/SceneUnderstanding;Lio/github/sceneview/ar/camera/ARCameraStream;Lcom/google/android/filament/View;Lio/github/sceneview/RenderQuality;ZLcom/google/android/filament/Renderer;Lcom/google/android/filament/Scene;Lio/github/sceneview/environment/Environment;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/node/LightNode;Lio/github/sceneview/ar/node/ARCameraNode;Ljava/lang/Float;Lio/github/sceneview/collision/CollisionSystem;Lio/github/sceneview/node/ViewNode$WindowManager;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lio/github/sceneview/utils/SurfaceMirrorer;Lio/github/sceneview/gesture/GestureDetector$OnGestureListener;Lkotlin/jvm/functions/Function2;Lio/github/sceneview/ar/ARPermissionHandler;Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIIIIIII)V
 	public static final fun frontCameraConfig (Lcom/google/ar/core/Session;)Lcom/google/ar/core/CameraConfig;
 	public static final fun highestResolutionCameraConfig (Lcom/google/ar/core/Session;)Lcom/google/ar/core/CameraConfig;
 	public static final fun rememberARCameraNode (Lcom/google/android/filament/Engine;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/github/sceneview/ar/node/ARCameraNode;
@@ -591,7 +630,8 @@ public final class io/github/sceneview/ar/ComposableSingletons$ARSceneScopeKt {
 public final class io/github/sceneview/ar/ComposableSingletons$ARSceneViewKt {
 	public static final field INSTANCE Lio/github/sceneview/ar/ComposableSingletons$ARSceneViewKt;
 	public fun <init> ()V
-	public final fun getLambda$2139196129$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$473211439$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$478031680$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/github/sceneview/ar/ComposableSingletons$PlaneDiscoveryGuideKt {

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
@@ -91,6 +91,9 @@ class ARCore(
     private var cameraPermissionRequested = false
     private var installRequested = false
 
+    /** Last context a session was created from, so a retry can create another one. */
+    private var lastContext: Context? = null
+
     internal var session: ARSession? = null
         private set
 
@@ -142,6 +145,7 @@ class ARCore(
      * @param context Android context.
      */
     fun createSession(context: Context) {
+        lastContext = context
         try {
             session = ARSession(
                 context,
@@ -150,9 +154,24 @@ class ARCore(
                 onPaused = onSessionPaused,
                 onConfigChanged = onSessionConfigChanged
             ).also(onSessionCreated)
+            publishAvailability(null)
         } catch (exception: Exception) {
-            onException(exception)
+            onSessionCreateFailed(exception)
         }
+    }
+
+    /**
+     * Reports a session-creation failure as a state the UI can show, then forwards it (#3374).
+     *
+     * `ArCoreApk` answering `SUPPORTED_INSTALLED` is not a promise that `Session()` will
+     * succeed — an emulator with Google Play Services for AR installed still fails to create
+     * one. That left the exact hang #3374 is about, one step further along: no verdict, no
+     * session, and the host's "initializing" copy up forever. Publishing
+     * [ARCoreAvailability.SessionFailed] closes that last silent path.
+     */
+    internal fun onSessionCreateFailed(exception: Exception) {
+        publishAvailability(ARCoreAvailability.SessionFailed)
+        onException(exception)
     }
 
     /**
@@ -241,9 +260,27 @@ class ARCore(
      * @param handler the permission handler; defaults to the one passed to [create].
      */
     fun retryARCoreAvailability(handler: ARPermissionHandler? = permissionHandler) {
+        // A session that failed to be created is retried by creating another one — the
+        // availability check already said "installed" and would say so again (#3374).
+        if (arCoreAvailability == ARCoreAvailability.SessionFailed) {
+            retrySession()
+            return
+        }
         handler ?: return
         installRequested = false
         checkPermissionAndInstall(handler)
+    }
+
+    /**
+     * Drops a session that failed to be created and creates a fresh one, resuming it when the
+     * host is resumed. No-op before any creation attempt.
+     */
+    fun retrySession(context: Context? = lastContext) {
+        val target = context ?: return
+        publishAvailability(null)
+        destroy()
+        createSession(target)
+        session?.resume()
     }
 
     /**

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
@@ -70,6 +70,24 @@ class ARCore(
     var isCameraPermissionDenied: Boolean = false
         private set
 
+    /**
+     * Called on the main thread whenever the ARCore availability verdict changes (#3374).
+     *
+     * `null` means "nothing to report": ARCore is installed and current, or the check is still
+     * running. A non-null value is terminal until the user acts — the device is not capable,
+     * Google Play Services for AR is missing or too old, or the check itself failed.
+     *
+     * Before #3374 an unsupported device produced no signal at all: the install request threw,
+     * the exception was swallowed into [onArSessionFailed], and hosts that had not wired that
+     * callback (every demo) sat on their own "initializing" copy forever.
+     * [ARSceneView] wires this to its built-in `arCoreAvailabilityOverlay`.
+     */
+    var onARCoreAvailability: ((availability: ARCoreAvailability?) -> Unit)? = null
+
+    /** The last verdict published through [onARCoreAvailability]. `null` when AR can start. */
+    var arCoreAvailability: ARCoreAvailability? = null
+        private set
+
     private var cameraPermissionRequested = false
     private var installRequested = false
 
@@ -164,22 +182,68 @@ class ARCore(
         } else {
             isCameraPermissionDenied = false
             try {
-                if (checkAvailability && !installRequested &&
-                    handler.checkARCoreAvailability() != Availability.SUPPORTED_INSTALLED
-                ) {
-                    if (handler.requestARCoreInstall(!installRequested)) {
-                        installRequested = true
-                    } else {
-                        return true
+                if (checkAvailability && !installRequested) {
+                    val availability = handler.checkARCoreAvailability()
+                    val unavailable = availability.toARCoreAvailability()
+                    if (unavailable == null) {
+                        publishAvailability(null)
+                        // Still `UNKNOWN_CHECKING`? ARCore has not answered yet: hold the
+                        // session back and let the next resume ask again, rather than
+                        // requesting an install for a device we have not classified.
+                        return availability == Availability.SUPPORTED_INSTALLED
+                    }
+                    publishAvailability(unavailable)
+                    // Only the install / update states have a Play Store flow to launch.
+                    // `UNSUPPORTED_DEVICE_NOT_CAPABLE` makes `requestInstall` throw, and a
+                    // failed check has nothing to install — both are surfaced, not retried
+                    // behind the user's back (#3374).
+                    if (unavailable == ARCoreAvailability.NotInstalled ||
+                        unavailable == ARCoreAvailability.NeedsUpdate
+                    ) {
+                        if (handler.requestARCoreInstall(!installRequested)) {
+                            installRequested = true
+                        } else {
+                            // ARCore reports it is installed after all.
+                            publishAvailability(null)
+                            return true
+                        }
                     }
                 } else {
+                    // Availability checks disabled, or the user is coming back from the Play
+                    // Store install we requested: the session may start, so drop any card.
+                    publishAvailability(null)
                     return true
                 }
             } catch (e: Exception) {
+                // `requestInstall` throws `Unavailable*Exception` on a device it cannot serve.
+                // Classify it so the UI can explain, then still report it to the host.
+                publishAvailability(e.toARCoreAvailability())
                 onException(e)
             }
         }
         return false
+    }
+
+    /** Publishes [availability] to [onARCoreAvailability] when it actually changed. */
+    private fun publishAvailability(availability: ARCoreAvailability?) {
+        if (arCoreAvailability == availability) return
+        arCoreAvailability = availability
+        onARCoreAvailability?.invoke(availability)
+    }
+
+    /**
+     * Re-runs the ARCore availability check after a verdict reported through
+     * [onARCoreAvailability], launching the install / update flow when there is one (#3374).
+     *
+     * Safe to call from an "Install" / "Update" / "Try again" tap: the install request is
+     * un-latched first, so a user who cancelled the Play Store flow can start it again.
+     *
+     * @param handler the permission handler; defaults to the one passed to [create].
+     */
+    fun retryARCoreAvailability(handler: ARPermissionHandler? = permissionHandler) {
+        handler ?: return
+        installRequested = false
+        checkPermissionAndInstall(handler)
     }
 
     /**

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCore.kt
@@ -183,63 +183,76 @@ class ARCore(
     fun checkPermissionAndInstall(handler: ARPermissionHandler): Boolean {
         // Camera permission
         if (checkCameraPermission && !handler.hasCameraPermission()) {
-            if (!cameraPermissionRequested) {
-                cameraPermissionRequested = true
-                handler.requestCameraPermission { granted ->
-                    isCameraPermissionDenied = !granted
-                    if (!granted) {
-                        // `shouldShowPermissionRationale()` is historically inverted on this
-                        // interface: it answers `true` once the system stops asking.
-                        onCameraPermissionDenied?.invoke(handler.shouldShowPermissionRationale())
-                    }
-                    // On grant the dialog's dismissal resumes the activity, and `resume()`
-                    // creates the session through the branch below.
-                }
-            }
+            requestCameraPermissionOnce(handler)
             // Denied (or still being asked): hold the session back instead of letting
             // `Session()` throw `CameraNotAvailable` on the next resume.
-        } else {
-            isCameraPermissionDenied = false
-            try {
-                if (checkAvailability && !installRequested) {
-                    val availability = handler.checkARCoreAvailability()
-                    val unavailable = availability.toARCoreAvailability()
-                    if (unavailable == null) {
-                        publishAvailability(null)
-                        // Still `UNKNOWN_CHECKING`? ARCore has not answered yet: hold the
-                        // session back and let the next resume ask again, rather than
-                        // requesting an install for a device we have not classified.
-                        return availability == Availability.SUPPORTED_INSTALLED
-                    }
-                    publishAvailability(unavailable)
-                    // Only the install / update states have a Play Store flow to launch.
-                    // `UNSUPPORTED_DEVICE_NOT_CAPABLE` makes `requestInstall` throw, and a
-                    // failed check has nothing to install — both are surfaced, not retried
-                    // behind the user's back (#3374).
-                    if (unavailable == ARCoreAvailability.NotInstalled ||
-                        unavailable == ARCoreAvailability.NeedsUpdate
-                    ) {
-                        if (handler.requestARCoreInstall(!installRequested)) {
-                            installRequested = true
-                        } else {
-                            // ARCore reports it is installed after all.
-                            publishAvailability(null)
-                            return true
-                        }
-                    }
-                } else {
-                    // Availability checks disabled, or the user is coming back from the Play
-                    // Store install we requested: the session may start, so drop any card.
-                    publishAvailability(null)
-                    return true
-                }
-            } catch (e: Exception) {
-                // `requestInstall` throws `Unavailable*Exception` on a device it cannot serve.
-                // Classify it so the UI can explain, then still report it to the host.
-                publishAvailability(e.toARCoreAvailability())
-                onException(e)
-            }
+            return false
         }
+        isCameraPermissionDenied = false
+        return try {
+            checkARCoreInstall(handler)
+        } catch (e: Exception) {
+            // `requestInstall` throws `Unavailable*Exception` on a device it cannot serve.
+            // Classify it so the UI can explain, then still report it to the host.
+            publishAvailability(e.toARCoreAvailability())
+            onException(e)
+            false
+        }
+    }
+
+    /** Asks for the camera permission at most once per instance. */
+    private fun requestCameraPermissionOnce(handler: ARPermissionHandler) {
+        if (cameraPermissionRequested) return
+        cameraPermissionRequested = true
+        handler.requestCameraPermission { granted ->
+            isCameraPermissionDenied = !granted
+            if (!granted) {
+                // `shouldShowPermissionRationale()` is historically inverted on this
+                // interface: it answers `true` once the system stops asking.
+                onCameraPermissionDenied?.invoke(handler.shouldShowPermissionRationale())
+            }
+            // On grant the dialog's dismissal resumes the activity, and `resume()` creates
+            // the session through [checkARCoreInstall].
+        }
+    }
+
+    /**
+     * Asks ARCore whether it can serve this device and launches the install / update flow
+     * when there is one, publishing the verdict on the way (#3374).
+     *
+     * @return `true` when the session may be created now.
+     */
+    private fun checkARCoreInstall(handler: ARPermissionHandler): Boolean {
+        if (!checkAvailability || installRequested) {
+            // Availability checks disabled, or the user is coming back from the Play Store
+            // install we requested: the session may start, so drop any card.
+            publishAvailability(null)
+            return true
+        }
+        val availability = handler.checkARCoreAvailability()
+        val unavailable = availability.toARCoreAvailability()
+        if (unavailable == null) {
+            publishAvailability(null)
+            // Still `UNKNOWN_CHECKING`? ARCore has not answered yet: hold the session back
+            // and let the next resume ask again, rather than requesting an install for a
+            // device we have not classified.
+            return availability == Availability.SUPPORTED_INSTALLED
+        }
+        publishAvailability(unavailable)
+        // Only the install / update states have a Play Store flow to launch.
+        // `UNSUPPORTED_DEVICE_NOT_CAPABLE` makes `requestInstall` throw, and a failed check
+        // has nothing to install — both are surfaced, not retried behind the user's back.
+        if (unavailable != ARCoreAvailability.NotInstalled &&
+            unavailable != ARCoreAvailability.NeedsUpdate
+        ) {
+            return false
+        }
+        if (!handler.requestARCoreInstall(!installRequested)) {
+            // ARCore reports it is installed after all.
+            publishAvailability(null)
+            return true
+        }
+        installRequested = true
         return false
     }
 

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
@@ -79,6 +79,9 @@ enum class ARCoreAvailability {
  *   start, so it maps to `null` and the host's own "initializing" copy stays up.
  *
  * Every other value is terminal until the user acts, so each maps to a state.
+ *
+ * Deliberately has no `else` branch: a future `ArCoreApk.Availability` constant then breaks
+ * the build here instead of silently falling into a bucket nobody chose.
  */
 fun ArCoreApk.Availability.toARCoreAvailability(): ARCoreAvailability? = when (this) {
     ArCoreApk.Availability.SUPPORTED_INSTALLED -> null
@@ -88,9 +91,6 @@ fun ArCoreApk.Availability.toARCoreAvailability(): ARCoreAvailability? = when (t
     ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE -> ARCoreAvailability.Unsupported
     ArCoreApk.Availability.UNKNOWN_ERROR -> ARCoreAvailability.CheckFailed
     ArCoreApk.Availability.UNKNOWN_TIMED_OUT -> ARCoreAvailability.CheckFailed
-    // Defensive: a future ARCore enum constant is treated as "we could not tell", never as
-    // "supported" — an honest retryable card beats an infinite initializing spinner.
-    else -> ARCoreAvailability.CheckFailed
 }
 
 /**

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
@@ -56,6 +56,14 @@ enum class ARCoreAvailability {
      * Retryable.
      */
     CheckFailed,
+
+    /**
+     * ARCore reported itself installed and current, but creating the session still failed —
+     * the emulator case found while validating #3374: `ArCoreApk` answers
+     * `SUPPORTED_INSTALLED`, then `Session()` throws and the host hangs on its own
+     * "initializing" copy exactly as an unsupported device used to. Retryable.
+     */
+    SessionFailed,
 }
 
 /**
@@ -143,6 +151,7 @@ internal fun ARCoreAvailability.titleRes(): Int = when (this) {
     ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_not_installed_title
     ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_needs_update_title
     ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_check_failed_title
+    ARCoreAvailability.SessionFailed -> R.string.sceneview_arcore_session_failed_title
 }
 
 /** Body string resource for this state. */
@@ -151,6 +160,7 @@ internal fun ARCoreAvailability.bodyRes(): Int = when (this) {
     ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_not_installed_body
     ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_needs_update_body
     ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_check_failed_body
+    ARCoreAvailability.SessionFailed -> R.string.sceneview_arcore_session_failed_body
 }
 
 /** Action label string resource, or `null` when the state has no action. */
@@ -159,6 +169,7 @@ internal fun ARCoreAvailability.actionRes(): Int? = when (this) {
     ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_install
     ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_update
     ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_retry
+    ARCoreAvailability.SessionFailed -> R.string.sceneview_arcore_retry
 }
 
 /**

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARCoreAvailabilityOverlay.kt
@@ -1,0 +1,227 @@
+package io.github.sceneview.ar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ar.core.ArCoreApk
+import com.google.ar.core.exceptions.UnavailableApkTooOldException
+import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException
+import com.google.ar.core.exceptions.UnavailableDeviceNotCompatibleException
+import com.google.ar.core.exceptions.UnavailableSdkTooOldException
+import com.google.ar.core.exceptions.UnavailableUserDeclinedInstallationException
+
+/**
+ * Why AR cannot start on this device, as reported by [ArCoreApk.checkAvailability] (#3374).
+ *
+ * `null` — the absence of this enum — is the normal case: ARCore is installed and current,
+ * or the availability query is still running. Only a value that will *not* resolve on its
+ * own is modelled here, precisely so hosts can tell "still initializing" from "never going
+ * to initialize". Before #3374 they could not: an unsupported device produced no state at
+ * all, so every AR demo sat on "Initializing AR — look around to start tracking" forever.
+ */
+enum class ARCoreAvailability {
+    /** The device cannot run ARCore at all. Nothing the user does will change that. */
+    Unsupported,
+
+    /** ARCore is supported but Google Play Services for AR is not installed. */
+    NotInstalled,
+
+    /** Google Play Services for AR is installed but too old for this session. */
+    NeedsUpdate,
+
+    /**
+     * The availability query itself failed (no network, Play Store unreachable, timeout).
+     * Distinct from [Unsupported]: the device may well be capable, we just could not ask.
+     * Retryable.
+     */
+    CheckFailed,
+}
+
+/**
+ * Maps an [ArCoreApk.Availability] to the state the UI should show, or `null` when there is
+ * nothing to show.
+ *
+ * Pure and free of Android framework types on purpose — this is the single place the
+ * availability contract lives, and it is pinned by `ARCoreAvailabilityTest`.
+ *
+ * - [ArCoreApk.Availability.SUPPORTED_INSTALLED] — AR is good to go.
+ * - [ArCoreApk.Availability.UNKNOWN_CHECKING] — genuinely transient: ARCore is still asking
+ *   the Play Store and will report again. Showing a card here would flash on every cold
+ *   start, so it maps to `null` and the host's own "initializing" copy stays up.
+ *
+ * Every other value is terminal until the user acts, so each maps to a state.
+ */
+fun ArCoreApk.Availability.toARCoreAvailability(): ARCoreAvailability? = when (this) {
+    ArCoreApk.Availability.SUPPORTED_INSTALLED -> null
+    ArCoreApk.Availability.UNKNOWN_CHECKING -> null
+    ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED -> ARCoreAvailability.NotInstalled
+    ArCoreApk.Availability.SUPPORTED_APK_TOO_OLD -> ARCoreAvailability.NeedsUpdate
+    ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE -> ARCoreAvailability.Unsupported
+    ArCoreApk.Availability.UNKNOWN_ERROR -> ARCoreAvailability.CheckFailed
+    ArCoreApk.Availability.UNKNOWN_TIMED_OUT -> ARCoreAvailability.CheckFailed
+    // Defensive: a future ARCore enum constant is treated as "we could not tell", never as
+    // "supported" — an honest retryable card beats an infinite initializing spinner.
+    else -> ARCoreAvailability.CheckFailed
+}
+
+/**
+ * Classifies an exception thrown by the ARCore install / update request (#3374).
+ *
+ * `ArCoreApk.requestInstall` throws rather than returning on a device it cannot serve, and
+ * that exception used to be the only trace an unsupported device left: it was swallowed
+ * into `onArSessionFailed`, which no demo wires.
+ *
+ * Anything unrecognised becomes [ARCoreAvailability.CheckFailed] — retryable and honest —
+ * never `null`, because a `null` here would be another silent hang.
+ */
+fun Throwable.toARCoreAvailability(): ARCoreAvailability = when (this) {
+    // The device will never run ARCore.
+    is UnavailableDeviceNotCompatibleException -> ARCoreAvailability.Unsupported
+    // Google Play Services for AR is installed but older than this app needs.
+    is UnavailableApkTooOldException -> ARCoreAvailability.NeedsUpdate
+    is UnavailableArcoreNotInstalledException -> ARCoreAvailability.NotInstalled
+    // The user backed out of the Play Store flow: the install is still the way forward,
+    // so offer it again rather than pretending the check failed.
+    is UnavailableUserDeclinedInstallationException -> ARCoreAvailability.NotInstalled
+    // The *app* was built against an ARCore SDK too old for the installed services. The
+    // user cannot fix that, but neither is the device incapable — say the check failed.
+    is UnavailableSdkTooOldException -> ARCoreAvailability.CheckFailed
+    else -> ARCoreAvailability.CheckFailed
+}
+
+/**
+ * `true` when the state offers the user something to do — an install / update flow, or a
+ * retry. [ARCoreAvailability.Unsupported] is the one dead end: the card explains, and
+ * offers no button that would do nothing.
+ */
+val ARCoreAvailability.isActionable: Boolean
+    get() = this != ARCoreAvailability.Unsupported
+
+/**
+ * What [ARSceneView] knows about an ARCore installation that cannot start a session (#3374).
+ *
+ * @property availability why AR is unavailable.
+ * @property retry re-runs the availability check and, when [ARCoreAvailability.isActionable],
+ *   launches the Google Play Services for AR install / update flow.
+ */
+@Immutable
+class ARCoreAvailabilityState(
+    val availability: ARCoreAvailability,
+    val retry: () -> Unit,
+)
+
+/** Test tags for [ARCoreAvailabilityOverlay]. */
+object ARCoreAvailabilityOverlayTags {
+    const val CARD = "sceneview-arcore-availability"
+    const val ACTION = "sceneview-arcore-availability-action"
+}
+
+/** Title string resource for this state. */
+internal fun ARCoreAvailability.titleRes(): Int = when (this) {
+    ARCoreAvailability.Unsupported -> R.string.sceneview_arcore_unsupported_title
+    ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_not_installed_title
+    ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_needs_update_title
+    ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_check_failed_title
+}
+
+/** Body string resource for this state. */
+internal fun ARCoreAvailability.bodyRes(): Int = when (this) {
+    ARCoreAvailability.Unsupported -> R.string.sceneview_arcore_unsupported_body
+    ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_not_installed_body
+    ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_needs_update_body
+    ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_check_failed_body
+}
+
+/** Action label string resource, or `null` when the state has no action. */
+internal fun ARCoreAvailability.actionRes(): Int? = when (this) {
+    ARCoreAvailability.Unsupported -> null
+    ARCoreAvailability.NotInstalled -> R.string.sceneview_arcore_install
+    ARCoreAvailability.NeedsUpdate -> R.string.sceneview_arcore_update
+    ARCoreAvailability.CheckFailed -> R.string.sceneview_arcore_retry
+}
+
+/**
+ * The built-in explanation drawn by [ARSceneView] when ARCore cannot start a session: the
+ * same dark card as [ARCameraPermissionOverlay] — the ground is a camera frame, so it does
+ * not follow the app theme — with one action, or none when the device is simply not capable.
+ *
+ * Public so hosts that pass their own `arCoreAvailabilityOverlay` can still reuse it, and so
+ * previews can render every variant without an ARCore session.
+ */
+@Composable
+fun BoxScope.ARCoreAvailabilityOverlay(
+    state: ARCoreAvailabilityState,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .align(Alignment.Center)
+            .padding(24.dp)
+            .widthIn(max = 320.dp)
+            .background(OverlayCardBackground, RoundedCornerShape(16.dp))
+            .padding(20.dp)
+            .testTag(ARCoreAvailabilityOverlayTags.CARD),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        BasicText(
+            text = stringResource(state.availability.titleRes()),
+            style = TextStyle(
+                color = Color.White,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            ),
+        )
+        Spacer(Modifier.height(8.dp))
+        BasicText(
+            text = stringResource(state.availability.bodyRes()),
+            style = TextStyle(
+                color = Color.White.copy(alpha = 0.72f),
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center,
+            ),
+        )
+        state.availability.actionRes()?.let { actionRes ->
+            Spacer(Modifier.height(16.dp))
+            Box(
+                modifier = Modifier
+                    .background(Color.White, RoundedCornerShape(22.dp))
+                    .clickable(role = Role.Button) { state.retry() }
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .testTag(ARCoreAvailabilityOverlayTags.ACTION),
+            ) {
+                BasicText(
+                    text = stringResource(actionRes),
+                    style = TextStyle(
+                        color = Color(0xFF1A1A2E),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private val OverlayCardBackground = Color.Black.copy(alpha = 0.85f)

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -777,6 +777,28 @@ fun ARSceneView(
         ARCameraPermissionOverlay(it)
     },
     /**
+     * What to draw over the scene when ARCore cannot start a session on this device (#3374):
+     * the device is not capable, Google Play Services for AR is missing or too old, or the
+     * availability check failed. Receives an [ARCoreAvailabilityState] whose
+     * [ARCoreAvailabilityState.retry] launches the install / update flow, or re-runs the check.
+     *
+     * Without it, an unsupported device produces no visible state at all and the host's own
+     * "initializing" copy stays up forever. Defaults to the built-in
+     * [ARCoreAvailabilityOverlay]; pass `null` to draw nothing and handle
+     * [onARCoreAvailability] yourself.
+     */
+    arCoreAvailabilityOverlay: (@Composable BoxScope.(ARCoreAvailabilityState) -> Unit)? = {
+        ARCoreAvailabilityOverlay(it)
+    },
+    /**
+     * Called when the ARCore availability verdict changes (#3374). `null` means AR can start
+     * (or the check is still running); any other value is terminal until the user acts.
+     *
+     * Use it to replace your own "initializing" chrome with an explicit state — the built-in
+     * [arCoreAvailabilityOverlay] already explains the situation over the scene.
+     */
+    onARCoreAvailability: ((availability: ARCoreAvailability?) -> Unit)? = null,
+    /**
      * DSL block for declaring AR nodes via [ARSceneScope].
      */
     content: (@Composable ARSceneScope.() -> Unit)? = null
@@ -949,6 +971,9 @@ fun ARSceneView(
     // Camera permission denial (#3308): `null` while granted or not yet answered, otherwise
     // whether the system has stopped asking. Cleared when a session finally comes up.
     var cameraPermissionDenial by remember { mutableStateOf<Boolean?>(null) }
+    // ARCore availability (#3374): `null` while AR can start or the check is still running,
+    // otherwise why it cannot. Cleared when a session finally comes up.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     val arCore = remember {
         // Snapshotted at first composition. ARCore requires setPlaybackDataset() to be called
         // BEFORE the first resume(), so we capture the param value once when the session is
@@ -960,6 +985,7 @@ fun ARSceneView(
         ARCore(
             onSessionCreated = { session ->
                 cameraPermissionDenial = null
+                arCoreAvailability = null
                 cameraStream?.let { session.setCameraTextureNames(it.cameraTextureIds) }
                 // Bind the playback source first — ARCore mandates the dataset is set before
                 // resume(), and configure() happens here, then resume() runs immediately
@@ -1114,6 +1140,13 @@ fun ARSceneView(
     }
 
     arCore.onCameraPermissionDenied = { permanently -> cameraPermissionDenial = permanently }
+    // Reassigned on each composition like the denial callback above, so the host lambda is
+    // never stale. Both are set during composition, before the `DisposableEffect` below runs
+    // `arCore.create()` — the first verdict is therefore never missed (#3374).
+    arCore.onARCoreAvailability = { availability ->
+        arCoreAvailability = availability
+        onARCoreAvailability?.invoke(availability)
+    }
 
     DisposableEffect(lifecycle) {
         arCore.create(context, permissionHandler, sessionFeatures)
@@ -1564,6 +1597,19 @@ fun ARSceneView(
                 )
             }
             cameraPermissionOverlay(state)
+        }
+
+        // The camera permission card wins when both apply: granting the camera is the first
+        // step, and stacking two explanations over the scene helps nobody (#3374).
+        val availability = arCoreAvailability
+        if (denial == null && availability != null && arCoreAvailabilityOverlay != null) {
+            val state = remember(availability, permissionHandler) {
+                ARCoreAvailabilityState(
+                    availability = availability,
+                    retry = { arCore.retryARCoreAvailability(permissionHandler) },
+                )
+            }
+            arCoreAvailabilityOverlay(state)
         }
     }
 

--- a/arsceneview/src/main/res/values/strings.xml
+++ b/arsceneview/src/main/res/values/strings.xml
@@ -15,6 +15,19 @@
     <string name="sceneview_camera_permission_grant">Grant camera access</string>
     <string name="sceneview_camera_permission_settings">Open settings</string>
 
+    <!-- ARCoreAvailabilityOverlay (#3374) — ARCore cannot start a session on this device. -->
+    <string name="sceneview_arcore_unsupported_title">AR isn\'t available on this device</string>
+    <string name="sceneview_arcore_unsupported_body">This device doesn\'t support ARCore, so the camera experience can\'t start. The other demos still work.</string>
+    <string name="sceneview_arcore_not_installed_title">AR needs Google Play Services for AR</string>
+    <string name="sceneview_arcore_not_installed_body">Install Google Play Services for AR to run this demo.</string>
+    <string name="sceneview_arcore_install">Install</string>
+    <string name="sceneview_arcore_needs_update_title">Update Google Play Services for AR</string>
+    <string name="sceneview_arcore_needs_update_body">The installed version of Google Play Services for AR is too old for this demo.</string>
+    <string name="sceneview_arcore_update">Update</string>
+    <string name="sceneview_arcore_check_failed_title">Couldn\'t check AR support</string>
+    <string name="sceneview_arcore_check_failed_body">Checking Google Play Services for AR failed. Check your connection and try again.</string>
+    <string name="sceneview_arcore_retry">Try again</string>
+
     <!-- PlaneDiscoveryGuide (#2241) — plane-discovery onboarding overlay.
          Lost-tracking copy reuses the sceneview_*_message strings above. -->
     <string name="sceneview_plane_discovery_hint">Move your phone to find a surface</string>

--- a/arsceneview/src/main/res/values/strings.xml
+++ b/arsceneview/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="sceneview_arcore_update">Update</string>
     <string name="sceneview_arcore_check_failed_title">Couldn\'t check AR support</string>
     <string name="sceneview_arcore_check_failed_body">Checking Google Play Services for AR failed. Check your connection and try again.</string>
+    <string name="sceneview_arcore_session_failed_title">Couldn\'t start AR</string>
+    <string name="sceneview_arcore_session_failed_body">Google Play Services for AR is installed, but this device could not start an AR session.</string>
     <string name="sceneview_arcore_retry">Try again</string>
 
     <!-- PlaneDiscoveryGuide (#2241) — plane-discovery onboarding overlay.

--- a/arsceneview/src/test/java/io/github/sceneview/ar/ARCoreAvailabilityTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/ARCoreAvailabilityTest.kt
@@ -1,0 +1,317 @@
+package io.github.sceneview.ar
+
+import com.google.ar.core.ArCoreApk
+import com.google.ar.core.exceptions.UnavailableApkTooOldException
+import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException
+import com.google.ar.core.exceptions.UnavailableDeviceNotCompatibleException
+import com.google.ar.core.exceptions.UnavailableSdkTooOldException
+import com.google.ar.core.exceptions.UnavailableUserDeclinedInstallationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * JVM unit tests pinning the ARCore availability → UI state contract (#3374).
+ *
+ * The bug this guards against: on a device without ARCore every AR demo sat on
+ * "Initializing AR — look around to start tracking" forever, because nothing in the
+ * public API ever said *why* the session would not start. These tests pin the two pure
+ * mappings and the [ARCore] flow that publishes them, so a future refactor cannot
+ * silently go back to reporting nothing.
+ */
+class ARCoreAvailabilityTest {
+
+    /** Records what [ARCore] publishes, without any Android or Filament dependency. */
+    private class FakeHandler(
+        var availability: ArCoreApk.Availability = ArCoreApk.Availability.SUPPORTED_INSTALLED,
+        var installResult: Boolean = false,
+        var installThrows: Exception? = null,
+        var availabilityThrows: Exception? = null,
+        var cameraGranted: Boolean = true,
+    ) : ARPermissionHandler {
+
+        var checkAvailabilityCallCount = 0
+        var requestInstallCallCount = 0
+
+        override fun hasCameraPermission(): Boolean = cameraGranted
+
+        override fun requestCameraPermission(onResult: (granted: Boolean) -> Unit) {
+            onResult(cameraGranted)
+        }
+
+        override fun shouldShowPermissionRationale(): Boolean = false
+
+        override fun openAppSettings() = Unit
+
+        override fun checkARCoreAvailability(): ArCoreApk.Availability {
+            checkAvailabilityCallCount++
+            availabilityThrows?.let { throw it }
+            return availability
+        }
+
+        override fun requestARCoreInstall(userRequestedInstall: Boolean): Boolean {
+            requestInstallCallCount++
+            installThrows?.let { throw it }
+            return installResult
+        }
+    }
+
+    private lateinit var handler: FakeHandler
+    private lateinit var published: MutableList<ARCoreAvailability?>
+    private lateinit var failures: MutableList<Exception>
+    private lateinit var arCore: ARCore
+
+    @Before
+    fun setUp() {
+        handler = FakeHandler()
+        published = mutableListOf()
+        failures = mutableListOf()
+        arCore = ARCore(
+            onSessionCreated = {},
+            onSessionResumed = {},
+            onSessionPaused = {},
+            onArSessionFailed = { failures += it },
+            onSessionConfigChanged = { _, _ -> },
+        ).apply {
+            permissionHandler = handler
+            onARCoreAvailability = { published += it }
+        }
+    }
+
+    // ── Availability → state ────────────────────────────────────────────────
+
+    @Test
+    fun `installed and current maps to no state`() {
+        assertNull(ArCoreApk.Availability.SUPPORTED_INSTALLED.toARCoreAvailability())
+    }
+
+    @Test
+    fun `still checking maps to no state so the host keeps its initializing copy`() {
+        assertNull(ArCoreApk.Availability.UNKNOWN_CHECKING.toARCoreAvailability())
+    }
+
+    @Test
+    fun `not installed maps to NotInstalled`() {
+        assertEquals(
+            ARCoreAvailability.NotInstalled,
+            ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED.toARCoreAvailability()
+        )
+    }
+
+    @Test
+    fun `apk too old maps to NeedsUpdate`() {
+        assertEquals(
+            ARCoreAvailability.NeedsUpdate,
+            ArCoreApk.Availability.SUPPORTED_APK_TOO_OLD.toARCoreAvailability()
+        )
+    }
+
+    @Test
+    fun `device not capable maps to Unsupported`() {
+        assertEquals(
+            ARCoreAvailability.Unsupported,
+            ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE.toARCoreAvailability()
+        )
+    }
+
+    @Test
+    fun `unknown error and timeout map to CheckFailed`() {
+        assertEquals(
+            ARCoreAvailability.CheckFailed,
+            ArCoreApk.Availability.UNKNOWN_ERROR.toARCoreAvailability()
+        )
+        assertEquals(
+            ARCoreAvailability.CheckFailed,
+            ArCoreApk.Availability.UNKNOWN_TIMED_OUT.toARCoreAvailability()
+        )
+    }
+
+    @Test
+    fun `every availability constant is classified - none silently unhandled`() {
+        // The whole point of #3374: no ARCore verdict may leave the UI without an answer.
+        // A new ARCore constant must land somewhere, and never on "supported".
+        val transient = setOf(
+            ArCoreApk.Availability.SUPPORTED_INSTALLED,
+            ArCoreApk.Availability.UNKNOWN_CHECKING,
+        )
+        ArCoreApk.Availability.values().forEach { value ->
+            val state = value.toARCoreAvailability()
+            if (value in transient) {
+                assertNull("$value must not raise a card", state)
+            } else {
+                assertNotNull("$value must map to an explicit state", state)
+            }
+        }
+    }
+
+    // ── Exception → state ───────────────────────────────────────────────────
+
+    @Test
+    fun `install exceptions are classified`() {
+        assertEquals(
+            ARCoreAvailability.Unsupported,
+            UnavailableDeviceNotCompatibleException().toARCoreAvailability()
+        )
+        assertEquals(
+            ARCoreAvailability.NeedsUpdate,
+            UnavailableApkTooOldException().toARCoreAvailability()
+        )
+        assertEquals(
+            ARCoreAvailability.NotInstalled,
+            UnavailableArcoreNotInstalledException().toARCoreAvailability()
+        )
+        assertEquals(
+            ARCoreAvailability.NotInstalled,
+            UnavailableUserDeclinedInstallationException().toARCoreAvailability()
+        )
+        assertEquals(
+            ARCoreAvailability.CheckFailed,
+            UnavailableSdkTooOldException().toARCoreAvailability()
+        )
+    }
+
+    @Test
+    fun `an unrecognised exception is retryable, never silent`() {
+        assertEquals(
+            ARCoreAvailability.CheckFailed,
+            IllegalStateException("boom").toARCoreAvailability()
+        )
+    }
+
+    // ── Actionability ───────────────────────────────────────────────────────
+
+    @Test
+    fun `only an incapable device has no action`() {
+        assertFalse(ARCoreAvailability.Unsupported.isActionable)
+        assertTrue(ARCoreAvailability.NotInstalled.isActionable)
+        assertTrue(ARCoreAvailability.NeedsUpdate.isActionable)
+        assertTrue(ARCoreAvailability.CheckFailed.isActionable)
+        assertNull(ARCoreAvailability.Unsupported.actionRes())
+        listOf(
+            ARCoreAvailability.NotInstalled,
+            ARCoreAvailability.NeedsUpdate,
+            ARCoreAvailability.CheckFailed,
+        ).forEach { assertNotNull("$it needs a button", it.actionRes()) }
+    }
+
+    // ── ARCore flow ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `unsupported device publishes Unsupported and never requests an install`() {
+        handler.availability = ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE
+
+        assertFalse(arCore.checkPermissionAndInstall(handler))
+
+        assertEquals(listOf<ARCoreAvailability?>(ARCoreAvailability.Unsupported), published)
+        assertEquals(ARCoreAvailability.Unsupported, arCore.arCoreAvailability)
+        // The pre-#3374 crash path: `requestInstall` throws on a non-capable device.
+        assertEquals(0, handler.requestInstallCallCount)
+    }
+
+    @Test
+    fun `installed device publishes nothing and creates the session`() {
+        assertTrue(arCore.checkPermissionAndInstall(handler))
+
+        assertTrue(published.isEmpty())
+        assertNull(arCore.arCoreAvailability)
+    }
+
+    @Test
+    fun `still checking holds the session without raising a card`() {
+        handler.availability = ArCoreApk.Availability.UNKNOWN_CHECKING
+
+        assertFalse(arCore.checkPermissionAndInstall(handler))
+
+        assertTrue(published.isEmpty())
+        assertNull(arCore.arCoreAvailability)
+    }
+
+    @Test
+    fun `missing ARCore publishes NotInstalled and launches the install flow`() {
+        handler.availability = ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED
+        handler.installResult = true
+
+        assertFalse(arCore.checkPermissionAndInstall(handler))
+
+        assertEquals(listOf<ARCoreAvailability?>(ARCoreAvailability.NotInstalled), published)
+        assertEquals(1, handler.requestInstallCallCount)
+    }
+
+    @Test
+    fun `returning from the install clears the card`() {
+        handler.availability = ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED
+        handler.installResult = true
+        arCore.checkPermissionAndInstall(handler)
+
+        // Second pass: `installRequested` is latched, so the session may start.
+        assertTrue(arCore.checkPermissionAndInstall(handler))
+
+        assertEquals(listOf(ARCoreAvailability.NotInstalled, null), published)
+        assertNull(arCore.arCoreAvailability)
+    }
+
+    @Test
+    fun `a throwing install request is classified instead of vanishing into onArSessionFailed`() {
+        handler.availability = ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED
+        handler.installThrows = UnavailableDeviceNotCompatibleException()
+
+        assertFalse(arCore.checkPermissionAndInstall(handler))
+
+        assertEquals(
+            listOf(ARCoreAvailability.NotInstalled, ARCoreAvailability.Unsupported),
+            published
+        )
+        // The host callback still fires — this adds a state, it does not swallow the error.
+        assertEquals(1, failures.size)
+    }
+
+    @Test
+    fun `retry re-runs the check and can recover`() {
+        handler.availability = ArCoreApk.Availability.UNKNOWN_ERROR
+        arCore.checkPermissionAndInstall(handler)
+        assertEquals(ARCoreAvailability.CheckFailed, arCore.arCoreAvailability)
+
+        handler.availability = ArCoreApk.Availability.SUPPORTED_INSTALLED
+        arCore.retryARCoreAvailability(handler)
+
+        assertEquals(listOf(ARCoreAvailability.CheckFailed, null), published)
+        assertNull(arCore.arCoreAvailability)
+    }
+
+    @Test
+    fun `retry un-latches a cancelled install so the flow can start again`() {
+        handler.availability = ArCoreApk.Availability.SUPPORTED_NOT_INSTALLED
+        handler.installResult = true
+        arCore.checkPermissionAndInstall(handler)
+        assertEquals(1, handler.requestInstallCallCount)
+
+        arCore.retryARCoreAvailability(handler)
+
+        assertEquals(2, handler.requestInstallCallCount)
+    }
+
+    @Test
+    fun `the same verdict is published once, not on every resume`() {
+        handler.availability = ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE
+
+        repeat(3) { arCore.checkPermissionAndInstall(handler) }
+
+        assertEquals(listOf<ARCoreAvailability?>(ARCoreAvailability.Unsupported), published)
+        assertEquals(3, handler.checkAvailabilityCallCount)
+    }
+
+    @Test
+    fun `disabling the availability check keeps the legacy behaviour`() {
+        arCore.checkAvailability = false
+        handler.availability = ArCoreApk.Availability.UNSUPPORTED_DEVICE_NOT_CAPABLE
+
+        assertTrue(arCore.checkPermissionAndInstall(handler))
+
+        assertTrue(published.isEmpty())
+        assertEquals(0, handler.checkAvailabilityCallCount)
+    }
+}

--- a/arsceneview/src/test/java/io/github/sceneview/ar/ARCoreAvailabilityTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/ARCoreAvailabilityTest.kt
@@ -190,12 +190,19 @@ class ARCoreAvailabilityTest {
         assertTrue(ARCoreAvailability.NotInstalled.isActionable)
         assertTrue(ARCoreAvailability.NeedsUpdate.isActionable)
         assertTrue(ARCoreAvailability.CheckFailed.isActionable)
+        assertTrue(ARCoreAvailability.SessionFailed.isActionable)
         assertNull(ARCoreAvailability.Unsupported.actionRes())
-        listOf(
-            ARCoreAvailability.NotInstalled,
-            ARCoreAvailability.NeedsUpdate,
-            ARCoreAvailability.CheckFailed,
-        ).forEach { assertNotNull("$it needs a button", it.actionRes()) }
+        ARCoreAvailability.values()
+            .filter { it != ARCoreAvailability.Unsupported }
+            .forEach { assertNotNull("$it needs a button", it.actionRes()) }
+    }
+
+    @Test
+    fun `every state has copy - a new one cannot ship blank`() {
+        ARCoreAvailability.values().forEach { state ->
+            assertTrue("$state needs a title", state.titleRes() != 0)
+            assertTrue("$state needs a body", state.bodyRes() != 0)
+        }
     }
 
     // ── ARCore flow ─────────────────────────────────────────────────────────
@@ -302,6 +309,38 @@ class ARCoreAvailabilityTest {
 
         assertEquals(listOf<ARCoreAvailability?>(ARCoreAvailability.Unsupported), published)
         assertEquals(3, handler.checkAvailabilityCallCount)
+    }
+
+    // ── Session creation failed although ARCore said "installed" ────────────
+
+    @Test
+    fun `a session that fails to be created publishes SessionFailed and still reports`() {
+        // The emulator case: `ArCoreApk` answers SUPPORTED_INSTALLED, then `Session()`
+        // throws. Before this, the exception went to `onArSessionFailed` alone — which no
+        // demo wires — and the host stayed on "Initializing AR" forever, exactly as #3374.
+        assertTrue(arCore.checkPermissionAndInstall(handler))
+
+        arCore.onSessionCreateFailed(IllegalStateException("session_create_implementation"))
+
+        assertEquals(listOf<ARCoreAvailability?>(ARCoreAvailability.SessionFailed), published)
+        assertEquals(ARCoreAvailability.SessionFailed, arCore.arCoreAvailability)
+        assertEquals(1, failures.size)
+    }
+
+    @Test
+    fun `retrying a failed session recreates it instead of re-asking availability`() {
+        arCore.onSessionCreateFailed(IllegalStateException("boom"))
+        val checksBefore = handler.checkAvailabilityCallCount
+
+        arCore.retryARCoreAvailability(handler)
+
+        // A second availability check would answer SUPPORTED_INSTALLED again and clear the
+        // card without a session behind it — the hang, one loop later.
+        assertEquals(checksBefore, handler.checkAvailabilityCallCount)
+        assertEquals(0, handler.requestInstallCallCount)
+        // No context was ever passed to `createSession`, so the card stays up rather than
+        // being cleared by a retry that could not run.
+        assertEquals(ARCoreAvailability.SessionFailed, arCore.arCoreAvailability)
     }
 
     @Test

--- a/changelog.d/3374-ar-unsupported-state.md
+++ b/changelog.d/3374-ar-unsupported-state.md
@@ -1,0 +1,15 @@
+<!-- category: Fixed -->
+- **AR no longer hangs on "Initializing AR" on devices without ARCore ([#3374](https://github.com/sceneview/sceneview/issues/3374)).** `ARCore` compared
+  `ArCoreApk.checkAvailability()` only against `SUPPORTED_INSTALLED`, then asked for an
+  install on every other verdict — including `UNSUPPORTED_DEVICE_NOT_CAPABLE`, where
+  `requestInstall` throws. The exception was swallowed into `onArSessionFailed`, a
+  callback no demo wires, so the session never started and the app sat on its own
+  "initializing" copy forever. Availability is now a first-class state: the new
+  `ARCoreAvailability` enum (`Unsupported`, `NotInstalled`, `NeedsUpdate`, `CheckFailed`)
+  is published through `ARCore.onARCoreAvailability`, and `ARSceneView` draws a built-in
+  explanation card — overridable via `arCoreAvailabilityOverlay`, or observable via
+  `onARCoreAvailability` — with an Install / Update / Try again action, and none at all on
+  a device that simply cannot run AR. `retryARCoreAvailability()` un-latches a cancelled
+  Play Store flow so the action works twice. Behaviour on a working ARCore device is
+  unchanged: `SUPPORTED_INSTALLED` starts the session immediately and `UNKNOWN_CHECKING`
+  still waits silently.

--- a/changelog.d/3374-ar-unsupported-state.md
+++ b/changelog.d/3374-ar-unsupported-state.md
@@ -5,11 +5,16 @@
   `requestInstall` throws. The exception was swallowed into `onArSessionFailed`, a
   callback no demo wires, so the session never started and the app sat on its own
   "initializing" copy forever. Availability is now a first-class state: the new
-  `ARCoreAvailability` enum (`Unsupported`, `NotInstalled`, `NeedsUpdate`, `CheckFailed`)
-  is published through `ARCore.onARCoreAvailability`, and `ARSceneView` draws a built-in
+  `ARCoreAvailability` enum (`Unsupported`, `NotInstalled`, `NeedsUpdate`, `CheckFailed`,
+  `SessionFailed`) is published through `ARCore.onARCoreAvailability`, and `ARSceneView` draws a built-in
   explanation card — overridable via `arCoreAvailabilityOverlay`, or observable via
   `onARCoreAvailability` — with an Install / Update / Try again action, and none at all on
   a device that simply cannot run AR. `retryARCoreAvailability()` un-latches a cancelled
-  Play Store flow so the action works twice. Behaviour on a working ARCore device is
+  Play Store flow so the action works twice. `SUPPORTED_INSTALLED` is not a promise that
+  `Session()` will succeed — an emulator with Google Play Services for AR installed still
+  fails to create one — so a session that throws on creation now publishes
+  `SessionFailed` and offers a "Try again" that destroys and recreates the session
+  (`ARCore.retrySession()`), instead of leaving the same silent hang one step further
+  along. Behaviour on a working ARCore device is
   unchanged: `SUPPORTED_INSTALLED` starts the session immediately and `UNKNOWN_CHECKING`
   still waits silently.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
@@ -42,6 +42,7 @@ import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import dev.romainguy.kotlin.math.Float4
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.rememberARCameraStream
 import io.github.sceneview.demo.common.QaCameraBackdrop
@@ -391,6 +392,10 @@ fun OrbitalARDemo(onBack: () -> Unit) {
     // ride this anchor — turning the phone shows them passing by in world space.
     var userAnchor by remember { mutableStateOf<Anchor?>(null) }
     var isTracking by remember { mutableStateOf(false) }
+    // ARCore verdict (#3374): non-null once we know AR cannot start on this device. The
+    // SDK draws the explanation over the scene; the demo's own status pill must then stop
+    // claiming AR is initializing, because it never will.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
@@ -490,6 +495,9 @@ fun OrbitalARDemo(onBack: () -> Unit) {
     // has been dismissed (#2481), the pill is gone entirely — the orbit is
     // self-explanatory at that point and a permanent banner only clutters the AR view.
     val statusText = when {
+        // ARCore will never start here — the SDK overlay explains why, so drop the pill
+        // rather than stack a second, and now false, message on top of it (#3374).
+        arCoreAvailability != null -> null
         !isTracking -> "Initializing AR — look around to start tracking"
         userAnchor == null -> "Locking world anchor…"
         !onboardingDismissed -> "Turn around — ${ORBITAL_PLANETS.size} models orbiting"
@@ -545,6 +553,7 @@ fun OrbitalARDemo(onBack: () -> Unit) {
                 cameraStream = if (qaBackdrop) null else cameraStream,
                 playbackDataset = arPlaybackDataset,
                 planeRenderer = false,
+                onARCoreAvailability = { arCoreAvailability = it },
                 sessionConfiguration = { _: Session, config: Config ->
                     // Plane detection off — the formation lives in world space around the
                     // user, not on a plane. Disabling planes is cheaper and gives a cleaner


### PR DESCRIPTION
Fixes #3374

## The hang

`ARCore.checkPermissionAndInstall` compared `ArCoreApk.checkAvailability()` only against
`SUPPORTED_INSTALLED`. Every other verdict — `UNSUPPORTED_DEVICE_NOT_CAPABLE` included —
fell through to `requestARCoreInstall(true)`, which **throws** on a device ARCore cannot
serve. The exception was routed to `onArSessionFailed`, which `ARSceneView` fans out only
to the optional `onSessionFailed` / `onSessionFailure` callbacks. No demo wires those, so
the failure was invisible, `isTracking` never flipped, and each demo's own `!isTracking`
pill stayed up forever: "Initializing AR — look around to start tracking".

There was no availability state anywhere in the public API, so a host had no way to tell
"still initializing" from "never going to initialize".

**A second way into the same hang, found on the emulator during QA:** `SUPPORTED_INSTALLED`
is not a promise that `Session()` will succeed. An AVD with Google Play Services for AR
1.54 installed answers `SUPPORTED_INSTALLED`, then session construction throws
(`ARCoreError: session_create_implementation.cc`) — and that exception took the exact same
swallowed path, producing an identical infinite "Initializing AR" one step further along.
Fixing only the availability verdict would have left that half of the bug in place.

## The state that was added

Mirrors the #3308 camera-permission pattern, at the SDK level, so all 28 AR demos and
every SDK consumer are fixed by one change rather than 28 edits.

- **`ARCoreAvailability`** — `Unsupported`, `NotInstalled`, `NeedsUpdate`, `CheckFailed`,
  `SessionFailed`. `null` (the absence of the enum) is the normal case: AR is fine, or the
  check is still running. Only verdicts that will *not* resolve on their own are modelled.
- **Two pure mappings**, `ArCoreApk.Availability.toARCoreAvailability()` and
  `Throwable.toARCoreAvailability()`. `UNKNOWN_CHECKING` deliberately maps to `null` so no
  card flashes on cold start; anything unrecognised (a future ARCore constant, an unknown
  exception) maps to the retryable `CheckFailed` — an honest card beats a silent hang.
- **`ARCore.onARCoreAvailability`** publishes the verdict on change (deduplicated, so a
  resume loop does not re-fire), exposes `arCoreAvailability`, and only launches the Play
  Store flow for the two states that actually have one. `retryARCoreAvailability()`
  un-latches `installRequested` so a cancelled install can be started again.
- **`SessionFailed`** is published from `createSession`'s catch, and its "Try again" routes
  to `ARCore.retrySession()`, which destroys and recreates the session rather than
  re-running the availability check — the check would answer "installed" again and clear
  the card with no session behind it.
- **`ARSceneView`** renders a built-in `ARCoreAvailabilityOverlay` — same dark card as
  `ARCameraPermissionOverlay`, since the ground is a camera frame and does not follow the
  app theme — with one action (Install / Update / Try again), or **no action at all** when
  the device is simply not capable: a button that would do nothing is worse than a plain
  explanation. Overridable via `arCoreAvailabilityOverlay = null` or a custom composable,
  and observable via a new `onARCoreAvailability` parameter.
- **`OrbitalARDemo`** consumes it: its "Initializing AR" pill is suppressed once a verdict
  arrives, so the card is the only thing on screen. The other AR demos get the SDK card for
  free; their own pills are untouched and read as ordinary tracking copy behind it.

Behaviour on a real ARCore device is unchanged by construction: `SUPPORTED_INSTALLED`
returns `true` immediately, `UNKNOWN_CHECKING` still holds the session silently, the
install/update flow still launches and clears its card on the way back, and a session that
is created successfully never publishes anything.

## Tests

`arsceneview/src/test/java/io/github/sceneview/ar/ARCoreAvailabilityTest.kt` — 20 JVM
tests, `./gradlew :arsceneview:testDebugUnitTest` green:

- every `ArCoreApk.Availability` constant pinned to its state, plus a loop asserting no
  constant is left unclassified and none but the two transient ones maps to `null`;
- each `Unavailable*Exception` pinned, and an unknown throwable landing on `CheckFailed`;
- `Unsupported` publishes its verdict and **never** calls `requestARCoreInstall` — the
  call that used to throw;
- a throwing install request is classified *and* still reported to `onArSessionFailed`;
- a session that fails to be created publishes `SessionFailed` and still reports the
  exception; retrying it recreates the session without re-asking availability;
- every enum constant has a title and a body, and every actionable one has a button — a
  new state cannot ship blank;
- retry recovers, retry re-launches a cancelled install, the same verdict is published
  once, and `checkAvailability = false` keeps the legacy path byte-for-byte.

## Verified

QA on emulator-5554 (`io.github.sceneview.demo/.MainActivity` confirmed via
`dumpsys activity activities` before the tap and after each capture):

- **Light** (`cmd uimode night no`) — the AR demo now shows the card: "Couldn't start AR /
  Google Play Services for AR is installed, but this device could not start an AR session.
  / Try again". Before this PR the same screen sat on "Initializing AR" indefinitely.
- **Dark** (`cmd uimode night yes`) — pixel-identical to light, by design: the overlay sits
  over a camera frame and is deliberately theme-independent, the same rule as
  `ARCameraPermissionOverlay`. `night no` restored afterwards.
- **"Try again"** — tapped: no crash, activity unchanged, the retry re-failed on this AVD
  and the card correctly stayed up rather than clearing into an empty scene.

Two honest caveats about this emulator run:

- **emulator-5554 is not the "no ARCore" case.** It has Google Play Services for AR
  1.54.260890493 installed, so `Unsupported` cannot be reproduced there; what it
  reproduces is the session-creation failure above. `Unsupported` stays covered by the JVM
  tests and by the `needs-device` pass below.
- The AVD logs `W ARCore-ContextUtils: The API key … could not be obtained!` before the
  failure. This worktree has no `local.properties`, so `${arcoreApiKey}` resolves empty —
  that may itself be what makes session creation fail here. It does not change the fix:
  whatever the cause, a session that cannot be created must say so instead of hanging.

## needs-device

These paths cannot be exercised on the emulator and need the Pixel 9 pass:

- `UNSUPPORTED_DEVICE_NOT_CAPABLE` → the no-action "AR isn't available on this device" card
  (needs a device without ARCore support);
- `SUPPORTED_NOT_INSTALLED` → Install card → Play Store flow → card clears on return;
- `SUPPORTED_APK_TOO_OLD` → Update card (needs a downgraded Google Play Services for AR);
- a healthy ARCore device: no card, AR starts as before — the non-regression that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
