### PR TITLE
fix(ar): stop the camera stream painting garbage before its first frame

### DIFF
--- a/arsceneview/src/androidTest/java/io/github/sceneview/ar/camera/ARCameraStreamTest.kt
+++ b/arsceneview/src/androidTest/java/io/github/sceneview/ar/camera/ARCameraStreamTest.kt
@@ -82,6 +82,23 @@ class ARCameraStreamTest {
     }
 
     /**
+     * #3373: the camera quad joins the Filament scene as soon as the stream is created, long
+     * before ARCore delivers a frame. In that window its external OES texture has no image
+     * attached and its UV buffer holds only the seeded identity UVs, so drawing it paints
+     * driver-defined garbage over the app's own UI — on the emulator, a coloured band across
+     * the "AR couldn't start" fallback. The renderable must therefore start hidden.
+     *
+     * Asserted through [ARCameraStream.hasCameraFrame] rather than the layer mask itself:
+     * Filament's Java `RenderableManager` exposes `setLayerMask` but no reader.
+     */
+    @Test
+    fun cameraQuad_isHiddenUntilTheFirstFrame() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            assertEquals(false, cameraStream.hasCameraFrame)
+        }
+    }
+
+    /**
      * The placeholder is 1×1 by design — a zero RG8 texel decodes to `depth_mm == 0`, which
      * the material treats as "no depth available" — but it must not survive the first depth
      * frame. This is the exact pre-fix state, pinned so a regression is unambiguous.

--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
@@ -520,6 +520,14 @@ open class ARCameraStream(
             CAMERA_UVS.size / VERTEX_COUNT * FLOAT_SIZE_IN_BYTES
         ).build(engine).apply {
             setBufferAt(engine, POSITION_BUFFER_INDEX, FloatBuffer.wrap(CAMERA_VERTICES))
+            // Seed identity UVs at build time (#3373). `update()` overwrites these with the
+            // ARCore display-transformed UVs on the first frame, but until that frame lands
+            // buffer 1 would otherwise be unset, and Filament draws the quad every frame from
+            // the moment the entity joins the scene — with undefined attribute data. On the
+            // emulator (no ARCore, so `update()` never runs) that painted a garbage band across
+            // the "AR couldn't start" fallback. Note: `CAMERA_UVS` directly, not `uvCoordinates`
+            // — that property is declared below and is still null inside this initializer.
+            setBufferAt(engine, UV_BUFFER_INDEX, FloatBuffer.wrap(CAMERA_UVS))
         }
 
     private val uvCoordinates: FloatBuffer =
@@ -562,7 +570,23 @@ open class ARCameraStream(
                 indexBuffer)
             .material(0, standardMaterial.defaultInstance)
             .build(engine, entity)
+
+        // Hidden until the first ARCore frame (#3373). The external OES textures created above
+        // have no image attached until ARCore writes into them, so sampling them is
+        // driver-defined — on the emulator's host-GL translation it returns a constant colour.
+        // Drawing the quad in that state paints an arbitrary background over the app's own
+        // fallback UI. Stay invisible until `update()` has bound a real camera texture.
+        setLayerVisible(false)
     }
+
+    /**
+     * Whether ARCore has delivered at least one camera frame, i.e. whether the quad is bound to
+     * a real camera texture and real display-transformed UVs (#3373).
+     *
+     * The renderable is kept out of the render pass until this flips true — see [update].
+     */
+    var hasCameraFrame: Boolean = false
+        private set
 
     fun update(session: Session, frame: Frame) {
         // Hot-path audit (#3157): this JNI read is the floor for this surface, not an oversight.
@@ -593,6 +617,13 @@ open class ARCameraStream(
                 transformedUvCoordinates.put(i, 1.0f - transformedUvCoordinates[i])
             }
             vertexBuffer.setBufferAt(engine, UV_BUFFER_INDEX, transformedUvCoordinates)
+        }
+
+        // Both the real camera texture and the real UVs are now bound, so the quad is safe to
+        // draw. Reveal it once (#3373).
+        if (!hasCameraFrame) {
+            hasCameraFrame = true
+            setLayerVisible(true)
         }
 
         // The depth texture feeds both the depth-occlusion material AND the people-occlusion

--- a/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt
@@ -584,8 +584,12 @@ open class ARCameraStream(
      * a real camera texture and real display-transformed UVs (#3373).
      *
      * The renderable is kept out of the render pass until this flips true — see [update].
+     *
+     * Internal: this is an implementation detail of the visibility gating, not a supported signal
+     * for consumers. It is readable from the module's own instrumentation tests because Filament's
+     * Java `RenderableManager` exposes `setLayerMask` but no reader for it.
      */
-    var hasCameraFrame: Boolean = false
+    internal var hasCameraFrame: Boolean = false
         private set
 
     fun update(session: Session, frame: Frame) {

--- a/changelog.d/3373-ar-fallback-teal-band.md
+++ b/changelog.d/3373-ar-fallback-teal-band.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+Fixed a coloured band painted across AR fallback screens when ARCore never delivers a camera
+frame (#3373). The camera-stream quad was drawn from the moment it joined the scene, sampling an
+external texture that had no image attached and reading an unset UV buffer. It now seeds identity
+UVs at build time and stays hidden until the first ARCore frame binds a real texture. The demo
+app's camera-init scrim also keeps its opaque backdrop after its defensive timeout, dropping only
+the spinner, so the "AR couldn't start" fallback always has a deliberate background.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -164,10 +164,13 @@ fun ErrorScrim(
  *
  * Defensive timeout (#2484): if the first frame never arrives — a device that fails
  * to open the camera, a session that errors before delivering a frame — the scrim
- * would otherwise cover the viewport forever. After [timeoutMillis] it dismisses
- * itself regardless, so the demo's own fallback / error messaging is never
- * permanently hidden. The happy path (first frame in ~1–3 s) flips [initializing]
- * false long before the timeout, so this only ever fires on a genuinely stuck start.
+ * would otherwise cover the viewport forever. After [timeoutMillis] the **spinner card**
+ * dismisses itself regardless, so the demo's own fallback / error messaging is never
+ * permanently hidden behind a progress indicator that is lying. The black backdrop stays
+ * (#3373) — an AR viewport that never received a frame is not black, and uncovering it
+ * painted a parasitic band across the fallback screen. See [arCameraInitScrimVisibility].
+ * The happy path (first frame in ~1–3 s) flips [initializing] false long before the
+ * timeout, so this only ever fires on a genuinely stuck start.
  */
 @Composable
 fun ARCameraInitScrim(
@@ -192,13 +195,19 @@ fun ARCameraInitScrim(
             timedOut = true
         }
     }
-    if (!initializing || timedOut) return
+    val visibility = arCameraInitScrimVisibility(
+        initializing = initializing,
+        timedOut = timedOut,
+        qaBackdropEnabled = io.github.sceneview.demo.common.qaCameraBackdropEnabled(),
+    )
+    if (visibility == ArCameraInitScrimVisibility.Hidden) return
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.Black),
         contentAlignment = Alignment.Center,
     ) {
+        if (visibility == ArCameraInitScrimVisibility.BackdropOnly) return@Box
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -220,6 +229,43 @@ fun ARCameraInitScrim(
             )
         }
     }
+}
+
+/** What [ARCameraInitScrim] should draw for a given session state (#2484, #3373). */
+internal enum class ArCameraInitScrimVisibility {
+    /** Nothing — the camera feed is live, or the QA backdrop owns the viewport. */
+    Hidden,
+
+    /** The opaque black backdrop only — the session is stuck, but the viewport must stay covered. */
+    BackdropOnly,
+
+    /** The black backdrop plus the spinner card — a normal, still-progressing camera start. */
+    BackdropAndSpinner,
+}
+
+/**
+ * Decides what [ARCameraInitScrim] draws. Pure so it can be unit-tested JVM-side.
+ *
+ * The defensive timeout (#2484) used to dismiss the whole scrim, backdrop included. That was the
+ * wrong half to drop (#3373): when ARCore never starts, the AR viewport behind the scrim is not
+ * black — it is whatever the uninitialised camera-stream quad happens to sample — so uncovering
+ * it painted a parasitic band across the demo's own "AR couldn't start" fallback. The timeout
+ * exists so the *spinner* stops lying about progress; the backdrop is what guarantees the
+ * fallback screen has a deliberate background. So after the timeout we keep the backdrop and
+ * drop only the spinner.
+ *
+ * The one case that still dismisses completely is the QA camera backdrop (#3308): there a
+ * synthetic room photo is deliberately rendered behind the viewport and must be visible.
+ */
+internal fun arCameraInitScrimVisibility(
+    initializing: Boolean,
+    timedOut: Boolean,
+    qaBackdropEnabled: Boolean,
+): ArCameraInitScrimVisibility = when {
+    !initializing -> ArCameraInitScrimVisibility.Hidden
+    !timedOut -> ArCameraInitScrimVisibility.BackdropAndSpinner
+    qaBackdropEnabled -> ArCameraInitScrimVisibility.Hidden
+    else -> ArCameraInitScrimVisibility.BackdropOnly
 }
 
 /**

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ArCameraInitScrimVisibilityTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ArCameraInitScrimVisibilityTest.kt
@@ -1,0 +1,90 @@
+package io.github.sceneview.demo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [arCameraInitScrimVisibility] — the scrim decision behind `ARCameraInitScrim`
+ * (#2484, #3373).
+ */
+class ArCameraInitScrimVisibilityTest {
+
+    @Test
+    fun `camera ready hides the scrim entirely`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = false,
+                timedOut = false,
+                qaBackdropEnabled = false,
+            )
+        )
+    }
+
+    @Test
+    fun `camera ready hides the scrim even if the timeout already fired`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = false,
+                timedOut = true,
+                qaBackdropEnabled = false,
+            )
+        )
+    }
+
+    @Test
+    fun `still starting shows backdrop and spinner`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.BackdropAndSpinner,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = false,
+                qaBackdropEnabled = false,
+            )
+        )
+    }
+
+    /**
+     * #3373: after the defensive timeout the spinner must stop, but the backdrop must not —
+     * otherwise the never-initialised AR viewport shows through the "AR couldn't start"
+     * fallback as a parasitic coloured band.
+     */
+    @Test
+    fun `timed out keeps the backdrop and drops the spinner`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.BackdropOnly,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = true,
+                qaBackdropEnabled = false,
+            )
+        )
+    }
+
+    /** #3308: the QA room-photo backdrop is deliberate content and must stay visible. */
+    @Test
+    fun `timed out with the QA backdrop dismisses completely`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = true,
+                qaBackdropEnabled = true,
+            )
+        )
+    }
+
+    /** The QA backdrop must not short-circuit the normal, still-progressing start. */
+    @Test
+    fun `QA backdrop before the timeout still shows the spinner`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.BackdropAndSpinner,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = false,
+                qaBackdropEnabled = true,
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes #3373

## Root cause

`ARCameraStream` builds its full-screen quad in `init`, and `ARSceneView` adds the entity to the
Filament scene on attach — so Filament draws it every frame from that moment on, including *before*
ARCore's first frame, and forever when ARCore never starts at all (emulator, unsupported device,
session error).

In that window the quad drew with two undefined inputs:

1. Its external OES sampler pointed at a texture created with `glGenTextures` + bind but **no image
   attached** — ARCore only attaches one when it writes a frame. Sampling it is driver-defined; the
   emulator's host-GL translation returns a constant colour.
2. `UV_BUFFER_INDEX` was never filled. Only `update()` wrote it, from the ARCore display transform.
   An unset `VertexBuffer` index yields undefined attribute data at draw time — which is why the
   artefact read as a *band* across part of the screen rather than a full-screen wash.

The demo app's `ARCameraInitScrim` hid this for the first 8 s, but its defensive timeout (#2484)
then dismissed the **whole** scrim — backdrop included — uncovering the garbage behind the
"AR couldn't start" coaching line.

## Fix

`arsceneview` — the real fix, benefiting every consumer, not just the demo:

- Seed identity UVs into buffer 1 at build time, so the quad never draws from an unset buffer.
- Keep the renderable out of the render pass (`setLayerVisible(false)`) until `update()` has bound a
  real camera texture and real display-transformed UVs; a new `hasCameraFrame` flag flips it visible
  exactly once, on the first frame.

`samples/android-demo` — defence in depth, shared by ~18 AR demos:

- The scrim's defensive timeout now drops only the **spinner card**; the opaque black backdrop
  stays, so the fallback UI always has a deliberate background. The QA room-photo backdrop (#3308)
  still dismisses completely, since that backdrop is deliberate content.
- The decision is extracted to a pure `arCameraInitScrimVisibility(...)` function so it is unit
  testable.

## Tests

- `samples/android-demo/src/test/.../ArCameraInitScrimVisibilityTest.kt` — 6 JVM tests covering
  camera-ready, still-starting, the #3373 timed-out case, and both #3308 QA-backdrop cases. Green.
- `arsceneview/src/androidTest/.../ARCameraStreamTest.kt` — new `cameraQuad_isHiddenUntilTheFirstFrame`.
  Asserted through `hasCameraFrame` because Filament's Java `RenderableManager` exposes
  `setLayerMask` but no reader.

## Validation

emulator-5554 (no ARCore, #2754), `sceneview://demo/ar-placement`, captured 14 s after launch — past
the 8 s scrim timeout — with `topResumedActivity` confirmed before and after each capture.

| | Result |
|---|---|
| Before (parent commit) | Teal band across the middle of the fallback screen |
| After, light | Fully black viewport, no band |
| After, dark | Fully black viewport, no band |

The banner, the "Tap to Place / Offline" chip and the Model/Soldier FAB all render correctly in
both modes. Night mode restored to `no` afterwards.

## needs-device

The emulator can only prove the *hidden* half of the contract, since it never delivers an ARCore
frame. The reveal path — that the quad becomes visible on the first real frame and the camera feed
still renders normally, with no added black flash at session start — needs a real ARCore device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
