### PR TITLE
Gate SELF_HOSTED_MACOS_ONLINE on free disk space

### DIFF
--- a/.claude/scripts/runner-heartbeat.sh
+++ b/.claude/scripts/runner-heartbeat.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Self-hosted runner heartbeat — pings GitHub every 5 min to confirm this Mac
+# is up, has room to work, AND that the actions/runner service is online.
+# Updates two repo variables:
+#
+#   SELF_HOSTED_MACOS_LAST_SEEN — ISO 8601 UTC timestamp, refreshed while usable
+#   SELF_HOSTED_MACOS_ONLINE    — "true" while runner.status == "online"
+#                                 AND free disk >= RUNNER_MIN_FREE_DISK_GB
+#
+# Workflows pick the runner via a one-line expression in `runs-on`. It is NOT
+# reproduced here: it also carries a fork-PR clause, and a copy in a comment is
+# a copy that drifts. Take it verbatim from the `self-hosted-runner` skill, or
+# from `.github/workflows/bridge-ios-compile.yml`, which holds the rationale.
+#
+# When this Mac is asleep / off the heartbeat stops; freshness of LAST_SEEN
+# acts as the safety net (a stale ONLINE=true is overridden by an aged
+# LAST_SEEN — see _pick-macos-runner.yml if you need timestamp arithmetic in a
+# pre-job).
+#
+# WHY THE DISK GATE (#2816)
+#   The promise of this pilot is transparent fallback when the Mac cannot take
+#   a job. Asleep, off and runner-process-dead were covered; "disk full" was
+#   not. On PR #2766 a Flutter iOS job routed here with ~4.6 GiB free, the
+#   2.1 GiB SDK download plus extraction hit ENOSPC, and the job died at
+#   exit 50 with a *truncated* Flutter.xcframework left in the runner tool
+#   cache — a poisoned cache that would have silently corrupted every later
+#   self-hosted Flutter job. A resource-starved host must produce a fallback,
+#   never a red that reads like a code failure.
+#
+#   Default threshold: 15 GiB. It is the sum of the two knowns, not a round
+#   number picked for looks — a Flutter setup alone peaks near 4.5 GiB, and the
+#   host's 6 GiB local-build gate must stay clear so an interactive session is
+#   never starved by CI; the remainder is headroom for Xcode/Gradle scratch.
+#   Override per host with RUNNER_MIN_FREE_DISK_GB.
+#
+#   The gate runs BEFORE the GitHub API probe: below threshold there is nothing
+#   the runner's status could say that would make this host usable.
+#
+# Installed by .claude/scripts/setup-self-hosted-runner.sh as a launchd job.
+
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-sceneview/sceneview}"
+RUNNER_NAME="${RUNNER_NAME:-sceneview-mac-$(hostname -s)}"
+MIN_FREE_DISK_GB="${RUNNER_MIN_FREE_DISK_GB:-15}"
+DISK_MOUNT="${RUNNER_DISK_MOUNT:-/}"
+NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[heartbeat] gh CLI not on PATH — skipping" >&2
+  exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "[heartbeat] gh not authenticated — skipping" >&2
+  exit 0
+fi
+
+mark_offline() {
+  gh variable set SELF_HOSTED_MACOS_ONLINE --repo "${REPO}" --body "false" >/dev/null
+}
+
+# Free space on the runner volume, in MiB (integer). `df -k` is POSIX and gives
+# enough resolution to report a sane decimal; `df -g` truncates to whole GiB.
+free_mib() {
+  df -k "${DISK_MOUNT}" 2>/dev/null | awk 'NR==2 { print int($4 / 1024); exit }'
+}
+
+FREE_MIB="$(free_mib || echo "")"
+
+if [[ -z "${FREE_MIB}" ]]; then
+  # Unreadable df is treated as unusable: the whole point of the gate is that a
+  # host we cannot vouch for must not take a job.
+  mark_offline
+  echo "[heartbeat] ${NOW} — could not read free disk on ${DISK_MOUNT}, marked OFFLINE"
+  exit 0
+fi
+
+FREE_GB_LABEL="$(awk -v m="${FREE_MIB}" 'BEGIN { printf "%.1f", m / 1024 }')"
+MIN_MIB=$(( MIN_FREE_DISK_GB * 1024 ))
+
+if (( FREE_MIB < MIN_MIB )); then
+  mark_offline
+  echo "[heartbeat] ${NOW} — free disk ${FREE_GB_LABEL} GiB on ${DISK_MOUNT} < ${MIN_FREE_DISK_GB} GiB minimum, marked OFFLINE (jobs fall back to macos-15; raise with RUNNER_MIN_FREE_DISK_GB or free space)"
+  exit 0
+fi
+
+# Probe runner liveness. If the actions/runner service is dead the heartbeat
+# refuses to mark ONLINE=true — workflows fall back to macos-15.
+STATUS="$(gh api "/repos/${REPO}/actions/runners" \
+  --jq ".runners[] | select(.name==\"${RUNNER_NAME}\") | .status" \
+  2>/dev/null || echo "")"
+
+if [[ "${STATUS}" == "online" ]]; then
+  gh variable set SELF_HOSTED_MACOS_ONLINE    --repo "${REPO}" --body "true"  >/dev/null
+  gh variable set SELF_HOSTED_MACOS_LAST_SEEN --repo "${REPO}" --body "${NOW}" >/dev/null
+  echo "[heartbeat] ${NOW} — online (runner=${RUNNER_NAME}, free=${FREE_GB_LABEL} GiB)"
+else
+  mark_offline
+  echo "[heartbeat] ${NOW} — runner status='${STATUS:-unknown}', marked OFFLINE"
+fi

--- a/.claude/scripts/setup-self-hosted-runner.sh
+++ b/.claude/scripts/setup-self-hosted-runner.sh
@@ -84,6 +84,13 @@ HEARTBEAT_LABEL="io.github.sceneview.runner-heartbeat"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HEARTBEAT_SCRIPT="${SCRIPT_DIR}/runner-heartbeat.sh"
 
+# Disk gate (#2816): the heartbeat refuses to mark the runner online below this
+# many free GiB on DISK_MOUNT, so a near-full host produces a transparent
+# fallback to macos-15 instead of an ENOSPC red mid-job. 15 GiB = a Flutter
+# setup's ~4.5 GiB peak + the host's 6 GiB local-build gate + scratch headroom.
+MIN_FREE_DISK_GB="${RUNNER_MIN_FREE_DISK_GB:-15}"
+DISK_MOUNT="${RUNNER_DISK_MOUNT:-/}"
+
 UID_NUM="$(id -u)"
 GUI_DOMAIN="gui/${UID_NUM}"
 
@@ -122,6 +129,21 @@ if [[ "${ACTION}" == "--check" ]]; then
   log ""
   log "Heartbeat LaunchAgent: ${HEARTBEAT_PLIST}"
   print_service_status "${HEARTBEAT_LABEL}"
+
+  log ""
+  log "Free disk (heartbeat gate, #2816):"
+  free_mib_check="$(df -k "${DISK_MOUNT}" 2>/dev/null | awk 'NR==2 { print int($4 / 1024); exit }')"
+  if [[ -n "${free_mib_check}" ]]; then
+    free_gb_check="$(awk -v m="${free_mib_check}" 'BEGIN { printf "%.1f", m / 1024 }')"
+    log "  ${DISK_MOUNT}: ${free_gb_check} GiB free (minimum ${MIN_FREE_DISK_GB} GiB)"
+    if (( free_mib_check < MIN_FREE_DISK_GB * 1024 )); then
+      log "  verdict:     BELOW threshold — heartbeat marks ONLINE=false, jobs use macos-15"
+    else
+      log "  verdict:     ok"
+    fi
+  else
+    log "  ${DISK_MOUNT}: unreadable — heartbeat marks ONLINE=false"
+  fi
 
   if [[ -f /tmp/sceneview-runner-heartbeat.log ]]; then
     log ""
@@ -313,6 +335,8 @@ cat > "${HEARTBEAT_PLIST}" <<PLIST
     <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>GITHUB_REPO</key><string>${REPO}</string>
     <key>RUNNER_NAME</key><string>${RUNNER_NAME}</string>
+    <key>RUNNER_MIN_FREE_DISK_GB</key><string>${MIN_FREE_DISK_GB}</string>
+    <key>RUNNER_DISK_MOUNT</key><string>${DISK_MOUNT}</string>
     <key>HOME</key><string>${HOME}</string>
   </dict>
   <key>StandardOutPath</key><string>/tmp/sceneview-runner-heartbeat.log</string>
@@ -332,5 +356,6 @@ log "  Runner name:  ${RUNNER_NAME}"
 log "  Label:        ${RUNNER_LABEL}"
 log "  LaunchAgent:  ${RUNNER_PLIST_LABEL} (KeepAlive, auto-restart on exit/update)"
 log "  Heartbeat:    every 300s -> /tmp/sceneview-runner-heartbeat.log"
+log "  Disk gate:    ONLINE only while ${DISK_MOUNT} has >= ${MIN_FREE_DISK_GB} GiB free (#2816)"
 log ""
 log "Verify with: bash $(basename "$0") --check"

--- a/changelog.d/2816-heartbeat-disk-gate.md
+++ b/changelog.d/2816-heartbeat-disk-gate.md
@@ -1,0 +1,19 @@
+<!-- category: Fixed -->
+- **The self-hosted macOS runner now falls back to `macos-15` when the host is nearly full
+  ([#2816](https://github.com/sceneview/sceneview/issues/2816)).** The runner heartbeat marked
+  the Mac `SELF_HOSTED_MACOS_ONLINE=true` on runner liveness alone, so a job could route to a
+  host with ~4.6 GiB free: a Flutter iOS type-check then died at `No space left on device` and
+  left a *truncated* `Flutter.xcframework` in the runner tool cache, poisoning every later
+  self-hosted Flutter job. `.claude/scripts/runner-heartbeat.sh` now refuses to declare the
+  runner online below `RUNNER_MIN_FREE_DISK_GB` free GiB (default 15 — a Flutter setup peaks
+  near 4.5 GiB and the host's 6 GiB local-build gate must stay clear), checked before the
+  GitHub API probe and logged with the reading that caused the refusal.
+  `setup-self-hosted-runner.sh --check` prints the current free-disk reading and its verdict
+  next to the heartbeat state.
+<!-- RELEASE NOTE (maintainer-only):
+     The heartbeat script itself was collateral damage of the harness removal in #3244:
+     setup-self-hosted-runner.sh still installed a LaunchAgent pointing at
+     .claude/scripts/runner-heartbeat.sh, which no longer existed. This PR restores it (with
+     the gate), so the repo variables stop drifting. On the pilot host at the time of writing
+     the heartbeat LaunchAgent is NOT loaded, SELF_HOSTED_MACOS_LAST_SEEN is nine days stale
+     and ONLINE is still "true" with 7.9 GiB free — rerun the installer to arm the gate. -->


### PR DESCRIPTION
## Problem

The runner heartbeat marked the self-hosted Mac `SELF_HOSTED_MACOS_ONLINE=true` on runner
liveness alone. A job could therefore route to a host with ~4.6 GiB free: the Flutter iOS
type-check on #2766 hit `No space left on device` (exit 50) and left a **truncated**
`Flutter.xcframework` in the runner tool cache — a poisoned cache that would have silently
corrupted every subsequent self-hosted Flutter job. The pilot promises transparent fallback
when the Mac cannot take a job; asleep, off and runner-process-dead were covered, disk
exhaustion was the missing fourth case.

## Change

- `.claude/scripts/runner-heartbeat.sh` reads free space on the runner volume **before** the
  GitHub API probe and refuses `ONLINE=true` below `RUNNER_MIN_FREE_DISK_GB` (default **15**).
  Below threshold there is nothing the runner status could say that would make the host usable.
- The refusal logs the reading, the threshold and the override, e.g.
  `[heartbeat] … — free disk 7.9 GiB on / < 15 GiB minimum, marked OFFLINE (jobs fall back to macos-15; …)`.
- An unreadable `df` is treated as unusable, for the same reason.
- Threshold and mount (`RUNNER_DISK_MOUNT`) are passed through the heartbeat LaunchAgent
  environment by the installer, so a host can be tuned without editing the script.
- `setup-self-hosted-runner.sh --check` prints the current free-disk reading and its verdict
  next to the heartbeat state.

### Why 15 GiB

The sum of two knowns rather than a round number: a Flutter setup alone peaks near 4.5 GiB,
and the host's 6 GiB local-build gate must stay clear so CI never starves an interactive
session. The remainder is Xcode/Gradle scratch headroom.

### Note on the restored file

`runner-heartbeat.sh` was collateral damage of the harness removal in #3244:
`setup-self-hosted-runner.sh` kept installing a LaunchAgent pointing at a path that no longer
existed, so the repo variables have been drifting since. It is restored here, with the gate.

## Validation

No Gradle build needed — shell + a generated plist.

- `bash -n` and `shellcheck` clean on both scripts.
- Gate exercised against a stubbed `gh` (no repo variable was written) on this 7.9 GiB-free
  host: threshold 15 → OFFLINE, threshold 1 → ONLINE, unreadable mount → OFFLINE.
- `--check` run for real (read-only) — prints `/: 7.9 GiB free (minimum 15 GiB)` and the
  BELOW-threshold verdict.
- The generated heartbeat plist parses (`plistlib`) with the two new environment keys.

## Needs a human

On the pilot host right now: the heartbeat LaunchAgent is **not loaded**,
`SELF_HOSTED_MACOS_LAST_SEEN` is nine days stale, and `SELF_HOSTED_MACOS_ONLINE` is still
`true` with 7.9 GiB free — the exact ENOSPC hazard this PR describes is armed. This PR does not
touch repo variables or reinstall the LaunchAgent; rerun
`bash .claude/scripts/setup-self-hosted-runner.sh` after merge to arm the gate.

Fixes #2816

🤖 Generated with [Claude Code](https://claude.com/claude-code)