### PR TITLE
docs(context): trim CLAUDE.md to what only CLAUDE.md carries

### DIFF
--- a/.github/workflows/rn-ios-compile.yml
+++ b/.github/workflows/rn-ios-compile.yml
@@ -124,7 +124,7 @@ jobs:
     # Deliberately NOT opted in to the self-hosted `sceneview-mac` runner: this
     # job runs `npm ci` and `pod install`, which write into shared per-user
     # caches (`~/.npm`, `~/Library/Caches/CocoaPods`). Keep it on a disposable
-    # hosted runner. See CLAUDE.md → self-hosted runner skill.
+    # hosted runner. Runner setup: `.claude/scripts/setup-self-hosted-runner.sh`.
     runs-on: macos-15
     timeout-minutes: 40
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Full API reference: [`llms.txt`](./llms.txt).
 - **`.filamat` blobs are compiled artifacts, not sources.** If `gradle/libs.versions.toml`
   bumps any of its three independent pins (`filament`, `filamentWebsite`, `filamentWeb`),
   recompile that pin's blobs with the matching `matc` in the same PR — v4.1.0 shipped
-  mismatched halves and crashed 10 demos at runtime. Two checks, both manual:
+  mismatched halves and crashed 10 demos at runtime. Two manual checks:
   `bash tools/GenerateFilamat.sh --check` (blob drift) and
   `bash .claude/scripts/check-web-filamat-abi.sh` (web runtime ABI, #2783).
 - **`local.properties` holds a live API key.** Never print it, never commit it.
@@ -44,26 +44,18 @@ Full API reference: [`llms.txt`](./llms.txt).
 
 ## Conventions
 
-- **UI**: design tokens live in [`DESIGN.md`](./DESIGN.md) — read it before writing any
-  UI, never hardcode colors or spacing, always light + dark. Demo-app UI is designed
+- **UI**: tokens live in [`DESIGN.md`](./DESIGN.md) — read it before writing any UI,
+  never hardcode colors or spacing, always light + dark. Demo-app UI is designed
   natively against real references (Sketchfab, Polycam, Reality Composer), never
   tool-generated.
 - **Changelog**: one fragment per PR, `changelog.d/<issue-or-pr>-<slug>.md` with a
   `<!-- category: Fixed -->` tag. `CHANGELOG.md` is generated — never hand-edit it, same
   for `gpt/knowledge-*.md` and every `CREDITS.md` (licence compliance).
 - **Public surfaces are English only** — commit messages and PR bodies included.
-- **Codex is a delegation lever, not a rule** — it bills the ChatGPT plan, a quota
-  separate from Claude's. The orchestrating session picks its delegate per task: Codex
-  (`ask` · `review` · `implement --new-worktree`) for well-scoped mechanical work or an
-  independent second opinion, Claude subagents when judgment or integration quality
-  matters. Always `.claude/scripts/codex-delegate.sh`, never a raw `codex`, never an
-  OpenAI API key. Commits, merges and releases stay with the lead session.
-
-## CI
-
-`.github/workflows/ci.yml` is the one PR workflow. Its `changes` job detects touched
-paths and gates every other job; `changes-verdict` ("Path filter completed") always runs
-and is the required check. Heavy suites (`render-tests.yml`, `device-qa.yml`) run
-on push to `main` and nightly, never cancelling each other; the one per-PR
-exception is `render-tests.yml`'s `android-library-render` job, path-gated on
-`sceneview/**`, `sceneview-core/**` and the Gradle files (#3216). Details in [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Codex is a delegation lever, not a rule** — it bills a quota separate from Claude's.
+  Always `.claude/scripts/codex-delegate.sh` (`ask` · `review` · `implement
+  --new-worktree`), never a raw `codex`, never an OpenAI API key. Commits, merges and
+  releases stay with the lead session.
+- **CI**: `.github/workflows/ci.yml` is the one PR workflow; its `changes` job gates
+  every other job and `changes-verdict` ("Path filter completed") is the required check.
+  Heavy suites and their path gates: [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/changelog.d/3001-session-preamble-diet.md
+++ b/changelog.d/3001-session-preamble-diet.md
@@ -1,0 +1,5 @@
+<!-- category: Changed -->
+`CLAUDE.md` no longer restates the CI path-gating detail that `CONTRIBUTING.md` already
+carries, and its Codex bullet is condensed to the rules an agent must follow. Every fact
+that only lived in `CLAUDE.md` is kept. The file goes from 4,074 to 3,566 bytes (-12.5%),
+which is the whole of what this repository contributes to a session preamble (#3001).


### PR DESCRIPTION
Refs #3001

## What this repository actually contributes to a preamble

Measured on this branch's base (`b0d3c436c`), against the file inventory the issue's
own comments established:

| candidate | in the preamble? | size |
|---|---|---|
| `CLAUDE.md` | **yes** | 4,074 B / 69 lines |
| `.claude/skills/` | no — the directory does not exist in this repo | — |
| `.claude/agents/` | no — does not exist | — |
| `.claude/commands/` | no — does not exist | — |
| `MEMORY.md` | no — user-level (`~/.claude/projects/**/memory/`), not in the repo | — |
| `.claude/mcp.json` | no — measured never to load (see below) | 113 B |
| `.claude/settings.json` | no — and it is gitignored | 66 B |
| `AGENTS.md` | no — read by Codex CLI, not injected by Claude Code | 4,212 B |
| `llms.txt`, `DESIGN.md`, `CONTRIBUTING.md` | no — read on demand via pointers | 395 / 19 / 30 KB |

**So the repo-controlled surface is one file, 4,074 bytes.** The skill / command /
agent listings and `MEMORY.md` that earlier comments in this thread costed against
sceneview are user-level; no PR in this repository can move them. That matches the
triage comment of 2026-08 and is restated here because three passes in a row have
gone looking for repo-side fat that is not there.

## The change

| | before | after | delta |
|---|---|---|---|
| `CLAUDE.md` bytes | 4,074 | 3,566 | **-508 (-12.5%)** |
| lines | 69 | 61 | -8 |
| est. tokens @ 2.56-2.79 chars/tok (the ratio measured in this issue, not 4) | ~1,460-1,590 | ~1,280-1,390 | **~-180 to -200 per request** |

Two blocks were restatements, not knowledge:

- **CI section** — repeated `render-tests.yml` / `device-qa.yml` push-and-nightly
  scheduling and the #3216 path gate. `CONTRIBUTING.md:341-367` carries all of it,
  and `CLAUDE.md` already linked there. What remains is the part a session needs
  before opening anything: `ci.yml` is the one PR workflow, `changes-verdict`
  ("Path filter completed") is the required check.
- **Codex bullet** — five lines re-deriving *when* to delegate. Condensed to the
  rules: the wrapper script, never a raw `codex`, never an OpenAI API key, git stays
  with the lead session. The "separate quota" rationale is kept, one clause.

Nothing that existed only in `CLAUDE.md` was removed. The Modules table and the whole
"Things that break if you don't know them" section are untouched: they are the highest
value-per-byte content in the file and there is no second copy of them.

## Verification

No build was needed. Every path, script and CI job name still referenced by
`CLAUDE.md` was checked to exist on disk: `tools/GenerateFilamat.sh`,
`.claude/scripts/{check-web-filamat-abi,setup-ar-emulator,device-qa,codex-delegate}.sh`,
`llms.txt`, `DESIGN.md`, `CONTRIBUTING.md`, the ten module directories, and the
`changes-verdict` / "Path filter completed" job names in `ci.yml:291-292`. All resolve.

That sweep found one dangling pointer, fixed here: `rn-ios-compile.yml:127` sent the
reader to a "CLAUDE.md -> self-hosted runner skill" that does not exist in `CLAUDE.md`
and never did. It now names `.claude/scripts/setup-self-hosted-runner.sh`, where the
runner setup actually lives.

## Honest bound, and what is left for a human

This saves roughly **200 tokens per request**. Against a preamble the issue last
measured at 66-69k that is ~0.3%. It is the *entire* remaining repo-side lever, and
this issue's own conclusion applies: worth doing once, not worth a standing campaign.

Two things surfaced that this PR deliberately does not do:

1. **`.claude/mcp.json` is documented, shipped, and appears never to load.** The
   issue measured zero `sceneview` tool names across 165 sessions; this session, run
   in a worktree containing that file, likewise has no `sceneview` MCP tools. Yet
   `.claude/mcp.json` is the install path published to users in `llms.txt:6089`,
   `gpt/knowledge-overview.md:452`, `website-static/.well-known/llms.txt:2396`,
   `mcp/demo/RELEASE_NOTES.md:40` and `docs/docs/ai-development.md:37`. If that path
   is wrong, an AI-first SDK is telling every user to install its MCP server where it
   will not load — a product bug, larger than this issue, and out of its scope.
   Note it also cuts the other way: *fixing* it would **add** the server's tool
   schemas to every preamble.
2. **The remaining levers are user-level, not repo-level** — `~/.claude/CLAUDE.md`,
   the memory hub, and the connector roster (the issue notes connectors that cannot
   authenticate are still loaded on every request). None of them can be changed by a
   pull request here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)