### PR TITLE
Make five guards report "could not run" instead of a fake verdict

### DIFF
--- a/.claude/scripts/check-web-filamat-abi.sh
+++ b/.claude/scripts/check-web-filamat-abi.sh
@@ -36,7 +36,9 @@
 #   bash .claude/scripts/check-web-filamat-abi.sh
 #
 # Exit code: 0 if every web blob matches its own runtime, 1 on any mismatch,
-# 2 if the repo layout is missing (not a checkout / files absent).
+# 2 if the leg COULD NOT RUN — the repo layout is missing (not a checkout /
+# files absent) or a required tool (a sha256 hasher) is unavailable. 1 is
+# reserved for "the blobs are wrong"; it must never mean "the gate is broken".
 
 set -u
 
@@ -79,12 +81,28 @@ blob_material_version() {
     od -A n -t u4 -j 12 -N 4 "$1" 2>/dev/null | tr -d ' \n'
 }
 
+# Resolve the hasher ONCE, up front. Doing it per call and falling through to
+# `sha256sum` unconditionally meant that on a host with neither hasher the
+# command printed `sha256sum: command not found`, `actual` came back EMPTY, and
+# every vendored runtime file was reported as "changed but RUNTIME.json was not
+# updated" — exit 1, i.e. "you broke the Filament runtime pin", for a host that
+# simply cannot hash. A gate that cannot run must say so (exit 2), never invent
+# a drift.
+if command -v shasum >/dev/null 2>&1; then
+    HASHER="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+    HASHER="sha256sum"
+else
+    echo "check-web-filamat-abi.sh: neither 'shasum' nor 'sha256sum' is available" >&2
+    echo "  This leg hashes the vendored Filament runtime; without a hasher it" >&2
+    echo "  cannot run. This is a tooling gap, not a blob mismatch." >&2
+    exit 2
+fi
+
 sha256_of() {
-    if command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 "$1" | awk '{print $1}'
-    else
-        sha256sum "$1" | awk '{print $1}'
-    fi
+    # Word-splitting on $HASHER is intentional (`shasum -a 256` or `sha256sum`).
+    # shellcheck disable=SC2086
+    $HASHER "$1" | awk '{print $1}'
 }
 
 # Minimal string/number field reader — RUNTIME.json is ours and flat, so this

--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -8,7 +8,7 @@
 # Exit codes:
 #   0 = all versions aligned
 #   1 = mismatches found (or fixed if --fix)
-#   2 = error
+#   2 = could not run (bad invocation, missing input, missing dependency)
 
 set -euo pipefail
 
@@ -26,6 +26,20 @@ NC='\033[0m' # No Color
 
 echo -e "${CYAN}=== SceneView Version Sync Check ===${NC}"
 echo ""
+
+# ─── Hard dependency ───────────────────────────────────────────────────────
+# Every package.json / version.json read AND every --fix rewrite goes through
+# `python3 -c "import json; ..."`. Those calls swallow their own failure
+# (`2>/dev/null || echo "MISSING"`), so on a host without python3 the run stayed
+# GREEN while silently dropping three checks and degrading five more to
+# warnings — and `--fix` would have rewritten nothing while reporting success.
+# A missing interpreter is "could not run" (exit 2), never a pass.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo -e "${RED}FATAL: python3 is required to read and rewrite the JSON version files${NC}" >&2
+    echo "  Every package.json / version.json check goes through python3; without it" >&2
+    echo "  this scan would report a green it did not verify." >&2
+    exit 2
+fi
 
 # ─── Source of truth ───────────────────────────────────────────────────────
 SOURCE_VERSION=$(grep '^VERSION_NAME=' "$REPO_ROOT/gradle.properties" | cut -d= -f2)

--- a/.claude/scripts/validate-release-artifact.sh
+++ b/.claude/scripts/validate-release-artifact.sh
@@ -185,6 +185,16 @@ echo "$DESC"
 #
 # Any hex versionCode literal is parsed and normalised to decimal so it
 # compares cleanly with the decimal value gradle was given.
+# The manifest is parsed with python3 — see the skip-vs-fail discipline at the
+# top of this file: missing validation tooling must WARN + SKIP, never block.
+if ! command -v python3 >/dev/null 2>&1; then
+  skip "manifest parsing skipped — 'python3' is not available. Without it the" \
+       "parsed package/versionName/versionCode would all come back empty and" \
+       "this guard would report 'could not parse … from artifact manifest' —" \
+       "a tooling gap dressed as a corrupt artifact. The upload proceeds" \
+       "unvalidated."
+fi
+
 read -r GOT_PKG GOT_NAME GOT_CODE < <(python3 - "$DESC" <<'PYEOF'
 import re, sys
 desc = sys.argv[1]

--- a/.claude/scripts/verify-published-version.sh
+++ b/.claude/scripts/verify-published-version.sh
@@ -39,7 +39,9 @@
 #      budget lapsed and the outcome is explicitly INCONCLUSIVE
 #   1  the registry is reachable and does NOT serve the version, or no probe
 #      ever reached the registry
-#   2  usage error
+#   2  could not run — usage error, or a tool the probes need (curl, and
+#      python3 for pub.dev) is unavailable. Never confused with 1: 1 is a
+#      claim ABOUT the publish, 2 says no claim could be made.
 #
 # Env overrides:
 #   PUBLISH_VERIFY_ATTEMPTS  probe count
@@ -90,6 +92,24 @@ case "$REGISTRY" in
         exit 2
         ;;
 esac
+
+# ─── Tooling the probes cannot do without ──────────────────────────────────
+# Every probe is a `curl`, and the pub.dev probe parses the package document
+# with python3. A missing tool used to be indistinguishable from a registry
+# that never answered: the probe printed nothing, the run reported UNREACHABLE
+# and exited 1 — "no probe ever reached the registry" — which reads as a failed
+# publish. That is exactly the false red this file exists to prevent, so a
+# missing tool is now its own outcome: could not run (exit 2).
+missing_tool() {
+    echo "CANNOT RUN: '$1' is not available — $2" >&2
+    echo "  This is a tooling gap on the runner, NOT evidence about the publish." >&2
+    exit 2
+}
+command -v curl >/dev/null 2>&1 || missing_tool curl "every registry probe is a curl"
+if [ "$REGISTRY" = "pub" ]; then
+    command -v python3 >/dev/null 2>&1 ||
+        missing_tool python3 "the pub.dev probe parses the package document with it"
+fi
 
 ATTEMPTS="${PUBLISH_VERIFY_ATTEMPTS:-$DEF_ATTEMPTS}"
 DELAY="${PUBLISH_VERIFY_DELAY:-$DEF_DELAY}"

--- a/.claude/scripts/web-bundle-smoke.sh
+++ b/.claude/scripts/web-bundle-smoke.sh
@@ -26,10 +26,29 @@
 # `web-desktop` job in ci.yml, which already has both gradle/JDK and node). The
 # spec self-skips when the bundle is not staged, so the lean node-only
 # `device-qa.sh --platform=web` leg never red-blocks on a missing artifact.
+#
+# Exit codes:
+#   0 = the staged bundle boots and renders
+#   1 = the bundle is broken (build failed, artifact missing, a spec failed)
+#   2 = could not run — node/npm/npx is unavailable on this host
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
+
+# ─── Tooling ───────────────────────────────────────────────────────────────
+# `npm install` / `npx playwright` are the only way this smoke test reaches a
+# browser. Under `set -e` a missing binary aborts the script with 127 and a
+# bare `npm: command not found`, which in a CI log is indistinguishable from
+# "the web bundle is broken". A host without node cannot run this leg; say so.
+for tool in node npm npx; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[web-bundle-smoke] CANNOT RUN: '$tool' is not available." >&2
+    echo "  This smoke test drives Playwright through npm; without node it cannot" >&2
+    echo "  run. That is a tooling gap, not a defect in the web bundle." >&2
+    exit 2
+  }
+done
 
 WEBDIR="samples/web-demo"
 STAGE="$WEBDIR/site/kotlin-bundle"

--- a/changelog.d/3192-gate-missing-tool-exit.md
+++ b/changelog.d/3192-gate-missing-tool-exit.md
@@ -1,0 +1,15 @@
+<!-- category: Fixed -->
+- **Repo guards now say "could not run" instead of faking a verdict when a tool is
+  missing ([#3192](https://github.com/sceneview/sceneview/issues/3192)).** Five checks
+  reported a result they had not actually verified when an interpreter or CLI was absent:
+  `check-web-filamat-abi.sh` exited `1` with two bogus `MISMATCH` blocks and an empty
+  hash when neither `shasum` nor `sha256sum` existed; `sync-versions.sh` printed a green
+  116-check report without `python3`, which is what reads and rewrites every JSON version
+  file; `verify-published-version.sh` turned a missing `curl` (or `python3` for pub.dev)
+  into a claim about the publish; `web-bundle-smoke.sh` died with a bare `npm: command
+  not found` (127) that reads like a broken web bundle; and `validate-release-artifact.sh`
+  blocked a Play Store upload with "could not parse 'package' from artifact manifest"
+  when the missing piece was `python3`, not the artifact. Each now resolves its tooling
+  up front and exits `2` (`0` WARN + SKIP for the release guard, whose own contract is
+  that missing validation tooling must never veto a release), so `1` keeps meaning "the
+  thing under test is wrong".


### PR DESCRIPTION
`Refs #3192` — this is **one** of the four workstreams; the issue stays open.

## Which workstream

- [x] **2. Gates that report a failing check when they could not run** — the whole workstream, re-scoped to current `main`
- [ ] 1. Tool-result UI resource hints — already merged (#3278, #3288); `mcp-gateway/src/mcp/transport.ts` already declares `_meta.ui.resourceUri`
- [ ] 3. The Hub — needs a maintainer retire-or-fold decision (touches money/Stripe), out of scope here
- [ ] 4. Skill/agent surface follow-ups — already merged

The issue's literal targets (`pre-push-check.sh`, `script_report_failure`) were removed in
`72e570993`. The defect class it names is alive elsewhere, and the issue itself says
"an audit of the remaining legs is the actual fix", so this PR is that audit plus its fixes.

## The convention

`0` = pass · `1` = the thing under test is wrong · `2` = the check could not run
(bad invocation, missing input, missing dependency). `tools/GenerateFilamat.sh` already
honours it — these five did not.

| Leg | Missing tool | Before | After |
|---|---|---|---|
| `check-web-filamat-abi.sh` | `shasum` **and** `sha256sum` | exit **1**, two false `MISMATCH` blocks, empty `actual` | exit 2 |
| `sync-versions.sh` | `python3` | exit **0** — a green it never verified | exit 2 |
| `verify-published-version.sh` | `curl` (or `python3` for pub.dev) | a claim about the publish | exit 2 |
| `web-bundle-smoke.sh` | `node`/`npm`/`npx` | **127**, `npm: command not found`, after a full gradle build | exit 2, before the build |
| `validate-release-artifact.sh` | `python3` | exit **1** — release **blocked** with "could not parse 'package' from artifact manifest" | exit 0, WARN + SKIP |

Two of these deserve a second look. `sync-versions.sh` was a **false green**: all 19
python3 call sites — the reads *and* the `--fix` rewrites — went through the interpreter,
yet the report still printed `Checks: 116 / Errors (MISMATCH): 0`. And
`validate-release-artifact.sh` **blocked a release**: its own header already states the
discipline ("the artifact is wrong" → 1; "the validation tooling is unavailable" → 0
WARN + SKIP, the way the bundletool and `aapt2` gaps beside it are handled), but the
manifest parser was an unguarded `python3` heredoc, so a missing interpreter arrived as a
corrupt artifact.

## Verification

Each defect was reproduced empirically, before and after, with a symlink **PATH farm** —
a directory of symlinks to every executable on `PATH` *except* the hidden one, so
`command -v` genuinely fails (a shell-function shadow would not). Farms: no sha256 hasher,
no `shasum` alone, no `python3`, no `curl`, no `node`.

The true-failure paths still fail: a `versionName` mismatch still exits 1; both hasher
branches (`shasum` / `sha256sum`) still agree and pass; `sync-versions.sh` output is
byte-identical at 116 / 0 / 9; a live npm probe still returns `VERIFIED`.

No build was run — the change is shell-only, and this machine sits at 5.1 Gi free
(under the 6 Gi floor).

## For the maintainer

`.github/workflows/release-fast.yml:128,130` wraps both `sync-versions.sh` invocations in
`|| true`, documented as load-bearing because `--fix` exits 1 by contract. That wrapper
swallows the new exit 2 exactly as it already swallowed 1 — pre-existing, not a regression
from this PR, but it means the false green survives in *that one caller*. Un-swallowing it
means teaching that step to tell 1 from 2, which is a workflow change I left out of a
shell-only PR. Your call.

No new script, gate, workflow or hook was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
