### PR TITLE
fix(ios-demo): capture the hovercar in App Store slot 1, not a second helmet

### DIFF
--- a/changelog.d/3006-hovercar-framing.md
+++ b/changelog.d/3006-hovercar-framing.md
@@ -1,0 +1,31 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+App Store slot 1 shows the Cyberpunk Hovercar again instead of a second copy of slot 2's
+Damaged Helmet. The issue reported the hovercar as "framed as plinth-sized, so it reads
+small next to the fixed slot 2"; the plinth half of that had already been fixed (#3315
+stripped the display plane from `cyberpunk_hovercar.usdz`, and the flattened USD confirms
+no plane prim remains). Capturing the demo on the 6.9" simulator showed the real cause:
+the `model-viewer` slot was not rendering the hovercar at all.
+
+Two independent changes collided. #3003 switched `dynamic-sky` — slot 2 — to
+`khronos_damaged_helmet`, and the showcase redesign (#3308) rewrote `ModelViewerDemo` to
+default `selectedModel` to `bundledModels[0]`, which is that same helmet. The redesign kept
+the "the hovercar is the iOS store hero" comment while making the code disagree with it, so
+the store hero silently stopped being captured and the listing showed one subject twice.
+Under `qa_mode` the view now selects `storeHeroAssetName` explicitly before the first load;
+the interactive first-run subject is unchanged — a new user still lands on the Khronos
+reference helmet.
+
+`captureFramingMargin` stays at 0.62, and the constant now records why rather than reading
+as a preference. Swept against live captures with the `-camera_distance` override (#2785):
+0.75 leaves the car at roughly 45 % of the frame width and 0.5 clips its tail against the
+right edge. It is a floor, not a choice.
+
+One framing defect is documented and deliberately left open, because it is an SDK change
+rather than a sample constant: the car renders right of the frame centre with the left
+third of the frame empty, and its silhouette is markedly smaller than the bounds the
+auto-fit pass is fitting. `CameraControls.fitRadius` inscribes the *space diagonal* of the
+union AABB in a sphere and fits that sphere to the narrower FOV axis — width, in a portrait
+store frame — so a wide, short subject whose authored bounds exceed its visible geometry
+cannot fill the frame however tight the margin gets. Fitting the projected AABB instead
+would close it.

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ModelViewerDemo.swift
@@ -27,7 +27,8 @@ import ARKit
 /// only, something useful renders offline (the bundled hero).
 struct ModelViewerDemo: View {
     /// Bundled models offered in the Models sheet. The Khronos set mirrors
-    /// Android's grid; the hovercar is the iOS store hero.
+    /// Android's grid; the hovercar is the iOS store hero, selected under
+    /// `qa_mode` by ``storeHeroAssetName`` rather than by being first here.
     private static let bundledModels: [BundledViewerModel] = [
         BundledViewerModel(assetName: "khronos_damaged_helmet", displayName: "Damaged Helmet"),
         BundledViewerModel(assetName: "khronos_fox", displayName: "Fox"),
@@ -47,10 +48,37 @@ struct ModelViewerDemo: View {
         ViewerEnvironment(assetName: "rooftop_night", displayName: "Rooftop Night"),
     ]
 
+    /// The subject App Store slot 1 is meant to show. The interactive default
+    /// is `bundledModels[0]` (Damaged Helmet) — the Khronos reference model a
+    /// first-run user should land on — but `dynamic-sky`, which fills slot 2,
+    /// loads that *same* helmet since #3003. Left alone the listing showed one
+    /// subject twice: the redesign (#3308) rewrote this view and kept the
+    /// "hovercar is the iOS store hero" comment while defaulting to index 0,
+    /// so the store hero silently stopped being captured (#3006). Under
+    /// `qa_mode` only — the interactive first-run subject is unchanged.
+    private static let storeHeroAssetName = "cyberpunk_hovercar"
+
     /// Fitted framing: the bounding sphere plus 12 % of air, which clears the
     /// dock band at the bottom of the viewport.
     private static let framingMargin: Float = 1.12
     /// Under `qa_mode` the pose is frozen, so the store capture fills the frame.
+    ///
+    /// Tighter than `DynamicSkyDemo`'s 0.75 because the subjects differ in
+    /// aspect, not in preference: the auto-fit pass inscribes the *space
+    /// diagonal* of the union bounds in a sphere and fits that sphere to the
+    /// narrower of the two FOV axes — width, in a portrait store frame. A
+    /// near-isotropic subject (the helmet) fills that sphere; the hovercar is
+    /// wide and short, so the same margin leaves it visibly smaller.
+    ///
+    /// 0.62 is the floor, not a preference: swept on the 6.9" simulator with
+    /// the `-camera_distance` override (#2785), 0.75 leaves the car at roughly
+    /// 45 % of the frame width and 0.5 clips its tail against the right edge.
+    /// It cannot go lower while the car renders off-centre — the union bounds
+    /// this pass fits are visibly wider than the car's silhouette, so the car
+    /// sits right of the frame centre and runs out of room on that side long
+    /// before the empty left third is used. Closing that gap is a
+    /// `CameraControls.fitRadius` change (fit the projected AABB rather than
+    /// the space-diagonal sphere), not a constant, and is out of scope here.
     private static let captureFramingMargin: Float = 0.62
 
     private enum ViewerSheet: Identifiable {
@@ -237,6 +265,13 @@ struct ModelViewerDemo: View {
         }
         #endif
         .task {
+            // Under `qa_mode` the store hero replaces the first-run default,
+            // so slot 1 captures the hovercar instead of repeating slot 2's
+            // helmet (#3006). Assigned before the load so a single pass runs.
+            if qaMode,
+               let hero = Self.bundledModels.first(where: { $0.assetName == Self.storeHeroAssetName }) {
+                selectedModel = hero
+            }
             await loadBundled(selectedModel)
         }
         .onChange(of: selectedAnimation) { _, index in


### PR DESCRIPTION
Fixes #3006

## What the issue said, and what was actually wrong

The issue reports slot 1's hovercar as "framed as plinth-sized, so it reads small next to
the fixed slot 2". Both halves of that premise turned out to be false, and the real defect
is worse.

**The plinth is already gone.** `a4ff16cd0` (#3315, merged 2026-08-23) stripped the display
plane from `cyberpunk_hovercar.usdz`, and `xcrun usdcat --flatten` on the current asset
confirms no plane prim remains.

**Slot 1 was not showing the hovercar at all.** Capturing `-demo model-viewer -qa_mode 1`
on the 6.9" simulator renders `khronos_damaged_helmet` — the exact subject `dynamic-sky`
(slot 2) has rendered since #3003. The listing showed one model twice, which is why the
reporter read slot 1 as "small next to" slot 2: they were comparing a stale committed PNG
against a fixed slot 2.

Two independent changes collided. #3003 moved slot 2 onto the helmet; the showcase redesign
`b1dc1dc59` (#3308) rewrote `ModelViewerDemo` to default `selectedModel` to
`bundledModels[0]` — that same helmet — while keeping the comment claiming "the hovercar is
the iOS store hero". Nobody re-captured, so the store hero silently stopped being shot.

## The fix

Under `qa_mode` only, the view selects `storeHeroAssetName` (`cyberpunk_hovercar`) before
the first load. The interactive first-run subject is deliberately unchanged: a new user
still lands on the Khronos reference helmet.

`captureFramingMargin` keeps its existing 0.62. It is now documented as a measured floor
rather than a preference — swept against live captures through the `-camera_distance`
override (#2785), 0.75 leaves the car at roughly 45 % of the frame width and 0.5 clips its
tail against the right edge.

## Visual proof

Captured on `iPhone 17 Pro Max` (iOS 26.3 Simulator, 1320×2868, status bar pinned to 9:41).
No physical device was used.

| capture | result |
|---|---|
| before, `-demo model-viewer -qa_mode 1` | Damaged Helmet — identical subject to slot 2 |
| after, same launch | Cyberpunk Hovercar, three-quarter pose, uncut on all four edges |
| after, margin 0.75 (sweep) | car at ~45 % of frame width — too small, rejected |
| after, margin 0.5 (sweep) | car's tail clipped on the right edge — rejected |
| after, light appearance | chrome pills lighten, scene identical — no regression |

## Known limitation, deliberately left open

The car renders **right of the frame centre**, with the left third of the frame empty, and
its silhouette is markedly smaller than the bounds the auto-fit pass is fitting. This is not
a sample constant: `CameraControls.fitRadius` inscribes the *space diagonal* of the union
AABB in a sphere and fits that sphere to the narrower of the two FOV axes — width, in a
portrait store frame (`fovY = 60°`, `aspect ≈ 0.46` → `fovX ≈ 29.8°`). A wide, short subject
whose authored bounds exceed its visible geometry therefore cannot fill the frame at *any*
margin, and the margin bottoms out on the right edge long before the empty left third is
used. Fitting the projected AABB rather than the space-diagonal sphere would close it — an
SDK change, out of scope for this issue.

## Not done here

- **The committed `appstore-screenshots/` PNGs are not refreshed.** Regenerating and
  uploading the listing is a human-gated gesture (`asc_listing.py --apply-screenshots` /
  the `Sync App Store screenshots` workflow with `confirm=true`), so this PR ships the
  source fix only.
- **iPad 13" not re-verified.** The margin is unchanged from `main`, so no regression is
  introduced on that class, but the hovercar's fit there has not been re-shot in this
  session — free disk on the build machine dropped to 5.0 GiB, below the agreed 6 GiB
  build floor, so no further simulator was booted and no rebuild was run. The 0.62 sweep
  was validated on the already-installed build through `-camera_distance`, which feeds the
  identical `framingMargin(_:)` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
