### PR TITLE
fix(demo): let the "AR unavailable" card through the demo chrome (#3341)

### DIFF
--- a/changelog.d/3341-ar-unsupported-demo-chrome.md
+++ b/changelog.d/3341-ar-unsupported-demo-chrome.md
@@ -16,5 +16,12 @@
   scanning pill all keyed off "not tracking yet", which on an unsupported device is
   permanently true — so "Initializing camera…" sat next to a card saying the camera was
   never going to start. They now read the verdict first, matching what the Orbital demo
-  already did. The demo scaffold's back control was already drawn above the scrim, so
-  leaving the demo has worked throughout; what was missing was any reason to.
+  already did.
+  The same reading covers the shared "Scanning for surfaces…" banner: seven more demos
+  gated it on a flag — `isTracking`, a detected-plane count, a first-plane boolean — that
+  an unsupported device leaves untouched forever, so the banner promised a scan that could
+  not start. Two of them, Depth Occlusion and AR Fog, only looked correct because the scrim
+  was covering them; uncovering the card exposed the banner underneath. All seven now
+  defer to the verdict.
+  The demo scaffold's back control was already drawn above the scrim, so leaving the demo
+  has worked throughout; what was missing was any reason to.

--- a/changelog.d/3341-ar-unsupported-demo-chrome.md
+++ b/changelog.d/3341-ar-unsupported-demo-chrome.md
@@ -1,0 +1,20 @@
+<!-- category: Fixed -->
+- **The demo app's own chrome hid the "AR unavailable" card it was supposed to let through
+  ([#3341](https://github.com/sceneview/sceneview/issues/3341)).**
+  #3374 gave the SDK a real availability state and an explanation card, but on an
+  unsupported device — every emulator (#2754) — the demos still showed a black viewport
+  forever. `ARCameraInitScrim` is a full-screen opaque backdrop drawn as a later sibling of
+  `ARSceneView`, dismissed when the first camera frame arrives; when ARCore rules the
+  session out that frame never comes, so after its eight-second timeout the scrim settled
+  into a permanent black cover *on top of* the card explaining why. It now takes the
+  verdict as a required argument and steps aside the moment ARCore answers, at any point in
+  the start sequence — waiting through the spinner phase is pointless once the answer is
+  "this device cannot run AR". Every demo that draws the scrim now passes the verdict
+  through, sourced from `onARCoreAvailability`.
+  The demos' status copy no longer contradicts the card either: the Rooftop Anchor sheet
+  and banner, the Cloud Anchor and Terrain Anchor guidance, and the Instant Placement
+  scanning pill all keyed off "not tracking yet", which on an unsupported device is
+  permanently true — so "Initializing camera…" sat next to a card saying the camera was
+  never going to start. They now read the verdict first, matching what the Orbital demo
+  already did. The demo scaffold's back control was already drawn above the scrim, so
+  leaving the demo has worked throughout; what was missing was any reason to.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.math.Position
 import java.io.File
 import kotlin.math.acos
@@ -150,17 +151,30 @@ fun ErrorScrim(
  *
  * ```kotlin
  * var cameraReady by remember { mutableStateOf(false) }
+ * var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
  * Box(Modifier.fillMaxSize()) {
  *     ARSceneView(
  *         onSessionUpdated = { _, _ -> cameraReady = true /* … */ },
+ *         onARCoreAvailability = { arCoreAvailability = it },
  *         …
  *     ) { … }
- *     ARCameraInitScrim(initializing = !cameraReady)
+ *     ARCameraInitScrim(
+ *         initializing = !cameraReady,
+ *         arCoreAvailability = arCoreAvailability,
+ *     )
  * }
  * ```
  *
  * Place it as the last child of the [Box] that wraps the `ARSceneView` so it draws
  * on top of the still-black viewport but below any other status overlays.
+ *
+ * [arCoreAvailability] is the ARCore verdict reported by `ARSceneView.onARCoreAvailability`,
+ * and it is **not optional** (#3341): a non-null verdict means ARCore will never deliver a
+ * frame on this device, so [initializing] stays true forever and the scrim would cover the
+ * viewport permanently — including the SDK's own
+ * [io.github.sceneview.ar.ARCoreAvailabilityOverlay] explanation card, which draws *inside*
+ * the `ARSceneView` and therefore *below* this scrim. Pass the verdict and the scrim steps
+ * aside the moment it lands. On an emulator (#2754) this is the only path there is.
  *
  * Defensive timeout (#2484): if the first frame never arrives — a device that fails
  * to open the camera, a session that errors before delivering a frame — the scrim
@@ -175,6 +189,7 @@ fun ErrorScrim(
 @Composable
 fun ARCameraInitScrim(
     initializing: Boolean,
+    arCoreAvailability: ARCoreAvailability?,
     label: String = "Starting camera…",
     timeoutMillis: Long = AR_CAMERA_INIT_SCRIM_TIMEOUT_MS,
 ) {
@@ -199,6 +214,7 @@ fun ARCameraInitScrim(
         initializing = initializing,
         timedOut = timedOut,
         qaBackdropEnabled = io.github.sceneview.demo.common.qaCameraBackdropEnabled(),
+        arCoreUnavailable = arCoreAvailability != null,
     )
     if (visibility == ArCameraInitScrimVisibility.Hidden) return
     Box(
@@ -254,14 +270,23 @@ internal enum class ArCameraInitScrimVisibility {
  * fallback screen has a deliberate background. So after the timeout we keep the backdrop and
  * drop only the spinner.
  *
- * The one case that still dismisses completely is the QA camera backdrop (#3308): there a
- * synthetic room photo is deliberately rendered behind the viewport and must be visible.
+ * Two cases dismiss completely. The QA camera backdrop (#3308): there a synthetic room photo
+ * is deliberately rendered behind the viewport and must be visible. And [arCoreUnavailable]
+ * (#3341): once ARCore has returned a verdict, the session will never start, so there is
+ * nothing left to wait for and the scrim is covering the SDK's own explanation card. That
+ * branch comes first — it must win over the spinner phase too, because a verdict makes the
+ * spinner wrong immediately, not eight seconds later. Uncovering the viewport is safe here
+ * for a reason #3373 did not have: since #3377 the camera-stream quad stays out of the render
+ * pass until a real frame is bound, so what shows through is the renderer's own opaque black
+ * clear colour — exactly the ground the dark explanation card is designed for.
  */
 internal fun arCameraInitScrimVisibility(
     initializing: Boolean,
     timedOut: Boolean,
     qaBackdropEnabled: Boolean,
+    arCoreUnavailable: Boolean,
 ): ArCameraInitScrimVisibility = when {
+    arCoreUnavailable -> ArCameraInitScrimVisibility.Hidden
     !initializing -> ArCameraInitScrimVisibility.Hidden
     !timedOut -> ArCameraInitScrimVisibility.BackdropAndSpinner
     qaBackdropEnabled -> ArCameraInitScrimVisibility.Hidden

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceArSession.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceArSession.kt
@@ -211,6 +211,7 @@ fun TapToPlaceArSession(
                 // Change-only write (60 Hz path): drives the ShadowReceiverPlane set.
                 if (trackedPlanes != tracked) trackedPlanes = tracked
             },
+            onARCoreAvailability = { state.arCoreAvailability = it },
             onTrackingFailureChanged = { reason ->
                 state.trackingFailureReason = reason
             },
@@ -385,8 +386,13 @@ fun TapToPlaceArSession(
             extraSceneContent?.invoke(this)
         }
 
-        // Cover the still-black AR viewport until the first camera frame (#2484).
-        ARCameraInitScrim(initializing = !state.cameraReady)
+        // Cover the still-black AR viewport until the first camera frame (#2484) — unless
+        // ARCore has already ruled the session out (#3341), in which case that frame is never
+        // coming and the scrim would bury the SDK's own explanation card.
+        ARCameraInitScrim(
+            initializing = !state.cameraReady,
+            arCoreAvailability = state.arCoreAvailability,
+        )
 
         overlays(state)
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceState.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/TapToPlaceState.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import com.google.ar.core.Anchor
 import com.google.ar.core.HitResult
 import com.google.ar.core.TrackingFailureReason
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.demo.common.ForcedTrackingFailure
 import io.github.sceneview.math.Rotation
 
@@ -92,6 +93,17 @@ enum class TapToPlaceUxState {
 class TapToPlaceState internal constructor() {
     /** True once the first `onSessionUpdated` frame arrived (drives the init scrim). */
     var cameraReady: Boolean by mutableStateOf(false)
+        internal set
+
+    /**
+     * Non-null once ARCore has ruled the session out on this device (#3341).
+     *
+     * [cameraReady] can never flip in that case, so everything keyed off "still starting" —
+     * the init scrim above all — has to read this too or it waits forever. The SDK draws the
+     * explanation card itself; this is what tells the demo's own chrome to stop claiming AR
+     * is on its way.
+     */
+    var arCoreAvailability: ARCoreAvailability? by mutableStateOf(null)
         internal set
 
     var isTracking: Boolean by mutableStateOf(false)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARBodyTrackerDemo.kt
@@ -37,6 +37,7 @@ import com.google.mediapipe.tasks.core.BaseOptions
 import com.google.mediapipe.tasks.vision.core.ImageProcessingOptions
 import com.google.mediapipe.tasks.vision.core.RunningMode
 import com.google.mediapipe.tasks.vision.poselandmarker.PoseLandmarker
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.cameraImage
 import io.github.sceneview.ar.body.BodyPose
@@ -139,6 +140,10 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
 
     // True after the first ARCore camera frame — used to dismiss ARCameraInitScrim (#2485).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var bodyPose by remember { mutableStateOf(BodyPose(emptyMap())) }
 
@@ -238,6 +243,7 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
                 sessionConfiguration = { _: Session, config: Config ->
                     config.planeFindingMode = Config.PlaneFindingMode.DISABLED
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _, frame: Frame ->
                     // First callback = camera is delivering frames; dismiss the init scrim.
                     if (!cameraReady) cameraReady = true
@@ -291,7 +297,10 @@ fun ARBodyTrackerDemo(onBack: () -> Unit) {
             // Cover the still-black ARSceneView surface until ARCore delivers its first
             // camera frame — on a cold start this can take several seconds and the
             // silent black screen reads as a crash (#2485, #1473).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARCloudAnchorDemo.kt
@@ -28,6 +28,7 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.CloudAnchorNode as CloudAnchorNodeImpl
 import io.github.sceneview.demo.ARCameraInitScrim
@@ -90,6 +91,10 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var hostedId by remember { mutableStateOf<String?>(null) }
     var statusMessage by remember { mutableStateOf("Tap a surface to place an anchor") }
@@ -258,6 +263,10 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
                 val isAnchorReady = hostedId != null || cloudAnchorId != null
                 val (guidanceText, guidanceTone) = when {
                     forcedMessage != null -> forcedMessage to DemoStatusTone.Guidance
+                    // ARCore will never start here, so "initializing" is a lie. The
+                    // SDK overlay in the viewport carries the real reason (#3341).
+                    arCoreAvailability != null ->
+                        "AR is unavailable on this device" to DemoStatusTone.Blocked
                     !isTracking ->
                         "Initializing camera — move slowly to find a surface" to
                             DemoStatusTone.Progress
@@ -306,6 +315,7 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
                 onSessionCreated = { session ->
                     arSession = session
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _, frame: Frame ->
                     cameraReady = true
                     latestFrame = frame
@@ -373,7 +383,10 @@ fun ARCloudAnchorDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthColliderDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthColliderDemo.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.Config
 import com.google.ar.core.Pose
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.physics.DepthCollider
 import io.github.sceneview.demo.ARCameraInitScrim
@@ -95,6 +96,10 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_depth_collider_title),
@@ -188,6 +193,7 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
                 // access to the live session + frame; we use them to (a) keep the latest
                 // camera pose so a future Drop tap spawns balls in front of the user (#1874),
                 // and (b) feed the per-frame collider region cull.
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _, frame ->
                     cameraReady = true
                     latestCameraPoseRef.value = frame.camera.pose
@@ -305,7 +311,10 @@ fun ARDepthColliderDemo(onBack: () -> Unit) {
         }
 
         // Cover the still-black AR viewport until the first camera frame (#2484).
-        ARCameraInitScrim(initializing = !cameraReady)
+        ARCameraInitScrim(
+            initializing = !cameraReady,
+            arCoreAvailability = arCoreAvailability,
+        )
       }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
@@ -47,6 +47,7 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.createARCameraStream
 import io.github.sceneview.ar.rememberARCameraStream
@@ -137,6 +138,10 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
     // remount so the entry scrim never re-fires on toggle — that 2-3 frame rebuild flash
     // already has its own dedicated affordance, the #1777 "Switching depth mode…" spinner.
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     // Latest Frame for hit testing in the gesture callback.
     var latestFrame by remember { mutableStateOf<Frame?>(null) }
@@ -349,6 +354,7 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
                             }
                         }
                     ),
+                    onARCoreAvailability = { arCoreAvailability = it },
                     onSessionUpdated = { _, frame: Frame ->
                         cameraReady = true
                         latestFrame = frame
@@ -409,7 +415,10 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
             // Cover the still-black AR viewport until the first camera frame (#2484).
             // Outside `key(depthOn)` so the depth toggle never resurrects the entry
             // scrim — the toggle's own #1777 spinner below covers that flash.
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
 
             // Depth-toggle transition spinner (#1777) — covers the 2-3 frame engine +
             // camera-stream rebuild triggered by the `key(depthOn)` remount. Without it

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARDepthOcclusionDemo.kt
@@ -261,7 +261,11 @@ fun ARDepthOcclusionDemo(onBack: () -> Unit) {
             // waiting for the next ARCore tracking-failure callback.
             val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
             AnimatedVisibility(
-                visible = !isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = (!isTracking && arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
@@ -18,6 +18,7 @@ import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.frontCameraConfig
 import io.github.sceneview.demo.ARCameraInitScrim
@@ -64,6 +65,10 @@ fun ARFaceDemo(onBack: () -> Unit) {
     // Frame-received sentinel — flips true on the first onSessionUpdated call so the
     // "slow front camera" hint knows the camera feed is live.
     var cameraActive by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraActive` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // Session resumed — set by onSessionResumed. The slow-camera hint is anchored on
     // this (not the composition) so its grace window starts when ARCore actually
     // resumes the session.
@@ -204,6 +209,7 @@ fun ARFaceDemo(onBack: () -> Unit) {
                     android.util.Log.e("ARFaceDemo", "AR session failed", error)
                     sessionFailed = true
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { session: Session, _: Frame ->
                     // Mark camera as active on the first frame so the slow-camera hint
                     // knows the front camera opened successfully.
@@ -238,6 +244,7 @@ fun ARFaceDemo(onBack: () -> Unit) {
             // spinner, not a black viewport, covers a slow front-camera start (#2484).
             ARCameraInitScrim(
                 initializing = !cameraActive && !sessionFailed,
+                arCoreAvailability = arCoreAvailability,
                 timeoutMillis = SLOW_FRONT_CAMERA_HINT_MS,
             )
         }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFogDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFogDemo.kt
@@ -265,7 +265,11 @@ fun ARFogDemo(onBack: () -> Unit) {
         bottomOverlay = {
             val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
             AnimatedVisibility(
-                visible = !isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = (!isTracking && arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFogDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFogDemo.kt
@@ -36,6 +36,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.createARCameraStream
 import io.github.sceneview.ar.node.ARFogNode
@@ -111,6 +112,10 @@ fun ARFogDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     // Replay a recorded ARCore dataset when the device-QA harness deep-links
     // the demo with `--es ar_playback_file <path>`. `null` for every normal
@@ -315,6 +320,7 @@ fun ARFogDemo(onBack: () -> Unit) {
                         }
                     },
                     cameraStream = cameraStream,
+                    onARCoreAvailability = { arCoreAvailability = it },
                     onSessionUpdated = { _, frame: Frame ->
                         cameraReady = true
                         isTracking = frame.camera.trackingState == TrackingState.TRACKING
@@ -348,7 +354,10 @@ fun ARFogDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageDemo.kt
@@ -42,6 +42,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.rememberARCameraStream
 import io.github.sceneview.demo.common.QaCameraBackdrop
@@ -110,6 +111,10 @@ fun ARImageDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // QA camera backdrop (#3308): synthetic room photo while no camera frame arrives.
     val cameraStream = rememberARCameraStream(materialLoader)
     val qaBackdrop = rememberQaCameraBackdropActive(cameraReady)
@@ -353,6 +358,7 @@ fun ARImageDemo(onBack: () -> Unit) {
                         runtimeDatabase.addImage("reference", referenceBitmap, 0.15f)
                     }
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _: Session, frame: Frame ->
                     cameraReady = true
                     latestFrame = frame
@@ -395,7 +401,10 @@ fun ARImageDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageStabilizationDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARImageStabilizationDemo.kt
@@ -35,6 +35,7 @@ import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.configure
 import io.github.sceneview.demo.DemoScaffold
@@ -124,6 +125,11 @@ fun ARImageStabilizationDemo(onBack: () -> Unit) {
     var placedAnchor by remember { mutableStateOf<Anchor?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var isTracking by remember { mutableStateOf(false) }
+
+    // #3341: non-null once ARCore has ruled this device out. The flag the scanning
+    // banner waits on never flips then, so that banner has to read the verdict or
+    // it promises a scan under the SDK's "AR unavailable" card, forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     // Auto-placement guard. The demo's whole point — "model stays anchored while
     // the camera bg stabilizes" — only lands if the user *sees* a model on screen
@@ -258,7 +264,11 @@ fun ARImageStabilizationDemo(onBack: () -> Unit) {
             // so flipping the override re-renders the overlay immediately.
             val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
             AnimatedVisibility(
-                visible = !isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = (!isTracking && arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -343,6 +353,7 @@ fun ARImageStabilizationDemo(onBack: () -> Unit) {
                             }
                     }
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onTrackingFailureChanged = { reason ->
                     trackingFailureReason = reason
                 },

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARInstantPlacementDemo.kt
@@ -45,6 +45,7 @@ import com.google.ar.core.InstantPlacementPoint
 import com.google.ar.core.Plane
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.AnchorNode as ArAnchorNode
 import io.github.sceneview.demo.DemoScaffold
@@ -322,7 +323,11 @@ fun ARInstantPlacementDemo(onBack: () -> Unit) {
             val effectiveReason =
                 ForcedTrackingFailure.override ?: sceneState.trackingFailureReason
             AnimatedVisibility(
-                visible = !sceneState.isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, `isTracking` stays false
+                // forever — this pill would sit under the SDK's "AR unavailable" card
+                // promising the camera is on its way. Drop it and let the card speak.
+                visible = (!sceneState.isTracking && sceneState.arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -406,6 +411,15 @@ private class InstantPlacementSceneState {
 
     /** Whether the ARCore camera is tracking — drives the scanning indicator. */
     var isTracking by mutableStateOf(false)
+
+    /**
+     * Non-null once ARCore has ruled the session out on this device (#3341).
+     *
+     * [isTracking] can never flip in that case, so the scanning indicator would claim the
+     * camera is "initializing" for as long as the demo is open, right next to the SDK
+     * overlay saying AR cannot run at all.
+     */
+    var arCoreAvailability by mutableStateOf<ARCoreAvailability?>(null)
 
     /** Latest ARCore-reported tracking failure, or `null` while tracking is healthy. */
     var trackingFailureReason by mutableStateOf<TrackingFailureReason?>(null)
@@ -498,6 +512,7 @@ private fun InstantPlacementScene(
             } else {
                 Config.InstantPlacementMode.DISABLED
             },
+            onARCoreAvailability = { state.arCoreAvailability = it },
             onSessionUpdated = { _, frame: Frame ->
                 latestFrame = frame
                 state.isTracking = frame.camera.trackingState == TrackingState.TRACKING

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMeasureDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARMeasureDemo.kt
@@ -36,6 +36,7 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.rememberARCameraStream
 import io.github.sceneview.demo.common.QaCameraBackdrop
@@ -160,6 +161,10 @@ fun ARMeasureDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera frame,
     // so the ~1-3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // QA camera backdrop (#3308) — see TapToPlaceArSession.
     val cameraStream = rememberARCameraStream(materialLoader)
     val qaBackdrop = rememberQaCameraBackdropActive(cameraReady)
@@ -361,6 +366,7 @@ fun ARMeasureDemo(onBack: () -> Unit) {
                     }
                 },
                 onSessionCreated = { created: Session -> session = created },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _: Session, frame: Frame ->
                     cameraReady = true
                     latestFrame = frame
@@ -453,7 +459,10 @@ fun ARMeasureDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPeopleOcclusionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPeopleOcclusionDemo.kt
@@ -36,6 +36,7 @@ import com.google.ar.core.SemanticLabel
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.semanticLabelFraction
 import io.github.sceneview.ar.createARCameraStream
@@ -105,6 +106,11 @@ fun ARPeopleOcclusionDemo(onBack: () -> Unit) {
     var placedAnchor by remember { mutableStateOf<Anchor?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var isTracking by remember { mutableStateOf(false) }
+
+    // #3341: non-null once ARCore has ruled this device out. The flag the scanning
+    // banner waits on never flips then, so that banner has to read the verdict or
+    // it promises a scan under the SDK's "AR unavailable" card, forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // Live PERSON-pixel fraction for the HUD — `0f` when no person is in frame.
     var personFraction by remember { mutableFloatStateOf(0f) }
 
@@ -201,7 +207,11 @@ fun ARPeopleOcclusionDemo(onBack: () -> Unit) {
             // Scanning / tracking-failure overlay — same vocabulary as ARDepthOcclusionDemo.
             val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
             AnimatedVisibility(
-                visible = !isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = (!isTracking && arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -282,6 +292,7 @@ fun ARPeopleOcclusionDemo(onBack: () -> Unit) {
                         // Cheap GPU-side fraction — no full semantic-image walk needed.
                         personFraction = frame.semanticLabelFraction(SemanticLabel.PERSON)
                     },
+                    onARCoreAvailability = { arCoreAvailability = it },
                     onTrackingFailureChanged = { reason ->
                         trackingFailureReason = reason
                     },

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneNodeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneNodeDemo.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.rememberDetectedPlanes
 import io.github.sceneview.demo.DemoScaffold
@@ -75,6 +76,11 @@ fun ARPlaneNodeDemo(onBack: () -> Unit) {
     // "Total ever detected" — incremented by the onAdded lifecycle callback so the count keeps
     // climbing even when ARCore subsumes a smaller plane into a larger coplanar one.
     var totalDetected by remember { mutableIntStateOf(0) }
+
+    // #3341: non-null once ARCore has ruled this device out. The flag the scanning
+    // banner waits on never flips then, so that banner has to read the verdict or
+    // it promises a scan under the SDK's "AR unavailable" card, forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
 
@@ -131,7 +137,10 @@ fun ARPlaneNodeDemo(onBack: () -> Unit) {
             // least one plane is tracked.
             val noPlanesYet = totalDetected == 0
             AnimatedVisibility(
-                visible = noPlanesYet,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = noPlanesYet && arCoreAvailability == null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -162,6 +171,7 @@ fun ARPlaneNodeDemo(onBack: () -> Unit) {
                 playbackDataset = arPlaybackDataset,
                 planeRenderer = true,
                 onSessionCreated = { session -> arSession = session },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onTrackingFailureChanged = { reason -> trackingFailureReason = reason },
             ) {
                 // ARPlaneManager parity: observe the live set of detected planes and react to

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneRendererV2Demo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneRendererV2Demo.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.ar.core.TrackingFailureReason
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.scene.PlaneRendererBase
 import io.github.sceneview.demo.DemoScaffold
@@ -92,6 +93,11 @@ fun ARPlaneRendererV2Demo(onBack: () -> Unit) {
 
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var planeDetected by remember { mutableStateOf(false) }
+
+    // #3341: non-null once ARCore has ruled this device out. The flag the scanning
+    // banner waits on never flips then, so that banner has to read the verdict or
+    // it promises a scan under the SDK's "AR unavailable" card, forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_plane_renderer_v2_title),
@@ -204,7 +210,10 @@ fun ARPlaneRendererV2Demo(onBack: () -> Unit) {
             // Scanning / tracking-failure status — never leave the user staring at a
             // black screen (#1617). Visible until at least one plane is tracked.
             AnimatedVisibility(
-                visible = !planeDetected,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = !planeDetected && arCoreAvailability == null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -246,6 +255,7 @@ fun ARPlaneRendererV2Demo(onBack: () -> Unit) {
                     } else {
                         PlaneRendererBase.Version.V1
                     },
+                    onARCoreAvailability = { arCoreAvailability = it },
                     onTrackingFailureChanged = { reason -> trackingFailureReason = reason },
                     onSessionUpdated = { _, frame ->
                         if (!planeDetected) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPoseDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPoseDemo.kt
@@ -25,6 +25,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.rememberARCameraNode
 import io.github.sceneview.demo.ARCameraInitScrim
@@ -77,6 +78,10 @@ fun ARPoseDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     // Base pose: 1 m in front of the camera at the moment the demo gained tracking.
     // Captured once per session to keep the lantern anchored in world space (so sliders
     // nudge it relative to that anchor, not to the moving camera).
@@ -148,6 +153,7 @@ fun ARPoseDemo(onBack: () -> Unit) {
                     config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
                     config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { _, frame: Frame ->
                     cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
@@ -207,7 +213,10 @@ fun ARPoseDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRecordPlaybackDemo.kt
@@ -58,6 +58,7 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.recording.ARRecorder
 import io.github.sceneview.ar.recording.rememberARRecorder
@@ -707,6 +708,10 @@ private fun ModeContent(
     // ARSceneView surface is bare black, so we cover it with ARCameraInitScrim rather
     // than leave a viewport that reads as frozen/broken (#1473).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
 
     // When the recorder transitions out of RECORDING (and back to IDLE), refresh the
     // recordings list so the new MP4 shows up in PLAYBACK mode.
@@ -746,6 +751,7 @@ private fun ModeContent(
             config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
             config.lightEstimationMode = Config.LightEstimationMode.ENVIRONMENTAL_HDR
         },
+        onARCoreAvailability = { arCoreAvailability = it },
         onSessionUpdated = { session: Session, frame: Frame ->
             cameraReady = true
             latestFrame = frame
@@ -850,6 +856,7 @@ private fun ModeContent(
     // entry doesn't read as a frozen screen with a dimmed record button (#1473).
     ARCameraInitScrim(
         initializing = !cameraReady,
+        arCoreAvailability = arCoreAvailability,
         label = when (mode) {
             Mode.PLAYBACK -> "Starting playback…"
             Mode.ANALYSE -> "Starting analysis…"

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRerunDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRerunDemo.kt
@@ -54,6 +54,7 @@ import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.rerun.RerunBridge
 import io.github.sceneview.ar.rerun.rememberRerunBridge
@@ -99,6 +100,11 @@ fun ARRerunDemo(onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
 
     var isTracking by remember { mutableStateOf(false) }
+
+    // #3341: non-null once ARCore has ruled this device out. The flag the scanning
+    // banner waits on never flips then, so that banner has to read the verdict or
+    // it promises a scan under the SDK's "AR unavailable" card, forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var frameCount by remember { mutableStateOf(0L) }
     var eventsPerSec by remember { mutableStateOf(0f) }
@@ -190,7 +196,11 @@ fun ARRerunDemo(onBack: () -> Unit) {
             // so flipping the override re-renders the overlay immediately.
             val effectiveReason = ForcedTrackingFailure.override ?: trackingFailureReason
             AnimatedVisibility(
-                visible = !isTracking || ForcedTrackingFailure.override != null,
+                // #3341: on a device ARCore has ruled out, the flag this banner waits on
+                // never flips, so the banner would promise a scan under the SDK's "AR
+                // unavailable" card. Drop it and let the card carry reason and retry.
+                visible = (!isTracking && arCoreAvailability == null) ||
+                    ForcedTrackingFailure.override != null,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -251,6 +261,7 @@ fun ARRerunDemo(onBack: () -> Unit) {
                         lastCameraPose = frame.camera.pose
                     }
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onTrackingFailureChanged = { reason ->
                     trackingFailureReason = reason
                 },

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRooftopAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARRooftopAnchorDemo.kt
@@ -35,6 +35,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import dev.romainguy.kotlin.math.Quaternion
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.RooftopAnchorNode
 import io.github.sceneview.demo.DemoScaffold
@@ -156,6 +157,10 @@ fun ARRooftopAnchorDemo(onBack: () -> Unit) {
 
     var arSession by remember { mutableStateOf<Session?>(null) }
     var isTracking by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `isTracking` never flips
+    // then, so every "waiting for the camera" line below has to read the verdict or it
+    // contradicts the SDK's own explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var earthTracking by remember { mutableStateOf(false) }
     // Tracked alongside `earthTracking` because `Earth.resolveAnchorOnRooftopAsync`
     // throws IllegalStateException if `earth.earthState != EarthState.ENABLED`. The
@@ -269,6 +274,9 @@ fun ARRooftopAnchorDemo(onBack: () -> Unit) {
                     geospatialUnavailable != null -> geospatialUnavailable!!
                     // Friendly, complete sentence from friendlyArSessionError (#2349).
                     sessionError != null -> sessionError!!
+                    // ARCore will never start here, so "waiting" is a lie — the SDK
+                    // overlay in the AR view carries the real explanation (#3341).
+                    arCoreAvailability != null -> "AR is unavailable on this device"
                     !isTracking -> "Waiting for camera tracking…"
                     !earthTracking -> "Waiting for VPS lock (go outside, look around)…"
                     cameraLat != null && cameraLng != null -> {
@@ -345,6 +353,10 @@ fun ARRooftopAnchorDemo(onBack: () -> Unit) {
                         "${geospatialUnavailable!!} — needs urban area with building data + Cloud API key",
                         tone = DemoStatusTone.Blocked,
                     )
+                // The SDK's availability overlay already fills the viewport with the
+                // reason and the retry; a second, now false, "Initializing camera…"
+                // underneath it only contradicts it (#3341).
+                arCoreAvailability != null -> Unit
                 !isTracking -> DemoStatusBanner("Initializing camera…", tone = DemoStatusTone.Progress)
                 else ->
                     DemoStatusBanner(
@@ -413,6 +425,7 @@ fun ARRooftopAnchorDemo(onBack: () -> Unit) {
                     // "FatalException" class name to the user.
                     sessionError = friendlyArSessionError(exception)
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { session: Session, frame: Frame ->
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
                     val earth = session.earth

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneMeshDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneMeshDemo.kt
@@ -44,6 +44,7 @@ import com.google.ar.core.Session
 import com.google.ar.core.StreetscapeGeometry
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.MeshClassification
 import io.github.sceneview.ar.node.toMeshClassification
@@ -220,6 +221,10 @@ fun ARSceneMeshDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var geometryCount by remember { mutableStateOf(0) }
     var noGeometryGuidance by remember { mutableStateOf(false) }
@@ -356,6 +361,7 @@ fun ARSceneMeshDemo(onBack: () -> Unit) {
                     Log.e(TAG, "AR session failed", exception)
                     sessionError = exception.message ?: exception.javaClass.simpleName
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { session: Session, frame: Frame ->
                     cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
@@ -386,7 +392,10 @@ fun ARSceneMeshDemo(onBack: () -> Unit) {
 
             // Cover the still-black AR viewport until the first camera frame; lifts on a
             // session error so the error banner below is never hidden (#2484).
-            ARCameraInitScrim(initializing = !cameraReady && sessionError == null)
+            ARCameraInitScrim(
+                initializing = !cameraReady && sessionError == null,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARStreetscapeDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARStreetscapeDemo.kt
@@ -41,6 +41,7 @@ import com.google.ar.core.Session
 import com.google.ar.core.StreetscapeGeometry
 import com.google.ar.core.TrackingFailureReason
 import com.google.ar.core.TrackingState
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.demo.ARCameraInitScrim
 import io.github.sceneview.demo.DemoScaffold
@@ -229,6 +230,10 @@ fun ARStreetscapeDemo(onBack: () -> Unit) {
     // Cover the jet-black ARSceneView surface until ARCore delivers its first camera
     // frame, so the ~1–3 s warm-up on entry doesn't read as a frozen screen (#2484).
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var trackingFailureReason by remember { mutableStateOf<TrackingFailureReason?>(null) }
     var geometryCount by remember { mutableStateOf(0) }
     // After this long tracking with `geometryCount == 0` and no unsupported-device
@@ -431,6 +436,7 @@ fun ARStreetscapeDemo(onBack: () -> Unit) {
                     // "FatalException" class name to the user.
                     sessionError = friendlyArSessionError(exception)
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { session: Session, frame: Frame ->
                     cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
@@ -463,7 +469,10 @@ fun ARStreetscapeDemo(onBack: () -> Unit) {
 
             // Cover the still-black AR viewport until the first camera frame; lifts on a
             // session error so the error banner below is never hidden (#2484).
-            ARCameraInitScrim(initializing = !cameraReady && sessionError == null)
+            ARCameraInitScrim(
+                initializing = !cameraReady && sessionError == null,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARTerrainAnchorDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARTerrainAnchorDemo.kt
@@ -35,6 +35,7 @@ import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import dev.romainguy.kotlin.math.Quaternion
+import io.github.sceneview.ar.ARCoreAvailability
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.node.TerrainAnchorNode
 import io.github.sceneview.demo.ARCameraInitScrim
@@ -159,6 +160,10 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
     // camera and delivered a frame. Until then the ARSceneView surface is bare black,
     // so we cover it with ARCameraInitScrim instead of leaving a frozen-looking screen.
     var cameraReady by remember { mutableStateOf(false) }
+    // #3341: non-null once ARCore has ruled this device out. `cameraReady` never flips
+    // then, so the init scrim below has to read the verdict or it covers the SDK's own
+    // explanation card forever.
+    var arCoreAvailability by remember { mutableStateOf<ARCoreAvailability?>(null) }
     var isTracking by remember { mutableStateOf(false) }
     var earthTracking by remember { mutableStateOf(false) }
     // Tracked alongside `earthTracking` because `Earth.resolveAnchorOnTerrainAsync`
@@ -344,6 +349,10 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
                         "${geospatialUnavailable!!} — needs outdoor area with VPS coverage + Cloud API key",
                         tone = DemoStatusTone.Blocked,
                     )
+                // The SDK's availability overlay already fills the viewport with the
+                // reason and the retry; a second, now false, "Initializing camera…"
+                // underneath it only contradicts it (#3341).
+                arCoreAvailability != null -> Unit
                 !isTracking -> DemoStatusBanner("Initializing camera…", tone = DemoStatusTone.Progress)
                 else ->
                     DemoStatusBanner(
@@ -414,6 +423,7 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
                     // "FatalException" class name to the user.
                     sessionError = friendlyArSessionError(exception)
                 },
+                onARCoreAvailability = { arCoreAvailability = it },
                 onSessionUpdated = { session: Session, frame: Frame ->
                     cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
@@ -446,7 +456,10 @@ fun ARTerrainAnchorDemo(onBack: () -> Unit) {
 
             // Cover the still-black ARSceneView surface until ARCore delivers its
             // first camera frame, so the entry doesn't read as a frozen screen (#1473).
-            ARCameraInitScrim(initializing = !cameraReady && sessionError == null)
+            ARCameraInitScrim(
+                initializing = !cameraReady && sessionError == null,
+                arCoreAvailability = arCoreAvailability,
+            )
         }
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/OrbitalARDemo.kt
@@ -947,7 +947,10 @@ fun OrbitalARDemo(onBack: () -> Unit) {
             }
 
             // Cover the still-black AR viewport until the first camera frame (#2484).
-            ARCameraInitScrim(initializing = !cameraReady)
+            ARCameraInitScrim(
+                initializing = !cameraReady,
+                arCoreAvailability = arCoreAvailability,
+            )
 
             // Off-screen target indicator (#1482, #3269) — one edge arrow per
             // off-screen planet, each labelled with the live distance to it, so the

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ArCameraInitScrimVisibilityTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ArCameraInitScrimVisibilityTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 /**
  * Unit tests for [arCameraInitScrimVisibility] — the scrim decision behind `ARCameraInitScrim`
- * (#2484, #3373).
+ * (#2484, #3373, #3341).
  */
 class ArCameraInitScrimVisibilityTest {
 
@@ -17,6 +17,7 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = false,
                 timedOut = false,
                 qaBackdropEnabled = false,
+                arCoreUnavailable = false,
             )
         )
     }
@@ -29,6 +30,7 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = false,
                 timedOut = true,
                 qaBackdropEnabled = false,
+                arCoreUnavailable = false,
             )
         )
     }
@@ -41,6 +43,7 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = true,
                 timedOut = false,
                 qaBackdropEnabled = false,
+                arCoreUnavailable = false,
             )
         )
     }
@@ -58,6 +61,7 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = true,
                 timedOut = true,
                 qaBackdropEnabled = false,
+                arCoreUnavailable = false,
             )
         )
     }
@@ -71,6 +75,7 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = true,
                 timedOut = true,
                 qaBackdropEnabled = true,
+                arCoreUnavailable = false,
             )
         )
     }
@@ -84,6 +89,59 @@ class ArCameraInitScrimVisibilityTest {
                 initializing = true,
                 timedOut = false,
                 qaBackdropEnabled = true,
+                arCoreUnavailable = false,
+            )
+        )
+    }
+
+    /**
+     * #3341: an unsupported device (every emulator — #2754) never delivers a first frame, so
+     * `initializing` stays true forever and the scrim used to settle on a permanent black
+     * cover. The SDK's own `ARCoreAvailabilityOverlay` draws inside the `ARSceneView`, i.e.
+     * *under* this scrim, so the verdict has to dismiss the scrim or the explanation is never
+     * seen.
+     */
+    @Test
+    fun `an ARCore verdict hides the scrim even though the camera never started`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = true,
+                qaBackdropEnabled = false,
+                arCoreUnavailable = true,
+            )
+        )
+    }
+
+    /**
+     * The verdict wins over the spinner phase: waiting is pointless the moment ARCore says
+     * the session cannot start, so the user should not watch a progress indicator for the
+     * eight seconds it takes the defensive timeout to fire.
+     */
+    @Test
+    fun `an ARCore verdict hides the scrim before the timeout fires`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = false,
+                qaBackdropEnabled = false,
+                arCoreUnavailable = true,
+            )
+        )
+    }
+
+    /** The QA backdrop and the verdict agree here — both want the viewport uncovered. */
+    @Test
+    fun `an ARCore verdict hides the scrim with the QA backdrop on`() {
+        assertEquals(
+            ArCameraInitScrimVisibility.Hidden,
+            arCameraInitScrimVisibility(
+                initializing = true,
+                timedOut = false,
+                qaBackdropEnabled = true,
+                arCoreUnavailable = true,
             )
         )
     }


### PR DESCRIPTION
Fixes #3341.

## The problem

On a device ARCore rules out — which is every emulator (#2754) — opening an AR
demo showed a black viewport with "Initializing AR — look around to start
tracking" and stayed there indefinitely. No timeout, no explicit "AR
unavailable" state; the only hint was a greyed `Offline` badge in the title
pill.

#3374 already gave the SDK a real availability state (`ARCoreAvailability`) and
an explanation card (`ARCoreAvailabilityOverlay`). The card was being drawn — the
demo app's own chrome was covering it.

## The fix

`ARCameraInitScrim` is a full-screen opaque backdrop drawn as a *later sibling*
of `ARSceneView` and dismissed on the first camera frame. When ARCore cannot
start a session that frame never arrives, so after its eight-second timeout
(#3373) the scrim settled into a permanent black cover — on top of the card
explaining why.

It now takes the verdict as a **required** argument (no default: every call site
has to answer the question) and steps aside as soon as ARCore answers, at any
point in the start sequence. Waiting through the spinner phase is pointless once
the answer is "this device cannot run AR". Every demo that draws the scrim
passes the verdict through, sourced from `onARCoreAvailability`.

The demos' status copy no longer contradicts the card either. The Rooftop Anchor
sheet and banner, the Cloud Anchor and Terrain Anchor guidance and the Instant
Placement scanning pill all keyed off "not tracking yet" — permanently true on
an unsupported device — so "Initializing camera…" sat next to a card saying the
camera was never going to start. They now read the verdict first, matching what
the Orbital demo already did.

The same reading covers the shared "Scanning for surfaces…" banner, which the
issue predicted would be the wide case. Seven more demos gate it on a flag an
unsupported device never flips — `isTracking` for Image Stabilization, People
Occlusion, Rerun, Depth Occlusion and AR Fog; `totalDetected == 0` for Plane
Lifecycle; a `planeDetected` boolean for Plane Renderer V2 — so the banner
promised a scan that could not start. Depth Occlusion and AR Fog are a
regression this PR itself introduced: their scrim used to cover the banner, and
dismissing the scrim exposed it. All seven now defer to the verdict.

The scaffold's back control was already drawn above the scrim, so the "way back"
has worked throughout; what was missing was any reason to use it.

## Verification

`:samples:android-demo:testDebugUnitTest --tests '*ArCameraInitScrimVisibilityTest*'`
— 9 tests green (3 new ones cover the verdict against the timeout, the spinner
phase and the QA backdrop).

Visually on `emulator-5554`, which has no ARCore support:

| Demo | Before | After |
|---|---|---|
| Orbital AR | black viewport, "Initializing AR — look around to start tracking" forever | "Couldn't start AR" card + `Try again` + back control |
| Rooftop Anchors | black viewport, "Initializing camera…" banner | card visible, banner states AR can't start |
| Instant Placement | black viewport, scanning pill promising the camera | card visible, pill gone |
| Depth Occlusion | black viewport, then "Scanning for surfaces…" under the card | card + `Try again` + back arrow, no banner |
| AR Fog | same | same |
| Plane Lifecycle | black viewport, "Scanning for surfaces…" forever | card + `Try again` + back arrow, plane counters read `0` |

## Notes

- No new public SDK symbol — `:arsceneview:apiCheck` is untouched.
- No new UI: the card is the SDK's, already built against `DESIGN.md` tokens.
  This change is wiring plus copy gating.
- Changelog fragment: `changelog.d/3341-ar-unsupported-demo-chrome.md`
  (named apart from the existing `3341-model-catalog-catchable.md` — same issue,
  different subject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
