### PR TITLE
fix(ar): stop the plane renderer raycasting to pick the centre plane

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/CenterPlaneSelection.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/CenterPlaneSelection.kt
@@ -1,0 +1,230 @@
+package io.github.sceneview.ar.scene
+
+import com.google.ar.core.Frame
+import com.google.ar.core.Plane
+import com.google.ar.core.Pose
+import com.google.ar.core.TrackingState
+import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.dot
+import io.github.sceneview.ar.arcore.displayOrientedPose
+import io.github.sceneview.ar.arcore.isTracking
+import io.github.sceneview.ar.arcore.position
+import io.github.sceneview.ar.arcore.yDirection
+import io.github.sceneview.ar.arcore.zDirection
+import kotlin.math.abs
+
+/**
+ * Centre-of-screen plane selection for [PlaneRenderer.PlaneRendererMode.RENDER_CENTER],
+ * computed analytically instead of through `Frame.hitTest` (#3339).
+ *
+ * ### Why this exists
+ *
+ * `RENDER_CENTER` only needs to answer one question — *which detected floor plane is the
+ * camera looking at?* — so that exactly one plane gets its grid highlighted. Until #3339 it
+ * answered it by firing a real ARCore raycast at the centre pixel on every processed frame:
+ *
+ * ```kotlin
+ * frame.hitTest(viewSize.width / 2f, viewSize.height / 2f)
+ *     .firstByTypeOrNull(planeTypes = setOf(Plane.Type.HORIZONTAL_UPWARD_FACING))
+ * ```
+ *
+ * `RENDER_CENTER` is the default mode and the plane renderer is on by default, so **every**
+ * AR screen ran that raycast continuously. `ARCore` internally attempts a depth sub-test
+ * inside `Frame.hitTest`; on devices where the motion-stereo depth pipeline is unavailable
+ * that sub-test fails and ARCore's own native logger emits, per call:
+ *
+ * ```
+ * W native: W0000 … session.cc:2805] FAILED_PRECONDITION:
+ * W native: ARCoreError: third_party/arcore/ar/core/depth_hit_test.cc:332
+ * W native: ARCoreError: vr/perception/depth/projects/motion_stereo/manager/motion_stereo_manager.cc:2029
+ * W native: Depth estimation is disabled for the requested depth type.; Error calculating
+ *           the depth hit tests. [… 'ArStatusErrorSpace::AR_ERROR_ILLEGAL_STATE']
+ * ```
+ *
+ * Those lines come from ARCore's **native** logger, not from SceneView, so nothing on the
+ * Kotlin side can filter them — the `depthPoint = false` result filter runs *after* the
+ * native call, and no `Frame.hitTest` overload accepts a trackable-type filter. The only way
+ * to stop the noise is to stop making the call. That is what this file does.
+ *
+ * The failure never removed anything the call site wanted: the result was filtered down to
+ * `HORIZONTAL_UPWARD_FACING` planes, and the depth sub-test could only ever have contributed
+ * `DepthPoint` candidates, which were discarded anyway.
+ *
+ * ### Why the approximation is sound here
+ *
+ * The replacement intersects the camera's optical-axis ray with each candidate plane. That
+ * is an approximation of a true centre-pixel unprojection — but the **centre pixel is
+ * exactly the case where it is best**. Any centre-preserving crop/fit (which is what the AR
+ * camera stream uses) maps the viewport centre to the camera-image centre, so aspect fitting
+ * drops out entirely and the only residual is the sub-degree principal-point offset. For
+ * deciding *which of a handful of floor planes to highlight*, that is far below the
+ * threshold that changes the answer.
+ *
+ * The maths mirrors [io.github.sceneview.collision.Plane.rayIntersection] — the repo's
+ * canonical ray/plane intersection — including its `1e-6` parallel-ray epsilon, but over
+ * immutable [Float3] instead of the mutable, allocating `Vector3` / `Ray` / `RayHit` triple.
+ *
+ * @see PlaneRenderer
+ * @see PlaneRendererV2
+ */
+
+/**
+ * Parallel-ray rejection threshold, matching the repo-canonical
+ * `io.github.sceneview.collision.Plane.NEAR_ZERO_THRESHOLD` (also used by
+ * `Box.rayIntersection`, `MeshCollider` and `MathHelper`).
+ */
+internal const val RAY_PLANE_PARALLEL_EPSILON = 1e-6f
+
+/**
+ * Distance along [rayDirection] at which the ray meets the infinite plane defined by
+ * [planeCenter] / [planeNormal], or `null` when there is no forward intersection.
+ *
+ * Returns `null` when the ray is parallel to the plane (`|denominator| <=`
+ * [RAY_PLANE_PARALLEL_EPSILON]) and when the intersection lies at or behind the ray origin.
+ * The `> 0f` test is deliberately strict — a hit exactly at the camera origin is not a
+ * surface the user is looking *at* — and is NaN-safe, since every comparison against `NaN`
+ * is false.
+ *
+ * [rayDirection] and [planeNormal] are expected to be unit length (both come from an ARCore
+ * [Pose], which is always normalized). Only the *ratio* matters for the returned distance's
+ * sign, so a non-unit normal still classifies correctly.
+ *
+ * @param rayOrigin    Ray origin in world space.
+ * @param rayDirection Ray direction in world space, normalized.
+ * @param planeCenter  Any point lying on the plane.
+ * @param planeNormal  Plane surface normal, normalized.
+ * @return Forward hit distance, or `null` if the ray misses.
+ */
+internal fun rayPlaneDistance(
+    rayOrigin: Float3,
+    rayDirection: Float3,
+    planeCenter: Float3,
+    planeNormal: Float3
+): Float? {
+    val denominator = dot(planeNormal, rayDirection)
+    if (abs(denominator) <= RAY_PLANE_PARALLEL_EPSILON) return null
+    val distance = dot(planeNormal, planeCenter - rayOrigin) / denominator
+    return distance.takeIf { it > 0f }
+}
+
+/**
+ * Plane geometry reduced to what the ray test needs, so the selection maths stays free of
+ * ARCore types (and therefore unit-testable on a plain JVM).
+ *
+ * @param center Plane centre in world space.
+ * @param normal Plane surface normal in world space, normalized.
+ */
+internal data class PlaneRayCandidate(val center: Float3, val normal: Float3)
+
+/**
+ * Index of the [candidates] entry the ray hits first, or `null` when it hits none.
+ *
+ * Candidates are infinite planes; [isInPolygon] re-imposes the finite boundary and is only
+ * invoked for candidates the ray actually meets in front of the origin. It receives the
+ * candidate index and the world-space hit point. This mirrors ARCore's own contract, where
+ * `HitResult` filtering applies `Plane.isPoseInPolygon` to a hit that already passed the
+ * infinite-plane test (see `firstByTypeOrNull`'s `planePoseInPolygon = true` default).
+ *
+ * Iterates with an index loop rather than `mapIndexedNotNull` / `minByOrNull` so the hot
+ * path allocates nothing beyond the hit points themselves.
+ *
+ * @param rayOrigin    Ray origin in world space.
+ * @param rayDirection Ray direction in world space, normalized.
+ * @param candidates   Planes to test, in any order.
+ * @param isInPolygon  Finite-boundary test for a candidate's hit point.
+ * @return Index into [candidates] of the nearest accepted hit, or `null`.
+ */
+internal fun nearestPlaneAlongRay(
+    rayOrigin: Float3,
+    rayDirection: Float3,
+    candidates: List<PlaneRayCandidate>,
+    isInPolygon: (index: Int, hitPoint: Float3) -> Boolean
+): Int? {
+    var nearestIndex: Int? = null
+    var nearestDistance = Float.MAX_VALUE
+    for (index in candidates.indices) {
+        val candidate = candidates[index]
+        val distance = rayPlaneDistance(
+            rayOrigin = rayOrigin,
+            rayDirection = rayDirection,
+            planeCenter = candidate.center,
+            planeNormal = candidate.normal
+        ) ?: continue
+        if (distance >= nearestDistance) continue
+        if (!isInPolygon(index, rayOrigin + rayDirection * distance)) continue
+        nearestIndex = index
+        nearestDistance = distance
+    }
+    return nearestIndex
+}
+
+/**
+ * ARCore-facing half of the centre-plane selection: turns a [Frame] plus a set of live
+ * planes into "the floor plane the camera is pointed at", with no `Frame.hitTest` call.
+ *
+ * Kept as its own object so the pure maths above compiles into a separate, ARCore-free class
+ * that JVM unit tests can load without the ARCore runtime.
+ */
+internal object CenterPlaneFinder {
+
+    /**
+     * The [Plane] the camera's optical axis meets first, or `null` when the camera is not
+     * tracking or no candidate qualifies.
+     *
+     * Applies the same acceptance rules the replaced
+     * `firstByTypeOrNull(planeTypes = setOf(HORIZONTAL_UPWARD_FACING))` call applied through
+     * its defaults: [TrackingState.TRACKING] only, `HORIZONTAL_UPWARD_FACING` only, and the
+     * hit point inside the plane polygon (`planePoseInPolygon = true`). Subsumed planes are
+     * additionally skipped — they are merged into a larger plane and are never rendered by
+     * `renderPlane`, so highlighting one would select a plane that is not drawn.
+     *
+     * The ray is built from [com.google.ar.core.Camera.getDisplayOrientedPose] — the pose
+     * SceneView's own KDoc prescribes for "building a screen-space ray for hit-testing" —
+     * whose forward axis is `-Z`.
+     *
+     * Each candidate's `centerPose` is fetched **once** (one JNI round trip per plane per
+     * call, at the renderer's ~7.5 Hz gate) and reused for both position and normal.
+     *
+     * @param frame      Current AR frame.
+     * @param candidates Live planes to consider — the renderer passes its updated planes
+     *                   unioned with the planes it currently draws.
+     * @return The centre plane, or `null`.
+     */
+    fun find(frame: Frame, candidates: Collection<Plane>): Plane? {
+        val camera = frame.camera
+        if (!camera.isTracking) return null
+
+        val cameraPose = camera.displayOrientedPose
+        val rayOrigin = cameraPose.position
+        // ARCore poses are OpenGL-style: the camera looks down its own -Z axis.
+        val rayDirection = -cameraPose.zDirection
+
+        val planes = ArrayList<Plane>(candidates.size)
+        val geometry = ArrayList<PlaneRayCandidate>(candidates.size)
+        for (plane in candidates) {
+            if (plane.trackingState != TrackingState.TRACKING) continue
+            if (plane.subsumedBy != null) continue
+            if (plane.type != Plane.Type.HORIZONTAL_UPWARD_FACING) continue
+            val centerPose = plane.centerPose
+            planes += plane
+            geometry += PlaneRayCandidate(
+                center = centerPose.position,
+                normal = centerPose.yDirection
+            )
+        }
+
+        val index = nearestPlaneAlongRay(
+            rayOrigin = rayOrigin,
+            rayDirection = rayDirection,
+            candidates = geometry
+        ) { candidateIndex, hitPoint ->
+            // `isPoseInPolygon` reads only the pose translation, so a translation-only pose
+            // is the exact equivalent of what ARCore's own hit-result filtering applies.
+            planes[candidateIndex].isPoseInPolygon(
+                Pose.makeTranslation(hitPoint.x, hitPoint.y, hitPoint.z)
+            )
+        }
+
+        return index?.let { planes[it] }
+    }
+}

--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/CenterPlaneSelection.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/CenterPlaneSelection.kt
@@ -125,8 +125,10 @@ internal data class PlaneRayCandidate(val center: Float3, val normal: Float3)
  * `HitResult` filtering applies `Plane.isPoseInPolygon` to a hit that already passed the
  * infinite-plane test (see `firstByTypeOrNull`'s `planePoseInPolygon = true` default).
  *
- * Iterates with an index loop rather than `mapIndexedNotNull` / `minByOrNull` so the hot
- * path allocates nothing beyond the hit points themselves.
+ * The planes the ray actually meets are ordered by distance and [isInPolygon] is applied
+ * from the nearest outwards, stopping at the first acceptance. At the ARCore call site that
+ * boundary test is a JNI round trip, so ordering first means it usually runs exactly once.
+ * Ties keep input order: [sortedBy] is a stable sort.
  *
  * @param rayOrigin    Ray origin in world space.
  * @param rayDirection Ray direction in world space, normalized.
@@ -139,24 +141,21 @@ internal fun nearestPlaneAlongRay(
     rayDirection: Float3,
     candidates: List<PlaneRayCandidate>,
     isInPolygon: (index: Int, hitPoint: Float3) -> Boolean
-): Int? {
-    var nearestIndex: Int? = null
-    var nearestDistance = Float.MAX_VALUE
-    for (index in candidates.indices) {
+): Int? = candidates.indices
+    .mapNotNull { index ->
         val candidate = candidates[index]
-        val distance = rayPlaneDistance(
+        rayPlaneDistance(
             rayOrigin = rayOrigin,
             rayDirection = rayDirection,
             planeCenter = candidate.center,
             planeNormal = candidate.normal
-        ) ?: continue
-        if (distance >= nearestDistance) continue
-        if (!isInPolygon(index, rayOrigin + rayDirection * distance)) continue
-        nearestIndex = index
-        nearestDistance = distance
+        )?.let { distance -> index to distance }
     }
-    return nearestIndex
-}
+    .sortedBy { (_, distance) -> distance }
+    .firstOrNull { (index, distance) ->
+        isInPolygon(index, rayOrigin + rayDirection * distance)
+    }
+    ?.first
 
 /**
  * ARCore-facing half of the centre-plane selection: turns a [Frame] plus a set of live
@@ -202,9 +201,7 @@ internal object CenterPlaneFinder {
         val planes = ArrayList<Plane>(candidates.size)
         val geometry = ArrayList<PlaneRayCandidate>(candidates.size)
         for (plane in candidates) {
-            if (plane.trackingState != TrackingState.TRACKING) continue
-            if (plane.subsumedBy != null) continue
-            if (plane.type != Plane.Type.HORIZONTAL_UPWARD_FACING) continue
+            if (!plane.isCenterPlaneCandidate()) continue
             val centerPose = plane.centerPose
             planes += plane
             geometry += PlaneRayCandidate(
@@ -227,4 +224,17 @@ internal object CenterPlaneFinder {
 
         return index?.let { planes[it] }
     }
+
+    /**
+     * Whether this plane is eligible to be the highlighted centre plane, before any ray
+     * geometry is considered.
+     *
+     * Ordered cheapest-first, and short-circuiting, because every term is a JNI getter.
+     */
+    private fun Plane.isCenterPlaneCandidate(): Boolean =
+        trackingState == TrackingState.TRACKING &&
+            // Subsumed planes are merged into a larger one and are never drawn by
+            // `renderPlane`, so highlighting one would select a plane nobody can see.
+            subsumedBy == null &&
+            type == Plane.Type.HORIZONTAL_UPWARD_FACING
 }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRenderer.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRenderer.kt
@@ -9,10 +9,8 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.PlaneVisualizer
-import io.github.sceneview.ar.arcore.firstByTypeOrNull
 import io.github.sceneview.ar.arcore.fps
 import io.github.sceneview.ar.arcore.getUpdatedPlanes
-import io.github.sceneview.ar.arcore.hitTest
 import io.github.sceneview.ar.arcore.isTracking
 import io.github.sceneview.loaders.MaterialLoader
 import io.github.sceneview.material.setParameter
@@ -100,11 +98,16 @@ class PlaneRenderer(
     var planeRendererMode = PlaneRendererMode.RENDER_CENTER
 
     /**
-     * ### Adjust the max screen [ArFrame.hitTest] number per seconds
+     * Maximum number of plane-renderer updates per second.
      *
-     * Decrease if you don't need a very precise position update and want to reduce frame
-     * consumption.
-     * Increase for a more accurate positioning update.
+     * The whole [update] pass is gated to this rate: polling ARCore's updated planes, picking
+     * the centre plane in [PlaneRendererMode.RENDER_CENTER], and pushing plane geometry to
+     * Filament. Decrease if you don't need a very precise position update and want to reduce
+     * frame consumption; increase for a more accurate positioning update.
+     *
+     * The name comes from the `Frame.hitTest` this gate used to throttle. That hit test is
+     * gone (#3339), but the gate, its default and its meaning as a rate limit are unchanged,
+     * so the name is kept for source and binary compatibility.
      */
     var maxHitTestPerSecond: Int = 10
 
@@ -168,23 +171,41 @@ class PlaneRenderer(
                     if (planeRendererMode == PlaneRendererMode.RENDER_ALL) {
                         updatedPlanes.forEach { renderPlane(it) }
                     } else if (planeRendererMode == PlaneRendererMode.RENDER_CENTER) {
-                        // Do a hitTest on the current frame. The result is used to render only
-                        // the top most plane Trackable visible at the centre of the screen.
-                        val centerPlane = if (isVisible) {
-                            // Don't make the hit test if we don't need to know the center plane
-                            frame.hitTest(viewSize.width / 2.0f, viewSize.height / 2.0f)
-                                .firstByTypeOrNull(
-                                    planeTypes = setOf(Plane.Type.HORIZONTAL_UPWARD_FACING)
-                                )?.trackable as? Plane
-                        } else null
-                        updatedPlanes.forEach { renderPlane(it, visible = it == centerPlane) }
                         // AR10 (#2504): `updatedPlanes` is ARCore's JNI-backed list, so the
                         // per-visualizer `plane !in updatedPlanes` below was an O(M) linear scan —
                         // O(N×M) across all visualizers every frame. Hoist a `HashSet` once so the
-                        // membership test is O(1). Identity-based set membership matches the list
-                        // `contains` exactly (ARCore returns the same `Plane` instance per trackable
-                        // across frames), so the visibility outcome is unchanged.
+                        // membership test is O(1). ARCore hands out a FRESH `Plane` wrapper per
+                        // frame, so this works on `Plane`'s native-handle value equality (see
+                        // `io.github.sceneview.ar.arcore.diffPlanes`), never on identity — set
+                        // membership matches the list `contains` exactly and the visibility
+                        // outcome is unchanged.
                         val updatedPlaneSet = updatedPlanes.toHashSet()
+                        // Find the top most plane Trackable at the centre of the screen; only that
+                        // one is rendered.
+                        //
+                        // #3339: this used to be a real `frame.hitTest(centreX, centreY)`. ARCore
+                        // attempts a depth sub-test inside every `hitTest`, and on devices whose
+                        // motion-stereo depth pipeline is unavailable that sub-test fails and its
+                        // NATIVE logger spams `depth_hit_test.cc` / `AR_ERROR_ILLEGAL_STATE`
+                        // warnings — here at the `maxHitTestPerSecond` rate, forever, on every AR
+                        // screen. Nothing on the Kotlin side can filter a native log, and no
+                        // `hitTest` overload accepts a trackable-type filter, so the only fix is
+                        // not to make the call. [CenterPlaneFinder] answers the same question
+                        // analytically, applying the same acceptance rules the discarded
+                        // `firstByTypeOrNull(HORIZONTAL_UPWARD_FACING)` filter applied.
+                        val centerPlane = if (isVisible) {
+                            // Don't look for the center plane if we don't need to know it
+                            CenterPlaneFinder.find(
+                                frame = frame,
+                                // Planes that did not change this frame are still tracked and
+                                // still drawn, so they stay eligible: union the updated planes
+                                // with the ones we currently visualize.
+                                candidates = HashSet(updatedPlaneSet).apply {
+                                    addAll(visualizers.keys)
+                                }
+                            )
+                        } else null
+                        updatedPlanes.forEach { renderPlane(it, visible = it == centerPlane) }
                         visualizers.forEach { (plane, visualizer) ->
                             if (plane !in updatedPlaneSet) {
                                 visualizer.setVisible(isVisible && plane == centerPlane)

--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererBase.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererBase.kt
@@ -26,11 +26,15 @@ import com.google.ar.core.Session
 sealed interface PlaneRendererBase {
 
     /**
-     * Display size (in pixels) of the surface this renderer draws into.
+     * Display size (in pixels) of the surface this renderer draws into. Set by `ARSceneView`
+     * whenever the surface is resized.
      *
-     * Used by V1 to drive its centre-screen hit-test in
-     * [PlaneRenderer.PlaneRendererMode.RENDER_CENTER]. Set by `ARSceneView` whenever the
-     * surface is resized.
+     * Both renderers used to read it to place their centre-screen `Frame.hitTest` in
+     * [PlaneRenderer.PlaneRendererMode.RENDER_CENTER]. Since #3339 that hit test is gone —
+     * centre-plane selection is computed analytically from the camera pose, which needs no
+     * viewport size — so nothing in the SDK reads this today. It stays part of the contract
+     * because it is public API, and because any future screen-space work in a renderer needs
+     * exactly this value.
      */
     var viewSize: Size
 

--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererV2.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererV2.kt
@@ -9,10 +9,8 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.PlaneVisualizerV2
-import io.github.sceneview.ar.arcore.firstByTypeOrNull
 import io.github.sceneview.ar.arcore.fps
 import io.github.sceneview.ar.arcore.getUpdatedPlanes
-import io.github.sceneview.ar.arcore.hitTest
 import io.github.sceneview.ar.arcore.isTracking
 import dev.romainguy.kotlin.math.Float3
 import io.github.sceneview.loaders.MaterialLoader
@@ -162,11 +160,16 @@ class PlaneRendererV2(
     var planeRendererMode = PlaneRenderer.PlaneRendererMode.RENDER_CENTER
 
     /**
-     * ### Adjust the max screen [ArFrame.hitTest] number per seconds
+     * Maximum number of plane-renderer updates per second.
      *
-     * Decrease if you don't need a very precise position update and want to reduce frame
-     * consumption.
-     * Increase for a more accurate positioning update.
+     * The whole [update] pass is gated to this rate: polling ARCore's updated planes, picking
+     * the centre plane in [PlaneRenderer.PlaneRendererMode.RENDER_CENTER], and pushing plane
+     * geometry to Filament. Decrease if you don't need a very precise position update and
+     * want to reduce frame consumption; increase for a more accurate positioning update.
+     *
+     * The name comes from the `Frame.hitTest` this gate used to throttle. That hit test is
+     * gone (#3339), but the gate, its default and its meaning as a rate limit are unchanged,
+     * so the name is kept for source and binary compatibility.
      */
     var maxHitTestPerSecond: Int = 10
 
@@ -232,25 +235,43 @@ class PlaneRendererV2(
                     if (planeRendererMode == PlaneRenderer.PlaneRendererMode.RENDER_ALL) {
                         updatedPlanes.forEach { renderPlane(it, frame = frame, camera = camera) }
                     } else if (planeRendererMode == PlaneRenderer.PlaneRendererMode.RENDER_CENTER) {
-                        // Do a hitTest on the current frame. The result is used to render only
-                        // the top most plane Trackable visible at the centre of the screen.
+                        // AR10 (#2504): `updatedPlanes` is ARCore's JNI-backed list, so the
+                        // per-visualizer `plane !in updatedPlanes` below was an O(M) linear scan —
+                        // O(N×M) across all visualizers every frame. Hoist a `HashSet` once so the
+                        // membership test is O(1). ARCore hands out a FRESH `Plane` wrapper per
+                        // frame, so this works on `Plane`'s native-handle value equality (see
+                        // `io.github.sceneview.ar.arcore.diffPlanes`), never on identity — set
+                        // membership matches the list `contains` exactly and the visibility
+                        // outcome is unchanged.
+                        val updatedPlaneSet = updatedPlanes.toHashSet()
+                        // Find the top most plane Trackable at the centre of the screen; only that
+                        // one is rendered.
+                        //
+                        // #3339: this used to be a real `frame.hitTest(centreX, centreY)`. ARCore
+                        // attempts a depth sub-test inside every `hitTest`, and on devices whose
+                        // motion-stereo depth pipeline is unavailable that sub-test fails and its
+                        // NATIVE logger spams `depth_hit_test.cc` / `AR_ERROR_ILLEGAL_STATE`
+                        // warnings — here at the `maxHitTestPerSecond` rate, forever, on every AR
+                        // screen. Nothing on the Kotlin side can filter a native log, and no
+                        // `hitTest` overload accepts a trackable-type filter, so the only fix is
+                        // not to make the call. [CenterPlaneFinder] answers the same question
+                        // analytically, applying the same acceptance rules the discarded
+                        // `firstByTypeOrNull(HORIZONTAL_UPWARD_FACING)` filter applied.
                         val centerPlane = if (isVisible) {
-                            // Don't make the hit test if we don't need to know the center plane
-                            frame.hitTest(viewSize.width / 2.0f, viewSize.height / 2.0f)
-                                .firstByTypeOrNull(
-                                    planeTypes = setOf(Plane.Type.HORIZONTAL_UPWARD_FACING)
-                                )?.trackable as? Plane
+                            // Don't look for the center plane if we don't need to know it
+                            CenterPlaneFinder.find(
+                                frame = frame,
+                                // Planes that did not change this frame are still tracked and
+                                // still drawn, so they stay eligible: union the updated planes
+                                // with the ones we currently visualize.
+                                candidates = HashSet(updatedPlaneSet).apply {
+                                    addAll(visualizers.keys)
+                                }
+                            )
                         } else null
                         updatedPlanes.forEach {
                             renderPlane(it, frame = frame, camera = camera, visible = it == centerPlane)
                         }
-                        // AR10 (#2504): `updatedPlanes` is ARCore's JNI-backed list, so the
-                        // per-visualizer `plane !in updatedPlanes` below was an O(M) linear scan —
-                        // O(N×M) across all visualizers every frame. Hoist a `HashSet` once so the
-                        // membership test is O(1). Identity-based set membership matches the list
-                        // `contains` exactly (ARCore returns the same `Plane` instance per trackable
-                        // across frames), so the visibility outcome is unchanged.
-                        val updatedPlaneSet = updatedPlanes.toHashSet()
                         visualizers.forEach { (plane, visualizer) ->
                             if (plane !in updatedPlaneSet) {
                                 visualizer.setVisible(isVisible && plane == centerPlane)

--- a/arsceneview/src/test/java/io/github/sceneview/ar/scene/CenterPlaneSelectionTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/scene/CenterPlaneSelectionTest.kt
@@ -1,0 +1,327 @@
+package io.github.sceneview.ar.scene
+
+import dev.romainguy.kotlin.math.Float3
+import dev.romainguy.kotlin.math.normalize
+import io.github.sceneview.utils.fps
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.sqrt
+
+/**
+ * JVM tests for the centre-plane selection maths that replaced `RENDER_CENTER`'s per-frame
+ * `Frame.hitTest` (#3339).
+ *
+ * **What this pins down.** [rayPlaneDistance] and [nearestPlaneAlongRay] are `internal`
+ * top-level functions with no ARCore types in their signatures, precisely so their
+ * correctness can be owned by a plain JVM test instead of by on-device AR QA. Everything the
+ * replaced hit test used to decide — which of the tracked floor planes the camera is aimed
+ * at, and nothing when it is aimed at none — now flows through them. A regression here does
+ * not throw: it shows up on a device as the plane grid highlighting the wrong plane, or as no
+ * grid at all.
+ *
+ * **What this does NOT cover.** [CenterPlaneFinder.find] itself, which needs a live ARCore
+ * `Frame` (native session) and is exercised by the device-QA harness —
+ * `bash .claude/scripts/device-qa.sh --platform=android`. Its ARCore-facing part is
+ * deliberately thin: filter to tracked, non-subsumed `HORIZONTAL_UPWARD_FACING` planes, read
+ * each `centerPose` once, then delegate to the functions tested here.
+ */
+class CenterPlaneSelectionTest {
+
+    // Camera at standing eye height above a floor at y = 0, looking straight down.
+    private val eye = Float3(0f, 1.6f, 0f)
+    private val down = Float3(0f, -1f, 0f)
+    private val up = Float3(0f, 1f, 0f)
+
+    /** An infinite horizontal upward-facing plane at height [y]. */
+    private fun floorAt(y: Float) = PlaneRayCandidate(
+        center = Float3(0f, y, 0f),
+        normal = up
+    )
+
+    private val acceptAll: (Int, Float3) -> Boolean = { _, _ -> true }
+
+    // ── rayPlaneDistance ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `looking straight down hits the floor at eye height`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = down,
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertEquals(1.6f, distance!!, 1e-5f)
+    }
+
+    @Test
+    fun `a 45 degree ray travels the drop times root two`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = normalize(Float3(1f, -1f, 0f)),
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertEquals(1.6f * sqrt(2f), distance!!, 1e-4f)
+    }
+
+    @Test
+    fun `the plane center may be any point on the plane`() {
+        // Same floor, centre pose 10 m away laterally — the intersection distance is
+        // unchanged because only the plane's height enters the equation.
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = down,
+            planeCenter = Float3(10f, 0f, -4f),
+            planeNormal = up
+        )
+
+        assertEquals(1.6f, distance!!, 1e-5f)
+    }
+
+    @Test
+    fun `a ray parallel to the plane never intersects`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = Float3(1f, 0f, 0f),
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a near parallel ray below the epsilon is rejected`() {
+        // Tilted by 5e-7 — under RAY_PLANE_PARALLEL_EPSILON, so the intersection would be
+        // hundreds of kilometres away and is meaningless.
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = Float3(1f, -5e-7f, 0f),
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a tilt just above the epsilon still intersects`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = Float3(1f, -2e-6f, 0f),
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNotNull(distance)
+        assertTrue(distance!! > 0f)
+    }
+
+    @Test
+    fun `a plane behind the camera is rejected`() {
+        // Looking up: the floor is behind the ray, at a negative distance.
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = up,
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a plane exactly at the ray origin is rejected`() {
+        // The camera sits on the plane: distance 0, which is not a surface it is looking at.
+        val distance = rayPlaneDistance(
+            rayOrigin = Float3(0f, 0f, 0f),
+            rayDirection = down,
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a NaN ray direction never produces a hit`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = Float3(0f, Float.NaN, 0f),
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a NaN plane center never produces a hit`() {
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = down,
+            planeCenter = Float3(0f, Float.NaN, 0f),
+            planeNormal = up
+        )
+
+        assertNull(distance)
+    }
+
+    @Test
+    fun `a non unit normal does not change the hit distance`() {
+        // Only the ratio of the two dot products matters, so scaling the normal cancels out.
+        val distance = rayPlaneDistance(
+            rayOrigin = eye,
+            rayDirection = down,
+            planeCenter = Float3(0f, 0f, 0f),
+            planeNormal = Float3(0f, 2f, 0f)
+        )
+
+        assertEquals(1.6f, distance!!, 1e-5f)
+    }
+
+    @Test
+    fun `the parallel epsilon matches the repo canonical threshold`() {
+        // io.github.sceneview.collision.Plane.NEAR_ZERO_THRESHOLD, also used by
+        // Box.rayIntersection, MeshCollider and MathHelper.
+        assertEquals(1e-6f, RAY_PLANE_PARALLEL_EPSILON, 0f)
+    }
+
+    // ── nearestPlaneAlongRay ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `no candidates means no plane`() {
+        assertNull(nearestPlaneAlongRay(eye, down, emptyList(), acceptAll))
+    }
+
+    @Test
+    fun `the single hit candidate wins`() {
+        assertEquals(0, nearestPlaneAlongRay(eye, down, listOf(floorAt(0f)), acceptAll))
+    }
+
+    @Test
+    fun `the single missed candidate loses`() {
+        // A floor above the camera, which is looking down.
+        assertEquals(null, nearestPlaneAlongRay(eye, down, listOf(floorAt(3f)), acceptAll))
+    }
+
+    @Test
+    fun `the nearest plane along the ray wins regardless of list order`() {
+        // Distances from the camera looking down: y=1.0 → 0.6, y=0.5 → 1.1, y=0.0 → 1.6.
+        val ground = floorAt(0f)
+        val step = floorAt(0.5f)
+        val table = floorAt(1.0f)
+
+        assertEquals(1, nearestPlaneAlongRay(eye, down, listOf(ground, table, step), acceptAll))
+        assertEquals(0, nearestPlaneAlongRay(eye, down, listOf(table, step, ground), acceptAll))
+        assertEquals(2, nearestPlaneAlongRay(eye, down, listOf(step, ground, table), acceptAll))
+    }
+
+    @Test
+    fun `a candidate outside its polygon falls through to the farther one`() {
+        val ground = floorAt(0f)
+        val table = floorAt(1.0f)
+
+        // The near plane (the table) is rejected by the polygon test: the camera is aimed
+        // past its edge, so the ground behind it is what the user is actually looking at.
+        assertEquals(
+            1,
+            nearestPlaneAlongRay(eye, down, listOf(table, ground)) { index, _ -> index != 0 }
+        )
+        // Same outcome with the list order flipped — rejection must not depend on the order
+        // ARCore happened to hand the planes over in.
+        assertEquals(
+            0,
+            nearestPlaneAlongRay(eye, down, listOf(ground, table)) { index, _ -> index != 1 }
+        )
+    }
+
+    @Test
+    fun `all candidates outside their polygons means no plane`() {
+        val candidates = listOf(floorAt(0f), floorAt(0.5f), floorAt(1.0f))
+
+        assertNull(nearestPlaneAlongRay(eye, down, candidates) { _, _ -> false })
+    }
+
+    @Test
+    fun `a plane met exactly at the origin gives way to a farther one`() {
+        // The camera stands on the upper plane; the floor below it is the real answer.
+        val candidates = listOf(floorAt(1.6f), floorAt(0f))
+
+        assertEquals(1, nearestPlaneAlongRay(eye, down, candidates, acceptAll))
+    }
+
+    @Test
+    fun `the polygon test is not consulted for planes the ray misses`() {
+        val wall = PlaneRayCandidate(center = Float3(2f, 0f, 0f), normal = Float3(1f, 0f, 0f))
+        val ceiling = floorAt(3f)
+        val ground = floorAt(0f)
+        val consulted = mutableListOf<Int>()
+
+        val index = nearestPlaneAlongRay(eye, down, listOf(wall, ceiling, ground)) { i, _ ->
+            consulted += i
+            true
+        }
+
+        // The wall is parallel to the ray and the ceiling is behind it, so neither reaches
+        // the polygon test — which on a device is a JNI round trip per call.
+        assertEquals(listOf(2), consulted)
+        assertEquals(2, index)
+    }
+
+    @Test
+    fun `the polygon test receives the world space hit point`() {
+        var hitPoint: Float3? = null
+
+        nearestPlaneAlongRay(
+            rayOrigin = eye,
+            rayDirection = normalize(Float3(1f, -1f, 0f)),
+            candidates = listOf(floorAt(0f))
+        ) { _, point ->
+            hitPoint = point
+            true
+        }
+
+        // A 45° ray from 1.6 m up lands 1.6 m ahead, on the plane.
+        assertNotNull(hitPoint)
+        assertEquals(1.6f, hitPoint!!.x, 1e-4f)
+        assertEquals(0f, hitPoint!!.y, 1e-4f)
+        assertEquals(0f, hitPoint!!.z, 1e-4f)
+    }
+
+    // ── Renderer rate gate ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the default rate gate admits one pass every fourth frame at 30 fps`() {
+        // Both renderers gate their whole update pass on
+        //     frame.fps(lastProcessedFrame) < maxHitTestPerSecond
+        // with maxHitTestPerSecond defaulting to 10. Comparing against the last *processed*
+        // frame rather than the previous frame is what makes the emergent rate 7.5 Hz rather
+        // than 10 Hz — the arithmetic that identified the plane renderer as the source of the
+        // 134 ms / 137 ms warning cadence in the #3339 log, and the reason a "10 per second"
+        // knob must not be read as a promise of 10 passes per second.
+        val maxHitTestPerSecond = 10
+        val frameIntervalNanos = 33_333_333L // the 30 fps camera stream seen in the log
+        var lastProcessed: Long? = null
+        val processed = mutableListOf<Long>()
+
+        repeat(60) { index ->
+            val timestamp = index * frameIntervalNanos
+            if (timestamp.fps(lastProcessed) < maxHitTestPerSecond) {
+                lastProcessed = timestamp
+                processed += timestamp
+            }
+        }
+
+        assertTrue(processed.size >= 2)
+        val periods = processed.zipWithNext { previous, current -> current - previous }
+        assertEquals(listOf(4 * frameIntervalNanos), periods.distinct())
+        assertEquals(133.3, (4 * frameIntervalNanos) / 1_000_000.0, 0.1)
+        assertEquals(7.5, 1_000_000_000.0 / (4 * frameIntervalNanos), 0.01)
+    }
+}

--- a/changelog.d/3339-plane-renderer-center-hit-test.md
+++ b/changelog.d/3339-plane-renderer-center-hit-test.md
@@ -1,0 +1,26 @@
+<!-- category: Fixed -->
+- **The plane renderer no longer fires an ARCore raycast just to pick which plane to
+  highlight ([#3339](https://github.com/sceneview/sceneview/issues/3339)).**
+  `PlaneRendererMode.RENDER_CENTER` is the default mode and the plane renderer is on by
+  default, so **every** AR screen ran a centre-screen `frame.hitTest()` continuously —
+  gated by `maxHitTestPerSecond = 10`, which against a 30 fps camera stream admits one
+  pass every fourth frame, 7.5 times a second, for the lifetime of the screen. ARCore
+  attempts a depth sub-test inside every `hitTest`, and on devices whose motion-stereo
+  depth pipeline is unavailable that sub-test fails and ARCore's **native** logger emits a
+  four-line `FAILED_PRECONDITION` / `depth_hit_test.cc` / `motion_stereo_manager.cc` /
+  `AR_ERROR_ILLEGAL_STATE` block per call — forever, on every AR screen, with no way to
+  opt out short of disabling the plane renderer. Nothing on the Kotlin side can filter a
+  native log (the `depthPoint = false` result filter runs *after* the native call) and no
+  `Frame.hitTest` overload accepts a trackable-type filter, so the only fix is not to make
+  the call. The centre plane is now found analytically, by intersecting the camera's
+  optical-axis ray with each candidate plane, applying exactly the acceptance rules the
+  discarded `firstByTypeOrNull(HORIZONTAL_UPWARD_FACING)` applied through its defaults:
+  `TRACKING` only, `HORIZONTAL_UPWARD_FACING` only, hit point inside the plane polygon.
+  Subsumed planes are additionally skipped, since they are never drawn and highlighting
+  one selected a plane that is not on screen. The failing depth sub-test never removed
+  anything the call site wanted — the result was narrowed to horizontal planes, so depth
+  could only ever have contributed `DepthPoint` candidates that were discarded anyway, and
+  the warning was benign: it did not prevent anchoring or placement. Public API is
+  unchanged — `maxHitTestPerSecond` keeps its name, default and meaning as a rate limit on
+  the whole update pass, and `PlaneRendererBase.viewSize` stays part of the contract.
+  Applies to both `PlaneRenderer` (V1, the default) and `PlaneRendererV2`.


### PR DESCRIPTION
Fixes #3339

## TL;DR

The log attached to #3339 is real and this PR removes its cause. But it is **not** the cause of the visual complaint in the issue title — I could not make the log explain "on voit pas grand chose", and I say why below rather than pretending otherwise.

The defect actually fixed: **a centre-screen ARCore raycast fired 7.5 times a second on every AR screen, forever, purely to decide which single plane to highlight**, with no way to opt out short of disabling the plane renderer.

## Diagnosis, grounded in the log lines

The report carries this block, repeating:

```
ARCoreError: third_party/arcore/ar/core/depth_hit_test.cc:332
ARCoreError: vr/perception/depth/projects/motion_stereo/manager/motion_stereo_manager.cc:2029
Depth estimation is disabled for the requested depth type.; Error calculating the depth hit tests. [AR_ERROR_ILLEGAL_STATE]
```

**The stated hypothesis was that the demo requests depth hit tests on a session where depth is neither supported nor enabled. I checked it and it does not hold** — it is structurally impossible in this SDK:

- `ArSession.configure` already downgrades an unsupported `depthMode` to `DISABLED` centrally, gated on `isDepthModeSupported`.
- `ARSceneView` defaults `depthMode = DISABLED` (`ARSceneView.kt:466`).
- No call site anywhere passes `depthPoint = true`, and every demo that touches depth gates on `isDepthModeSupported` first.

So who fires the hit test? The cadence identifies it exactly:

1. `planeRenderer = true` (`ARSceneView.kt:548`), `planeRendererVersion = V1` (`:567`), and `planeRendererMode` defaults to `RENDER_CENTER` (`PlaneRenderer.kt:98`). Nothing in the SDK or the demos changes either. **Every AR screen ran a centre-screen `frame.hitTest()` continuously.**
2. The gate is `frame.fps(this.frame) < maxHitTestPerSecond` with `maxHitTestPerSecond = 10`, comparing against the last **processed** frame, not the previous frame. Against a 30 fps camera stream that admits exactly one pass every fourth frame: **133.3 ms, 7.5 Hz** — not the 10 Hz the knob's name suggests.
3. The warnings in the issue log are **134 ms and 137 ms apart, on every fourth camera frame**. Exact match. The reticle's hit test is unthrottled at 30 Hz and cannot produce this cadence.
4. ARCore attempts a depth sub-test **inside** every `Frame.hitTest`. On this Pixel 9 build the motion-stereo pipeline is unavailable, that sub-test fails, and ARCore's own **native** logger (`session.cc:2805`) emits the four-line block. Sibling issue #3340's log corroborates a broken motion-stereo pipeline on the same PID, with an `E`-severity `spherical_rectifier.cc:161` RET_CHECK.

### Why the two requested behaviours could not be implemented as asked

- **"No depth hit test if depth is not active, with a fallback to the plane hit test."** Not implementable at the call site: **no `Frame.hitTest` overload accepts a trackable-type filter.** You cannot ask ARCore for "planes only". SceneView's `depthPoint = false` filter runs on the *result list*, after the native call has already run and already logged. And the plane fallback being asked for already exists and already works — the call site already narrowed the result to `HORIZONTAL_UPWARD_FACING`.
- **"One warning once, not 8 per second."** The lines come from ARCore's native logger inside the JNI call. No Kotlin-side change can suppress, throttle or deduplicate them. The only lever is **not making the call**.

### The warning is benign, and it does not explain the visual symptom

The call **did not throw** — the enclosing `catch` logs `"PlaneRenderer update error"`, which is absent from the log, and rendering continued at a metronomic 30 fps. The failing depth sub-test removed nothing the call site wanted: the result was already narrowed to horizontal planes, so depth could only ever have contributed `DepthPoint` candidates that were discarded anyway. **Anchoring and placement were unaffected.**

The "on voit pas grand chose" symptom is most likely already fixed. The reported build is `4.32.0-main.a4e8f4d`; `main` is 33 commits ahead of it and four AR rendering fixes landed in between: `b6694ae5a` (#3340/#3363 occlusion inversion), `1808d115c` (#3369 sRGB EOTF on the camera feed), `49da761ec` (#3377 camera stream painting garbage before its first frame), `1a146bfb6` (#3376 explicit state when ARCore cannot start). **That needs a re-test on `main` before any further rendering work — see the separate items at the bottom.**

## The fix

`CenterPlaneFinder` answers the same question analytically: intersect the camera's optical-axis ray with each candidate plane and take the nearest acceptable hit. It applies **exactly** the acceptance rules the discarded `firstByTypeOrNull(HORIZONTAL_UPWARD_FACING)` applied through its defaults — `TRACKING` only, `HORIZONTAL_UPWARD_FACING` only, hit point inside the plane polygon (via `Plane.isPoseInPolygon`, which reads only the pose translation, so a translation-only pose is the exact equivalent of ARCore's own filtering).

One deliberate behaviour change: **subsumed planes are now skipped.** They are never drawn, so highlighting one previously selected a plane that is not on screen.

Why the optical-axis approximation is sound here: the centre pixel is precisely where it is exact for a pinhole camera, and centre-preserving crop/fit makes the aspect fitting drop out. Only a sub-degree principal-point offset remains.

Public API is unchanged:

- `maxHitTestPerSecond` **keeps its name, default and meaning** as a rate limit on the whole update pass. The KDoc now explains that the name is historical, kept for source and binary compatibility.
- `PlaneRendererBase.viewSize` **stays part of the contract** even though nothing in the SDK reads it any more — it is public API and any future screen-space work needs exactly that value. KDoc updated to say so plainly.

Applies to both `PlaneRenderer` (V1, the default) and `PlaneRendererV2`.

### Rejected alternatives

- **Just lowering `maxHitTestPerSecond`** — reduces but does not remove steady-state spam.
- **Unprojecting the centre pixel through the view/projection matrices** — a handedness/NDC/row-order mistake would silently produce **no grid at all**, worsening the reported symptom, and would be unverifiable without AR QA on a repo where merging to `main` auto-deploys.
- **An opt-in flag to restore the ARCore hit test** — rejected on purpose: it would keep the spamming code path alive as public API.

Also corrected in passing: the pre-existing AR10 comment in **both** renderers claimed the `HashSet` membership test works because ARCore returns identical `Plane` instances. It does not — ARCore hands out a **fresh** wrapper every frame, and it is `TrackableBase`'s value equality on the native handle that makes it work. The outcome was always right; the stated rationale was wrong.

## JVM tests

22 new tests in `arsceneview/src/test/java/io/github/sceneview/ar/scene/CenterPlaneSelectionTest.kt`. The ray/plane maths is deliberately `internal`, top-level and ARCore-free in its signatures, following the repo's existing idiom (`pointInPolygon2D`, `diffTrackedSet`, `cameraIntrinsicsSnapshot`), so its correctness is owned by a plain JVM test instead of by on-device AR QA. A regression here does not throw — on a device it shows up as the wrong plane highlighted, or no grid at all.

- `rayPlaneDistance` (12): straight-down and 45° intersections; centre pose anywhere on the plane; exactly-parallel and sub-epsilon-tilt rejection; just-above-epsilon acceptance; plane behind the camera; plane exactly at the ray origin; NaN direction and NaN centre; non-unit normals; and that `RAY_PLANE_PARALLEL_EPSILON` equals the repo-canonical `1e-6` of `collision.Plane.NEAR_ZERO_THRESHOLD`.
- `nearestPlaneAlongRay` (9): nearest-of-three asserted across **all three list orderings**; polygon rejection falling through to the farther plane, asserted in **both** orders; all-rejected; the polygon callback not being consulted for planes the ray misses (it is a JNI round trip per call on device); and the callback receiving the correct world-space hit point.
- The gate arithmetic itself (1): replays 60 frames at 30 fps through the real `Long.fps` chain and asserts the emergent period is exactly four frames, 133.3 ms, 7.5 Hz — pinning the reasoning that identified the plane renderer as the log's source, and documenting that "10 per second" is not a promise of 10 passes per second.

`:arsceneview:testDebugUnitTest` is green, including every pre-existing arsceneview test.

## Emulator smoke test — and its honest limits

`emulator-5554`, debug APK built from this branch:

- `BUILD SUCCESSFUL in 40s`; `adb install -r -t` → `Success`.
- `am start -W -n io.github.sceneview.demo/.MainActivity` → `Status: ok`, `LaunchState: COLD`, `TotalTime: 793`, PID 11375.
- Navigated Home → **AR View** hub → **Tap to Place** (the screen that instantiates `PlaneRenderer`, i.e. the changed code path).
- **PID still alive. No `FATAL`, no `AndroidRuntime` exception, no ANR, no `SceneView`-tagged error, and no `PlaneRenderer update error` / `PlaneRendererV2 update error` anywhere in logcat.**
- `CenterPlaneFinder`, `CenterPlaneSelection` and `CenterPlaneSelectionKt` are all confirmed present in the installed APK's dex.

**What this does not prove.** It does **not** validate the plane-renderer change. ARCore never creates a session on this AVD (#2754 — no camera HAL id 0 on arm64 Apple Silicon); logcat shows the failure at `session_create_implementation_shared.cc`, well before any hit test. `PlaneRenderer.update()` is therefore never invoked and `CenterPlaneFinder.find` never runs against a real `Frame`. The demo reached the graceful "Couldn't start AR" state from #3376 — correct behaviour, but it means the smoke test proves compile/dex/install/launch/navigate-without-crash and nothing more.

(Worth noting for anyone reading the AVD: the AR hub optimistically reports "AR ready on this device." because Google Play Services for AR *is* installed on the emulator, while actual session creation still fails at the demo screen. That string does not contradict #2754.)

## needs-device

Requires a physical ARCore device — the Pixel 9 from the report, on a build of `main` with this branch merged. **I have not run any of this**; it cannot be automated here.

1. **The grid still appears.** Point at a floor in a lit room: the procedural grid must draw on the detected plane exactly as before. *(Highest-value check — a regression in the new maths shows up as no grid at all.)*
2. **Only the aimed-at plane is highlighted.** With two horizontal surfaces detected (floor and a table or step), only the one the phone's centre is aimed at is visible.
3. **The highlight switches correctly when panning** between the floor and the raised surface, and switches back. Near-plane-first ordering must hold: aiming at the table highlights the table, not the floor behind it.
4. **Aiming past a plane's edge falls through** to the surface behind it, rather than keeping the near plane highlighted.
5. **Tap-to-place still anchors** — the placement path is untouched, so this is a no-regression check.
6. **The log block is gone.** With the plane renderer on, `depth_hit_test.cc` / `motion_stereo_manager.cc` / `AR_ERROR_ILLEGAL_STATE` must no longer repeat at ~7.5 Hz in logcat. Other AR features may still emit it from their own hit tests (see item 4 below) — this PR only removes the plane renderer's contribution, which was the continuous, unavoidable one.

## Separate subjects, not grouped into this PR

Flagged for separate issues rather than guessed at:

1. **The rendering complaint itself is unverified.** "On voit pas grand chose" needs a re-test on current `main` against #3363 / #3369 / #3377 / #3376 before any further work. It may already be fixed.
2. **The in-app bug reporter records neither the current demo screen nor more than the last 30 log lines**, which is what forced this entire forensic reconstruction from a cadence measurement. #3339 could only be bracketed to a screen by its timestamps against #3338 and #3340.
3. **`PlaneRendererV2`'s class KDoc still claims "V2 is the default plane renderer as of this release"**, and `PlaneRendererV2Test.kt:43-45`'s `@Suppress("DEPRECATION")` comment still calls V1 deprecated. Both contradict `Version.V1` at `ARSceneView.kt:567` and `PlaneRendererBase.kt:78`.
4. **`ReticleNode` / `PlacementReticleNode` cannot forward `HitResultNode.refreshIntervalMs`**, so their per-frame ARCore hit test cannot be rate-limited by any caller. On a device with a broken depth pipeline that path emits the same native warnings at the full frame rate whenever a reticle is on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
