### PR TITLE
docs(arsceneview): stop PlaneRendererV2's KDoc claiming V2 is the default

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/PlaneVisualizerV2.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/PlaneVisualizerV2.kt
@@ -31,11 +31,14 @@ import java.nio.FloatBuffer
 /**
  * Renders a single ARCore Plane using native Filament geometry — V2 implementation.
  *
- * **V2 is the default plane renderer as of this release.** See
- * [#2203](https://github.com/sceneview/sceneview/issues/2203) for the umbrella that delivered
- * it. The legacy V1 [io.github.sceneview.ar.PlaneVisualizer] remains available behind
- * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V1)` for one release cycle
- * and is now `@Deprecated`.
+ * **V2 is an experimental opt-in — it is not the default.** The default is
+ * [io.github.sceneview.ar.scene.PlaneRendererBase.Version.V1], drawn by [PlaneVisualizer].
+ * v4.16.0 briefly shipped V2 as the default, but on-device QA showed the V2 visual output not
+ * matching the design intent, so v4.16.1 reverted the default to V1 while V2 is polished. V1
+ * was never deprecated and remains fully supported. Opt into V2 with
+ * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V2)` — see
+ * [#2203](https://github.com/sceneview/sceneview/issues/2203) for the umbrella and the
+ * research notes.
  *
  * **PR #3 status** ([#2203](https://github.com/sceneview/sceneview/issues/2203)): the V2
  * plane is now a real PBR surface lit by the real room. Four user-visible effects:
@@ -204,7 +207,7 @@ class PlaneVisualizerV2(
     /**
      * Reusable 2-element backing list for [updateRenderable]'s primitive selection (#2328 / #2402).
      *
-     * V2 is the default renderer, so this per-frame path runs often. Building the primitive list
+     * This runs once per plane per frame whenever V2 is opted into. Building the primitive list
      * with a fresh `buildList { }` each call churned one short-lived list per plane per frame; the
      * selection is recomputed into this single reused list every call (cleared first via
      * [selectPlanePrimitives]), so no cached state can go stale — only the allocation is removed.

--- a/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererV2.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/scene/PlaneRendererV2.kt
@@ -24,11 +24,14 @@ import io.github.sceneview.texture.ImageTexture
 /**
  * Control rendering of ARCore planes — V2 implementation.
  *
- * **V2 is the default plane renderer as of this release.** See
- * [#2203](https://github.com/sceneview/sceneview/issues/2203) for the umbrella that delivered
- * it. The legacy V1 [PlaneRenderer] remains available behind
- * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V1)` for one release cycle
- * and is now `@Deprecated`.
+ * **V2 is an experimental opt-in — it is not the default.** The default is
+ * [PlaneRendererBase.Version.V1], rendered by [PlaneRenderer]. v4.16.0 briefly shipped V2 as
+ * the default, but on-device QA showed the V2 visual output not matching the design intent,
+ * so v4.16.1 reverted the default to V1 while V2 is polished. V1 was never deprecated and
+ * remains fully supported. Opt into V2 with
+ * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V2)` — see
+ * [#2203](https://github.com/sceneview/sceneview/issues/2203) for the umbrella and the
+ * research notes.
  *
  * **PR #4 status** ([#2203](https://github.com/sceneview/sceneview/issues/2203)): a floor,
  * a ceiling and a wall visible at once now read as three distinct surfaces.
@@ -61,18 +64,18 @@ import io.github.sceneview.texture.ImageTexture
  * V2 falls back transparently to the V1 flat-polygon mesh (with smooth `(0, 1, 0)` normals
  * so the lit shader still reads as a level surface). Never crashes, never blanks.
  *
- * **#2203 sprint — all 5 PRs landed**:
+ * **#2203 sprint — 5 PRs landed, #5 since reverted**:
  *
  * | PR  | Effect                                                                       |
  * |-----|------------------------------------------------------------------------------|
  * | #2  | Depth-driven tessellation + polygon clip + slope-aware unlit grid. **DONE.** |
  * | #3  | PBR + HDR reflections + scan-in ring + reflection fade-in. **DONE.**         |
  * | #4  | Type-aware shading: floor / ceiling / wall get distinct identities. **DONE.** |
- * | #5  | V2 becomes the default. V1 gets `@Deprecated` for one release cycle. **DONE.** |
+ * | #5  | V2 made the default in v4.16.0. **REVERTED in v4.16.1** — see below.        |
  *
- * V2 is now the default — no opt-in required. Pass
- * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V1)` to fall back to V1
- * during the one-cycle deprecation window.
+ * PR #5 did not survive on-device QA. v4.16.1 restored V1 as the default and removed the
+ * `@Deprecated` that PR #5 had put on V1. Pass
+ * `ARSceneView(planeRendererVersion = PlaneRendererBase.Version.V2)` to opt into V2.
  *
  * @see PlaneRendererBase
  * @see PlaneRenderer
@@ -151,11 +154,11 @@ class PlaneRendererV2(
      *
      * The default mode is `RENDER_TOP_MOST`
      */
-    // PlaneRendererMode is nested inside the now-@Deprecated V1 PlaneRenderer class. The
-    // enum itself is reused as-is by V2 (no V2-specific replacement was introduced); the
-    // suppression is the textbook case for referencing a deprecated container of a
-    // still-valid nested type. When V1 is removed in a future release, PlaneRendererMode
-    // will be hoisted onto PlaneRendererBase.
+    // PlaneRendererMode is nested inside the V1 PlaneRenderer class; the enum is reused as-is
+    // by V2 (no V2-specific replacement was introduced). The suppression dates from the
+    // v4.16.0 window, when V1 was briefly @Deprecated. v4.16.1 restored V1 as the default and
+    // removed that deprecation, so this @Suppress is inert today — it only becomes
+    // load-bearing again if V1 is ever deprecated for real.
     @Suppress("DEPRECATION")
     var planeRendererMode = PlaneRenderer.PlaneRendererMode.RENDER_CENTER
 

--- a/changelog.d/3392-planerendererv2-kdoc-stale-default.md
+++ b/changelog.d/3392-planerendererv2-kdoc-stale-default.md
@@ -1,0 +1,18 @@
+<!-- category: Fixed -->
+- **`PlaneRendererV2`'s KDoc no longer claims V2 is the default plane renderer
+  ([#3392](https://github.com/sceneview/sceneview/issues/3392)).** The class documentation
+  still described the v4.16.0 state — "V2 is the default plane renderer as of this release"
+  and "the legacy V1 `PlaneRenderer` ... is now `@Deprecated`" — while the code has said
+  the opposite since v4.16.1: `ARSceneView`'s `planeRendererVersion` defaults to
+  `PlaneRendererBase.Version.V1`, and `PlaneRenderer` carries no `@Deprecated` annotation.
+  v4.16.0 briefly shipped V2 as the default, on-device QA showed the visual output not
+  matching the design intent, and v4.16.1 reverted the default to V1 while V2 is polished
+  ([#2203](https://github.com/sceneview/sceneview/issues/2203)) — that revert updated
+  `PlaneRendererBase`, `PlaneRenderer`, `ARSceneView` and `llms.txt` but missed
+  `PlaneRendererV2`, `PlaneVisualizerV2` and the `ARPlaneRendererV2Demo` sample, so a
+  reader landing on the V2 class was told to expect V2 behaviour on a stock `ARSceneView`
+  and that V1 was on its way out. All three now state that V2 is an experimental opt-in
+  (`Version.V2`), that V1 is the default, and that V1 was never deprecated; the `#2203`
+  sprint table records PR #5 as reverted instead of landed. The demo's KDoc distinguishes
+  its own starting state (it opts into V2 explicitly) from the SDK default. Documentation
+  only — no behaviour, no API and no default changed.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneRendererV2Demo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlaneRendererV2Demo.kt
@@ -48,8 +48,9 @@ import io.github.sceneview.rememberModelLoader
 /**
  * AR showcase demo — **Plane Renderer V2** ([#2203](https://github.com/sceneview/sceneview/issues/2203)).
  *
- * Single-screen AR scene that runs `ARSceneView` with **V2 as the live default** and gives
- * the user a top-end [Switch] to flip V1 ↔ V2 on the fly so the difference reads instantly:
+ * Single-screen AR scene that opts `ARSceneView` into V2 — **this demo starts on V2; the SDK
+ * default is still [PlaneRendererBase.Version.V1]** — and gives the user a top-end [Switch] to
+ * flip V1 ↔ V2 on the fly so the difference reads instantly:
  *
  * | Toggle state | Renderer       | What you see                                                     |
  * |--------------|----------------|------------------------------------------------------------------|
@@ -143,8 +144,8 @@ fun ARPlaneRendererV2Demo(onBack: () -> Unit) {
         },
         // Both bottom tenants live in the scaffold slot (#2779). They used to be
         // hand-anchored `BottomStart` (legend) and `BottomCenter` (scanning pill), and
-        // both are visible the instant the demo opens — V2 is the default and no plane
-        // is tracked yet — so they shared the same band. The slot is a bottom-aligned
+        // both are visible the instant the demo opens — the toggle starts on V2 and no
+        // plane is tracked yet — so they shared the same band. The slot is a bottom-aligned
         // Column: siblings stack and cannot overlap.
         bottomOverlay = {
             // Legend card — names the colour codes V2 ships per plane type so the user


### PR DESCRIPTION
## What the code actually says

`PlaneRendererV2`'s KDoc and `ARSceneView`'s default disagreed. The code wins, and it is
unambiguous:

| Source | Says |
|---|---|
| `ARSceneView.kt:567` | `planeRendererVersion: PlaneRendererBase.Version = PlaneRendererBase.Version.V1` |
| `ARSceneView.kt:2145` (deprecated `ARScene` alias) | same default — `Version.V1` |
| `PlaneRenderer.kt:44` | class declared plainly — **no `@Deprecated` anywhere in the file** |
| `PlaneRendererV2.kt` KDoc | "**V2 is the default plane renderer as of this release**" ❌ |
| `PlaneRendererV2.kt` KDoc | "The legacy V1 `PlaneRenderer` … **is now `@Deprecated`**" ❌ |

So **both** claims in the V2 KDoc were false, not just the one the issue reports.

## Why it drifted

v4.16.0 briefly shipped V2 as the default (#2203, PR #5). On-device QA showed the visual
output not matching the design intent, and v4.16.1 reverted the default to V1 while V2 is
polished. That revert updated `PlaneRendererBase`, `PlaneRenderer`, `ARSceneView` and
`llms.txt` — but missed three files, all of which still describe the v4.16.0 world:

- `arsceneview/.../scene/PlaneRendererV2.kt` — the class KDoc, plus the `#2203` sprint
  table recording PR #5 ("V2 becomes the default. V1 gets `@Deprecated`.") as **DONE**.
- `arsceneview/.../PlaneVisualizerV2.kt` — the same paragraph, repeated verbatim, plus a
  per-frame comment reasoning from "V2 is the default renderer, so this path runs often".
- `samples/android-demo/.../ARPlaneRendererV2Demo.kt` — "**V2 as the live default**",
  ambiguous between the demo's own starting state and the SDK default. Locally true only
  for the demo, which opts into `Version.V2` explicitly.

The result: a reader landing on the V2 class was told to expect V2 behaviour on a stock
`ARSceneView`, and that V1 was on its way out. Neither is true.

## What this PR changes

All three files now say V2 is an **experimental opt-in** (`Version.V2`), that **V1 is the
default**, and that **V1 was never deprecated**. The sprint table records PR #5 as
reverted in v4.16.1 rather than landed. The demo's KDoc distinguishes its own starting
state from the SDK default.

Already correct, verified and left untouched: `PlaneRendererBase.kt` (interface + `Version`
enum KDoc), `PlaneRenderer.kt` ("### Default renderer (v4.16.1 onwards)"), `ARSceneView.kt`
and `llms.txt`. A repo-wide sweep for the stale phrasings now returns nothing outside the
generated `CHANGELOG.md` / `gpt/`.

**The diff touches comment lines exclusively** — `git diff` filtered to non-comment lines
is empty. No behaviour, no API and no default changed.

## The default itself is not the bug

To answer the question the issue implicitly raises: the code is not wrong, the doc was.
`PlaneRendererBase.kt`'s own KDoc already records the product decision and its reason
(v4.16.0's V2 default failed on-device QA). Whether V2 *should* become the default again
is a separate product call and is deliberately not touched here.

## Follow-up candidate (deliberately not done here)

With V1's deprecation gone since v4.16.1, the two `@Suppress("DEPRECATION")` annotations in
`PlaneRendererV2.kt` (on `planeRendererMode`, and inside `update()`) suppress nothing. This
PR corrects the misleading comment above the first one to say the suppression is inert, but
leaves both annotations in place — removing them is a code change, out of scope for a
documentation fix. Happy to ticket it.

## Verification

Comment-only diff, so no build was run: this worktree's volume is at 7.4 Gi free with
several agents in flight, below the agreed 8 Gi floor for Gradle work. Every KDoc link
added resolves in its file's scope — `PlaneRendererBase` / `PlaneRenderer` are same-package
in `PlaneRendererV2.kt`, `PlaneVisualizerV2.kt` uses the fully-qualified form because it
does not import `PlaneRendererBase`, and the demo already imports it (line 38).

Fixes #3392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
