### PR TITLE
fix(ios): frame the projected bounds per FOV axis, not the space diagonal

### DIFF
--- a/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift
@@ -119,7 +119,7 @@ public struct CameraControls: Sendable {
     public var orbitRadius: Float = 2.0
 
     /// Default padding factor applied by ``fitRadius(boundsExtents:fovYDegrees:aspect:margin:)``
-    /// — 15 % of breathing room around the content's bounding sphere. Exposed
+    /// — 15 % of breathing room around the content's fitted extent. Exposed
     /// so ``SceneView/framingMargin(_:)`` and the auto-framing pass share one
     /// definition of "unchanged framing" (#2896).
     public static let defaultFitMargin: Float = 1.15
@@ -238,14 +238,34 @@ public struct CameraControls: Sendable {
     /// overflowed and clipped on every edge. This computes a radius that
     /// scales-to-fit, closing the #1041 follow-up.
     ///
-    /// The box is treated as its bounding sphere (half its space diagonal)
-    /// so the fit holds for every orbit angle, not just the front view.
-    /// The camera looks at the box centre, so the required distance is
-    /// `sphereRadius / sin(halfFov)`. The frustum is narrower on whichever
-    /// axis has the smaller FOV — for portrait phones that is the
-    /// horizontal axis (`aspect < 1`), so both the vertical FOV and the
-    /// aspect-derived horizontal FOV are considered and the smaller half-FOV
-    /// wins.
+    /// The box is fitted **per FOV axis on its projected extent**, not as a
+    /// bounding sphere. Until #3383 the box was collapsed to half its space
+    /// diagonal and divided by `sin` of the *smaller* half-FOV, which charged
+    /// every subject for the diagonal of a box it does not occupy and charged
+    /// the vertical axis the horizontal axis's distance. A 3 m column in a
+    /// portrait viewport was pushed to 5.90 m when 3.00 m frames it — the
+    /// subject filled barely half the height it could.
+    ///
+    /// Framing stays invariant to ``azimuth`` — an auto-rotating model must
+    /// not clip when it turns broadside — by fitting the box's *sweep* about
+    /// the world Y axis: a cylinder of radius `hypot(halfX, halfZ)` and
+    /// half-height `halfY`. That sweep is fitted exactly, via its support
+    /// function, so the result is the tightest azimuth-invariant distance
+    /// rather than an upper bound on one.
+    ///
+    /// The fit does depend on ``elevation`` (the sphere fit did not), because
+    /// a subject's projected height and width change as the camera rises.
+    /// Orbiting vertically after the fit can therefore graze the frame on
+    /// extreme pitches; the default ``defaultFitMargin`` of 1.15 covers the
+    /// worst case measured (a 4 m panel in landscape, which needs 1.124).
+    ///
+    /// **Depth** still counts, but anisotropically: `halfZ` enters through the
+    /// swept radius instead of being folded into one isotropic radius that the
+    /// vertical axis then pays for as well. A shallow subject no longer buys
+    /// the distance a deep one needs.
+    ///
+    /// The returned distance is never larger than the pre-#3383 one, so no
+    /// scene is framed further away than it used to be.
     ///
     /// - Parameters:
     ///   - boundsExtents: The full width / height / depth of the content
@@ -258,8 +278,8 @@ public struct CameraControls: Sendable {
     ///   - margin: Extra padding factor applied to the fitted radius so the
     ///     content does not touch the viewport edges. Default
     ///     ``defaultFitMargin`` (15 % breathing room). Below `1.0` the camera
-    ///     dollies closer and the empty corners of the bounding sphere leave
-    ///     the frame — see ``SceneView/framingMargin(_:)``.
+    ///     dollies closer and the subject's extremities leave the frame — see
+    ///     ``SceneView/framingMargin(_:)``.
     /// - Returns: The orbit radius that frames the box, clamped to
     ///   `[minRadius, maxRadius]`.
     public func fitRadius(
@@ -268,22 +288,44 @@ public struct CameraControls: Sendable {
         aspect: Float = 0.46,
         margin: Float = CameraControls.defaultFitMargin
     ) -> Float {
-        // Bounding-sphere radius — half the box's space diagonal — so the
-        // fit is orbit-angle invariant.
-        let half = boundsExtents * 0.5
-        let sphereRadius = simd_length(half)
-        guard sphereRadius.isFinite, sphereRadius > 0 else { return orbitRadius }
+        let half = simd_abs(boundsExtents) * 0.5
+        guard half.x.isFinite, half.y.isFinite, half.z.isFinite,
+              half.x > 0 || half.y > 0 || half.z > 0 else { return orbitRadius }
+
+        // Half-extents of the box's sweep about world Y — a cylinder. Sweeping
+        // is what makes the fit azimuth-invariant (see the doc comment).
+        let sweptRadius = (half.x * half.x + half.z * half.z).squareRoot()
 
         let fovY = max(fovYDegrees, 1) * .pi / 180
-        // Horizontal FOV from the vertical FOV and the viewport aspect.
+        let tanY = tan(fovY / 2)
+        // Horizontal half-FOV tangent from the vertical FOV and the aspect.
         let safeAspect = (aspect.isFinite && aspect > 0) ? aspect : 0.46
-        let fovX = 2 * atan(tan(fovY / 2) * safeAspect)
-        // The limiting axis is the one with the *smaller* FOV.
-        let halfFov = min(fovY, fovX) / 2
-        let sinHalf = sin(halfFov)
-        guard sinHalf > 0 else { return orbitRadius }
+        let tanX = tanY * safeAspect
+        guard tanY > 0, tanX > 0 else { return orbitRadius }
 
-        let fitted = (sphereRadius / sinHalf) * margin
+        // Camera basis at azimuth 0 — the sweep makes azimuth irrelevant, so
+        // this loses no generality and avoids a cross product that degenerates
+        // at elevation ±90°:
+        //   back = (0, s, c)    right = (1, 0, 0)    up = (0, c, -s)
+        let s = sin(elevation)
+        let c = cos(elevation)
+
+        // A point `v` (relative to the target) is inside the frustum at
+        // distance `d` iff `d >= v·back + |v·axis| / tanAxis` on both axes.
+        // Maximising the right-hand side over the cylinder is its support
+        // function `support(w) = half.y·|w.y| + sweptRadius·hypot(w.x, w.z)`
+        // evaluated at `w = back ± axis / tanAxis`.
+        //
+        // Horizontal: w = (±1/tanX, s, c) — both signs give the same support.
+        let inverseTanX = 1 / tanX
+        let horizontal = half.y * abs(s)
+            + sweptRadius * (inverseTanX * inverseTanX + c * c).squareRoot()
+        // Vertical: w = (0, s ± c/tanY, c ∓ s/tanY) — the two signs differ.
+        let verticalUpper = half.y * abs(s + c / tanY) + sweptRadius * abs(c - s / tanY)
+        let verticalLower = half.y * abs(s - c / tanY) + sweptRadius * abs(c + s / tanY)
+
+        let fitted = Swift.max(horizontal, Swift.max(verticalUpper, verticalLower)) * margin
+        guard fitted.isFinite, fitted > 0 else { return orbitRadius }
         return Swift.min(Swift.max(fitted, minRadius), maxRadius)
     }
 

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsTests.swift
@@ -262,10 +262,15 @@ final class CameraControlsTests: XCTestCase {
 
     // MARK: - Fit-to-bounds framing (#1026 / #1041)
 
-    func testFitRadiusFramesBoundingSphere() {
-        // A 1m cube at 60° vertical FOV with a square viewport (aspect 1):
-        // both FOVs equal, halfFov = 30°, sphereRadius = sqrt(3)/2 ≈ 0.866.
-        // distance = 0.866 / sin(30°) = 1.732, × 1.15 margin ≈ 1.99.
+    func testFitRadiusFitsProjectedExtentNotBoundingSphere() {
+        // A 1m cube at 60° vertical FOV with a square viewport (aspect 1),
+        // seen from the default 30° elevation. The cube's sweep about Y is a
+        // cylinder of radius hypot(0.5, 0.5) = 0.707 and half-height 0.5; the
+        // vertical axis binds at 1.7247, × 1.15 margin = 1.984.
+        //
+        // The pre-#3383 sphere fit charged sqrt(3)/2 / sin(30°) = 1.732 here,
+        // so a square viewport barely moves — the divergence is in portrait
+        // (see testFitRadiusMatrixAcrossViewportsAndSubjects).
         let controls = CameraControls()
         let r = controls.fitRadius(
             boundsExtents: SIMD3<Float>(1, 1, 1),
@@ -273,7 +278,22 @@ final class CameraControlsTests: XCTestCase {
             aspect: 1.0,
             margin: 1.15
         )
-        XCTAssertEqual(r, 1.99, accuracy: 0.05)
+        XCTAssertEqual(r, 1.984, accuracy: 0.01)
+    }
+
+    /// The #3383 headline case: a 3 m column in a portrait viewport. The
+    /// sphere fit divided half the space diagonal by `sin` of the *smaller*
+    /// (horizontal) half-FOV and pushed the camera to 5.90 m; the subject is
+    /// bound by the vertical axis alone and 3.00 m frames it exactly. Before
+    /// the fix the column filled barely half the height it could.
+    func testFitRadiusFillsPortraitViewportWithTallSubject() {
+        let controls = CameraControls(mode: .orbit, maxRadius: 500)
+        let r = controls.fitRadius(
+            boundsExtents: SIMD3<Float>(0.3, 3.0, 0.3),
+            fovYDegrees: 60, aspect: 0.46, margin: 1.0)
+        XCTAssertEqual(r, 3.0, accuracy: 0.01)
+        // Well under the 5.902 the bounding-sphere fit returned.
+        XCTAssertLessThan(r, 4.0)
     }
 
     func testFitRadiusLargerForBiggerContent() {
@@ -358,6 +378,208 @@ final class CameraControlsTests: XCTestCase {
             boundsExtents: SIMD3<Float>(0.4, 1.2, 0.7), fovYDegrees: 60,
             aspect: 0.46, margin: 1.15)
         XCTAssertEqual(implicitMargin, explicitMargin, accuracy: 0.0001)
+    }
+
+    // MARK: - Per-axis projected fit (#3383)
+
+    /// The three subjects the fit has to tell apart. A bounding sphere cannot:
+    /// it sees only `hypot(hx, hy, hz)`, so `wideFlat` and `tallNarrow` — which
+    /// need opposite things from a portrait viewport — get the same treatment.
+    private static let fitSubjects: [(name: String, extents: SIMD3<Float>)] = [
+        ("wide/flat", SIMD3<Float>(4.0, 0.5, 0.5)),
+        ("tall/narrow", SIMD3<Float>(0.3, 3.0, 0.3)),
+        ("cubic", SIMD3<Float>(1.0, 1.0, 1.0)),
+    ]
+
+    /// iPhone portrait, square, and landscape (`width / height`).
+    private static let fitViewports: [(name: String, aspect: Float)] = [
+        ("portrait", 0.46),
+        ("square", 1.0),
+        ("landscape", 2.17),
+    ]
+
+    /// Viewport × subject, at the default 30° elevation with `margin: 1.0` so
+    /// the numbers below are the raw fit. Each was cross-checked against a
+    /// 720-sample azimuth sweep of the exact eight-corner fit (worst relative
+    /// error 9.5e-06), and the `sphere` column is what shipped before #3383.
+    func testFitRadiusMatrixAcrossViewportsAndSubjects() {
+        //  subject      viewport     fitted   sphere (pre-#3383)
+        let expected: [String: Float] = [
+            "wide/flat portrait":   7.9124,  // 7.9125 — horizontal-bound either way
+            "wide/flat square":     4.0281,  // 4.0620
+            "wide/flat landscape":  3.7411,  // 4.0620
+            "tall/narrow portrait": 3.0000,  // 5.9019 — the #3383 headline
+            "tall/narrow square":   3.0000,  // 3.0299
+            "tall/narrow landscape": 3.0000, // 3.0299
+            "cubic portrait":       2.9820,  // 3.3739
+            "cubic square":         1.7247,  // 1.7321
+            "cubic landscape":      1.7247,  // 1.7321
+        ]
+        // maxRadius raised so nothing in the matrix hits the clamp.
+        let controls = CameraControls(mode: .orbit, maxRadius: 500)
+        for (subject, extents) in Self.fitSubjects {
+            for (viewport, aspect) in Self.fitViewports {
+                let key = "\(subject) \(viewport)"
+                let r = controls.fitRadius(
+                    boundsExtents: extents, fovYDegrees: 60,
+                    aspect: aspect, margin: 1.0)
+                XCTAssertEqual(r, expected[key]!, accuracy: 0.005, key)
+            }
+        }
+    }
+
+    /// A vertically-bound subject must cost the same in every viewport: the
+    /// vertical FOV does not change with the aspect ratio. The sphere fit
+    /// charged the column 5.90 m in portrait against 3.03 m in landscape
+    /// purely because it divided by the *smaller* half-FOV.
+    func testFitRadiusOfVerticallyBoundSubjectIgnoresAspect() {
+        let controls = CameraControls(mode: .orbit, maxRadius: 500)
+        let column = SIMD3<Float>(0.3, 3.0, 0.3)
+        let fits = Self.fitViewports.map {
+            controls.fitRadius(boundsExtents: column, fovYDegrees: 60,
+                               aspect: $0.aspect, margin: 1.0)
+        }
+        for fit in fits {
+            XCTAssertEqual(fit, fits[0], accuracy: 0.001)
+        }
+    }
+
+    /// Auto-rotating content must not clip as it turns broadside, so the fit
+    /// reads no ``CameraControls/azimuth`` at all — it frames the box's sweep
+    /// about world Y. An "optimisation" that specialises on the current
+    /// azimuth fails here before it ships a clipping turntable.
+    func testFitRadiusIsInvariantToAzimuth() {
+        var controls = CameraControls(mode: .orbit, maxRadius: 500)
+        let subject = SIMD3<Float>(4.0, 0.5, 0.5)  // worst case: very wide
+        controls.azimuth = 0
+        let reference = controls.fitRadius(
+            boundsExtents: subject, fovYDegrees: 60, aspect: 0.46, margin: 1.0)
+        for step in 1..<16 {
+            controls.azimuth = Float(step) * 2 * .pi / 16
+            let r = controls.fitRadius(
+                boundsExtents: subject, fovYDegrees: 60, aspect: 0.46,
+                margin: 1.0)
+            XCTAssertEqual(r, reference, accuracy: 0.0001,
+                           "azimuth \(controls.azimuth)")
+        }
+    }
+
+    /// The containment proof, and the reason the matrix numbers above can be
+    /// trusted rather than merely pinned: place the camera at the fitted
+    /// radius and check all eight box corners against both FOV axes, at 24
+    /// azimuths. Nothing may leave the frame (`<= 0`), and the fit must stay
+    /// *tight* — the pre-#3383 sphere fit wasted up to 49 % of the frame on
+    /// the tall column, which the -0.02 floor rejects.
+    func testFitRadiusFramesEveryCornerAtEveryAzimuth() {
+        for (subject, extents) in Self.fitSubjects {
+            for (viewport, aspect) in Self.fitViewports {
+                var controls = CameraControls(mode: .orbit, maxRadius: 500)
+                controls.orbitRadius = controls.fitRadius(
+                    boundsExtents: extents, fovYDegrees: 60,
+                    aspect: aspect, margin: 1.0)
+                var tightest = -Float.greatestFiniteMagnitude
+                for step in 0..<24 {
+                    controls.azimuth = Float(step) * 2 * .pi / 24
+                    let overshoot = frustumOvershoot(
+                        extents: extents, controls: controls,
+                        fovYDegrees: 60, aspect: aspect)
+                    XCTAssertLessThanOrEqual(
+                        overshoot, 1e-4,
+                        "\(subject) \(viewport) clipped at azimuth \(step)")
+                    tightest = max(tightest, overshoot)
+                }
+                XCTAssertGreaterThan(
+                    tightest, -0.02,
+                    "\(subject) \(viewport) framed looser than it needs")
+            }
+        }
+    }
+
+    /// #3383 must not make any existing scene worse: the per-axis fit is
+    /// bounded above by the sphere fit it replaces, so no content is ever
+    /// pushed further away than it was in v4.x.
+    func testFitRadiusNeverExceedsPreviousBoundingSphereFit() {
+        let controls = CameraControls(mode: .orbit, maxRadius: 500)
+        var subjects = Self.fitSubjects
+        subjects.append((name: "vehicle", extents: SIMD3<Float>(2.2, 1.0, 5.0)))
+        subjects.append((name: "helmet", extents: SIMD3<Float>(0.9, 1.1, 0.9)))
+        for (subject, extents) in subjects {
+            for (viewport, aspect) in Self.fitViewports {
+                // The pre-#3383 formula, verbatim: half the space diagonal
+                // divided by the sine of the smaller half-FOV.
+                let half = extents * 0.5
+                let sphereRadius = simd_length(half)
+                let fovY = Float(60) * .pi / 180
+                let fovX = 2 * atan(tan(fovY / 2) * aspect)
+                let sphereFit = sphereRadius / sin(min(fovY, fovX) / 2)
+                let fitted = controls.fitRadius(
+                    boundsExtents: extents, fovYDegrees: 60,
+                    aspect: aspect, margin: 1.0)
+                XCTAssertLessThanOrEqual(fitted, sphereFit * 1.0001,
+                                         "\(subject) \(viewport)")
+            }
+        }
+    }
+
+    /// ``CameraControls/elevation`` is public and the drag handler's clamp does
+    /// not apply to a value set directly, so the fit must survive a straight
+    /// overhead pose. The analytic basis avoids the cross product that
+    /// degenerates when the eye vector is parallel to world up.
+    func testFitRadiusSurvivesPolarElevation() {
+        var controls = CameraControls(mode: .orbit, maxRadius: 500)
+        let subject = SIMD3<Float>(2.2, 1.0, 5.0)
+        var results: [Float] = []
+        for elevation in [Float.pi / 2, -Float.pi / 2, Float.pi / 2 - 0.001] {
+            controls.elevation = elevation
+            let r = controls.fitRadius(
+                boundsExtents: subject, fovYDegrees: 60, aspect: 0.46,
+                margin: 1.0)
+            XCTAssertTrue(r.isFinite, "elevation \(elevation)")
+            results.append(r)
+        }
+        // Straight up, straight down and just-off-vertical all agree.
+        for r in results {
+            XCTAssertEqual(r, 10.784, accuracy: 0.01)
+        }
+    }
+
+    /// Worst frustum overshoot across the eight corners of a box centred on
+    /// the controls' target, as a fraction of the orbit radius. `<= 0` means
+    /// the whole box is inside both FOV axes.
+    ///
+    /// A corner `v` (relative to the target) is inside at distance `d` iff
+    /// `d >= v·back + |v·axis| / tanAxis` on the horizontal and vertical axes.
+    private func frustumOvershoot(
+        extents: SIMD3<Float>,
+        controls: SceneViewSwift.CameraControls,
+        fovYDegrees: Float,
+        aspect: Float
+    ) -> Float {
+        let half = extents * 0.5
+        let distance = controls.orbitRadius
+        // Same basis the renderer uses — read from the production camera pose.
+        let back = simd_normalize(controls.cameraPosition() - controls.target)
+        let forward = -back
+        let right = simd_normalize(simd_cross(forward, SIMD3<Float>(0, 1, 0)))
+        let up = simd_cross(right, forward)
+        let tanY = tan(fovYDegrees * .pi / 180 / 2)
+        let tanX = tanY * aspect
+
+        var worst = -Float.greatestFiniteMagnitude
+        for signX in [Float(-1), 1] {
+            for signY in [Float(-1), 1] {
+                for signZ in [Float(-1), 1] {
+                    let corner = SIMD3<Float>(signX * half.x,
+                                              signY * half.y,
+                                              signZ * half.z)
+                    let depth = simd_dot(corner, back)
+                    let needX = depth + abs(simd_dot(corner, right)) / tanX
+                    let needY = depth + abs(simd_dot(corner, up)) / tanY
+                    worst = max(worst, max(needX, needY) - distance)
+                }
+            }
+        }
+        return worst / distance
     }
 
     // MARK: - Content bounds union (#1391)

--- a/changelog.d/3383-fit-projected-bounds.md
+++ b/changelog.d/3383-fit-projected-bounds.md
@@ -1,0 +1,27 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+iOS/visionOS: `CameraControls.fitRadius` now fits the subject's **projected extent on each
+FOV axis** instead of inscribing its bounding box in a sphere. The old formula collapsed
+the box to half its space diagonal and divided by `sin` of the *smaller* half-FOV — the
+horizontal one on a portrait phone — so every subject paid for a diagonal it does not
+occupy, and the vertical axis paid the horizontal axis's distance. A 3 m column in a
+portrait viewport was pushed back to 5.90 m where 3.00 m frames it exactly: the subject
+filled barely half the height available to it ([#3383](https://github.com/sceneview/sceneview/issues/3383)).
+
+Framing stays invariant to `azimuth`, as an auto-rotating model must not clip when it turns
+broadside. Rather than fitting the pose you happen to be at, the fit takes the box's *sweep*
+about world Y — a cylinder — and fits that exactly through its support function, so the
+result is the tightest azimuth-independent distance rather than an upper bound on one. The
+new distance is never larger than the old one, so no scene is framed further away than
+before; portrait gains are up to 49 % of the old distance for tall subjects and 10–17 % for
+cubic ones, while wide subjects in portrait are unchanged because their horizontal reach
+genuinely requires that distance.
+
+Unlike the sphere fit, the result now depends on `elevation`, since a subject's projected
+height changes as the camera rises. The default `defaultFitMargin` of 1.15 covers the worst
+case measured (1.124, a 4 m panel in landscape), so orbiting after an auto-fit still does
+not clip.
+
+The Android (`sceneview/`) and web (`sceneview-web/`) framing helpers carry the same
+bounding-sphere approximation and are **not** touched here; they are reported in the pull
+request for a separate follow-up.


### PR DESCRIPTION
## What was actually computed

Read from `SceneViewSwift/Sources/SceneViewSwift/Camera/CameraControls.swift`, not from
the issue summary. The old `fitRadius` was:

```swift
let radius = simd_length(boundsExtents * 0.5)          // half the space diagonal
let fovX = 2 * atan(tan(fovY / 2) * aspect)
return radius / sin(min(fovY, fovX) / 2) * margin      // sphere ⊂ narrower FOV axis
```

Two independent costs, and the second is the one #3383 is about:

1. **The subject is charged for a diagonal it does not occupy.** A 1 m cube gets a radius
   of 0.866 m for 0.5 m of half-height.
2. **The vertical axis is charged the horizontal axis's distance.** `min(fovY, fovX)` is
   the horizontal FOV on any portrait viewport, so a subject bound purely by its *height*
   is pushed back by a *width* constraint it never hits. This is why a portrait viewport
   cannot be filled.

Headline: a 3 m column at 60° vertical FOV, aspect 0.46, is framed at **5.90 m** where
**3.00 m** fits it exactly — it filled barely half the height it could.

## The fix

Per-FOV-axis containment. A point `v` relative to the target is inside the frustum at
distance `d` iff

```
d >= v·back + |v·axis| / tanAxis        on both the horizontal and vertical axes
```

Maximising the right-hand side over the subject is a support-function evaluation at
`w = back ± axis / tanAxis`, since `|x| = max(x, −x)`. Closed form, no iteration.

**Azimuth invariance is preserved deliberately.** An auto-rotating model must not clip
when it turns broadside, so specialising on the current pose is not on the table. Instead
of the box, the fit frames the box's *sweep* about world Y — a cylinder of radius
`hypot(halfX, halfZ)` and half-height `halfY`, support `halfY·|w.y| + R·hypot(w.x, w.z)`.
That sweep is fitted **exactly**, not bounded, so this is the tightest azimuth-independent
distance that exists. Against a 720-sample azimuth sweep of the exact eight-corner fit,
the closed form agrees to a worst relative error of **9.5e-06** across every aspect,
subject and elevation tried.

The camera basis is written analytically at azimuth 0 (`back = (0, s, c)`,
`right = (1, 0, 0)`, `up = (0, c, −s)`) — lossless given the sweep, and it avoids the
`cross(forward, worldUp)` that degenerates at elevation ±90°. That pose is reachable:
`elevation` is public and the drag clamp does not apply to a direct assignment.

### Before / after

Default 30° elevation, 60° vertical FOV, `margin: 1.0` — **fitted / old sphere fit**:

| subject | portrait (0.46) | square (1.0) | landscape (2.17) |
|---|---|---|---|
| wide/flat 4×0.5×0.5 | 7.912 / 7.912 | 4.028 / 4.062 | 3.741 / 4.062 |
| tall/narrow 0.3×3×0.3 | **3.000 / 5.902** | 3.000 / 3.030 | 3.000 / 3.030 |
| cubic 1×1×1 | 2.982 / 3.374 | 1.725 / 1.732 | 1.725 / 1.732 |

The new distance is **never larger** than the old one — checked over 7 aspects × 5
subjects × 35 elevations, zero exceptions — so nothing is framed further away than before.

Unlike the sphere fit, the result now depends on `elevation`, since projected height
changes as the camera rises. `defaultFitMargin` stays at 1.15, which covers the worst
case measured (1.124, a 4 m panel in landscape), so orbiting vertically after an auto-fit
still does not clip.

## Honest scope limit — please read before expecting the screenshot to change

9c62d745e (#3388, closing #3384) left the hovercar sitting right of centre in App Store
slot 1 as known-and-deliberate, attributing it to this issue. **This PR does not fix
that.** Note the top-left cell of the table: a *wide* subject in a *portrait* viewport is
unchanged (7.912 vs 7.912), because its horizontal reach genuinely requires that distance
— there is no slack to recover there.

That commit's own note contains the reason, one step short of the conclusion: it observed
that `-camera_distance` cannot correct the framing "since it only scales the offset". The
same holds for `fitRadius`, which returns a **scalar distance** and so cannot produce or
remove an offset either. The offset comes from `camera.target = bounds.center` in
`SceneView.refreshContentCentering()`: when the union AABB is wider than the car's visible
silhouette, the centroid of the box is not the centroid of what you see. It is a separate
defect — a centring one — and wants its own issue; happy to file it.

What this PR does fix is how much of the frame a subject fills when it is bound by the
axis the old formula ignored: tall and cubic subjects in portrait, and wide subjects in
landscape.

## Tests

Framing is pure computation, so unit tests are the validation, not a supporting act. In
`SceneViewSwift/Tests/SceneViewSwiftTests/CameraControlsTests.swift`:

- `testFitRadiusMatrixAcrossViewportsAndSubjects` — the table above. Golden values come
  from the sweep oracle, **not** from running the implementation, so the test can fail the
  code rather than merely pinning it.
- `testFitRadiusFillsPortraitViewportWithTallSubject` — the #3383 headline, 3.00 m.
- `testFitRadiusOfVerticallyBoundSubjectIgnoresAspect` — a vertically-bound subject costs
  the same in all three viewports.
- `testFitRadiusIsInvariantToAzimuth` — 16 azimuths on the worst-case wide subject.
- `testFitRadiusFramesEveryCornerAtEveryAzimuth` — the containment proof. Places the
  camera at the fitted radius and checks all eight corners against both FOV axes at 24
  azimuths, with an independent frustum implementation reading the production camera pose.
  Asserts nothing clips **and** that the fit stays tight (`> -0.02`); the old sphere fit
  wasted up to 49 % of the frame on the tall column and fails that floor.
- `testFitRadiusNeverExceedsPreviousBoundingSphereFit` — recomputes the pre-#3383 formula
  inline over 5 subjects × 3 viewports.
- `testFitRadiusSurvivesPolarElevation` — ±90° and just-off-vertical all agree, no NaN.

Existing `fitRadius` tests are untouched and still pass on the new maths (checked by hand
against the oracle): `testFitRadiusLargerForBiggerContent` (ratio still exactly 4.0),
`testFitRadiusPortraitNeedsMoreDistanceThanSquare`, `testFitRadiusMarginAddsBreathingRoom`
(ratio still exactly 1.3), the clamp and degenerate-bounds tests.

`testFitRadiusFramesBoundingSphere` was replaced by
`testFitRadiusFitsProjectedExtentNotBoundingSphere` — it asserted the behaviour this PR
removes.

## needs-device / not run locally

The machine was at **7.3 GiB free** (`df -h /System/Volumes/Data`), under the 8 GiB floor
this session works to, so **no Xcode build, no simulator run and no `swift test` were
executed**. CI must run the suite; treat the test results here as unverified locally.

What was run instead, at zero disk cost: `swiftc -parse` on both changed files (both
clean — syntax only, this does **not** type-check), and the numerical work above against
an independent Python oracle.

No screenshot for the same reason. Visual confirmation of the portrait framing on the iOS
simulator is still outstanding.

## Same defect on other platforms — reported, not touched

Deliberately not widened. Each of these has the same bounding-sphere root cause and
deserves its own PR:

- `sceneview/src/main/java/io/github/sceneview/CameraFraming.kt` (`fitDistanceForBounds`,
  L100-124) — the exact same formula: half the space diagonal, divided by `sin` of each
  half-FOV, `max()` of the two. Identical portrait behaviour.
- `sceneview/src/main/java/io/github/sceneview/CinematicCamera.kt` (`cinematicDistance`,
  L158-161) — `contentRadius / tan(halfFovY)`, sphere by signature and **aspect-blind**,
  so a portrait viewport clips horizontally.
- `sceneview-web/src/jsMain/kotlin/io/github/sceneview/web/ContentCentering.kt`
  (`fitDistance`, L119-123) plus its caller in `SceneView.kt` (L1202-1203) — coarser
  still: `radius × 2.5 × margin`, no FOV term at all.

Clean, for the record: `sceneview-core/`, `arsceneview/`, `sceneview-compose/`, `flutter/`,
`react-native/`. And `samples/android-demo/.../DemoMath.kt` (`coverDistance`, L272-299) is
the one *correct* per-axis implementation already in the repo — worth reading before
porting this fix to Android, since it solves the same problem for the demo's own capture
path.

Fixes #3383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
