### PR TITLE
fix(ar): let callers throttle the reticle hit test

### DIFF
--- a/arsceneview/api/arsceneview.api
+++ b/arsceneview/api/arsceneview.api
@@ -175,13 +175,13 @@ public final class io/github/sceneview/ar/ARSceneScope : io/github/sceneview/Sce
 	public final fun DepthHitResultNode (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun DepthHitResultNode (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun DepthMeshNode (Lio/github/sceneview/ar/node/DepthMeshNode;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public final fun HitResultNode (FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public final fun HitResultNode (FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public final fun HitResultNode (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public final fun PlacementReticle (FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public final fun PlacementReticle (FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public final fun PlaneNode (Lcom/google/ar/core/Plane;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun PointCloudNode (Lio/github/sceneview/ar/node/PointCloudNode;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun PoseNode (Lcom/google/ar/core/Pose;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public final fun ReticleNode (FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public final fun ReticleNode (FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public final fun RooftopAnchorNode (Lio/github/sceneview/ar/node/RooftopAnchorNode;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun SceneMeshNode (Lcom/google/ar/core/StreetscapeGeometry;Ljava/util/Set;Lcom/google/ar/core/StreetscapeGeometry$Quality;Lcom/google/android/filament/MaterialInstance;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public final fun ShadowReceiverPlane (Lcom/google/ar/core/Plane;FLjava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
@@ -624,7 +624,7 @@ public final class io/github/sceneview/ar/CloudAnchorRegistry$DefaultImpls {
 public final class io/github/sceneview/ar/ComposableSingletons$ARSceneScopeKt {
 	public static final field INSTANCE Lio/github/sceneview/ar/ComposableSingletons$ARSceneScopeKt;
 	public fun <init> ()V
-	public final fun getLambda$-829785509$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1192742845$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/github/sceneview/ar/ComposableSingletons$ARSceneViewKt {
@@ -1829,8 +1829,8 @@ public class io/github/sceneview/ar/node/PlacementReticleNode : io/github/scenev
 	public static final field $stable I
 	public static final field Companion Lio/github/sceneview/ar/node/PlacementReticleNode$Companion;
 	public static final field DEFAULT_ORIENTATION_SMOOTHING F
-	public fun <init> (Lcom/google/android/filament/Engine;FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/google/android/filament/Engine;FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/google/android/filament/Engine;FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;J)V
+	public synthetic fun <init> (Lcom/google/android/filament/Engine;FFZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getHitResult ()Lcom/google/ar/core/HitResult;
 	public final fun getOrientationSmoothing ()F
 	protected fun resolveHitPose (Lcom/google/ar/core/Pose;)Lcom/google/ar/core/Pose;
@@ -1909,8 +1909,8 @@ public class io/github/sceneview/ar/node/PoseNode : io/github/sceneview/node/Nod
 
 public class io/github/sceneview/ar/node/ReticleNode : io/github/sceneview/ar/node/HitResultNode {
 	public static final field $stable I
-	public fun <init> (Lcom/google/android/filament/Engine;FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/google/android/filament/Engine;FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/google/android/filament/Engine;FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;J)V
+	public synthetic fun <init> (Lcom/google/android/filament/Engine;FFLjava/util/Set;ZZZLjava/util/Set;Ljava/util/Set;ZLjava/lang/Float;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getHitResult ()Lcom/google/ar/core/HitResult;
 	public final fun getOnHitResultChanged ()Lkotlin/jvm/functions/Function1;
 	public fun setHitResult (Lcom/google/ar/core/HitResult;)V

--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneScope.kt
@@ -290,6 +290,11 @@ class ARSceneScope internal constructor(
      * @param minCameraDistance         Camera-to-hit floor (meters). Default `0.3f`; `null` to disable.
      * @param minCameraDistanceFromPlane Legacy plane-only distance gate. Prefer [minCameraDistance].
      * @param predicate                 Custom filter applied to each [HitResult].
+     * @param refreshIntervalMs         Minimum interval (ms) between two ARCore hit tests. `0`
+     *                                  (the default) runs the hit test every updated frame — the
+     *                                  original behaviour; a positive value (e.g. `100` = 10 Hz)
+     *                                  rate-limits the raycast. Live-updatable on recomposition
+     *                                  (#3391).
      * @param apply                     Additional imperative configuration on [HitResultNodeImpl].
      * @param content                   Optional child nodes declared in a [NodeScope].
      */
@@ -309,6 +314,7 @@ class ARSceneScope internal constructor(
         minCameraDistance: Float? = 0.3f,
         minCameraDistanceFromPlane: Pair<Camera, Float>? = null,
         predicate: ((HitResult) -> Boolean)? = null,
+        refreshIntervalMs: Long = 0L,
         apply: HitResultNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null
     ) {
@@ -326,8 +332,14 @@ class ARSceneScope internal constructor(
                 planePoseInPolygon = planePoseInPolygon,
                 minCameraDistance = minCameraDistance,
                 minCameraDistanceFromPlane = minCameraDistanceFromPlane,
-                predicate = predicate
+                predicate = predicate,
+                refreshIntervalMs = refreshIntervalMs
             ).apply(apply)
+        }
+        // Not a `remember` key: the throttle is a live-writable var, so a changed rate must
+        // re-rate the existing node, never destroy and re-create it (#3391).
+        SideEffect {
+            node.refreshIntervalMs = refreshIntervalMs
         }
         NodeLifecycle(node, content)
     }
@@ -418,6 +430,11 @@ class ARSceneScope internal constructor(
      * @param predicate                 Custom filter applied to each candidate [HitResult].
      * @param onHitResultChanged        Invoked whenever the resolved hit changes (including
      *                                  `null` ↔ value transitions).
+     * @param refreshIntervalMs         Minimum interval (ms) between two ARCore hit tests. `0`
+     *                                  (the default) runs the hit test every updated frame — the
+     *                                  original behaviour; a positive value (e.g. `100` = 10 Hz)
+     *                                  rate-limits the raycast for the whole placement flow. The
+     *                                  marker keeps easing between hits (#3391).
      * @param apply                     Additional imperative configuration on the underlying
      *                                  [ReticleNodeImpl].
      * @param content                   Optional child nodes (the visual marker geometry) declared
@@ -440,6 +457,7 @@ class ARSceneScope internal constructor(
         minCameraDistanceFromPlane: Pair<Camera, Float>? = null,
         predicate: ((HitResult) -> Boolean)? = null,
         onHitResultChanged: ((HitResult?) -> Unit)? = null,
+        refreshIntervalMs: Long = 0L,
         apply: ReticleNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null
     ) {
@@ -458,15 +476,19 @@ class ARSceneScope internal constructor(
                 minCameraDistance = minCameraDistance,
                 minCameraDistanceFromPlane = minCameraDistanceFromPlane,
                 predicate = predicate,
-                onHitResultChanged = onHitResultChanged
+                onHitResultChanged = onHitResultChanged,
+                refreshIntervalMs = refreshIntervalMs
             ).apply(apply)
         }
         // Keep the live `onHitResultChanged` callback in sync with the latest
         // composition — without this, a recomposed callback (e.g. closing over
         // fresh state) would never get invoked because the node held the
-        // original lambda captured at remember time.
+        // original lambda captured at remember time. Same for the hit-test rate:
+        // it is a live-writable var, never a `remember` key, so changing it
+        // re-rates the existing node instead of destroying it (#3391).
         SideEffect {
             node.onHitResultChanged = onHitResultChanged
+            node.refreshIntervalMs = refreshIntervalMs
         }
         NodeLifecycle(node, content)
     }
@@ -516,6 +538,12 @@ class ARSceneScope internal constructor(
      *                               live-updatable on recomposition.
      * @param onHitResultChanged     Invoked on every hit change (including to/from `null`) —
      *                               drives AIMING/READY host state.
+     * @param refreshIntervalMs      Minimum interval (ms) between two ARCore hit tests. `0` (the
+     *                               default) runs the hit test every updated frame — the original
+     *                               behaviour; a positive value (e.g. `100` = 10 Hz) rate-limits
+     *                               the raycast. Independent of [orientationSmoothing], which
+     *                               keeps damping every frame, so a throttled cursor still eases
+     *                               rather than steps. Live-updatable on recomposition (#3391).
      * @param apply                  Additional imperative configuration on the node.
      * @param content                Custom visual; `null` = the built-in cyan disc.
      */
@@ -528,6 +556,7 @@ class ARSceneScope internal constructor(
         orientationSmoothing: Float = PlacementReticleNodeImpl.DEFAULT_ORIENTATION_SMOOTHING,
         predicate: ((HitResult) -> Boolean)? = null,
         onHitResultChanged: ((HitResult?) -> Unit)? = null,
+        refreshIntervalMs: Long = 0L,
         apply: PlacementReticleNodeImpl.() -> Unit = {},
         content: (@Composable NodeScope.() -> Unit)? = null
     ) {
@@ -540,13 +569,17 @@ class ARSceneScope internal constructor(
                 depthPoint = depthPoint,
                 orientationSmoothing = orientationSmoothing,
                 predicate = predicate,
-                onHitResultChanged = onHitResultChanged
+                onHitResultChanged = onHitResultChanged,
+                refreshIntervalMs = refreshIntervalMs
             ).apply(apply)
         }
         // Keep the recomposition-facing knobs live (see ReticleNode above / #2506).
+        // `refreshIntervalMs` is deliberately NOT a `remember` key: re-rating an existing
+        // reticle must never destroy and re-create it mid-placement (#3391).
         SideEffect {
             node.onHitResultChanged = onHitResultChanged
             node.orientationSmoothing = orientationSmoothing
+            node.refreshIntervalMs = refreshIntervalMs
         }
         // ONE NodeLifecycle call site: branching between two NodeLifecycle calls on
         // `content != null` would destroy-and-reattach the remembered node when a host

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/PlacementReticleNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/PlacementReticleNode.kt
@@ -90,6 +90,14 @@ internal class ReticleOrientationSmoother(smoothing: Float) {
  * @param onHitResultChanged    Invoked whenever the resolved [HitResult] changes
  *                              (including transitions to / from `null`) — drives
  *                              AIMING / READY host state.
+ * @param refreshIntervalMs     Minimum interval, in milliseconds, between two ARCore hit
+ *                              tests. `0` (the default) runs the hit test on every updated
+ *                              frame — the original behaviour; a positive value (e.g. `100`
+ *                              = 10 Hz) rate-limits the raycast. Forwarded through
+ *                              [ReticleNode] to [HitResultNode.refreshIntervalMs] (#3391).
+ *                              Note the two rates are independent: the *orientation
+ *                              smoothing* keeps running every frame, so a throttled reticle
+ *                              still eases rather than steps between hits.
  *
  * @see io.github.sceneview.ar.ARSceneScope.PlacementReticle
  * @see ReticleNode
@@ -102,7 +110,8 @@ open class PlacementReticleNode(
     depthPoint: Boolean = false,
     orientationSmoothing: Float = DEFAULT_ORIENTATION_SMOOTHING,
     predicate: ((HitResult) -> Boolean)? = null,
-    onHitResultChanged: ((HitResult?) -> Unit)? = null
+    onHitResultChanged: ((HitResult?) -> Unit)? = null,
+    refreshIntervalMs: Long = 0L
 ) : ReticleNode(
     engine = engine,
     xPx = xPx,
@@ -114,7 +123,8 @@ open class PlacementReticleNode(
     point = !snapToPlane,
     depthPoint = depthPoint,
     predicate = predicate,
-    onHitResultChanged = onHitResultChanged
+    onHitResultChanged = onHitResultChanged,
+    refreshIntervalMs = refreshIntervalMs
 ) {
 
     private val smoother = ReticleOrientationSmoother(orientationSmoothing)

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/ReticleNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/ReticleNode.kt
@@ -36,6 +36,17 @@ import com.google.ar.core.TrackingState
  * pose on tap-to-place — without attaching a separate `onSessionUpdated`
  * listener that re-runs an identical hit test.
  *
+ * ### Hit-test cost
+ *
+ * The reticle inherits [HitResultNode.refreshIntervalMs] and forwards it from its own
+ * constructor ([#3391](https://github.com/sceneview/sceneview/issues/3391)). `0` — the
+ * default — runs ARCore's [HitResult] raycast on **every** updated frame, the original
+ * byte-for-byte behaviour. Because a reticle is the one node that is on screen for the
+ * whole placement flow, it is also the one most likely to want a ceiling: pass a positive
+ * value (e.g. `100` = 10 Hz) to rate-limit the raycast. Between hit tests the reticle keeps
+ * its last pose and the inherited smooth-transform easing still runs every frame, so the
+ * marker keeps gliding rather than stepping.
+ *
  * ### When to use [ReticleNode] vs raw [HitResultNode]
  *
  * - Use [ReticleNode] for a placement cursor where you need a one-call callback
@@ -85,6 +96,12 @@ import com.google.ar.core.TrackingState
  * @param predicate                 Custom filter applied to each candidate [HitResult].
  * @param onHitResultChanged        Invoked whenever the resolved [HitResult] changes
  *                                  (including transitions to / from `null`).
+ * @param refreshIntervalMs         Minimum interval, in milliseconds, between two ARCore
+ *                                  hit tests. `0` (the default) runs the hit test on every
+ *                                  updated frame — the original behaviour; a positive value
+ *                                  (e.g. `100` = 10 Hz) rate-limits the raycast. Forwarded
+ *                                  to [HitResultNode.refreshIntervalMs], which stays
+ *                                  writable afterwards for live changes (#3391).
  */
 open class ReticleNode(
     engine: Engine,
@@ -102,7 +119,8 @@ open class ReticleNode(
     minCameraDistance: Float? = 0.3f,
     minCameraDistanceFromPlane: Pair<Camera, Float>? = null,
     predicate: ((HitResult) -> Boolean)? = null,
-    var onHitResultChanged: ((HitResult?) -> Unit)? = null
+    var onHitResultChanged: ((HitResult?) -> Unit)? = null,
+    refreshIntervalMs: Long = 0L
 ) : HitResultNode(
     engine = engine,
     xPx = xPx,
@@ -116,7 +134,8 @@ open class ReticleNode(
     planePoseInPolygon = planePoseInPolygon,
     minCameraDistance = minCameraDistance,
     minCameraDistanceFromPlane = minCameraDistanceFromPlane,
-    predicate = predicate
+    predicate = predicate,
+    refreshIntervalMs = refreshIntervalMs
 ) {
 
     /**

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/ReticleThrottleForwardingTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/ReticleThrottleForwardingTest.kt
@@ -1,0 +1,325 @@
+package io.github.sceneview.ar.node
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pins the reticle hit-test throttle forwarding of
+ * [#3391](https://github.com/sceneview/sceneview/issues/3391).
+ *
+ * [HitResultNode] has exposed an opt-in `refreshIntervalMs` rate-limit on its ARCore
+ * [com.google.ar.core.Frame.hitTest] since #2328 — but [ReticleNode] and
+ * [PlacementReticleNode] neither declared nor forwarded it, so every caller silently
+ * inherited the `0` ("every updated frame") default. The knob was reachable in principle
+ * (`refreshIntervalMs` is a public `var` on the base class, so `.apply { }` worked) yet
+ * undiscoverable in practice: absent from both constructors, from both KDocs, and from
+ * every reticle composable signature. A reticle is on screen for the *whole* placement
+ * flow, which makes it the single node most likely to want a ceiling.
+ *
+ * What this pins:
+ *
+ * 1. Both reticle class constructors declare `refreshIntervalMs: Long = 0L` and forward
+ *    it to their supertype — `0L` keeping the byte-for-byte original behaviour.
+ * 2. Neither class re-implements the throttle: no timestamp field, no
+ *    [hitResultRefreshThrottled] call of their own (the #1882 thin-wrapper contract).
+ * 3. Both are documented — the fix is discoverability, so a missing `@param` is a
+ *    regression of the fix itself.
+ * 4. The three `ARSceneScope` composables that build these nodes
+ *    (`HitResultNode` / `ReticleNode` / `PlacementReticle`) expose the parameter,
+ *    pass it at construction, and re-apply it in a `SideEffect`.
+ * 5. `refreshIntervalMs` is never a `remember` key — re-rating an existing reticle must
+ *    never destroy and re-create the node mid-placement (the #2506 live-knob contract).
+ *
+ * Source-introspection ("strings + regex"), the same style as
+ * [io.github.sceneview.ar.ReticleNodeDefaultsTest]: these node types need a Filament
+ * `Engine` and cannot be instantiated on the JVM. The throttle *gate* itself is covered
+ * behaviourally by [HitResultNodeThrottleTest].
+ */
+class ReticleThrottleForwardingTest {
+
+    private val reticleNodeFile =
+        File("src/main/java/io/github/sceneview/ar/node/ReticleNode.kt")
+    private val placementReticleNodeFile =
+        File("src/main/java/io/github/sceneview/ar/node/PlacementReticleNode.kt")
+    private val arSceneScopeFile =
+        File("src/main/java/io/github/sceneview/ar/ARSceneScope.kt")
+
+    private val reticleNodeSource: String by lazy { read(reticleNodeFile) }
+    private val placementReticleNodeSource: String by lazy { read(placementReticleNodeFile) }
+    private val arSceneScopeSource: String by lazy { read(arSceneScopeFile) }
+
+    // ── Class constructors ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ReticleNode constructor declares refreshIntervalMs defaulting to every frame`() {
+        val pattern = Regex("""refreshIntervalMs\s*:\s*Long\s*=\s*0L""")
+        assertTrue(
+            "ReticleNode must declare `refreshIntervalMs: Long = 0L` so callers can rate-limit " +
+                "the hit test (#3391). `0L` keeps the original every-frame behaviour. " +
+                "Did not match $pattern.",
+            pattern.containsMatchIn(reticleNodeSource)
+        )
+    }
+
+    @Test
+    fun `ReticleNode forwards refreshIntervalMs to HitResultNode`() {
+        val supertypeCall = supertypeCall(reticleNodeSource, "HitResultNode")
+        val pattern = Regex("""refreshIntervalMs\s*=\s*refreshIntervalMs""")
+        assertTrue(
+            "ReticleNode must pass `refreshIntervalMs = refreshIntervalMs` into its " +
+                "`: HitResultNode(` supertype call — declaring the parameter without " +
+                "forwarding it would silently drop it (#3391). Did not match $pattern.",
+            pattern.containsMatchIn(supertypeCall)
+        )
+    }
+
+    @Test
+    fun `PlacementReticleNode constructor declares refreshIntervalMs defaulting to every frame`() {
+        val pattern = Regex("""refreshIntervalMs\s*:\s*Long\s*=\s*0L""")
+        assertTrue(
+            "PlacementReticleNode must declare `refreshIntervalMs: Long = 0L` (#3391). " +
+                "Did not match $pattern.",
+            pattern.containsMatchIn(placementReticleNodeSource)
+        )
+    }
+
+    @Test
+    fun `PlacementReticleNode forwards refreshIntervalMs to ReticleNode`() {
+        val supertypeCall = supertypeCall(placementReticleNodeSource, "ReticleNode")
+        val pattern = Regex("""refreshIntervalMs\s*=\s*refreshIntervalMs""")
+        assertTrue(
+            "PlacementReticleNode must pass `refreshIntervalMs = refreshIntervalMs` into its " +
+                "`: ReticleNode(` supertype call so the rate reaches HitResultNode two levels " +
+                "down (#3391). Did not match $pattern.",
+            pattern.containsMatchIn(supertypeCall)
+        )
+    }
+
+    @Test
+    fun `reticles do not re-implement the throttle`() {
+        // The thin-wrapper contract (#1882): the rate-limit state and gate live in
+        // HitResultNode. A private timestamp field or a hitResultRefreshThrottled call in a
+        // subclass would be a second, divergent throttle running against the same hit test.
+        listOf(
+            "ReticleNode" to reticleNodeSource,
+            "PlacementReticleNode" to placementReticleNodeSource
+        ).forEach { (name, src) ->
+            assertTrue(
+                "$name must NOT keep its own hit-test timestamp — the throttle state belongs to " +
+                    "HitResultNode (#1882 thin wrapper / #3391).",
+                !src.contains("lastHitTestTimestampMs")
+            )
+            assertTrue(
+                "$name must NOT call `hitResultRefreshThrottled(` — the gate is applied once, in " +
+                    "HitResultNode.update (#1882 thin wrapper / #3391).",
+                !src.contains("hitResultRefreshThrottled(")
+            )
+        }
+    }
+
+    @Test
+    fun `both reticle classes document refreshIntervalMs`() {
+        // The defect was discoverability, not reachability: `refreshIntervalMs` was already a
+        // public var on the base class. An undocumented parameter re-creates the bug.
+        val pattern = Regex("""@param\s+refreshIntervalMs\s""")
+        assertTrue(
+            "ReticleNode KDoc must carry an `@param refreshIntervalMs` — the #3391 fix is " +
+                "discoverability. Did not match $pattern.",
+            pattern.containsMatchIn(reticleNodeSource)
+        )
+        assertTrue(
+            "PlacementReticleNode KDoc must carry an `@param refreshIntervalMs` (#3391). " +
+                "Did not match $pattern.",
+            pattern.containsMatchIn(placementReticleNodeSource)
+        )
+    }
+
+    // ── ARSceneScope composables ──────────────────────────────────────────────────────
+
+    @Test
+    fun `ARSceneScope HitResultNode composable exposes refreshIntervalMs`() {
+        assertComposableExposesRefreshInterval(HIT_RESULT_NODE)
+    }
+
+    @Test
+    fun `ARSceneScope ReticleNode composable exposes refreshIntervalMs`() {
+        assertComposableExposesRefreshInterval(RETICLE_NODE)
+    }
+
+    @Test
+    fun `ARSceneScope PlacementReticle composable exposes refreshIntervalMs`() {
+        assertComposableExposesRefreshInterval(PLACEMENT_RETICLE)
+    }
+
+    @Test
+    fun `ARSceneScope composables pass refreshIntervalMs at construction`() {
+        listOf(HIT_RESULT_NODE, RETICLE_NODE, PLACEMENT_RETICLE).forEach { composable ->
+            val block = composableBlock(composable)
+            val pattern = Regex("""refreshIntervalMs\s*=\s*refreshIntervalMs""")
+            assertTrue(
+                "ARSceneScope.${composable.functionName} must pass " +
+                    "`refreshIntervalMs = refreshIntervalMs` into its node constructor so the " +
+                    "very first frame is already rate-limited (#3391). Did not match $pattern.",
+                pattern.containsMatchIn(block)
+            )
+        }
+    }
+
+    @Test
+    fun `ARSceneScope composables re-apply refreshIntervalMs in a SideEffect`() {
+        listOf(HIT_RESULT_NODE, RETICLE_NODE, PLACEMENT_RETICLE).forEach { composable ->
+            val block = composableBlock(composable)
+            val sideEffect = block.substringAfter("SideEffect {", "").substringBefore("}")
+            val pattern = Regex("""node\.refreshIntervalMs\s*=\s*refreshIntervalMs""")
+            assertTrue(
+                "ARSceneScope.${composable.functionName} must re-apply " +
+                    "`node.refreshIntervalMs = refreshIntervalMs` in a `SideEffect` — otherwise a " +
+                    "recomposed rate would never reach the remembered node (#2506 / #3391). " +
+                    "Did not match $pattern.",
+                pattern.containsMatchIn(sideEffect)
+            )
+        }
+    }
+
+    @Test
+    fun `refreshIntervalMs is never a remember key`() {
+        // Making the rate a `remember` key would destroy and re-create the node on every
+        // change — for a reticle that means losing the cursor mid-placement. The knob is a
+        // live-writable var, so a changed rate must re-rate the node in place (#3391).
+        listOf(HIT_RESULT_NODE, RETICLE_NODE, PLACEMENT_RETICLE).forEach { composable ->
+            val block = composableBlock(composable)
+            val keyLists = Regex("""remember\(([^)]*)\)\s*\{""").findAll(block)
+                .map { it.groupValues[1] }
+                .toList()
+            assertTrue(
+                "Expected at least one `remember(...) {` call in ARSceneScope." +
+                    "${composable.functionName} — the extraction markers are stale.",
+                keyLists.isNotEmpty()
+            )
+            keyLists.forEach { keys ->
+                assertTrue(
+                    "ARSceneScope.${composable.functionName} must NOT use refreshIntervalMs as a " +
+                        "`remember` key: re-rating the hit test would destroy and re-create the " +
+                        "node mid-placement (#3391). Found it in `remember($keys)`.",
+                    !keys.contains("refreshIntervalMs")
+                )
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────
+
+    private fun assertComposableExposesRefreshInterval(composable: Composable) {
+        val signature = composableSignature(composable)
+        val pattern = Regex("""refreshIntervalMs\s*:\s*Long\s*=\s*0L""")
+        assertTrue(
+            "ARSceneScope.${composable.functionName} must expose " +
+                "`refreshIntervalMs: Long = 0L` so the throttle is discoverable from the " +
+                "composable signature (#3391). Did not match $pattern in the extracted " +
+                "signature.",
+            pattern.containsMatchIn(signature)
+        )
+    }
+
+    /**
+     * A composable in `ARSceneScope.kt`, addressed by its `fun` header and by the section
+     * divider that follows it, so an assertion about one composable can never be satisfied
+     * by a sibling declared in the same file.
+     */
+    private data class Composable(
+        val functionName: String,
+        val header: String,
+        val endMarker: String
+    )
+
+    /** Everything between [Composable.header] and the next section divider. */
+    private fun composableBlock(composable: Composable): String {
+        val src = arSceneScopeSource
+        assertTrue(
+            "Expected a `${composable.header}` composable in ARSceneScope.kt (#3391).",
+            src.contains(composable.header)
+        )
+        val afterHeader = src.substringAfter(composable.header)
+        assertTrue(
+            "Expected the `${composable.endMarker}` section divider after " +
+                "`${composable.header}` in ARSceneScope.kt — the extraction markers are stale.",
+            afterHeader.contains(composable.endMarker)
+        )
+        return afterHeader.substringBefore(composable.endMarker)
+    }
+
+    /**
+     * The parameter list of [composable], by walking to the matching close paren of its
+     * `fun` header — a body-level match (a constructor argument, say) must not satisfy an
+     * assertion about the declared signature.
+     */
+    private fun composableSignature(composable: Composable): String {
+        val src = arSceneScopeSource
+        val start = src.indexOf(composable.header)
+        assertTrue(
+            "Expected a `${composable.header}` composable in ARSceneScope.kt (#3391).",
+            start >= 0
+        )
+        return balancedParens(src, src.indexOf('(', start))
+    }
+
+    /**
+     * The supertype constructor call of a class — the `(...)` following `: [superName](`
+     * — so a "forwarded to the supertype" assertion can't be satisfied by the subclass's
+     * own parameter list.
+     */
+    private fun supertypeCall(src: String, superName: String): String {
+        val marker = Regex(""":\s*$superName\s*\(""").find(src)
+        assertTrue(
+            "Expected a `: $superName(` supertype call — the class hierarchy changed.",
+            marker != null
+        )
+        return balancedParens(src, src.indexOf('(', marker!!.range.first))
+    }
+
+    /** Substring from [open] to its matching close paren, inclusive. */
+    private fun balancedParens(src: String, open: Int): String {
+        var depth = 0
+        var i = open
+        while (i < src.length) {
+            when (src[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return src.substring(open, i + 1)
+                }
+            }
+            i++
+        }
+        return src.substring(open)
+    }
+
+    private fun read(file: File): String {
+        assertTrue(
+            "Expected to find ${file.absolutePath} — JVM test must run from the arsceneview " +
+                "module root.",
+            file.exists()
+        )
+        return file.readText()
+    }
+
+    private companion object {
+        /** The View-coordinate overload — the one that owns the hit test parameters. */
+        val HIT_RESULT_NODE = Composable(
+            functionName = "HitResultNode",
+            header = "fun HitResultNode(",
+            endMarker = "// ── ReticleNode"
+        )
+        val RETICLE_NODE = Composable(
+            functionName = "ReticleNode",
+            header = "fun ReticleNode(",
+            endMarker = "// ── PlacementReticle"
+        )
+        val PLACEMENT_RETICLE = Composable(
+            functionName = "PlacementReticle",
+            header = "fun PlacementReticle(",
+            endMarker = "// ── DepthHitResultNode"
+        )
+    }
+}

--- a/changelog.d/3391-reticle-hit-test-throttle.md
+++ b/changelog.d/3391-reticle-hit-test-throttle.md
@@ -1,0 +1,29 @@
+<!-- category: Fixed -->
+<!-- breaking -->
+- **`ReticleNode` and `PlacementReticle` can now be throttled like every other AR hit-test node ([#3391](https://github.com/sceneview/sceneview/issues/3391)).** `HitResultNode` has
+  rate-limited its per-frame ARCore `Frame.hitTest()` through `refreshIntervalMs` since
+  #2328, but neither reticle subclass accepted or forwarded that value: it appeared in no
+  constructor, no KDoc and no composable parameter list, so both silently inherited the
+  `0` = every-frame default and the raycast ran once per rendered frame whatever the caller
+  wanted. Both classes and all three composables now take `refreshIntervalMs` and forward it
+  to the base node. `0` remains the default and byte-for-byte the previous behaviour; `100`
+  gives a 10 Hz reticle. The throttle covers the hit test only — the inherited
+  smooth-transform easing, and `PlacementReticle`'s orientation smoothing, still run every
+  frame, so a rate-limited reticle glides between hits instead of stepping.
+
+<!-- category: Added -->
+- **`refreshIntervalMs` on the `HitResultNode` composable.** The class has honoured the
+  throttle since #2328, but `ARSceneScope.HitResultNode` never exposed it, so Compose callers
+  had to reach through `apply { }` to find a knob the class already had. All three
+  composables (`HitResultNode`, `ReticleNode`, `PlacementReticle`) now take the parameter and
+  re-apply it in a `SideEffect` instead of keying `remember` on it — changing the rate
+  re-rates the live node rather than destroying and re-creating it.
+
+<!-- category: Changed -->
+- **Binary compatibility:** the new `refreshIntervalMs` parameter added to the
+  already-released public `ReticleNode` / `PlacementReticleNode` constructors and to the
+  `HitResultNode` / `ReticleNode` / `PlacementReticle` composables is source-compatible but
+  **binary-incompatible** (it changes the shipped JVM signatures and the Kotlin default-args
+  synthetics). It therefore rides a MINOR release, never a patch, and binary consumers of
+  `arsceneview` must recompile against the new artifact — the same rule the `predicate`
+  parameter followed when it was added to these same classes.

--- a/llms.txt
+++ b/llms.txt
@@ -1300,15 +1300,20 @@ ARSceneView(modifier = Modifier.fillMaxSize()) {
 ```
 
 **Rate-limit the ARCore hit test (perf, [#2328](https://github.com/sceneview/sceneview/issues/2328)).**
-`HitResultNode.refreshIntervalMs` (default `0` = `Frame.hitTest` every frame) throttles the
-raycast the same way `PointCloudNode` / `DepthMeshNode` rate-limit their rebuilds: a positive
-value (e.g. `100` = 10 Hz) keeps the node's last pose between hit tests, cutting hit-test load
-on scenes with several cursors. Set it in the `apply` block:
+`refreshIntervalMs` (default `0` = `Frame.hitTest` every frame) throttles the raycast the same
+way `PointCloudNode` / `DepthMeshNode` rate-limit their rebuilds: a positive value (e.g. `100`
+= 10 Hz) keeps the node's last pose between hit tests, cutting hit-test load on scenes with
+several cursors. Since [#3391](https://github.com/sceneview/sceneview/issues/3391) it is a
+first-class parameter on **`HitResultNode`, `ReticleNode` and `PlacementReticle`** alike —
+constructors and composables:
 ```kotlin
-HitResultNode(xPx = viewWidth / 2f, yPx = viewHeight / 2f, apply = { refreshIntervalMs = 100 }) {
+HitResultNode(xPx = viewWidth / 2f, yPx = viewHeight / 2f, refreshIntervalMs = 100L) {
     CubeNode(size = Size(0.05f))
 }
 ```
+It stays a writable `var` afterwards and the composables re-apply it on recomposition without
+re-creating the node, so it is safe to drive from state (e.g. 10 Hz on low battery, every
+frame while the user is actively aiming).
 
 ### ReticleNode — placement reticle with auto-hide
 
@@ -1336,10 +1341,17 @@ tap-to-place); use `HitResultNode` directly otherwise. New in v4.x (#1882).
     minCameraDistanceFromPlane: Pair<Camera, Float>? = null,   // legacy plane-only gate
     predicate: ((HitResult) -> Boolean)? = null,
     onHitResultChanged: ((HitResult?) -> Unit)? = null,        // null when the ray misses every trackable
+    refreshIntervalMs: Long = 0L,                              // 0 = hit test every frame; >0 rate-limits (100 = 10 Hz) (#3391)
     apply: ReticleNode.() -> Unit = {},
     content: (@Composable NodeScope.() -> Unit)? = null        // visual marker (e.g. a thin disc)
 )
 ```
+
+A reticle is on screen for the whole placement flow, which makes it the node most likely to
+want a hit-test ceiling. `refreshIntervalMs` is forwarded straight to
+`HitResultNode.refreshIntervalMs` (#3391): between hit tests the reticle keeps its last pose
+and the inherited smooth-transform easing still runs every frame, so the marker keeps gliding
+rather than stepping.
 
 Typical "what-you-see-is-what-you-get" placement:
 ```kotlin
@@ -1394,7 +1406,13 @@ ARSceneView(
 Semantics: `snapToPlane = true` (default) is plane-only (#1891 contract);
 `snapToPlane = false` is FREE PLACEMENT — feature-point hits accepted, plane hits still
 in-polygon. Project acceptance policies (max distance, custom rules) go through `predicate`
-(construction-time). The smoothing knob and callback are live-updatable on recomposition.
+(construction-time). The smoothing knob, the callback and `refreshIntervalMs` are all
+live-updatable on recomposition.
+
+`PlacementReticle(..., refreshIntervalMs = 100)` rate-limits the ARCore hit test to 10 Hz
+(#3391; `0`, the default, hit-tests every frame). The two rates are independent: the
+orientation smoothing keeps running every frame, so a throttled reticle still eases toward
+each new hit rather than stepping to it.
 
 Platform matrix: **iOS** — ships (v4.20+, #894): `ARSceneView(showPlacementReticle: true)` runs
 the tap-to-place raycast every frame and drives a surface-snapped disc (orientation slerp `0.75`,


### PR DESCRIPTION
Fixes #3391

## Summary

`HitResultNode` has been able to rate-limit its per-frame ARCore `Frame.hitTest()` via `refreshIntervalMs` since #2328, and `DepthMeshNode`, `PointCloudNode` and `PlaneRenderer` all carry the equivalent knob. `ReticleNode` and `PlacementReticleNode` were the gap in that family: neither accepted nor forwarded the value, so both silently raycast on every rendered frame no matter what the caller wanted — at 30 fps, 30 native hit tests per second, each able to emit ARCore's own native warnings at full frame rate. This surfaced while investigating #3339, where a *different* unthrottled hit test (the plane renderer's) turned out to be the actual warning source, but the audit found the reticle path had the same latent problem with no way out for callers.

The base `refreshIntervalMs` property is already a public `var`, so a determined caller could reach it via `apply { refreshIntervalMs = 100 }`. The defect is discoverability: the parameter appeared in no reticle constructor, no KDoc and no composable parameter list.

Both classes now take `refreshIntervalMs` as the trailing constructor parameter — the same position `HitResultNode` uses, keeping existing positional call sites source-compatible — and forward it down to the base node. No throttle logic is duplicated; the gate stays the single `hitResultRefreshThrottled` function on `HitResultNode`, overflow guard (#2186) included. The three `ARSceneScope` composables (`HitResultNode`, `ReticleNode`, `PlacementReticle`) now expose it too — `HitResultNode`'s composable never surfaced the parameter either, despite the class having it since #2328, so that's fixed in the same pass. The value is passed at construction and re-applied in a `SideEffect` on all three, never used as a `remember` key: it's a live-writable var, and keying `remember` on it would destroy and recreate the reticle mid-placement on every rate change (the existing #2506 pattern already used for `onHitResultChanged` and `orientationSmoothing`).

Scope of the throttle is the ARCore hit test only — the inherited smooth-transform easing and `PlacementReticleNode`'s orientation smoothing still run every frame, so a throttled reticle glides between hits instead of stepping. Both KDoc blocks say so.

Binary compatibility: adding a parameter to already-released public constructors and composables is source-compatible but binary-incompatible, so this targets the next MINOR release, never a patch — the same rule followed when `refreshIntervalMs` was added to these classes' siblings.

## Type

- [x] Bug fix

## Testing done

All from `/Users/thomasgorisse/Projects/sceneview` on this branch, no source changes needed beyond the regenerated API dump:

- `./gradlew :arsceneview:apiDump` — regenerated `arsceneview/api/arsceneview.api` for the new trailing `Long` parameter (JVM signature gains a `J`) and the shifted Compose default/changed bitmask parameters (`Composer;II` → `Composer;III`) on the three touched composables. Committed as part of this PR; `apiCheck` (CI's binary-compatibility gate) is green against it.
- `./gradlew :arsceneview:detekt` — clean, no new findings.
- `./gradlew :arsceneview:testDebugUnitTest` — green, including the new `ReticleThrottleForwardingTest` (12/12 passing, confirmed via its JUnit XML report). It pins the forwarding contract by source introspection — these node classes need a live Filament `Engine`, so they can't be instantiated off-device — asserting both classes declare and forward the parameter, that neither re-implements the throttle, that all three composables expose/construct/re-apply it, and that none uses it as a `remember` key.
- `./gradlew :snippets-check:compileDebugKotlin` — green; the two edited ```kotlin blocks in `llms.txt` are tagged `compile` and compiled standalone.

## needs-device

ARCore never creates a session on this repo's emulator (#2754 — no camera HAL id 0 on Apple Silicon arm64 AVDs, no ARCore emulator build), so the forwarding above is only verified by source introspection until it runs against a real ARCore session. Requires a physical ARCore device (Pixel 9) on a build of `main` with this branch merged:

1. **`refreshIntervalMs = 0` (default) still tracks every frame.** Point at a plane and pan slowly: the reticle must follow the surface with no visible stutter or lag, exactly as before this change.
2. **`refreshIntervalMs = 100L` visibly reduces the update cadence.** Same pan, same surface: the reticle should now visibly lag behind the camera motion at roughly 10 updates/second instead of tracking continuously.
3. **Changing `refreshIntervalMs` live doesn't reset or snap the reticle.** With the reticle already tracking a plane, flip the value between `0` and `100L` at runtime: it must keep its current pose and smoothly adjust its update rate, never jump or momentarily disappear — this is the SideEffect-not-remember-key guarantee, which can't be observed from source alone.
4. **Tap-to-place still anchors correctly at both throttle settings.** With the reticle visible on a plane, tap to place an object at `refreshIntervalMs = 0` and again at `100L`: the object must anchor at the reticle's last shown position both times, with no placement regression.

## Checklist

- [ ] `/review` passed — no threading, Compose API, or style issues
- [x] `/document` run — KDoc updated for changed public APIs, `llms.txt` updated (already done in the prior commit on this branch)
- [x] `/review --coverage` run — new tests added for new behaviour (`ReticleThrottleForwardingTest`, 12 cases)
- [ ] `./gradlew :sceneview:assembleDebug :arsceneview:assembleDebug` passes — not run this pass; `:arsceneview:testDebugUnitTest` and `:snippets-check:compileDebugKotlin` were run instead (see Testing done)
- [x] Filament materials recompiled (if `.mat` files changed) — N/A, no `.mat` files touched
- [x] Minimal diff — no unrelated reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
