### PR TITLE
docs(demo): reword stale four-tab comments to match the three-entry RootTab

### DIFF
--- a/changelog.d/3401-stale-four-tabs-comments.md
+++ b/changelog.d/3401-stale-four-tabs-comments.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+- **The Android demo's "four tabs" comments now describe the real three-entry
+  `RootTab` ([#3401](https://github.com/sceneview/sceneview/issues/3401)).** Three
+  comments still described a four-tab bottom bar while `RootTab` has had three
+  entries (`Showcase`, `ArView`, `About`) for a while: `MainActivity.kt`'s "list"
+  route claimed a "4-tab root (Explore / AR View / Samples / About)" whose
+  "Samples" tab hosted a `DemoListScreen` that no longer exists (demo deep links
+  actually navigate straight to `demo/<id>`), `RootScreen.kt` said "the four tabs
+  get their 168 dp of dead bottom gutter back" — a figure that survives only in
+  that comment, the gutter having been reclaimed when the feedback FAB became a
+  sibling card — and `FeedbackReport.kt` quoted #1930 as requiring the button "on
+  the 4 tabs". All three now match the code, and the obsolete 168 dp figure is
+  gone so nobody reintroduces it as a real constant. Comment-only — no behaviour
+  change.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -292,10 +292,11 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
             popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() }
         ) {
             composable("list") {
-                // New 4-tab root (Explore / AR View / Samples / About). The legacy
-                // category-grouped DemoListScreen lives untouched inside the
-                // "Samples" tab so existing deep-link flows (`adb am start ... --es
-                // demo <id>`) and the in-app update banner remain wired up.
+                // Three-tab root (Showcase / AR View / About). Demo deep links
+                // (`adb am start ... --es demo <id>`) never land here — they
+                // navigate straight to "demo/<id>" (see the pending-demo
+                // handling above) — and the in-app update banner floats over
+                // this whole Box, so both stay wired up whatever tab is active.
                 RootScreen(onDemoClick = { id -> navController.navigate("demo/$id") })
             }
             composable(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackReport.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/FeedbackReport.kt
@@ -324,8 +324,8 @@ data class PendingBugReport(
  *
  * The sheet is owned by `SceneViewDemoApp` (it wraps the whole `NavHost`),
  * but a report entry point also lives in `DemoScaffold` — the shared scaffold
- * for every demo screen (#1930 requires the button "on the 4 tabs AND inside
- * every demo"). A demo's top-app-bar action has no direct handle on the
+ * for every demo screen (#1930 requires the button on the root tabs AND
+ * inside every demo). A demo's top-app-bar action has no direct handle on the
  * host's sheet state, so it raises this flag; `SceneViewDemoApp` observes it,
  * opens the sheet, and clears it.
  */

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
@@ -365,8 +365,9 @@ private fun AboutTabContent() {
         // than the viewport there is always another card in the band, so the
         // FAB masked text at every scroll position but the top one. No
         // clearance constant can fix that shape. As a sibling in this column
-        // it cannot overlap anything, the four tabs get their 168 dp of dead
-        // bottom gutter back, and the in-context path is untouched: a demo
+        // it cannot overlap anything, the three tabs got their dead bottom
+        // gutter back (see `ListGutter.kt`), and the in-context path is
+        // untouched: a demo
         // screen still raises `FeedbackOpenRequest` from its own top app bar.
         AboutInfoCard(
             icon = Icons.Filled.BugReport,


### PR DESCRIPTION
Fixes #3401

Three comments in the Android demo app still described a four-tab bottom bar while `RootTab` has had three entries (`Showcase`, `ArView`, `About`) for a while. This is the comment-only fix — no behaviour change.

## Changes

- **`MainActivity.kt`** — the `"list"` route's comment claimed a "4-tab root (Explore / AR View / Samples / About)" whose "Samples" tab hosted the legacy `DemoListScreen`. That file no longer exists anywhere in the tree (verified: zero references besides comments), and demo deep links (`adb am start ... --es demo <id>`) never pass through the tab host — they navigate straight to `demo/<id>` via the pending-demo handling. The comment now says exactly that.
- **`RootScreen.kt`** — "the four tabs get their 168 dp of dead bottom gutter back": reworded to three tabs, and the obsolete 168 dp figure is dropped (it survived only inside this comment) with a pointer to `ListGutter.kt`, which documents that history accurately.
- **`FeedbackReport.kt`** — the #1930 requirement quote "on the 4 tabs AND inside every demo" is now paraphrased as "on the root tabs AND inside every demo" so it stays true whatever the tab count.

## Verified

- `grep -rni 'four tab|4 tab|4-tab|168 dp|168dp'` over the demo sources: the only remaining hit is `ListGutter.kt`'s deliberate historical note ("the tabs *used to* leave `FEEDBACK_FAB_RESERVED_SPACE` (168 dp)"), which describes a past state correctly and warns against reintroducing the constant — left as is.
- `RootTab` enum re-read: three entries, matching the new wording.
- Comment-only diff (plus the changelog fragment) — nothing to compile-check beyond that.

## Out of scope (noted, not fixed here)

`ArViewTab.kt` line ~615 still says its card "mirrors `DemoListScreen.kt`'s `DemoCard`" — also a reference to the deleted file, but it is a style-lineage note, not a tab-count claim, so it is outside #3401's list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)