### PR TITLE
fix(demo): drop the redundant "report sent" snackbar

### DIFF
--- a/changelog.d/3398-remove-bug-report-sent-snackbar.md
+++ b/changelog.d/3398-remove-bug-report-sent-snackbar.md
@@ -1,0 +1,13 @@
+<!-- category: Fixed -->
+- **Sending a bug report from the demo app no longer pops a confirmation
+  snackbar ([#3398](https://github.com/sceneview/sceneview/issues/3398)).**
+  Handing a report off to GitHub or the share sheet used to greet the user
+  back with a "GitHub opened — finish and submit there" / "Report shared"
+  snackbar (#3263). The hand-off itself is already the acknowledgement — the
+  sheet dismisses and the browser opens on the pre-filled issue (or the
+  system share sheet takes over) — so the snackbar was redundant, and it
+  could not be truthful anyway: with no GitHub API call on device, "sent"
+  only ever meant "intent launched". The failure path is untouched: when no
+  app can handle the intent, the sheet still stays open and shows the error
+  inline. `BugReportSheet` loses its `onSent` callback, `MainActivity` its
+  snackbar host, and the two now-unused strings are gone.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import io.github.sceneview.demo.fragments.GeneratedDemos
 import io.github.sceneview.demo.theme.SceneViewDemoTheme
-import io.github.sceneview.demo.theme.SceneViewTokens
 import io.github.sceneview.demo.ui.RootScreen
 import io.github.sceneview.sample.common.update.InAppUpdateManager
 import io.github.sceneview.sample.common.update.UpdateBanner
@@ -37,9 +36,6 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
@@ -47,7 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
@@ -362,7 +357,6 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
         // re-opening re-captures in <100 ms.
         var bugReport by remember { mutableStateOf<PendingBugReport?>(null) }
         val reportScope = rememberCoroutineScope()
-        val snackbarHostState = remember { SnackbarHostState() }
 
         fun openBugReport() {
             if (bugReport != null) return
@@ -409,42 +403,16 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
                 // after the sheet is gone. The app-start sweep
                 // (sweepStaleFeedbackMedia) reclaims the few-hundred-KB file
                 // on the next launch instead.
+                // No "sent" confirmation on return to the app (#3398): the
+                // hand-off itself is the acknowledgement — the browser opens
+                // on the pre-filled GitHub issue, or the system share sheet
+                // takes over. The snackbar that used to greet the user back
+                // (#3263, positioned in #3325) was redundant with it, and
+                // could not be truthful anyway — with no GitHub API call on
+                // device, "sent" only ever meant "intent launched".
                 onDismiss = { bugReport = null },
-                onSent = { message ->
-                    reportScope.launch {
-                        snackbarHostState.currentSnackbarData?.dismiss()
-                        snackbarHostState.showSnackbar(
-                            message = message,
-                            duration = SnackbarDuration.Long,
-                        )
-                    }
-                },
             )
         }
-
-        // Confirms a sent bug report (#3263) — sits above everything else in
-        // this Box, same z-order reasoning as the update banner above. This Box
-        // wraps the whole NavHost, so it has no visibility into whichever
-        // bottom chrome the current screen shows (RootScreen's NavigationBar,
-        // ~80dp, or a DemoScaffold's floating dock). Previously it had zero
-        // bottom padding and rendered flush with the window edge — on top of
-        // that chrome's buttons in z-order instead of floating clear above
-        // them, and only partly visible behind the gesture nav bar (#3325).
-        // `SETTINGS_FAB_RESERVED_SPACE` (104dp, `DemoScaffold.kt`) is the
-        // dock's own floor and comfortably clears the shorter NavigationBar
-        // too, so it doubles as the conservative clearance here.
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .windowInsetsPadding(
-                    WindowInsets.safeDrawing.only(
-                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
-                    )
-                )
-                .padding(horizontal = SceneViewTokens.Space.md)
-                .padding(bottom = SETTINGS_FAB_RESERVED_SPACE + SceneViewTokens.Space.sm),
-        )
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/BugReportSheet.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/feedback/BugReportSheet.kt
@@ -75,20 +75,19 @@ import kotlinx.coroutines.launch
  * text only for the GitHub path, since a URL cannot carry the image, and the
  * UI says so).
  *
- * On a successful hand-off the sheet dismisses itself and [onSent] fires
- * with a short confirmation message for the host to surface (e.g. a
- * snackbar) — there is no server-side GitHub API call here (no auth token
- * on device), so "success" means the browser/share intent launched, not
- * that an issue was actually filed; the confirmation copy reflects that.
- * When no app can handle the intent, the sheet stays open and shows the
- * error inline instead (#3263).
+ * On a successful hand-off the sheet simply dismisses itself — the browser
+ * or share sheet opening over the app IS the visible confirmation, so no
+ * extra snackbar/toast greets the user on their return (#3398). There is no
+ * server-side GitHub API call here (no auth token on device), so "success"
+ * means the browser/share intent launched, not that an issue was actually
+ * filed. When no app can handle the intent, the sheet stays open and shows
+ * the error inline instead (#3263).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BugReportSheet(
     report: PendingBugReport,
     onDismiss: () -> Unit,
-    onSent: (String) -> Unit = {},
 ) {
     val context = LocalContext.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -107,8 +106,6 @@ fun BugReportSheet(
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).resolveActivity(context.packageManager) != null
     }
     val voicePrompt = stringResource(R.string.feedback_report_voice_prompt)
-    val sentGitHubMessage = stringResource(R.string.feedback_report_sent_github)
-    val sentShareMessage = stringResource(R.string.feedback_report_sent_share)
     val noAppError = stringResource(R.string.feedback_report_no_app)
     val speechLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -225,7 +222,6 @@ fun BugReportSheet(
                 onClick = {
                     if (openGitHubIssue(context, report.info, note)) {
                         sendError = null
-                        onSent(sentGitHubMessage)
                         onDismiss()
                     } else {
                         sendError = noAppError
@@ -245,7 +241,6 @@ fun BugReportSheet(
                 onClick = {
                     if (shareReport(context, report, note, includeScreenshot)) {
                         sendError = null
-                        onSent(sentShareMessage)
                         onDismiss()
                     } else {
                         sendError = noAppError

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -379,8 +379,6 @@
     <string name="feedback_report_open_github">Send to GitHub</string>
     <string name="feedback_report_share_chooser">Share bug report</string>
     <string name="feedback_report_no_app">No app available to send the report</string>
-    <string name="feedback_report_sent_github">GitHub opened — finish and submit there. Thanks!</string>
-    <string name="feedback_report_sent_share">Report shared — thanks!</string>
     <string name="feedback_report_voice_cd">Dictate description</string>
     <string name="feedback_report_voice_prompt">Describe the issue</string>
 </resources>


### PR DESCRIPTION
Fixes #3398

Sending a bug report from the demo app no longer pops a confirmation snackbar on return to the app.

## What changed

- **`BugReportSheet.kt`** — the `onSent` callback is gone, along with the two sent-message string lookups; the KDoc now states that the hand-off itself is the confirmation.
- **`MainActivity.kt`** — the `SnackbarHost`, its state, the `onSent` lambda and the imports the removal orphans (`SnackbarDuration`/`SnackbarHost`/`SnackbarHostState`, `SceneViewTokens`, `padding`) are removed. A comment at the `BugReportSheet` call site records why there is deliberately no "sent" confirmation (#3398), so it does not get re-added as an oversight fix.
- **`strings.xml`** — `feedback_report_sent_github` and `feedback_report_sent_share` removed (only `values/` existed, no per-locale copies).

## Is the user left without a signal? No.

The snackbar was **not** the only acknowledgement, so nothing needs to replace it:

- On the GitHub path, the sheet dismisses and the browser opens on the pre-filled issue — the user is looking at their report.
- On the share path, the system share sheet takes over.
- The snackbar could not be truthful anyway: there is no GitHub API call on device, so "sent" only ever meant "intent launched", never "issue filed" — the sheet's own KDoc already said as much.
- The **failure** path is untouched: when no app can handle the intent, the sheet stays open and shows the error inline (#3263).

No follow-up issue needed on that front.

## Verified

- `:samples:android-demo:compileReleaseKotlin` — green.
- `:samples:android-demo:testReleaseUnitTest` — 575 tests, 13 failures, all in `DemoScaffoldBottomBandTest` / `DemoScaffoldTopBandTest` / `DemoBackgroundRoleTest`; re-ran those exact classes against untouched `origin/main` sources in the same environment and they fail identically — **pre-existing, unrelated** to this change. Every `feedback/` test passes.
- `grep -rn 'onSent\|feedback_report_sent'` over `samples/` and the Maestro flows: zero remaining references.

Not visually validated on a device/emulator (none available to this session) — the change is a pure removal, but if a QA pass of the report flow is wanted, it belongs to the main session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)