### PR TITLE
fix(demo): draw the demo's accents from the design system, not Material swatches

### DIFF
--- a/changelog.d/3242-demo-brand-palette.md
+++ b/changelog.d/3242-demo-brand-palette.md
@@ -1,0 +1,6 @@
+<!-- category: Fixed -->
+The demo app's visible surfaces now draw their colours from the design system instead of
+hardcoded Material swatches: the category accents sample `DESIGN.md`'s `gradient-hero`
+ramp (blue → violet, with a dark variant) rather than a six-hue rainbow, the About tab's
+icons, hero gradient and rating star follow the theme in both light and dark, and the
+Explore category chips use the primary container instead of the tertiary one.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/RootScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.ViewInAr
 import androidx.compose.material3.Badge
@@ -311,14 +312,12 @@ private fun AboutTabContent() {
     ) {
         AboutHeroCard()
         AboutInfoCard(
-            icon = Icons.Filled.Favorite,
-            iconColor = Color(0xFFE91E63),
+            icon = Icons.Filled.Public,
             title = stringResource(R.string.about_card_open_source_title),
             subtitle = stringResource(R.string.about_card_open_source_subtitle),
         )
         AboutInfoCard(
             icon = Icons.Filled.Book,
-            iconColor = Color(0xFF2196F3),
             title = stringResource(R.string.about_card_docs_title),
             subtitle = stringResource(R.string.about_card_docs_subtitle),
             trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
@@ -326,7 +325,6 @@ private fun AboutTabContent() {
         )
         AboutInfoCard(
             icon = Icons.Filled.Code,
-            iconColor = Color(0xFF5C6BC0),
             title = stringResource(R.string.about_card_github_title),
             subtitle = stringResource(R.string.about_card_github_subtitle),
             trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
@@ -334,7 +332,6 @@ private fun AboutTabContent() {
         )
         AboutInfoCard(
             icon = Icons.Filled.PlayArrow,
-            iconColor = Color(0xFFFF9800),
             title = stringResource(R.string.about_card_playground_title),
             subtitle = stringResource(R.string.about_card_playground_subtitle),
             trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
@@ -342,7 +339,6 @@ private fun AboutTabContent() {
         )
         AboutInfoCard(
             icon = Icons.Filled.Favorite,
-            iconColor = Color(0xFFF44336),
             title = stringResource(R.string.about_card_sponsor_title),
             subtitle = stringResource(R.string.about_card_sponsor_subtitle),
             trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
@@ -350,7 +346,6 @@ private fun AboutTabContent() {
         )
         AboutInfoCard(
             icon = Icons.Filled.Group,
-            iconColor = Color(0xFF26A69A),
             title = stringResource(R.string.about_card_credits_title),
             subtitle = stringResource(R.string.about_card_credits_subtitle),
             trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
@@ -370,7 +365,6 @@ private fun AboutTabContent() {
         // screen still raises `FeedbackOpenRequest` from its own top app bar.
         AboutInfoCard(
             icon = Icons.Filled.BugReport,
-            iconColor = Color(0xFF7E57C2),
             title = stringResource(R.string.about_card_feedback_title),
             subtitle = stringResource(R.string.about_card_feedback_subtitle),
             onClick = { FeedbackOpenRequest.request() },
@@ -405,7 +399,7 @@ private fun AboutTabContent() {
                 Icon(
                     Icons.Filled.Favorite,
                     contentDescription = null,
-                    tint = Color(0xFFE91E63),
+                    tint = MaterialTheme.colorScheme.primary,
                     // The gap on BOTH sides of the heart lives here, not in the
                     // strings: a leading space in a resource is stripped by aapt
                     // unless quoted, which is why this read "…<heart>by Thomas
@@ -446,10 +440,12 @@ private fun AboutHeroCard() {
                 modifier = Modifier
                     .size(110.dp)
                     .background(
+                        // DESIGN.md `gradient-hero`: the theme's primary → tertiary pair IS
+                        // #005bc1 → #6446cd in light and #a4c1ff → #d2a8ff in dark.
                         brush = Brush.linearGradient(
                             colors = listOf(
-                                Color(0xFF2196F3).copy(alpha = 0.55f),
-                                Color(0xFF9C27B0).copy(alpha = 0.40f),
+                                MaterialTheme.colorScheme.primary,
+                                MaterialTheme.colorScheme.tertiary,
                             ),
                         ),
                         shape = RoundedCornerShape(28.dp),
@@ -459,7 +455,7 @@ private fun AboutHeroCard() {
                 Icon(
                     Icons.Filled.ViewInAr,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.size(56.dp),
                 )
             }
@@ -484,7 +480,7 @@ private fun AboutHeroCard() {
                     Icon(
                         Icons.Filled.Star,
                         contentDescription = null,
-                        tint = Color(0xFF4CAF50),
+                        tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(14.dp),
                     )
                     Spacer(Modifier.width(6.dp))
@@ -509,7 +505,7 @@ private fun AboutHeroCard() {
 @Composable
 private fun AboutInfoCard(
     icon: ImageVector,
-    iconColor: Color,
+    iconColor: Color = MaterialTheme.colorScheme.primary,
     title: String,
     subtitle: String,
     trailingIcon: ImageVector? = null,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/explore/ExploreTabScreen.kt
@@ -953,14 +953,14 @@ private fun CategoryChip(category: SketchfabCategory, onClick: (SketchfabCategor
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(SceneViewTokens.Radius.full))
-            .background(MaterialTheme.colorScheme.tertiaryContainer)
+            .background(MaterialTheme.colorScheme.primaryContainer)
             .clickable { onClick(category) }
             .padding(horizontal = SceneViewTokens.Space.md, vertical = SceneViewTokens.Space.sm),
     ) {
         Text(
             text = category.displayName,
             style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
             fontWeight = FontWeight.Medium,
         )
     }

--- a/samples/common/src/main/java/io/github/sceneview/sample/ui/DemoCategoryAccent.kt
+++ b/samples/common/src/main/java/io/github/sceneview/sample/ui/DemoCategoryAccent.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.graphics.Color
 /**
  * The one place a sample category's accent colour is defined.
  *
- * The light palette mirrors the v4.1.0 SceneView design system (see `DESIGN.md`); the dark
- * palette desaturates each hue and lifts its lightness so tinted gradients and icon tints do
- * not burn at >9:1 contrast against an M3 dark `surfaceContainer`.
+ * Both palettes are sampled along the `gradient-hero` tokens in `DESIGN.md` — light runs
+ * `#005bc1 → #6446cd`, dark runs `#a4c1ff → #d2a8ff` — so every category accent stays inside
+ * the brand's blue-to-violet span instead of introducing hues the design system does not
+ * have. The reference apps the demo UI is anchored on (Sketchfab, Polycam, Reality Composer)
+ * differentiate list categories by position and label, not by hue family; the ramp keeps a
+ * subtle per-category shift without turning the list into a rainbow.
  *
  * Before this existed the palette was copied into three screens, one of them carrying a
  * "keep these in sync by hand" comment and one of them having no dark variant at all — so in
@@ -20,25 +23,25 @@ import androidx.compose.ui.graphics.Color
  */
 object DemoCategoryAccent {
 
-    /** Accent used for a category this palette does not know. */
+    /** Accent used for a category this palette does not know — `gradient-hero`'s end stop. */
     val Fallback: Color = Color(0xFF6446CD)
 
     private val light: Map<String, Color> = mapOf(
-        "3D Basics" to Color(0xFF6446CD),
-        "Lighting & Environment" to Color(0xFFE6A23C),
-        "Content" to Color(0xFF42A5F5),
-        "Interaction" to Color(0xFFEC407A),
-        "Advanced" to Color(0xFF26A69A),
-        "Augmented Reality" to Color(0xFF66BB6A),
+        "3D Basics" to Color(0xFF005BC1),
+        "Lighting & Environment" to Color(0xFF1457C3),
+        "Content" to Color(0xFF2853C6),
+        "Interaction" to Color(0xFF3C4EC8),
+        "Advanced" to Color(0xFF504ACB),
+        "Augmented Reality" to Color(0xFF6446CD),
     )
 
     private val dark: Map<String, Color> = mapOf(
-        "3D Basics" to Color(0xFFB39DDB),
-        "Lighting & Environment" to Color(0xFFFFCC80),
-        "Content" to Color(0xFF90CAF9),
-        "Interaction" to Color(0xFFF48FB1),
-        "Advanced" to Color(0xFF80CBC4),
-        "Augmented Reality" to Color(0xFFA5D6A7),
+        "3D Basics" to Color(0xFFA4C1FF),
+        "Lighting & Environment" to Color(0xFFADBCFF),
+        "Content" to Color(0xFFB6B7FF),
+        "Interaction" to Color(0xFFC0B2FF),
+        "Advanced" to Color(0xFFC9ADFF),
+        "Augmented Reality" to Color(0xFFD2A8FF),
     )
 
     /** Every category this palette covers, in design-system order. */


### PR DESCRIPTION
## What was broken

The demo app's visible surfaces carried colours the design system does not have:

- **Category accents** (`DemoCategoryAccent`, consumed by the home cards and the AR View tab) were a six-hue Material rainbow — orange, pink, green, teal, light blue, purple — with a hand-desaturated dark variant.
- **About tab**: the hero tile gradient, the GitHub-stars star (green), the sponsor heart / footer heart (pink) and every info-card leading icon each hardcoded their own arbitrary Material swatch, so none of them followed the theme.
- **Explore**: the category chips used the tertiary container while every other accent surface is primary-driven.

## The fix

- Both category-accent palettes now sample `DESIGN.md`'s `gradient-hero` ramp — light runs `#005bc1 → #6446cd`, dark runs `#a4c1ff → #d2a8ff` — so every accent stays inside the brand's blue-to-violet span. The reference apps the demo UI is anchored on differentiate categories by position and label, not hue family.
- The About tab reads every tint from the Material theme (`primary` / `tertiary` / `onPrimary`), whose pairs are exactly the `gradient-hero` stops in both schemes.
- The Explore category chips use `primaryContainer` / `onPrimaryContainer`.

## Notes for review

- This is a rescue of work authored before the demo redesign (#3308/#3314) landed, rebased onto today's `main`: the parts of the original patch that recoloured the since-deleted `FiltersBar` / `SourcePickerRow` chips were dropped, as were its re-recorded `demo_list_*.png` goldens — those goldens no longer exist (they became `home_*.png`).
- `:samples:android-demo:verifyRoborazziDebug` and `:samples:common` unit tests pass **against the existing goldens, unchanged** — the home snapshot scenes render photo-preview cards, where the category accent is not drawn, so no re-record was needed or done.
- Validated on-device (emulator, light **and** dark): About tab hero gradient, star, heart and icons are pixel-exact to the theme values in both modes; the full home list shows no rainbow hue left, with the one accent-bearing card (Gesture Feedback, icon-tile fallback) sampling `#3C4EC8` light / `#C0B2FF` dark from the ramp.

Fixes #3242

🤖 Generated with [Claude Code](https://claude.com/claude-code)