### PR TITLE
docs(demo): update the tablet Model Viewer framing bullet for the v3 captures

### DIFF
--- a/changelog.d/3350-tablet-orbit-bullet-v3.md
+++ b/changelog.d/3350-tablet-orbit-bullet-v3.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+The Play Store graphics README's follow-up bullet on tablet Model Viewer framing
+non-determinism no longer cites the retired v2 evidence. The v3 re-capture
+([#3350](https://github.com/sceneview/sceneview/pull/3350)) replaced the frames the
+bullet pointed at, and in the committed v3 set the helmet holds the same head-on pose
+on both tablet classes (Model Viewer is slot 2 there, not slot 1) — verified by
+comparing `tablet7-screenshot-2.png` and `tablet10-screenshot-2.png` by eye. The
+bullet now records that the committed pair matches while keeping the standing lesson:
+the hero orbit is free-running, so any re-capture rolls the pose lottery again and the
+camera distance must survive the widest orbit pose.

--- a/samples/android-demo/distribution/play-store/en-GB/graphics/README.md
+++ b/samples/android-demo/distribution/play-store/en-GB/graphics/README.md
@@ -245,13 +245,17 @@ passes the variance check and is still unusable.
 - **#2913 (fixed and re-captured, #3106)** — the scene takes the viewport aspect
   into account, `multi-model` is back in the tablet set, and both tablet classes
   were re-shot at three slots. No follow-up left here.
-- **Tablet `model-viewer` framing is not deterministic.** In the committed set
-  the helmet sits at a visibly different orientation on `tablet7-screenshot-1`
-  than on `tablet10-screenshot-1`, while `dynamic-sky` matches across both
-  classes. Two runs of the same demo should differ only by aspect, so this is a
-  demo-side non-determinism worth pinning before the next re-capture. Still true
-  after #3106 — the cause is the free-running hero orbit, so the captured pose is
-  whatever instant the settle window lands on. That is why the tablet distance was
+- **Tablet Model Viewer framing is not deterministic — but the committed v3 pair
+  happens to match.** The cause is the free-running hero orbit: the captured pose
+  is whatever instant the settle window lands on, so two runs of the same demo
+  can differ by more than aspect — which is exactly what the v2 set showed (a
+  visibly different helmet orientation on `tablet7-screenshot-1` vs
+  `tablet10-screenshot-1`, still true after #3106). The v2 evidence is gone:
+  #3350 re-captured both tablet classes with set v3, where Model Viewer sits at
+  slot 2, and judged by eye the helmet holds the same head-on pose on
+  `tablet7-screenshot-2` and `tablet10-screenshot-2` — the committed set no
+  longer shows the mismatch. The orbit itself is still unpinned, so any future
+  re-capture rolls the pose lottery again; that is why the tablet distance was
   probed at several orbit instants and chosen to survive the *widest* pose rather
   than to suit one frame: 3.5 m looked right on the 3/4 pose and clipped the
   head-on one.


### PR DESCRIPTION
## Summary
The graphics README's "Known follow-ups" bullet about tablet `model-viewer` framing non-determinism still cited the retired v2 set (`tablet7-screenshot-1`, "still true after #3106"). #3350 re-captured both tablet classes with set v3, where Model Viewer sits at slot 2.

Compared `tablet7-screenshot-2.png` and `tablet10-screenshot-2.png` by eye: the helmet holds the same head-on pose on both tablet classes, so the committed set no longer shows the mismatch. The bullet is updated (not retired) — it now records that the committed v3 pair matches, while keeping the standing caveat: the hero orbit is still free-running, so any future re-capture rolls the pose lottery again, which is why the tablet camera distance was probed to survive the widest orbit pose.

Changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)