### PR TITLE
docs(store): say the release workflows sync the listings (#2844)

### DIFF
--- a/changelog.d/2844-store-ar-visuals.md
+++ b/changelog.d/2844-store-ar-visuals.md
@@ -12,4 +12,5 @@ needs a device camera: ARCore's recording/playback path fails on the QA
 emulators (session creation probes camera HAL id 0 before consulting the
 playback dataset, and the arm64 AVDs have none). The existing real captures
 were shifted down one slot, not replaced. Committing is not uploading — the
-store consoles are updated manually.
+release workflows sync both listings from the repository, so the visuals reach
+the stores with the next minor release.


### PR DESCRIPTION
The changelog fragment added by #3420 ends on "Committing is not uploading — the store consoles are updated manually". Tracing the upload path shows that is not how the visuals ship:

- `app-store.yml`'s submit step calls `asc_listing.py`'s `apply_screenshots()` **inline**, at the one moment an editable iOS version exists. `sorted(glob("*.png"))` plus delete-then-upload reproduces the repository order, so `00-ar.png` lands in slot 1 unaided.
- `play-store.yml`'s `sync-listing` job runs `play_listing.py --apply` (text *and* images) on every minor bump.

So no one uploads by hand — and on iOS no one can: once a version is Ready for Distribution the App Store media manager exposes no file input, and `asc_listing.py` never creates a version by design. The sentence pointed at a console gesture that cannot be performed.

Only the fragment changes; `CHANGELOG.md` has not consumed it yet, so no generated file is touched. `samples/ios-demo/appstore-screenshots/README.md` already names `store-sync/asc_listing.py --apply-screenshots` and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)