### PR TITLE
fix(demo): tap me only fires from the picking card's button

### DIFF
--- a/changelog.d/3422-picking-card-tap.md
+++ b/changelog.d/3422-picking-card-tap.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **Demo app — "Tap me" on the Picking & Collision card now fires only from its Button
+  ([#3422](https://github.com/sceneview/sceneview/issues/3422)).** The card was a
+  `Card(onClick = onTap, …)` wrapping the button, so a tap anywhere on the card — its title,
+  its shape/tap counters, the padding around them — counted the same as pressing "Tap me".
+  The card is a plain, non-clickable `Card` now; only the `Button` has an `onClick`. A tap
+  Compose does not consume this way used to fall through to the scene's `onGestureListener`
+  as a `ViewNode` hit and bump the counter there too — that fallback branch is gone, so a
+  miss on the card is now a true miss, exactly like the ray-cast half of the demo. Shape
+  picking on the rest of the scene is unaffected.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PickingAndCollisionDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PickingAndCollisionDemo.kt
@@ -1,6 +1,7 @@
 package io.github.sceneview.demo.demos
 
 import android.view.MotionEvent
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -75,13 +76,25 @@ import io.github.sceneview.sample.rememberMaterialInstance
  * [io.github.sceneview.demo.DeepLinkRouter.DEMO_ID_ALIASES]; `view-node` no longer
  * pre-selects a tab because there is none.
  *
- * ## Why both faces of the card are clickable
+ * ## Why both faces of the card forward touches
  *
  * The card slowly turns, so the face under the finger is the back one for half of every
- * revolution. A non-interactive back meant the tap reached no Compose target at all and only
+ * revolution. A non-forwarding back meant the tap reached no Compose target at all and only
  * bumped the scene-level counter — the "the tap is not on the Compose component" of #3329.
- * Both faces are now real `Card(onClick = …)` targets, and the library maps a back-face pick
- * onto the pixel the user is actually looking at (see `ViewNode.onTouchEvent`).
+ * Both faces keep [io.github.sceneview.node.ViewNode.isTouchForwardingEnabled] on (the
+ * default), and the library maps a back-face pick onto the pixel the user is actually
+ * looking at (see `ViewNode.onTouchEvent`).
+ *
+ * ## Why only the button counts as a tap (#3422)
+ *
+ * The card itself is a plain, non-clickable `Card` — only its `Button` has an `onClick`. A
+ * tap that lands elsewhere on the card (its title, its counters, the padding around them) is
+ * therefore not consumed by anything in the embedded Compose tree, falls through
+ * `ViewNode.onTouchEvent` untouched, and reaches [rememberOnGestureListener]'s
+ * `onSingleTapUp` as a plain node hit. That fallback used to bump [tapCount] itself, which
+ * made the *whole card* count as "the button" — this demo instead lets it no-op (a `ViewNode`
+ * carries no `name`, so the shape-highlight branch below does not match it either), so
+ * `tapCount` only ever increases from the real `Button.onClick`.
  */
 @Composable
 fun PickingAndCollisionDemo(onBack: () -> Unit) {
@@ -127,21 +140,21 @@ fun PickingAndCollisionDemo(onBack: () -> Unit) {
         // Only a tap that actually PICKS something counts — an empty-space tap arrives with
         // `node == null` and changes nothing, which is the whole point of a picking demo.
         //
-        // The embedded Compose tree is the FIRST to see a tap on the card (#2845): both faces are
-        // clickable, so they consume it and increment the counter themselves. A gesture the view
-        // consumes never reaches this listener, so the `ViewNode` branch here is only the fallback
-        // for taps Compose lets through (forwarding turned off, an unmeasured card, …).
+        // The embedded Compose tree is the FIRST to see a tap on the card (#2845): the card's
+        // `Button` is the only clickable target on it, so a tap on the button consumes the
+        // gesture and increments `tapCount` itself (via its own `onClick`, not from here). A
+        // tap anywhere else on the card is NOT consumed by Compose (#3422 — "tap me" must only
+        // fire from the button) and falls through to this listener as a plain `ViewNode` hit;
+        // it is deliberately ignored below (a `ViewNode` has no `name`, so it does not match
+        // the shape-highlight branch either) rather than bumping the counter.
         onSingleTapUp = { _: MotionEvent, node: Node? ->
-            when {
-                node is ViewNode -> tapCount++
-                node != null -> {
-                    val index = node.name?.removePrefix(PickingLayout.NAME_PREFIX)?.toIntOrNull()
-                    if (index != null) {
-                        highlightedIndices = if (index in highlightedIndices) {
-                            highlightedIndices - index
-                        } else {
-                            highlightedIndices + index
-                        }
+            if (node != null) {
+                val index = node.name?.removePrefix(PickingLayout.NAME_PREFIX)?.toIntOrNull()
+                if (index != null) {
+                    highlightedIndices = if (index in highlightedIndices) {
+                        highlightedIndices - index
+                    } else {
+                        highlightedIndices + index
                     }
                 }
             }
@@ -365,9 +378,10 @@ private object PickingLayout {
 }
 
 /**
- * The card rendered inside the 3D quad. Clickable as a whole *and* through its button: since #2845
- * a tap anywhere on the quad is a real Compose click, so the whole card counts — exactly as it
- * would on screen.
+ * The card rendered inside the 3D quad. Only its `Button` is clickable (#3422) — the card
+ * container itself has no `onClick`, so a tap has to actually land on "Tap me" to count, the
+ * same as it would on screen. Since #2845 that button click is a real Compose click forwarded
+ * through the quad; a tap elsewhere on the card is inert (see the demo-level KDoc above).
  *
  * @param containerRole picks the container colour *inside* the re-applied theme, so it follows
  * light/dark like every other surface. It cannot be a resolved [Color] handed in by the caller:
@@ -393,10 +407,11 @@ private fun PickedCard(
 }
 
 /** Which themed container colour a [PickedCard] wears — resolved inside the card's own theme. */
-private enum class CardRole { Front, Back }
+internal enum class CardRole { Front, Back }
 
 @Composable
-private fun PickedCardContent(
+@VisibleForTesting
+internal fun PickedCardContent(
     title: String,
     highlighted: Int,
     total: Int,
@@ -408,8 +423,10 @@ private fun PickedCardContent(
         CardRole.Front -> MaterialTheme.colorScheme.primaryContainer
         CardRole.Back -> MaterialTheme.colorScheme.secondaryContainer
     }
+    // Plain, non-clickable Card (#3422): the whole card used to be a `Card(onClick = onTap)`,
+    // so any tap on it — not just the "Tap me" button — counted. Only the Button below has an
+    // onClick now; the rest of the card (title, counters, padding) is inert.
     Card(
-        onClick = onTap,
         colors = CardDefaults.cardColors(containerColor = containerColor),
         modifier = Modifier.padding(8.dp)
     ) {

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/PickedCardContentTapTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/PickedCardContentTapTest.kt
@@ -1,0 +1,100 @@
+package io.github.sceneview.demo.demos
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.github.sceneview.demo.theme.SceneViewDemoTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins #3422: the "Tap me" interaction on the [PickingAndCollisionDemo] card must fire
+ * ONLY from the card's `Button`, not from a tap anywhere else on the card.
+ *
+ * Before the fix, `PickedCardContent` wrapped its content in `Card(onClick = onTap, …)`.
+ * A clickable `Card` merges its descendants' semantics (the same mechanism that lets a
+ * test — or TalkBack — treat a clickable list row and its label as one target), so
+ * `onNodeWithText(title)` resolved to a node that carried the *card's* click action and
+ * `performClick()` on it fired `onTap` — i.e. tapping the title counted exactly like
+ * tapping the button. Run on pure JVM via Robolectric — no emulator needed.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PickedCardContentTapTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun tappingTheButton_invokesOnTap() {
+        var tapCount = 0
+        composeRule.setContent {
+            SceneViewDemoTheme {
+                PickedCardContent(
+                    title = "Live Compose in 3D",
+                    highlighted = 0,
+                    total = 5,
+                    tapCount = tapCount,
+                    containerRole = CardRole.Front,
+                    onTap = { tapCount++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Tap me").assertHasClickAction()
+        composeRule.onNodeWithText("Tap me").performClick()
+
+        assertEquals(1, tapCount)
+    }
+
+    @Test
+    fun tappingTheTitle_hasNoClickAction_andDoesNotInvokeOnTap() {
+        var tapCount = 0
+        composeRule.setContent {
+            SceneViewDemoTheme {
+                PickedCardContent(
+                    title = "Live Compose in 3D",
+                    highlighted = 0,
+                    total = 5,
+                    tapCount = tapCount,
+                    containerRole = CardRole.Front,
+                    onTap = { tapCount++ },
+                )
+            }
+        }
+
+        // The regression this pins: the title used to inherit the outer Card's click
+        // action through merged semantics. The card is a plain, non-clickable Card now,
+        // so the title carries no click action of its own to perform.
+        composeRule.onNodeWithText("Live Compose in 3D").assertHasNoClickAction()
+
+        assertEquals(0, tapCount)
+    }
+
+    @Test
+    fun tappingTheShapesCounter_hasNoClickAction() {
+        var tapCount = 0
+        composeRule.setContent {
+            SceneViewDemoTheme {
+                PickedCardContent(
+                    title = "Live Compose in 3D",
+                    highlighted = 2,
+                    total = 5,
+                    tapCount = tapCount,
+                    containerRole = CardRole.Front,
+                    onTap = { tapCount++ },
+                )
+            }
+        }
+
+        // Same regression as the title, pinned on a second piece of card content so a
+        // fix that only special-cased the title would not slip through.
+        composeRule.onNodeWithText("2 / 5 shapes lit").assertHasNoClickAction()
+    }
+}


### PR DESCRIPTION
## Summary
- `PickedCardContent`'s `Card` had `onClick = onTap`, so a tap anywhere on the card — its title,
  its "n / 5 shapes lit" / "Tapped n times" counters, the padding around them — counted as
  pressing "Tap me", not just the `Button` itself.
- A tap Compose did not consume also fell through `ViewNode.onTouchEvent` to the scene's
  `onGestureListener` as a plain `ViewNode` hit, and that fallback branch bumped the counter
  again — a second path to the same bug.
- Fix: the card is a plain, non-clickable `Card` now (only the `Button` has an `onClick`), and
  the `ViewNode` fallback branch in the gesture listener is removed, so a Compose-unconsumed tap
  on the card is now a true no-op. Shape ray-picking on the rest of the scene is untouched.

## Test plan
- [x] `./gradlew :samples:android-demo:testDebugUnitTest` — full suite green (586 tests)
- [x] New `PickedCardContentTapTest` (Robolectric + compose-ui-test, pure JVM):
  - tapping "Tap me" invokes `onTap`
  - the title text carries no click action (was inherited from the card's merged semantics
    before the fix) and does not invoke `onTap`
  - the "shapes lit" counter text likewise carries no click action
- [x] On-device verification (`emulator-5554`, Picking & Collision demo, deep link
  `sceneview://demo/picking-collision`):
  - Fresh launch → tapped the "Tap me" button → `Tapped 0 times` → `Tapped 1 times`.
  - Immediately tapped the card's title text (same card, non-button area) → counter stayed at
    `Tapped 1 times` — a tap that lands on the card but misses the button is now a true no-op.
  - Captured light and dark theme — both render correctly (card colors, button, glow) with no
    regression from removing the outer `onClick`.
  - Screenshots saved under `.qa-captures/` locally (not committed): `3422-after-button-tap.png`
    (light, post button-tap, count=1), `3422-after-title-tap.png` (light, post title-tap, count
    still 1), `3422-dark.png` (dark theme).

Fixes #3422

🤖 Generated with [Claude Code](https://claude.com/claude-code)