### PR TITLE
fix(audio): prepare SpatialAudioNode's MediaPlayer asynchronously

### DIFF
--- a/changelog.d/3427-spatial-audio-beep-lag.md
+++ b/changelog.d/3427-spatial-audio-beep-lag.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+- **`SpatialAudioNode` no longer hitches the frame the sound starts on
+  ([#3427](https://github.com/sceneview/sceneview/issues/3427), reported as "a slight lag
+  right when the beep plays" in the Spatial Audio demo).** `SpatialAudioPlayer` built its
+  private `MediaPlayer` with a synchronous, blocking `prepare()` — documented as
+  "sub-millisecond" for a short in-`assets` clip, but the container parse and decoder setup
+  it triggers is real main-thread work, and it landed inside the exact composition pass that
+  also calls `play()` via `autoPlay`. Playback now goes through `prepareAsync()` and starts
+  from the `onPrepared` callback instead, via a small `PreparePlayGate` state machine that
+  defers a `play()` requested before the player is ready. Measured on the emulator with
+  `dumpsys gfxinfo`: the frame around the bell's first loop went from a clear janky-frame
+  spike to indistinguishable from the surrounding frames.

--- a/changelog.d/3427-spatial-audio-beep-lag.md
+++ b/changelog.d/3427-spatial-audio-beep-lag.md
@@ -1,12 +1,10 @@
 <!-- category: Fixed -->
-- **`SpatialAudioNode` no longer hitches the frame the sound starts on
-  ([#3427](https://github.com/sceneview/sceneview/issues/3427), reported as "a slight lag
-  right when the beep plays" in the Spatial Audio demo).** `SpatialAudioPlayer` built its
-  private `MediaPlayer` with a synchronous, blocking `prepare()` — documented as
+- **`SpatialAudioNode` no longer runs a blocking `MediaPlayer.prepare()` on the frame the
+  sound starts on ([#3427](https://github.com/sceneview/sceneview/issues/3427), reported as
+  "a slight lag right when the beep plays" in the Spatial Audio demo).** `SpatialAudioPlayer`
+  built its private `MediaPlayer` with a synchronous, blocking `prepare()` — documented as
   "sub-millisecond" for a short in-`assets` clip, but the container parse and decoder setup
   it triggers is real main-thread work, and it landed inside the exact composition pass that
   also calls `play()` via `autoPlay`. Playback now goes through `prepareAsync()` and starts
-  from the `onPrepared` callback instead, via a small `PreparePlayGate` state machine that
-  defers a `play()` requested before the player is ready. Measured on the emulator with
-  `dumpsys gfxinfo`: the frame around the bell's first loop went from a clear janky-frame
-  spike to indistinguishable from the surrounding frames.
+  from the `onPrepared` callback instead, via a small `PreparePlayGate` state machine (unit
+  tested) that defers a `play()` requested before the player is ready.

--- a/sceneview/src/main/java/io/github/sceneview/audio/SpatialAudioPlayer.kt
+++ b/sceneview/src/main/java/io/github/sceneview/audio/SpatialAudioPlayer.kt
@@ -24,9 +24,13 @@ import io.github.sceneview.math.Position
  * handler binds to the constructing thread's `Looper`; building it on a Looper-less pool
  * thread silently breaks every callback-driven feature). Only opening the asset file
  * descriptor — which [AudioSource.openFd] does — touches the file system, and it is cheap
- * enough to run inline. Every public method is `@MainThread`. The class is constructed
- * inside a composable `remember { … }` block, registered with [SpatialAudioEngine] in a
- * `DisposableEffect`, and fully released on dispose.
+ * enough to run inline. Preparation itself is `prepareAsync()`, not the blocking `prepare()`
+ * (#3427): even a short in-`assets` clip's container parse + decoder setup is enough to drop
+ * a frame when it runs synchronously on the exact composition pass that also calls `play()`
+ * — that stall is what the beep's "légers lag" bug report was. [PreparePlayGate] defers
+ * `play()` until the async `onPrepared` callback fires. Every public method is `@MainThread`.
+ * The class is constructed inside a composable `remember { … }` block, registered with
+ * [SpatialAudioEngine] in a `DisposableEffect`, and fully released on dispose.
  *
  * Phase 1 backend: `MediaPlayer` + manual L/R pan via `setVolume(left, right)`. Falloff
  * gain is multiplied into both channels. Phase 2 will introduce a `Spatializer` path
@@ -61,6 +65,13 @@ internal class SpatialAudioPlayer
     private var destroyed = false
 
     /**
+     * Deferred-play state machine (#3427) — see [PreparePlayGate]. Every call that reaches
+     * the `MediaPlayer` before `onPrepared` fires goes through this gate instead of the
+     * native player directly.
+     */
+    private val prepareGate = PreparePlayGate()
+
+    /**
      * This player's private [MediaPlayer]. Built on the constructing (main) thread so its
      * event handler has a live `Looper`. `null` only if construction failed.
      */
@@ -74,27 +85,45 @@ internal class SpatialAudioPlayer
                     .build()
             )
             afd.use { setDataSource(it.fileDescriptor, it.startOffset, it.length) }
-            // Synchronous prepare — the asset is a short, in-`assets` clip so the blocking
-            // initialise is sub-millisecond. Running it on the main thread is intentional:
-            // construction MUST stay main-thread so the event handler binds to a Looper.
-            prepare()
+            setOnPreparedListener { onPrepared() }
+            setOnErrorListener { _, what, extra ->
+                Log.w(TAG, "MediaPlayer error for ${source.assetPath}: what=$what extra=$extra")
+                true
+            }
+            // Async prepare (#3427) — the container parse + decoder setup this triggers is
+            // NOT the "sub-millisecond" no-op a short in-`assets` clip suggests: on a real
+            // device it lands squarely inside the same composition pass that also calls
+            // `play()` (autoPlay), i.e. main-thread work landing on the exact frame the
+            // sound is meant to start — a dropped frame heard as a hitch on the beep itself.
+            // `prepareAsync()` still requires construction on a Looper thread (main, here),
+            // but returns immediately and reports readiness through `onPrepared` instead of
+            // blocking it. `play()` before that point only records [pendingPlay]; the actual
+            // `start()` happens from [onPrepared].
+            prepareAsync()
         }
     }.onFailure {
         Log.w(TAG, "Failed to create MediaPlayer for ${source.assetPath}: ${it.message}")
     }.getOrNull()
 
-    init {
+    /** Runs on the main thread once the async `prepareAsync()` above completes. */
+    private fun onPrepared() {
+        if (destroyed) return
         applyLoop()
         applyPitch()
         // Default gain — silenced until the engine pushes a real listener pose. Prevents a
         // half-second of full-volume audio bleeding through during the first compose pass.
-        mediaPlayer?.runCatching { setVolume(0f, 0f) }
+        runCatching { mediaPlayer?.setVolume(0f, 0f) }
+        if (prepareGate.markPrepared()) play()
     }
 
     @MainThread
     fun play() {
         if (destroyed) return
         val mp = mediaPlayer ?: return
+        if (!prepareGate.requestPlay()) {
+            // Preparing is still in flight — start() as soon as onPrepared fires instead.
+            return
+        }
         runCatching {
             if (!mp.isPlaying) mp.start()
             isPlayingState.value = mp.isPlaying
@@ -106,6 +135,8 @@ internal class SpatialAudioPlayer
     @MainThread
     fun pause() {
         if (destroyed) return
+        prepareGate.cancelPendingPlay()
+        if (!prepareGate.isPrepared) return
         runCatching {
             mediaPlayer?.takeIf { it.isPlaying }?.pause()
             isPlayingState.value = mediaPlayer?.isPlaying ?: false
@@ -115,6 +146,8 @@ internal class SpatialAudioPlayer
     @MainThread
     fun stop() {
         if (destroyed) return
+        prepareGate.cancelPendingPlay()
+        if (!prepareGate.isPrepared) return
         // MediaPlayer.stop() requires a re-prepare() before next start(); we instead pause
         // + seekTo(0) so the caller can hit play() again immediately. This matches the
         // expectation from AudioController.stop() docs ("rewinds to 0").
@@ -128,7 +161,7 @@ internal class SpatialAudioPlayer
 
     @MainThread
     fun seekTo(positionMs: Long) {
-        if (destroyed) return
+        if (destroyed || !prepareGate.isPrepared) return
         runCatching {
             val clamped = positionMs.coerceIn(0L, source.durationMs.coerceAtLeast(0L))
             mediaPlayer?.seekTo(clamped.toInt())
@@ -218,5 +251,49 @@ internal class SpatialAudioPlayer
 
     internal companion object {
         const val TAG = "SpatialAudio"
+    }
+}
+
+/**
+ * Deferred-play state machine for [SpatialAudioPlayer] (#3427).
+ *
+ * `MediaPlayer.prepareAsync()` returns immediately and reports readiness later via
+ * `onPrepared`; a `play()` requested before that (as `autoPlay` always does — it fires from
+ * the same `DisposableEffect` that constructs the player) must wait rather than call
+ * `start()` on a player that is not ready yet. This class holds only that one decision —
+ * "start now, or remember to start once prepared" — with no `MediaPlayer` reference, so it
+ * is plain-JVM testable independently of the JNI-bound class around it (see the class KDoc
+ * on `SpatialAudioNodeTest` for why `SpatialAudioPlayer` itself is not).
+ */
+internal class PreparePlayGate {
+    var isPrepared: Boolean = false
+        private set
+    private var pendingPlay = false
+
+    /**
+     * Call when `play()` is requested. Returns `true` if the caller should start the native
+     * player immediately; if `false`, the request has been recorded and will be honoured by
+     * the next [markPrepared] call instead.
+     */
+    fun requestPlay(): Boolean {
+        if (isPrepared) return true
+        pendingPlay = true
+        return false
+    }
+
+    /** Call when `pause()` or `stop()` is requested — clears any deferred play request. */
+    fun cancelPendingPlay() {
+        pendingPlay = false
+    }
+
+    /**
+     * Call from `onPrepared`. Returns `true` if a [requestPlay] call arrived before this one
+     * and is still pending — the caller should start the native player now.
+     */
+    fun markPrepared(): Boolean {
+        isPrepared = true
+        val shouldPlay = pendingPlay
+        pendingPlay = false
+        return shouldPlay
     }
 }

--- a/sceneview/src/test/java/io/github/sceneview/audio/PreparePlayGateTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/audio/PreparePlayGateTest.kt
@@ -1,0 +1,82 @@
+package io.github.sceneview.audio
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [PreparePlayGate] — the deferred-play decision [SpatialAudioPlayer]
+ * uses to avoid calling `MediaPlayer.start()` before `prepareAsync()`'s `onPrepared`
+ * callback fires (#3427). `SpatialAudioPlayer` itself is JNI-bound and deliberately not unit
+ * tested (see [SpatialAudioNodeTest]'s KDoc) — this class is the one bit of its lifecycle
+ * that has no `MediaPlayer` dependency, so it is tested directly instead.
+ *
+ * @see SpatialAudioNodeTest
+ */
+class PreparePlayGateTest {
+
+    @Test
+    fun `play requested after prepared starts immediately`() {
+        val gate = PreparePlayGate()
+        gate.markPrepared()
+        assertTrue("already prepared — play() should start now", gate.requestPlay())
+    }
+
+    @Test
+    fun `play requested before prepared is deferred`() {
+        val gate = PreparePlayGate()
+        assertFalse("not prepared yet — play() must wait", gate.requestPlay())
+        assertFalse(gate.isPrepared)
+    }
+
+    @Test
+    fun `markPrepared honours a play requested earlier`() {
+        val gate = PreparePlayGate()
+        gate.requestPlay()
+        assertTrue("a pending play() must be honoured once prepared", gate.markPrepared())
+        assertTrue(gate.isPrepared)
+    }
+
+    @Test
+    fun `markPrepared without a prior play request does not start playback`() {
+        val gate = PreparePlayGate()
+        assertFalse(gate.markPrepared())
+    }
+
+    @Test
+    fun `markPrepared only honours a pending play once`() {
+        val gate = PreparePlayGate()
+        gate.requestPlay()
+        assertTrue(gate.markPrepared())
+        // A second onPrepared callback (should not happen in practice, but the gate must
+        // not replay a stale request) must not re-trigger playback.
+        assertFalse(gate.markPrepared())
+    }
+
+    @Test
+    fun `cancelPendingPlay clears a deferred play request`() {
+        val gate = PreparePlayGate()
+        gate.requestPlay()
+        gate.cancelPendingPlay()
+        assertFalse(
+            "pause()/stop() before prepared must cancel the deferred play",
+            gate.markPrepared()
+        )
+    }
+
+    @Test
+    fun `cancelPendingPlay does not affect the prepared flag`() {
+        val gate = PreparePlayGate()
+        gate.markPrepared()
+        gate.cancelPendingPlay()
+        assertTrue(gate.isPrepared)
+    }
+
+    @Test
+    fun `play requested twice before prepared still starts once prepared`() {
+        val gate = PreparePlayGate()
+        gate.requestPlay()
+        gate.requestPlay()
+        assertTrue(gate.markPrepared())
+    }
+}


### PR DESCRIPTION
## Summary
- `SpatialAudioPlayer` built its private `MediaPlayer` with a synchronous, blocking
  `prepare()`. The code comment called this "sub-millisecond" for a short in-`assets` clip, but
  the container parse + decoder setup it triggers is real main-thread work, and it lands inside
  the exact composition pass that also calls `play()` via `autoPlay` — i.e. the frame the sound
  is meant to start on. That is the "slight lag right when the beep plays" from the bug report.
- Playback now goes through `prepareAsync()` and starts from the `onPrepared` callback instead.
  A new `PreparePlayGate` (plain-JVM, unit tested — `MediaPlayer` itself stays untested per this
  file's existing policy, it's JNI-bound) defers a `play()` requested before the player is ready
  and honours it once `onPrepared` fires. `pause()`/`stop()`/`seekTo()` also gate on the same
  "prepared" flag now, matching the states those calls are actually valid in.
- Loop/pitch/mute application moved from the constructor to `onPrepared` — under
  `prepareAsync()` those `MediaPlayer` setters are not guaranteed valid mid-`Preparing`, so they
  now apply once the player is provably ready instead of racing it.

## Test plan
- [x] `./gradlew :sceneview:testDebugUnitTest` — full suite green (644 tests)
- [x] New `PreparePlayGateTest` (8 pure-JVM cases) pins the deferred-play state machine: play
  before/after prepared, pause/stop cancelling a pending play, `markPrepared` firing at most once.
- [x] On-device functional check (`emulator-5554`, Spatial Audio demo): app launches, the bell
  loops correctly with no crash and no silence, falloff mode switching still works.
- [~] On-device jank measurement (`dumpsys gfxinfo io.github.sceneview.demo`), attempted but
  **inconclusive** — reporting honestly rather than a cherry-picked number:
  - Ran matched before/after trials (baseline = this branch's parent commit, fixed = this PR),
    same protocol each time: force-stop, `dumpsys gfxinfo reset`, `am start -W` the
    `spatial-audio` deep link, wait, dump stats. Cold-launch aggregate jank swung wildly between
    runs of the *same* APK (e.g. baseline 90th percentile ranged 133–500ms across 3 trials of the
    unmodified code) and a same-protocol warm-relaunch `framestats` capture showed steady-state
    frame costs 3–5× higher during the "fixed" measurement window than during the "baseline"
    window on frames that have nothing to do with audio at all.
  - That pattern points to heavy, variable **host** contention (this Mac was running concurrent
    CI/agent Gradle builds during the measurement window) swamping the few-millisecond signal
    this fix targets — not a regression from the change, which touches only audio-thread
    scheduling and cannot plausibly slow down unrelated render frames by 3–5×.
  - I did not want to present a noisy or lucky-timing number as evidence, so this PR relies on
    the code-level argument (a genuinely blocking main-thread call is removed from the `play()`
    frame) plus the unit-tested state machine and the functional on-device pass. Re-running the
    measurement on a quiet host (or a real device, as the original report was filed from a
    Pixel 9) would be the way to get a clean number if desired before merge.

Fixes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)