### PR TITLE
fix(camera): frame the projected bounds per FOV axis, and make zoom relative to the subject

### DIFF
--- a/changelog.d/3426-camera-fit-and-zoom.md
+++ b/changelog.d/3426-camera-fit-and-zoom.md
@@ -1,0 +1,38 @@
+<!-- category: Fixed -->
+
+**Camera framing and zoom.** Three defects that shared one theme — the camera was told the wrong
+thing about the subject in front of it.
+
+- **Auto-fit framed the bounding sphere, not the subject.** `fitDistanceForBounds` charged every
+  scene for half its AABB's *space diagonal*, then billed each field-of-view axis the *other*
+  axis's distance. On a portrait viewport the horizontal FOV is the narrow one, so a subject bound
+  purely by its height was pushed back by a width constraint it never hits, and the viewport could
+  never be filled. The fit is now per FOV axis, in closed form, and frames the subject's sweep
+  about world Y so an auto-rotating model still never clips at any yaw. It is never further than
+  the old distance, and up to 2× closer for tall or compact subjects. This is the Android
+  counterpart of the iOS fix in #3383. Pass `azimuthInvariant = false` for a static head-on scene
+  that should not pay for a rotation it never performs. (#3426)
+
+- **Pinch-to-zoom moved the camera a fixed number of metres.** Filament's orbit manipulator
+  translates the eye by `zoomSpeed × scrolldelta` world units regardless of how far away it is, so
+  one full-screen pinch moved it ~11 cm: on a scene framed 5 m away that is forty gestures to
+  halve the distance, and on a 5 cm model the same gesture punched the eye straight through the
+  orbit pivot — at which point Filament flips the manipulator and the next drag rebuilds the view
+  from a negative distance, aiming the camera away from the subject. Zoom is now a *ratio* of the
+  current camera-to-target distance and is clamped either side of the framed distance, so one
+  pinch is one comfortable step at any scale and the camera can never cross its own pivot.
+  (#3403, #3426)
+
+- **The Model Viewer reset its camera whenever anything nearby changed.** Its manipulator was
+  rebuilt from `remember(framing, modelCenter, recenterGeneration, sliderDistance)`, and a Filament
+  manipulator carries the whole camera pose — so every step of the zoom slider threw the user's
+  orbit away (#3403), and so did opening the animation bar, which is when the scaffold first
+  measures its identity row and changes the framing insets (#3404). The manipulator is now keyed on
+  the content alone and reads the framing, pivot and zoom live. Pinch and the "Camera distance"
+  slider drive the same number, and that slider's range is now relative to the model's own fitted
+  distance instead of a fixed `0.5–10 m`.
+
+Demos re-framed off a shared, aspect-aware helper instead of hand-tuned literals: the Model Viewer
+gallery (one fixed radius served models normalised from 0.20 to 0.85 units), Lighting Lab's
+sky section and Secondary Camera's main view (both inherited the library's stock 2.78 m pose), and
+Camera & Gestures' node-editing scene (its axes gizmo was framed at a third of the frame width).

--- a/changelog.d/3426-camera-fit-and-zoom.md
+++ b/changelog.d/3426-camera-fit-and-zoom.md
@@ -33,6 +33,5 @@ thing about the subject in front of it.
   distance instead of a fixed `0.5–10 m`.
 
 Demos re-framed off a shared, aspect-aware helper instead of hand-tuned literals: the Model Viewer
-gallery (one fixed radius served models normalised from 0.20 to 0.85 units), Lighting Lab's
-sky section and Secondary Camera's main view (both inherited the library's stock 2.78 m pose), and
-Camera & Gestures' node-editing scene (its axes gizmo was framed at a third of the frame width).
+gallery (one fixed radius served models normalised from 0.20 to 0.85 units), Lighting Lab's sky
+section and Secondary Camera's main view.

--- a/llms.txt
+++ b/llms.txt
@@ -3450,13 +3450,24 @@ Library-level helper (`io.github.sceneview`, #1439) that frames a model so it fi
 viewport regardless of its intrinsic glTF size — no per-model `scaleToUnits` tuning.
 
 ```kotlin
-// Pure trigonometry — bounds + camera projection → orbit distance. Fits the content
-// bounding SPHERE, so the result is yaw-invariant (an orbiting camera never clips).
+// Pure trigonometry — bounds + camera projection → orbit distance. Each FOV axis is
+// fitted with its OWN half-angle (#3426), so a tall subject on a portrait viewport is
+// no longer pushed back by a width constraint it never hits. Yaw-invariant by default:
+// it frames the box's sweep about world +Y, so an orbiting or auto-rotating camera
+// never clips — set `azimuthInvariant = false` for a static head-on scene that should
+// not pay for a rotation it never performs.
 fun fitDistanceForBounds(
     bounds: Aabb, verticalFovDegrees: Double, aspect: Double,
-    padding: Float = DEFAULT_FRAMING_PADDING  // 0.15 = 15% breathing room
+    padding: Float = DEFAULT_FRAMING_PADDING,           // 0.15 = 15% breathing room
+    elevationDegrees: Double = DEFAULT_FRAMING_ELEVATION_DEGREES,  // 0.0 = level with the target
+    azimuthInvariant: Boolean = true
 ): Float
 ```
+
+Before v4.34.0 this fitted the content bounding *sphere* — half the AABB's space diagonal —
+and charged both axes the worse of the two. The result was never wrong, only always too far;
+the new fit is never further and up to 2× closer for tall or compact subjects. Same fix as
+iOS #3383.
 
 Usage:
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -802,6 +802,118 @@ fun rememberHeroOrbitCameraManipulator(
     }
 }
 
+/**
+ * Fraction of the frame a demo's subject should span. `0.92` is the value the Model Viewer's own
+ * framing (`DemoMath.VIEWER_HORIZONTAL_FILL`) settled on after on-device QA: on a portrait phone
+ * the *horizontal* axis is what binds an orbiting subject, and anything tighter than ~0.9 there
+ * reads as a small object floating in a large empty frame. Expressed as a *padding* fraction to
+ * [io.github.sceneview.fitDistanceForBounds]: `1 / 0.92 - 1 ≈ 0.087`.
+ */
+const val DEMO_FRAMING_FILL: Float = 0.92f
+
+/**
+ * Orbit radius that frames a subject of the given world-space extents on **this** viewport
+ * (#3426).
+ *
+ * Every non-AR sample used to carry a hand-tuned literal — `radius = 2.0f`, `2.2f`, `2.4f`,
+ * `Position(0f, 0.1f, 2f)`, or nothing at all, which left the library's stock 2.78 m pose. None of
+ * them looked at the aspect ratio, so the same number that framed a subject on a 16:9 phone either
+ * cropped it or shrank it to a quarter of the frame elsewhere, and the numbers had drifted apart
+ * between demos showing the *same* subject at the *same* scale. This is the one place that answers
+ * "how far back" now; the per-demo constants that survive are the ones describing the *content*,
+ * not the camera.
+ *
+ * The aspect comes from the device configuration rather than a `BoxWithConstraints`, because the
+ * demos that need this render their scene edge-to-edge and most are not inside one.
+ *
+ * @param extentX          Content width, world units (full extent, not half).
+ * @param extentY          Content height, world units.
+ * @param extentZ          Content depth, world units.
+ * @param elevationDegrees Camera elevation above the content centre — pass the same pitch the
+ *                         demo's camera uses, since projected height shrinks as the camera rises.
+ * @param fill             Fraction of the binding axis the subject should span.
+ * @param azimuthInvariant `true` when the camera orbits (auto-orbit or user drag) and the subject
+ *                         must never clip as it turns broadside; `false` for a fixed head-on shot.
+ * @param focalLengthMm    Lens the demo's camera uses. SceneView's default is 28 mm.
+ */
+@Composable
+fun rememberFitOrbitRadius(
+    extentX: Float,
+    extentY: Float,
+    extentZ: Float,
+    elevationDegrees: Float = 0f,
+    fill: Float = DEMO_FRAMING_FILL,
+    azimuthInvariant: Boolean = true,
+    focalLengthMm: Double = 28.0,
+): Float {
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val aspect = androidx.compose.runtime.remember(
+        configuration.screenWidthDp,
+        configuration.screenHeightDp,
+    ) {
+        val w = configuration.screenWidthDp.toFloat()
+        val h = configuration.screenHeightDp.toFloat()
+        if (w > 0f && h > 0f) w / h else 0.47f
+    }
+    return androidx.compose.runtime.remember(
+        extentX, extentY, extentZ, elevationDegrees, fill, azimuthInvariant, aspect,
+    ) {
+        fitOrbitRadius(
+            extentX, extentY, extentZ, aspect, elevationDegrees, fill, azimuthInvariant,
+            focalLengthMm,
+        )
+    }
+}
+
+/**
+ * Elevation, in degrees above the target, of the eye the library's `orbitRadius` overloads place
+ * the camera at — `io.github.sceneview.gesture.DEFAULT_ORBIT_DIRECTION` is `(0, 0.4, 2.75)`
+ * normalised, i.e. `asin(0.4 / 2.7789) ≈ 8.27°`. Pass it to [rememberFitOrbitRadius] whenever the
+ * result feeds `rememberCameraManipulator(orbitRadius = …)`, so the fit knows the pose it is
+ * fitting for.
+ */
+const val DEFAULT_ORBIT_ELEVATION_DEGREES: Float = 8.27f
+
+/**
+ * Non-Compose form of [rememberFitOrbitRadius] — the pure function, so it can be unit-tested on
+ * the JVM and called from a `remember` block that already knows its viewport.
+ */
+fun fitOrbitRadius(
+    extentX: Float,
+    extentY: Float,
+    extentZ: Float,
+    aspect: Float,
+    elevationDegrees: Float = 0f,
+    fill: Float = DEMO_FRAMING_FILL,
+    azimuthInvariant: Boolean = true,
+    focalLengthMm: Double = 28.0,
+): Float {
+    val safeFill = if (fill.isFinite() && fill > 0f) fill else DEMO_FRAMING_FILL
+    val radius = io.github.sceneview.fitDistanceForBounds(
+        bounds = io.github.sceneview.Aabb(
+            halfExtent = Position(
+                x = maxOf(extentX, 0f) / 2f,
+                y = maxOf(extentY, 0f) / 2f,
+                z = maxOf(extentZ, 0f) / 2f,
+            )
+        ),
+        verticalFovDegrees = io.github.sceneview.verticalFovDegreesForFocalLength(focalLengthMm),
+        aspect = aspect.toDouble(),
+        padding = 1f / safeFill - 1f,
+        elevationDegrees = elevationDegrees.toDouble(),
+        azimuthInvariant = azimuthInvariant,
+    )
+    // A degenerate content box must not put the camera on the subject; fall back to the library's
+    // stock 2.78 m pose rather than 0.
+    return if (radius.isFinite() && radius > 0f) radius.coerceIn(0.2f, 900f) else 2.78f
+}
+
+/** Closest the Model Viewer's pinch may take the camera, as a fraction of the auto-fit distance. */
+const val VIEWER_MIN_ZOOM_FACTOR: Float = 0.25f
+
+/** Furthest the Model Viewer's pinch may take the camera, as a multiple of the auto-fit distance. */
+const val VIEWER_MAX_ZOOM_FACTOR: Float = 4f
+
 /** Default polar-angle floor (degrees from world +Y) used by [clampOrbitEyePitch]. */
 internal const val DEFAULT_MIN_ORBIT_POLAR_DEGREES: Float = 1f
 
@@ -898,9 +1010,12 @@ internal fun clampOrbitEyePitch(
  * mid-flight is a different framing every run.
  */
 class EntranceCameraManipulator(
-    private val eye: Position,
-    private val target: Position,
+    private val eye: () -> Position,
+    private val target: () -> Position,
     private val progress: () -> Float,
+    private val fitDistance: () -> Float = { 1f },
+    private val distanceOverride: () -> Float? = { null },
+    private val onDistanceChange: (Float) -> Unit = {},
     private val startDistanceScale: Float = 1.55f,
     private val startYawDegrees: Float = 24f,
     private val startLiftFraction: Float = 0.22f,
@@ -912,6 +1027,8 @@ class EntranceCameraManipulator(
 
     /** Eye position for the current [progress] — [eye] itself once the flight is over. */
     private fun currentEye(): Position {
+        val eye = eye()
+        val target = target()
         val p = progress().coerceIn(0f, 1f)
         if (p >= 1f) return eye
         val remaining = 1f - p
@@ -934,20 +1051,52 @@ class EntranceCameraManipulator(
         )
     }
 
-    private fun flightTransform(): io.github.sceneview.math.Transform =
+    private fun flightTransform(): io.github.sceneview.math.Transform = aimedAt(currentEye())
+
+    /** `lookAt` from [from] to the live target, with world +Y up. */
+    private fun aimedAt(from: Position): io.github.sceneview.math.Transform =
         io.github.sceneview.math.Transform(
             dev.romainguy.kotlin.math.lookAt(
-                eye = currentEye(),
-                target = target,
+                eye = from,
+                target = target(),
                 up = dev.romainguy.kotlin.math.Float3(0f, 1f, 0f),
             )
         )
 
+    /**
+     * Re-places [from] at [distance] from the live target **along the current view ray** (#3403).
+     * Changing the zoom therefore never disturbs the yaw and pitch the user dragged to — which is
+     * exactly what rebuilding the manipulator on every slider step used to do.
+     */
+    private fun atDistance(from: Position, distance: Float): Position {
+        val t = target()
+        val dx = from.x - t.x
+        val dy = from.y - t.y
+        val dz = from.z - t.z
+        val length = sqrt(dx * dx + dy * dy + dz * dz)
+        if (!length.isFinite() || length <= 1e-5f || !distance.isFinite() || distance <= 0f) return from
+        val k = distance / length
+        return Position(t.x + dx * k, t.y + dy * k, t.z + dz * k)
+    }
+
+    /** Camera-to-target distance on screen right now. */
+    private fun effectiveDistance(): Float {
+        distanceOverride()?.takeIf { it.isFinite() && it > 0f }?.let { return it }
+        val t = target()
+        val e = fallback?.getTransform()?.position ?: currentEye()
+        val d = sqrt(
+            (e.x - t.x) * (e.x - t.x) + (e.y - t.y) * (e.y - t.y) + (e.z - t.z) * (e.z - t.z)
+        )
+        return if (d.isFinite() && d > 0f) d else fitDistance()
+    }
+
     private fun ensureFallback() {
         if (fallback == null) {
+            // Hand off at the exact pose on screen — flight position and zoom override included —
+            // so the first drag continues from where the user was looking, with no snap.
             fallback = io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator(
-                eyePosition = currentEye(),
-                targetPosition = target,
+                eyePosition = getTransform().position,
+                targetPosition = target(),
             ).also { it.setViewport(viewportW, viewportH) }
         }
     }
@@ -959,21 +1108,15 @@ class EntranceCameraManipulator(
     }
 
     override fun getTransform(): io.github.sceneview.math.Transform {
-        val fb = fallback ?: return flightTransform()
+        val override = distanceOverride()?.takeIf { it.isFinite() && it > 0f }
+        val fb = fallback
+            ?: return if (override == null) flightTransform()
+            else aimedAt(atDistance(currentEye(), override))
         // Same polar clamp as the hero orbit (#2487): the stock manipulator lets a drag
         // carry the eye onto the orbit pole, where `lookAt`'s fixed world-up collapses
         // and the model flips upside-down.
-        val transform = fb.getTransform()
-        val eyeNow = transform.position
-        val clampedEye = clampOrbitEyePitch(eyeNow, target)
-        if (clampedEye == eyeNow) return transform
-        return io.github.sceneview.math.Transform(
-            dev.romainguy.kotlin.math.lookAt(
-                eye = clampedEye,
-                target = target,
-                up = dev.romainguy.kotlin.math.Float3(0f, 1f, 0f),
-            )
-        )
+        val eyeNow = clampOrbitEyePitch(fb.getTransform().position, target())
+        return aimedAt(if (override == null) eyeNow else atDistance(eyeNow, override))
     }
 
     override fun grabBegin(x: Int, y: Int, strafe: Boolean) {
@@ -991,11 +1134,23 @@ class EntranceCameraManipulator(
 
     override fun scrollBegin(x: Int, y: Int, separation: Float) {
         ensureFallback()
-        fallback?.scrollBegin(x, y, separation)
     }
 
     override fun scrollUpdate(x: Int, y: Int, prevSeparation: Float, currSeparation: Float) {
-        fallback?.scrollUpdate(x, y, prevSeparation, currSeparation)
+        // The pinch PUBLISHES a distance instead of translating the delegate, so it and the
+        // "Camera distance" slider drive the same number (#3403). The step is a fraction of the
+        // current distance, so the gesture feels the same on a 5 cm model and a 150 m one, and the
+        // clamps are relative to the model's own fitted distance (#3426).
+        val fit = fitDistance().takeIf { it.isFinite() && it > 0f } ?: 1f
+        onDistanceChange(
+            io.github.sceneview.gesture.zoomedDistanceForPinch(
+                distance = effectiveDistance(),
+                prevSeparation = prevSeparation,
+                currSeparation = currSeparation,
+                minDistance = fit * VIEWER_MIN_ZOOM_FACTOR,
+                maxDistance = fit * VIEWER_MAX_ZOOM_FACTOR,
+            )
+        )
     }
 
     override fun scrollEnd() {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
@@ -60,7 +60,9 @@ import io.github.sceneview.demo.common.SceneAction
 import io.github.sceneview.demo.common.SceneActionBar
 import io.github.sceneview.demo.common.rememberModelDemoEnvironment
 import io.github.sceneview.demo.initialDemoMode
+import io.github.sceneview.demo.DEFAULT_ORBIT_ELEVATION_DEGREES
 import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.demo.rememberFitOrbitRadius
 import io.github.sceneview.gesture.CameraGestureDetector
 import io.github.sceneview.gesture.orbitHomePosition
 import io.github.sceneview.gesture.targetPosition
@@ -425,6 +427,14 @@ private fun HoldKeyButton(
 private const val MODEL_SCALE_UNITS = 0.3f
 private const val AXIS_TO_MODEL_RATIO = 1.5f
 
+/**
+ * Union extent of the node-gestures scene (#3426): the helmet reaches `MODEL_SCALE_UNITS / 2` on
+ * the negative side of each axis, the `Axes3DNode` reaches `MODEL_SCALE_UNITS · AXIS_TO_MODEL_RATIO`
+ * on the positive side. What the camera has to frame is the sum.
+ */
+private const val GESTURES_CONTENT_EXTENT =
+    MODEL_SCALE_UNITS / 2f + MODEL_SCALE_UNITS * AXIS_TO_MODEL_RATIO
+
 @Composable
 private fun NodeGesturesSection(
     onBack: () -> Unit,
@@ -567,7 +577,19 @@ private fun NodeGesturesSection(
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,
             environment = rememberModelDemoEnvironment(environmentLoader),
-            cameraManipulator = rememberCameraManipulator(),
+            // #3426 — the library's stock 2.78 m pose framed a 0.3-unit helmet plus its 0.45-unit
+            // axes gizmo at barely a third of the frame width. This section is about *touching*
+            // the model, so an undersized target is the one thing it cannot afford. Fitted to the
+            // gizmo, which is the widest thing on screen: the helmet spans ±MODEL_SCALE_UNITS/2 and
+            // the axes reach out to MODEL_SCALE_UNITS·AXIS_TO_MODEL_RATIO on the positive side.
+            cameraManipulator = rememberCameraManipulator(
+                orbitRadius = rememberFitOrbitRadius(
+                    extentX = GESTURES_CONTENT_EXTENT,
+                    extentY = GESTURES_CONTENT_EXTENT,
+                    extentZ = GESTURES_CONTENT_EXTENT,
+                    elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES,
+                )
+            ),
             onGestureListener = rememberOnGestureListener(
                 onDown = { _, node ->
                     gestureMode = when {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
@@ -60,9 +60,7 @@ import io.github.sceneview.demo.common.SceneAction
 import io.github.sceneview.demo.common.SceneActionBar
 import io.github.sceneview.demo.common.rememberModelDemoEnvironment
 import io.github.sceneview.demo.initialDemoMode
-import io.github.sceneview.demo.DEFAULT_ORBIT_ELEVATION_DEGREES
 import io.github.sceneview.demo.rememberFirstFrameState
-import io.github.sceneview.demo.rememberFitOrbitRadius
 import io.github.sceneview.gesture.CameraGestureDetector
 import io.github.sceneview.gesture.orbitHomePosition
 import io.github.sceneview.gesture.targetPosition
@@ -427,14 +425,6 @@ private fun HoldKeyButton(
 private const val MODEL_SCALE_UNITS = 0.3f
 private const val AXIS_TO_MODEL_RATIO = 1.5f
 
-/**
- * Union extent of the node-gestures scene (#3426): the helmet reaches `MODEL_SCALE_UNITS / 2` on
- * the negative side of each axis, the `Axes3DNode` reaches `MODEL_SCALE_UNITS · AXIS_TO_MODEL_RATIO`
- * on the positive side. What the camera has to frame is the sum.
- */
-private const val GESTURES_CONTENT_EXTENT =
-    MODEL_SCALE_UNITS / 2f + MODEL_SCALE_UNITS * AXIS_TO_MODEL_RATIO
-
 @Composable
 private fun NodeGesturesSection(
     onBack: () -> Unit,
@@ -577,19 +567,7 @@ private fun NodeGesturesSection(
             materialLoader = materialLoader,
             environmentLoader = environmentLoader,
             environment = rememberModelDemoEnvironment(environmentLoader),
-            // #3426 — the library's stock 2.78 m pose framed a 0.3-unit helmet plus its 0.45-unit
-            // axes gizmo at barely a third of the frame width. This section is about *touching*
-            // the model, so an undersized target is the one thing it cannot afford. Fitted to the
-            // gizmo, which is the widest thing on screen: the helmet spans ±MODEL_SCALE_UNITS/2 and
-            // the axes reach out to MODEL_SCALE_UNITS·AXIS_TO_MODEL_RATIO on the positive side.
-            cameraManipulator = rememberCameraManipulator(
-                orbitRadius = rememberFitOrbitRadius(
-                    extentX = GESTURES_CONTENT_EXTENT,
-                    extentY = GESTURES_CONTENT_EXTENT,
-                    extentZ = GESTURES_CONTENT_EXTENT,
-                    elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES,
-                )
-            ),
+            cameraManipulator = rememberCameraManipulator(),
             onGestureListener = rememberOnGestureListener(
                 onDown = { _, node ->
                     gestureMode = when {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
@@ -42,7 +42,9 @@ import io.github.sceneview.demo.LoadingScrim
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.common.rememberModelDemoEnvironment
 import io.github.sceneview.demo.initialDemoMode
+import io.github.sceneview.demo.DEFAULT_ORBIT_ELEVATION_DEGREES
 import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.demo.rememberFitOrbitRadius
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
 import io.github.sceneview.environment.Environment
 import io.github.sceneview.math.Position
@@ -251,7 +253,17 @@ private fun SkySection(
                 // visible at night when the sun is below the horizon, and the matching skybox
                 // gives the user a clear visual feedback that time-of-day actually changed.
                 mainLightNode = null,
-                cameraManipulator = rememberCameraManipulator()
+                // #3426 — this section shipped with no manipulator argument at all, so it inherited
+                // the library's stock 2.78 m pose while its own helmet is normalised to 0.5 units:
+                // the subject filled barely half the frame width, and the three sibling sections
+                // below (which do pass a radius) framed the same helmet visibly larger. Fitted to
+                // the subject now, like they are.
+                cameraManipulator = rememberCameraManipulator(
+                    orbitRadius = rememberFitOrbitRadius(
+                        extentX = 0.5f, extentY = 0.5f, extentZ = 0.5f,
+                        elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES,
+                    )
+                )
             ) {
                 DynamicSkyNode(
                     timeOfDay = timeOfDay,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -305,6 +305,15 @@ private fun SingleModelSection(
     // the button doesn't get stuck in the loading state.
     var surpriseInFlight by remember { mutableStateOf(false) }
 
+    // `DemoSettings.cameraDistance` is process-global — Geometry, Camera & Gestures and the Park
+    // section all read it. Until #3426 only the slider could write it, which is a deliberate act;
+    // now a pinch does too, so the section has to clean up after itself or a two-finger gesture
+    // here would silently re-frame an unrelated demo three taps later. A cold launch never passes
+    // through the dispose, so the `--ef camera_distance` / `?cameraDistance=` deep link is intact.
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        onDispose { DemoSettings.cameraDistance = null }
+    }
+
     val context = LocalContext.current
     val arSupported by produceState<Boolean?>(initialValue = null, context) {
         var availability = ArCoreApk.getInstance().checkAvailability(context)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -97,6 +97,9 @@ import io.github.sceneview.demo.demos.internal.parkCameraDistance
 import io.github.sceneview.demo.initialDemoMode
 import io.github.sceneview.demo.EntranceCameraManipulator
 import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.demo.VIEWER_MAX_ZOOM_FACTOR
+import io.github.sceneview.demo.VIEWER_MIN_ZOOM_FACTOR
+import io.github.sceneview.demo.rememberFitOrbitRadius
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
 import io.github.sceneview.demo.rememberHeroYaw
 import io.github.sceneview.demo.sketchfab.AssetSourceProbe
@@ -522,12 +525,18 @@ private fun SingleModelSection(
             // Camera-distance slider — makes zoom discoverable without a pinch
             // gesture (and Maestro-testable, see #1571). The displayed value is
             // the slider override when set, otherwise the live auto-fit radius.
+            // #3426 — the range used to be a fixed `0.5f..10f`, which is meaningless for a model
+            // that auto-fits at 0.4 m (the slider could only ever push it away) or at 90 m (the
+            // slider could not reach it at all). It is now the same bounds-relative window the
+            // pinch is clamped to, so both controls span the subject rather than a guessed metre
+            // range.
             LabeledSlider(
                 label = "Camera distance",
-                value = sliderDistance ?: autoFitRadius,
+                value = (sliderDistance ?: autoFitRadius)
+                    .coerceIn(autoFitRadius * VIEWER_MIN_ZOOM_FACTOR, autoFitRadius * VIEWER_MAX_ZOOM_FACTOR),
                 onValueChange = { DemoSettings.cameraDistance = it },
-                valueRange = 0.5f..10f,
-                valueText = "%.1f m".format(Locale.US, sliderDistance ?: autoFitRadius),
+                valueRange = (autoFitRadius * VIEWER_MIN_ZOOM_FACTOR)..(autoFitRadius * VIEWER_MAX_ZOOM_FACTOR),
+                valueText = "%.2f m".format(Locale.US, sliderDistance ?: autoFitRadius),
             )
             Row(Modifier.fillMaxWidth().toggleable(spinScene) { spinScene = it }, horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text("Spin scene")
@@ -545,7 +554,12 @@ private fun SingleModelSection(
             DockItem(Icons.Outlined.Category, "Models", { modelSheetOpen = true }),
             DockItem(Icons.Outlined.WbSunny, "Lighting", { environmentSheetOpen = true }),
         ) + (if (animationNames.isNotEmpty()) listOf(DockItem(Icons.Outlined.Animation, "Animate", { animationBarOpen = !animationBarOpen }, selected = animationBarOpen)) else emptyList()) +
-            listOf(DockItem(Icons.Outlined.RestartAlt, "Recenter", { recenterGeneration++ })),
+            listOf(DockItem(Icons.Outlined.RestartAlt, "Recenter", {
+                // Recenter drops the zoom override too (#3403) — the camera returning to its
+                // framed home pose while keeping a 4x zoom is not "recentred".
+                DemoSettings.cameraDistance = null
+                recenterGeneration++
+            })),
         // Always composed when the model has clips, so the bar can slide in and out with
         // the standard M3 enter/exit instead of appearing and vanishing between frames
         // (#3406). An `AnimatedVisibility` that is not visible measures zero, so the
@@ -592,31 +606,41 @@ private fun SingleModelSection(
                 )
             }
             LaunchedEffect(framing) { framing?.let { autoFitRadius = it.distance } }
-            // Camera orbits; model stays fixed at its glTF pose. Recenter rebuilds the same
-            // manipulator, which snaps the camera back to exactly this home pose. A non-null
-            // `DemoSettings.cameraDistance` (slider or deep link) scales the eye along the
-            // same view ray so the pitch and the band centring survive the override.
+            // Camera orbits; the model stays fixed at its glTF pose. The resting pose is flown
+            // to when the model lands (#3406) and then held live.
             //
-            // The resting pose is wrapped in an [EntranceCameraManipulator] so the camera
-            // *flies to* it when the model lands (#3406); `entranceProgress` at 1 makes it
-            // behave exactly like the stock manipulator it replaced, and the first touch
-            // hands off at whatever eye the flight had reached.
-            val cameraManipulator = remember(framing, modelCenter, recenterGeneration, sliderDistance) {
-                val f = framing ?: return@remember createDefaultCameraManipulator(
-                    orbitHomePosition = Position(modelCenter.x, modelCenter.y, sliderDistance ?: 1.4f),
-                    targetPosition = modelCenter,
-                )
-                val (_, ty, tz) = f.targetOffset
-                val (_, ey, ez) = f.eyeOffset
-                val zoom = sliderDistance?.let { it / f.distance } ?: 1f
+            // #3403 / #3404 — the manipulator is deliberately keyed on the CONTENT ONLY. A
+            // Filament manipulator carries the whole camera pose, so rebuilding it discards the
+            // user's orbit and snaps the camera back to the front view. The previous
+            // `remember(framing, modelCenter, recenterGeneration, sliderDistance)` did exactly
+            // that on every zoom-slider step (#3403), and again the first time the chrome measured
+            // its identity row and moved the framing insets (#3404) — a visible "décroché" from a
+            // control that must not touch the camera at all. Framing, pivot and zoom are read live
+            // through providers now, so a settling inset or a zoom change moves the distance and
+            // nothing else.
+            val liveFraming = androidx.compose.runtime.rememberUpdatedState(framing)
+            val liveCenter = androidx.compose.runtime.rememberUpdatedState(modelCenter)
+            val livePivot = {
+                val f = liveFraming.value
+                val c = liveCenter.value
+                if (f == null) c
+                else Position(c.x, c.y + f.targetOffset.second, c.z + f.targetOffset.third)
+            }
+            val cameraManipulator = remember(activeModelInstance, recenterGeneration) {
                 EntranceCameraManipulator(
-                    eye = Position(
-                        modelCenter.x,
-                        modelCenter.y + ty + (ey - ty) * zoom,
-                        modelCenter.z + tz + (ez - tz) * zoom,
-                    ),
-                    target = Position(modelCenter.x, modelCenter.y + ty, modelCenter.z + tz),
+                    eye = {
+                        val f = liveFraming.value
+                        val c = liveCenter.value
+                        if (f == null) Position(c.x, c.y, c.z + 1.4f)
+                        else Position(c.x, c.y + f.eyeOffset.second, c.z + f.eyeOffset.third)
+                    },
+                    target = livePivot,
                     progress = { entranceProgress.value },
+                    fitDistance = { liveFraming.value?.distance ?: 1.4f },
+                    distanceOverride = { DemoSettings.cameraDistance },
+                    // A pinch publishes its distance to the SAME state the slider writes, so the
+                    // two controls agree and the readout follows the gesture.
+                    onDistanceChange = { DemoSettings.cameraDistance = it },
                 )
             }
             SceneView(
@@ -1264,9 +1288,19 @@ private fun GallerySection(
         // bound to a different model. yHeight = 0 keeps the model centered in
         // portrait without the empty-top-band artefact (QA finding
         // 2026-05-11).
+        //
+        // #3426 — the radius used to be a flat `1.6f` for *every* chip, while the gallery's slugs
+        // are normalised anywhere from 0.20 to 0.85 units. The same shot therefore ranged from a
+        // model overflowing the frame to one filling a sixth of it, purely by which chip was
+        // tapped. It is now fitted per chip, so switching chips changes the model and not its
+        // apparent size.
         val cameraManipulator = rememberHeroOrbitCameraManipulator(
             trigger = modelInstance != null,
-            radius = 1.6f,
+            radius = rememberFitOrbitRadius(
+                extentX = selectedSlug?.scaleToUnits ?: 0.5f,
+                extentY = selectedSlug?.scaleToUnits ?: 0.5f,
+                extentZ = selectedSlug?.scaleToUnits ?: 0.5f,
+            ),
             yHeight = 0f,
             durationMillis = 24_000,
         )

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/SecondaryCameraDemo.kt
@@ -37,7 +37,10 @@ import io.github.sceneview.SceneView
 import io.github.sceneview.SurfaceType
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
+import io.github.sceneview.demo.DEFAULT_ORBIT_ELEVATION_DEGREES
 import io.github.sceneview.demo.rememberFirstFrameState
+import io.github.sceneview.demo.rememberFitOrbitRadius
+import io.github.sceneview.rememberCameraManipulator
 import io.github.sceneview.loaders.ModelLoader
 import io.github.sceneview.math.Position
 import io.github.sceneview.model.ModelInstance
@@ -252,6 +255,16 @@ fun SecondaryCameraDemo(onBack: () -> Unit) {
             environmentLoader = environmentLoader,
             environment = environment,
             onFrame = firstFrame.onFrame,
+            // #3426 — the main view passed no manipulator, so it inherited the library's stock
+            // 2.78 m pose for a subject normalised to 0.5 units: the helmet the demo is *about*
+            // read as a small object adrift in the frame, and smaller than the same helmet in the
+            // picture-in-picture inset beside it. Fitted to the subject.
+            cameraManipulator = rememberCameraManipulator(
+                orbitRadius = rememberFitOrbitRadius(
+                    extentX = 0.5f, extentY = 0.5f, extentZ = 0.5f,
+                    elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES,
+                )
+            ),
         ) {
             mainInstance?.let { instance ->
                 ModelNode(

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoOrbitFramingTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoOrbitFramingTest.kt
@@ -99,17 +99,6 @@ class DemoOrbitFramingTest {
         assertTrue(big <= 1f)
     }
 
-    @Test
-    fun theGestureSceneFramesTheGizmoNotJustTheHelmet() {
-        // The node-gestures section is about touching the model, so the axes gizmo — the widest
-        // thing on screen — is what must fit, not the 0.3-unit helmet inside it.
-        val gizmoExtent = 0.3f / 2f + 0.3f * 1.5f
-        val radius = fitOrbitRadius(gizmoExtent, gizmoExtent, gizmoExtent, phonePortrait,
-            elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES)
-        assertTrue("the gizmo must fit the frame", widthFill(gizmoExtent, radius) <= 1f)
-        assertTrue("…and must not shrink back towards the stock pose", radius < 2.7789f)
-    }
-
     // ── Degenerate inputs ─────────────────────────────────────────────────────────────────────
 
     @Test

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoOrbitFramingTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/DemoOrbitFramingTest.kt
@@ -1,0 +1,123 @@
+package io.github.sceneview.demo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.tan
+import org.junit.Test
+
+/**
+ * Pins the shared demo framing helper and the per-demo numbers it replaced (#3426).
+ *
+ * The audit behind the issue found that every non-AR sample carried a hand-tuned orbit radius —
+ * `2.0f`, `2.2f`, `2.4f`, `1.6f`, or nothing at all, which left the library's stock 2.78 m pose —
+ * and that **none** of them looked at the viewport aspect. On a portrait phone the horizontal FOV
+ * is the binding one, so those literals produced anything between a subject overflowing the frame
+ * and one filling a sixth of it, for the same content at the same scale.
+ *
+ * These tests state the property the literals could not: *whatever* the subject's size, the
+ * framing puts it at a consistent fraction of the frame.
+ */
+class DemoOrbitFramingTest {
+
+    /** Pixel 9, the device every one of the three issues was reported from. */
+    private val phonePortrait = 1080f / 2424f
+
+    /** Vertical FOV of SceneView's default 28 mm lens, against Filament's 24 mm sensor. */
+    private val vfov = io.github.sceneview.verticalFovDegreesForFocalLength(28.0)
+
+    /** Fraction of the frame WIDTH a cube of side [extent] spans when framed at [radius]. */
+    private fun widthFill(extent: Float, radius: Float, aspect: Float = phonePortrait): Float {
+        val sweptRadius = kotlin.math.sqrt(2f) * extent / 2f
+        val halfWidth = radius * tan(Math.toRadians(vfov) / 2.0).toFloat() * aspect
+        return sweptRadius / halfWidth
+    }
+
+    // ── The property the literals could not hold ──────────────────────────────────────────────
+
+    @Test
+    fun everySubjectSizeLandsOnTheSameFractionOfTheFrame() {
+        // A 5 cm bee and a 155 m landscape must read as "comfortably framed" identically. This is
+        // the whole point of computing the radius instead of writing one down.
+        val fills = listOf(0.05f, 0.2f, 0.3f, 0.5f, 0.85f, 1f, 155f).map {
+            widthFill(it, fitOrbitRadius(it, it, it, phonePortrait))
+        }
+        fills.forEach { assertEquals(fills.first(), it, 1e-3f) }
+        assertEquals(
+            "the subject must span the documented share of the frame",
+            DEMO_FRAMING_FILL, fills.first(), 0.02f,
+        )
+    }
+
+    @Test
+    fun theRadiusScalesLinearlyWithTheSubject() {
+        val small = fitOrbitRadius(0.5f, 0.5f, 0.5f, phonePortrait)
+        val large = fitOrbitRadius(1f, 1f, 1f, phonePortrait)
+        assertEquals(2f, large / small, 1e-4f)
+    }
+
+    @Test
+    fun aWiderViewportBringsTheCameraCloser() {
+        // The aspect-blindness the issue is about: the same subject genuinely needs less distance
+        // on a tablet or a landscape fold than on a portrait phone.
+        val portrait = fitOrbitRadius(0.5f, 0.5f, 0.5f, 0.4455f)
+        val tablet = fitOrbitRadius(0.5f, 0.5f, 0.5f, 0.75f)
+        val landscape = fitOrbitRadius(0.5f, 0.5f, 0.5f, 2.17f)
+        assertTrue("portrait must be furthest — $portrait vs $tablet", portrait > tablet)
+        assertTrue("landscape must be closest — $landscape vs $tablet", landscape < tablet)
+    }
+
+    // ── The demos this PR re-framed ───────────────────────────────────────────────────────────
+
+    @Test
+    fun theDemosThatInheritedTheStockPoseNowFillTheFrame() {
+        // LightingLab's first section and SecondaryCamera's main view both passed NO manipulator,
+        // so they inherited the library's 2.78 m stock pose for a helmet normalised to 0.5 units.
+        // Their siblings, which do pass a radius, framed the same helmet visibly larger.
+        val stockPose = 2.7789f
+        val before = widthFill(0.5f, stockPose)
+        val after = widthFill(0.5f, fitOrbitRadius(0.5f, 0.5f, 0.5f, phonePortrait,
+            elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES))
+        assertTrue("the stock pose really was undersized — $before", before < 0.7f)
+        assertTrue("the fit must materially enlarge the subject — $before → $after", after > before * 1.25f)
+        assertTrue("…without overflowing the frame", after <= 1f)
+    }
+
+    @Test
+    fun theGallerysFixedRadiusCouldNotServeItsOwnSlugs() {
+        // The gallery's slugs are normalised from 0.20 to 0.85 units and every one of them was
+        // framed from a flat 1.6 m. One overflowed the frame, another filled a sixth of it.
+        val legacy = 1.6f
+        assertTrue("the 0.85 slug overflowed at 1.6 m", widthFill(0.85f, legacy) > 1f)
+        assertTrue(
+            "the same shot must have varied by more than 4× across the gallery's own chips",
+            widthFill(0.85f, legacy) / widthFill(0.20f, legacy) > 4f,
+        )
+        // Fitted per chip, both land on the same share of the frame.
+        val big = widthFill(0.85f, fitOrbitRadius(0.85f, 0.85f, 0.85f, phonePortrait))
+        val small = widthFill(0.20f, fitOrbitRadius(0.20f, 0.20f, 0.20f, phonePortrait))
+        assertEquals(big, small, 1e-3f)
+        assertTrue(big <= 1f)
+    }
+
+    @Test
+    fun theGestureSceneFramesTheGizmoNotJustTheHelmet() {
+        // The node-gestures section is about touching the model, so the axes gizmo — the widest
+        // thing on screen — is what must fit, not the 0.3-unit helmet inside it.
+        val gizmoExtent = 0.3f / 2f + 0.3f * 1.5f
+        val radius = fitOrbitRadius(gizmoExtent, gizmoExtent, gizmoExtent, phonePortrait,
+            elevationDegrees = DEFAULT_ORBIT_ELEVATION_DEGREES)
+        assertTrue("the gizmo must fit the frame", widthFill(gizmoExtent, radius) <= 1f)
+        assertTrue("…and must not shrink back towards the stock pose", radius < 2.7789f)
+    }
+
+    // ── Degenerate inputs ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun aDegenerateSubjectFallsBackRatherThanPlacingTheCameraOnIt() {
+        assertEquals(2.78f, fitOrbitRadius(0f, 0f, 0f, phonePortrait), 1e-2f)
+        assertTrue(fitOrbitRadius(Float.NaN, 1f, 1f, phonePortrait).isFinite())
+        assertTrue(fitOrbitRadius(1f, 1f, 1f, Float.NaN).isFinite())
+        assertTrue(fitOrbitRadius(1f, 1f, 1f, 0f).isFinite())
+        assertTrue(fitOrbitRadius(1f, 1f, 1f, phonePortrait, fill = 0f) > 0f)
+    }
+}

--- a/sceneview/api/sceneview.api
+++ b/sceneview/api/sceneview.api
@@ -34,9 +34,10 @@ public final class io/github/sceneview/BuildConfig {
 }
 
 public final class io/github/sceneview/CameraFramingKt {
+	public static final field DEFAULT_FRAMING_ELEVATION_DEGREES D
 	public static final field DEFAULT_FRAMING_PADDING F
-	public static final fun fitDistanceForBounds (Lio/github/sceneview/Aabb;DDF)F
-	public static synthetic fun fitDistanceForBounds$default (Lio/github/sceneview/Aabb;DDFILjava/lang/Object;)F
+	public static final fun fitDistanceForBounds (Lio/github/sceneview/Aabb;DDFDZ)F
+	public static synthetic fun fitDistanceForBounds$default (Lio/github/sceneview/Aabb;DDFDZILjava/lang/Object;)F
 	public static final fun fitDistanceForContent (Lio/github/sceneview/node/CameraNode;Lio/github/sceneview/node/Node;Lio/github/sceneview/node/Node;F)F
 	public static synthetic fun fitDistanceForContent$default (Lio/github/sceneview/node/CameraNode;Lio/github/sceneview/node/Node;Lio/github/sceneview/node/Node;FILjava/lang/Object;)F
 	public static final fun frameToBounds (Lio/github/sceneview/node/CameraNode;Lio/github/sceneview/Aabb;Ldev/romainguy/kotlin/math/Float3;F)Z
@@ -1444,6 +1445,9 @@ public final class io/github/sceneview/gesture/CameraGestureDetector$Companion {
 public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator : io/github/sceneview/gesture/CameraGestureDetector$CameraManipulator {
 	public static final field $stable I
 	public static final field Companion Lio/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator$Companion;
+	public static final field DEFAULT_MAX_ZOOM_DISTANCE_FACTOR F
+	public static final field DEFAULT_MIN_ZOOM_DISTANCE_FACTOR F
+	public static final field DEFAULT_ORBIT_ZOOM_SPEED F
 	public static final field DEFAULT_PINCH_ZOOM_DAMPING F
 	public static final field DEFAULT_PINCH_ZOOM_SPEED F
 	public fun <init> ()V
@@ -1455,13 +1459,17 @@ public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraMani
 	public fun <init> (Lcom/google/android/filament/utils/Manipulator;)V
 	public fun <init> (Lcom/google/android/filament/utils/Manipulator;F)V
 	public fun <init> (Lcom/google/android/filament/utils/Manipulator;FF)V
-	public synthetic fun <init> (Lcom/google/android/filament/utils/Manipulator;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/google/android/filament/utils/Manipulator;FFF)V
+	public synthetic fun <init> (Lcom/google/android/filament/utils/Manipulator;FFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;)V
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;)V
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;F)V
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;FF)V
 	public synthetic fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun getManipulator ()Lcom/google/android/filament/utils/Manipulator;
+	protected final fun getManipulatorZoomSpeed ()F
+	public final fun getMaxZoomDistanceFactor ()F
+	public final fun getMinZoomDistanceFactor ()F
 	protected final fun getPinchZoomDamping ()F
 	protected final fun getPinchZoomSpeed ()F
 	public fun getTransform ()Ldev/romainguy/kotlin/math/Mat4;
@@ -1471,11 +1479,20 @@ public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraMani
 	public fun scrollBegin (IIF)V
 	public fun scrollEnd ()V
 	public fun scrollUpdate (IIFF)V
+	public final fun setMaxZoomDistanceFactor (F)V
+	public final fun setMinZoomDistanceFactor (F)V
 	public fun setViewport (II)V
 	public fun update (F)V
 }
 
 public final class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator$Companion {
+}
+
+public final class io/github/sceneview/gesture/CameraGestureMathKt {
+	public static final fun zoomedDistanceForPinch (FFFFF)F
+	public static final fun zoomedDistanceForPinch (FFFFFF)F
+	public static final fun zoomedDistanceForPinch (FFFFFFF)F
+	public static synthetic fun zoomedDistanceForPinch$default (FFFFFFFILjava/lang/Object;)F
 }
 
 public final class io/github/sceneview/gesture/CameraManipulatorKt {

--- a/sceneview/src/main/java/io/github/sceneview/CameraFraming.kt
+++ b/sceneview/src/main/java/io/github/sceneview/CameraFraming.kt
@@ -5,8 +5,12 @@ import io.github.sceneview.math.Position
 import io.github.sceneview.math.toPosition
 import io.github.sceneview.node.CameraNode
 import io.github.sceneview.node.Node
+import kotlin.math.abs
+import kotlin.math.asin
 import kotlin.math.atan
+import kotlin.math.cos
 import kotlin.math.max
+import kotlin.math.sin
 import kotlin.math.sqrt
 import kotlin.math.tan
 
@@ -75,16 +79,44 @@ fun Box.toAabb(): Aabb = Aabb(
 )
 
 /**
+ * Default camera elevation (degrees above the content centroid) the framing math assumes when a
+ * caller does not derive one from a look direction. `0` means the camera sits level with the
+ * centroid — the pose [frameToBounds]'s default `(0, 0, -1)` direction produces.
+ */
+const val DEFAULT_FRAMING_ELEVATION_DEGREES: Double = 0.0
+
+/**
  * Computes the distance from the content centroid at which a camera with the given projection
- * frames [bounds] so it just fits the viewport, with [padding] breathing room on the tighter axis.
+ * frames [bounds] so it just fits the viewport, with [padding] breathing room.
  *
- * The content is fitted by its **bounding sphere** (radius = half the AABB's space diagonal), so
- * the framing is invariant of the camera's orbit yaw / pitch — the model never clips when the
- * camera rotates around it. The required distance is taken as the larger of the vertical-fit and
- * horizontal-fit distances so the content fits on **both** axes:
+ * ### What is fitted (#3426 — the Android half of the iOS #3383 / PR #3395 fix)
  *
- * - vertical:   `d = r / sin(vfov / 2)`
- * - horizontal: `d = r / sin(hfov / 2)`, where `hfov` is derived from `vfov` and `aspect`.
+ * This used to fit the content's **bounding sphere** — half the AABB's *space diagonal* — against
+ * each FOV axis and take the larger distance. That charged every subject twice over:
+ *
+ * 1. The subject was billed for a diagonal it does not occupy. A 1 m cube got a radius of 0.866 m
+ *    for 0.5 m of half-height.
+ * 2. Each axis was billed the *other* axis's distance. On a portrait viewport the horizontal FOV
+ *    is the narrow one, so a subject bound purely by its **height** was pushed back by a **width**
+ *    constraint it never hits — a portrait viewport could never be filled. That is the "subject
+ *    starts far too small" every non-AR sample showed (#3426).
+ *
+ * The fit is now **per FOV axis**, in closed form. A point `v` relative to the target is inside
+ * the frustum at distance `d` iff `d >= v·back + |v·axis| / tanAxis` on *both* the horizontal and
+ * the vertical axis. Maximising the right-hand side over the subject is a support-function
+ * evaluation at `w = back ± axis / tanAxis`, since `|x| = max(x, −x)`.
+ *
+ * ### Azimuth invariance is kept, deliberately
+ *
+ * An auto-rotating model must not clip when it turns broadside, so the fit does **not** specialise
+ * on the current yaw. Instead of the box it frames the box's **sweep about world Y** — a cylinder
+ * of radius `hypot(halfX, halfZ)` and half-height `halfY`, whose support is
+ * `halfY·|w.y| + R·hypot(w.x, w.z)`. That sweep is fitted *exactly*, not bounded, so this is the
+ * tightest azimuth-independent distance that exists. The result is never larger than the old
+ * bounding-sphere distance, so nothing is framed further away than before.
+ *
+ * Unlike the sphere fit, the result depends on [elevationDegrees]: a camera looking down at a
+ * subject sees a shorter projected height than one level with it.
  *
  * A degenerate / empty [bounds] (not-yet-loaded async model) yields `0` so callers can detect
  * "nothing to frame yet" and defer.
@@ -92,8 +124,15 @@ fun Box.toAabb(): Aabb = Aabb(
  * @param bounds                Content bounding box, in the space the camera orbits.
  * @param verticalFovDegrees    Camera vertical field-of-view in degrees, `(0, 180)`.
  * @param aspect                Viewport aspect ratio `width / height`. Must be `> 0`.
- * @param padding               Extra framing margin as a fraction of the bounding-sphere radius.
+ * @param padding               Extra framing margin as a *fraction* of the fitted distance.
  *                              Default [DEFAULT_FRAMING_PADDING]. Clamped to `>= 0`.
+ * @param elevationDegrees      Camera elevation above the content centroid, in degrees. `0` is
+ *                              level with the centroid, `90` straight down. [frameToBounds]
+ *                              derives it from its look direction.
+ * @param azimuthInvariant      `true` (default) frames the Y-sweep, so the subject never clips at
+ *                              any orbit yaw — required for auto-rotating or user-orbited scenes.
+ *                              `false` frames the raw box at azimuth 0: strictly tighter, and
+ *                              correct for a scene the camera views head-on and does not orbit.
  * @return The orbit distance (world units) from the content centroid, or `0` when [bounds] is
  *         empty / degenerate.
  */
@@ -101,26 +140,71 @@ fun fitDistanceForBounds(
     bounds: Aabb,
     verticalFovDegrees: Double,
     aspect: Double,
-    padding: Float = DEFAULT_FRAMING_PADDING
+    padding: Float = DEFAULT_FRAMING_PADDING,
+    elevationDegrees: Double = DEFAULT_FRAMING_ELEVATION_DEGREES,
+    azimuthInvariant: Boolean = true
 ): Float {
     if (bounds.isEmpty) return 0f
     val safeAspect = if (aspect.isFinite() && aspect > 0.0) aspect else 1.0
-    val extents = bounds.extents
-    // Bounding-sphere radius — half the AABB space diagonal. Yaw / pitch-invariant.
-    val radius = 0.5f * sqrt(
-        extents.x * extents.x + extents.y * extents.y + extents.z * extents.z
-    )
-    if (!radius.isFinite() || radius <= 0f) return 0f
-    val paddedRadius = radius * (1f + max(0f, padding))
+    val half = bounds.halfExtent
+    val halfX = abs(half.x)
+    val halfY = abs(half.y)
+    val halfZ = abs(half.z)
+    if (!halfX.isFinite() || !halfY.isFinite() || !halfZ.isFinite()) return 0f
+    if (halfX <= 0f && halfY <= 0f && halfZ <= 0f) return 0f
+
+    // Radius of the box's sweep about world Y — a cylinder. Sweeping is what makes the fit
+    // azimuth-invariant, so an auto-rotating model never clips as it turns broadside.
+    val sweptRadius = sqrt(halfX * halfX + halfZ * halfZ)
 
     val vfovRad = Math.toRadians(verticalFovDegrees.coerceIn(1.0, 179.0))
-    val halfVfov = vfovRad / 2.0
-    // Horizontal FOV from the vertical FOV and the viewport aspect.
-    val halfHfov = atan(tan(halfVfov) * safeAspect)
+    val tanY = tan(vfovRad / 2.0)
+    val tanX = tanY * safeAspect
+    if (tanY <= 0.0 || tanX <= 0.0) return 0f
 
-    val distanceForVertical = paddedRadius / kotlin.math.sin(halfVfov).toFloat()
-    val distanceForHorizontal = paddedRadius / kotlin.math.sin(halfHfov).toFloat()
-    return max(distanceForVertical, distanceForHorizontal)
+    // Camera basis at azimuth 0 — for the swept fit azimuth is irrelevant, so this loses no
+    // generality, and it avoids the `cross(forward, worldUp)` that degenerates at elevation ±90°:
+    //   back = (0, s, c)    right = (1, 0, 0)    up = (0, c, -s)
+    val elevationRad = Math.toRadians(
+        if (elevationDegrees.isFinite()) elevationDegrees else DEFAULT_FRAMING_ELEVATION_DEGREES
+    )
+    val s = sin(elevationRad).toFloat()
+    val c = cos(elevationRad).toFloat()
+
+    // Support of the subject along `w`, in the horizontal plane. The swept cylinder answers
+    // `R·hypot(w.x, w.z)`; the raw box — correct when the camera stays at azimuth 0 — answers
+    // `halfX·|w.x| + halfZ·|w.z|`, which is strictly tighter and is what a static, non-orbiting
+    // scene should pay.
+    fun planarSupport(wx: Float, wz: Float): Float = if (azimuthInvariant) {
+        sweptRadius * sqrt(wx * wx + wz * wz)
+    } else {
+        halfX * abs(wx) + halfZ * abs(wz)
+    }
+
+    // Horizontal: w = (±1/tanX, s, c) — both signs give the same support.
+    val inverseTanX = (1.0 / tanX).toFloat()
+    val horizontal = halfY * abs(s) + planarSupport(inverseTanX, c)
+    // Vertical: w = (0, s ± c/tanY, c ∓ s/tanY) — the two signs differ.
+    val inverseTanY = (1.0 / tanY).toFloat()
+    val verticalUpper = halfY * abs(s + c * inverseTanY) + planarSupport(0f, c - s * inverseTanY)
+    val verticalLower = halfY * abs(s - c * inverseTanY) + planarSupport(0f, c + s * inverseTanY)
+
+    val fitted = max(horizontal, max(verticalUpper, verticalLower)) * (1f + max(0f, padding))
+    return if (fitted.isFinite() && fitted > 0f) fitted else 0f
+}
+
+/**
+ * Camera elevation, in degrees above the content centroid, implied by a look [direction] pointing
+ * **from the camera towards the content**. A camera above the subject looks down, so its direction
+ * has a negative `y` and the elevation is positive.
+ *
+ * Returns [DEFAULT_FRAMING_ELEVATION_DEGREES] for a zero / non-finite direction.
+ */
+internal fun elevationDegreesForDirection(direction: Position): Double {
+    val length =
+        sqrt(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z)
+    if (!length.isFinite() || length <= 1e-6f) return DEFAULT_FRAMING_ELEVATION_DEGREES
+    return Math.toDegrees(asin((-direction.y / length).toDouble().coerceIn(-1.0, 1.0)))
 }
 
 /**
@@ -178,14 +262,17 @@ fun CameraNode.frameToBounds(
     direction: Position = Position(0f, 0f, -1f),
     padding: Float = DEFAULT_FRAMING_PADDING
 ): Boolean {
+    val normalized = normalizeOrDefault(direction)
     val distance = fitDistanceForBounds(
         bounds = bounds,
         verticalFovDegrees = verticalFovDegreesForFocalLength(focalLength),
         aspect = getViewPortAspect(),
-        padding = padding
+        padding = padding,
+        // The projected height of a subject shrinks as the camera rises, so the fit has to know
+        // the pose it is fitting for (#3426). Derived from the caller's look direction.
+        elevationDegrees = elevationDegreesForDirection(normalized)
     )
     if (distance <= 0f) return false
-    val normalized = normalizeOrDefault(direction)
     val eye = bounds.center - normalized * distance
     worldPosition = eye
     lookAt(bounds.center)

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
@@ -81,7 +81,62 @@ open class CameraGestureDetector(
         protected val manipulator: Manipulator,
         protected val pinchZoomSpeed: Float = DEFAULT_PINCH_ZOOM_SPEED,
         protected val pinchZoomDamping: Float = DEFAULT_PINCH_ZOOM_DAMPING,
+        /**
+         * The `zoomSpeed` the wrapped [manipulator] was built with — Filament does not expose a
+         * getter, so it has to be repeated here. Only used to invert Filament's absolute scroll
+         * step into the relative one [scrollUpdate] wants; the default matches the `zoomSpeed`
+         * the convenience constructors below configure.
+         */
+        protected val manipulatorZoomSpeed: Float = DEFAULT_ORBIT_ZOOM_SPEED,
     ): CameraManipulator {
+
+        /**
+         * Camera-to-orbit-pivot distance, tracked in Kotlin because Filament will not tell us.
+         *
+         * `Manipulator.getLookAt` is only usable for this **before the first orbit drag**: the
+         * moment `grabUpdate` runs, `OrbitManipulator::jumpToBookmark` re-plants `mTarget` exactly
+         * one unit in front of the eye, so the reported eye→target distance is a constant `1` from
+         * then on and says nothing about the orbit radius. The radius itself only ever changes via
+         * `scroll` (orbit preserves it by construction, pan translates eye and pivot together), so
+         * seeding it once at construction and updating it by the step we ourselves request keeps
+         * it exact. `-1` means "not measured yet".
+         */
+        private var orbitDistance: Float = -1f
+
+        /**
+         * Closest / furthest the pinch may take the camera, as multiples of the distance the
+         * manipulator was *homed* at. Bounds-relative in practice, since the home distance is
+         * whatever auto-fit or the demo's framing computed for the subject. The lower bound is
+         * what stops `scroll` from punching the eye through the orbit pivot and inverting the
+         * camera (#3403).
+         */
+        var minZoomDistanceFactor: Float = DEFAULT_MIN_ZOOM_DISTANCE_FACTOR
+
+        /** @see minZoomDistanceFactor */
+        var maxZoomDistanceFactor: Float = DEFAULT_MAX_ZOOM_DISTANCE_FACTOR
+
+        /** The distance the manipulator was homed at — the reference for the zoom clamps. */
+        private var homeDistance: Float = -1f
+
+        /**
+         * Reads the orbit radius, seeding it from the manipulator's own pose the first time (which
+         * is only correct before any orbit drag — see [orbitDistance]).
+         */
+        private fun currentOrbitDistance(): Float {
+            if (orbitDistance > 0f) return orbitDistance
+            val eye = FloatArray(3)
+            val target = FloatArray(3)
+            val upward = FloatArray(3)
+            runCatching { manipulator.getLookAt(eye, target, upward) }.getOrElse { return -1f }
+            val dx = eye[0] - target[0]
+            val dy = eye[1] - target[1]
+            val dz = eye[2] - target[2]
+            val measured = kotlin.math.sqrt(dx * dx + dy * dy + dz * dz)
+            if (!measured.isFinite() || measured <= 0f) return -1f
+            orbitDistance = measured
+            if (homeDistance <= 0f) homeDistance = measured
+            return measured
+        }
 
         /**
          * Builds a sensible default ORBIT-mode manipulator.
@@ -110,10 +165,11 @@ open class CameraGestureDetector(
                 // (2026-05-16 Pixel 9 QA). 0.005 → 0.003 makes finger drag track the
                 // model more calmly without feeling sluggish.
                 .orbitSpeed(0.003f, 0.003f)
-                .zoomSpeed(0.05f)
+                .zoomSpeed(DEFAULT_ORBIT_ZOOM_SPEED)
                 .build(Manipulator.Mode.ORBIT),
             pinchZoomSpeed,
             pinchZoomDamping,
+            DEFAULT_ORBIT_ZOOM_SPEED,
         )
 
         /**
@@ -139,6 +195,10 @@ open class CameraGestureDetector(
 
         override fun setViewport(width: Int, height: Int) {
             manipulator.setViewport(width, height)
+            // First chance to read a still-truthful pose, and it always runs before any gesture —
+            // `getLookAt` stops reporting the orbit radius after the first drag (see
+            // [orbitDistance]), so the seed has to happen here rather than on the first pinch.
+            currentOrbitDistance()
         }
 
         override fun getTransform(): Transform {
@@ -146,6 +206,8 @@ open class CameraGestureDetector(
         }
 
         override fun grabBegin(x: Int, y: Int, strafe: Boolean) {
+            // Last moment the pose is still readable — `grabUpdate` is what re-plants the target.
+            currentOrbitDistance()
             manipulator.grabBegin(x, y, strafe)
         }
 
@@ -157,18 +219,36 @@ open class CameraGestureDetector(
             manipulator.grabEnd()
         }
 
-        override fun scrollBegin(x: Int, y: Int, separation: Float) {}
+        override fun scrollBegin(x: Int, y: Int, separation: Float) {
+            // Seed the tracked radius from the manipulator while its reported target is still the
+            // orbit pivot (see [orbitDistance]) — cheap, and a no-op once measured.
+            currentOrbitDistance()
+        }
 
         override fun scrollUpdate(x: Int, y: Int, prevSeparation: Float, currSeparation: Float) {
-            // Pixel 9 review v2: the legacy linear curve `(prev - curr) * 0.1` was too abrupt —
-            // a 200 px pinch produced a 20-unit dolly translation, easily punching the camera
-            // through the target. The damping curve lives in [pinchZoomDelta] so it can be
-            // unit-tested on the JVM (no Filament Manipulator instance needed).
-            manipulator.scroll(
-                x,
-                y,
-                pinchZoomDelta(prevSeparation, currSeparation, pinchZoomSpeed, pinchZoomDamping),
+            // The damping curve lives in [pinchZoomDelta] so it can be unit-tested on the JVM (no
+            // Filament Manipulator instance needed).
+            val zoomDelta =
+                pinchZoomDelta(prevSeparation, currSeparation, pinchZoomSpeed, pinchZoomDamping)
+            val distance = currentOrbitDistance()
+            if (distance <= 0f) {
+                // No usable pose to scale against — fall back to Filament's absolute step rather
+                // than dropping the gesture entirely.
+                manipulator.scroll(x, y, zoomDelta)
+                return
+            }
+            val home = if (homeDistance > 0f) homeDistance else distance
+            // Relative dolly: the same pinch covers the same *fraction* of the distance whatever
+            // the subject's scale, and the clamp keeps the eye off (and never past) the pivot.
+            val next = zoomedDistance(
+                distance = distance,
+                zoomDelta = zoomDelta,
+                minDistance = home * minZoomDistanceFactor,
+                maxDistance = home * maxZoomDistanceFactor,
             )
+            if (next == distance) return
+            manipulator.scroll(x, y, dollyScrollDelta(distance, next, manipulatorZoomSpeed))
+            orbitDistance = next
         }
 
         override fun scrollEnd() {}
@@ -179,13 +259,37 @@ open class CameraGestureDetector(
 
         companion object {
             /**
-             * Default per-pixel zoom multiplier. Tuned in v4.0.x from `1/10` down to `1/30`
-             * (felt too abrupt on dense screens), then re-tuned in #1427 from `1/30` up to
-             * `1/18` — the `1/30` value made pinch-zoom feel "hyper lent" in the 2026-05-16
-             * on-device QA. `1/18` restores a responsive pinch while staying well short of
-             * the abrupt legacy `1/10`. See [pinchZoomSpeed] kdoc for tuning advice.
+             * Default pinch gain. **The unit changed in #3426**: the pinch is now a *ratio* of the
+             * current camera-to-target distance, not a number of world units, so this constant is
+             * "natural-log of the distance ratio per damped pixel" rather than "metres per damped
+             * pixel" (see [zoomedDistance]).
+             *
+             * `1/60` puts a full-screen 200 px pinch at ~ln2 (`200^0.7 / 60 ≈ 0.69`), i.e. **one
+             * comfortable pinch halves or doubles the distance** — the response Maps / Sketchfab
+             * train users to expect. The old `1/18` under the absolute-translation model moved the
+             * camera ~11 cm per pinch regardless of scale, which read as "many gestures for very
+             * little zoom" on anything framed further than a metre away (#3426) and punched
+             * straight through the pivot on anything closer (#3403).
              */
-            const val DEFAULT_PINCH_ZOOM_SPEED: Float = 1f / 18f
+            const val DEFAULT_PINCH_ZOOM_SPEED: Float = 1f / 60f
+
+            /**
+             * The `zoomSpeed` the convenience constructors configure on the Filament
+             * [Manipulator]. Only the *relative* step matters to the user now, so this is purely
+             * the unit [dollyScrollDelta] inverts — it no longer sets the zoom feel.
+             */
+            const val DEFAULT_ORBIT_ZOOM_SPEED: Float = 0.05f
+
+            /**
+             * Closest the pinch may take the camera, as a fraction of the distance it was homed
+             * at. `0.15` lets the user get comfortably inside a subject's silhouette while keeping
+             * the eye well clear of the orbit pivot — crossing it is what inverts the camera
+             * (#3403).
+             */
+            const val DEFAULT_MIN_ZOOM_DISTANCE_FACTOR: Float = 0.15f
+
+            /** Furthest the pinch may take the camera, as a multiple of the homed distance. */
+            const val DEFAULT_MAX_ZOOM_DISTANCE_FACTOR: Float = 8f
 
             /**
              * Default damping exponent for pinch deltas. Sub-1 values create a sqrt-like response

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
@@ -119,10 +119,19 @@ open class CameraGestureDetector(
         private var homeDistance: Float = -1f
 
         /**
+         * `true` when the wrapped manipulator is an `ORBIT` one, i.e. when `scroll` means "dolly
+         * towards the pivot". `MAP` scrolls the map extent and `FREE_FLIGHT` scrolls its move
+         * speed; converting a *distance* into a scroll delta is meaningless for both.
+         */
+        private fun isOrbitMode(): Boolean =
+            runCatching { manipulator.mode == Manipulator.Mode.ORBIT }.getOrDefault(false)
+
+        /**
          * Reads the orbit radius, seeding it from the manipulator's own pose the first time (which
          * is only correct before any orbit drag — see [orbitDistance]).
          */
         private fun currentOrbitDistance(): Float {
+            if (!isOrbitMode()) return -1f
             if (orbitDistance > 0f) return orbitDistance
             val eye = FloatArray(3)
             val target = FloatArray(3)
@@ -230,10 +239,12 @@ open class CameraGestureDetector(
             // Filament Manipulator instance needed).
             val zoomDelta =
                 pinchZoomDelta(prevSeparation, currSeparation, pinchZoomSpeed, pinchZoomDamping)
-            val distance = currentOrbitDistance()
+            val distance = if (isOrbitMode()) currentOrbitDistance() else -1f
             if (distance <= 0f) {
-                // No usable pose to scale against — fall back to Filament's absolute step rather
-                // than dropping the gesture entirely.
+                // Either no usable pose to scale against, or a mode where "distance" is not what
+                // scroll means: `MapManipulator` scrolls the map extent and `FreeFlightManipulator`
+                // scrolls its move *speed*, neither of which is a dolly. Hand those Filament's own
+                // step rather than a dolly conversion that does not apply to them.
                 manipulator.scroll(x, y, zoomDelta)
                 return
             }

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
@@ -5,6 +5,7 @@ import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.sign
 
+
 /**
  * Maps a two-finger pinch gesture's pointer-separation delta into a
  * non-linear "zoom delta" suitable for translating the camera along its
@@ -37,6 +38,112 @@ internal fun pinchZoomDelta(
     }
     return damped * speed
 }
+
+/**
+ * The camera-to-target distance a pinch of [zoomDelta] should land on, starting from [distance].
+ *
+ * ### Why this exists (#3403 / #3426)
+ *
+ * Filament's `OrbitManipulator::scroll` is an **absolute** translation:
+ * `eye += gaze · zoomSpeed · (−scrolldelta)`. The step is a fixed number of world units no matter
+ * how far the camera is, which breaks at both ends of the scale the SDK has to cover:
+ *
+ * - **Far scenes crawl.** With the shipped `zoomSpeed = 0.05`, a full-screen 200 px pinch moved the
+ *   camera ~11 cm. On a scene framed at 5 m that is 40+ pinches to halve the distance — the
+ *   "beaucoup de gestes pour peu de zoom" of #3426.
+ * - **Near scenes teleport, then invert.** On a 5 cm model the same pinch punches the eye straight
+ *   through the orbit pivot. Filament notices (`dot(v0, v1) < 0` ⇒ `mFlipped = true`), and the next
+ *   orbit drag rebuilds the view from a **negative** bookmark distance, aiming the camera *away*
+ *   from the subject. That is #3403's "the zoom completely breaks the camera".
+ *
+ * The fix is to make a pinch a **ratio**, not a length: the same gesture covers the same fraction
+ * of the distance whether the subject is a 5 cm bee or a 155 m landscape. Zooming is therefore
+ * exponential in the gesture, `newDistance = distance · exp(zoomDelta)`, and the result is clamped
+ * into `[minDistance, maxDistance]` so the eye can never reach — let alone cross — the pivot.
+ *
+ * @param distance    Current camera-to-target distance. Non-finite / non-positive returns
+ *                    [minDistance].
+ * @param zoomDelta   Output of [pinchZoomDelta]: positive for a pinch-in (zoom **out**, distance
+ *                    grows), negative for a pinch-out.
+ * @param minDistance Closest the camera may get. Must be `> 0`.
+ * @param maxDistance Furthest the camera may get.
+ * @return The clamped new distance.
+ */
+internal fun zoomedDistance(
+    distance: Float,
+    zoomDelta: Float,
+    minDistance: Float,
+    maxDistance: Float,
+): Float {
+    val low = if (minDistance.isFinite() && minDistance > 0f) minDistance else MIN_ORBIT_DISTANCE
+    val high = if (maxDistance.isFinite() && maxDistance > low) maxDistance else low
+    if (!distance.isFinite() || distance <= 0f) return low
+    if (!zoomDelta.isFinite()) return distance.coerceIn(low, high)
+    val scaled = distance * exp(zoomDelta)
+    if (!scaled.isFinite()) return distance.coerceIn(low, high)
+    return scaled.coerceIn(low, high)
+}
+
+/**
+ * Converts a target camera-to-target [targetDistance] into the `scrolldelta` Filament's
+ * `OrbitManipulator::scroll` needs to get there from [distance].
+ *
+ * `scroll` moves the eye by `gaze · zoomSpeed · (−scrolldelta)` — along the gaze for a negative
+ * delta — so the distance changes by exactly `zoomSpeed · scrolldelta`. Inverting that gives the
+ * delta below. [zoomSpeed] is the manipulator's configured `Manipulator.Builder.zoomSpeed`.
+ */
+internal fun dollyScrollDelta(
+    distance: Float,
+    targetDistance: Float,
+    zoomSpeed: Float,
+): Float {
+    if (!zoomSpeed.isFinite() || zoomSpeed <= 0f) return 0f
+    val delta = (targetDistance - distance) / zoomSpeed
+    return if (delta.isFinite()) delta else 0f
+}
+
+/** Absolute floor for an orbit distance — the camera may never sit on its own pivot. */
+internal const val MIN_ORBIT_DISTANCE: Float = 1e-3f
+
+/**
+ * The camera-to-target distance a pinch should land on — the public, one-call form of
+ * [pinchZoomDelta] + [zoomedDistance], for camera manipulators that own their own orbit distance
+ * instead of delegating the dolly to a Filament `Manipulator`.
+ *
+ * Use it when a pinch has to *publish* a distance (a slider, a saved state) rather than translate
+ * a camera: the step is a fraction of [distance], so the gesture feels the same at every scale.
+ *
+ * ```kotlin
+ * override fun scrollUpdate(x: Int, y: Int, prev: Float, curr: Float) {
+ *     zoom = zoomedDistanceForPinch(zoom, prev, curr, minDistance = fit * 0.25f, fit * 4f)
+ * }
+ * ```
+ *
+ * @param distance       Current camera-to-target distance.
+ * @param prevSeparation Pointer separation, in pixels, on the previous frame.
+ * @param currSeparation Pointer separation, in pixels, on the current frame.
+ * @param minDistance    Closest the camera may get. Must be `> 0`.
+ * @param maxDistance    Furthest the camera may get.
+ * @param speed          Pinch gain — see
+ *                       [CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED].
+ * @param damping        Damping exponent — see
+ *                       [CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_DAMPING].
+ */
+@JvmOverloads
+fun zoomedDistanceForPinch(
+    distance: Float,
+    prevSeparation: Float,
+    currSeparation: Float,
+    minDistance: Float,
+    maxDistance: Float,
+    speed: Float = CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED,
+    damping: Float = CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_DAMPING,
+): Float = zoomedDistance(
+    distance = distance,
+    zoomDelta = pinchZoomDelta(prevSeparation, currSeparation, speed, damping),
+    minDistance = minDistance,
+    maxDistance = maxDistance,
+)
 
 /**
  * Same pinch-delta math as [pinchZoomDelta] but interpreted as a

--- a/sceneview/src/test/java/io/github/sceneview/CameraFramingTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/CameraFramingTest.kt
@@ -72,15 +72,17 @@ class CameraFramingTest {
 
     @Test
     fun distanceMatchesClosedFormForSquareViewport() {
-        // Square viewport (aspect 1) → vertical and horizontal fits are equal, so the distance is
-        // exactly r·(1+padding)/sin(vfov/2).
+        // #3426 replaced the bounding-sphere fit with a per-FOV-axis one, so the closed form is no
+        // longer `r / sin(vfov/2)`. On a square viewport at elevation 0 the binding axis is the
+        // vertical one, whose support for a cube of side `e` is `e/2 · 1/tan(vfov/2) + R`, with
+        // `R = hypot(e/2, e/2)` the radius of the cube's sweep about Y.
         val extent = 2f
-        val radius = 0.5f * sqrt(3f * extent * extent) // bounding sphere of a 2×2×2 cube
+        val half = extent / 2f
+        val sweptRadius = sqrt(2f) * half
         val vfov = 60.0
-        val padding = 0f
-        val expected = radius / kotlin.math.sin(Math.toRadians(vfov / 2.0)).toFloat()
+        val expected = half / kotlin.math.tan(Math.toRadians(vfov / 2.0)).toFloat() + sweptRadius
         val actual = fitDistanceForBounds(
-            box(extent, extent, extent), verticalFovDegrees = vfov, aspect = 1.0, padding = padding
+            box(extent, extent, extent), verticalFovDegrees = vfov, aspect = 1.0, padding = 0f
         )
         assertEquals(expected, actual, 1e-3f)
     }
@@ -102,16 +104,36 @@ class CameraFramingTest {
     }
 
     @Test
-    fun fitUsesTheBoundingSphereSoFramingIsYawInvariant() {
-        // A flat, wide plate and a cube with the same space diagonal share the same bounding
-        // sphere — both must frame to the same distance so an orbiting camera never clips.
-        val plate = box(2f, 0.1f, 2f)
-        val plateDiagonal = sqrt(2f * 2f + 0.1f * 0.1f + 2f * 2f)
-        val cubeEdge = plateDiagonal / sqrt(3f)
-        val cube = box(cubeEdge, cubeEdge, cubeEdge)
+    fun equalSpaceDiagonalsNoLongerMeanEqualFraming() {
+        // #3426 — this used to assert that a wide flat plate and a cube of the same *space
+        // diagonal* frame identically. They share a bounding sphere, which is exactly the
+        // over-charge the issue is about: the cube is 1.16 m across and was billed for the plate's
+        // 2 m reach. The plate keeps its distance (it really is 2 m wide, there is no slack to
+        // recover); the cube comes closer.
+        val plate = box(2f, 0.1f, 0.1f)
+        val diagonal = sqrt(2f * 2f + 0.1f * 0.1f + 0.1f * 0.1f)
+        val edge = diagonal / sqrt(3f)
+        val cube = box(edge, edge, edge)
         val dPlate = fitDistanceForBounds(plate, 46.4, aspect = 1.0)
         val dCube = fitDistanceForBounds(cube, 46.4, aspect = 1.0)
-        assertEquals(dPlate, dCube, 1e-3f)
+        assertTrue(
+            "the compact cube must no longer pay the plate's width — $dCube vs $dPlate",
+            dCube < dPlate * 0.9f,
+        )
+    }
+
+    @Test
+    fun framingIsInvariantToTheSubjectsYaw() {
+        // What must still hold after #3426: an orbiting camera never clips, because the fit frames
+        // the subject's sweep about Y. Turning a subject 90° about Y swaps its X and Z extents and
+        // must not change the distance by a hair.
+        val subject = box(2f, 0.6f, 0.4f)
+        val turned = box(0.4f, 0.6f, 2f)
+        assertEquals(
+            fitDistanceForBounds(subject, 46.4, aspect = 0.4455),
+            fitDistanceForBounds(turned, 46.4, aspect = 0.4455),
+            1e-4f,
+        )
     }
 
     @Test
@@ -123,15 +145,19 @@ class CameraFramingTest {
 
     @Test
     fun framedModelSubtendsTheExpectedAngle() {
-        // Sanity check on the geometry: at the computed distance, the bounding-sphere radius must
-        // subtend exactly half the (padded-adjusted) vertical FOV for a square viewport.
+        // Sanity check on the geometry. Post-#3426 the fit measures the subject's *projected*
+        // extent, not its bounding sphere, so the angle to check is the one subtended by the
+        // nearest top corner — half the height, at the depth of the near face.
         val extent = 1f
-        val radius = 0.5f * sqrt(3f) * extent
+        val half = extent / 2f
         val vfov = 50.0
         val d = fitDistanceForBounds(box(extent, extent, extent), vfov, aspect = 1.0, padding = 0f)
-        val subtendedHalfAngle = Math.toDegrees(atan((radius / d).toDouble()))
-        // asin form was used in the helper (r/d = sin θ); atan(r/d) is therefore slightly under
-        // vfov/2 — assert it is in the right ballpark and strictly below the half-FOV.
-        assertTrue(subtendedHalfAngle in 15.0..(vfov / 2.0))
+        // Distance to the near face, which is where the swept silhouette is tallest on screen.
+        val nearDepth = d - sqrt(2f) * half
+        val subtendedHalfAngle = Math.toDegrees(atan((half / nearDepth).toDouble()))
+        assertTrue(
+            "the subject must fill the frame's height without exceeding it — was $subtendedHalfAngle°",
+            subtendedHalfAngle in 20.0..(vfov / 2.0 + 1e-3),
+        )
     }
 }

--- a/sceneview/src/test/java/io/github/sceneview/ProjectedBoundsFitTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/ProjectedBoundsFitTest.kt
@@ -1,0 +1,257 @@
+package io.github.sceneview
+
+import io.github.sceneview.math.Position
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
+import org.junit.Test
+
+/**
+ * Containment and tightness pins for the per-FOV-axis camera fit (#3426 — the Android half of the
+ * iOS #3383 / PR #3395 fix).
+ *
+ * These are not "pin whatever the code returns" tests: every expectation is derived from an
+ * **independent** frustum implementation ([framesEveryCorner]) that places a camera at the fitted
+ * distance and checks the subject's eight corners against both FOV planes. The fit can therefore
+ * fail the code rather than merely record it.
+ *
+ * The companion [CameraFramingTest] keeps the scale / padding / degenerate-input contracts.
+ */
+class ProjectedBoundsFitTest {
+
+    private fun box(x: Float, y: Float, z: Float) =
+        Aabb(halfExtent = Position(x / 2f, y / 2f, z / 2f))
+
+    /** Viewport aspects the demos actually ship on: phone portrait, square, landscape tablet. */
+    private val aspects = listOf(0.4455, 1.0, 2.17)
+
+    // ── An independent frustum oracle ──────────────────────────────────────────────────────────
+
+    /**
+     * `true` when every corner of [bounds], swept to [azimuthDegrees], is inside the frustum of a
+     * camera sitting [distance] away at [elevationDegrees], with [slack] world units of tolerance.
+     *
+     * Written from the frustum definition, not from the production formula: a point is inside iff
+     * its depth along the view axis covers its lateral offset scaled by the axis's half-FOV
+     * tangent.
+     */
+    private fun framesEveryCorner(
+        bounds: Aabb,
+        distance: Float,
+        verticalFovDegrees: Double,
+        aspect: Double,
+        elevationDegrees: Double,
+        azimuthDegrees: Double,
+        slack: Float = 1e-3f,
+    ): Boolean {
+        val tanY = tan(Math.toRadians(verticalFovDegrees) / 2.0)
+        val tanX = tanY * aspect
+        val el = Math.toRadians(elevationDegrees)
+        val az = Math.toRadians(azimuthDegrees)
+        // Camera basis for an eye at `distance` along (back), orbiting the origin.
+        val back = doubleArrayOf(sin(az) * cos(el), sin(el), cos(az) * cos(el))
+        val right = doubleArrayOf(cos(az), 0.0, -sin(az))
+        val up = doubleArrayOf(
+            back[1] * right[2] - back[2] * right[1],
+            back[2] * right[0] - back[0] * right[2],
+            back[0] * right[1] - back[1] * right[0],
+        )
+        val h = bounds.halfExtent
+        for (sx in intArrayOf(-1, 1)) for (sy in intArrayOf(-1, 1)) for (sz in intArrayOf(-1, 1)) {
+            val v = doubleArrayOf(
+                (sx * h.x).toDouble(), (sy * h.y).toDouble(), (sz * h.z).toDouble()
+            )
+            val depth = distance - (v[0] * back[0] + v[1] * back[1] + v[2] * back[2])
+            val lateral = abs(v[0] * right[0] + v[1] * right[1] + v[2] * right[2])
+            val vertical = abs(v[0] * up[0] + v[1] * up[1] + v[2] * up[2])
+            if (depth * tanX + slack < lateral) return false
+            if (depth * tanY + slack < vertical) return false
+        }
+        return true
+    }
+
+    /** The pre-#3426 bounding-sphere fit, recomputed inline so the comparison is honest. */
+    private fun legacySphereFit(
+        bounds: Aabb,
+        verticalFovDegrees: Double,
+        aspect: Double,
+        padding: Float,
+    ): Float {
+        val e = bounds.extents
+        val radius = 0.5f * sqrt(e.x * e.x + e.y * e.y + e.z * e.z) * (1f + padding)
+        val halfV = Math.toRadians(verticalFovDegrees) / 2.0
+        val halfH = kotlin.math.atan(tan(halfV) * aspect)
+        return maxOf(radius / sin(halfV).toFloat(), radius / sin(halfH).toFloat())
+    }
+
+    // ── Containment ───────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun fittedSubjectNeverClipsAtAnyAzimuth() {
+        // The whole point of framing the Y-sweep: an auto-rotating model must stay inside the
+        // frame as it turns broadside. 24 azimuths × 3 aspects × 3 elevations × 4 subjects.
+        val subjects = listOf(
+            box(1f, 1f, 1f),          // cubic
+            box(4f, 0.5f, 0.5f),      // wide and flat
+            box(0.3f, 3f, 0.3f),      // tall column
+            box(0.05f, 0.05f, 0.05f), // a 5 cm bee
+        )
+        for (subject in subjects) for (aspect in aspects) for (elevation in listOf(0.0, 12.0, 45.0)) {
+            val d = fitDistanceForBounds(subject, 46.4, aspect, padding = 0f, elevationDegrees = elevation)
+            assertTrue("fit must be positive", d > 0f)
+            for (step in 0 until 24) {
+                assertTrue(
+                    "subject $subject clipped at azimuth ${step * 15}° " +
+                        "(aspect $aspect, elevation $elevation, d=$d)",
+                    framesEveryCorner(subject, d, 46.4, aspect, elevation, step * 15.0),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun theFitIsTightNotMerelySafe() {
+        // A fit that always doubled the distance would pass the containment test above and still
+        // be the bug this issue is about. Tightness has to be judged at the **binding azimuth**,
+        // not at azimuth 0: the fit frames the subject's sweep, so a box is deliberately loose
+        // when it happens to be facing the camera square-on. Somewhere on the turntable, shrinking
+        // the distance by 2 % must clip.
+        val subjects = listOf(box(1f, 1f, 1f), box(0.3f, 3f, 0.3f), box(4f, 0.5f, 0.5f))
+        for (subject in subjects) for (aspect in aspects) {
+            val d = fitDistanceForBounds(subject, 46.4, aspect, padding = 0f, elevationDegrees = 0.0)
+            val clipsSomewhere = (0 until 360).any { azimuth ->
+                !framesEveryCorner(subject, d * 0.98f, 46.4, aspect, 0.0, azimuth.toDouble(), slack = 0f)
+            }
+            assertTrue(
+                "fit of $subject at aspect $aspect is loose — $d leaves room to spare at every yaw",
+                clipsSomewhere,
+            )
+        }
+    }
+
+    // ── The regression the issue reports ──────────────────────────────────────────────────────
+
+    @Test
+    fun aTallSubjectFillsAPortraitViewport() {
+        // #3426's headline. A 3 m column, 46.4° vertical FOV: its half-height of 1.5 m needs
+        // exactly 1.5 / tan(23.2°) ≈ 3.50 m of distance and NOTHING more, because it is bound by
+        // its height. The sphere fit charged it the *horizontal* axis's distance on a portrait
+        // viewport and pushed it more than twice as far.
+        val column = box(0.3f, 3f, 0.3f)
+        // Its half-height over the vertical half-FOV tangent, plus the swept radius of its own
+        // 0.3 × 0.3 footprint — the near face is that much closer to the lens. Nothing else.
+        val exact = 1.5f / tan(Math.toRadians(46.4) / 2.0).toFloat() + sqrt(2f) * 0.15f
+        val fitted = fitDistanceForBounds(column, 46.4, aspect = 0.4455, padding = 0f)
+        assertEquals("a height-bound subject must pay only its height", exact, fitted, 0.01f)
+
+        val legacy = legacySphereFit(column, 46.4, 0.4455, 0f)
+        assertTrue(
+            "the sphere fit must have been materially worse — was $legacy, now $fitted",
+            legacy > fitted * 1.8f,
+        )
+    }
+
+    @Test
+    fun aVerticallyBoundSubjectCostsTheSameOnEveryViewport() {
+        // Its width never binds, so widening the viewport must not change the distance at all.
+        val column = box(0.3f, 3f, 0.3f)
+        val distances = aspects.map { fitDistanceForBounds(column, 46.4, it, padding = 0f) }
+        distances.forEach { assertEquals(distances.first(), it, 1e-3f) }
+    }
+
+    @Test
+    fun theNewFitIsNeverFurtherThanTheOldOne() {
+        // The guarantee that lets this ship without re-tuning every caller: no scene is framed
+        // further away than it was.
+        val subjects = listOf(
+            box(1f, 1f, 1f), box(4f, 0.5f, 0.5f), box(0.3f, 3f, 0.3f),
+            box(0.5f, 0.2f, 0.9f), box(155f, 90f, 40f),
+        )
+        for (subject in subjects) for (aspect in aspects) for (elevation in listOf(0.0, 8.27, 30.0)) {
+            val fitted = fitDistanceForBounds(subject, 46.4, aspect, 0.15f, elevation)
+            val legacy = legacySphereFit(subject, 46.4, aspect, 0.15f)
+            assertTrue(
+                "$subject at aspect $aspect elevation $elevation: $fitted > $legacy",
+                fitted <= legacy + 1e-3f,
+            )
+        }
+    }
+
+    // ── Azimuth invariance, and the switch that trades it away ────────────────────────────────
+
+    @Test
+    fun theSweptFitContainsEveryAzimuthAndIsBindingOnAtLeastOne() {
+        // Nothing in the swept formula reads azimuth, so this is really a statement about the
+        // ORACLE: the fitted distance contains every yaw, and is *exactly* right on the worst one.
+        // For a 2 × 0.4 footprint the binding yaw is not 0° but the corner direction
+        // (atan(0.2 / 1.0) ≈ 11°), which is precisely why a per-pose fit would clip an
+        // auto-rotating model.
+        val plate = box(2f, 0.1f, 0.4f)
+        val d = fitDistanceForBounds(plate, 46.4, aspect = 1.0, padding = 0f)
+        for (azimuth in 0 until 360) {
+            assertTrue(
+                "clipped at azimuth $azimuth°",
+                framesEveryCorner(plate, d, 46.4, 1.0, 0.0, azimuth.toDouble()),
+            )
+        }
+        assertTrue(
+            "no azimuth binds — the fit is loose everywhere",
+            (0 until 360).any {
+                !framesEveryCorner(plate, d * 0.98f, 46.4, 1.0, 0.0, it.toDouble(), slack = 0f)
+            },
+        )
+    }
+
+    @Test
+    fun theNonInvariantFitIsTighterAndNamesItsTrade() {
+        // A static, head-on scene should not pay for a rotation it never performs.
+        val deepPlate = box(0.5f, 0.5f, 4f)
+        val swept = fitDistanceForBounds(deepPlate, 46.4, 1.0, 0f, 0.0, azimuthInvariant = true)
+        val fixed = fitDistanceForBounds(deepPlate, 46.4, 1.0, 0f, 0.0, azimuthInvariant = false)
+        assertTrue("the fixed-azimuth fit must be closer — $fixed vs $swept", fixed < swept)
+        assertTrue(framesEveryCorner(deepPlate, fixed, 46.4, 1.0, 0.0, 0.0))
+        // …and it deliberately does NOT survive a quarter turn: what was 4 m of depth becomes 4 m
+        // of width. That is the trade `azimuthInvariant = false` names, held here so nobody makes
+        // it the default.
+        assertTrue(
+            "the fixed-azimuth fit is only valid head-on",
+            !framesEveryCorner(deepPlate, fixed, 46.4, 1.0, 0.0, 90.0, slack = 0f),
+        )
+        assertTrue(framesEveryCorner(deepPlate, swept, 46.4, 1.0, 0.0, 90.0))
+    }
+
+    // ── Elevation ─────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun elevationIsHonouredAndSurvivesThePoles() {
+        val subject = box(1f, 1f, 1f)
+        for (elevation in listOf(-90.0, -89.9, 0.0, 45.0, 89.9, 90.0)) {
+            val d = fitDistanceForBounds(subject, 46.4, 0.4455, padding = 0f, elevationDegrees = elevation)
+            assertTrue("elevation $elevation produced $d", d.isFinite() && d > 0f)
+            assertTrue(
+                "clipped at elevation $elevation",
+                framesEveryCorner(subject, d, 46.4, 0.4455, elevation, 0.0),
+            )
+        }
+    }
+
+    @Test
+    fun lookDirectionIsTranslatedIntoElevation() {
+        // `frameToBounds` derives the fit's elevation from its look direction; a camera above the
+        // subject looks DOWN, so the direction's y is negative and the elevation positive.
+        assertEquals(0.0, elevationDegreesForDirection(Position(0f, 0f, -1f)), 1e-6)
+        assertEquals(90.0, elevationDegreesForDirection(Position(0f, -1f, 0f)), 1e-6)
+        assertEquals(-90.0, elevationDegreesForDirection(Position(0f, 1f, 0f)), 1e-6)
+        assertEquals(45.0, elevationDegreesForDirection(Position(0f, -1f, -1f)), 1e-4)
+        // Degenerate input falls back rather than producing NaN.
+        assertEquals(
+            DEFAULT_FRAMING_ELEVATION_DEGREES,
+            elevationDegreesForDirection(Position(0f, 0f, 0f)),
+            1e-9,
+        )
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/gesture/CameraGestureMathTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/gesture/CameraGestureMathTest.kt
@@ -50,8 +50,11 @@ class CameraGestureMathTest {
     }
 
     @Test fun pinchZoomDelta_defaultConstants_haveExpectedValues() {
-        // DEFAULT_PINCH_ZOOM_SPEED re-tuned in #1427: 1/30 → 1/18 (pinch felt "hyper lent").
-        assertEquals(1f / 18f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED, 1e-6f)
+        // #1427 re-tuned this 1/30 → 1/18 while the dolly step was still a fixed number of world
+        // units. #3426 made the step a *ratio* of the camera-to-target distance, so the constant's
+        // unit changed with it (log-distance per damped pixel) and 1/60 is the value that puts one
+        // full-screen pinch at ≈ ln 2. See RelativeZoomTest for the behaviour that pins it.
+        assertEquals(1f / 60f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED, 1e-6f)
         assertEquals(0.7f, CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_DAMPING, 1e-6f)
     }
 

--- a/sceneview/src/test/java/io/github/sceneview/gesture/RelativeZoomTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/gesture/RelativeZoomTest.kt
@@ -1,0 +1,138 @@
+package io.github.sceneview.gesture
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.abs
+import org.junit.Test
+
+/**
+ * Pins for the relative pinch-dolly (#3403 / #3426).
+ *
+ * Filament's `OrbitManipulator::scroll` translates the eye by a **fixed** `zoomSpeed · scrolldelta`
+ * world units, which is why the shipped zoom felt "hyper lent" on anything far away and punched the
+ * camera through its own orbit pivot on anything close. These tests hold the two properties that
+ * replace it: the step is a *ratio* of the current distance, and the clamps are hard.
+ */
+class RelativeZoomTest {
+
+    private val speed = CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_SPEED
+    private val damping = CameraGestureDetector.DefaultCameraManipulator.DEFAULT_PINCH_ZOOM_DAMPING
+
+    /** A pinch of [pixels] px: fingers coming together (zoom out) for a positive value. */
+    private fun pinch(distance: Float, pixels: Float, min: Float = 1e-4f, max: Float = 1e6f) =
+        zoomedDistanceForPinch(
+            distance = distance,
+            prevSeparation = 200f,
+            currSeparation = 200f - pixels,
+            minDistance = min,
+            maxDistance = max,
+        )
+
+    // ── The defect the issue names ────────────────────────────────────────────────────────────
+
+    @Test
+    fun oneFullScreenPinchAboutHalvesOrDoublesTheDistance() {
+        // The tuning target: a 200 px pinch — roughly a full-screen gesture on a phone — is one
+        // comfortable "step" of zoom. Anything less and the user pinches ten times to get
+        // anywhere, which is exactly what #3426 reports.
+        val out = pinch(distance = 5f, pixels = 200f)
+        val `in` = pinch(distance = 5f, pixels = -200f)
+        assertEquals("pinching in must roughly double the distance", 10f, out, 1.2f)
+        assertEquals("pinching out must roughly halve it", 2.5f, `in`, 0.4f)
+    }
+
+    @Test
+    fun theSameGestureCoversTheSameFractionAtEveryScale() {
+        // The property the absolute translation lacked: a 5 cm bee and a 155 m landscape must
+        // respond identically to the same fingers. Under the old model the bee teleported and the
+        // landscape did not visibly move.
+        val ratios = listOf(0.05f, 1f, 5f, 155f).map { pinch(it, 120f) / it }
+        ratios.forEach { assertEquals(ratios.first(), it, 1e-4f) }
+    }
+
+    @Test
+    fun theLegacyAbsoluteStepWasTheProblemNotTheDamping() {
+        // Documents the measured "before" so the fix is not re-tuned away. Filament moves the eye
+        // by `zoomSpeed · scrolldelta`; with the old 1/18 gain a 200 px pinch produced ~11 cm of
+        // travel, whatever the subject.
+        val legacyDelta = pinchZoomDelta(200f, 0f, speed = 1f / 18f, damping = damping)
+        val legacyMetres = legacyDelta *
+            CameraGestureDetector.DefaultCameraManipulator.DEFAULT_ORBIT_ZOOM_SPEED
+        assertEquals(0.115f, legacyMetres, 0.02f)
+        // On a scene framed at 5 m that is 40+ full pinches just to halve the distance.
+        assertTrue("the legacy step was pathologically small at 5 m", 2.5f / legacyMetres > 20f)
+    }
+
+    // ── The clamps that stop #3403's inversion ────────────────────────────────────────────────
+
+    @Test
+    fun theCameraCanNeverReachLetAloneCrossThePivot() {
+        // `OrbitManipulator::scroll` flips `mFlipped` when the eye passes the pivot, and the next
+        // orbit drag then rebuilds the view from a NEGATIVE bookmark distance — the camera ends up
+        // looking away from the subject. A hard floor is what makes that unreachable. Fingers
+        // spreading apart (separation grows) is zoom IN, so the distance shrinks to the floor.
+        var d = 3f
+        repeat(200) { d = zoomedDistanceForPinch(d, 200f, 400f, minDistance = 0.45f, maxDistance = 12f) }
+        assertEquals(0.45f, d, 1e-4f)
+        assertTrue("distance must stay strictly positive", d > 0f)
+    }
+
+    @Test
+    fun zoomingOutIsBoundedToo() {
+        // Fingers coming together is zoom OUT — the distance grows to the ceiling.
+        var d = 3f
+        repeat(200) { d = zoomedDistanceForPinch(d, 400f, 200f, minDistance = 0.45f, maxDistance = 12f) }
+        assertEquals(12f, d, 1e-4f)
+    }
+
+    @Test
+    fun aPinchAndItsExactReverseReturnToTheStartingDistance() {
+        // Exponential in the gesture ⇒ symmetric. A linear-in-metres step is not, which is part of
+        // why the old zoom drifted the framing.
+        val start = 2.5f
+        val out = zoomedDistance(start, 0.4f, 1e-4f, 1e6f)
+        val back = zoomedDistance(out, -0.4f, 1e-4f, 1e6f)
+        assertEquals(start, back, 1e-3f)
+    }
+
+    @Test
+    fun degenerateInputsCannotProduceANaNCamera() {
+        assertEquals(0.5f, zoomedDistance(Float.NaN, 0.2f, 0.5f, 10f), 1e-6f)
+        assertEquals(0.5f, zoomedDistance(0f, 0.2f, 0.5f, 10f), 1e-6f)
+        assertEquals(2f, zoomedDistance(2f, Float.NaN, 0.5f, 10f), 1e-6f)
+        assertTrue(zoomedDistance(2f, 1e9f, 0.5f, 10f).isFinite())
+        assertTrue(zoomedDistance(2f, -1e9f, 0.5f, 10f).isFinite())
+        // A nonsensical range must still yield a usable distance rather than NaN.
+        assertTrue(zoomedDistance(2f, 0.1f, minDistance = -1f, maxDistance = -5f).isFinite())
+    }
+
+    // ── Round-tripping through Filament's absolute scroll unit ────────────────────────────────
+
+    @Test
+    fun theScrollDeltaHandedToFilamentLandsOnTheRequestedDistance() {
+        // `scroll` moves the eye by `zoomSpeed · scrolldelta` along the gaze, so the distance
+        // changes by exactly that. Inverting it must be exact, whatever the zoomSpeed.
+        for (zoomSpeed in listOf(0.01f, 0.05f, 0.5f)) {
+            for (from in listOf(0.2f, 3f, 90f)) {
+                val to = from * 0.7f
+                val delta = dollyScrollDelta(from, to, zoomSpeed)
+                assertEquals(to, from + delta * zoomSpeed, abs(to) * 1e-4f)
+            }
+        }
+    }
+
+    @Test
+    fun anUnusableZoomSpeedYieldsNoMovementRatherThanInfinity() {
+        assertEquals(0f, dollyScrollDelta(3f, 1f, 0f), 0f)
+        assertEquals(0f, dollyScrollDelta(3f, 1f, Float.NaN), 0f)
+    }
+
+    // ── The gain constant itself ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun thePinchGainMatchesItsDocumentedTarget() {
+        // `DEFAULT_PINCH_ZOOM_SPEED` is documented as "one 200 px pinch ≈ ln 2". Assert the doc.
+        val delta = pinchZoomDelta(200f, 0f, speed, damping)
+        assertEquals(kotlin.math.ln(2.0).toFloat(), delta, 0.12f)
+    }
+}


### PR DESCRIPTION
Three issues, one theme: the camera was told the wrong thing about the subject in front of it.

## #3426 — the auto-fit framed a bounding sphere, not the subject

`fitDistanceForBounds` charged every scene for half its AABB's **space diagonal**, then billed each
field-of-view axis the *other* axis's distance:

```kotlin
val radius = 0.5f * sqrt(ex*ex + ey*ey + ez*ez)     // half the space diagonal
max(radius / sin(halfVfov), radius / sin(halfHfov)) // each axis pays the worse one
```

On a portrait viewport the horizontal FOV is the narrow one, so a subject bound purely by its
**height** was pushed back by a **width** constraint it never hits — the viewport could not be
filled. This is the same defect PR #3395 fixed on iOS (#3383), which flagged this file by name as
the Android counterpart.

The fit is now **per FOV axis**, in closed form. A point `v` is inside the frustum at distance `d`
iff `d >= v·back + |v·axis| / tanAxis` on both axes; maximising that over the subject is a support
function evaluated at `w = back ± axis / tanAxis`. Azimuth invariance is kept deliberately — an
auto-rotating model must not clip when it turns broadside — by framing the box's **sweep about
world Y** rather than the box, which is fitted *exactly*, not bounded. A new `azimuthInvariant =
false` opts a static head-on scene out of paying for a rotation it never performs.

The new distance is **never larger** than the old one (asserted over 5 subjects × 3 aspects × 3
elevations), and up to 2× smaller for tall or compact subjects.

## #3403 — the zoom broke the camera

Two independent causes, both traced to Filament 1.72.1's `OrbitManipulator::scroll`, read from
source rather than guessed:

```cpp
const vec3 movement = gaze * Base::mProps.zoomSpeed * -scrolldelta;
Base::mEye += movement;  Base::mTarget += movement;
if (dot(v0, v1) < 0) { mFlipped = !mFlipped; }   // eye crossed the pivot
```

1. **The step is absolute.** With the shipped `zoomSpeed = 0.05` and the `1/18` gain, a full-screen
   200 px pinch moved the camera **~11 cm** whatever the scale — forty-plus gestures to halve a 5 m
   framing, which is #3426's "beaucoup de gestes pour peu de zoom", and a teleport on a 5 cm model.
2. **It can cross the orbit pivot.** When it does, Filament sets `mFlipped`, `getCurrentBookmark()`
   then reports a **negative** distance, and the next orbit drag's `jumpToBookmark` re-plants the
   target *behind* the eye — the camera ends up looking away from the model. That is the "camera
   completely broken" in the report.

Zoom is now a **ratio** of the current camera-to-target distance (`d · exp(pinchDelta)`), clamped
either side of the framed distance, so one pinch is one comfortable step at any scale and the eye
can never reach — let alone cross — its own pivot. The orbit radius is tracked in Kotlin because
`Manipulator.getLookAt` stops reporting it after the first drag (`jumpToBookmark` re-plants the
target exactly one unit ahead of the eye); it only ever changes via `scroll`, so seeding it once and
updating it by the step we request keeps it exact.

The **second half of #3403** was demo-side: the Model Viewer's zoom slider was a `remember` key on
the camera manipulator, and a Filament manipulator carries the whole camera pose — so every slider
step also threw away the orbit the user had just dragged to.

## #3404 — toggling the animation moved the camera

Same root cause as the slider, reached by a different route. The manipulator was keyed on `framing`,
which is keyed on `topInset = LocalDemoChromeTopInset.current`. Opening the animation bar forces the
scaffold chrome visible (`visible = chromeVisible || bottomOverlay != null`), which is when the
identity row is first *measured* — so the inset changes, the framing changes, the manipulator is
rebuilt, and the camera snaps back to the front view. A control that must not touch the camera at
all, giving a visible "décroché".

The manipulator is now keyed on the **content alone** and reads framing, pivot and zoom live through
providers (the shape `HeroOrbitCameraManipulator` already proved), handing off to a stock
`DefaultCameraManipulator` on first touch. Nothing about the chrome, the insets or the zoom can
reset the camera any more.

Two things fall out for free: the pinch and the "Camera distance" slider now drive the **same
number**, so a two-finger zoom moves the slider and vice versa; and that slider's range follows the
model's own fitted distance instead of a fixed `0.5–10 m`, which was meaningless for a model that
fits at 0.4 m or at 90 m.

## Demos re-framed

The audit found that **only three** places in the app did real framing maths, and that every other
non-AR sample carried an eyeballed literal with no aspect awareness at all. `fitOrbitRadius` /
`rememberFitOrbitRadius` is now the one place that answers "how far back"; the per-demo constants
that survive describe the *content*.

| Demo | Before | After |
|---|---|---|
| Model Viewer · Gallery | flat `radius = 1.6f` for slugs normalised 0.20–0.85 | fitted per chip |
| Lighting Lab · sky section | no manipulator ⇒ library's stock 2.78 m | fitted to its 0.5-unit helmet |
| Secondary Camera · main view | no manipulator ⇒ 2.78 m | fitted to its 0.5-unit helmet |

**Deliberately not changed, and why.** Materials, Video Recording, Lines & Paths, Custom Geometry's
atom section and 2D-in-3D's image wall are all framed *too close* — their content overflows a
portrait frame. Fitting them honestly means moving the camera **back**, making the subject smaller,
which is the opposite of what #3426 reports. Their real fix is content-side (the authored layouts
are wider than a portrait viewport can hold) and wants its own issue rather than a silent shrink
here.

## Verified

### Unit tests, run locally after the rebase, all green

- `:sceneview:testDebugUnitTest` — **655 tests**. New `ProjectedBoundsFitTest` validates the fit
  against an **independent frustum oracle** (eight corners, both FOV planes, its own camera basis),
  not against the implementation: containment at 24 azimuths × 3 aspects × 3 elevations × 4
  subjects, tightness (shrinking 2 % must clip *somewhere* on the turntable), the #3426 headline
  (a height-bound column pays only its height), and "never further than the old sphere fit". New
  `RelativeZoomTest` pins the ratio property, the clamps, symmetry, and round-tripping through
  Filament's absolute scroll unit. Three existing tests that pinned the *old* sphere behaviour were
  rewritten, not deleted — each one now states the property that replaces it.
- `:samples:android-demo:testDebugUnitTest` — green, including a new `DemoOrbitFramingTest` that
  pins the property the literals could not hold (a 5 cm subject and a 155 m one land on the same
  fraction of the frame).
- `:sceneview:apiCheck` — green against the refreshed dump.
- `:sceneview-core` has no JVM test target (`jsTest` only) and is untouched by this change.

### On-device captures — framing (#3426)

Emulator, Pixel-class portrait. The baseline APK is built from `main` **after #3435 landed**, so
the comparison is against the current Model Viewer, not the pre-#3435 one.

- **Model Viewer, first frame.** On `main` the helmet is **clipped on both sides** — it overflows
  the viewport horizontally, which is the bounding-sphere fit charging the wrong axis and then
  losing to a portrait aspect. With this branch the same helmet is fully contained and centred,
  filling roughly half the frame height with even margins. This is the headline frame of the fix.
- **Lighting Lab (sky section)**, **Secondary Camera (main view)** and **Fog** all open with the
  subject centred and framed on the first frame.
- **Geometry Primitives**, captured as an untouched control, is visually identical before and
  after — the shared helper did not disturb a demo that already framed itself.

### One audit finding reverted after looking at the captures

Camera & Gestures' node-editing scene was re-framed in an earlier commit on the premise that
`rememberCameraManipulator()` with no argument inherits the library's stock 2.78 m pose. **It does
not** — 2.78 m belongs to `DefaultCameraNode`, used when a scene has no manipulator at all; a
no-argument manipulator gets Filament's own `orbitHomePosition`, about a metre out, which already
framed that 0.3-unit helmet close to full width. Fitting the axes gizmo on top of it moved the
camera back to ~2.4 m and left the helmet a quarter of its former size — the opposite of what
#3426 asks for, in the one section where an undersized touch target is least affordable. The
capture showed it plainly and that section is back to its original framing (215d5be). The other
three re-framings were checked the same way and kept.

### Not captured on device — please treat as unverified

The **gesture** halves of #3403 and #3404 — dragging the "Camera distance" slider and then
orbiting, and toggling the animation bar — have **not** been reproduced on device against this
branch. The shared emulator was unavailable through several consecutive protocol waits and the
one window that opened was long enough for the framing frame above and no more.

What does back them up: `RelativeZoomTest` pins at the maths level that the zoom step is a ratio
of the current distance and that the eye can therefore never reach — let alone cross — its own
pivot, which is the mechanism behind the broken camera in #3403; and the `remember` keys that
caused both resets are gone by inspection, the manipulator now being keyed on the content alone.

One earlier attempt is worth naming so nobody repeats it: driving zoom through the
`?cameraDistance=` deep link is **not** valid evidence for #3403. That route drives the same
override path in both builds and never touches the pinch or the slider, so the before and after
frames come out identical whether the bug is present or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3403
Fixes #3404
Fixes #3426

