### PR TITLE
fix(demo): make the Model Viewer's arrival and its dock legible (#3402, #3406)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -285,12 +285,15 @@ M3 Expressive shape scale — corner radius communicates component weight and pr
 
 ### App Motion (Android demo)
 
-One spring, one fade — nothing else animates in the demo chrome.
+One spring and one fade for the chrome; one shared-axis spec for screen changes and
+one fly-in for a 3D subject's arrival. Nothing else animates.
 
 | Token | Value | Usage |
 |---|---|---|
-| `motion-spring` | `spring(dampingRatio = 0.85, stiffness = 450)` | Press scale (0.97–0.98), sheet open/close, dock show/hide |
-| `motion-fade` | `tween(300ms, FastOutSlowIn)` | Every opacity change — chrome toggle, menus, preview crossfade |
+| `motion-spring` | `spring(dampingRatio = 0.85, stiffness = 450)` | Press scale (0.97–0.98), sheet open/close, dock show/hide, panel expand |
+| `motion-fade` | `tween(300ms, FastOutSlowIn)` | Every opacity change — chrome toggle, menus, loading-cover crossfade |
+| `motion-screen` | `tween(350ms, ease-expressive)` | Screen transitions — Material shared-axis X, both screens travelling ⅙ of the viewport while they cross-fade |
+| `motion-entrance` | `tween(700ms, ease-expressive)` | The camera fly-in when a 3D scene's subject arrives — once per screen, cancelled by the first touch |
 
 ---
 
@@ -358,13 +361,23 @@ themed surface — so it is theme-independent and uses the "Button glass" row.
 |---|---|
 | `dock-height` | 64dp |
 | `dock-radius` | `radius-full` |
-| `dock-item` | 48dp square touch target |
+| `dock-item` | 48dp minimum touch target; icon over caption |
 | `dock-icon` | 22dp |
+| `dock-caption` | `type-caption`, 2dp under the icon, one line, never truncated |
 | `dock-items` | at most 4 items + 1 optional accent (primary-tinted) item |
 
 The dock replaces FABs and top app bars in demo screens; its Controls item opens the
 settings sheet. Show/hide uses `motion-spring`; tap on the scene toggles the chrome
 with `motion-fade`.
+
+- **Every dock item is labelled.** An icon-only dock makes the user decode glyphs, and
+  two actions in the same row can legitimately want the same picture — the viewer had
+  an outlined cube for "Models" beside a filled cube for "View in AR". The caption is
+  one word (`Models`, `Lighting`, `Animate`, `Recenter`, `Settings`, `AR`); if an
+  action needs more than one word to be understood, the wrong action is in the dock.
+  Icon and caption share a colour, so a selected toggle reads as one unit.
+- **The caption is not the accessible name.** The content description stays the full
+  phrase ("Demo settings"); only the visible caption is shortened ("Settings").
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -373,9 +373,12 @@ with `motion-fade`.
 - **Every dock item is labelled.** An icon-only dock makes the user decode glyphs, and
   two actions in the same row can legitimately want the same picture — the viewer had
   an outlined cube for "Models" beside a filled cube for "View in AR". The caption is
-  one word (`Models`, `Lighting`, `Animate`, `Recenter`, `Settings`, `AR`); if an
-  action needs more than one word to be understood, the wrong action is in the dock.
-  Icon and caption share a colour, so a selected toggle reads as one unit.
+  one word (`Models`, `Lighting`, `Animate`, `Recenter`, `Settings`); if an action
+  needs more than one word to be understood, the wrong action is in the dock. Icon and
+  caption share a colour, so a selected toggle reads as one unit.
+- **The accent is the exception.** It is a 48dp filled, primary-tinted button and stays
+  icon-only — a caption would not fit `dock-height`, and its treatment already sets it
+  apart from the labelled items the way a FAB is set apart from a navigation bar.
 - **The caption is not the accessible name.** The content description stays the full
   phrase ("Demo settings"); only the visible caption is shortened ("Settings").
 

--- a/changelog.d/3402-model-viewer-ux.md
+++ b/changelog.d/3402-model-viewer-ux.md
@@ -1,0 +1,5 @@
+<!-- category: Changed -->
+Model Viewer demo: the launch cover is a real loading state instead of the demo's
+preview image (no more wrong-picture flash), the dock items carry labels and clearer
+icons, the default environment is the punchy Sunset HDR, and the model now arrives on
+a short Material-standard camera dolly-in.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -875,3 +875,134 @@ internal fun clampOrbitEyePitch(
         z = target.z + hz * newHorizontal,
     )
 }
+
+/**
+ * A [io.github.sceneview.gesture.CameraGestureDetector.CameraManipulator] that flies
+ * the camera **in** to its resting pose when the model arrives, then behaves exactly
+ * like the stock `DefaultCameraManipulator` (#3406).
+ *
+ * At `progress() == 0` the eye sits [startDistanceScale]× further from [target], swung
+ * [startYawDegrees] around world +Y and lifted by [startLiftFraction] of the orbit
+ * radius; at `progress() == 1` it is exactly [eye]. The caller animates that progress —
+ * one `tween(duration, ease-expressive)` is the whole effect — so the model is not
+ * merely displayed, it is arrived at. The model itself never moves, which is what keeps
+ * lights and reflections landing on the surfaces the resting frame will show.
+ *
+ * The first touch hands off to a stock manipulator seeded with the eye the flight had
+ * reached, so interrupting the entrance is seamless rather than a snap — the same
+ * hand-off [HeroOrbitCameraManipulator] does, for the same reason. There is no resume:
+ * once the user has taken the camera it is theirs, and replaying a fly-in under their
+ * fingers would be a bug, not a flourish.
+ *
+ * In [DemoSettings.qaMode] the caller pins progress at `1f`: a screenshot taken
+ * mid-flight is a different framing every run.
+ */
+class EntranceCameraManipulator(
+    private val eye: Position,
+    private val target: Position,
+    private val progress: () -> Float,
+    private val startDistanceScale: Float = 1.55f,
+    private val startYawDegrees: Float = 24f,
+    private val startLiftFraction: Float = 0.22f,
+) : io.github.sceneview.gesture.CameraGestureDetector.CameraManipulator {
+    private var fallback: io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator? =
+        null
+    private var viewportW = 1
+    private var viewportH = 1
+
+    /** Eye position for the current [progress] — [eye] itself once the flight is over. */
+    private fun currentEye(): Position {
+        val p = progress().coerceIn(0f, 1f)
+        if (p >= 1f) return eye
+        val remaining = 1f - p
+        val dx = eye.x - target.x
+        val dy = eye.y - target.y
+        val dz = eye.z - target.z
+        val radius = sqrt(dx * dx + dy * dy + dz * dz)
+        // Degenerate framing: nothing to fly along, sit at the resting pose.
+        if (!radius.isFinite() || radius <= 1e-6f) return eye
+        // Swing the offset around world +Y, push it out along itself, and lift it.
+        val yaw = Math.toRadians((startYawDegrees * remaining).toDouble()).toFloat()
+        val c = cos(yaw)
+        val s = sin(yaw)
+        val scale = 1f + (startDistanceScale - 1f) * remaining
+        val lift = radius * startLiftFraction * remaining
+        return Position(
+            x = target.x + (dx * c + dz * s) * scale,
+            y = target.y + (dy + lift) * scale,
+            z = target.z + (dz * c - dx * s) * scale,
+        )
+    }
+
+    private fun flightTransform(): io.github.sceneview.math.Transform =
+        io.github.sceneview.math.Transform(
+            dev.romainguy.kotlin.math.lookAt(
+                eye = currentEye(),
+                target = target,
+                up = dev.romainguy.kotlin.math.Float3(0f, 1f, 0f),
+            )
+        )
+
+    private fun ensureFallback() {
+        if (fallback == null) {
+            fallback = io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator(
+                eyePosition = currentEye(),
+                targetPosition = target,
+            ).also { it.setViewport(viewportW, viewportH) }
+        }
+    }
+
+    override fun setViewport(width: Int, height: Int) {
+        viewportW = width.coerceAtLeast(1)
+        viewportH = height.coerceAtLeast(1)
+        fallback?.setViewport(viewportW, viewportH)
+    }
+
+    override fun getTransform(): io.github.sceneview.math.Transform {
+        val fb = fallback ?: return flightTransform()
+        // Same polar clamp as the hero orbit (#2487): the stock manipulator lets a drag
+        // carry the eye onto the orbit pole, where `lookAt`'s fixed world-up collapses
+        // and the model flips upside-down.
+        val transform = fb.getTransform()
+        val eyeNow = transform.position
+        val clampedEye = clampOrbitEyePitch(eyeNow, target)
+        if (clampedEye == eyeNow) return transform
+        return io.github.sceneview.math.Transform(
+            dev.romainguy.kotlin.math.lookAt(
+                eye = clampedEye,
+                target = target,
+                up = dev.romainguy.kotlin.math.Float3(0f, 1f, 0f),
+            )
+        )
+    }
+
+    override fun grabBegin(x: Int, y: Int, strafe: Boolean) {
+        ensureFallback()
+        fallback?.grabBegin(x, y, strafe)
+    }
+
+    override fun grabUpdate(x: Int, y: Int) {
+        fallback?.grabUpdate(x, y)
+    }
+
+    override fun grabEnd() {
+        fallback?.grabEnd()
+    }
+
+    override fun scrollBegin(x: Int, y: Int, separation: Float) {
+        ensureFallback()
+        fallback?.scrollBegin(x, y, separation)
+    }
+
+    override fun scrollUpdate(x: Int, y: Int, prevSeparation: Float, currSeparation: Float) {
+        fallback?.scrollUpdate(x, y, prevSeparation, currSeparation)
+    }
+
+    override fun scrollEnd() {
+        fallback?.scrollEnd()
+    }
+
+    override fun update(deltaTime: Float) {
+        fallback?.update(deltaTime)
+    }
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -32,11 +31,13 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -56,7 +57,6 @@ import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -70,6 +70,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -85,20 +86,19 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -137,10 +137,19 @@ enum class AssetSourceState { Streamed, Streaming, Bundled }
 /**
  * One item of the [DemoScaffold] bottom dock.
  *
- * Rendered as a 48 dp icon button inside the floating toolbar; [label] is its
- * content description. [selected] tints the icon with the theme primary so a
- * toggle (wireframe on, grid on) reads as active. At most four items are shown
- * before the auto-appended Controls item and the optional accent.
+ * Rendered inside the floating toolbar as an icon over a visible [caption], on a
+ * 48 dp-minimum touch target; [label] is its content description. [selected] tints
+ * icon and caption with the theme primary so a toggle (wireframe on, grid on) reads
+ * as active. At most four items are shown before the auto-appended Controls item and
+ * the optional accent.
+ *
+ * **Why the caption (#3402).** Icon-only docks force the user to decode glyphs: the
+ * viewer's Recenter reticle read as a zoom control, and "Models" and "View in AR"
+ * were the same cube twice — once outlined, once filled. A one-word caption under
+ * each icon is the M3 navigation-bar idiom and `DESIGN.md` already reserves
+ * `type-caption` for "dock labels". [caption] defaults to [label] so a call site
+ * only overrides it when the accessible name is longer than the visible one
+ * ("Demo settings" → "Settings").
  */
 data class DockItem(
     val icon: ImageVector,
@@ -148,6 +157,7 @@ data class DockItem(
     val onClick: () -> Unit,
     val enabled: Boolean = true,
     val selected: Boolean = false,
+    val caption: String = label,
 )
 
 /**
@@ -182,12 +192,13 @@ data class DockItem(
  * that taps the viewport and then asserts on the chrome keeps working.
  *
  * **Loading**: `firstFrameRendered != null` covers the viewport until the
- * first Filament frame is presented (#1022) — with the demo's [previewRes]
- * image when given, else a surface-tinted scrim — and crossfades it out over
- * 350 ms. After 12 s without a frame the cover gives way to an explicit
- * "Still loading…" card with a Retry action ([onReset]) instead of a blank
- * viewport. AR demos pass `null` on purpose: their viewport is the live camera
- * feed (#1361).
+ * first Filament frame is presented (#1022) — the stage colour, a progress
+ * indicator and the optional [loadingLabel] — and crossfades it out over
+ * 350 ms. It never shows the demo's preview image: that flashed a picture
+ * framed and lit unlike the scene about to replace it (#3402). After 12 s
+ * without a frame the cover gives way to an explicit "Still loading…" card
+ * with a Retry action ([onReset]) instead of a blank viewport. AR demos pass
+ * `null` on purpose: their viewport is the live camera feed (#1361).
  *
  * **Settings sheet** (the single settings surface, #3328): a [ModalBottomSheet]
  * on the theme's `surfaceContainer` with a 28 dp top radius, opened from the
@@ -231,7 +242,7 @@ fun DemoScaffold(
     bottomOverlayReservesScene: Boolean = false,
     dock: List<DockItem> = emptyList(),
     dockAccent: DockItem? = null,
-    previewRes: Int? = null,
+    loadingLabel: String? = null,
     chromeToggleOnTap: Boolean = false,
     scene: @Composable BoxScope.() -> Unit
 ) {
@@ -354,7 +365,7 @@ fun DemoScaffold(
             if (firstFrameRendered != null) {
                 FirstFrameCover(
                     firstFrameRendered = firstFrameRendered,
-                    previewRes = previewRes,
+                    loadingLabel = loadingLabel,
                     onRetry = onReset,
                 )
             }
@@ -448,11 +459,15 @@ fun DemoScaffold(
                 dockAccent = dockAccent,
                 controlsItem = DockItem(
                     icon = Icons.Outlined.Tune,
+                    // The content description stays "Demo settings" verbatim —
+                    // `DemoInteractionTest` and the band tests key on it. Only the
+                    // visible caption is shortened, so the dock stays one word wide.
                     label = stringResource(R.string.demo_settings_fab_cd),
                     onClick = {
                         haptic.selection()
                         settingsExpanded = true
                     },
+                    caption = stringResource(R.string.demo_settings_title),
                 ),
                 onIdentityRowHeight = { identityRowPx = maxOf(identityRowPx, it) },
                 onDockBandHeight = { dockBandPx = maxOf(dockBandPx, it) },
@@ -662,10 +677,12 @@ private fun BoxScope.DemoIdentityRow(
 }
 
 /**
- * Bottom dock: a glass [HorizontalFloatingToolbar] with 48 dp items, 22 dp icons,
- * and the optional accent as a filled primary button. The dock's shown height
- * (toolbar + gutter, after the navigation-bar inset) is reported so the bottom
- * overlay slot can stack above it.
+ * Bottom dock: a glass [HorizontalFloatingToolbar] whose items are an icon over a
+ * caption on a 48 dp-minimum touch target, and the optional accent as a filled
+ * primary button carrying its own caption. The dock's shown height (toolbar +
+ * gutter, after the navigation-bar inset) is reported so the bottom overlay slot
+ * can stack above it — measured, never assumed, which is why growing the dock for
+ * the captions (#3402) does not move a single call site.
  */
 @Composable
 private fun BoxScope.DemoDock(
@@ -697,21 +714,34 @@ private fun BoxScope.DemoDock(
             shape = RoundedCornerShape(SceneViewTokens.Radius.full),
             trailingContent = if (accent != null) {
                 {
-                    FilledIconButton(
-                        onClick = accent.onClick,
-                        enabled = accent.enabled,
-                        modifier = Modifier
-                            .size(SceneViewTokens.Layout.touchTarget)
-                            .testTag(DemoScaffoldTestTags.DOCK_ACCENT),
-                        colors = IconButtonDefaults.filledIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                        ),
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center,
                     ) {
-                        Icon(
-                            imageVector = accent.icon,
-                            contentDescription = accent.label,
-                            modifier = Modifier.size(SceneViewTokens.Layout.dockIconSize),
+                        FilledIconButton(
+                            onClick = accent.onClick,
+                            enabled = accent.enabled,
+                            modifier = Modifier
+                                .size(SceneViewTokens.Layout.touchTarget)
+                                .testTag(DemoScaffoldTestTags.DOCK_ACCENT),
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                            ),
+                        ) {
+                            Icon(
+                                imageVector = accent.icon,
+                                contentDescription = accent.label,
+                                modifier = Modifier.size(SceneViewTokens.Layout.dockIconSize),
+                            )
+                        }
+                        DockCaption(
+                            text = accent.caption,
+                            color = if (accent.enabled) {
+                                SceneViewTokens.Glass.onGlass
+                            } else {
+                                SceneViewTokens.Glass.onGlass.copy(alpha = DOCK_DISABLED_ALPHA)
+                            },
                         )
                     }
                 }
@@ -729,6 +759,13 @@ private fun BoxScope.DemoDock(
     }
 }
 
+/**
+ * One dock item: the icon over its [DockItem.caption], both in the same colour so a
+ * selected toggle reads as one unit. The touch target stays at least
+ * [SceneViewTokens.Layout.touchTarget] wide and tall; a caption wider than that grows
+ * the item rather than being ellipsised — a truncated label is worse than the icon
+ * alone, which is the defect this replaced (#3402).
+ */
 @Composable
 private fun DockIconButton(item: DockItem, modifier: Modifier = Modifier) {
     val interaction = remember { MutableInteractionSource() }
@@ -738,37 +775,69 @@ private fun DockIconButton(item: DockItem, modifier: Modifier = Modifier) {
         animationSpec = SceneViewTokens.Motion.spring(),
         label = "dock-press",
     )
-    IconButton(
-        onClick = item.onClick,
-        enabled = item.enabled,
-        interactionSource = interaction,
+    val contentColor = when {
+        !item.enabled -> SceneViewTokens.Glass.onGlass.copy(alpha = DOCK_DISABLED_ALPHA)
+        item.selected -> MaterialTheme.colorScheme.primary
+        else -> SceneViewTokens.Glass.onGlass
+    }
+    Column(
         modifier = modifier
-            .size(SceneViewTokens.Layout.touchTarget)
+            .widthIn(min = SceneViewTokens.Layout.touchTarget)
+            .heightIn(min = SceneViewTokens.Layout.touchTarget)
+            .clip(RoundedCornerShape(SceneViewTokens.Radius.md))
+            .clickable(
+                interactionSource = interaction,
+                indication = ripple(),
+                enabled = item.enabled,
+                onClick = item.onClick,
+            )
             .graphicsLayer { scaleX = scale; scaleY = scale }
-            .semantics { contentDescription = item.label },
-        colors = IconButtonDefaults.iconButtonColors(
-            contentColor = if (item.selected) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                SceneViewTokens.Glass.onGlass
-            },
-            disabledContentColor = SceneViewTokens.Glass.onGlass.copy(alpha = 0.38f),
-        ),
+            .padding(horizontal = SceneViewTokens.Space.xs)
+            .semantics(mergeDescendants = true) { contentDescription = item.label },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
         Icon(
             imageVector = item.icon,
             contentDescription = null,
+            tint = contentColor,
             modifier = Modifier.size(SceneViewTokens.Layout.dockIconSize),
         )
+        DockCaption(text = item.caption, color = contentColor)
     }
 }
 
+/** The one-word label under a dock icon — `DESIGN.md` `type-caption`, never wrapped. */
+@Composable
+private fun DockCaption(text: String, color: Color) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = color,
+        maxLines = 1,
+        softWrap = false,
+        modifier = Modifier.padding(top = DOCK_CAPTION_GAP),
+    )
+}
+
+/** Content alpha of a disabled dock item (M3 `disabled` opacity). */
+private const val DOCK_DISABLED_ALPHA = 0.38f
+
+/** Gap between a dock icon and its caption. */
+private val DOCK_CAPTION_GAP = 2.dp
+
 /**
  * Covers the 3D viewport until the SceneView presents its first Filament frame
- * (#1022): the demo's [previewRes] image when it has one — the same image the
- * home card shows, so the transition reads as the card coming alive — else a
- * surface-tinted scrim with a progress indicator. Cross-fades out over
- * `duration-medium` (350 ms) once [firstFrameRendered] flips, never the reverse.
+ * (#1022): the stage colour, a progress indicator and the demo's own
+ * [loadingLabel]. Cross-fades out over `duration-medium` (350 ms) once
+ * [firstFrameRendered] flips, never the reverse.
+ *
+ * **This used to be the demo's preview image (#3402).** Full-bleed, cropped, and
+ * lit nothing like the live scene — so opening the Model Viewer flashed a
+ * white-field studio photo of a helmet, then cut to a dark stage showing a
+ * differently framed model. Two pictures of the same demo, neither of them the
+ * one the user asked for. An honest loading state says "loading" instead of
+ * guessing at the frame that has not been rendered yet.
  *
  * After [FIRST_FRAME_SCRIM_TIMEOUT_MS] without a frame the cover fades and an
  * explicit "Still loading…" card takes its place, with Retry wired to the
@@ -777,7 +846,7 @@ private fun DockIconButton(item: DockItem, modifier: Modifier = Modifier) {
 @Composable
 private fun BoxScope.FirstFrameCover(
     firstFrameRendered: androidx.compose.runtime.State<Boolean>,
-    previewRes: Int?,
+    loadingLabel: String?,
     onRetry: (() -> Unit)?,
 ) {
     var timedOut by remember { mutableStateOf(false) }
@@ -809,19 +878,24 @@ private fun BoxScope.FirstFrameCover(
                 .testTag(DemoScaffoldTestTags.FIRST_FRAME_SCRIM),
             contentAlignment = Alignment.Center,
         ) {
-            if (previewRes != null) {
-                Image(
-                    painter = painterResource(previewRes),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            } else {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.md),
+            ) {
                 androidx.compose.material3.CircularProgressIndicator(
                     modifier = Modifier.size(SceneViewTokens.Space.xl + SceneViewTokens.Space.sm),
                     color = MaterialTheme.colorScheme.primary,
                     strokeWidth = SceneViewTokens.Space.xs,
                 )
+                if (loadingLabel != null) {
+                    Text(
+                        text = loadingLabel,
+                        style = MaterialTheme.typography.labelLarge,
+                        // The cover is the stage colour in both themes, so its text is
+                        // the glass content colour, not an `onSurface` role.
+                        color = SceneViewTokens.Glass.onGlassMuted,
+                    )
+                }
             }
         }
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoScaffold.kt
@@ -712,36 +712,28 @@ private fun BoxScope.DemoDock(
                 toolbarContentColor = SceneViewTokens.Glass.onGlass,
             ),
             shape = RoundedCornerShape(SceneViewTokens.Radius.full),
+            // The accent stays icon-only: it is a 48 dp filled button, and a caption under
+            // it needs 66 dp in a 64 dp toolbar — it was silently clipped. Its filled,
+            // primary-tinted treatment is what distinguishes it from the labelled items,
+            // the way a FAB is distinguished from a navigation bar; the accessible name
+            // ("View in AR") carries the wording.
             trailingContent = if (accent != null) {
                 {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
+                    FilledIconButton(
+                        onClick = accent.onClick,
+                        enabled = accent.enabled,
+                        modifier = Modifier
+                            .size(SceneViewTokens.Layout.touchTarget)
+                            .testTag(DemoScaffoldTestTags.DOCK_ACCENT),
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
                     ) {
-                        FilledIconButton(
-                            onClick = accent.onClick,
-                            enabled = accent.enabled,
-                            modifier = Modifier
-                                .size(SceneViewTokens.Layout.touchTarget)
-                                .testTag(DemoScaffoldTestTags.DOCK_ACCENT),
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                            ),
-                        ) {
-                            Icon(
-                                imageVector = accent.icon,
-                                contentDescription = accent.label,
-                                modifier = Modifier.size(SceneViewTokens.Layout.dockIconSize),
-                            )
-                        }
-                        DockCaption(
-                            text = accent.caption,
-                            color = if (accent.enabled) {
-                                SceneViewTokens.Glass.onGlass
-                            } else {
-                                SceneViewTokens.Glass.onGlass.copy(alpha = DOCK_DISABLED_ALPHA)
-                            },
+                        Icon(
+                            imageVector = accent.icon,
+                            contentDescription = accent.label,
+                            modifier = Modifier.size(SceneViewTokens.Layout.dockIconSize),
                         )
                     }
                 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import io.github.sceneview.demo.fragments.GeneratedDemos
 import io.github.sceneview.demo.theme.SceneViewDemoTheme
+import io.github.sceneview.demo.theme.SceneViewTokens
 import io.github.sceneview.demo.ui.RootScreen
 import io.github.sceneview.sample.common.update.InAppUpdateManager
 import io.github.sceneview.sample.common.update.UpdateBanner
@@ -281,10 +282,16 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
         NavHost(
             navController = navController,
             startDestination = if (initialDemo != null) "demo/$initialDemo" else "list",
-            enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
-            exitTransition = { slideOutHorizontally(targetOffsetX = { -it / 4 }) + fadeOut() },
-            popEnterTransition = { slideInHorizontally(initialOffsetX = { -it / 4 }) + fadeIn() },
-            popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() }
+            // Material shared-axis X (#3406): both screens move a short distance in the
+            // same direction while they cross-fade, on `duration-medium` /
+            // `ease-expressive` from DESIGN.md. The full-window slide this replaced was
+            // an iOS-style push — the incoming screen travelled a whole viewport on
+            // Compose's default spring, which on a demo that then has to load a model
+            // read as two separate waits stacked on each other.
+            enterTransition = { slideInHorizontally(navMotion()) { it / NAV_SLIDE_FRACTION } + fadeIn(navMotion()) },
+            exitTransition = { slideOutHorizontally(navMotion()) { -it / NAV_SLIDE_FRACTION } + fadeOut(navMotion()) },
+            popEnterTransition = { slideInHorizontally(navMotion()) { -it / NAV_SLIDE_FRACTION } + fadeIn(navMotion()) },
+            popExitTransition = { slideOutHorizontally(navMotion()) { it / NAV_SLIDE_FRACTION } + fadeOut(navMotion()) }
         ) {
             composable("list") {
                 // Three-tab root (Showcase / AR View / About). Demo deep links
@@ -445,6 +452,19 @@ fun DemoRouter(id: String, onBack: () -> Unit) {
         PlaceholderDemo(id = id, onBack = onBack)
     }
 }
+
+/**
+ * Fraction of the viewport a screen travels during a navigation transition — a
+ * sixth, the short shared-axis distance, not the full-window push (#3406).
+ */
+private const val NAV_SLIDE_FRACTION = 6
+
+/** The one spec every navigation slide and fade shares: `duration-medium`, `ease-expressive`. */
+private fun <T> navMotion(): androidx.compose.animation.core.FiniteAnimationSpec<T> =
+    androidx.compose.animation.core.tween(
+        durationMillis = SceneViewTokens.Duration.mediumMillis,
+        easing = SceneViewTokens.Ease.expressive,
+    )
 
 @Composable
 fun PlaceholderDemo(id: String, onBack: () -> Unit) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -572,7 +572,7 @@ private fun SingleModelSection(
         }} else null,
         dockAccent = DockItem(Icons.Filled.ViewInAr, "View in AR", {
             DemoSettings.requestedRoute = "demo/ar-placement?model=${selectedModel.assetPath}"
-        }, enabled = arSupported == true, caption = "AR"),
+        }, enabled = arSupported == true),
         chromeToggleOnTap = true,
     ) {
         // The scene fills the viewport edge to edge; the chrome floats over it. Framing

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -1,5 +1,10 @@
 package io.github.sceneview.demo.demos
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.horizontalScroll
@@ -14,16 +19,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.ViewInAr
-import androidx.compose.material.icons.outlined.CenterFocusStrong
-import androidx.compose.material.icons.outlined.PlayCircle
-import androidx.compose.material.icons.outlined.ViewInAr
+import androidx.compose.material.icons.outlined.Animation
+import androidx.compose.material.icons.outlined.Category
+import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,7 +44,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.activity.compose.BackHandler
 import io.github.sceneview.environment.Environment
-import io.github.sceneview.demo.DemoPreviews
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.key
@@ -92,6 +95,7 @@ import io.github.sceneview.demo.demos.internal.PARK_SLOTS
 import io.github.sceneview.demo.demos.internal.ParkSlot
 import io.github.sceneview.demo.demos.internal.parkCameraDistance
 import io.github.sceneview.demo.initialDemoMode
+import io.github.sceneview.demo.EntranceCameraManipulator
 import io.github.sceneview.demo.rememberFirstFrameState
 import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
 import io.github.sceneview.demo.rememberHeroYaw
@@ -174,6 +178,15 @@ fun ModelViewerDemo(onBack: () -> Unit) {
  */
 private const val MODEL_COVER_FRAMES = 3
 
+/**
+ * Length of the camera fly-in when the model lands (#3406). Twice `duration-medium`:
+ * a screen transition is 350 ms, but this one is the subject arriving rather than a
+ * surface changing, and under 500 ms the dolly reads as a stutter instead of a move.
+ * Long enough to be seen, short enough that the first drag is never waiting on it —
+ * and a touch cancels it outright.
+ */
+private const val CAMERA_ENTRANCE_MILLIS = 700
+
 private enum class ModelViewerMode(val label: String) {
     Single("Single Model"),
     Multi("Multi-Model"),
@@ -248,11 +261,21 @@ private fun SingleModelSection(
     var selectedModel by remember { mutableStateOf(bundledModels.first()) }
     var modelSheetOpen by remember { mutableStateOf(false) }
     var environmentSheetOpen by remember { mutableStateOf(false) }
+    // Chinese Garden leads, and the flagship viewer opens on it (#3402). The old default —
+    // `studio_2k` — is a grey box with white softboxes: correct light, no colour, and on the
+    // near-black stage the hero read as a grey object on a black field. Measured on the
+    // emulator against every bundled HDR: `studio_warm` is the same picture a shade warmer,
+    // `sunset` reflects mostly pale sky and washes the model out, `outdoor_cloudy` is flat
+    // by construction, and the two night maps are darker than the stage. The garden is the
+    // one that makes a PBR viewer look like a PBR viewer — green canopy and blue sky across
+    // the chrome, a hard sun glint, real depth in the visor — and it is bright enough that
+    // the model never sinks into the stage in either theme. The list still leads with the
+    // default so "Reset lighting" is the first tile.
     val viewerEnvironments = remember { listOf(
+        ViewerEnvironment("environments/chinese_garden_2k.hdr", "Chinese Garden"),
+        ViewerEnvironment("environments/sunset_2k.hdr", "Sunset"),
         ViewerEnvironment("environments/studio_2k.hdr", "Studio"),
         ViewerEnvironment("environments/studio_warm_2k.hdr", "Studio Warm"),
-        ViewerEnvironment("environments/sunset_2k.hdr", "Sunset"),
-        ViewerEnvironment("environments/chinese_garden_2k.hdr", "Chinese Garden"),
         ViewerEnvironment("environments/outdoor_cloudy_2k.hdr", "Outdoor Cloudy"),
         ViewerEnvironment("environments/night_sky_2k.hdr", "Night Sky"),
         ViewerEnvironment("environments/rooftop_night_2k.hdr", "Rooftop Night"),
@@ -357,13 +380,14 @@ private fun SingleModelSection(
     // Live auto-fit distance, written by the scene block (which knows the chrome insets) so the
     // "Camera distance" slider below can display it. 1.4 m until the bounds are measurable.
     var autoFitRadius by remember { mutableStateOf(1.4f) }
-    // Re-run the settle animation for every newly measured instance and on Recenter.
+    // Settle drop — the model rises the last few centimetres into its resting pose.
+    // Driven, with the camera entrance below, by one effect gated on the first frame
+    // that actually shows the model.
     val fitProgress = remember { Animatable(0f) }
-    LaunchedEffect(bounds, recenterGeneration) {
-        if (bounds == null) return@LaunchedEffect
-        fitProgress.snapTo(0f)
-        fitProgress.animateTo(1f, SceneViewTokens.Motion.spring())
-    }
+    // Camera entrance (#3406). One tween on `ease-expressive`: the camera starts wide,
+    // swung off-axis and lifted, and flies to the resting framing while the model settles
+    // under it. See [EntranceCameraManipulator] for the geometry.
+    val entranceProgress = remember { Animatable(0f) }
     val modelYaw = rememberHeroYaw(trigger = spinScene && activeModelInstance != null, durationMillis = 20_000, staticYaw = 0f)
 
     // Camera-distance slider state. Wired directly to [DemoSettings.cameraDistance]
@@ -445,6 +469,38 @@ private fun SingleModelSection(
     LaunchedEffect(viewerEnvironment, iblIntensity) {
         viewerEnvironment.indirectLight?.intensity = 30_000f * iblIntensity
     }
+    // The arrival (#3406) — camera fly-in and model settle, started together and gated on
+    // the frame that actually SHOWS the model. Keying these on `bounds` alone (what the
+    // settle used to do) spent the whole animation behind the loading cover: the model was
+    // measured seconds before the backend finished linking its materials, so by the time
+    // anything was on screen the spring had long since come to rest. `firstModelFrame` is
+    // the same latch the cover releases on, so the entrance plays *as* the scene appears.
+    // In `qaMode` both snap to their resting values — a screenshot taken mid-flight frames
+    // the model differently every run.
+    val modelPresented = firstModelFrame.value
+    LaunchedEffect(bounds, recenterGeneration, modelPresented, DemoSettings.qaMode) {
+        if (bounds == null) return@LaunchedEffect
+        if (DemoSettings.qaMode) {
+            entranceProgress.snapTo(1f)
+            fitProgress.snapTo(1f)
+            return@LaunchedEffect
+        }
+        if (!modelPresented) {
+            entranceProgress.snapTo(0f)
+            fitProgress.snapTo(0f)
+            return@LaunchedEffect
+        }
+        entranceProgress.snapTo(0f)
+        fitProgress.snapTo(0f)
+        launch { fitProgress.animateTo(1f, SceneViewTokens.Motion.spring()) }
+        entranceProgress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(
+                durationMillis = CAMERA_ENTRANCE_MILLIS,
+                easing = SceneViewTokens.Ease.expressive,
+            ),
+        )
+    }
     // Back closes transient chrome before leaving the demo.
     BackHandler(enabled = animationBarOpen || modelSheetOpen || environmentSheetOpen) {
         animationBarOpen = false; modelSheetOpen = false; environmentSheetOpen = false
@@ -455,12 +511,13 @@ private fun SingleModelSection(
         onBack = onBack,
         assetSource = assetSource,
         firstFrameRendered = firstModelFrame,
-        // #3324 — this was hardcoded `dark = true`, so a light-theme device flashed the
-        // DARK preview edge-to-edge as the loading cover: a visibly wrong (mismatched)
-        // image before the sample's first real Filament frame took over. Every other
-        // preview consumer (`DemoEntry.previewPainter`) already keys off the live
-        // scheme; this is the one that didn't.
-        previewRes = DemoPreviews.resourceFor("model-viewer", dark = isSystemInDarkTheme()),
+        // No preview image on the cover any more (#3402). It used to draw
+        // `preview_model_viewer_<scheme>.webp` edge-to-edge: a white-field studio photo,
+        // cropped to fill a phone, of a helmet lit and framed nothing like the scene that
+        // replaced it half a second later — the "picture of the previous card" the report
+        // describes. The cover now says what is happening instead of guessing at a frame
+        // that has not been rendered.
+        loadingLabel = stringResource(R.string.demo_model_viewer_loading),
         controls = {
             // Camera-distance slider — makes zoom discoverable without a pinch
             // gesture (and Maestro-testable, see #1571). The displayed value is
@@ -477,26 +534,45 @@ private fun SingleModelSection(
                 Switch(spinScene, null)
             }
         },
+        // Dock order reads left to right as the questions a viewer answers: *what* am I
+        // looking at, *under what light*, *does it move*, and *put it back where it was*
+        // (#3402). Every icon changed with it. `ViewInAr` outlined was "Models" while
+        // `ViewInAr` filled was the AR accent right beside it — the same cube twice, which
+        // is what made the row unreadable; `Category` (three solids) says "pick a model"
+        // and leaves the cube to mean AR. `CenterFocusStrong`'s reticle read as a zoom or
+        // a camera-focus control, so Recenter is `RestartAlt` — an action, not a viewfinder.
         dock = listOf(
-            DockItem(Icons.Outlined.CenterFocusStrong, "Recenter", { recenterGeneration++ }),
-            DockItem(Icons.Outlined.WbSunny, "Environment", { environmentSheetOpen = true }),
-            DockItem(Icons.Outlined.ViewInAr, "Models", { modelSheetOpen = true }),
-        ) + if (animationNames.isNotEmpty()) listOf(DockItem(Icons.Outlined.PlayCircle, "Animate", { animationBarOpen = !animationBarOpen }, selected = animationBarOpen)) else emptyList(),
-        bottomOverlay = if (animationBarOpen && animationNames.isNotEmpty()) {{
-            AnimationBar(animationNames, selectedAnimation, animationPlaying, animationProgress,
-                onPlayingChange = { animationPlaying = it },
-                onClipChange = { selectedAnimation = it; animationProgress = 0f },
-                onProgressChange = {
-                    animationProgress = it
-                    activeModelInstance?.animator?.takeIf { selectedAnimation in 0 until it.animationCount }?.let { animator ->
-                        animator.applyAnimation(selectedAnimation, it * animator.getAnimationDuration(selectedAnimation))
-                        animator.updateBoneMatrices()
-                    }
-                })
+            DockItem(Icons.Outlined.Category, "Models", { modelSheetOpen = true }),
+            DockItem(Icons.Outlined.WbSunny, "Lighting", { environmentSheetOpen = true }),
+        ) + (if (animationNames.isNotEmpty()) listOf(DockItem(Icons.Outlined.Animation, "Animate", { animationBarOpen = !animationBarOpen }, selected = animationBarOpen)) else emptyList()) +
+            listOf(DockItem(Icons.Outlined.RestartAlt, "Recenter", { recenterGeneration++ })),
+        // Always composed when the model has clips, so the bar can slide in and out with
+        // the standard M3 enter/exit instead of appearing and vanishing between frames
+        // (#3406). An `AnimatedVisibility` that is not visible measures zero, so the
+        // scaffold's measured bottom band is unchanged while it is closed.
+        bottomOverlay = if (animationNames.isNotEmpty()) {{
+            AnimatedVisibility(
+                visible = animationBarOpen,
+                enter = fadeIn(SceneViewTokens.Motion.fade()) +
+                    expandVertically(SceneViewTokens.Motion.spring(), expandFrom = Alignment.Bottom),
+                exit = fadeOut(SceneViewTokens.Motion.fade()) +
+                    shrinkVertically(SceneViewTokens.Motion.spring(), shrinkTowards = Alignment.Bottom),
+            ) {
+                AnimationBar(animationNames, selectedAnimation, animationPlaying, animationProgress,
+                    onPlayingChange = { animationPlaying = it },
+                    onClipChange = { selectedAnimation = it; animationProgress = 0f },
+                    onProgressChange = {
+                        animationProgress = it
+                        activeModelInstance?.animator?.takeIf { selectedAnimation in 0 until it.animationCount }?.let { animator ->
+                            animator.applyAnimation(selectedAnimation, it * animator.getAnimationDuration(selectedAnimation))
+                            animator.updateBoneMatrices()
+                        }
+                    })
+            }
         }} else null,
         dockAccent = DockItem(Icons.Filled.ViewInAr, "View in AR", {
             DemoSettings.requestedRoute = "demo/ar-placement?model=${selectedModel.assetPath}"
-        }, enabled = arSupported == true),
+        }, enabled = arSupported == true, caption = "AR"),
         chromeToggleOnTap = true,
     ) {
         // The scene fills the viewport edge to edge; the chrome floats over it. Framing
@@ -520,6 +596,11 @@ private fun SingleModelSection(
             // manipulator, which snaps the camera back to exactly this home pose. A non-null
             // `DemoSettings.cameraDistance` (slider or deep link) scales the eye along the
             // same view ray so the pitch and the band centring survive the override.
+            //
+            // The resting pose is wrapped in an [EntranceCameraManipulator] so the camera
+            // *flies to* it when the model lands (#3406); `entranceProgress` at 1 makes it
+            // behave exactly like the stock manipulator it replaced, and the first touch
+            // hands off at whatever eye the flight had reached.
             val cameraManipulator = remember(framing, modelCenter, recenterGeneration, sliderDistance) {
                 val f = framing ?: return@remember createDefaultCameraManipulator(
                     orbitHomePosition = Position(modelCenter.x, modelCenter.y, sliderDistance ?: 1.4f),
@@ -528,13 +609,14 @@ private fun SingleModelSection(
                 val (_, ty, tz) = f.targetOffset
                 val (_, ey, ez) = f.eyeOffset
                 val zoom = sliderDistance?.let { it / f.distance } ?: 1f
-                createDefaultCameraManipulator(
-                    orbitHomePosition = Position(
+                EntranceCameraManipulator(
+                    eye = Position(
                         modelCenter.x,
                         modelCenter.y + ty + (ey - ty) * zoom,
                         modelCenter.z + tz + (ez - tz) * zoom,
                     ),
-                    targetPosition = Position(modelCenter.x, modelCenter.y + ty, modelCenter.z + tz),
+                    target = Position(modelCenter.x, modelCenter.y + ty, modelCenter.z + tz),
+                    progress = { entranceProgress.value },
                 )
             }
             SceneView(
@@ -838,7 +920,7 @@ private fun MultiModelSection(
         onBack = onBack,
         assetSource = assetSource,
         firstFrameRendered = firstFrame.rendered,
-        dock = listOf(DockItem(Icons.Outlined.ViewInAr, "Models", { modelSheetOpen = true })),
+        dock = listOf(DockItem(Icons.Outlined.Category, "Models", { modelSheetOpen = true })),
         controls = {
             Text("Visibility", style = MaterialTheme.typography.labelLarge)
             // Labels come from the resolved slug's curated-English `displayName`

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/viewer/EnvironmentSheet.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/viewer/EnvironmentSheet.kt
@@ -23,7 +23,7 @@ data class ViewerEnvironment(val assetPath: String, val displayName: String) { v
 
 @Composable fun EnvironmentSheet(environments: List<ViewerEnvironment>, selectedPath: String, intensity: Float, showEnvironment: Boolean, onSelect: (ViewerEnvironment) -> Unit, onIntensity: (Float) -> Unit, onShowEnvironment: (Boolean) -> Unit, onReset: () -> Unit, onDismiss: () -> Unit) {
     ModalBottomSheet(onDismissRequest = onDismiss, containerColor = MaterialTheme.colorScheme.surfaceContainer, shape = RoundedCornerShape(topStart = SceneViewTokens.Radius.xl, topEnd = SceneViewTokens.Radius.xl)) {
-        Text("Environment", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.md))
+        Text("Lighting", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.md))
         Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(SceneViewTokens.Space.md), horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm)) {
             environments.forEach { env ->
                 val selected = env.assetPath == selectedPath


### PR DESCRIPTION
## Summary

Opening the Model Viewer showed a picture of a helmet that was **not** the helmet about to
render, then a row of icons that did not say what they did, then a grey model. This PR fixes
all four complaints in #3402 and lands the camera entrance of #3406.

- **The launch flash is gone.** The loading cover drew `preview_model_viewer_<scheme>.webp`
  edge-to-edge — a white-field studio photo cropped to fill a phone — and half a second later
  cut to a dark stage holding a differently framed, differently lit model. It is now an honest
  loading state: the stage colour, a progress indicator and the demo's label. `previewRes` is
  removed from `DemoScaffold` (the Model Viewer was its only caller); the preview images stay
  what they were built for, the home cards.
- **Every dock item is labelled, and the guessing icons changed.** "Models" was an outlined
  `ViewInAr` cube sitting next to the filled `ViewInAr` cube of the AR accent — the same picture
  twice — and Recenter was a `CenterFocusStrong` reticle that reads as zoom. Now: `Category`
  **Models** · `WbSunny` **Lighting** · `Animation` **Animate** · `RestartAlt` **Recenter** ·
  `Tune` **Settings**, each over its own caption, plus the filled AR accent. `DESIGN.md` already
  reserved `type-caption` for dock labels; it now documents the rule. Accessible names are
  untouched — only the visible captions are shortened, so `DemoInteractionTest`'s
  `By.desc("Demo settings")` still matches. The Lighting sheet's title moved from "Environment"
  to "Lighting" so the sheet and the item that opens it agree.
- **A default environment that pops.** `studio_2k` is correct light and no colour; on the
  near-black stage the hero read as a grey object on a black field. `chinese_garden_2k` is the
  new default and leads the list, so "Reset lighting" returns to it.
- **The model arrives instead of appearing (#3406).** `EntranceCameraManipulator` flies the
  camera in from wide, off-axis and lifted to the resting framing over 700 ms on
  `ease-expressive`; the first touch hands off to the stock manipulator at whatever eye the
  flight had reached, so interrupting it is seamless. The settle drop is gated on the same
  latch — both used to key off `bounds`, measured seconds before the backend finishes linking
  materials, so the whole animation was spent behind the loading cover. `qaMode` snaps both to
  their resting values, and Recenter replays the flight.
- **Two cheap standard motions.** Screen changes are Material shared-axis X on
  `duration-medium` / `ease-expressive` (both screens travel ⅙ of the viewport while they
  cross-fade) instead of a full-window iOS-style push, and the animation bar expands and
  collapses instead of blinking in and out.

## On the environment choice

The issue suggests "maybe the third one in the list" — Sunset. Captured on the emulator against
all seven bundled HDRs, Sunset turned out to be the *least* punchy of the candidates: the helmet
reflects mostly pale sky and washes out to light blue. Studio Warm is Studio a shade warmer,
Outdoor Cloudy is flat by construction, and the two night maps are darker than the stage.
Chinese Garden is the one that makes a PBR viewer look like a PBR viewer — canopy and sky across
the chrome, a hard sun glint, real depth in the visor. It is one line to change if you disagree
(`viewerEnvironments.first()` is the default).

## Also noticed, not fixed here

`preview_model_viewer_*.webp` shows a **rusty Khronos DamagedHelmet**, but
`models/khronos_damaged_helmet.glb` loads a **sci-fi helmet with a green visor** — the model
picker's own thumbnail agrees with the GLB, the preview does not. That mismatch is why the old
cover looked like "a picture of the previous card"; it no longer shows on this screen, but the
home card still carries the wrong picture. Worth its own issue.

## Verified

Captured on `emulator-5554` (Pixel-class, 1080×2400 @ 420 dpi), light and dark, before and
after, on the final build.

| Capture | What it shows |
|---|---|
| `before-light-boot-2` | The defect: a full-bleed crop of the white-field preview photo under the chrome, before any Filament frame |
| `before-light-settled` | The old default — grey `studio_2k` IBL, and the dock's two identical cubes (Models, View in AR) beside the focus reticle |
| `probe-{sunset,studiowarm,chinesegarden}` | The same helmet under three candidate HDRs, used to pick the default |
| `after-light-loading2` | The new cover: stage colour, spinner, "Loading model…", with the labelled dock already legible |
| `after-light-final` / `after-dark-settled` | Settled scene, light and dark: Chinese Garden reflections, `Models · Lighting · Recenter · Settings · AR` |
| `scene-04` → `scene-05` → settled | The camera entrance mid-flight — the model appears small and high behind the fading cover, then flies to its resting framing |
| `after-dark-five-items` | Five items plus the accent (animated Soldier) fit a 411 dp screen with margin — no clipping |
| `after-dark-animate-bar` | The animation bar expanded above the dock; the Animate item's icon *and* caption tint primary as one unit |

`:samples:android-demo:testDebugUnitTest` and `verifyRoborazziDebug` both green — the band tests
assert measured invariants, and the taller dock content stays inside the same 64 dp band.

Fixes #3402
Fixes #3406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
