### PR TITLE
build: compile every Android module against SDK 37 (#3385)

### DIFF
--- a/arsceneview/build.gradle
+++ b/arsceneview/build.gradle
@@ -51,7 +51,7 @@ android {
     // Consumers must also add this to their own app-level build.gradle (#2226).
     experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
 
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         minSdk 24

--- a/changelog.d/3385-compilesdk-37.md
+++ b/changelog.d/3385-compilesdk-37.md
@@ -1,0 +1,22 @@
+<!-- category: Changed -->
+- **Every Android module now compiles against SDK 37, and the `okhttp` bump it blocked has
+  landed ([#3385](https://github.com/sceneview/sceneview/issues/3385)).** `okhttp-android`
+  5.5.0 raised its own compile-SDK floor to 37, so `checkDebugAarMetadata` failed the build
+  and pinned the SDK at 5.4.0. `compileSdk` moves 36 → 37 in `sceneview`, `arsceneview`,
+  `sceneview-compose`, `samples/common`, `samples/android-demo`, `samples/android-tv-demo`
+  and `tools/snippets-check`, and 35 → 37 in the Flutter (`flutter/sceneview_flutter/android`)
+  and React Native (`react-native/react-native-sceneview/android`) bridges, whose host demo
+  apps follow so a plugin never compiles against a higher SDK than the app embedding it.
+  `targetSdk` is deliberately unchanged at 36: the AAR-metadata floor is a *compile* floor,
+  and moving `targetSdk` opts the Play Store app into API 37 runtime behaviour changes that
+  need their own device QA. AGP stays at 8.13.2, which was tested up to 36, so
+  `android.suppressUnsupportedCompileSdk=37.0` documents the gap in each of the four
+  independent builds' `gradle.properties` — remove it with the AGP upgrade.
+<!-- RELEASE NOTE (maintainer-only):
+     compileSdk 37 unblocks okhttp 5.5.0 (#3345) and nothing else. navigation-compose 2.10.0
+     (#3416) and Compose Multiplatform 1.12.0 (#3418) fail the same task for a DIFFERENT
+     reason — their AAR metadata demands "Android Gradle plugin 9.1.0 or higher", verified
+     locally on this branch. Both stay blocked until AGP moves to 9.1+, which is a separate
+     migration (the repo is on 8.13.2 and AGP 9 is a major). The `androidx.compose.material3`
+     ignore rule in .github/dependabot.yml stays for the same reason: its "AGP 9.1+ /
+     compileSdk 37+" note now has only its compileSdk half satisfied. -->

--- a/flutter/sceneview_flutter/android/build.gradle
+++ b/flutter/sceneview_flutter/android/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 android {
     namespace 'io.github.sceneview.flutter'
-    compileSdk 35
+    compileSdk 37
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,14 @@ android.useAndroidX=true
 # Non-transitive R classes reduce APK size and improve build speed
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
+# compileSdk 37 with AGP 8.13.2 (#3385). AGP 8.13.2 was tested up to
+# compileSdk 36, so it prints an "unsupported compile SDK" warning on every
+# module; the build, unit tests and AAR-metadata checks all pass against 37.
+# The move to 37 is forced by dependencies that raised their own compile-SDK
+# floor (okhttp 5.5.0, navigation-compose 2.10.0, Compose Multiplatform
+# 1.12.0). REMOVE THIS LINE when `agp` in gradle/libs.versions.toml moves to a
+# version that officially supports 37 — the warning is then a real signal again.
+android.suppressUnsupportedCompileSdk=37.0
 
 ######################
 # Filament Plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ arCore = "1.54.0"
 
 # Networking
 fuel = "2.3.1"
-okhttp = "5.4.0"
+okhttp = "5.5.0"
 kotlinxSerialization = "1.11.0"
 
 # UI

--- a/react-native/react-native-sceneview/android/build.gradle.kts
+++ b/react-native/react-native-sceneview/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 android {
     namespace = "io.github.sceneview.reactnative"
-    compileSdk = 35
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -56,7 +56,7 @@ android {
     // Accepted values: "4k" (default), "16k", "64k".
     experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
 
-    compileSdk 36
+    compileSdk 37
 
 
     defaultConfig {

--- a/samples/android-tv-demo/build.gradle
+++ b/samples/android-tv-demo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 android {
     namespace = "io.github.sceneview.sample.tv"
 
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         applicationId "io.github.sceneview.sample.tv"

--- a/samples/common/build.gradle
+++ b/samples/common/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = 'io.github.sceneview.sample.common'
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         minSdk 24

--- a/samples/flutter-demo/android/app/build.gradle.kts
+++ b/samples/flutter-demo/android/app/build.gradle.kts
@@ -7,7 +7,12 @@ plugins {
 
 android {
     namespace = "io.github.sceneview.demo.flutter"
-    compileSdk = flutter.compileSdkVersion
+    // NOT `flutter.compileSdkVersion` (#3385). The `flutter_sceneview` plugin
+    // compiles against SDK 37, and Flutter's own Gradle plugin fails the app
+    // build unless the host app compiles against at least the highest SDK any
+    // plugin uses. Restore `flutter.compileSdkVersion` once the pinned Flutter
+    // SDK's default reaches 37.
+    compileSdk = 37
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/samples/flutter-demo/android/gradle.properties
+++ b/samples/flutter-demo/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# The `flutter_sceneview` plugin module compiles against SDK 37 (#3385) while
+# this Flutter app's AGP (settings.gradle.kts) was tested up to a lower one.
+# Remove when Flutter's Android template ships an AGP that supports 37.
+android.suppressUnsupportedCompileSdk=37.0

--- a/samples/react-native-demo/android/build.gradle
+++ b/samples/react-native-demo/android/build.gradle
@@ -2,7 +2,11 @@ buildscript {
     ext {
         buildToolsVersion = "34.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 34
+        // 37, not 34 (#3385): the `@sceneview-sdk/react-native` bridge module
+        // this demo consumes from source compiles against SDK 37, and a host
+        // app must compile against at least the highest SDK any of its modules
+        // uses. `targetSdkVersion` deliberately stays put — see the PR.
+        compileSdkVersion = 37
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"
         kotlinVersion = "1.8.0"

--- a/samples/react-native-demo/android/gradle.properties
+++ b/samples/react-native-demo/android/gradle.properties
@@ -39,3 +39,8 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# The bridge module compiles against SDK 37 (#3385) while React Native 0.73's
+# Gradle plugin supplies an older AGP that was tested against a lower one.
+# Remove when this demo moves to a React Native release shipping AGP 9.1+.
+android.suppressUnsupportedCompileSdk=37.0

--- a/sceneview-compose/build.gradle.kts
+++ b/sceneview-compose/build.gradle.kts
@@ -112,7 +112,7 @@ kotlin {
 
 android {
     namespace = "io.github.sceneview.compose"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24

--- a/sceneview/build.gradle
+++ b/sceneview/build.gradle
@@ -48,7 +48,7 @@ android {
     // at pack time. Consumers must also add this to their own app-level build.gradle (#2226).
     experimentalProperties["android.nativeLibraryAlignmentPageSize"] = "16k"
 
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         minSdk 24

--- a/tools/rn-android-compile/gradle.properties
+++ b/tools/rn-android-compile/gradle.properties
@@ -17,3 +17,8 @@ org.gradle.caching=false
 # `gradle.lifecycle.beforeProject` resolution-strategy hook, and this build is
 # a single tiny module where configuration caching buys nothing.
 org.gradle.configuration-cache=false
+
+# compileSdk 37 with AGP 8.13.2 (#3385) — same suppression as the repo root's
+# gradle.properties, repeated here because this standalone build does not
+# inherit it. Remove when the pinned AGP (settings.gradle.kts) supports 37.
+android.suppressUnsupportedCompileSdk=37.0

--- a/tools/snippets-check/build.gradle
+++ b/tools/snippets-check/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 android {
     namespace = 'io.github.sceneview.docsnippets'
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         minSdk 24


### PR DESCRIPTION
`com.squareup.okhttp3:okhttp-android:5.5.0` raised its own compile-SDK floor to 37, so `checkDebugAarMetadata` failed on every module that depends on it and held the repo at okhttp 5.4.0. This moves the whole Android surface to `compileSdk 37` and takes the okhttp bump with it.

Fixes #3385

## What changed and why

### `compileSdk` 36 → 37 (root Gradle build)

| File | Why |
|---|---|
| `sceneview/build.gradle` | Published library — must compile against the same SDK as its consumers |
| `arsceneview/build.gradle` | Same |
| `sceneview-compose/build.gradle.kts` | Same |
| `samples/common/build.gradle` | Depends on okhttp through `android-demo`'s shared helpers; failed `checkDebugAarMetadata` |
| `samples/android-demo/build.gradle` | The module the issue's stack trace names — declares `libs.okhttp` / `libs.okhttp.coroutines` directly |
| `samples/android-tv-demo/build.gradle` | Kept in step with the rest of the build |
| `tools/snippets-check/build.gradle` | Doc-snippet compile guard — compiles the same public API, so it has to see the same SDK |

### `compileSdk` 35 → 37 (bridges and their host apps)

| File | Why |
|---|---|
| `flutter/sceneview_flutter/android/build.gradle` | The bridge was two SDK levels behind the SDK it wraps |
| `samples/flutter-demo/android/app/build.gradle.kts` | `flutter.compileSdkVersion` resolves to 36; Flutter's Gradle plugin then errors with *"the following plugin(s) require to be compiled against a higher Android SDK version: flutter_sceneview compiles against Android SDK 37"*. The app now pins 37 explicitly, with a comment saying to restore `flutter.compileSdkVersion` once the pinned Flutter SDK's default catches up |
| `react-native/react-native-sceneview/android/build.gradle.kts` | Same lag as the Flutter bridge |
| `samples/react-native-demo/android/build.gradle` | `ext.compileSdkVersion` 34 → 37 for the same host-app reason: the demo consumes the bridge module from source, so the bridge would compile at 37 inside an app configured for 34 |

### Dependency

- `gradle/libs.versions.toml` — `okhttp` 5.4.0 → 5.5.0. This is the version ref behind `okhttp`, `okhttp-coroutines` and `mockwebserver3`; all three resolve and the unit suites that use `mockwebserver3` pass. This makes Dependabot #3345 redundant.

### AGP warning suppression

AGP is pinned at 8.13.2, which Google tested up to `compileSdk` 36, so it prints an *"unsupported compile SDK"* warning per module. `android.suppressUnsupportedCompileSdk=37.0` is added to the **four independent builds'** `gradle.properties` — none of them inherits another's:

- `gradle.properties` (root build)
- `tools/rn-android-compile/gradle.properties` (the standalone RN bridge compile gate, #3042)
- `samples/flutter-demo/android/gradle.properties` (Flutter's own build, AGP 8.11.1)
- `samples/react-native-demo/android/gradle.properties` (React Native 0.73's build)

Each carries the condition for removing it again: the AGP upgrade.

## What deliberately did **not** change

- **`targetSdk` stays at 36.** The AAR-metadata floor is a *compile-time* floor. Moving `targetSdk` opts the Play Store app into API 37 runtime behaviour changes (permissions, edge-to-edge, background restrictions) — merging to `main` rolls the demo out automatically, so that move belongs in its own change with device QA behind it. Nothing in this PR needs it.
- **AGP stays at 8.13.2.** AGP 9.x is a major migration; see below.
- **`.github/dependabot.yml` is untouched.** Its `androidx.compose.material3` ignore rule reads *"requires AGP 9.1+ / compileSdk 37+"* — this PR satisfies only the `compileSdk` half, so the rule still applies.
- **No CI workflow needed a change.** No workflow pins an SDK platform or calls `sdkmanager`; the emulator jobs (`render-tests.yml`, `device-qa.yml`) run `api-level: 30`, which is a *runtime* level and unaffected by a compile-SDK move. AGP downloads platform 37 on the runners the same way it does 36 today.

## ⚠️ The other two Dependabot PRs are **not** unblocked by this

Verified locally on this branch, at `compileSdk 37`:

- **#3345 okhttp 5.5.0** — ✅ passes. Included in this PR.
- **#3416 navigation-compose 2.10.0** — ❌ still fails, for a *different* reason:
  ```
  1.  Dependency 'androidx.navigation:navigation-compose-android:2.10.0' requires Android Gradle plugin 9.1.0 or higher.
      This build currently uses Android Gradle plugin 8.13.2.
  2.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-compose-android:2.11.0' requires Android Gradle plugin 9.1.0 or higher.
  3.  Dependency 'androidx.lifecycle:lifecycle-runtime-compose-android:2.11.0' requires Android Gradle plugin 9.1.0 or higher.
  ```
- **#3418 Compose Multiplatform 1.12.0** — ❌ still fails, same reason, 8 issues:
  ```
  1.  Dependency 'androidx.compose.animation:animation-core-android:1.12.0' requires Android Gradle plugin 9.1.0 or higher.
      This build currently uses Android Gradle plugin 8.13.2.
  ...
  ```

Those two need an **AGP 9.1+** migration, which is a separate, much larger change. Rebasing them onto this will not turn them green.

## Verified

Local build, `openjdk 21`, Android SDK platform 37 installed for this work (`sdkmanager "platforms;android-37.0"` — the package is minor-versioned now; AGP resolves `compileSdk 37` to it).

| Task | Result |
|---|---|
| `:sceneview:compileDebugKotlin :arsceneview:compileDebugKotlin :sceneview-compose:compileDebugKotlin :samples:common:compileDebugKotlin :samples:android-demo:compileDebugKotlin :samples:android-tv-demo:compileDebugKotlin :snippets-check:compileDebugKotlin` | ✅ BUILD SUCCESSFUL |
| `:samples:android-demo:checkDebugAarMetadata :samples:common:checkDebugAarMetadata :samples:android-tv-demo:checkDebugAarMetadata :sceneview-compose:checkDebugAarMetadata :sceneview:checkDebugAarMetadata :arsceneview:checkDebugAarMetadata` | ✅ BUILD SUCCESSFUL (with okhttp 5.5.0 resolved, `--rerun-tasks`) |
| `:sceneview:testDebugUnitTest :arsceneview:testDebugUnitTest :samples:android-demo:testDebugUnitTest :samples:common:testDebugUnitTest :samples:android-tv-demo:testDebugUnitTest` | ✅ BUILD SUCCESSFUL in 9m 15s |
| `:sceneview:lintDebug :arsceneview:lintDebug` | ✅ BUILD SUCCESSFUL — no new lint errors from API 37 |
| `tools/rn-android-compile` → `:react-native-sceneview:compileDebugKotlin` | ✅ BUILD SUCCESSFUL (the standalone RN bridge gate) |
| `-p samples/flutter-demo/android :flutter_sceneview:compileDebugKotlin :app:compileDebugKotlin` | ✅ BUILD SUCCESSFUL — plugin/app SDK-mismatch warning gone after pinning the app to 37 |

There is no `checkDebugUnitTestAarMetadata` task in this project; `checkDebugAarMetadata` is the one the failing CI legs run.

Not verified locally: `samples/react-native-demo` (needs `npm install` + the React Native toolchain, and it is built by no CI job — the `ext.compileSdkVersion` bump there is a consistency fix so the bridge is not compiled at 37 inside an app declaring 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)