### PR TITLE
fix(demo): give testReleaseUnitTest a working ComponentActivity host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,24 @@ jobs:
         # was already in the `android` path filter that gates this job, so the
         # module was compiled on every relevant PR while its 5 tests were not.
         # Local run before wiring: 5 tests, 0 failures, 7s.
+        #
+        # `:samples:android-demo:testReleaseUnitTest` (#3410): the demo's JVM
+        # tests otherwise only ever reach CI as a dependency of
+        # `verifyRoborazziDebug` above, which is `debug`-only — the `release`
+        # variant of the same unit tests had no coverage at all. That hid a
+        # real divergence: 13 compose-rule tests (`DemoScaffold*BandTest`,
+        # `DemoBackgroundRoleTest`) failed on `testReleaseUnitTest` while
+        # passing on debug, because `createComposeRule()`'s bare
+        # `ComponentActivity` host was declared only via a
+        # `debugImplementation` dependency (`androidx.compose.ui:ui-test-manifest`)
+        # — invisible to the release variant's own resource-link pipeline. Fixed
+        # by declaring that manifest entry directly in
+        # `samples/android-demo/src/main/AndroidManifest.xml` so both variants
+        # see it; this task is what makes a regression of that fix (or any
+        # other release-only divergence) fail a PR instead of sitting silent
+        # on `main`. Plain task, not a Roborazzi verify — the demo has no
+        # release-specific goldens, so no second screenshot pass to duplicate.
+        # Local run: 591 tests, 0 failures, ~2 min warm.
         run: |
           # The goldens under samples/android-demo/src/test/snapshots/ are a
           # declared input of the demo's test task (`roborazziGoldens` in its
@@ -480,6 +498,7 @@ jobs:
             :samples:common:testDebugUnitTest \
             :samples:android-tv-demo:testDebugUnitTest \
             :samples:android-demo:verifyRoborazziDebug \
+            :samples:android-demo:testReleaseUnitTest \
             --stacktrace
 
       - name: Upload unit test reports

--- a/changelog.d/3410-release-unit-tests.md
+++ b/changelog.d/3410-release-unit-tests.md
@@ -1,0 +1,26 @@
+<!-- category: Fixed -->
+<!-- breaking: false -->
+`:samples:android-demo:testReleaseUnitTest` failed 13 tests on `main`
+(`DemoScaffoldTopBandTest`, `DemoScaffoldBottomBandTest`, `DemoBackgroundRoleTest`) while
+the exact same tests passed in the `debug` variant, and nothing in CI ever ran the release
+variant to notice — the demo's JVM tests only reached CI as a dependency of
+`verifyRoborazziDebug`, which is `debug`-only.
+
+The cause was a dependency scope, not application behaviour. Every failing test hosts a
+composable through `createComposeRule()`, which launches a bare
+`androidx.activity.ComponentActivity` by explicit component name. That activity's manifest
+entry came from `androidx.compose.ui:ui-test-manifest` on `debugImplementation` — correct
+per that artifact's own guidance ("never let it reach a shipped APK"), but it also meant the
+entry only reached the `debug` variant's manifest and resource-link pipeline.
+`testReleaseUnitTest` links its unit-test resource package from the `release` variant's own
+implementation graph, which a `debugImplementation` dependency never touches, so every
+Robolectric-hosted compose-rule test in the release variant died with "Unable to resolve
+activity ... ComponentActivity".
+
+Fixed by declaring the same `ComponentActivity` manifest entry directly in
+`samples/android-demo/src/main/AndroidManifest.xml` instead of pulling it in from
+`ui-test-manifest` — it has no launcher intent-filter and nothing in the app calls it, so it
+ships as an inert, unreachable entry in every build type and now resolves for both unit-test
+variants. `:samples:android-demo:testReleaseUnitTest` is also now wired into the `Unit
+tests` CI job (same `android` path gate as the existing debug suite), so this variant has
+real coverage going forward instead of sitting invisible on `main`.

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -297,14 +297,19 @@ dependencies {
     // every existing check: a Roborazzi golden only fails if a human looks at
     // the diff, and the overlap it captures is 4 dp.
     testImplementation libs.androidx.compose.ui.test.junit4
-    // `debugImplementation`, not `testImplementation`, and that is not a slip:
-    // this artifact is nothing but a manifest declaring the bare
-    // `ComponentActivity` the compose rule launches into, and a unit test reads
-    // the *debug variant's merged manifest*. On `testImplementation` it is on
-    // the classpath but not in the manifest, and every test dies with
-    // "Unable to resolve activity for Intent … ComponentActivity". Debug-only,
-    // so it never reaches the release APK Play ships.
-    debugImplementation libs.androidx.compose.ui.test.manifest
+    // No `androidx.compose.ui:ui-test-manifest` dependency here (#3410): that
+    // artifact's sole content is a manifest declaring the bare
+    // `ComponentActivity` `createComposeRule()` launches into, and it is
+    // documented to be added `debugImplementation`-only. That works for
+    // `testDebugUnitTest` but not `testReleaseUnitTest` — AGP links the
+    // release variant's unit-test resource package from the release
+    // implementation graph, which a `debugImplementation` dependency never
+    // reaches, so every compose-rule Robolectric test failed to resolve
+    // `ComponentActivity` in the release variant only (CI never ran it to
+    // notice: `verifyRoborazziDebug` is debug-only). The same manifest entry
+    // is declared directly in `src/main/AndroidManifest.xml` instead, so it
+    // reaches both variants' real manifest/resource-link pipeline — see the
+    // comment there.
 
     testImplementation libs.kotlin.coroutines.test
     // Local HTTP double for SketchfabService's cooperative-cancellation test

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -181,13 +181,17 @@
             debug-only). Declaring the same entry here — main manifest, shipped
             in every build type — puts it in both variants' real manifest and
             resource-link pipeline. It has no launcher intent-filter and nothing
-            in the app calls it, so it never appears as an entry point; the
-            android:exported requirement to be resolvable by explicit intent is
-            the only reason it says `true`.
+            in the app calls it, so it never appears as an entry point.
+            `exported="false"`: `ActivityScenario`'s launch is an explicit intent
+            from inside the app's own process/package, which Android resolves
+            against non-exported components too — exported is only needed for a
+            *different* package to target this activity, which nothing
+            legitimate has a reason to do. Verified both `testDebugUnitTest` and
+            `testReleaseUnitTest` still resolve it with `exported="false"`.
         -->
         <activity
             android:name="androidx.activity.ComponentActivity"
-            android:exported="true"
+            android:exported="false"
             android:theme="@android:style/Theme.Material.Light.NoActionBar" />
     </application>
 </manifest>

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -164,5 +164,30 @@
                 <data android:scheme="https" android:host="sceneview.github.io" android:pathPrefix="/open" />
             </intent-filter>
         </activity>
+
+        <!--
+            Test-only host for `createComposeRule()` (#3410). Robolectric-hosted
+            compose-rule tests (DemoScaffold*BandTest, DemoBackgroundRoleTest, …)
+            launch this bare `androidx.activity.ComponentActivity` by explicit
+            component name via `ActivityScenario`. It is normally supplied by
+            `androidx.compose.ui:ui-test-manifest` on `debugImplementation`, but
+            that dependency's manifest fragment only reaches the resource-linked
+            package AGP builds for `testDebugUnitTest` — `testReleaseUnitTest`
+            links its unit-test resource package from the `release` variant's own
+            implementation graph, which never sees a `debugImplementation`
+            dependency, so every compose-rule unit test failed with "Unable to
+            resolve activity ... ComponentActivity" in the release variant only,
+            and CI never ran that variant to notice (`verifyRoborazziDebug` is
+            debug-only). Declaring the same entry here — main manifest, shipped
+            in every build type — puts it in both variants' real manifest and
+            resource-link pipeline. It has no launcher intent-filter and nothing
+            in the app calls it, so it never appears as an entry point; the
+            android:exported requirement to be resolvable by explicit intent is
+            the only reason it says `true`.
+        -->
+        <activity
+            android:name="androidx.activity.ComponentActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar" />
     </application>
 </manifest>


### PR DESCRIPTION
## Summary

`:samples:android-demo:testReleaseUnitTest` failed 13 tests on `main` (`DemoScaffoldTopBandTest`, `DemoScaffoldBottomBandTest`, `DemoBackgroundRoleTest`) while the exact same tests passed on `testDebugUnitTest`, and CI never ran the release variant to notice — the demo's JVM tests only ever reached CI as a dependency of `verifyRoborazziDebug`, which is `debug`-only.

**Root cause**: every failing test hosts a composable via `createComposeRule()`, which launches a bare `androidx.activity.ComponentActivity` by explicit component name through `ActivityScenario`. That activity's manifest entry came from `androidx.compose.ui:ui-test-manifest` on `debugImplementation` — correct per that artifact's own guidance ("never let it reach a shipped APK"), but it also meant the entry only reached the `debug` variant's manifest. AGP links `testReleaseUnitTest`'s unit-test resource package from the `release` variant's own implementation graph, which a `debugImplementation` dependency never touches, so `ComponentActivity` resolved for `debug` and threw `Unable to resolve activity for Intent … ComponentActivity` for `release`. Confirmed empirically: even though the release variant's plain merged-manifest text carried the entry when the dependency was moved to `testImplementation`, the AAPT2-linked resource package Robolectric actually reads for activity resolution did not — `testImplementation` dependencies don't reach that link step for either build type.

**Fix**: declare the same `ComponentActivity` manifest entry directly in `samples/android-demo/src/main/AndroidManifest.xml` instead of relying on `ui-test-manifest`. It has no launcher intent-filter and nothing in the app calls it, so it ships as an inert, unreachable entry in every build type and now resolves for both unit-test variants — confirmed `assembleRelease` still builds clean (lint vital passes, no manifest-merger conflicts).

Also wires `:samples:android-demo:testReleaseUnitTest` into the existing `Unit tests` CI job, gated by the same `android` path filter as the rest of that job, so this variant gets real coverage instead of sitting invisible on `main`.

## Verified

- `./gradlew :samples:android-demo:testDebugUnitTest` — 599 tests, 0 failures
- `./gradlew :samples:android-demo:testReleaseUnitTest` — 591 tests, 0 failures (the 8-test gap vs debug is `DemoHostRoutableTest` + `ARBundledRecordingsTest`, both legitimately under `src/testDebug/` since they exercise the debug-only `DemoHostActivity`)
- `./gradlew :samples:android-demo:assembleRelease -PSV_ALLOW_MISSING_SECRETS=1` — builds clean, no lint/manifest-merger regressions from the new manifest entry

Fixes #3410

🤖 Generated with [Claude Code](https://claude.com/claude-code)