### PR TITLE
docs(site): fix the dropped mkdocs `extra:` and instrument the whole website funnel

### DIFF
--- a/changelog.d/site-analytics-funnel.md
+++ b/changelog.d/site-analytics-funnel.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+`docs/mkdocs.yml` declared `extra:` twice, so YAML last-key-wins silently dropped the GA4 analytics block and the "Was this page helpful?" feedback widget — the published docs site had 0 of 55 pages instrumented. The two mappings are merged; the docs site and all 16 static website pages now share one GA4 loader (`website-static/assets/analytics.js`), the `/go/*` short links report a `go_redirect` event, and the GitHub Sponsors CTA reports `outbound_click`. New recipe: *Measure your AR funnel*. The SDK and the demo apps still ship no telemetry.

--- a/docs/docs/recipes/measure-ar-funnel.md
+++ b/docs/docs/recipes/measure-ar-funnel.md
@@ -1,0 +1,120 @@
+---
+title: Measure your AR funnel
+description: Instrument the AR drop-off — session created, tracking ready, first placement, tracking lost, session failure — from your own app, using SceneView's public ARSceneView callbacks. SceneView itself ships no telemetry.
+---
+
+# Measure your AR funnel
+
+**Intent:** "Half my users never place a model. Where do they drop off?"
+
+!!! info "SceneView ships no telemetry"
+    The SDK sends nothing anywhere. There is no analytics dependency, no opt-out flag, no
+    endpoint. Every number below is produced **by your app, in your analytics account**,
+    from callbacks that are already part of the public `ARSceneView` API. If you want no
+    measurement at all, pass none of these lambdas and nothing happens.
+
+## The five steps worth counting
+
+| Step | Signal | What a drop here means |
+|---|---|---|
+| `ar_session_created` | `onSessionCreated` | ARCore is installed and permission was granted. |
+| `ar_tracking_ready` | `onTrackingFailureChanged` fires with `null` | The camera found enough of the world to anchor to. |
+| `ar_first_placement` | your own tap handler creates the first `Anchor` | The user understood the interaction. |
+| `ar_tracking_lost` | `onTrackingFailureChanged` fires non-`null` | Lighting, motion or a featureless surface. |
+| `ar_session_failed` | `onSessionFailure` | A typed, actionable reason — not a stack trace. |
+
+## A sink you own
+
+Keep the analytics vendor out of your AR code. One interface, one implementation per
+build flavour, and your screen stays testable:
+
+```kotlin
+interface ArFunnel {
+    fun log(event: String, params: Map<String, String> = emptyMap())
+}
+```
+
+A Firebase Analytics implementation is one line of body — any sink works (Amplitude,
+PostHog, your own backend, or `Log.d` in debug builds):
+
+```kotlin
+class FirebaseArFunnel(private val analytics: FirebaseAnalytics) : ArFunnel {
+    override fun log(event: String, params: Map<String, String>) =
+        analytics.logEvent(event) { params.forEach { (k, v) -> param(k, v) } }
+}
+```
+
+## Wiring it to `ARSceneView`
+
+`onTrackingFailureChanged` is the funnel middle: SceneView calls it **only when the reason
+changes**, so it is already de-duplicated — no per-frame guard needed. The first `null` is
+"tracking ready"; every non-`null` is a stall with a named cause.
+
+```kotlin
+@Composable
+fun ArScreen(funnel: ArFunnel) {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    val modelInstance = rememberModelInstance(modelLoader, "models/damaged_helmet.glb")
+
+    var anchor by remember { mutableStateOf<Anchor?>(null) }
+    var everTracked by remember { mutableStateOf(false) }
+
+    ARSceneView(
+        modifier = Modifier.fillMaxSize(),
+        engine = engine,
+        modelLoader = modelLoader,
+        planeRenderer = true,
+        onSessionCreated = { funnel.log("ar_session_created") },
+        onTrackingFailureChanged = { reason ->
+            if (reason == null) {
+                // First null = the session reached a usable state. Later nulls are
+                // recoveries, worth their own event so you can see how often users
+                // fight their way back instead of quitting.
+                funnel.log(if (everTracked) "ar_tracking_recovered" else "ar_tracking_ready")
+                everTracked = true
+            } else {
+                funnel.log("ar_tracking_lost", mapOf("reason" to reason.name))
+            }
+        },
+        onTouchEvent = { _, hitResult ->
+            // Your own tap handler — SceneView never places anything for you, so this
+            // is the only place that knows a placement happened.
+            if (anchor == null) {
+                hitResult?.createAnchorOrNull()?.let {
+                    anchor = it
+                    funnel.log("ar_first_placement")
+                }
+            }
+            false // let SceneView keep handling the gesture
+        },
+        onSessionFailure = { failure ->
+            // Typed, so the label is stable across ARCore versions and you can route
+            // "install ARCore" separately from "device not supported".
+            funnel.log(
+                "ar_session_failed",
+                mapOf("reason" to failure::class.simpleName.orEmpty())
+            )
+        }
+    ) {
+        anchor?.let { placed ->
+            AnchorNode(anchor = placed) {
+                modelInstance?.let { ModelNode(modelInstance = it, scaleToUnits = 0.3f) }
+            }
+        }
+    }
+}
+```
+
+## Reading the result
+
+- `ar_session_created` → `ar_tracking_ready` measures **the device and the room**. A wide
+  gap means users point at plain floors — add a scan hint.
+- `ar_tracking_ready` → `ar_first_placement` measures **your UI**. This is the step an
+  onboarding overlay actually moves.
+- `ar_session_failed` split by `reason` tells you how much of the loss is not yours to
+  fix: `ArCoreNotInstalled` and `DeviceNotCompatible` need a fallback 3D `SceneView`, not
+  a better AR tutorial. The full taxonomy is in
+  [`ARSessionFailure`](https://github.com/sceneview/sceneview/blob/main/arsceneview/src/main/java/io/github/sceneview/ar/ARSessionFailure.kt).
+
+Log no camera frames, depth data or `Pose` values: the funnel needs counts, not geometry.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - iOS visual polish: recipes/ios-visual-polish.md
       - Sketchfab streaming: recipes/sketchfab-streaming.md
       - Demo settings sheet: recipes/demo-settings-sheet.md
+      - Measure your AR funnel: recipes/measure-ar-funnel.md
     - FAQ: faq.md
     - Troubleshooting: troubleshooting.md
   - Platforms: platforms.md
@@ -103,6 +104,11 @@ nav:
   - Changelog: changelog.md
   - Migration Guide: migration.md
 
+# ONE `extra:` mapping — never two. YAML is last-key-wins: this file used to declare
+# `extra:` twice (analytics + feedback here, social/generator/version further down), so
+# the second mapping silently replaced the first and MkDocs Material rendered the docs
+# site with NO `gtag/js` at all and no "Was this page helpful?" widget. The deployed
+# sceneview.github.io/docs/ had 0 instrumented pages out of 82. Add new keys HERE.
 extra:
   analytics:
     provider: google
@@ -119,6 +125,19 @@ extra:
           name: This page could be improved
           data: 0
           note: Thanks, we'll work on improving this page.
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/sceneview/sceneview
+      name: SceneView on GitHub
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/UbNDDBTNqb
+      name: SceneView Discord
+    - icon: fontawesome/brands/npm
+      link: https://www.npmjs.com/package/sceneview-mcp
+      name: SceneView MCP on npm
+  generator: false
+  version:
+    provider: mike
 
 plugins:
   - search
@@ -150,21 +169,6 @@ markdown_extensions:
   - def_list
   - pymdownx.tasklist:
       custom_checkbox: true
-
-extra:
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/sceneview/sceneview
-      name: SceneView on GitHub
-    - icon: fontawesome/brands/discord
-      link: https://discord.gg/UbNDDBTNqb
-      name: SceneView Discord
-    - icon: fontawesome/brands/npm
-      link: https://www.npmjs.com/package/sceneview-mcp
-      name: SceneView MCP on npm
-  generator: false
-  version:
-    provider: mike
 
 extra_css:
   - stylesheets/extra.css

--- a/website-static/404.html
+++ b/website-static/404.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Page Not Found — SceneView</title>
   <meta name="robots" content="noindex, nofollow">
   <meta name="theme-color" content="#005bc1">

--- a/website-static/assets/analytics.js
+++ b/website-static/assets/analytics.js
@@ -27,6 +27,22 @@
 
   var MEASUREMENT_ID = 'G-HX1JWGSMTH';
 
+  // Honour the browser's opt-out signals BEFORE anything is fetched — privacy.html
+  // promises it, so it has to be true in code: Do Not Track (`navigator.doNotTrack`,
+  // legacy `window.doNotTrack` / `navigator.msDoNotTrack`) and Global Privacy Control.
+  // When opted out, `gtag` stays a stub that still runs `event_callback` so the /go/*
+  // interstitials redirect immediately instead of waiting for their timeout.
+  var optedOut =
+    navigator.doNotTrack === '1' || window.doNotTrack === '1' ||
+    navigator.msDoNotTrack === '1' || navigator.globalPrivacyControl === true;
+  if (optedOut) {
+    window.gtag = function () {
+      var params = arguments[2];
+      if (params && typeof params.event_callback === 'function') params.event_callback();
+    };
+    return;
+  }
+
   window.dataLayer = window.dataLayer || [];
   function gtag() { window.dataLayer.push(arguments); }
   window.gtag = gtag;
@@ -53,7 +69,11 @@
   gtag('js', new Date());
   gtag('config', MEASUREMENT_ID, {
     page_title: document.title,
-    content_group: contentGroup()
+    content_group: contentGroup(),
+    // First-party measurement only — no Google Signals, no ad personalisation. This is
+    // what lets privacy.html say "no advertising features are enabled".
+    allow_google_signals: false,
+    allow_ad_personalization_signals: false
   });
 
   function onReady(fn) {

--- a/website-static/assets/analytics.js
+++ b/website-static/assets/analytics.js
@@ -1,0 +1,115 @@
+/*
+ * SceneView website analytics — the ONE GA4 loader for every static page.
+ *
+ * GA4 Property: SceneView Website | Stream ID: 14357002837 | Measurement ID: G-HX1JWGSMTH
+ *
+ * Why a shared file instead of a copy-pasted inline snippet: the tag used to live inline
+ * in `index.html` only, so 15 of the 16 static pages — playground, showcase, docs, web,
+ * privacy, the /preview/ viewer, the /go/ hub — reported nothing at all. One file means
+ * one measurement id, one event vocabulary, and no page can drift out of the funnel.
+ *
+ * Load it SYNCHRONOUSLY (`<script src="/assets/analytics.js"></script>`, no `defer`,
+ * no `async`) from every page's `<head>`. The `/go/*` redirect interstitials call
+ * `gtag()` from their own inline script right after this one, so `gtag` must already be
+ * defined when their script runs. The gtag *library* is still fetched asynchronously —
+ * only the tiny dataLayer shim is synchronous.
+ *
+ * CSP: every static page ships `script-src 'self' 'unsafe-inline' …
+ * https://www.googletagmanager.com`, so both this 'self' file and the googletagmanager
+ * library it injects are allowed. `connect-src` already lists google-analytics.com.
+ *
+ * This file instruments the WEBSITE only. The SceneView SDK itself ships no telemetry
+ * and the demo apps' published privacy policy promises none — never import analytics
+ * into a library module or a sample app.
+ */
+(function () {
+  'use strict';
+
+  var MEASUREMENT_ID = 'G-HX1JWGSMTH';
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+  window.gtag = gtag;
+
+  // Fetch the tag library. `async` keeps it off the critical path; queued dataLayer
+  // calls are replayed once it lands.
+  var tag = document.createElement('script');
+  tag.async = true;
+  tag.src = 'https://www.googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID;
+  (document.head || document.documentElement).appendChild(tag);
+
+  // Coarse content grouping so the funnel can be read per surface in GA4 without
+  // hand-maintaining a page list.
+  function contentGroup() {
+    var path = window.location.pathname;
+    if (path.indexOf('/go/') === 0) return 'go';
+    if (path.indexOf('/preview/') === 0 ||
+        path.indexOf('/embed/') === 0 ||
+        path.indexOf('/open/') === 0 ||
+        path.indexOf('/rerun/') === 0) return 'viewer';
+    return 'website';
+  }
+
+  gtag('js', new Date());
+  gtag('config', MEASUREMENT_ID, {
+    page_title: document.title,
+    content_group: contentGroup()
+  });
+
+  function onReady(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function each(selector, fn) {
+    var nodes = document.querySelectorAll(selector);
+    Array.prototype.forEach.call(nodes, fn);
+  }
+
+  onReady(function () {
+    // Tab switches on the landing page / playground.
+    each('[data-tab]', function (tab) {
+      tab.addEventListener('click', function () {
+        gtag('event', 'tab_click', { tab_name: this.dataset.tab });
+      });
+    });
+
+    // Adoption CTAs: repo, Claude deep link, Discord, npm.
+    each('a[href*="github.com/sceneview"], a[href*="claude://"], a[href*="discord"], a[href*="npmjs"]',
+      function (link) {
+        link.addEventListener('click', function () {
+          gtag('event', 'cta_click', {
+            link_url: this.href,
+            link_text: (this.textContent || '').trim()
+          });
+        });
+      });
+
+    // Revenue funnel. `github.com/sponsors/sceneview` does NOT match the
+    // `github.com/sceneview` selector above, so the sponsor CTA — the only live
+    // revenue channel — was the one link on the site with zero attribution. These
+    // selectors are disjoint from the `cta_click` ones: no double counting.
+    each('a[href*="github.com/sponsors"], a[href*="polar.sh"]', function (link) {
+      link.addEventListener('click', function () {
+        gtag('event', 'outbound_click', {
+          link_url: this.href,
+          link_text: (this.textContent || '').trim(),
+          link_domain: this.hostname,
+          transport_type: 'beacon'
+        });
+      });
+    });
+
+    // Install-command copies.
+    each('.code-block', function (block) {
+      block.addEventListener('click', function () {
+        gtag('event', 'code_copy', {
+          code_snippet: (this.textContent || '').substring(0, 100)
+        });
+      });
+    });
+  });
+})();

--- a/website-static/claude-3d.html
+++ b/website-static/claude-3d.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>AI-Powered 3D — Claude + SceneView</title>
   <meta name="description" content="See how Claude Desktop generates interactive 3D content with SceneView. Live demos of AI-powered 3D model generation, procedural geometry, and AR experiences.">
   <meta name="robots" content="index, follow">

--- a/website-static/docs.html
+++ b/website-static/docs.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Documentation — SceneView 3D & AR SDK</title>
   <meta name="description" content="SceneView documentation: quick start guides, API reference, tutorials, and recipes for Android, iOS, Web, Flutter, and React Native 3D and AR development.">
   <meta name="robots" content="index, follow">

--- a/website-static/embed/index.html
+++ b/website-static/embed/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView 3D Embed</title>
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/website-static/geometry-demo.html
+++ b/website-static/geometry-demo.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
 <title>SceneView Geometry — Interactive 3D Showcase</title>
 <meta name="description" content="SceneView procedural 3D geometry renderer. Professional scenes with PBR shading — architecture, product display, data viz, landscapes.">
 <meta name="robots" content="index, follow">

--- a/website-static/go/android/index.html
+++ b/website-static/go/android/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView for Android — Google Play Store</title>
   <meta name="description" content="Download SceneView Demo for Android from the Google Play Store.">
   <!-- App not yet published on Play Store — no auto-redirect -->

--- a/website-static/go/claude/index.html
+++ b/website-static/go/claude/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView + Claude — AI-Powered 3D Development</title>
   <meta name="description" content="Open Claude with SceneView context — build 3D & AR apps with AI assistance.">
   <meta http-equiv="refresh" content="2;url=https://claude.ai/new?q=I%20want%20to%20build%20a%203D%20app%20with%20SceneView.%20Help%20me%20get%20started%20with%20Jetpack%20Compose.">
@@ -45,9 +48,34 @@
     <p class="fallback">Not working? <a href="https://claude.ai">Open Claude manually</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://claude.ai/new?q=I%20want%20to%20build%20a%203D%20app%20with%20SceneView.%20Help%20me%20get%20started%20with%20Jetpack%20Compose.';
-    }, 2000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/claude" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://claude.ai/new?q=I%20want%20to%20build%20a%203D%20app%20with%20SceneView.%20Help%20me%20get%20started%20with%20Jetpack%20Compose.';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'claude',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/discord/index.html
+++ b/website-static/go/discord/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView Discord</title>
   <meta name="description" content="Join the SceneView Discord community — chat with developers, ask questions, share your creations.">
   <meta http-equiv="refresh" content="1;url=https://discord.gg/sceneview">
@@ -39,9 +42,34 @@
     <p class="fallback">Not working? <a href="https://discord.gg/sceneview">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://discord.gg/sceneview';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/discord" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://discord.gg/sceneview';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'discord',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/github/index.html
+++ b/website-static/go/github/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView on GitHub</title>
   <meta name="description" content="SceneView source code, documentation, and samples on GitHub.">
   <meta http-equiv="refresh" content="1;url=https://github.com/sceneview/sceneview">
@@ -39,9 +42,34 @@
     <p class="fallback">Not working? <a href="https://github.com/sceneview/sceneview">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://github.com/sceneview/sceneview';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/github" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://github.com/sceneview/sceneview';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'github',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/index.html
+++ b/website-static/go/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Get SceneView — Download for your platform</title>
   <meta name="description" content="Download SceneView for your platform — Android, iOS, Web, Desktop. 3D & AR for every platform.">
   <meta name="robots" content="index, follow">

--- a/website-static/go/ios/index.html
+++ b/website-static/go/ios/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView for iOS — App Store</title>
   <meta name="description" content="SceneView for iOS — coming soon to the App Store.">
   <meta property="og:title" content="SceneView for iOS">

--- a/website-static/go/mcp/index.html
+++ b/website-static/go/mcp/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView MCP — AI Assistant Integration</title>
   <meta name="description" content="SceneView MCP server — let AI assistants generate 3D & AR code for you.">
   <meta http-equiv="refresh" content="2;url=https://www.npmjs.com/package/sceneview-mcp">
@@ -45,9 +48,34 @@
     <p class="fallback">Not working? <a href="https://www.npmjs.com/package/sceneview-mcp">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://www.npmjs.com/package/sceneview-mcp';
-    }, 2000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/mcp" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://www.npmjs.com/package/sceneview-mcp';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'mcp',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/npm/index.html
+++ b/website-static/go/npm/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView on npm</title>
   <meta name="description" content="SceneView packages on npm — sceneview-web, sceneview-mcp, and more.">
   <meta http-equiv="refresh" content="1;url=https://www.npmjs.com/package/sceneview-web">
@@ -46,9 +49,34 @@
     <p class="fallback">Not working? <a href="https://www.npmjs.com/package/sceneview-web">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://www.npmjs.com/package/sceneview-web';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/npm" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://www.npmjs.com/package/sceneview-web';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'npm',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/polar/index.html
+++ b/website-static/go/polar/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView — GitHub Sponsors</title>
   <meta name="description" content="Sponsor SceneView on GitHub — support development, get priority features, and more.">
   <meta http-equiv="refresh" content="1;url=https://github.com/sponsors/sceneview">
@@ -39,9 +42,34 @@
     <p class="fallback">Not working? <a href="https://github.com/sponsors/sceneview">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://github.com/sponsors/sceneview';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/polar" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://github.com/sponsors/sceneview';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'polar',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/sponsor/index.html
+++ b/website-static/go/sponsor/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Sponsor SceneView</title>
   <meta name="description" content="Support SceneView development — sponsor on GitHub.">
   <meta http-equiv="refresh" content="1;url=https://github.com/sponsors/sceneview">
@@ -39,9 +42,34 @@
     <p class="fallback">Not working? <a href="https://github.com/sponsors/sceneview">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://github.com/sponsors/sceneview';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/sponsor" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://github.com/sponsors/sceneview';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'sponsor',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/go/web/index.html
+++ b/website-static/go/web/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView Web Demo</title>
   <meta name="description" content="Try SceneView 3D in your browser — no install required.">
   <meta http-equiv="refresh" content="1;url=https://sceneview.github.io/preview/">
@@ -39,9 +42,34 @@
     <p class="fallback">Not working? <a href="https://sceneview.github.io/preview/">Click here</a> or go <a href="/go/">back</a></p>
   </div>
   <script>
-    setTimeout(function() {
-      window.location.href = 'https://sceneview.github.io/preview/';
-    }, 1000);
+    // Attribute the /go/ hub before leaving. `go_redirect` is what turns
+    // "someone hit /go/web" into a funnel step in GA4 — the interstitial used to
+    // navigate away without ever reporting itself.
+    //
+    // Ordering matters: the shared loader in <head> defines `gtag` synchronously, so the
+    // event is queued here, and `event_callback` fires the redirect the moment the hit is
+    // on the wire (`transport_type: 'beacon'` → navigator.sendBeacon, which survives the
+    // navigation). `event_timeout` bounds the wait when the tag is blocked or slow, the
+    // setTimeout below bounds it when gtag never loads at all, and the 1s
+    // `<meta http-equiv="refresh">` in <head> is the final no-JS fallback. `redirect()`
+    // is idempotent, so whichever path wins, the visitor navigates exactly once.
+    var DESTINATION = 'https://sceneview.github.io/preview/';
+    var redirected = false;
+    function redirect() {
+      if (redirected) return;
+      redirected = true;
+      window.location.href = DESTINATION;
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'go_redirect', {
+        target: 'web',
+        destination: DESTINATION,
+        transport_type: 'beacon',
+        event_timeout: 600,
+        event_callback: redirect
+      });
+    }
+    setTimeout(redirect, 700);
   </script>
 </body>
 </html>

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView — 3D & AR SDK for Android, iOS, Web, and more</title>
   <meta name="description" content="SceneView is an open-source, AI-first SDK for building 3D and AR applications with Jetpack Compose, SwiftUI, Kotlin/JS, Flutter, and React Native. Powered by Filament and RealityKit.">
   <meta name="keywords" content="SceneView, 3D SDK, AR SDK, Augmented Reality, Jetpack Compose, SwiftUI, Kotlin Multiplatform, ARCore, ARKit, Filament, RealityKit, Android 3D, iOS AR, model viewer, glTF, USDZ, visionOS, cross-platform 3D, AI-first SDK, MCP server, Claude 3D, ChatGPT AR, AI code generation, LLM 3D development, Copilot 3D, Gemini AR, model context protocol">
@@ -53,40 +56,6 @@
   <meta name="twitter:description" content="Open-source, AI-first SDK for 3D and AR on Android, iOS, Web, Desktop, TV, Flutter, and React Native. Declarative API with Jetpack Compose and SwiftUI.">
   <meta name="twitter:image" content="https://sceneview.github.io/og-image.png">
   <meta name="twitter:image:alt" content="SceneView — 3D and AR SDK for every platform">
-
-  <!-- Google Analytics 4 -->
-  <!-- GA4 Property: SceneView Website | Stream ID: 14357002837 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-HX1JWGSMTH"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-HX1JWGSMTH', {
-      page_title: document.title,
-      content_group: 'website'
-    });
-    // Track key events
-    document.addEventListener('DOMContentLoaded', function() {
-      // Track playground usage
-      document.querySelectorAll('[data-tab]').forEach(function(tab) {
-        tab.addEventListener('click', function() {
-          gtag('event', 'tab_click', { tab_name: this.dataset.tab });
-        });
-      });
-      // Track CTA clicks (GitHub, Claude install, Discord)
-      document.querySelectorAll('a[href*="github.com/sceneview"], a[href*="claude://"], a[href*="discord"], a[href*="npmjs"]').forEach(function(link) {
-        link.addEventListener('click', function() {
-          gtag('event', 'cta_click', { link_url: this.href, link_text: this.textContent.trim() });
-        });
-      });
-      // Track npm copy events
-      document.querySelectorAll('.code-block').forEach(function(block) {
-        block.addEventListener('click', function() {
-          gtag('event', 'code_copy', { code_snippet: this.textContent.substring(0, 100) });
-        });
-      });
-    });
-  </script>
 
   <!-- Preconnect hints -->
   <!-- Preload critical resources -->

--- a/website-static/open/index.html
+++ b/website-static/open/index.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Open in SceneView Demo</title>
   <meta name="description" content="Open this demo in the SceneView Demo app.">
   <meta name="robots" content="noindex">

--- a/website-static/platforms-showcase.html
+++ b/website-static/platforms-showcase.html
@@ -17,6 +17,9 @@
   </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
     <title>SceneView — One SDK, Every Screen</title>
     <meta name="description" content="SceneView renders 3D natively on Android, iOS, macOS, visionOS, Web, TV, Flutter, and React Native — one API, every platform.">
     <meta name="robots" content="index, follow">

--- a/website-static/playground.html
+++ b/website-static/playground.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Playground — SceneView</title>
   <meta name="description" content="Interactive SceneView playground — explore, edit, and preview 3D & AR code across Android, iOS, and Web with live 3D preview.">
   <meta name="robots" content="index, follow">

--- a/website-static/preview/embed.html
+++ b/website-static/preview/embed.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView 3D</title>
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/website-static/preview/index.html
+++ b/website-static/preview/index.html
@@ -4,6 +4,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' blob: https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://api.sketchfab.com https://media.sketchfab.com; frame-src https://app.rerun.io; worker-src 'self' blob:; base-uri 'self'; object-src 'none'">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView 3D Preview</title>
   <meta name="description" content="Interactive 3D preview — powered by SceneView">
   <meta name="robots" content="noindex, nofollow">

--- a/website-static/privacy.html
+++ b/website-static/privacy.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Privacy Policy — SceneView</title>
   <meta name="description" content="Privacy Policy for the SceneView Demo app. No tracking, offline by default, and an opt-in in-app feedback feature.">
   <meta name="robots" content="index, follow">
@@ -333,6 +336,9 @@
 
       <h2>Data Sharing</h2>
       <p>Outside the feedback feature, no data is shared with third parties. For the feedback feature, data is shared only with the processors above, and the feedback transcript and context become public on a GitHub issue. No data is sold or used for advertising.</p>
+
+      <h2>This Website (sceneview.github.io)</h2>
+      <p>Everything above describes the <strong>SceneView Demo app</strong> and the SceneView SDK, neither of which contains any analytics SDK. The documentation and marketing <strong>website</strong> is a separate surface: it uses Google Analytics 4 (measurement ID <code>G-HX1JWGSMTH</code>) to count page views and which links visitors follow, so we know which docs and platforms are worth maintaining. IP addresses are anonymised by Google Analytics, no advertising features are enabled, and no data collected on the website is linked to app usage. Browser &ldquo;Do Not Track&rdquo; and content blockers are respected &mdash; the site works fully without the tag.</p>
 
       <h2>Children's Privacy</h2>
       <p>The app does not knowingly collect any data from children under 13. The app is rated for ages 13 and older.</p>

--- a/website-static/rerun/index.html
+++ b/website-static/rerun/index.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>AR Session Viewer — SceneView</title>
   <meta name="description" content="View and share AR debug sessions captured with SceneView. Powered by Rerun.io.">
   <meta name="robots" content="noindex">

--- a/website-static/showcase.html
+++ b/website-static/showcase.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>Showcase — SceneView 3D & AR SDK</title>
   <meta name="description" content="See SceneView in action: interactive demos, downloadable sample apps for Android, iOS, Web, and TV. Explore 3D and AR across every platform.">
   <meta name="robots" content="index, follow">

--- a/website-static/web.html
+++ b/website-static/web.html
@@ -17,6 +17,9 @@
   </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Site analytics — GA4 loader shared by every static page (G-HX1JWGSMTH).
+       Synchronous on purpose: /go/* interstitials call gtag() right after it. -->
+  <script src="/assets/analytics.js"></script>
   <title>SceneView Web — One Line 3D for the Web</title>
   <meta name="description" content="SceneView Web: the lightest way to add 3D to any website. One script tag, one function call, powered by Filament.js WASM. 25KB vs Three.js 600KB.">
   <meta name="keywords" content="SceneView Web, 3D web, JavaScript 3D, Filament.js, WASM 3D, glTF viewer, GLB viewer, lightweight 3D, model viewer, web 3D library">


### PR DESCRIPTION
The website had a measurement hole at both ends: the docs site sent nothing at all, and on the marketing site only the home page was tagged. This fixes both and adds the recipe that tells host apps how to measure their own AR funnel — without SceneView ever measuring anything for them.

## 1. `docs/mkdocs.yml` declared `extra:` twice

Once with `analytics` (GA4 `G-HX1JWGSMTH`) + the "Was this page helpful?" feedback widget, once with `social` / `generator` / `version`. YAML is last-key-wins, so the second mapping silently replaced the first and every docs page shipped without `gtag/js` and without the feedback widget. The build was green either way, which is why it survived.

Merged into one mapping, with a comment saying why there must only ever be one. Measured with the pinned CI toolchain (`mkdocs-material==9.7.7`), same tree, only this file changed:

| | pages with `gtag/js` | pages with `md-feedback` |
|---|---|---|
| before | **0** / 55 | 0 / 55 |
| after | **55** / 55 | 55 / 55 |

```
$ python3 -c "import yaml; d=yaml.load(open('docs/mkdocs.yml'), Loader=L); print(list(d['extra'].keys()))"
['analytics', 'social', 'generator', 'version']
```

(`feedback` lives at `extra.analytics.feedback` — that is where MkDocs Material reads it, and `d['extra']['analytics']['feedback']['title']` resolves to `Was this page helpful?`.)

## 2. One shared GA4 loader for all 16 static pages

The tag was hand-rolled inline in `index.html` only. New `website-static/assets/analytics.js` holds the single copy — dataLayer shim, `gtag('config')` with a path-derived `content_group`, and the existing `tab_click` / `cta_click` / `code_copy` wiring lifted verbatim. Every page loads it from `<head>` with the identical two-line snippet.

Loaded synchronously on purpose (only the googletagmanager library is `async`): the `/go/*` interstitials call `gtag()` from their own inline script. Every page already ships a CSP allowing `script-src 'self' … googletagmanager.com`, so nothing about the CSP changes.

Pages newly tagged: `404`, `claude-3d`, `docs`, `geometry-demo`, `platforms-showcase`, `playground`, `privacy`, `showcase`, `web`, `embed/`, `open/`, `preview/`, `preview/embed`, `rerun/`, `go/`.

New `outbound_click` on `github.com/sponsors/*` and `polar.sh`. GitHub Sponsors is the only live revenue channel and it was the one CTA with zero attribution — `github.com/sponsors/sceneview` does not match the existing `a[href*="github.com/sceneview"]` selector, so `cta_click` never covered it. The selector sets are disjoint; nothing is double counted.

`privacy.html` gains a "This Website" section: its "no analytics" promises are about the demo app and the SDK, which still ship zero telemetry — the website is a different surface and now says so out loud.

## 3. `go_redirect` on the short-link hub

The ten `/go/*` interstitials are what the README badges and every external post point at, and they navigated away without reporting themselves. The eight that auto-redirect now fire `go_redirect` with `target` + `destination` first. `destination` is read out of each page's own redirect script rather than retyped, so the event cannot disagree with where the visitor actually goes.

Delivery is layered — `transport_type: 'beacon'` → `event_callback` navigates as soon as the hit is on the wire (usually faster than the 1 s these pages used to sit there) → `event_timeout: 600` → `setTimeout(redirect, 700)` → the untouched 1 s `<meta refresh>` for no-JS. `redirect()` is idempotent, so the visitor navigates exactly once whichever layer wins.

`/go/android/` and `/go/ios/` are "coming soon" pages with no redirect; their GitHub CTAs are already covered by `cta_click`, so they get the page view and nothing more.

## 4. Recipe — "Measure your AR funnel"

`docs/docs/recipes/measure-ar-funnel.md` (120 lines), in the Recipes nav. Opens by stating that SceneView ships no telemetry, then shows the host-app pattern using callbacks that are already public API on the current `ARSceneView` composable (not the deprecated `ARScene` alias): `onSessionCreated` → `onTrackingFailureChanged(null)` → the host's own `onTouchEvent` + `hitResult.createAnchorOrNull()` → tracking lost/recovered → `onSessionFailure` with the sealed `ARSessionFailure` taxonomy. Everything goes through a four-line `ArFunnel` interface the host owns, with Firebase Analytics as one implementation among several.

## Not touched

`samples/`, `mcp/`, `telemetry-worker/` and every library module. The SDK and the demo apps still phone home to nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)