### PR TITLE
fix(demo): make Point & Ask an explicit state machine and validate the frame

### DIFF
--- a/changelog.d/3407-point-and-ask-states.md
+++ b/changelog.d/3407-point-and-ask-states.md
@@ -1,0 +1,13 @@
+<!-- category: Fixed -->
+**Demo app — Point & Ask now shows what it is doing, and stops lying about your phone.**
+On a Pixel 9 the demo answered nothing, "saw nothing" on the AR frame, and after a few taps
+declared it could not run on that device at all. Three defects behind that: the frame was
+read back from the whole *window*, which can lose the Filament `SurfaceView` layer the AR
+scene lives in; the only validation was a transparency probe, so the same lost layer coming
+back as opaque black passed straight through to Gemini Nano; and a retry counter promoted
+three ordinary failures into a permanent "not supported on this device". The frame is now
+read back from the AR view itself, validated for size, transparency *and* flatness before it
+leaves the app, and the screen is an explicit state machine — checking, downloading, ready,
+capturing, thinking, answer, or a failure that names its cause and offers the one action that
+fixes it. Only a report from the platform can say a device is unsupported. Debug builds show
+a thumbnail of the exact frame that was sent.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
@@ -43,6 +43,16 @@ object DemoSettings {
     var qaBackdrop: Boolean? by mutableStateOf(null)
 
     /**
+     * QA-only Point & Ask card override (#3407). `--es qa_ask_state <id>` pins the demo's
+     * bottom card to one state — see [io.github.sceneview.demo.ai.askStepForQaOverride] and
+     * [io.github.sceneview.demo.ai.ASK_QA_STATE_IDS] — so a light + dark screenshot of every
+     * state can be taken on an emulator that has neither ARCore nor AICore (#2754). `null`
+     * (default) leaves the demo running its real state machine; an unrecognised id is
+     * ignored the same way.
+     */
+    var qaAskState: String? by mutableStateOf(null)
+
+    /**
      * Optional camera-to-model distance, in metres, the 3D demos should frame the model at
      * when they start — i.e. a zoom level. When non-null, the shared hero-orbit camera
      * ([rememberHeroOrbitCameraManipulator]) uses this value as its orbit radius instead of

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -105,6 +105,7 @@ class MainActivity : ComponentActivity() {
         // showcase frozen until process death.
         DemoSettings.qaMode = intent?.getBooleanExtra("qa_mode", false) ?: false
         DemoSettings.qaBackdrop = resolveQaBackdrop(intent)
+        DemoSettings.qaAskState = intent?.getStringExtra("qa_ask_state")
         // Optional path to an ARCore playback fixture (.mp4). Confined to the app's own
         // external-files dir so a malicious deep link can't probe arbitrary device paths
         // (`/data/data/...`, photos, configs). The path is consumed once by
@@ -141,6 +142,7 @@ class MainActivity : ComponentActivity() {
             ?: DeepLinkRouter.parse(intent.data)
         DemoSettings.qaMode = intent.getBooleanExtra("qa_mode", false)
         DemoSettings.qaBackdrop = resolveQaBackdrop(intent)
+        DemoSettings.qaAskState = intent.getStringExtra("qa_ask_state")
         DemoSettings.arPendingPlaybackFile = intent.getStringExtra("ar_playback_file")
             ?.takeIf { isWithinAppFilesDir(it) }
         DemoSettings.cameraDistance = resolveCameraDistance(intent)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskEngine.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskEngine.kt
@@ -149,6 +149,22 @@ class CannedAskEngine : AskEngine {
 }
 
 /**
+ * Projects the ML Kit-flavoured [AskEngineStatus] onto the plain-Kotlin [AskAvailability] the
+ * state machine speaks. The seam exists so `AskFlow` — and its JVM tests — never has to touch
+ * an ML Kit type (#3407).
+ *
+ * [AskEngineStatus.Unavailable] is the one and only route to [AskAvailability.Unsupported]
+ * that does not come from a terminal inference error: both are the **platform** reporting
+ * that this device cannot run the model. Nothing else in the demo may reach that state.
+ */
+fun AskEngineStatus.toAvailability(): AskAvailability = when (this) {
+    AskEngineStatus.Ready -> AskAvailability.Ready
+    AskEngineStatus.Downloadable -> AskAvailability.Downloadable
+    is AskEngineStatus.Downloading -> AskAvailability.Downloading(totalBytesDownloaded)
+    AskEngineStatus.Unavailable -> AskAvailability.Unsupported
+}
+
+/**
  * Engine for the current run: [CannedAskEngine] under QA mode, [GeminiNanoAskEngine] otherwise.
  * Closed automatically when it leaves composition (or when QA mode is toggled mid-session).
  */

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFailure.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFailure.kt
@@ -17,44 +17,104 @@ import io.github.sceneview.demo.R
  *
  * Each value therefore carries:
  *  - [messageRes], one sentence saying what happened;
- *  - [isTerminal], whether retrying on this device can plausibly change the outcome.
- *    A terminal failure retires the retry affordance and shows the "not available here"
- *    explanation instead — the honest answer, and the one #2648 promised (on-device only,
- *    no cloud fallback).
+ *  - [isTerminal], whether the **platform** reported that this device cannot run the model
+ *    at all. Only a terminal failure may retire the demo (`AskAvailability.Unsupported`);
+ *    a pile of non-terminal ones may not, however tall (#3407);
+ *  - [recovery], the one next step the card offers — a real button, not a sentence.
  */
 enum class AskFailure(
     @StringRes val messageRes: Int,
     val isTerminal: Boolean,
+    val recovery: AskRecovery,
 ) {
-    /** The composited frame never arrived (PixelCopy failure/timeout, or a transparent hole). */
-    CaptureFailed(R.string.demo_point_and_ask_error_capture, isTerminal = false),
+    /** The frame never arrived (read-back failure or timeout). */
+    CaptureFailed(
+        R.string.demo_point_and_ask_error_capture,
+        isTerminal = false,
+        recovery = AskRecovery.Retry,
+    ),
+
+    /**
+     * The read-back came back with the AR viewport punched out — a fully transparent region
+     * where the camera + virtual objects should be (#2654/#3276). Retrying is worth one shot
+     * (compositor state changes frame to frame), and the message says what is missing rather
+     * than blaming the model.
+     */
+    CaptureMissingArLayer(
+        R.string.demo_point_and_ask_error_capture_layer,
+        isTerminal = false,
+        recovery = AskRecovery.Retry,
+    ),
+
+    /**
+     * The frame was read back intact but is essentially one flat colour — a black viewport,
+     * a covered lens, or a lost AR layer in its opaque form. Sending it produced exactly the
+     * "the model sees nothing" report in #3407, so it is now caught before it leaves.
+     */
+    CaptureBlank(
+        R.string.demo_point_and_ask_error_capture_blank,
+        isTerminal = false,
+        recovery = AskRecovery.AimAndRetry,
+    ),
 
     /**
      * The model ran and returned nothing. Not an exception — a completed stream with no
      * text, which the pre-#3343 code reported with the same wording as a hard failure.
      */
-    EmptyAnswer(R.string.demo_point_and_ask_error_empty, isTerminal = false),
+    EmptyAnswer(
+        R.string.demo_point_and_ask_error_empty,
+        isTerminal = false,
+        recovery = AskRecovery.Rephrase,
+    ),
 
     /** `NOT_AVAILABLE` / `NOT_SUPPORTED` / `AICORE_INCOMPATIBLE`. */
-    ModelUnavailable(R.string.demo_point_and_ask_error_unavailable, isTerminal = true),
+    ModelUnavailable(
+        R.string.demo_point_and_ask_error_unavailable,
+        isTerminal = true,
+        recovery = AskRecovery.OpenAicoreSettings,
+    ),
 
     /** `NEEDS_SYSTEM_UPDATE` — AICore is behind the ML Kit client. */
-    NeedsSystemUpdate(R.string.demo_point_and_ask_error_system_update, isTerminal = true),
+    NeedsSystemUpdate(
+        R.string.demo_point_and_ask_error_system_update,
+        isTerminal = true,
+        recovery = AskRecovery.OpenAicoreSettings,
+    ),
 
     /** `NOT_ENOUGH_DISK_SPACE`. */
-    NotEnoughDiskSpace(R.string.demo_point_and_ask_error_disk_space, isTerminal = false),
+    NotEnoughDiskSpace(
+        R.string.demo_point_and_ask_error_disk_space,
+        isTerminal = false,
+        recovery = AskRecovery.FreeStorage,
+    ),
 
     /** `BUSY` / battery quota / background-use block — transient, retry genuinely helps. */
-    Busy(R.string.demo_point_and_ask_error_busy, isTerminal = false),
+    Busy(
+        R.string.demo_point_and_ask_error_busy,
+        isTerminal = false,
+        recovery = AskRecovery.Retry,
+    ),
 
     /** `REQUEST_TOO_LARGE` / `REQUEST_TOO_SMALL` — the prompt itself is out of bounds. */
-    RequestTooLarge(R.string.demo_point_and_ask_error_too_large, isTerminal = false),
+    RequestTooLarge(
+        R.string.demo_point_and_ask_error_too_large,
+        isTerminal = false,
+        recovery = AskRecovery.Rephrase,
+    ),
 
     /** `INVALID_INPUT_IMAGE` — the captured frame was rejected by the model. */
-    InvalidImage(R.string.demo_point_and_ask_error_image, isTerminal = false),
+    InvalidImage(
+        R.string.demo_point_and_ask_error_image,
+        isTerminal = false,
+        recovery = AskRecovery.AimAndRetry,
+    ),
 
     /** Anything else, including a non-ML-Kit throwable. */
-    Unknown(R.string.demo_point_and_ask_error, isTerminal = false),
+    Unknown(
+        R.string.demo_point_and_ask_error,
+        isTerminal = false,
+        recovery = AskRecovery.Retry,
+    ),
     ;
 
     companion object {
@@ -119,8 +179,29 @@ enum class AskFailure(
 }
 
 /**
- * Consecutive failures after which the demo stops offering "tap to try again" and explains
- * itself instead. A terminal failure escalates on the first occurrence; this covers the
- * non-terminal codes that nonetheless never recover in practice on a given device.
+ * The one concrete next step a failure card offers, as a button (#3407).
+ *
+ * The #3343 card ended at a sentence — and once a retry counter tripped, at a sentence that
+ * told a working Pixel 9 it could not run the model. Every failure now names an action the
+ * user can actually take, and [openable] says whether taking it leaves the app.
  */
-const val ASK_FAILURE_ESCALATION_THRESHOLD = 3
+enum class AskRecovery(@StringRes val labelRes: Int, val openable: Boolean = false) {
+    /** Just try the round again — nothing about the device needs to change. */
+    Retry(R.string.demo_point_and_ask_action_retry),
+
+    /** Point at something with a bit of texture and light, then ask again. */
+    AimAndRetry(R.string.demo_point_and_ask_action_aim),
+
+    /** The question, not the frame, is the problem — put the cursor back in the field. */
+    Rephrase(R.string.demo_point_and_ask_action_rephrase),
+
+    /** Free space, then retry — opens the storage settings screen. */
+    FreeStorage(R.string.demo_point_and_ask_action_storage, openable = true),
+
+    /**
+     * Opens the system app details for Android System Intelligence / AICore, where the user
+     * can check for an update. The only action offered for the two terminal causes: there is
+     * no cloud fallback by design (#2648), so the honest next step is a platform one.
+     */
+    OpenAicoreSettings(R.string.demo_point_and_ask_action_aicore, openable = true),
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFlow.kt
@@ -1,0 +1,281 @@
+package io.github.sceneview.demo.ai
+
+/**
+ * Availability of the on-device engine, as the flow tracks it. Mirrors [AskEngineStatus] but
+ * is independent of ML Kit types so the whole state machine stays a plain-Kotlin, JVM-testable
+ * unit (#3407).
+ */
+sealed interface AskAvailability {
+    /** The availability probe has not answered yet. */
+    data object Checking : AskAvailability
+
+    /** Supported device, model not fetched — the user can start the download. */
+    data object Downloadable : AskAvailability
+
+    /** Download in flight. `null` bytes until the first progress tick. */
+    data class Downloading(val bytesDownloaded: Long? = null) : AskAvailability
+
+    /** Model present — the demo can be asked questions. */
+    data object Ready : AskAvailability
+
+    /**
+     * The **platform** reported that this device cannot run the model. Only ever reached
+     * from a real report — `FeatureStatus` saying so, a failed download, or a terminal ML
+     * Kit error code — never from a retry counter (#3407).
+     */
+    data object Unsupported : AskAvailability
+}
+
+/** What the demo is doing about the current question, once the model is [AskAvailability.Ready]. */
+sealed interface AskRound {
+    /** Nothing in flight — tap to ask. */
+    data object Idle : AskRound
+
+    /** A tap was registered; the AR frame is being read back and validated. */
+    data object CapturingFrame : AskRound
+
+    /** A valid frame is with the model. */
+    data object Thinking : AskRound
+
+    /** Answer text so far; [streaming] while deltas keep arriving. */
+    data class Answered(val text: String, val streaming: Boolean) : AskRound
+
+    /**
+     * The round failed before any text arrived. [consecutive] is how many rounds in a row
+     * have now failed — used only to change the *wording* ("this keeps failing"), never to
+     * declare the device unsupported.
+     */
+    data class Failed(val failure: AskFailure, val consecutive: Int) : AskRound
+}
+
+/**
+ * The single state the Point & Ask UI renders. Exactly one card is on screen at a time, so
+ * exactly one value describes it.
+ */
+sealed interface AskStep {
+    data object CheckingAvailability : AskStep
+    data object ModelDownloadable : AskStep
+    data class ModelDownloading(val bytesDownloaded: Long?) : AskStep
+    data object ModelUnsupported : AskStep
+    data object Ready : AskStep
+    data object CapturingFrame : AskStep
+    data object Thinking : AskStep
+    data class Answered(val text: String, val streaming: Boolean) : AskStep
+
+    /**
+     * [persistent] is `true` once the same round has failed
+     * [ASK_FAILURE_PERSISTENT_THRESHOLD] times in a row. It changes the headline from "that
+     * didn't work" to "this keeps failing" — and nothing else. The card still names
+     * [failure]'s actual cause and still offers [AskFailure.recovery]. A device is declared
+     * unable to run the model only through [AskStep.ModelUnsupported], which only the
+     * platform can trigger (#3407).
+     */
+    data class Failed(val failure: AskFailure, val persistent: Boolean) : AskStep
+}
+
+/**
+ * Consecutive failures after which the failure card changes its headline to "this keeps
+ * failing here". It does **not** retire the retry, and it does **not** claim the device is
+ * unsupported: #3343 wired a retry counter straight to "Point & Ask can't answer on this
+ * device", so three ordinary capture failures on a perfectly capable Pixel 9 ended the demo
+ * with a dead-end lie (#3407).
+ */
+const val ASK_FAILURE_PERSISTENT_THRESHOLD = 3
+
+/**
+ * The Point & Ask state machine, as a plain object with no Android, Compose, ARCore or ML Kit
+ * dependency — every transition below is exercised by `AskFlowTest` on the JVM.
+ *
+ * Two orthogonal axes, deliberately kept apart:
+ *  - [availability] — can this device answer at all? Owned by the engine probe and the
+ *    download flow, and by terminal ML Kit error codes. This is the ONLY axis that can say
+ *    "not on this phone".
+ *  - [round] — what is happening to the current question. Owned by the tap, the frame
+ *    capture, and the inference stream. However many rounds fail, this axis never promotes
+ *    itself to "unsupported".
+ *
+ * [step] projects both onto the one card the user sees.
+ */
+class AskFlow(
+    availability: AskAvailability = AskAvailability.Checking,
+    round: AskRound = AskRound.Idle,
+) {
+    var availability: AskAvailability = availability
+        private set
+
+    var round: AskRound = round
+        private set
+
+    /** How many rounds in a row have failed with no text at all. Reset by any answer. */
+    var consecutiveFailures: Int = 0
+        private set
+
+    /** The single state the UI renders. */
+    val step: AskStep
+        get() = when (val a = availability) {
+            AskAvailability.Checking -> AskStep.CheckingAvailability
+            AskAvailability.Downloadable -> AskStep.ModelDownloadable
+            is AskAvailability.Downloading -> AskStep.ModelDownloading(a.bytesDownloaded)
+            AskAvailability.Unsupported -> AskStep.ModelUnsupported
+            AskAvailability.Ready -> when (val r = round) {
+                AskRound.Idle -> AskStep.Ready
+                AskRound.CapturingFrame -> AskStep.CapturingFrame
+                AskRound.Thinking -> AskStep.Thinking
+                is AskRound.Answered -> AskStep.Answered(r.text, r.streaming)
+                is AskRound.Failed -> AskStep.Failed(
+                    failure = r.failure,
+                    persistent = r.consecutive >= ASK_FAILURE_PERSISTENT_THRESHOLD,
+                )
+            }
+        }
+
+    /**
+     * `true` while a round is in flight. Taps are ignored, and the round cannot be replaced
+     * out from under itself.
+     */
+    val isBusy: Boolean
+        get() = round == AskRound.CapturingFrame ||
+            round == AskRound.Thinking ||
+            (round as? AskRound.Answered)?.streaming == true
+
+    /** `true` when a tap would start a round right now. */
+    val canAsk: Boolean
+        get() = availability == AskAvailability.Ready && !isBusy
+
+    /**
+     * The engine probe (or the download flow) reported [status]. A status change while a
+     * round is in flight abandons the round: the answer it was going to produce is no longer
+     * meaningful once the model has gone away, and leaving it "thinking" forever is exactly
+     * the wedge #3188 fixed.
+     */
+    fun onAvailability(status: AskAvailability) {
+        if (status == availability) return
+        availability = status
+        if (status != AskAvailability.Ready) {
+            round = AskRound.Idle
+        }
+    }
+
+    /**
+     * A tap landed. Returns `true` when it starts a round (and the caller should capture a
+     * frame), `false` when it was ignored — no model, or a round already running.
+     */
+    fun onTap(): Boolean {
+        if (!canAsk) return false
+        round = AskRound.CapturingFrame
+        return true
+    }
+
+    /** A frame passed [inspectAskFrame] and is on its way to the model. */
+    fun onFrameAccepted() {
+        if (round == AskRound.CapturingFrame) round = AskRound.Thinking
+    }
+
+    /** One streamed delta; [text] is the answer accumulated so far. */
+    fun onDelta(text: String) {
+        if (round !is AskRound.CapturingFrame && round !is AskRound.Thinking &&
+            round !is AskRound.Answered
+        ) {
+            return
+        }
+        consecutiveFailures = 0
+        round = AskRound.Answered(text, streaming = true)
+    }
+
+    /**
+     * The stream completed normally. A stream that produced no text at all is a failure the
+     * user can act on (rephrase), not a silent success — it is one of the two shapes #3407
+     * was reported as.
+     */
+    fun onStreamCompleted() {
+        val answered = round as? AskRound.Answered
+        if (answered == null || answered.text.isBlank()) {
+            onFailure(AskFailure.EmptyAnswer)
+            return
+        }
+        round = AskRound.Answered(answered.text, streaming = false)
+    }
+
+    /**
+     * The round failed. Text already streamed is kept and marked complete — a partial answer
+     * beats an error card. Otherwise the failure is surfaced, and a **terminal** failure
+     * (the platform saying this device cannot run the model) also moves [availability] to
+     * [AskAvailability.Unsupported], which is the only honest route to "not on this phone".
+     */
+    fun onFailure(failure: AskFailure) {
+        val partial = (round as? AskRound.Answered)?.text?.takeIf { it.isNotBlank() }
+        if (partial != null) {
+            consecutiveFailures = 0
+            round = AskRound.Answered(partial, streaming = false)
+            return
+        }
+        consecutiveFailures++
+        round = AskRound.Failed(failure, consecutiveFailures)
+        if (failure.isTerminal) availability = AskAvailability.Unsupported
+    }
+
+    /** A finished answer timed out on screen. */
+    fun onAnswerDismissed() {
+        val answered = round as? AskRound.Answered ?: return
+        if (!answered.streaming) round = AskRound.Idle
+    }
+
+    /**
+     * The user tapped the failure card's action. The counter goes back to zero: they made a
+     * deliberate gesture, so the next failure is a first failure again and the wording starts
+     * over instead of staying escalated forever.
+     */
+    fun onRetry() {
+        consecutiveFailures = 0
+        round = AskRound.Idle
+    }
+
+    /** Demo Reset — clears the round and the failure history, keeps the availability probe. */
+    fun reset() {
+        consecutiveFailures = 0
+        round = AskRound.Idle
+    }
+}
+
+/**
+ * QA-only step override (`--es qa_ask_state <id>`), so every card can be screenshot in light
+ * and dark on an emulator that has neither ARCore nor AICore (#2754). Returns `null` for an
+ * absent or unrecognised id, which leaves the demo running its real state machine.
+ *
+ * Pure lookup — unit-tested rather than trusted, because a typo here would silently produce
+ * a QA sweep of the wrong card.
+ */
+fun askStepForQaOverride(id: String?): AskStep? = when (id?.trim()?.lowercase()) {
+    null, "" -> null
+    "checking" -> AskStep.CheckingAvailability
+    "downloadable" -> AskStep.ModelDownloadable
+    "downloading" -> AskStep.ModelDownloading(bytesDownloaded = 412L * 1024 * 1024)
+    "unsupported" -> AskStep.ModelUnsupported
+    "ready" -> AskStep.Ready
+    "capturing" -> AskStep.CapturingFrame
+    "thinking" -> AskStep.Thinking
+    "answered" -> AskStep.Answered(QA_SAMPLE_ANSWER, streaming = false)
+    "streaming" -> AskStep.Answered(QA_SAMPLE_ANSWER.take(34), streaming = true)
+    "failed" -> AskStep.Failed(AskFailure.CaptureBlank, persistent = false)
+    "failed-persistent" -> AskStep.Failed(AskFailure.CaptureMissingArLayer, persistent = true)
+    else -> null
+}
+
+/** Every id [askStepForQaOverride] accepts, in the order a QA sweep should walk them. */
+val ASK_QA_STATE_IDS = listOf(
+    "checking",
+    "downloadable",
+    "downloading",
+    "unsupported",
+    "ready",
+    "capturing",
+    "thinking",
+    "streaming",
+    "answered",
+    "failed",
+    "failed-persistent",
+)
+
+/** Answer text used by the QA overrides. Not localized — the harness asserts on it. */
+private const val QA_SAMPLE_ANSWER =
+    "A small wooden side table with a potted plant on it, lit from the window on the left."

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFrameCapture.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFrameCapture.kt
@@ -1,0 +1,288 @@
+package io.github.sceneview.demo.ai
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.PixelCopy
+import android.view.SurfaceView
+import android.view.TextureView
+import android.view.View
+import android.view.ViewGroup
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/** Logcat tag shared by every Point & Ask capture / inference path. */
+const val ASK_LOG_TAG = "PointAndAskDemo"
+
+/** Which layer the frame handed to the model was read back from. */
+enum class AskCaptureSource(val label: String) {
+    /** `PixelCopy` on the Filament `SurfaceView` itself — camera + virtual objects, no chrome. */
+    ArSurface("AR surface"),
+
+    /** `TextureView.getBitmap()` — the surface type QA mode uses for the backdrop (#3308). */
+    ArTexture("AR texture"),
+
+    /** `PixelCopy` on the whole window — the pre-#3407 path, now only a fallback. */
+    Window("window composite"),
+}
+
+/** A frame that passed [inspectAskFrame] and is ready to be sent. Caller owns [bitmap]. */
+class AskFrame(val bitmap: Bitmap, val source: AskCaptureSource)
+
+/** Result of trying every capture path in order. */
+sealed interface AskCaptureOutcome {
+    data class Captured(val frame: AskFrame) : AskCaptureOutcome
+
+    /**
+     * Every path either failed or produced a frame the model could not use. [verdict] is the
+     * *best* (most informative) rejection seen, so the card can name what was wrong rather
+     * than falling back to a generic "couldn't capture".
+     */
+    data class Rejected(val verdict: AskFrameVerdict, val source: AskCaptureSource?) :
+        AskCaptureOutcome
+}
+
+/**
+ * Reads back the AR frame and returns the one that will actually be sent to Gemini Nano —
+ * cropped around the tap, downscaled to the model's budget, and **validated** (#3407).
+ *
+ * Why the order matters. The demo used to read back the whole **window** and check only for
+ * an `alpha == 0` hole. But the AR scene is a Filament `SurfaceView`: a separate compositor
+ * layer that "punches a hole through the window" (the repo says so itself, in
+ * `QaCameraBackdrop`'s KDoc), and whose absence from a window read-back has already been
+ * observed with a SUCCESS result (#2654). When that layer comes back **opaque black** rather
+ * than transparent — the shape an opaque window background produces — the alpha probe passes,
+ * the #3343 crop then centres tightly on that very region, and the model is handed a flat
+ * frame. That is the "sees nothing on the AR frame" half of #3407.
+ *
+ * So the AR view is now read back **directly**, by the API meant for it, and the window
+ * composite is kept only as a fallback. Each candidate is validated before it is accepted, so
+ * a defect in one path silently promotes the next instead of reaching the model.
+ *
+ * @param focusX/[focusY] tap position in **window** coordinates; translated per candidate.
+ */
+suspend fun captureAskFrame(
+    activity: Activity,
+    focusX: Float?,
+    focusY: Float?,
+): AskCaptureOutcome {
+    val decor = activity.window?.decorView
+    if (decor == null || decor.width <= 0 || decor.height <= 0) {
+        return AskCaptureOutcome.Rejected(
+            AskFrameVerdict.TooSmall(decor?.width ?: 0, decor?.height ?: 0),
+            source = null,
+        )
+    }
+
+    var bestRejection: Pair<AskFrameVerdict, AskCaptureSource>? = null
+    for (candidate in captureCandidates(activity, decor)) {
+        val raw = runCatching { candidate.capture() }.getOrElse {
+            Log.w(ASK_LOG_TAG, "Capture via ${candidate.source.label} threw (#3407).", it)
+            null
+        } ?: continue
+
+        val offsetX = focusX?.minus(candidate.originX)
+        val offsetY = focusY?.minus(candidate.originY)
+        val framed = frameForModel(raw, offsetX, offsetY)
+        val verdict = inspectFrameForModel(framed)
+        if (verdict == AskFrameVerdict.Usable) {
+            return AskCaptureOutcome.Captured(AskFrame(framed, candidate.source))
+        }
+        Log.w(
+            ASK_LOG_TAG,
+            "Frame from ${candidate.source.label} rejected: $verdict " +
+                "(${framed.width}×${framed.height}) — trying the next capture path (#3407).",
+        )
+        framed.recycle()
+        // Keep the most informative rejection: a lost layer / blank frame explains more than
+        // a degenerate size, and the first path tried is the most representative one.
+        if (bestRejection == null || bestRejection.first is AskFrameVerdict.TooSmall) {
+            bestRejection = verdict to candidate.source
+        }
+    }
+    return AskCaptureOutcome.Rejected(
+        bestRejection?.first ?: AskFrameVerdict.TooSmall(decor.width, decor.height),
+        bestRejection?.second,
+    )
+}
+
+/** One capture path: where its pixels come from, and where its origin sits in the window. */
+private class CaptureCandidate(
+    val source: AskCaptureSource,
+    val originX: Float,
+    val originY: Float,
+    val capture: suspend () -> Bitmap?,
+)
+
+/** The capture paths to try, best first. */
+private fun captureCandidates(activity: Activity, decor: View): List<CaptureCandidate> {
+    val candidates = mutableListOf<CaptureCandidate>()
+    val arView = decor.findArRenderView()
+    if (arView != null && arView.width > 0 && arView.height > 0) {
+        val location = IntArray(2).also { arView.getLocationInWindow(it) }
+        when (arView) {
+            is TextureView -> candidates += CaptureCandidate(
+                source = AskCaptureSource.ArTexture,
+                originX = location[0].toFloat(),
+                originY = location[1].toFloat(),
+                capture = { arView.bitmap },
+            )
+
+            is SurfaceView -> candidates += CaptureCandidate(
+                source = AskCaptureSource.ArSurface,
+                originX = location[0].toFloat(),
+                originY = location[1].toFloat(),
+                capture = { copySurfaceView(arView) },
+            )
+        }
+    }
+    candidates += CaptureCandidate(
+        source = AskCaptureSource.Window,
+        originX = 0f,
+        originY = 0f,
+        capture = { copyWindow(activity, decor.width, decor.height) },
+    )
+    return candidates
+}
+
+/**
+ * Depth-first search for the view the AR scene renders into. `SceneView` attaches Filament to
+ * either a `SurfaceView` or a `TextureView` depending on `surfaceType` (QA-backdrop runs pick
+ * the latter), and the demo composes exactly one of them, so the first hit is the right one.
+ */
+internal fun View.findArRenderView(): View? {
+    if (this is SurfaceView || this is TextureView) return this
+    val group = this as? ViewGroup ?: return null
+    for (i in 0 until group.childCount) {
+        group.getChildAt(i).findArRenderView()?.let { return it }
+    }
+    return null
+}
+
+/** `PixelCopy` straight off the AR `SurfaceView` — the layer the window read-back can lose. */
+private suspend fun copySurfaceView(view: SurfaceView): Bitmap? {
+    if (!view.holder.surface.isValid) return null
+    val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+    return suspendCancellableCoroutine { continuation ->
+        try {
+            PixelCopy.request(
+                view,
+                bitmap,
+                { result ->
+                    if (result == PixelCopy.SUCCESS) {
+                        continuation.resume(bitmap)
+                    } else {
+                        bitmap.recycle()
+                        Log.w(ASK_LOG_TAG, "PixelCopy on the AR surface failed: $result (#3407).")
+                        continuation.resume(null)
+                    }
+                },
+                Handler(Looper.getMainLooper()),
+            )
+        } catch (e: IllegalArgumentException) {
+            // Surface torn down between the validity check and the request.
+            bitmap.recycle()
+            Log.w(ASK_LOG_TAG, "AR surface went away mid-capture (#3407).", e)
+            continuation.resume(null)
+        }
+    }
+}
+
+/** The pre-#3407 path, kept as a fallback for devices where the surface read-back is refused. */
+private suspend fun copyWindow(activity: Activity, width: Int, height: Int): Bitmap? {
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    return suspendCancellableCoroutine { continuation ->
+        try {
+            PixelCopy.request(
+                activity.window,
+                bitmap,
+                { result ->
+                    if (result == PixelCopy.SUCCESS) {
+                        continuation.resume(bitmap)
+                    } else {
+                        bitmap.recycle()
+                        Log.w(ASK_LOG_TAG, "PixelCopy on the window failed: $result (#3343).")
+                        continuation.resume(null)
+                    }
+                },
+                Handler(Looper.getMainLooper()),
+            )
+        } catch (e: IllegalArgumentException) {
+            bitmap.recycle()
+            Log.w(ASK_LOG_TAG, "Window not capturable (#3343).", e)
+            continuation.resume(null)
+        }
+    }
+}
+
+/**
+ * Crops [capture] to [askCaptureRegion] around ([focusX], [focusY]) and downscales it to the
+ * model's budget, recycling the oversized original. Returns [capture] unchanged when it is
+ * already within budget, so the caller's ownership contract holds either way.
+ *
+ * Why this exists rather than trusting ML Kit's own resize: genai-prompt 1.0.0-beta4 rescales
+ * only when `min(width, height) > 768`, and only the SHORT edge — a 1080×2424 window capture
+ * arrives as 768×1723. See `ASK_IMAGE_MAX_EDGE` (#3343).
+ */
+internal fun frameForModel(capture: Bitmap, focusX: Float?, focusY: Float?): Bitmap {
+    val region = askCaptureRegion(
+        sourceWidth = capture.width,
+        sourceHeight = capture.height,
+        focusX = focusX,
+        focusY = focusY,
+    )
+    val unchanged = region.x == 0 && region.y == 0 &&
+        region.width == capture.width && region.height == capture.height &&
+        region.scaledWidth == capture.width && region.scaledHeight == capture.height
+    if (unchanged) return capture
+    return runCatching {
+        val cropped = Bitmap.createBitmap(
+            capture, region.x, region.y, region.width, region.height,
+        )
+        val scaled = if (
+            cropped.width == region.scaledWidth && cropped.height == region.scaledHeight
+        ) {
+            cropped
+        } else {
+            Bitmap.createScaledBitmap(
+                cropped, region.scaledWidth, region.scaledHeight, true,
+            ).also { if (it !== cropped) cropped.recycle() }
+        }
+        // `createBitmap`/`createScaledBitmap` may return the source itself when nothing had
+        // to change; only recycle the capture when a genuinely new bitmap came back.
+        if (scaled !== capture) capture.recycle()
+        scaled
+    }.getOrElse {
+        Log.w(ASK_LOG_TAG, "Could not reframe the capture for the model; sending it whole.", it)
+        capture
+    }
+}
+
+/** Strided sampling stride, both axes. Every 4th pixel is plenty at ≤ 768 px. */
+private const val ASK_FRAME_SAMPLE_STEP = 4
+
+/**
+ * Reads a strided sample out of [bitmap] and hands it to the pure [inspectAskFrame]. The only
+ * Android-flavoured half of the validation, kept to one function on purpose.
+ */
+internal fun inspectFrameForModel(bitmap: Bitmap): AskFrameVerdict {
+    if (bitmap.width < ASK_FRAME_MIN_EDGE || bitmap.height < ASK_FRAME_MIN_EDGE) {
+        return AskFrameVerdict.TooSmall(bitmap.width, bitmap.height)
+    }
+    val row = IntArray(bitmap.width)
+    val samples = ArrayList<Int>((bitmap.width / ASK_FRAME_SAMPLE_STEP + 1) *
+        (bitmap.height / ASK_FRAME_SAMPLE_STEP + 1))
+    var y = 0
+    while (y < bitmap.height) {
+        bitmap.getPixels(row, 0, bitmap.width, 0, y, bitmap.width, 1)
+        var x = 0
+        while (x < row.size) {
+            samples += row[x]
+            x += ASK_FRAME_SAMPLE_STEP
+        }
+        y += ASK_FRAME_SAMPLE_STEP
+    }
+    return inspectAskFrame(bitmap.width, bitmap.height, samples.toIntArray())
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFrameCheck.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFrameCheck.kt
@@ -1,0 +1,129 @@
+package io.github.sceneview.demo.ai
+
+/**
+ * Verdict on the frame Point & Ask is about to hand to Gemini Nano (#3407).
+ *
+ * Before this existed the only check was "is a meaningful share of the capture fully
+ * transparent" (`hasTransparentHole`, #2654/#3276). That catches exactly ONE shape of a lost
+ * `SurfaceView` layer — the one where the compositor leaves `alpha == 0` behind. The other,
+ * more common shape leaves **opaque black** in the AR region instead, sails through an
+ * alpha-only probe, and is then cropped tighter around the tap (#3343) so the frame that
+ * reaches the model is uniformly flat. The model is asked to describe a blank image and
+ * either says it sees nothing or completes with no text at all — "aucune réponse Gemini qui
+ * voit rien sur la frame AR" (#3407).
+ *
+ * So: a frame is validated for **size**, **transparency** AND **flatness** before it leaves
+ * the app, and each failure names its own cause.
+ */
+sealed interface AskFrameVerdict {
+
+    /** The frame carries real content — send it. */
+    data object Usable : AskFrameVerdict
+
+    /** Degenerate capture: zero-size, or too small to carry anything a model could read. */
+    data class TooSmall(val width: Int, val height: Int) : AskFrameVerdict
+
+    /**
+     * A meaningful share of the frame is fully transparent — the signature of a read-back
+     * that skipped the Filament `SurfaceView` layer (camera + placed AR objects) while still
+     * reporting success (#2654).
+     */
+    data class MissingArLayer(val transparentFraction: Float) : AskFrameVerdict
+
+    /**
+     * The frame is opaque but essentially one flat colour — a black viewport, a covered
+     * lens, or the same lost-layer defect in its opaque form. [lumaSpread] is the observed
+     * 1st..99th-percentile luminance span, out of 255.
+     */
+    data class Blank(val lumaSpread: Int) : AskFrameVerdict
+}
+
+/** Shortest edge a frame must have before it is worth a round-trip to the model. */
+const val ASK_FRAME_MIN_EDGE = 64
+
+/**
+ * Share of fully transparent samples above which the frame is treated as missing its AR
+ * layer. Matches the bug-report screenshot probe (#2654): a correctly composited read-back
+ * of an opaque app window contains no `alpha == 0` pixels at all, so any real share of them
+ * means a layer was punched out.
+ */
+const val ASK_FRAME_TRANSPARENT_FRACTION = 0.05f
+
+/**
+ * Luminance span (1st..99th percentile, out of 255) below which the frame is treated as
+ * flat. Deliberately conservative: a real camera frame of a bare white wall still spans
+ * well over this once sensor noise and vignetting are in it, while a black or single-colour
+ * composite spans 0. The percentiles — rather than min/max — keep a stray bright pixel (a
+ * status-bar glyph clipped into the crop, a hot pixel) from vouching for an otherwise empty
+ * frame.
+ */
+const val ASK_FRAME_MIN_LUMA_SPREAD = 8
+
+/**
+ * Inspects a strided sample of the frame that is about to be sent to the model.
+ *
+ * Pure on purpose — no `Bitmap`, no Android types — so every branch is unit-testable on the
+ * JVM (`AskFrameCheckTest`). The Android side (`inspectFrameForModel`) only reads the pixels
+ * out of the bitmap and calls this.
+ *
+ * @param width  width of the frame the samples came from, in pixels
+ * @param height height of the frame the samples came from, in pixels
+ * @param samples ARGB_8888 pixels sampled across the frame, in any order
+ */
+fun inspectAskFrame(width: Int, height: Int, samples: IntArray): AskFrameVerdict {
+    if (width < ASK_FRAME_MIN_EDGE || height < ASK_FRAME_MIN_EDGE || samples.isEmpty()) {
+        return AskFrameVerdict.TooSmall(width, height)
+    }
+
+    var transparent = 0
+    val histogram = IntArray(256)
+    var opaque = 0
+    for (pixel in samples) {
+        if (pixel ushr 24 == 0) {
+            transparent++
+            continue
+        }
+        opaque++
+        // Rec. 601 luma, integer-only — the exact weights do not matter here, only that a
+        // flat region maps to a single bucket and a textured one does not.
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        histogram[(299 * r + 587 * g + 114 * b) / 1000]++
+    }
+
+    val transparentFraction = transparent.toFloat() / samples.size
+    if (transparentFraction >= ASK_FRAME_TRANSPARENT_FRACTION) {
+        return AskFrameVerdict.MissingArLayer(transparentFraction)
+    }
+    // Every sample transparent-but-under-threshold is impossible (the branch above would
+    // have caught it), so `opaque` is non-zero here; guard anyway rather than divide by it
+    // on faith.
+    if (opaque == 0) return AskFrameVerdict.Blank(lumaSpread = 0)
+
+    val low = percentileLuma(histogram, opaque, 0.01f)
+    val high = percentileLuma(histogram, opaque, 0.99f)
+    val spread = high - low
+    if (spread < ASK_FRAME_MIN_LUMA_SPREAD) return AskFrameVerdict.Blank(spread)
+
+    return AskFrameVerdict.Usable
+}
+
+/** The luminance bucket at [fraction] of [total] samples, walking [histogram] from 0. */
+private fun percentileLuma(histogram: IntArray, total: Int, fraction: Float): Int {
+    val target = (total * fraction).toInt().coerceIn(0, total - 1)
+    var seen = 0
+    for (luma in histogram.indices) {
+        seen += histogram[luma]
+        if (seen > target) return luma
+    }
+    return histogram.lastIndex
+}
+
+/** The user-facing failure a rejected frame maps to. [AskFrameVerdict.Usable] has none. */
+fun AskFrameVerdict.asFailure(): AskFailure? = when (this) {
+    AskFrameVerdict.Usable -> null
+    is AskFrameVerdict.TooSmall -> AskFailure.CaptureFailed
+    is AskFrameVerdict.MissingArLayer -> AskFailure.CaptureMissingArLayer
+    is AskFrameVerdict.Blank -> AskFailure.CaptureBlank
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
@@ -6,11 +6,9 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.ConnectivityManager
-import android.os.Handler
-import android.os.Looper
+import android.provider.Settings
 import android.speech.RecognizerIntent
 import android.util.Log
-import android.view.PixelCopy
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -19,6 +17,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -45,6 +44,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface as M3Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -62,7 +62,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -73,6 +75,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import com.google.ar.core.Anchor
 import com.google.ar.core.Frame
 import com.google.ar.core.Plane
@@ -80,21 +83,34 @@ import com.google.ar.core.Point
 import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.position
+import io.github.sceneview.ar.rememberARCameraStream
+import io.github.sceneview.demo.BuildConfig
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.R
-import io.github.sceneview.demo.ai.ASK_FAILURE_ESCALATION_THRESHOLD
+import io.github.sceneview.demo.ai.ASK_LOG_TAG
+import io.github.sceneview.demo.ai.AskCaptureOutcome
+import io.github.sceneview.demo.ai.AskCaptureSource
 import io.github.sceneview.demo.ai.AskEngine
-import io.github.sceneview.demo.ai.AskEngineStatus
 import io.github.sceneview.demo.ai.AskFailure
-import io.github.sceneview.demo.ai.askCaptureRegion
+import io.github.sceneview.demo.ai.AskFlow
+import io.github.sceneview.demo.ai.AskFrame
+import io.github.sceneview.demo.ai.AskRecovery
+import io.github.sceneview.demo.ai.AskStep
+import io.github.sceneview.demo.ai.asFailure
+import io.github.sceneview.demo.ai.askStepForQaOverride
+import io.github.sceneview.demo.ai.captureAskFrame
 import io.github.sceneview.demo.ai.rememberAskEngine
+import io.github.sceneview.demo.ai.toAvailability
 import io.github.sceneview.demo.common.ForceTrackingFailureMenu
+import io.github.sceneview.demo.common.QaCameraBackdrop
 import io.github.sceneview.demo.common.putVoiceSilenceExtras
+import io.github.sceneview.demo.common.qaCameraBackdropEnabled
+import io.github.sceneview.demo.common.qaCameraBackdropSurfaceType
+import io.github.sceneview.demo.common.rememberQaCameraBackdropActive
 import io.github.sceneview.demo.demos.internal.ArPlacement
 import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.demo.demos.internal.rememberTexturesSettled
-import io.github.sceneview.demo.feedback.hasTransparentHole
 import io.github.sceneview.demo.rememberArPlaybackDataset
 import io.github.sceneview.demo.theme.SceneViewDemoTheme
 import io.github.sceneview.demo.theme.SceneViewTokens
@@ -111,37 +127,29 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /** Test tags for the Point & Ask QA flows (Maestro / layout dumps). */
 object PointAndAskTestTags {
     const val ANSWER_CARD = "point_and_ask_answer_card"
     const val QUESTION_FIELD = "point_and_ask_question_field"
     const val PROP_PICKER = "point_and_ask_prop_picker"
+    const val FAILURE_CARD = "point_and_ask_failure_card"
+    const val FAILURE_ACTION = "point_and_ask_failure_action"
+    const val DEBUG_FRAME = "point_and_ask_debug_frame"
 }
 
-/** Lifecycle of one "ask" round-trip, driving the bottom card. */
-private sealed interface AskState {
-    /** Nothing in flight — tap to ask. */
-    data object Idle : AskState
-
-    /** Tap registered, composited window capture in flight. */
-    data object Capturing : AskState
-
-    /** Frame captured, Gemini Nano inference in flight. */
-    data object Thinking : AskState
-
-    /**
-     * Answer text so far. While [streaming] the model is still appending deltas (P3
-     * progressive display); once `false` the answer is complete and auto-dismisses.
-     */
-    data class Answered(val text: String, val streaming: Boolean = false) : AskState
-
-    /**
-     * Inference or capture failed. [failure] says which cause, so the card can name it and
-     * a terminal one can retire the "tap to try again" invitation entirely (#3343).
-     */
-    data class Failed(val failure: AskFailure) : AskState
-}
+/**
+ * The frame that was actually handed to the model, kept for the debug/QA preview (#3407).
+ * A thumbnail copy, made before the round recycles the real frame — so "the model saw
+ * nothing" is checkable on the spot instead of from a bug report three days later.
+ */
+private class AskFramePreview(
+    val thumbnail: Bitmap,
+    val width: Int,
+    val height: Int,
+    val source: AskCaptureSource,
+)
 
 /**
  * One bundled showcase model offered by Drop-3D mode's picker (#3083). All three ship in
@@ -200,14 +208,14 @@ private class AnswerPanel(
      * already succeeded, and keeping the panel makes the failure visible where the user
      * pointed instead of silently un-pinning it.
      */
-    fun accept(state: AskState, failedText: (AskFailure) -> String) {
-        when (state) {
-            is AskState.Answered -> {
-                text = state.text
-                streaming = state.streaming
+    fun accept(step: AskStep, failedText: (AskFailure) -> String) {
+        when (step) {
+            is AskStep.Answered -> {
+                text = step.text
+                streaming = step.streaming
             }
-            is AskState.Failed -> {
-                if (text.isBlank()) text = failedText(state.failure)
+            is AskStep.Failed -> {
+                if (text.isBlank()) text = failedText(step.failure)
                 streaming = false
             }
             else -> Unit
@@ -221,17 +229,39 @@ private class AnswerPanel(
  * **Gemini Nano on-device** through ML Kit's GenAI Prompt API, and the streamed answer
  * is shown in an overlay card. Fully offline — the frame never leaves the device.
  *
- * Long-press a surface to drop a virtual prop into the room: because the capture is the
- * composited window (PixelCopy), the on-device model *sees the augmented scene* — tap the
- * shiba you just placed and Nano describes a dog that only exists in AR. That is the
- * demo's whole point, which is why a tap on a node is never swallowed (#3187).
+ * Long-press a surface to drop a virtual prop into the room: because the capture reads the
+ * AR view itself, the on-device model *sees the augmented scene* — tap the shiba you just
+ * placed and Nano describes a dog that only exists in AR. That is the demo's whole point,
+ * which is why a tap on a node is never swallowed (#3187).
  *
- *  - Availability is gated honestly: AICore devices (Pixel 8+, recent flagships) get the
- *    real engine; a `DOWNLOADABLE` model gets a download CTA with progress; unsupported
- *    devices see an explanatory banner. No cloud fallback — on-device only (#2648).
- *  - Under `DemoSettings.qaMode` the engine is a deterministic canned stand-in and the
- *    capture falls back to a synthetic frame (AICore/camera are structurally unavailable
- *    on emulators) — the tap → capture → answer UI flow stays device-QA-able.
+ * **The screen is one explicit state machine** ([AskFlow], plain Kotlin, JVM-tested):
+ * checking availability → downloadable / downloading (with progress) → ready → capturing
+ * the frame → thinking → answer (screen card + world-anchored panel) → or a failure that
+ * names its cause and offers the single action that could fix it. Two rules hold it
+ * together, and both come from #3407:
+ *
+ *  - **Only the platform may say "not on this phone."** `AskStep.ModelUnsupported` is
+ *    reachable from a `FeatureStatus` report, a failed download, or a terminal ML Kit error
+ *    code — and from nothing else. A run of ordinary failures changes the failure card's
+ *    headline and nothing more. The previous build promoted three failures into a permanent
+ *    "Point & Ask can't answer on this device" on a Pixel 9 whose Gemini Nano was working
+ *    the whole time.
+ *  - **Nothing unusable reaches the model.** The frame is read back from the AR view
+ *    (`captureAskFrame`), cropped around the tap, downscaled to the model's budget, and then
+ *    validated for size, transparency AND flatness (`inspectAskFrame`). The old path read
+ *    the whole window — which can lose the Filament `SurfaceView` layer the AR scene lives
+ *    in — and checked only for `alpha == 0`, so that layer coming back opaque black went
+ *    straight to Gemini Nano as a blank image.
+ *
+ * No cloud fallback — on-device only, by design (#2648), and the controls sheet says so
+ * rather than leaving it to the failure copy. In a debug/QA build the same sheet shows a
+ * thumbnail of the exact frame that was sent, so "it sees nothing" is checkable on the spot.
+ *
+ * Under `DemoSettings.qaMode` the engine is a deterministic canned stand-in, and a capture
+ * the emulator cannot produce falls back to a synthetic (textured, so it passes the real
+ * validation) frame — the tap → capture → answer UI flow stays device-QA-able. Every card
+ * can additionally be pinned for screenshots with `--es qa_ask_state <id>`
+ * (`ASK_QA_STATE_IDS`), because an emulator has neither ARCore nor AICore (#2754).
  *
  * P1+P2+P3 of [#2648](https://github.com/sceneview/sceneview/issues/2648), plus the
  * film-mode polish pass: composited capture, long-press placement, tap ping, quieter
@@ -271,12 +301,36 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
 
     val askEngine = rememberAskEngine()
-    var engineStatus by remember { mutableStateOf<AskEngineStatus?>(null) }
-    LaunchedEffect(askEngine) { engineStatus = askEngine.status() }
 
-    var askState by remember { mutableStateOf<AskState>(AskState.Idle) }
+    // The whole screen is one explicit state machine (#3407), and it lives in plain Kotlin
+    // (`AskFlow`) so every transition is unit-tested off-device. `step` is the snapshot the
+    // UI reads; `syncStep` republishes it after any transition. Keeping the machine itself
+    // free of Compose is what makes "does a pile of capture failures declare the phone
+    // unsupported?" a JVM test rather than a device question.
+    val flow = remember { AskFlow() }
+    var step by remember { mutableStateOf<AskStep>(AskStep.CheckingAvailability) }
+    val syncStep: () -> Unit = { step = flow.step }
+
+    // QA-only card override (`--es qa_ask_state <id>`): pins the bottom card to one state so
+    // an emulator with neither ARCore nor AICore (#2754) can still screenshot every state in
+    // light and dark. `null` for every normal launch.
+    val qaStep = remember(DemoSettings.qaAskState) { askStepForQaOverride(DemoSettings.qaAskState) }
+    val shownStep = qaStep ?: step
+
+    LaunchedEffect(askEngine) {
+        flow.onAvailability(askEngine.status().toAvailability())
+        syncStep()
+    }
+
     var isTracking by remember { mutableStateOf(false) }
     var latestFrame by remember { mutableStateOf<Frame?>(null) }
+    // QA camera backdrop (#3308): the emulator has no camera HAL, so a blurred room photo
+    // stands in for the camera feed until a real frame arrives. This demo had none, which
+    // meant its emulator screenshots were flat black — the same thing a lost AR layer looks
+    // like, so the QA sweep could not tell the fix from the bug (#3407).
+    var cameraReady by remember { mutableStateOf(false) }
+    val cameraStream = rememberARCameraStream(materialLoader)
+    val qaBackdrop = rememberQaCameraBackdropActive(cameraReady)
     // Camera world position, refreshed every AR frame — read by each anchored answer
     // card's per-frame billboard (#3276). A plain holder, not Compose state: it is only
     // read inside an `onFrame` node callback, never inside a composable body, so there is
@@ -297,16 +351,15 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     var nextPanelId by remember { mutableStateOf(0) }
     var pendingPanel by remember { mutableStateOf<AnswerPanel?>(null) }
 
-    // A round is busy while the screen card is working OR any anchored panel is
-    // still streaming. An anchored round hands the screen card back to Idle on
-    // its first delta, so `askState` alone under-reports it. The tap guard and
-    // the status pill BOTH read this single value — otherwise the pill returns
-    // to "tap to ask" mid-stream while the guard silently drops every tap.
+    // A round is busy while the screen card is working OR any anchored panel is still
+    // streaming. `AskFlow.isBusy` covers the screen card; the panels add the anchored half.
+    // The tap guard and the status pill BOTH read this single value — otherwise the pill
+    // returns to "tap to ask" mid-stream while the guard silently drops every tap.
     val busy by remember {
         derivedStateOf {
-            askState == AskState.Capturing ||
-                askState == AskState.Thinking ||
-                (askState as? AskState.Answered)?.streaming == true ||
+            step == AskStep.CapturingFrame ||
+                step == AskStep.Thinking ||
+                (step as? AskStep.Answered)?.streaming == true ||
                 panels.any { it.streaming }
         }
     }
@@ -334,9 +387,23 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     // to the answer that follows. Keyed by timestamp so consecutive taps re-animate.
     var ping by remember { mutableStateOf<Pair<Offset, Long>?>(null) }
 
-    // Overlays are hidden for the few frames around the PixelCopy so the captured
-    // composite is a clean viewfinder (no pill, no card baked into the AI's input).
+    // In-scene overlays (the plane grid, the anchored answer cards) are hidden for the few
+    // frames around the read-back: they live INSIDE the Filament surface, so leaving them up
+    // would bake a grid and the model's own earlier answers into the next question. The 2D
+    // chrome no longer has to be hidden — the capture reads the AR view directly rather than
+    // the whole window (#3407) — so the screen stops blinking on every tap.
     var hideOverlaysForCapture by remember { mutableStateOf(false) }
+
+    // What was actually sent to the model, kept as a thumbnail for the debug/QA preview in
+    // the controls sheet (#3407). Never built in a release build.
+    var lastFramePreview by remember { mutableStateOf<AskFramePreview?>(null) }
+    val keepFramePreview = BuildConfig.DEBUG || DemoSettings.qaMode
+
+    // Bumped by every tap that starts a round. The capture effect keys off it rather than
+    // off the state: two consecutive rounds produce the same `AskStep.CapturingFrame` value,
+    // so a state-keyed effect would simply not re-run — and "the second tap does nothing" is
+    // the kind of silence #3407 is about.
+    var captureToken by remember { mutableIntStateOf(0) }
 
     // Free-form question (P3): blank = the default English prompt (best Nano quality),
     // which asks the model to describe what the tap pointed at. The field starts blank so
@@ -350,14 +417,9 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     // callbacks, and the message now depends on which failure occurred (#3343).
     val failedText: (AskFailure) -> String = { context.getString(it.messageRes) }
 
-    // How many rounds in a row have failed, and with what. Once a failure is terminal, or
-    // the same non-terminal one repeats, the card stops saying "tap to try again" — the
-    // exact loop reported in #3343 — and explains the situation instead.
-    var consecutiveFailures by remember { mutableIntStateOf(0) }
-
     // Where the last tap landed, in window pixels. The capture is cropped around it so the
     // model is shown what the user pointed at rather than the whole floor-to-ceiling frame
-    // (see `askCaptureRegion`). Null before the first tap and for QA's synthetic frame.
+    // (see `askCaptureRegion`). Null before the first tap.
     var tapFocus by remember { mutableStateOf<Offset?>(null) }
 
     // Voice input (#3083): the question field's optional mic button. Same zero-permission
@@ -382,115 +444,106 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         }
     }
 
-    // Composited capture (film mode): PixelCopy on the window sees camera + virtual
-    // props exactly as the user does. qaMode keeps the synthetic-frame fallback so the
-    // flow stays deterministic on emulators (#1645).
-    LaunchedEffect(askState) {
-        if (askState != AskState.Capturing) {
-            // A state change mid-capture (e.g. reset) cancels the capturing run at its
-            // settle delay before the PixelCopy callback un-hides the overlays — this
-            // relaunch is the only place left to restore them.
-            hideOverlaysForCapture = false
-            return@LaunchedEffect
-        }
+    // -- One ask round -----------------------------------------------------------------
+    // Keyed by `captureToken`, not by the state: two rounds in a row produce the same
+    // `AskStep.CapturingFrame` value, and a state-keyed effect would simply not re-run.
+    //
+    // The read-back itself moved to `captureAskFrame` (#3407). The demo used to PixelCopy
+    // the whole WINDOW and accept anything that was not `alpha == 0`. But the AR scene is a
+    // Filament `SurfaceView` -- its own compositor layer, which "punches a hole through the
+    // window" -- and when a window read-back loses that layer as opaque black rather than as
+    // transparent, the alpha probe passes, the #3343 crop then centres tightly on exactly
+    // that region, and Gemini Nano is handed a flat frame. It answers about nothing, or
+    // completes empty. That is #3407's "aucune reponse Gemini qui voit rien sur la frame AR".
+    // Now the AR view is read back directly, every candidate frame is validated before it
+    // leaves the app, and a rejected frame names its own cause.
+    LaunchedEffect(captureToken) {
+        if (captureToken == 0) return@LaunchedEffect
         // Where this round's answer goes: the panel pinned by the tap (P2), or the
         // screen-space card when the tap hit nothing trackable. Resolved once, here, so a
         // panel pinned by a LATER tap can never steal this round's deltas.
-        // Counting failures here rather than in a `LaunchedEffect(askState)` is deliberate:
-        // two identical failures in a row produce the SAME `AskState.Failed` value, so a
-        // state-keyed effect would never re-run — and "the same error over and over" is
-        // precisely the case #3343 is about.
-        val onResult = answerSink(pendingPanel, failedText) { state ->
-            when (state) {
-                is AskState.Failed -> consecutiveFailures++
-                is AskState.Answered -> consecutiveFailures = 0
-                else -> Unit
-            }
-            askState = state
+        val panel = pendingPanel
+        val onStep: (AskStep) -> Unit = { newStep ->
+            panel?.accept(newStep, failedText)
+            step = newStep
         }
-        if (DemoSettings.qaMode) {
-            delay(QA_CAPTURE_TIMEOUT_MS)
-            if (askState != AskState.Capturing) return@LaunchedEffect
-            askState = AskState.Thinking
-            val synthetic = Bitmap.createBitmap(640, 480, Bitmap.Config.ARGB_8888)
-            askJob = scope.askAboutBitmap(synthetic, askEngine, question, onResult)
-            return@LaunchedEffect
+        val fail: (AskFailure) -> Unit = { failure ->
+            Log.w(ASK_LOG_TAG, "Point & Ask round failed: $failure (#3407).")
+            flow.onFailure(failure)
+            onStep(flow.step)
         }
+
         val activity = context.findActivity()
-        val decor = activity?.window?.decorView
-        if (decor == null || decor.width == 0 || decor.height == 0) {
-            onResult(AskState.Failed(AskFailure.CaptureFailed))
+        if (activity == null) {
+            fail(AskFailure.CaptureFailed)
             return@LaunchedEffect
         }
+
+        // Only the IN-SCENE overlays come down: they are drawn inside the Filament surface
+        // this capture reads, so a plane grid or a previous anchored answer would become
+        // part of the question. The 2D chrome stays up -- it is not in that surface, so the
+        // screen no longer blinks on every tap.
         hideOverlaysForCapture = true
-        delay(CAPTURE_OVERLAY_SETTLE_MS)
-        val bitmap = Bitmap.createBitmap(decor.width, decor.height, Bitmap.Config.ARGB_8888)
-        // If PixelCopy never calls back, nothing else would ever leave `Capturing`: the
-        // overlays stay hidden, `busy` stays true and every later tap is dropped — a
-        // permanent blank viewfinder (#3188). The round is failed after a timeout instead;
-        // `roundLive` keeps a late callback from resurrecting it.
-        var roundLive = true
-        PixelCopy.request(
-            activity.window,
-            bitmap,
-            { result ->
-                if (!roundLive) {
-                    bitmap.recycle()
-                    return@request
+        try {
+            delay(CAPTURE_OVERLAY_SETTLE_MS)
+            // A read-back that never comes back would otherwise wedge the demo in
+            // `CapturingFrame` forever, with `busy` stuck true and every later tap dropped
+            // (#3188). Time it out into an ordinary, retryable failure instead.
+            val outcome = withTimeoutOrNull(CAPTURE_TIMEOUT_MS) {
+                captureAskFrame(activity, tapFocus?.x, tapFocus?.y)
+            }
+            val frame = when (outcome) {
+                null -> {
+                    Log.w(ASK_LOG_TAG, "Frame capture exceeded its budget (#3188).")
+                    fail(AskFailure.CaptureFailed)
+                    return@LaunchedEffect
                 }
-                roundLive = false
-                hideOverlaysForCapture = false
-                // `PixelCopy.SUCCESS` alone does not prove the frame is usable (#3276). The
-                // same compositor quirk already tracked for the bug-report screenshot
-                // (`hasTransparentHole`, #2654) — a read-back that reports SUCCESS while the
-                // Filament `SurfaceView` layer (camera + placed AR objects) was left out of
-                // the composite, an `alpha == 0` hole exactly where the augmented scene
-                // should be — applies just as much here. Sending that hole to Gemini is
-                // literally "the model sees nothing": no exception, no failure banner, just
-                // an on-device answer about a blank/transparent image. Guard for it the same
-                // way the feedback screenshot does, and log so a future report of this can be
-                // correlated with logcat instead of re-diagnosed from scratch.
-                if (result == PixelCopy.SUCCESS && !hasTransparentHole(bitmap)) {
-                    askState = AskState.Thinking
-                    // Crop around the tap and downscale before handing the frame to ML
-                    // Kit (#3343). ML Kit only clamps the SHORT edge to 768 px, so the
-                    // raw window capture reached Gemini Nano as a full-height strip —
-                    // mostly floor and ceiling, and a vision-token bill the on-device
-                    // budget has no room for. See `askCaptureRegion`.
-                    val framed = frameForModel(bitmap, tapFocus)
-                    askJob = scope.askAboutBitmap(framed, askEngine, question, onResult)
-                } else {
-                    if (result == PixelCopy.SUCCESS) {
-                        Log.w(
-                            ASK_LOG_TAG,
-                            "Composited capture came back with a transparent hole where the " +
-                                "AR viewport should be (PixelCopy reported SUCCESS) — refusing " +
-                                "to send a blank frame to Gemini (#3276).",
-                        )
+
+                is AskCaptureOutcome.Rejected -> {
+                    // An emulator has no camera HAL and no AICore (#2754), so every capture
+                    // path there legitimately comes back blank. QA mode substitutes a
+                    // synthetic frame so the tap -> capture -> answer flow stays screenshot-
+                    // able -- but only AFTER the real validation has run and logged, so the
+                    // QA path exercises exactly the code a device does.
+                    if (DemoSettings.qaMode) {
+                        AskFrame(syntheticQaFrame(), AskCaptureSource.Window)
                     } else {
-                        Log.w(ASK_LOG_TAG, "PixelCopy failed with result $result (#3343).")
+                        fail(outcome.verdict.asFailure() ?: AskFailure.CaptureFailed)
+                        return@LaunchedEffect
                     }
-                    bitmap.recycle()
-                    onResult(AskState.Failed(AskFailure.CaptureFailed))
                 }
-            },
-            Handler(Looper.getMainLooper()),
-        )
-        delay(CAPTURE_TIMEOUT_MS)
-        if (roundLive) {
-            roundLive = false
+
+                is AskCaptureOutcome.Captured -> outcome.frame
+            }
+
+            if (keepFramePreview) {
+                lastFramePreview?.thumbnail?.recycle()
+                lastFramePreview = framePreviewOf(frame)
+            }
+            flow.onFrameAccepted()
+            onStep(flow.step)
+            askJob = scope.askAboutBitmap(frame.bitmap, askEngine, question) { failure, text ->
+                when {
+                    failure != null -> flow.onFailure(failure)
+                    text != null -> flow.onDelta(text)
+                    else -> flow.onStreamCompleted()
+                }
+                onStep(flow.step)
+            }
+        } finally {
             hideOverlaysForCapture = false
-            Log.w(ASK_LOG_TAG, "PixelCopy never called back within the capture budget (#3188).")
-            onResult(AskState.Failed(AskFailure.CaptureFailed))
         }
     }
 
     // Auto-dismiss a completed answer so nothing lingers over the viewfinder.
-    LaunchedEffect(askState) {
-        val answered = askState as? AskState.Answered ?: return@LaunchedEffect
+    LaunchedEffect(step) {
+        val answered = step as? AskStep.Answered ?: return@LaunchedEffect
         if (answered.streaming) return@LaunchedEffect
         delay(ANSWER_AUTO_DISMISS_MS)
-        if (askState == answered) askState = AskState.Idle
+        if (step == answered) {
+            flow.onAnswerDismissed()
+            syncStep()
+        }
     }
 
     DemoScaffold(
@@ -499,10 +552,10 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         onReset = {
             askJob?.cancel()
             askJob = null
-            askState = AskState.Idle
-            // Reset clears the escalated failure card too — the user explicitly asked for
-            // a clean slate, so the demo gives the device another honest chance (#3343).
-            consecutiveFailures = 0
+            // Reset clears the failure history too — the user explicitly asked for a clean
+            // slate, so the demo gives the device another honest chance (#3343).
+            flow.reset()
+            syncStep()
             placedProps.forEach { runCatching { it.anchor.detach() } }
             placedProps.clear()
             pendingPanel = null
@@ -514,6 +567,18 @@ fun PointAndAskDemo(onBack: () -> Unit) {
             selectedProp = DROP_PROPS[0]
         },
         controls = {
+            // Which engine answers, stated up front rather than only in the failure copy.
+            // There is no cloud fallback in this demo and no API key anywhere near it: the
+            // frame is captured, cropped and inferred on-device (#2648). Saying so where the
+            // user can see it is the "make the choice explicit" half of #3407 — the choice
+            // here is that there is only one, and it is the private one.
+            Text(
+                text = stringResource(R.string.demo_point_and_ask_engine_on_device),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(12.dp))
+
             // Free-form question (P3) — blank falls back to the default prompt, which the
             // placeholder shows. The next tap asks THIS question about the composited frame.
             // Voice input (#3083): the trailing mic launches the system speech recognizer and
@@ -580,6 +645,50 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                 }
             }
 
+            // Debug / QA only: exactly what went to the model, at the size it went. "It
+            // sees nothing on the AR frame" (#3407) was un-diagnosable from a bug report —
+            // the frame was never visible anywhere, and the logcat line that would have said
+            // so is drowned by ~90 ARCore "Use dataspace" lines a second, so the reporter's
+            // last-53-lines window never contains it. Now it is on screen.
+            if (keepFramePreview) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.demo_point_and_ask_debug_frame_label),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Spacer(Modifier.height(6.dp))
+                val preview = lastFramePreview
+                if (preview == null) {
+                    Text(
+                        text = stringResource(R.string.demo_point_and_ask_debug_frame_none),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+                    )
+                } else {
+                    Image(
+                        bitmap = preview.thumbnail.asImageBitmap(),
+                        contentDescription =
+                            stringResource(R.string.demo_point_and_ask_debug_frame_cd),
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .height(DEBUG_FRAME_PREVIEW_HEIGHT)
+                            .testTag(PointAndAskTestTags.DEBUG_FRAME),
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.demo_point_and_ask_debug_frame_meta,
+                            preview.width,
+                            preview.height,
+                            preview.source.label,
+                            question,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+                    )
+                }
+            }
+
             if (DemoSettings.qaMode) {
                 ForceTrackingFailureMenu()
             }
@@ -590,10 +699,7 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         // (#3237).
         topOverlay = {
             AnimatedVisibility(
-                visible = !hideOverlaysForCapture &&
-                    askState == AskState.Idle &&
-                    !busy &&
-                    engineStatus != null,
+                visible = shownStep == AskStep.Ready && !busy,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
@@ -604,13 +710,10 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                     shape = MaterialTheme.shapes.small,
                 ) {
                     Text(
-                        text = when {
-                            engineStatus == AskEngineStatus.Ready && !isTracking ->
-                                stringResource(R.string.ar_status_scanning)
-                            engineStatus == AskEngineStatus.Ready ->
-                                stringResource(R.string.demo_point_and_ask_status_ready)
-                            else ->
-                                stringResource(R.string.demo_point_and_ask_status_limited)
+                        text = if (isTracking) {
+                            stringResource(R.string.demo_point_and_ask_status_ready)
+                        } else {
+                            stringResource(R.string.ar_status_scanning)
                         },
                         style = MaterialTheme.typography.labelLarge,
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
@@ -623,8 +726,11 @@ fun PointAndAskDemo(onBack: () -> Unit) {
         // under it: this card is `fillMaxWidth()`, so at plain `Alignment.BottomCenter`
         // it ran into the bottom-end FAB by construction, in every state (#2779).
         bottomOverlay = {
-            // Bottom overlay — exactly one of: unavailable banner, download CTA/progress,
-            // thinking indicator, answer card, transient failure.
+            // Exactly one card, chosen by exactly one value. Every state the demo can be in
+            // is named here and none of them is a dead end: availability has its own cards
+            // (checking / download / downloading / unsupported), a round has its own
+            // (capturing / thinking / answer), and a failure names its cause AND offers the
+            // one action that could fix it (#3407).
             if (!hideOverlaysForCapture) Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -633,21 +739,48 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                     // FAB, so only the end edge is inset (0.dp when there is no FAB).
                     .padding(end = settingsFabReservedSpace),
             ) {
-                when (val status = engineStatus) {
-                    // Say so in words while the availability check runs: a blank bottom
-                    // edge here was indistinguishable from a broken demo (#3188).
-                    null -> BottomCard {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            CircularProgressIndicator(modifier = Modifier.size(18.dp))
-                            Text(
-                                text = stringResource(R.string.demo_point_and_ask_status_checking),
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(start = 12.dp),
-                            )
+                when (val current = shownStep) {
+                    // Say so in words while the availability probe runs: a blank bottom edge
+                    // here was indistinguishable from a broken demo (#3188).
+                    AskStep.CheckingAvailability -> BottomCard {
+                        ProgressRow(stringResource(R.string.demo_point_and_ask_status_checking))
+                    }
+
+                    AskStep.ModelDownloadable -> BottomCard {
+                        Text(
+                            text = stringResource(R.string.demo_point_and_ask_download_title),
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Button(onClick = {
+                            scope.launch {
+                                askEngine.download().collect {
+                                    flow.onAvailability(it.toAvailability())
+                                    syncStep()
+                                }
+                            }
+                        }) {
+                            Text(stringResource(R.string.demo_point_and_ask_download_cta))
                         }
                     }
 
-                    AskEngineStatus.Unavailable -> BottomCard {
+                    is AskStep.ModelDownloading -> BottomCard {
+                        ProgressRow(
+                            current.bytesDownloaded
+                                ?.let { bytes ->
+                                    stringResource(
+                                        R.string.demo_point_and_ask_downloading_progress,
+                                        bytes / (1024 * 1024),
+                                    )
+                                }
+                                ?: stringResource(R.string.demo_point_and_ask_downloading),
+                        )
+                    }
+
+                    // The ONLY card that says this device cannot run the demo — and it is
+                    // reached only from a platform report (`FeatureStatus`, a failed
+                    // download, or a terminal ML Kit code), never from a retry count (#3407).
+                    AskStep.ModelUnsupported -> BottomCard {
                         Text(
                             text = stringResource(R.string.demo_point_and_ask_unavailable_title),
                             style = MaterialTheme.typography.titleSmall,
@@ -657,107 +790,85 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                             text = stringResource(R.string.demo_point_and_ask_unavailable_body),
                             style = MaterialTheme.typography.bodySmall,
                         )
+                        Spacer(Modifier.height(8.dp))
+                        TextButton(onClick = { context.openAicoreSettings() }) {
+                            Text(stringResource(R.string.demo_point_and_ask_action_aicore))
+                        }
                     }
 
-                    AskEngineStatus.Downloadable -> BottomCard {
+                    // Ready and idle: the pill above carries the instruction, the viewfinder
+                    // stays clear.
+                    AskStep.Ready -> Unit
+
+                    AskStep.CapturingFrame -> BottomCard {
+                        ProgressRow(stringResource(R.string.demo_point_and_ask_status_capturing))
+                    }
+
+                    AskStep.Thinking -> BottomCard {
+                        ProgressRow(stringResource(R.string.demo_point_and_ask_status_thinking))
+                    }
+
+                    is AskStep.Answered -> BottomCard(
+                        testTag = PointAndAskTestTags.ANSWER_CARD,
+                    ) {
                         Text(
-                            text = stringResource(R.string.demo_point_and_ask_download_title),
-                            style = MaterialTheme.typography.titleSmall,
+                            text = question,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        // "▌" = live-typing cursor while deltas keep arriving.
+                        Text(
+                            text = renderMarkdownLite(
+                                if (current.streaming) "${current.text}▌" else current.text
+                            ),
+                            style = MaterialTheme.typography.bodyLarge,
                         )
                         Spacer(Modifier.height(8.dp))
-                        Button(onClick = {
-                            scope.launch {
-                                askEngine.download().collect { engineStatus = it }
-                            }
-                        }) {
-                            Text(stringResource(R.string.demo_point_and_ask_download_cta))
-                        }
-                    }
-
-                    is AskEngineStatus.Downloading -> BottomCard {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            CircularProgressIndicator(modifier = Modifier.size(20.dp))
-                            Text(
-                                text = status.totalBytesDownloaded
-                                    ?.let { bytes ->
-                                        stringResource(
-                                            R.string.demo_point_and_ask_downloading_progress,
-                                            bytes / (1024 * 1024),
-                                        )
-                                    }
-                                    ?: stringResource(R.string.demo_point_and_ask_downloading),
-                                style = MaterialTheme.typography.bodySmall,
-                                modifier = Modifier.padding(start = 12.dp),
-                            )
-                        }
-                    }
-
-                    AskEngineStatus.Ready -> when (val ask = askState) {
-                        AskState.Idle -> Unit
-
-                        AskState.Capturing, AskState.Thinking -> BottomCard {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                CircularProgressIndicator(modifier = Modifier.size(18.dp))
-                                Text(
-                                    text = stringResource(
-                                    R.string.demo_point_and_ask_status_thinking
-                                ),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    modifier = Modifier.padding(start = 12.dp),
-                                )
-                            }
-                        }
-
-                        is AskState.Answered -> BottomCard(
-                            testTag = PointAndAskTestTags.ANSWER_CARD,
-                        ) {
-                            Text(
-                                text = question,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
-                            )
-                            Spacer(Modifier.height(6.dp))
-                            // "▌" = live-typing cursor while deltas keep arriving.
-                            Text(
-                                text = renderMarkdownLite(
-                                    if (ask.streaming) "${ask.text}▌" else ask.text
-                                ),
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            Text(
-                                text = stringResource(
-                                    if (context.isOffline()) {
-                                        R.string.demo_point_and_ask_answer_source_offline
-                                    } else {
-                                        R.string.demo_point_and_ask_answer_source
-                                    }
-                                ),
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-
-                        // One card per cause, and — once retrying is demonstrably not
-                        // going to help — an explanation instead of an invitation to keep
-                        // tapping (#3343).
-                        is AskState.Failed -> AskFailureCard(
-                            failure = ask.failure,
-                            escalated = ask.failure.isTerminal ||
-                                consecutiveFailures >= ASK_FAILURE_ESCALATION_THRESHOLD,
+                        Text(
+                            text = stringResource(
+                                if (context.isOffline()) {
+                                    R.string.demo_point_and_ask_answer_source_offline
+                                } else {
+                                    R.string.demo_point_and_ask_answer_source
+                                }
+                            ),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
+
+                    is AskStep.Failed -> AskFailureCard(
+                        failure = current.failure,
+                        persistent = current.persistent,
+                        onAction = {
+                            when (current.failure.recovery) {
+                                AskRecovery.OpenAicoreSettings -> context.openAicoreSettings()
+                                AskRecovery.FreeStorage -> context.openStorageSettings()
+                                else -> Unit
+                            }
+                            flow.onRetry()
+                            syncStep()
+                        },
+                    )
                 }
             }
         },
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
+            // QA camera backdrop (#3308). The demo had none, so every emulator screenshot of
+            // it landed on flat black — which is also a frame the model would see nothing in,
+            // making the emulator indistinguishable from the device defect this fixes.
+            if (qaBackdrop) QaCameraBackdrop(seed = "point-and-ask")
             ARSceneView(
                 modifier = Modifier.fillMaxSize(),
                 engine = engine,
                 modelLoader = modelLoader,
                 materialLoader = materialLoader,
+                isOpaque = !qaCameraBackdropEnabled(),
+                surfaceType = qaCameraBackdropSurfaceType(),
+                cameraStream = if (qaBackdrop) null else cameraStream,
                 playbackDataset = arPlaybackDataset,
                 // Planes are shown so the user can see where a tap will pin its answer —
                 // but never during the capture window: the composited frame is what Nano
@@ -767,6 +878,7 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                 viewNodeWindowManager = viewNodeManager,
                 onSessionUpdated = { _, frame ->
                     latestFrame = frame
+                    cameraReady = true
                     isTracking = frame.camera.trackingState == TrackingState.TRACKING
                     // Keep the camera world position fresh so every anchored answer card can
                     // billboard toward the viewer (#3276) — same pattern as `ARMLObjectLabelDemo`'s
@@ -786,7 +898,10 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                         // prop you just dropped and an answer already pinned. A `node ==
                         // null` guard here swallowed every tap on the object the user most
                         // wanted described — no ping, no capture, no answer (#3187).
-                        if (engineStatus == AskEngineStatus.Ready && !busy) {
+                        // `busy` is the anchored half of the guard; `flow.canAsk` is the
+                        // screen half (model ready, no round in flight). A QA state override
+                        // pins the card, so taps must not fight it.
+                        if (qaStep == null && flow.canAsk && !busy) {
                             ping = Offset(e.x, e.y) to System.nanoTime()
                             // Same point the capture is cropped around: the model is asked
                             // about what the finger landed on, not the whole room (#3343).
@@ -837,7 +952,9 @@ fun PointAndAskDemo(onBack: () -> Unit) {
                             while (panels.size > MAX_PANELS) {
                                 panels.removeAt(0).also { runCatching { it.anchor.detach() } }
                             }
-                            askState = AskState.Capturing
+                            flow.onTap()
+                            syncStep()
+                            captureToken++
                         }
                     },
                     // Long-press drops the Drop-3D picker's currently selected model (#3083)
@@ -1112,31 +1229,7 @@ internal fun clampedPanelScale(distanceMeters: Float): Float {
 /** How many answers stay pinned before the oldest is retired. */
 private const val MAX_PANELS = 8
 
-/**
- * Routes one ask round's results: always to [screenCard] (the bottom card), and ALSO into
- * [panel] when the tap pinned one (P2).
- *
- * The screen card is never handed off. An earlier version drove it back to [AskState.Idle]
- * once a panel existed, so an anchored round drew zero screen chrome — no card, no pill, no
- * failure text — and when the in-scene card was off-screen, edge-on or its texture had not
- * come up, the answer was simply invisible (#3188). The bottom card is the guaranteed
- * surface; the anchored card is the bonus that stays in the room after the bottom card
- * auto-dismisses.
- */
-private fun answerSink(
-    panel: AnswerPanel?,
-    failedText: (AskFailure) -> String,
-    screenCard: (AskState) -> Unit,
-): (AskState) -> Unit = if (panel == null) {
-    screenCard
-} else {
-    { state ->
-        panel.accept(state, failedText)
-        screenCard(state)
-    }
-}
-
-/** Unwraps the [Activity] hosting this composition (needed for window PixelCopy). */
+/** Unwraps the [Activity] hosting this composition (needed for the frame read-back). */
 private tailrec fun Context.findActivity(): Activity? = when (this) {
     is Activity -> this
     is ContextWrapper -> baseContext.findActivity()
@@ -1150,38 +1243,61 @@ private fun Context.isOffline(): Boolean {
 }
 
 /**
- * Runs one streamed [AskEngine.askStream] round-trip over [bitmap], reporting a growing
- * [AskState.Answered] per delta and the final state on completion. A failure mid-stream
- * keeps the text already received (marked complete) — only a failure before any delta
- * surfaces [AskState.Failed]. Takes ownership of [bitmap] (recycled when the round ends).
+ * Opens the system app-details screen for AICore / Android System Intelligence — the one
+ * place a user can actually check for the update the two terminal failures ask for. Falls
+ * back to the generic app-settings screen when that package is not installed (which is
+ * itself the reason the model is unavailable), and does nothing at all rather than crash if
+ * neither resolves.
+ */
+private fun Context.openAicoreSettings() {
+    val targets = listOf(
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            .setData("package:$AICORE_PACKAGE".toUri()),
+        Intent(Settings.ACTION_APPLICATION_SETTINGS),
+    )
+    for (intent in targets) {
+        if (runCatching { startActivity(intent) }.isSuccess) return
+    }
+    Log.w(ASK_LOG_TAG, "No settings activity accepted the AICore intent (#3407).")
+}
+
+/** Opens the storage settings screen — the action offered for `NOT_ENOUGH_DISK_SPACE`. */
+private fun Context.openStorageSettings() {
+    runCatching { startActivity(Intent(Settings.ACTION_INTERNAL_STORAGE_SETTINGS)) }
+        .onFailure { Log.w(ASK_LOG_TAG, "No storage settings activity (#3407).", it) }
+}
+
+/** The system package that hosts AICore / Gemini Nano. */
+private const val AICORE_PACKAGE = "com.google.android.aicore"
+
+/**
+ * Runs one streamed [AskEngine.askStream] round-trip over [bitmap], reporting results through
+ * [onEvent]: a non-null failure, else a non-null accumulated answer for each delta, else
+ * `(null, null)` for "the stream completed". Takes ownership of [bitmap] (recycled when the
+ * round ends).
  *
- * The throwable is classified rather than swallowed (#3343): the card names the actual
- * cause, and every failure is logged with its ML Kit error code so the next report of
- * "it only says it can't answer" arrives with the code attached instead of needing to be
- * re-diagnosed from scratch. A stream that completes with no text at all is [
- * AskFailure.EmptyAnswer] — a distinct outcome from a thrown inference error, and one the
- * user can act on (rephrase) rather than retry blindly.
+ * The throwable is classified rather than swallowed (#3343): the card names the actual cause,
+ * and every failure is logged with its ML Kit error code. Interpreting those events — keeping
+ * a partial answer, counting a run of failures, deciding whether the platform actually said
+ * "unsupported" — is `AskFlow`'s job, not this function's, which is exactly why that logic is
+ * unit-tested and this glue is not (#3407).
  */
 private fun CoroutineScope.askAboutBitmap(
     bitmap: Bitmap,
     askEngine: AskEngine,
     question: String,
-    onResult: (AskState) -> Unit,
+    onEvent: (failure: AskFailure?, text: String?) -> Unit,
 ) = launch {
     var text = ""
     try {
         askEngine.askStream(bitmap, question).collect { delta ->
             text += delta
-            onResult(AskState.Answered(text, streaming = true))
+            onEvent(null, text)
         }
-        onResult(
-            if (text.isBlank()) {
-                Log.w(ASK_LOG_TAG, "Gemini Nano completed the stream with no text (#3343).")
-                AskState.Failed(AskFailure.EmptyAnswer)
-            } else {
-                AskState.Answered(text)
-            }
-        )
+        if (text.isBlank()) {
+            Log.w(ASK_LOG_TAG, "Gemini Nano completed the stream with no text (#3343).")
+        }
+        onEvent(null, null)
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -1190,62 +1306,65 @@ private fun CoroutineScope.askAboutBitmap(
         // coroutine scope silently and leave the demo wedged in `Thinking` (cf. #3188).
         val failure = AskFailure.of(e)
         Log.w(ASK_LOG_TAG, "Gemini Nano inference failed — classified as $failure (#3343).", e)
-        onResult(
-            if (text.isBlank()) AskState.Failed(failure) else AskState.Answered(text)
-        )
+        onEvent(failure, null)
     } finally {
         bitmap.recycle()
     }
 }
 
-/** Logcat tag for every Point & Ask failure path — one grep away in a bug report. */
-private const val ASK_LOG_TAG = "PointAndAskDemo"
+/**
+ * A deterministic stand-in frame for QA runs on an emulator, which has no camera HAL and so
+ * no real frame to read back (#2754/#3308). Deliberately textured rather than flat, so it
+ * passes the same [io.github.sceneview.demo.ai.inspectAskFrame] validation a device frame
+ * must pass — a QA frame that could not survive the real check would be testing nothing.
+ */
+private fun syntheticQaFrame(): Bitmap {
+    val size = 256
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val pixels = IntArray(size * size)
+    for (y in 0 until size) {
+        for (x in 0 until size) {
+            val checker = if (((x / 32) + (y / 32)) % 2 == 0) 40 else 200
+            pixels[y * size + x] = (0xFF shl 24) or (checker shl 16) or (checker shl 8) or checker
+        }
+    }
+    bitmap.setPixels(pixels, 0, size, 0, 0, size, size)
+    return bitmap
+}
+
+/** Longest edge of the debug frame thumbnail kept in memory between rounds. */
+private const val DEBUG_FRAME_PREVIEW_MAX_EDGE = 192
+
+/** On-screen height of that thumbnail in the controls sheet. */
+private val DEBUG_FRAME_PREVIEW_HEIGHT = 140.dp
 
 /**
- * Crops [capture] to [askCaptureRegion] around [focus] and downscales it to the model's
- * budget, recycling the oversized original. Returns [capture] unchanged when it is already
- * within budget, so the caller's ownership contract (the returned bitmap is recycled once
- * the round ends) holds either way.
- *
- * Why this exists rather than trusting ML Kit's own resize: genai-prompt 1.0.0-beta4
- * rescales only when `min(width, height) > 768`, and only the SHORT edge — a 1080×2424
- * window capture arrives as 768×1723. See `ASK_IMAGE_MAX_EDGE` (#3343).
+ * A small copy of the frame about to be sent, for the debug/QA preview. A copy, because the
+ * round recycles the real bitmap the moment inference ends — and the whole point is to still
+ * be able to look at what the model looked at afterwards (#3407).
  */
-private fun frameForModel(capture: Bitmap, focus: Offset?): Bitmap {
-    val region = askCaptureRegion(
-        sourceWidth = capture.width,
-        sourceHeight = capture.height,
-        focusX = focus?.x,
-        focusY = focus?.y,
+private fun framePreviewOf(frame: AskFrame): AskFramePreview? = runCatching {
+    val longest = maxOf(frame.bitmap.width, frame.bitmap.height).coerceAtLeast(1)
+    val scale = (DEBUG_FRAME_PREVIEW_MAX_EDGE.toFloat() / longest).coerceAtMost(1f)
+    val thumbnail = Bitmap.createScaledBitmap(
+        frame.bitmap,
+        (frame.bitmap.width * scale).toInt().coerceAtLeast(1),
+        (frame.bitmap.height * scale).toInt().coerceAtLeast(1),
+        true,
     )
-    val unchanged = region.x == 0 && region.y == 0 &&
-        region.width == capture.width && region.height == capture.height &&
-        region.scaledWidth == capture.width && region.scaledHeight == capture.height
-    if (unchanged) return capture
-    return runCatching {
-        val cropped = Bitmap.createBitmap(
-            capture, region.x, region.y, region.width, region.height,
-        )
-        val scaled = if (
-            cropped.width == region.scaledWidth && cropped.height == region.scaledHeight
-        ) {
-            cropped
+    AskFramePreview(
+        // `createScaledBitmap` can hand back the source itself; copy so recycling the frame
+        // at the end of the round does not blank the preview.
+        thumbnail = if (thumbnail === frame.bitmap) {
+            frame.bitmap.copy(Bitmap.Config.ARGB_8888, false)
         } else {
-            Bitmap.createScaledBitmap(
-                cropped, region.scaledWidth, region.scaledHeight, true,
-            ).also { if (it !== cropped) cropped.recycle() }
-        }
-        // `createBitmap`/`createScaledBitmap` may return the source itself when nothing
-        // had to change; only recycle the capture when a genuinely new bitmap came back.
-        if (scaled !== capture) capture.recycle()
-        scaled
-    }.getOrElse {
-        // Out of memory or a degenerate rectangle — the full frame is still a usable
-        // question, so degrade to it rather than failing the round.
-        Log.w(ASK_LOG_TAG, "Could not reframe the capture for the model; sending it whole.", it)
-        capture
-    }
-}
+            thumbnail
+        },
+        width = frame.bitmap.width,
+        height = frame.bitmap.height,
+        source = frame.source,
+    )
+}.getOrNull()
 
 /**
  * The in-scene answer card rendered by an anchored `ViewNode` (P2). Mirrors the states of
@@ -1339,22 +1458,29 @@ private val ANCHORED_CARD_WIDTH = 320.dp
 private val ANCHORED_CARD_HEIGHT = 200.dp
 
 /**
- * The failure card (#3343). Two shapes, one component:
+ * The failure card (#3343, reworked by #3407). One shape, one component:
  *
- *  - **transient** — a single line naming what actually went wrong, so a busy model, a
- *    rejected frame and a failed capture read differently instead of all being "Gemini
- *    Nano couldn't answer";
- *  - **escalated** — reached when the failure is terminal (this device cannot run the
- *    model at all) or the same kind of failure has repeated
- *    [ASK_FAILURE_ESCALATION_THRESHOLD] times. The retry invitation is dropped and the
- *    card explains the on-device-only design and what the user can actually check.
+ *  - it always names the **actual cause**, so a busy model, a rejected frame, a lost AR
+ *    layer and a blank frame read differently;
+ *  - it always offers the **one action** that could fix that cause
+ *    ([AskFailure.recovery]) — a button, not a sentence;
+ *  - when [persistent] it changes only its headline, to say the step keeps failing. It does
+ *    NOT claim the device cannot run the model. #3343 wired a retry counter straight to
+ *    "Point & Ask can't answer on this device", so three ordinary capture failures on a
+ *    perfectly capable Pixel 9 ended the demo in a dead end that also happened to be untrue
+ *    (#3407). "Not on this phone" is now `AskStep.ModelUnsupported`'s card alone, and only
+ *    the platform can put the demo there.
  *
  * `DESIGN.md`'s "Blocked" severity: an error indicator plus the theme's `error` role, so
  * both schemes stay legible without a hardcoded colour.
  */
 @Composable
-private fun AskFailureCard(failure: AskFailure, escalated: Boolean) {
-    BottomCard {
+private fun AskFailureCard(
+    failure: AskFailure,
+    persistent: Boolean,
+    onAction: () -> Unit,
+) {
+    BottomCard(testTag = PointAndAskTestTags.FAILURE_CARD) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Outlined.ErrorOutline,
@@ -1364,21 +1490,21 @@ private fun AskFailureCard(failure: AskFailure, escalated: Boolean) {
             )
             Text(
                 text = stringResource(
-                    if (escalated) {
+                    if (persistent) {
                         R.string.demo_point_and_ask_error_repeated_title
                     } else {
                         failure.messageRes
                     }
                 ),
                 style = MaterialTheme.typography.bodyMedium,
-                fontWeight = if (escalated) FontWeight.SemiBold else FontWeight.Normal,
+                fontWeight = if (persistent) FontWeight.SemiBold else FontWeight.Normal,
                 modifier = Modifier.padding(start = 12.dp),
             )
         }
-        if (escalated) {
+        if (persistent) {
             Spacer(Modifier.height(6.dp))
-            // The specific cause stays on screen under the explanation — it is what makes
-            // a bug report actionable, and it is the line that matches logcat.
+            // The specific cause stays on screen under the headline — it is what makes a bug
+            // report actionable, and it is the line that matches logcat.
             Text(
                 text = stringResource(failure.messageRes),
                 style = MaterialTheme.typography.bodySmall,
@@ -1391,6 +1517,26 @@ private fun AskFailureCard(failure: AskFailure, escalated: Boolean) {
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
             )
         }
+        Spacer(Modifier.height(4.dp))
+        TextButton(
+            onClick = onAction,
+            modifier = Modifier.testTag(PointAndAskTestTags.FAILURE_ACTION),
+        ) {
+            Text(stringResource(failure.recovery.labelRes))
+        }
+    }
+}
+
+/** Spinner + one line of copy — the shape every "working on it" card shares. */
+@Composable
+private fun ProgressRow(text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CircularProgressIndicator(modifier = Modifier.size(18.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(start = 12.dp),
+        )
     }
 }
 

--- a/samples/android-demo/src/main/res/values/strings_demo_point_and_ask.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_point_and_ask.xml
@@ -32,12 +32,41 @@
     <string name="demo_point_and_ask_error_busy">Gemini Nano is busy or throttled right now — tap again in a moment</string>
     <string name="demo_point_and_ask_error_too_large">The question was too long for the on-device model — try a shorter one</string>
     <string name="demo_point_and_ask_error_image">Gemini Nano rejected the captured frame — point at something and tap again</string>
+    <!-- The AR viewport was punched out of the read-back: camera + virtual objects missing,
+         everything else intact (#2654/#3276/#3407). -->
+    <string name="demo_point_and_ask_error_capture_layer">The AR view was missing from the captured frame — nothing for the model to look at</string>
+    <!-- The read-back was intact but flat: a black viewport, a covered lens, or a lost AR
+         layer in its opaque form. Caught before it reaches the model (#3407). -->
+    <string name="demo_point_and_ask_error_capture_blank">The captured frame was blank — Gemini Nano would have seen nothing</string>
 
-    <!-- Shown once a failure repeats (or a terminal one occurs): stop offering a retry
-         that cannot work, explain instead (#3343). -->
-    <string name="demo_point_and_ask_error_repeated_title">Point &amp; Ask can\'t answer on this device</string>
-    <string name="demo_point_and_ask_error_repeated_body">Answers run entirely on-device through Google AICore — there is no cloud fallback, by design. Check that Android System Intelligence is up to date, or try again after a restart.</string>
+    <!-- Shown once the SAME round keeps failing. It changes the headline only: the precise
+         cause and its action stay on the card, and nothing here claims the device cannot run
+         the model — that claim is reserved for a platform report (#3407). -->
+    <string name="demo_point_and_ask_error_repeated_title">This keeps failing here</string>
+    <string name="demo_point_and_ask_error_repeated_body">Gemini Nano is installed and ready on this device — it is this step that keeps going wrong. Try aiming at a well-lit, textured surface, or reset the demo to start a clean session.</string>
     <string name="demo_point_and_ask_error_cd">Error</string>
+
+    <!-- One concrete next step per failure (AskRecovery). -->
+    <string name="demo_point_and_ask_action_retry">Try again</string>
+    <string name="demo_point_and_ask_action_aim">Aim and try again</string>
+    <string name="demo_point_and_ask_action_rephrase">Edit the question</string>
+    <string name="demo_point_and_ask_action_storage">Free up storage</string>
+    <string name="demo_point_and_ask_action_aicore">Open system settings</string>
+
+    <!-- Capture state — the frame read-back is now a state the user can see, instead of a
+         silent gap between the tap and "thinking" (#3407). -->
+    <string name="demo_point_and_ask_status_capturing">Capturing the AR frame…</string>
+
+    <!-- Where answers come from. Stated up front rather than only in the failure copy: the
+         demo has no cloud fallback and never sends the frame anywhere (#2648). -->
+    <string name="demo_point_and_ask_engine_on_device">On-device only · Gemini Nano · the frame never leaves this phone</string>
+
+    <!-- Debug / QA build only: what was actually sent to the model, so "it sees nothing" is
+         verifiable on the spot instead of from a bug report (#3407). -->
+    <string name="demo_point_and_ask_debug_frame_label" translatable="false">Last frame sent to the model</string>
+    <string name="demo_point_and_ask_debug_frame_none" translatable="false">No frame captured yet — tap the view to ask.</string>
+    <string name="demo_point_and_ask_debug_frame_meta" translatable="false">%1$d×%2$d · %3$s · %4$s</string>
+    <string name="demo_point_and_ask_debug_frame_cd" translatable="false">Frame sent to the model</string>
 
     <!-- Free-form question input (P3) -->
     <string name="demo_point_and_ask_question_label">Ask anything about what you see</string>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFlowTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFlowTest.kt
@@ -1,0 +1,283 @@
+package io.github.sceneview.demo.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for the Point & Ask state machine (#3407).
+ *
+ * The regression that matters most is `a run of ordinary failures never declares the device
+ * unsupported`: #3343 wired a retry counter straight to "Point & Ask can't answer on this
+ * device", so three capture failures on a working Pixel 9 ended the demo with a dead end that
+ * was also a lie — the report in #3407, verbatim, "dis qu'il peut pas tourner sur ce tel au
+ * bout de 4 demandes".
+ */
+class AskFlowTest {
+
+    private fun readyFlow() = AskFlow().apply { onAvailability(AskAvailability.Ready) }
+
+    @Test
+    fun `starts by saying the availability check is running`() {
+        assertEquals(AskStep.CheckingAvailability, AskFlow().step)
+    }
+
+    @Test
+    fun `each availability maps to its own card`() {
+        val flow = AskFlow()
+        flow.onAvailability(AskAvailability.Downloadable)
+        assertEquals(AskStep.ModelDownloadable, flow.step)
+        flow.onAvailability(AskAvailability.Downloading(1_024L))
+        assertEquals(AskStep.ModelDownloading(1_024L), flow.step)
+        flow.onAvailability(AskAvailability.Ready)
+        assertEquals(AskStep.Ready, flow.step)
+        flow.onAvailability(AskAvailability.Unsupported)
+        assertEquals(AskStep.ModelUnsupported, flow.step)
+    }
+
+    @Test
+    fun `a tap only starts a round when the model is ready`() {
+        val flow = AskFlow()
+        assertFalse("no model yet", flow.onTap())
+        assertEquals(AskStep.CheckingAvailability, flow.step)
+
+        flow.onAvailability(AskAvailability.Ready)
+        assertTrue(flow.onTap())
+        assertEquals(AskStep.CapturingFrame, flow.step)
+    }
+
+    @Test
+    fun `a tap during a round is ignored rather than restarting it`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        assertEquals(AskStep.Thinking, flow.step)
+        assertFalse("a round is already in flight", flow.onTap())
+        assertEquals(AskStep.Thinking, flow.step)
+    }
+
+    @Test
+    fun `the happy path walks capture, thinking, streaming, answer`() {
+        val flow = readyFlow()
+        flow.onTap()
+        assertEquals(AskStep.CapturingFrame, flow.step)
+        flow.onFrameAccepted()
+        assertEquals(AskStep.Thinking, flow.step)
+        flow.onDelta("A wooden")
+        assertEquals(AskStep.Answered("A wooden", streaming = true), flow.step)
+        flow.onDelta("A wooden table")
+        flow.onStreamCompleted()
+        assertEquals(AskStep.Answered("A wooden table", streaming = false), flow.step)
+        assertFalse(flow.isBusy)
+    }
+
+    @Test
+    fun `a completed answer auto-dismisses back to ready, a streaming one does not`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onDelta("half an answer")
+        flow.onAnswerDismissed()
+        assertEquals("still streaming", AskStep.Answered("half an answer", true), flow.step)
+        flow.onStreamCompleted()
+        flow.onAnswerDismissed()
+        assertEquals(AskStep.Ready, flow.step)
+    }
+
+    @Test
+    fun `a stream that completes with no text is a rephrasable failure, not a success`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onStreamCompleted()
+        assertEquals(AskStep.Failed(AskFailure.EmptyAnswer, persistent = false), flow.step)
+        assertEquals(AskRecovery.Rephrase, AskFailure.EmptyAnswer.recovery)
+    }
+
+    @Test
+    fun `a run of ordinary failures never declares the device unsupported`() {
+        val flow = readyFlow()
+        // Well past the wording threshold, and past the four rounds of #3407.
+        repeat(8) {
+            flow.onTap()
+            flow.onFailure(AskFailure.CaptureBlank)
+        }
+        val step = flow.step
+        assertTrue("still an ordinary failure card", step is AskStep.Failed)
+        assertEquals(AskFailure.CaptureBlank, (step as AskStep.Failed).failure)
+        assertEquals(
+            "availability must be untouched by round failures",
+            AskAvailability.Ready,
+            flow.availability,
+        )
+    }
+
+    @Test
+    fun `repeated failures change the wording but keep the cause and the action`() {
+        val flow = readyFlow()
+        repeat(ASK_FAILURE_PERSISTENT_THRESHOLD - 1) {
+            flow.onTap()
+            flow.onFailure(AskFailure.CaptureMissingArLayer)
+            assertFalse((flow.step as AskStep.Failed).persistent)
+        }
+        flow.onTap()
+        flow.onFailure(AskFailure.CaptureMissingArLayer)
+        val step = flow.step as AskStep.Failed
+        assertTrue(step.persistent)
+        assertEquals(
+            "the persistent card still names the same cause",
+            AskFailure.CaptureMissingArLayer,
+            step.failure,
+        )
+        assertEquals(AskRecovery.Retry, step.failure.recovery)
+    }
+
+    @Test
+    fun `only a terminal failure moves the demo to unsupported`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFailure(AskFailure.ModelUnavailable)
+        assertEquals(AskAvailability.Unsupported, flow.availability)
+        assertEquals(AskStep.ModelUnsupported, flow.step)
+        assertFalse("no more rounds once the platform said no", flow.onTap())
+    }
+
+    @Test
+    fun `a needs-system-update report is terminal too`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFailure(AskFailure.NeedsSystemUpdate)
+        assertEquals(AskStep.ModelUnsupported, flow.step)
+    }
+
+    @Test
+    fun `a failure mid-stream keeps the text already received`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onDelta("A small wooden")
+        flow.onFailure(AskFailure.Busy)
+        assertEquals(AskStep.Answered("A small wooden", streaming = false), flow.step)
+        assertEquals("a partial answer clears the failure run", 0, flow.consecutiveFailures)
+    }
+
+    @Test
+    fun `an answer resets the failure run`() {
+        val flow = readyFlow()
+        repeat(2) {
+            flow.onTap()
+            flow.onFailure(AskFailure.CaptureFailed)
+        }
+        assertEquals(2, flow.consecutiveFailures)
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onDelta("there it is")
+        assertEquals(0, flow.consecutiveFailures)
+        flow.onStreamCompleted()
+
+        flow.onTap()
+        flow.onFailure(AskFailure.CaptureFailed)
+        assertFalse(
+            "the next failure starts a fresh run",
+            (flow.step as AskStep.Failed).persistent,
+        )
+    }
+
+    @Test
+    fun `taking the recovery action starts the wording over`() {
+        val flow = readyFlow()
+        repeat(ASK_FAILURE_PERSISTENT_THRESHOLD) {
+            flow.onTap()
+            flow.onFailure(AskFailure.CaptureBlank)
+        }
+        assertTrue((flow.step as AskStep.Failed).persistent)
+        flow.onRetry()
+        assertEquals(AskStep.Ready, flow.step)
+        flow.onTap()
+        flow.onFailure(AskFailure.CaptureBlank)
+        assertFalse((flow.step as AskStep.Failed).persistent)
+    }
+
+    @Test
+    fun `reset clears the round and the failure history but not the availability`() {
+        val flow = readyFlow()
+        repeat(4) {
+            flow.onTap()
+            flow.onFailure(AskFailure.Unknown)
+        }
+        flow.reset()
+        assertEquals(AskStep.Ready, flow.step)
+        assertEquals(0, flow.consecutiveFailures)
+        assertEquals(AskAvailability.Ready, flow.availability)
+    }
+
+    @Test
+    fun `losing the model mid-round abandons the round instead of wedging it`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onAvailability(AskAvailability.Unsupported)
+        assertEquals(AskStep.ModelUnsupported, flow.step)
+        assertFalse(flow.isBusy)
+    }
+
+    @Test
+    fun `a late delta from an abandoned round cannot resurrect it`() {
+        val flow = readyFlow()
+        flow.onTap()
+        flow.onFrameAccepted()
+        flow.onAvailability(AskAvailability.Downloadable)
+        flow.onDelta("ghost")
+        assertEquals(AskStep.ModelDownloadable, flow.step)
+    }
+
+    @Test
+    fun `busy covers capture, thinking and streaming only`() {
+        val flow = readyFlow()
+        assertFalse(flow.isBusy)
+        flow.onTap()
+        assertTrue(flow.isBusy)
+        flow.onFrameAccepted()
+        assertTrue(flow.isBusy)
+        flow.onDelta("x")
+        assertTrue(flow.isBusy)
+        flow.onStreamCompleted()
+        assertFalse(flow.isBusy)
+    }
+
+    @Test
+    fun `every QA state id resolves to a step`() {
+        ASK_QA_STATE_IDS.forEach { id ->
+            assertTrue("id $id must resolve", askStepForQaOverride(id) != null)
+        }
+        assertEquals(
+            "every id must name a distinct card",
+            ASK_QA_STATE_IDS.size,
+            ASK_QA_STATE_IDS.mapNotNull { askStepForQaOverride(it) }.distinct().size,
+        )
+    }
+
+    @Test
+    fun `an absent or unknown QA state id leaves the real machine alone`() {
+        assertNull(askStepForQaOverride(null))
+        assertNull(askStepForQaOverride(""))
+        assertNull(askStepForQaOverride("   "))
+        assertNull(askStepForQaOverride("not-a-state"))
+    }
+
+    @Test
+    fun `QA state ids are case and whitespace tolerant`() {
+        assertEquals(AskStep.Thinking, askStepForQaOverride("  Thinking "))
+    }
+
+    @Test
+    fun `the QA failure states cover both wordings without claiming unsupported`() {
+        val transient = askStepForQaOverride("failed") as AskStep.Failed
+        val persistent = askStepForQaOverride("failed-persistent") as AskStep.Failed
+        assertFalse(transient.persistent)
+        assertTrue(persistent.persistent)
+        assertFalse("a persistent card is never a terminal one", persistent.failure.isTerminal)
+    }
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFrameCheckTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ai/AskFrameCheckTest.kt
@@ -1,0 +1,183 @@
+package io.github.sceneview.demo.ai
+
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for the frame validation that stands between the AR read-back and Gemini
+ * Nano (#3407).
+ *
+ * The regression these exist for: the pre-#3407 check looked only for `alpha == 0`. A window
+ * read-back that lost the Filament `SurfaceView` layer as **opaque black** — the shape an
+ * opaque window background produces — sailed through it, was then cropped tighter around the
+ * tap (#3343), and reached the model as a flat frame. "Qui voit rien sur la frame AR."
+ */
+class AskFrameCheckTest {
+
+    private fun argb(a: Int, r: Int, g: Int, b: Int) =
+        (a shl 24) or (r shl 16) or (g shl 8) or b
+
+    /** A frame of one flat colour. */
+    private fun flat(color: Int, count: Int = 4_096) = IntArray(count) { color }
+
+    /** A frame with real texture: pseudo-random but deterministic luminance. */
+    private fun textured(count: Int = 4_096): IntArray {
+        val random = Random(seed = 3407)
+        return IntArray(count) {
+            val v = random.nextInt(256)
+            argb(0xFF, v, v, v)
+        }
+    }
+
+    @Test
+    fun `a textured opaque frame is usable`() {
+        assertEquals(
+            AskFrameVerdict.Usable,
+            inspectAskFrame(768, 576, textured()),
+        )
+    }
+
+    @Test
+    fun `an opaque black frame is rejected as blank - the #3407 regression`() {
+        val verdict = inspectAskFrame(768, 576, flat(argb(0xFF, 0, 0, 0)))
+        assertTrue("an all-black frame must not reach the model", verdict is AskFrameVerdict.Blank)
+        assertEquals(AskFailure.CaptureBlank, verdict.asFailure())
+    }
+
+    @Test
+    fun `a flat mid-grey frame is rejected too, not just black`() {
+        val verdict = inspectAskFrame(768, 576, flat(argb(0xFF, 128, 128, 128)))
+        assertTrue(verdict is AskFrameVerdict.Blank)
+    }
+
+    @Test
+    fun `a flat white frame is rejected - a covered lens is not a question`() {
+        assertTrue(
+            inspectAskFrame(768, 576, flat(argb(0xFF, 255, 255, 255)))
+                is AskFrameVerdict.Blank
+        )
+    }
+
+    @Test
+    fun `a transparent hole is named as a lost AR layer, not as a blank frame`() {
+        // A tenth of the frame punched out, the rest textured.
+        val samples = textured().also { pixels ->
+            for (i in 0 until pixels.size / 10) pixels[i] = argb(0, 0, 0, 0)
+        }
+        val verdict = inspectAskFrame(768, 576, samples)
+        assertTrue(verdict is AskFrameVerdict.MissingArLayer)
+        assertEquals(AskFailure.CaptureMissingArLayer, verdict.asFailure())
+    }
+
+    @Test
+    fun `a handful of transparent pixels does not condemn an otherwise good frame`() {
+        val samples = textured().also { pixels ->
+            // Well under ASK_FRAME_TRANSPARENT_FRACTION.
+            for (i in 0 until 10) pixels[i] = argb(0, 0, 0, 0)
+        }
+        assertEquals(AskFrameVerdict.Usable, inspectAskFrame(768, 576, samples))
+    }
+
+    @Test
+    fun `the transparency threshold is what the constant says it is`() {
+        val total = 1_000
+        val justUnder = textured(total).also { pixels ->
+            val holes = (total * ASK_FRAME_TRANSPARENT_FRACTION).toInt() - 1
+            for (i in 0 until holes) pixels[i] = argb(0, 0, 0, 0)
+        }
+        assertEquals(AskFrameVerdict.Usable, inspectAskFrame(768, 576, justUnder))
+
+        val atThreshold = textured(total).also { pixels ->
+            val holes = (total * ASK_FRAME_TRANSPARENT_FRACTION).toInt()
+            for (i in 0 until holes) pixels[i] = argb(0, 0, 0, 0)
+        }
+        assertTrue(inspectAskFrame(768, 576, atThreshold) is AskFrameVerdict.MissingArLayer)
+    }
+
+    @Test
+    fun `a fully transparent frame reads as a lost layer`() {
+        val verdict = inspectAskFrame(768, 576, flat(argb(0, 0, 0, 0)))
+        assertTrue(verdict is AskFrameVerdict.MissingArLayer)
+        assertEquals(1f, (verdict as AskFrameVerdict.MissingArLayer).transparentFraction, 1e-6f)
+    }
+
+    @Test
+    fun `a degenerate size is caught before anything else`() {
+        assertEquals(
+            AskFrameVerdict.TooSmall(0, 0),
+            inspectAskFrame(0, 0, textured()),
+        )
+        assertTrue(inspectAskFrame(32, 512, textured()) is AskFrameVerdict.TooSmall)
+        assertTrue(inspectAskFrame(512, 32, textured()) is AskFrameVerdict.TooSmall)
+        assertEquals(
+            AskFailure.CaptureFailed,
+            inspectAskFrame(0, 0, textured()).asFailure(),
+        )
+    }
+
+    @Test
+    fun `an empty sample set is a degenerate frame, not a usable one`() {
+        assertTrue(inspectAskFrame(768, 576, IntArray(0)) is AskFrameVerdict.TooSmall)
+    }
+
+    @Test
+    fun `a frame at exactly the minimum edge is allowed through`() {
+        assertEquals(
+            AskFrameVerdict.Usable,
+            inspectAskFrame(ASK_FRAME_MIN_EDGE, ASK_FRAME_MIN_EDGE, textured()),
+        )
+    }
+
+    @Test
+    fun `a nearly-flat frame with a few stray bright pixels is still blank`() {
+        // The percentile bounds exist for this: a clipped status-bar glyph must not vouch
+        // for a frame that is otherwise a black rectangle.
+        val samples = flat(argb(0xFF, 2, 2, 2), count = 1_000).also { pixels ->
+            for (i in 0 until 5) pixels[i] = argb(0xFF, 255, 255, 255)
+        }
+        assertTrue(inspectAskFrame(768, 576, samples) is AskFrameVerdict.Blank)
+    }
+
+    @Test
+    fun `a real gradient is not mistaken for a flat frame`() {
+        // A gentle wall-lit gradient — the closest a legitimate camera frame gets to flat.
+        val samples = IntArray(1_000) { i ->
+            val v = 80 + (i * 60 / 1_000)
+            argb(0xFF, v, v, v)
+        }
+        assertEquals(AskFrameVerdict.Usable, inspectAskFrame(768, 576, samples))
+    }
+
+    @Test
+    fun `the blank verdict reports the spread it measured`() {
+        val verdict = inspectAskFrame(768, 576, flat(argb(0xFF, 10, 10, 10)))
+        assertEquals(0, (verdict as AskFrameVerdict.Blank).lumaSpread)
+    }
+
+    @Test
+    fun `only a usable frame maps to no failure`() {
+        assertNull(AskFrameVerdict.Usable.asFailure())
+        listOf(
+            AskFrameVerdict.TooSmall(1, 1),
+            AskFrameVerdict.MissingArLayer(0.5f),
+            AskFrameVerdict.Blank(0),
+        ).forEach { assertTrue("$it must name a failure", it.asFailure() != null) }
+    }
+
+    @Test
+    fun `a colourful but equally-luminant frame still counts as content`() {
+        // Luma is the probe, so guard the case where colour varies more than brightness:
+        // it must not be called blank, because there is plainly something to describe.
+        val samples = IntArray(1_000) { i ->
+            when (i % 3) {
+                0 -> argb(0xFF, 200, 20, 20)
+                1 -> argb(0xFF, 20, 200, 20)
+                else -> argb(0xFF, 20, 20, 200)
+            }
+        }
+        assertEquals(AskFrameVerdict.Usable, inspectAskFrame(768, 576, samples))
+    }
+}


### PR DESCRIPTION
Fixes #3407

## The report

A Pixel 9 (Android 17), on `point-and-ask`: *"ça marche pas la reconnaissance du tout … aucune
réponse Gemini qui voit rien sur la frame AR et dis qu'il peut pas tourner sur ce tel au bout
de 4 demandes."* No answer, the model sees nothing on the AR frame, and after four taps the
demo declares the phone incapable of running it at all.

The attached log carries no `PointAndAskDemo` line — which is itself a finding, see §4.

## The failure chain

**1. The frame was read back from the wrong layer.** The demo did `PixelCopy.request(window, …)`.
But the AR scene is a Filament `SurfaceView` — its own compositor layer. This repo already
says so twice: `QaCameraBackdrop`'s KDoc ("a `SurfaceView` punches a hole through the window")
and #2654, where a window read-back returned `SUCCESS` with that layer missing.

**2. The only validation was an alpha probe.** `hasTransparentHole` catches the shape of the
defect where the missing layer leaves `alpha == 0`. It cannot catch the other, more common
shape — the AR region coming back **opaque black**, which is what an opaque window background
produces. That frame passed validation untouched.

**3. #3343's crop then aimed straight at the empty region.** The tap-centred 4:3 crop added in
#3364 is, by construction, centred on the AR viewport — i.e. on exactly the region that had
gone blank — and it discarded the surrounding chrome that at least had pixels in it. Gemini
Nano was asked to describe a flat image. It answers about nothing, or completes the stream
with no text: `AskFailure.EmptyAnswer`.

**4. A retry counter then lied about the device.** `EmptyAnswer` and `CaptureFailed` are
non-terminal, but `consecutiveFailures >= ASK_FAILURE_ESCALATION_THRESHOLD` (3) swapped the
card for *"Point & Ask can't answer on this device — answers run entirely on-device through
Google AICore …"*. That claim was false: the tap handler only fires when
`engineStatus == Ready`, so Gemini Nano was installed and working the whole time. It was also
a dead end — only Reset cleared it.

**5. And the diagnosis was invisible.** #3364 added a classified log line on every failure
path. ARCore emits ~90 `Use dataspace` lines a second on this device, so the bug reporter's
last-53-lines window covers ~0.6 s and never contains one. The evidence existed and could not
reach the report.

## The state model

Two axes, deliberately separate, in plain Kotlin (`AskFlow.kt`, no Compose / ARCore / ML Kit):

- **availability** — `Checking → Downloadable → Downloading(bytes) → Ready`, or `Unsupported`.
- **round** — `Idle → CapturingFrame → Thinking → Answered(text, streaming)`, or
  `Failed(failure, consecutive)`.

`AskFlow.step` projects both onto the single card on screen: `CheckingAvailability`,
`ModelDownloadable`, `ModelDownloading`, `ModelUnsupported`, `Ready`, `CapturingFrame`,
`Thinking`, `Answered`, `Failed(failure, persistent)`.

Two invariants carry the fix:

- **Only the platform may say "not on this phone."** `ModelUnsupported` is reachable from a
  `FeatureStatus` report, a failed download, or a terminal ML Kit code — nothing else. A run
  of ordinary failures now changes only the failure card's *headline* ("This keeps failing
  here"); it keeps naming the real cause and keeps offering the action.
- **Every failure ends in a button, not a sentence.** `AskRecovery`: `Retry`, `AimAndRetry`,
  `Rephrase`, `FreeStorage` (opens storage settings), `OpenAicoreSettings` (opens the AICore
  app details). Taking the action resets the run, so the wording starts over instead of
  staying escalated forever.

## The frame

`captureAskFrame` tries the AR view first — `PixelCopy.request(SurfaceView, …)`, or
`TextureView.getBitmap()` under the QA backdrop — and keeps the window composite only as a
fallback. Each candidate is cropped around the tap, downscaled to the model's budget, and then
validated by `inspectAskFrame` (pure, JVM-tested) for **size**, **transparency** *and*
**flatness** (1st–99th-percentile luma spread < 8/255). A rejected candidate promotes the next
one; if all fail, the card names which check failed. `CaptureMissingArLayer` and `CaptureBlank`
are new, distinct causes.

Side effects: the 2D chrome no longer has to be hidden for the capture (it is not in that
surface), so the screen stops blinking on every tap; only the plane grid and the anchored
answer cards still come down.

The demo has **no cloud path and no API key** — I checked: `genai-prompt` is the only Gemini
dependency in `samples/android-demo/build.gradle`. So "make the choice explicit" is a statement
rather than a switch: the controls sheet now leads with *"On-device only · Gemini Nano · the
frame never leaves this phone"*.

Debug/QA builds show a thumbnail of the exact frame that was sent, with its size and which
layer it came from — "it sees nothing" is now checkable on the spot.

## Tests

`:samples:android-demo:testDebugUnitTest` green — 637 tests, 0 failures, 38 of them new.
(On `testReleaseUnitTest`, see the note at the end of **Verified**: the new tests pass there too,
but that variant has 16 pre-existing failures unrelated to this change.)

- `AskFlowTest` (22) — every transition; a tap only starts a round when ready; a tap during a
  round is ignored; a partial answer survives a mid-stream failure; an empty stream is a
  rephrasable failure; losing the model mid-round abandons it rather than wedging it; a late
  delta cannot resurrect an abandoned round. The load-bearing one is **`a run of ordinary
  failures never declares the device unsupported`** — eight consecutive `CaptureBlank`s, well
  past the four rounds of the report, and `availability` is still `Ready`.
- `AskFrameCheckTest` (16) — an opaque black frame is rejected (the #3407 regression), so are
  flat grey and flat white; a transparent hole is named as a lost AR layer, not as a blank
  frame; the transparency threshold is asserted at the constant; a wall-lit gradient and a
  colourful-but-equally-luminant frame are *not* mistaken for flat; stray bright pixels cannot
  vouch for a black rectangle (that is what the percentile bounds are for).

## UI

Tokens only, `DESIGN.md`'s "Blocked" severity for the failure card (error indicator + the
theme's `error` role). No new colours, no new spacing. The demo also gains the QA camera
backdrop every other AR demo already had (#3308) — it had none, so its emulator screenshots
were flat black, which is indistinguishable from the defect being fixed.

## Verified

`emulator-5554` (Pixel 7a AVD, no ARCore session, no AICore — #2754), `qa_mode` +
`qa_backdrop`, **24 captures: all 11 states in light and dark, plus the controls sheet in
both**. Driven with the new `--es qa_ask_state <id>` override, so each card was reached
without needing the hardware that produces it.

- **`failed-persistent`** — the state at the heart of the report. It now reads *"This keeps
  failing here"*, with the precise cause underneath (*"The AR view was missing from the
  captured frame — nothing for the model to look at"*), the honest explanation (*"Gemini Nano
  is installed and ready on this device — it is this step that keeps going wrong"*) and a
  working **Try again**. The old build showed *"Point & Ask can't answer on this device"* here.
- **`unsupported`** — the only card that still says a device cannot run the demo, now with an
  **Open system settings** action.
- **`answered` / `streaming`** — the question label, the answer, and the `✦ Gemini Nano ·
  on-device` attribution; the streaming capture shows the live-typing cursor mid-sentence.
- **`checking` / `downloading` / `capturing` / `thinking`** — one progress row each, so no
  state is a blank bottom edge any more. `capturing` is new: the frame read-back used to be a
  silent gap between the tap and "thinking".
- **`downloadable`** — title + **Download model**.
- **Controls sheet** — leads with *"On-device only · Gemini Nano · the frame never leaves this
  phone"*, and ends with the debug **Last frame sent to the model** panel (showing its
  "No frame captured yet" placeholder, since the emulator's AR session never starts).
- Light and dark are pixel-for-pixel the same layout with the theme's own roles; nothing is
  hardcoded. The demo also picks up the QA camera backdrop, so these are the first Point & Ask
  captures that are not flat black.

Tests: `:samples:android-demo:testDebugUnitTest` **637 tests, 0 failures**.
`testReleaseUnitTest` runs the same 38 new tests green (56 across the `ai` package); its 16
pre-existing failures are all Compose-rule tests dying on
`Unable to resolve activity … ComponentActivity` — `androidx.compose.ui:ui-test-manifest` is
declared `debugImplementation` on purpose (see the comment at `samples/android-demo/build.gradle:300`),
so those classes cannot run in the release variant on `main` either. CI gates
`testDebugUnitTest` only.

## Needs device

The AICore path cannot run on an emulator (#2754), so on a Pixel 9:

1. **A tap produces a real answer.** Point at a lit, textured object and tap. Expect
   `Capturing the AR frame…` → `✦ Gemini Nano is thinking…` → streamed text, plus a
   world-anchored card at the tapped surface.
2. **The frame is the AR view, not the window.** Long-press to drop a prop, tap it, and check
   the answer describes the virtual object. Open Settings → *Last frame sent to the model*:
   the thumbnail must show the camera + the prop, and the meta line must read `AR surface`
   (not `window composite`). If it reads `window composite`, the direct surface read-back was
   refused on that device — worth its own issue, with that line quoted.
3. **The dead end is gone.** Force failures (cover the lens, or tap at the ceiling) four or
   more times. Expect *"This keeps failing here"* with the specific cause underneath and a
   working action button — and **never** "Point & Ask can't answer on this device" while
   Gemini Nano is installed.
4. **The honest unsupported path still works.** If you have a device without AICore, the
   unavailable banner plus *Open system settings* should appear before any tap is possible.
5. **Blank-frame rejection does not over-trigger.** Point at a plain white wall in good light
   and tap: this must still answer, not report a blank frame. That is the one threshold I
   could not tune against real camera data (`ASK_FRAME_MIN_LUMA_SPREAD = 8`); if a legitimate
   wall trips it, the number needs raising the other way and I would rather hear it than guess.
6. **Storage / update actions.** Tapping *Open system settings* on a terminal failure should
   land on the AICore app-details screen.

Every state can also be pinned for inspection without waiting for it:
`adb shell am start -n io.github.sceneview.demo/.MainActivity --es demo point-and-ask
--ez qa_mode true --es qa_ask_state failed-persistent` (ids in `ASK_QA_STATE_IDS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
