### PR TITLE
device-QA: probe for a dead route with the radio on, not just airplane mode (#2959)

### DIFF
--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -24,7 +24,7 @@
 #
 # Usage:
 #   bash .claude/scripts/device-qa.sh [--platform=android|ios|web|ar|all]
-#                                     [--fast] [--ci] [--out <dir>]
+#                                     [--fast] [--ci] [--out <dir>] [--allow-offline]
 #
 # Flags:
 #   --platform=<p>   Which platform(s) to run. `all` (default) runs every
@@ -61,6 +61,14 @@
 #                    `web` leg itself is intentionally NOT advisory: it is
 #                    reliable and BLOCKING.
 #                    Pass `--advisory=` (empty) to make every leg blocking.
+#   --allow-offline  Acknowledge a deliberately offline run (#2959). The
+#                    `sketchfab` / `arcore-cloud` sub-legs already report an
+#                    honest `skipped` (never a pass) when the leased emulator
+#                    has no real route to the streamed-asset host — this flag
+#                    only controls how LOUDLY that gets surfaced: without it, a
+#                    missing route prints a boxed banner (same convention as
+#                    the API-key-absent banner); with it, a single quiet log
+#                    line. The verdict and exit code are unchanged either way.
 #   -h | --help      Show this help.
 #
 # API keys (#2343):
@@ -105,6 +113,12 @@ source "$SCRIPT_DIR/lib/emulator-select.sh"
 # keyless run reports the key-gated legs as honestly `skipped` (never green).
 # shellcheck source=lib/qa-keys.sh
 source "$SCRIPT_DIR/lib/qa-keys.sh"
+# Real network-reachability probe (#2959) — layered on top of the key-presence
+# gate above: a key can be present while the leased emulator has no actual
+# route (airplane mode, captive portal, dead DNS), which would still resolve
+# every streamed slug to its bundled fallback silently. See lib/qa-connectivity.sh.
+# shellcheck source=lib/qa-connectivity.sh
+source "$SCRIPT_DIR/lib/qa-connectivity.sh"
 
 # The demo debug APK both Android-emulator legs install. Kept as the single
 # canonical path qa-android-demos.sh expects and the CI build-android-apk job
@@ -177,6 +191,14 @@ OUT_DIR="$REPO_ROOT"
 # key must surface as a WARN, never hard-block a dev's run.
 ADVISORY="android,ar,ios,web-perf,sketchfab,arcore-cloud"
 ADVISORY_SET=false
+# --allow-offline (#2959): the sketchfab/arcore-cloud sub-legs are already
+# advisory-skip (never a hard block) when the connectivity probe finds no
+# route — that is what stops a dead network from turning into a silent pass.
+# Without this flag a missing route still prints a LOUD boxed banner (same
+# convention as the key-absent banner) so an offline run is never mistaken
+# for a clean one. With it, the banner is downgraded to a single quiet log
+# line — for a deliberately offline dev box that already knows.
+ALLOW_OFFLINE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -186,6 +208,7 @@ while [[ $# -gt 0 ]]; do
     --ci)         CI_MODE=true; shift ;;
     --out=*)      OUT_DIR="${1#--out=}"; shift ;;
     --out)        OUT_DIR="${2:?--out needs a directory}"; shift 2 ;;
+    --allow-offline) ALLOW_OFFLINE=true; shift ;;
     --advisory=*) ADVISORY="${1#--advisory=}"; ADVISORY_SET=true; shift ;;
     --advisory)   ADVISORY="${2-}"; ADVISORY_SET=true; shift 2 ;;
     -h|--help)
@@ -307,6 +330,19 @@ RESULT_REASONS=()
 RESULT_SUMMARIES=()  # path to a platform JSON summary, or "" if none
 RESULT_DURATIONS=()
 RESULT_LOGS=()       # path to a captured device/simulator log, or "" if none
+# Compact JSON connectivity object (#2959, lib/qa-connectivity.sh's
+# qa_connectivity_json), or "" when connectivity was not probed for this
+# entry — only the streamed-asset sub-legs (sketchfab/arcore-cloud) set it.
+RESULT_CONNECTIVITY=()
+
+# Names of streamed sub-legs skipped this run because the connectivity probe
+# found no route — printed as the explicit list in the final banner/verdict.
+OFFLINE_SKIPPED_LEGS=()
+# Whether record_streamed_subleg actually ran a connectivity probe this run
+# (i.e. a key was present for at least one streamed sub-leg). Stays false on a
+# keyless run so the final verdict says "not applicable", never "checked" —
+# a probe that never ran must not read like one that passed.
+CONNECTIVITY_PROBED=false
 
 record() {
   RESULT_PLATFORMS+=("$1")
@@ -315,6 +351,7 @@ record() {
   RESULT_SUMMARIES+=("$4")
   RESULT_DURATIONS+=("$5")
   RESULT_LOGS+=("${6:-}")
+  RESULT_CONNECTIVITY+=("${7:-}")
   log "$1 -> $2 ${3:+($3)}"
 }
 
@@ -368,39 +405,58 @@ record_key_subleg() {
   fi
 }
 
-# device_has_connectivity — probe the leased emulator's radio state (#2959).
-# setup-ar-emulator.sh's ensure_airplane_mode_disabled already repairs this
-# right after boot; this is the backstop for an emulator that was leased
-# already-running (never went through that repair) or where the repair
-# itself failed. Echoes "true"/"false"; empty ANDROID_SERIAL or an adb error
-# is treated as "unknown connectivity" — NOT as present, so a broken probe
+# device_has_connectivity — probe the leased emulator's ACTUAL network route
+# (#2959), not just its radio state. setup-ar-emulator.sh's
+# ensure_airplane_mode_disabled already repairs a booted-in-airplane-mode
+# snapshot; this is the backstop for an emulator that was leased
+# already-running (never went through that repair), where the repair itself
+# failed, or — the gap the airplane-mode-only check could not see — one whose
+# radio is on but whose route is dead (captive portal, dead DNS, dropped VPN).
+# Delegates to lib/qa-connectivity.sh's 3-signal probe (airplane mode +
+# dumpsys-validated + a real ping to the streamed-asset host) and exports the
+# full probe detail via the QA_CONNECTIVITY_* globals for the caller to embed
+# in the report. Echoes "true"/"false"/"unknown"; "unknown" — empty serial, or
+# every signal inconclusive — is NOT treated as present, so a broken probe
 # fails closed into an honest skip rather than a silent false-pass.
 device_has_connectivity() {
   local serial="${1:-${ANDROID_SERIAL:-}}"
-  [[ -n "$serial" ]] || { echo false; return; }
-  local mode
-  mode="$(adb -s "$serial" shell settings get global airplane_mode_on 2>/dev/null | tr -d '\r\n')"
-  [[ "$mode" == "0" ]] && echo true || echo false
+  [[ -n "$serial" ]] || { QA_CONNECTIVITY_STATUS="unknown"; echo unknown; return; }
+  qa_connectivity_probe "$serial"
+  echo "${QA_CONNECTIVITY_STATUS:-unknown}"
 }
 
 # record_streamed_subleg — like record_key_subleg, but for a sub-leg whose
 # path is BOTH key-gated AND network-gated (#2959): a present key with the
-# emulator stuck in airplane mode silently resolves every streamed slug to
-# its bundled fallback (measured closing #2942 — see
-# ensure_airplane_mode_disabled in setup-ar-emulator.sh). Reports which of
-# the two gates was missing so a skip is actionable, not just advisory noise.
+# emulator stuck in airplane mode (or reachable-in-name-only — captive portal,
+# dead DNS) silently resolves every streamed slug to its bundled fallback
+# (measured closing #2942). Reports which of the two gates was missing so a
+# skip is actionable, not just advisory noise, and embeds the connectivity
+# probe detail into the report's `connectivity` field for this entry.
 record_streamed_subleg() {
   local name="$1" parent="$2" key_present="$3" path="$4" serial="${5:-}"
   if [[ "$key_present" != "true" ]]; then
     record_key_subleg "$name" "$parent" "$key_present" "$path"
     return
   fi
+  CONNECTIVITY_PROBED=true
   local net; net="$(device_has_connectivity "$serial")"
-  if [[ "$net" != "true" ]]; then
-    record "$name" skipped "key present but no connectivity on the emulator (airplane mode, or unresolved) — ${path} would silently resolve to its bundled fallback (#2959), NOT tested" "" 0
+  local conn_json; conn_json="$(qa_connectivity_json)"
+  if [[ "$net" != "online" ]]; then
+    OFFLINE_SKIPPED_LEGS+=("$name")
+    record "$name" skipped "key present but no confirmed route on the emulator (status=${net} — airplane mode, captive portal, or dead DNS) — ${path} would silently resolve to its bundled fallback (#2959), NOT tested" "" 0 "" "$conn_json"
+    if $ALLOW_OFFLINE; then
+      log "$(qa_connectivity_verdict_line) — ${name} skipped (--allow-offline)"
+    else
+      qa_connectivity_banner_offline "$name"
+    fi
     return
   fi
-  record_key_subleg "$name" "$parent" "$key_present" "$path"
+  local pstatus; pstatus="$(last_status_of "$parent")"
+  if [[ "$pstatus" == "passed" ]]; then
+    record "$name" passed "key present — ${path} exercised by the ${parent} flow" "" 0 "" "$conn_json"
+  else
+    record "$name" skipped "${parent} leg did not pass (${pstatus:-not run}) — ${path} not exercised" "" 0 "" "$conn_json"
+  fi
 }
 
 # --- Pool emulator acquisition ---------------------------------------------
@@ -542,7 +598,12 @@ run_ios() {
   $FAST && flow="3d-basics"
 
   local rc=0
-  bash "$SCRIPT_DIR/ios-device-qa.sh" --install --flow "$flow" \
+  local ios_offline_flag=()
+  # #2959: pass the offline acknowledgement through so the iOS leg's own
+  # host-side connectivity probe (lib/qa-connectivity.sh's
+  # qa_connectivity_probe_host) prints the same quiet-vs-loud banner choice.
+  $ALLOW_OFFLINE && ios_offline_flag=(--allow-offline)
+  bash "$SCRIPT_DIR/ios-device-qa.sh" --install --flow "$flow" ${ios_offline_flag[@]+"${ios_offline_flag[@]}"} \
     > "$ARTIFACTS/ios-output.txt" 2>&1 || rc=$?
   cat "$ARTIFACTS/ios-output.txt"
 
@@ -924,6 +985,7 @@ for i in "${!RESULT_PLATFORMS[@]}"; do
   export "DQ_SUMMARY_$i=${RESULT_SUMMARIES[$i]}"
   export "DQ_DURATION_$i=${RESULT_DURATIONS[$i]}"
   export "DQ_LOG_$i=${RESULT_LOGS[$i]}"
+  export "DQ_CONN_$i=${RESULT_CONNECTIVITY[$i]}"
   if is_advisory "${RESULT_PLATFORMS[$i]}"; then
     export "DQ_ADVISORY_$i=true"
   else
@@ -964,6 +1026,11 @@ for i in range(n):
         # Path to the captured device/simulator log for this leg (currently
         # the iOS crash-gate os_log tail), or null if the leg keeps none.
         "log":      os.environ.get(f"DQ_LOG_{i}", "") or None,
+        # Connectivity probe detail (#2959) for the streamed-asset sub-legs
+        # (sketchfab/arcore-cloud) — null for every other entry, which never
+        # sets it.
+        "connectivity": (lambda raw: json.loads(raw) if raw else None)(
+            os.environ.get(f"DQ_CONN_{i}", "")),
     })
 
 # --- Release-gate verdict (#1651 / #1670) ----------------------------------
@@ -1063,6 +1130,17 @@ done
 echo "───────────────────────────────────────────────────────"
 echo "  passed=$PASSED  failed=$FAILED (of which timeout=$TIMED_OUT)  skipped=$SKIPPED  ->  $OVERALL"
 echo "  advisory legs: ${ADVISORY:-(none)}  (a red advisory leg is a release WARN, not a block — #1651)"
+# One-line connectivity verdict (#2959) — always printed, even when every
+# streamed sub-leg was exercised, so "connectivity was checked" is never
+# something you have to infer from an absent warning.
+if [[ ${#OFFLINE_SKIPPED_LEGS[@]} -gt 0 ]]; then
+  offline_csv="$(IFS=,; echo "${OFFLINE_SKIPPED_LEGS[*]}")"
+  echo "  connectivity: OFFLINE — streamed demos skipped: ${offline_csv} (#2959)"
+elif $CONNECTIVITY_PROBED; then
+  echo "  connectivity: checked, no streamed sub-leg skipped for lack of a route"
+else
+  echo "  connectivity: not probed this run (no streamed sub-leg had a key present)"
+fi
 echo "═══════════════════════════════════════════════════════"
 
 if [[ "$OVERALL" == "passed" ]]; then

--- a/.claude/scripts/ios-device-qa.sh
+++ b/.claude/scripts/ios-device-qa.sh
@@ -24,7 +24,7 @@
 #
 # Usage:
 #   bash .claude/scripts/ios-device-qa.sh [--install] [--flow <name>] \
-#       [--simulator <name>]
+#       [--simulator <name>] [--allow-offline]
 #
 # Options:
 #   --install            Build the SceneViewDemo app for the simulator and
@@ -45,6 +45,12 @@
 #                        Explore/Sketchfab + streamed-USDZ demos are exercised;
 #                        without one the build is keyless and that path is
 #                        loudly reported NOT-tested. Key value is never logged.
+#   --allow-offline      Acknowledge a deliberately offline run (#2959). When a
+#                        Sketchfab key IS present, this script also probes the
+#                        HOST's actual route to the streamed-asset host (the
+#                        Simulator shares the Mac's network stack) — without
+#                        this flag, no route prints a loud boxed banner; with
+#                        it, a single quiet log line. Never flips the verdict.
 #   -h | --help          Show this help.
 #
 # Note — a full `xcodebuild` simulator build is heavy (Swift Package resolve +
@@ -75,6 +81,14 @@ source "$SCRIPT_DIR/lib/qa-keys.sh"
 # Waits for CoreSimulator, then resolves a simulator by UDID at run time rather
 # than pinning a model name (#3174).
 source "$SCRIPT_DIR/lib/ios-simulator.sh"
+# shellcheck source=lib/qa-connectivity.sh
+# Host-side connectivity probe (#2959): the Simulator shares the Mac's own
+# network stack, so probing the SIMULATOR would just re-measure the host --
+# qa_connectivity_probe_host hits the real streamed-asset host directly from
+# the host via curl. Symmetric with device-qa.sh's on-device probe for the
+# Android emulator (which has its own network namespace and needs an adb-shell
+# probe instead).
+source "$SCRIPT_DIR/lib/qa-connectivity.sh"
 
 BUNDLE_ID="io.github.sceneview.demo"
 # The demo app's CFBundleExecutable — what `log stream` sees as the process
@@ -92,12 +106,17 @@ FLOW="catalog"
 # --simulator <name> opts back into a fixed model, and back into rotting the day
 # Xcode replaces the device set.
 SIMULATOR=""
+# --allow-offline (#2959): downgrades the connectivity-probe banner below from
+# a loud boxed warning to a single quiet log line, for a deliberately offline
+# run. Mirrors device-qa.sh's flag of the same name.
+ALLOW_OFFLINE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --install)   INSTALL=true; shift ;;
     --flow)      FLOW="${2:?--flow needs a name}"; shift 2 ;;
     --simulator) SIMULATOR="${2:?--simulator needs a name}"; shift 2 ;;
+    --allow-offline) ALLOW_OFFLINE=true; shift ;;
     --sketchfab-key)
       # Explicit key override for a keyed build (#2356). Takes precedence over
       # the env / local.properties resolution below. The value is consumed, not
@@ -168,6 +187,29 @@ echo "[ios-qa] using simulator $BOOTED_UDID"
 # reported as NOT tested via the loud banner, mirroring Android #2343.
 qa_keys_resolve_sketchfab || true
 echo "[ios-qa] Sketchfab API key present: ${QA_SKETCHFAB_KEY_PRESENT}"
+
+# --- Connectivity probe (#2959) --------------------------------------------
+# A key present is necessary but not sufficient: if the HOST (which the
+# Simulator's network stack IS) has no real route to api.sketchfab.com --
+# airplane mode on the Mac, a captive portal, a dropped VPN -- the streamed
+# demos would silently resolve to their bundled fallback exactly like the
+# Android case measured closing #2942, just via a different radio. Only
+# worth probing when a key is present — a keyless run already reports the
+# streamed path NOT-tested via the banner below, so there is nothing this
+# probe could add.
+QA_IOS_CONNECTIVITY_NOTE=""
+if [[ "${QA_SKETCHFAB_KEY_PRESENT}" == "true" ]]; then
+  qa_connectivity_probe_host
+  echo "[ios-qa] $(qa_connectivity_verdict_line)"
+  if [[ "${QA_CONNECTIVITY_STATUS}" != "online" ]]; then
+    QA_IOS_CONNECTIVITY_NOTE="key present but the host has no confirmed route to ${QA_CONNECTIVITY_HOST} (status=${QA_CONNECTIVITY_STATUS}) -- streamed demos would silently resolve to their bundled fallback (#2959), NOT tested"
+    if $ALLOW_OFFLINE; then
+      echo "[ios-qa] NOTE: ${QA_IOS_CONNECTIVITY_NOTE} (--allow-offline)" >&2
+    else
+      qa_connectivity_banner_offline "ios streamed-USDZ demos"
+    fi
+  fi
+fi
 # The Info.plist substitutes SketchfabAPIKey = $(SKETCHFAB_API_KEY). When the
 # key is present we pass it as a `xcodebuild` user-defined build setting (which
 # OVERRIDES the Config.xcconfig `#include?` of Secrets.xcconfig — so the harness
@@ -317,12 +359,19 @@ fi
 if [[ "${QA_SKETCHFAB_KEY_PRESENT:-false}" != "true" ]]; then
   QA_ARCORE_KEY_PRESENT=true qa_keys_banner_if_absent
   echo "[ios-qa] NOTE: Sketchfab key absent — Explore/Sketchfab + streamed-USDZ demos NOT tested (keyless build)." >&2
+elif [[ -n "$QA_IOS_CONNECTIVITY_NOTE" ]]; then
+  # Key present, but the connectivity probe above found no route (#2959) --
+  # mirrors the Android `sketchfab` sub-leg's skip reason. Advisory: it does
+  # not flip the QA verdict.
+  echo "[ios-qa] NOTE: ${QA_IOS_CONNECTIVITY_NOTE}" >&2
 fi
 
 if [[ "$MAESTRO_RC" -eq 0 ]]; then
   echo "[ios-qa] PASS — $FLOW flow completed, no crash detected."
-  if [[ "${QA_SKETCHFAB_KEY_PRESENT:-false}" == "true" ]]; then
-    echo "[ios-qa] (Sketchfab key WAS present — Explore/Sketchfab path was exercised.)"
+  if [[ "${QA_SKETCHFAB_KEY_PRESENT:-false}" == "true" && -z "$QA_IOS_CONNECTIVITY_NOTE" ]]; then
+    echo "[ios-qa] (Sketchfab key WAS present and the host route was confirmed — Explore/Sketchfab path was exercised.)"
+  elif [[ -n "$QA_IOS_CONNECTIVITY_NOTE" ]]; then
+    echo "[ios-qa] (streamed-USDZ path NOT confirmed exercised: ${QA_IOS_CONNECTIVITY_NOTE})"
   fi
 elif [[ "$MAESTRO_RC" -eq 124 ]]; then
   # A budget that expired is NOT a demo crash — grading both as `FAIL` is what

--- a/.claude/scripts/lib/qa-connectivity.sh
+++ b/.claude/scripts/lib/qa-connectivity.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# qa-connectivity.sh — probe REAL network reachability before trusting a
+# streamed-asset device-QA leg (#2959).
+#
+# THE GAP THIS CLOSES
+# --------------------
+# device-qa.sh already asked `settings get global airplane_mode_on` (#2959,
+# PR #3317) before trusting the `sketchfab` / `arcore-cloud` sub-legs — that
+# catches the exact failure measured closing #2942 (a `qa-clean` snapshot
+# cold-booting with the radio in airplane mode, so two different Sketchfab
+# slugs both rendered the same bundled helmet). It does NOT catch a device
+# whose radio is ON but whose route is dead: a captive portal, a DNS resolver
+# that stopped answering, a dropped VPN, or a host Wi-Fi with no upstream. In
+# every one of those the airplane-mode-only check reports "online" while every
+# streamed slug still silently resolves to its bundled fallback — the exact
+# #2959 failure mode, through a different door.
+#
+# This probe layers three signals, most to least specific, and refuses to
+# call the result "online" unless one of them actually proves a route out:
+#   1. airplane_mode_on       — radio state (the original #2959 signal).
+#   2. `dumpsys connectivity` — Android's own captive-portal-VALIDATED
+#      NetworkAgentInfo flag: the SAME signal the status-bar icon uses, so it
+#      already folds in DNS + HTTP + captive-portal detection.
+#   3. `ping` to the real streamed-asset host — DNS resolution + an ICMP round
+#      trip to `api.sketchfab.com`, the host every SampleAssets.kt streamed
+#      entry actually resolves through (SketchfabConfig.BASE_URL, mirrored on
+#      iOS by SceneViewDemo/Services/SketchfabConfig.swift). `curl` is not
+#      assumed present on a stock emulator image (verify-sketchfab-key.sh
+#      already guards curl host-side only); `ping` (toybox) is present on
+#      every Android API level this harness targets.
+#
+# Any step whose command errors or is unavailable reports "unknown" for that
+# signal — never "false". A probe that could not run must never manufacture a
+# verdict either way: an "unknown" signal cannot turn the combined result
+# "online" (fail-closed, the same rule #2959 established for a missing
+# ANDROID_SERIAL), but it also does not by itself turn it "offline" — only a
+# signal that positively answered "no route" does.
+#
+# Usage:
+#   source lib/qa-connectivity.sh
+#   qa_connectivity_probe "$serial"
+#   echo "$QA_CONNECTIVITY_STATUS"   # online | offline | unknown
+#   qa_connectivity_json             # compact JSON for a report file
+#   qa_connectivity_verdict_line     # one human-readable line
+
+# Guard against double-sourcing in the same shell (same pattern as qa-keys.sh).
+if [[ -n "${QA_CONNECTIVITY_SH_SOURCED:-}" ]]; then
+  # shellcheck disable=SC2317
+  return 0 2>/dev/null || true
+fi
+QA_CONNECTIVITY_SH_SOURCED=1
+
+# The host every streamed demo (Android + iOS) actually resolves through.
+QA_CONNECTIVITY_CHECK_HOST="api.sketchfab.com"
+
+# qa_connectivity_probe <serial> — probes the given device/emulator and
+# exports:
+#   QA_CONNECTIVITY_STATUS          online | offline | unknown
+#   QA_CONNECTIVITY_AIRPLANE_MODE   0 | 1 | unknown
+#   QA_CONNECTIVITY_VALIDATED       true | false | unknown  (dumpsys signal)
+#   QA_CONNECTIVITY_HOST_REACHABLE  true | false | unknown  (ping signal)
+#   QA_CONNECTIVITY_HOST            the host probed (QA_CONNECTIVITY_CHECK_HOST)
+#   QA_CONNECTIVITY_METHOD          free-text trace of what decided the verdict
+qa_connectivity_probe() {
+  local serial="${1:?qa_connectivity_probe needs a device serial}"
+  local adb_bin="${ADB_BIN:-adb}"
+
+  QA_CONNECTIVITY_AIRPLANE_MODE="unknown"
+  QA_CONNECTIVITY_VALIDATED="unknown"
+  QA_CONNECTIVITY_HOST_REACHABLE="unknown"
+  QA_CONNECTIVITY_HOST="$QA_CONNECTIVITY_CHECK_HOST"
+
+  local mode
+  mode="$("$adb_bin" -s "$serial" shell settings get global airplane_mode_on 2>/dev/null | tr -d '\r\n')"
+  case "$mode" in
+    0|1) QA_CONNECTIVITY_AIRPLANE_MODE="$mode" ;;
+    *)   QA_CONNECTIVITY_AIRPLANE_MODE="unknown" ;;
+  esac
+
+  # Short-circuit: a CONFIRMED airplane mode ON is definitive — no point
+  # probing further, and it keeps this the cheap, common case fast.
+  if [[ "$QA_CONNECTIVITY_AIRPLANE_MODE" == "1" ]]; then
+    QA_CONNECTIVITY_STATUS="offline"
+    QA_CONNECTIVITY_METHOD="airplane_mode_on=1"
+    export QA_CONNECTIVITY_STATUS QA_CONNECTIVITY_AIRPLANE_MODE QA_CONNECTIVITY_VALIDATED \
+           QA_CONNECTIVITY_HOST_REACHABLE QA_CONNECTIVITY_HOST QA_CONNECTIVITY_METHOD
+    return 0
+  fi
+
+  # Signal 2: Android's own captive-portal-validated network flag. Output
+  # shape varies by API level; treat any explicit VALIDATED mention as a pass,
+  # a real dump with no such mention as a real "no", and a dumpsys failure
+  # (permission, absent) as "unknown".
+  local dump
+  if dump="$("$adb_bin" -s "$serial" shell dumpsys connectivity 2>/dev/null)" && [[ -n "$dump" ]]; then
+    if printf '%s' "$dump" | grep -qiE 'validated:[[:space:]]*true|\[VALIDATED\]|VALIDATED\}'; then
+      QA_CONNECTIVITY_VALIDATED="true"
+    else
+      QA_CONNECTIVITY_VALIDATED="false"
+    fi
+  fi
+
+  # Signal 3: an actual fetch of the real streamed-asset host — DNS
+  # resolution + an ICMP round trip through the device's own network
+  # namespace (not the host's). A missing/erroring `ping` is "unknown", never
+  # "false": a locked-down or minimal emulator image without `ping` must not
+  # manufacture an offline verdict off a tool gap.
+  local ping_out
+  ping_out="$("$adb_bin" -s "$serial" shell ping -c 1 -W 2 "$QA_CONNECTIVITY_CHECK_HOST" 2>&1)"
+  if printf '%s' "$ping_out" | grep -qE '1 packets transmitted, 1 (packets )?received'; then
+    QA_CONNECTIVITY_HOST_REACHABLE="true"
+  elif printf '%s' "$ping_out" | grep -qiE 'unknown host|bad address|name or service not known|network is unreachable|100% packet loss'; then
+    QA_CONNECTIVITY_HOST_REACHABLE="false"
+  fi
+  # else: unrecognized output (e.g. "ping: not found", permission denied) —
+  # stays "unknown", per the fail-closed rule above.
+
+  if [[ "$QA_CONNECTIVITY_VALIDATED" == "true" || "$QA_CONNECTIVITY_HOST_REACHABLE" == "true" ]]; then
+    QA_CONNECTIVITY_STATUS="online"
+  elif [[ "$QA_CONNECTIVITY_VALIDATED" == "false" && "$QA_CONNECTIVITY_HOST_REACHABLE" == "false" ]]; then
+    QA_CONNECTIVITY_STATUS="offline"
+  else
+    QA_CONNECTIVITY_STATUS="unknown"
+  fi
+  QA_CONNECTIVITY_METHOD="airplane_mode_on=0 dumpsys_validated=${QA_CONNECTIVITY_VALIDATED} ping:${QA_CONNECTIVITY_CHECK_HOST}=${QA_CONNECTIVITY_HOST_REACHABLE}"
+
+  export QA_CONNECTIVITY_STATUS QA_CONNECTIVITY_AIRPLANE_MODE QA_CONNECTIVITY_VALIDATED \
+         QA_CONNECTIVITY_HOST_REACHABLE QA_CONNECTIVITY_HOST QA_CONNECTIVITY_METHOD
+}
+
+# qa_connectivity_json — compact single-line JSON object from the last probe,
+# for embedding into a `connectivity` field in a machine-readable report.
+# Never call before qa_connectivity_probe — falls back to "unknown"/empty
+# fields rather than erroring, so a caller that forgot the probe gets an
+# honest "unknown" record instead of a crash.
+qa_connectivity_json() {
+  printf '{"status":"%s","airplaneMode":"%s","checkedHost":"%s","method":"%s"}' \
+    "${QA_CONNECTIVITY_STATUS:-unknown}" \
+    "${QA_CONNECTIVITY_AIRPLANE_MODE:-unknown}" \
+    "${QA_CONNECTIVITY_HOST:-$QA_CONNECTIVITY_CHECK_HOST}" \
+    "${QA_CONNECTIVITY_METHOD:-not probed}"
+}
+
+# qa_connectivity_verdict_line — one human-readable line for the run log.
+qa_connectivity_verdict_line() {
+  echo "[qa-connectivity] status=${QA_CONNECTIVITY_STATUS:-unknown} airplane_mode=${QA_CONNECTIVITY_AIRPLANE_MODE:-unknown} checked_host=${QA_CONNECTIVITY_HOST:-$QA_CONNECTIVITY_CHECK_HOST} (${QA_CONNECTIVITY_METHOD:-not probed})"
+}
+
+# qa_connectivity_probe_host -- HOST-side reachability probe (#2959), for a
+# platform whose test runner shares the HOST's network stack rather than a
+# device's own namespace -- the iOS Simulator is the case this harness has
+# today: probing the simulator itself would just re-measure the Mac's own
+# network, so ios-device-qa.sh calls this instead of qa_connectivity_probe.
+# Uses `curl` (present on every macOS host this harness runs on, unlike a
+# stock Android emulator image) against the same streamed-asset host. Sets
+# the same QA_CONNECTIVITY_* globals as qa_connectivity_probe so callers can
+# share qa_connectivity_json / qa_connectivity_verdict_line either way.
+qa_connectivity_probe_host() {
+  QA_CONNECTIVITY_AIRPLANE_MODE="n/a"    # meaningless for a host probe
+  QA_CONNECTIVITY_VALIDATED="n/a"
+  QA_CONNECTIVITY_HOST="$QA_CONNECTIVITY_CHECK_HOST"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    QA_CONNECTIVITY_HOST_REACHABLE="unknown"
+    QA_CONNECTIVITY_STATUS="unknown"
+    QA_CONNECTIVITY_METHOD="curl not available on host"
+    export QA_CONNECTIVITY_STATUS QA_CONNECTIVITY_AIRPLANE_MODE QA_CONNECTIVITY_VALIDATED \
+           QA_CONNECTIVITY_HOST_REACHABLE QA_CONNECTIVITY_HOST QA_CONNECTIVITY_METHOD
+    return 0
+  fi
+
+  # Any HTTP response (even a 4xx) proves a route exists -- only a connection
+  # failure (curl's synthetic "000") means no route. No auth token needed:
+  # this only asks "is the host reachable", not "is the key valid" (that is
+  # verify-sketchfab-key.sh's job).
+  local http_status
+  http_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    --connect-timeout 5 --max-time 10 \
+    "https://${QA_CONNECTIVITY_CHECK_HOST}/v3/" 2>/dev/null || echo "000")"
+
+  if [[ "$http_status" == "000" ]]; then
+    QA_CONNECTIVITY_HOST_REACHABLE="false"
+    QA_CONNECTIVITY_STATUS="offline"
+  else
+    QA_CONNECTIVITY_HOST_REACHABLE="true"
+    QA_CONNECTIVITY_STATUS="online"
+  fi
+  QA_CONNECTIVITY_METHOD="host curl https://${QA_CONNECTIVITY_CHECK_HOST}/v3/ -> ${http_status}"
+
+  export QA_CONNECTIVITY_STATUS QA_CONNECTIVITY_AIRPLANE_MODE QA_CONNECTIVITY_VALIDATED \
+         QA_CONNECTIVITY_HOST_REACHABLE QA_CONNECTIVITY_HOST QA_CONNECTIVITY_METHOD
+}
+
+# qa_connectivity_banner_offline <legs...> — LOUD boxed stderr banner, same
+# convention as qa_keys_banner_if_absent, for the DEFAULT (no --allow-offline)
+# path: the caller is refusing to let this pass unnoticed. With --allow-offline
+# the caller should print a single quiet line instead (see device-qa.sh).
+qa_connectivity_banner_offline() {
+  local legs="$*"
+  {
+    echo ""
+    echo "┌────────────────────────────────────────────────────────────────────────────┐"
+    echo "│ ⚠️  QA INCOMPLETE — no route to ${QA_CONNECTIVITY_HOST:-$QA_CONNECTIVITY_CHECK_HOST} (#2959)"
+    echo "│                                                                            │"
+    echo "│ Streamed-asset legs would silently resolve to their bundled fallback — the  │"
+    echo "│ same file in, same file out, so the reload path never runs (measured        │"
+    echo "│ closing #2942). Skipped, never counted as a pass: ${legs}"
+    echo "│                                                                            │"
+    echo "│ airplane_mode_on=${QA_CONNECTIVITY_AIRPLANE_MODE:-unknown}  dumpsys validated=${QA_CONNECTIVITY_VALIDATED:-unknown}  ping ${QA_CONNECTIVITY_HOST:-$QA_CONNECTIVITY_CHECK_HOST}=${QA_CONNECTIVITY_HOST_REACHABLE:-unknown}"
+    echo "│                                                                            │"
+    echo "│ Pass --allow-offline to acknowledge this and silence the banner on a        │"
+    echo "│ deliberately offline run.                                                   │"
+    echo "└────────────────────────────────────────────────────────────────────────────┘"
+  } >&2
+}

--- a/.claude/scripts/setup-ar-emulator.sh
+++ b/.claude/scripts/setup-ar-emulator.sh
@@ -1278,9 +1278,11 @@ select_or_boot_emulator() {
 # fires and a round-trip QA pass can report green while the streamed path
 # never actually ran (measured closing #2942: two different Sketchfab slugs
 # both rendered the same bundled helmet, `airplane_mode_on=1` was the cause).
-# Best-effort: this only repairs the *emulator's* radio state, not host
-# network reachability — qa-android-demos.sh's key-gated sub-legs are still
-# the backstop for "key present but no route" (#2959 proposal 2).
+# Best-effort: this only repairs the *emulator's* radio state (airplane
+# mode), not a dead route with the radio on (captive portal, dead DNS, a
+# dropped VPN) — device-qa.sh's connectivity-gated sub-legs
+# (record_streamed_subleg, lib/qa-connectivity.sh's 3-signal probe) are the
+# backstop for "key present but still no real route" (#2959 proposal 2).
 ensure_airplane_mode_disabled() {
   local serial="$1"
   local mode

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -122,6 +122,14 @@ treated as NOT having tested the Sketchfab path (advisory, mirroring Android's
 `sketchfab` skipped sub-leg). `Config.xcconfig` `#include?`s `Secrets.xcconfig`
 optionally, so a checkout without the file builds keyless and silently.
 
+A key present is still not sufficient on its own (#2959): both `device-qa.sh`
+(Android, via an on-device probe) and `ios-device-qa.sh` (host-side, since the
+Simulator shares the Mac's network) also probe an actual route to the
+streamed-asset host before trusting that a keyed run exercised it — airplane
+mode, a captive portal, or a dead DNS resolver would otherwise resolve every
+streamed slug to its bundled fallback silently. See `lib/qa-connectivity.sh`
+and pass `--allow-offline` to acknowledge a deliberately offline run.
+
 ### iOS coverage and known gaps
 
 - **CI wiring — nightly + release-checkpoint, advisory

--- a/changelog.d/2959-device-qa-connectivity-probe.md
+++ b/changelog.d/2959-device-qa-connectivity-probe.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+`device-qa.sh`'s `sketchfab` / `arcore-cloud` sub-legs only checked
+`airplane_mode_on` before trusting a streamed-asset run — a radio that was ON
+but routeless (captive portal, dead DNS, a dropped VPN) still passed the gate,
+so every streamed Sketchfab slug could silently resolve to its bundled
+fallback while the report said the path was exercised (measured closing
+#2942). A new `lib/qa-connectivity.sh` layers a real probe — airplane mode,
+Android's own captive-portal-validated `dumpsys connectivity` signal, and an
+actual `ping` to the streamed-asset host — and fails closed to an honest
+`skipped` when none of them prove a route. `ios-device-qa.sh` gets the
+symmetric host-side probe (the Simulator shares the Mac's network). Both
+scripts record the probe detail in their reports and accept `--allow-offline`
+to downgrade the loud connectivity banner to a quiet, explicit skip list for a
+deliberately offline run.


### PR DESCRIPTION
## Summary

Fixes #2959. #3317 already closed the exact failure measured on #2942 (a
`qa-clean` snapshot cold-booting with the radio in airplane mode) by checking
`airplane_mode_on` before trusting the `sketchfab` / `arcore-cloud` sub-legs —
but it never linked the issue closed, never touched iOS, and left a real gap
it called out itself: a radio that is **on** with no actual route (captive
portal, dead DNS, a dropped VPN) still passed that check while every streamed
slug silently fell back to its bundled asset.

- New `.claude/scripts/lib/qa-connectivity.sh` layers three signals — airplane
  mode, Android's own captive-portal-validated `dumpsys connectivity` flag,
  and a real `ping` to the streamed-asset host (`api.sketchfab.com`, the host
  `SketchfabConfig.BASE_URL` actually resolves through) — and fails closed to
  `"unknown"` (never counted as online) when a signal can't be read.
- `device-qa.sh`'s `record_streamed_subleg` now uses this probe, embeds the
  connectivity detail into `device-qa-report.json` per sub-leg, and prints a
  one-line connectivity verdict plus an explicit skipped-leg list in the human
  summary.
- `ios-device-qa.sh` gets the symmetric **host-side** probe (the Simulator
  shares the Mac's own network stack) before crediting a keyed run with
  exercising the streamed-USDZ path.
- New `--allow-offline` flag on both scripts downgrades the loud boxed
  no-route banner to a single quiet log line for a deliberately offline run —
  the verdict and exit code are unchanged either way; the sub-leg was already
  advisory-skip (never a hard block), matching the existing key-presence gate
  (#2343) philosophy.
- Changelog fragment, header-comment/README updates.

## Verified

On `emulator-5554` (never the USB Pixel 4a), sourcing the new
`qa_connectivity_probe` directly:

**Online:**
```
[qa-connectivity] status=online airplane_mode=0 checked_host=api.sketchfab.com (airplane_mode_on=0 dumpsys_validated=false ping:api.sketchfab.com=true)
{"status":"online","airplaneMode":"0","checkedHost":"api.sketchfab.com","method":"airplane_mode_on=0 dumpsys_validated=false ping:api.sketchfab.com=true"}
```
Note `dumpsys_validated=false` on this emulator image even while genuinely
online — exactly the reason the probe doesn't rely on a single signal; the
`ping` check caught the real route and the combined verdict is correct.

**After `adb shell cmd connectivity airplane-mode enable`:**
```
[qa-connectivity] status=offline airplane_mode=1 checked_host=api.sketchfab.com (airplane_mode_on=1)
{"status":"offline","airplaneMode":"1","checkedHost":"api.sketchfab.com","method":"airplane_mode_on=1"}
```

Airplane mode was then disabled again and re-verified back to
`airplane_mode_on=0` / `status=online` before releasing the emulator lock.

## Test plan

- [x] `bash -n` on every touched script
- [x] `shellcheck -x` on every touched script — no new warnings
- [x] Real-device probe: online branch, airplane-mode-on branch (both pasted
      above), airplane mode restored off and re-verified online
- [ ] Full `device-qa.sh --platform=android` run with a Sketchfab key present
      (not exercised this session — the probe itself needed no build, and the
      demo APK/build tree was not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)