### PR TITLE
fix(release): read the GA4 stream id from analytics.js, where #3443 moved it

### DIFF
--- a/.claude/scripts/sync-versions.sh
+++ b/.claude/scripts/sync-versions.sh
@@ -651,7 +651,11 @@ fi
 # The check pins the exact id ($GA4_STREAM_ID): any other value, dotted or
 # not, is a corrupted carrier. Matching `Stream ID: <value>` with a trailing
 # space/`-->` boundary means a bump that only appended digits fails too.
-STREAM_ID_FOUND=$(grep -rhoE 'Stream ID: [0-9][0-9.]*' "$REPO_ROOT/website-static" --include="*.html" 2>/dev/null | sed 's/^Stream ID: //' | sort -u || true)
+# #3443 moved the GA4 loader (and the `Stream ID:` comment that carries the id)
+# out of every page into `website-static/assets/analytics.js`, so the carrier
+# is a `.js` file now; the `.html` include alone found nothing and the gate
+# blocked the 4.34.0 release on an empty read.
+STREAM_ID_FOUND=$(grep -rhoE 'Stream ID: [0-9][0-9.]*' "$REPO_ROOT/website-static" --include="*.html" --include="*.js" 2>/dev/null | sed 's/^Stream ID: //' | sort -u || true)
 if [ "$STREAM_ID_FOUND" = "$GA4_STREAM_ID" ]; then
     add_check "website-static GA4 stream id ($GA4_STREAM_ID, carrier intact)" "$SOURCE_VERSION"
 else

--- a/changelog.d/3443-sync-versions-ga4-carrier.md
+++ b/changelog.d/3443-sync-versions-ga4-carrier.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+- **The release gate reads the GA4 stream id from its new carrier.** #3443 moved the analytics loader and its `Stream ID:` comment into `website-static/assets/analytics.js`; `sync-versions.sh` only searched `.html` files, read an empty id, reported the carrier as corrupted and blocked the 4.34.0 `Release fast` run at the version gate. The check now covers `.js` carriers too.


### PR DESCRIPTION
## Summary

The 4.34.0 `Release fast` run ([33770712175](https://github.com/sceneview/sceneview/actions/runs/33770712175)) failed at the version gate with:

```
website-static GA4 stream id (expected 14357002837, found:  ) CORRUPTED    MISMATCH
Errors (MISMATCH): 1
```

#3443 moved the GA4 loader — and the `Stream ID: 14357002837` comment the guard reads — out of every static page into `website-static/assets/analytics.js`. `sync-versions.sh` searched `website-static` with `--include="*.html"` only, so it read an empty id and reported the carrier as corrupted. The guard now also searches `.js` files. The version sweep itself never touches `analytics.js` (each carrier is rewritten by its own anchored sed), so the id cannot be re-corrupted through that path.

## Verified

`bash .claude/scripts/sync-versions.sh` on current `main` plus this change:

```
website-static GA4 stream id (14357002837, carrier intact)   OK
Errors (MISMATCH): 0
```

Once merged, `Release fast` will be re-dispatched for 4.34.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)