### PR TITLE
fix(build): colon-free Kotlin module names so the demo release bundle packages under AGP 9 (#3467)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
       # skipped on every run — which GitHub reports as success. A gate that
       # can never fire looks exactly like a gate that always passes.
       compose: ${{ steps.filter.outputs.compose }}
+      # Build-system-only changes (the `shared` anchor). Gates the demo's
+      # release bundle in `build` — the task the Play deploys run and the one
+      # the AGP 9 move never exercised (#3467).
+      build-system: ${{ steps.filter.outputs.build-system }}
     steps:
       # Checked out only on `push`. `dorny/paths-filter` reads the diff from
       # the GitHub API on `pull_request` and never touches the working tree; it
@@ -187,6 +191,12 @@ jobs:
               - 'gradle.properties'
               - 'gradlew'
               - 'gradlew.bat'
+            # Exactly `shared`, exposed as its own verdict: a PR that changes
+            # the build system also builds the demo's RELEASE bundle (#3467),
+            # which no per-PR job did before — the AGP 9 move merged green and
+            # broke every Play deploy from `main` at `buildReleasePreBundle`.
+            build-system:
+              - *shared
             android:
               - *shared
               - 'sceneview/**'
@@ -255,6 +265,7 @@ jobs:
             flutter=${{ steps.filter.outputs.flutter }}
             kmp=${{ steps.filter.outputs.kmp }}
             compose=${{ steps.filter.outputs.compose }}
+            build-system=${{ steps.filter.outputs.build-system }}
         run: |
           set -euo pipefail
           bad=0
@@ -343,6 +354,22 @@ jobs:
             :samples:android-demo:assembleDebug \
             :samples:android-tv-demo:assembleDebug \
             --stacktrace
+
+      # The release BUNDLE is a different packaging path from the debug APK:
+      # R8 rewrites the Kotlin metadata resources and AGP 9's pre-bundle step
+      # validates every zip entry name. The AGP 9 move (#3459) passed every
+      # per-PR job and then failed the first Play deploy from `main` there
+      # (#3467). Only on build-system changes — ~3 extra minutes of R8 on the
+      # PRs that can actually break this, nothing on the rest. Unsigned: the
+      # `release` signing config is only attached when the keystore env var is
+      # set, and `bundleRelease` is fine without it. `SV_ALLOW_MISSING_SECRETS`
+      # skips the #1915 store-secret guard, which is a deploy concern, not a
+      # packaging one.
+      - name: Build demo release bundle (build-system change)
+        if: inputs.force-all || needs.changes.outputs.build-system == 'true'
+        env:
+          SV_ALLOW_MISSING_SECRETS: "1"
+        run: ./gradlew :samples:android-demo:bundleRelease --stacktrace
 
   lint:
     name: Lint

--- a/arsceneview/api/arsceneview.api
+++ b/arsceneview/api/arsceneview.api
@@ -624,23 +624,23 @@ public final class io/github/sceneview/ar/CloudAnchorRegistry$DefaultImpls {
 public final class io/github/sceneview/ar/ComposableSingletons$ARSceneScopeKt {
 	public static final field INSTANCE Lio/github/sceneview/ar/ComposableSingletons$ARSceneScopeKt;
 	public fun <init> ()V
-	public final fun getLambda$1192742845$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1192742845$arsceneview_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/github/sceneview/ar/ComposableSingletons$ARSceneViewKt {
 	public static final field INSTANCE Lio/github/sceneview/ar/ComposableSingletons$ARSceneViewKt;
 	public fun <init> ()V
-	public final fun getLambda$473211439$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda$478031680$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$473211439$arsceneview_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$478031680$arsceneview_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/github/sceneview/ar/ComposableSingletons$PlaneDiscoveryGuideKt {
 	public static final field INSTANCE Lio/github/sceneview/ar/ComposableSingletons$PlaneDiscoveryGuideKt;
 	public fun <init> ()V
-	public final fun getLambda$-245446278$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-608761358$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-705560747$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1423115325$SceneView_arsceneview_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-245446278$arsceneview_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-608761358$arsceneview_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-705560747$arsceneview_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1423115325$arsceneview_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/github/sceneview/ar/FloorWallSeam {

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,47 @@ subprojects {
         }
     }
 
+    // Colon-free Kotlin module names (#3467).
+    //
+    // Kotlin Gradle plugin 2.4 names every JVM/Android compilation
+    // `<project.group>:<project.name>` (+ `_<compilation>` off `main`), and a
+    // subproject's default Gradle group is the root project's name — so each
+    // module here compiled as `SceneView:<module>`. The compiler writes the
+    // `.kotlin_module` file under a sanitised name (`SceneView_sceneview_release`),
+    // which is why debug APKs and the AARs never showed it; but the raw name is
+    // recorded in every class's Kotlin metadata, and R8 re-emits the resource
+    // under it on minified release builds. AGP 9's bundle packaging validates
+    // zip entry names, and `:samples:android-demo:buildReleasePreBundle` died
+    // on `root/META-INF/SceneView:sceneview_release.kotlin_module`, breaking
+    // every Play deploy from `main`. The app's `META-INF/*.kotlin_module`
+    // packaging exclude is no fallback: it is not applied on the bundle path
+    // at all (the AAB still carries every library's `.kotlin_module`).
+    //
+    // Pin the pre-2.4 convention instead: `<project.name>` for `main`,
+    // `<project.name>_<compilation>` otherwise (`sceneview_release`,
+    // `sceneview-core`, `android-demo_release`). Applied through the
+    // compilation API so it reaches `kotlin-android` modules and every
+    // multiplatform JVM-flavoured target alike — `androidTarget()`, AGP 9's
+    // `androidLibrary { }` and `jvm()`. Native and JS compilations do not have
+    // JVM compiler options and are left as they are. Check with
+    // `./gradlew :samples:android-demo:bundleRelease` (the task the deploys run).
+    def colonFreeModuleName = { compilation ->
+        def options = compilation.compilerOptions.options
+        if (options instanceof org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions) {
+            options.moduleName = compilation.name == "main"
+                ? project.name
+                : "${project.name}_${compilation.name}".toString()
+        }
+    }
+    plugins.withId("org.jetbrains.kotlin.android") {
+        kotlin.target.compilations.configureEach(colonFreeModuleName)
+    }
+    plugins.withId("org.jetbrains.kotlin.multiplatform") {
+        kotlin.targets.configureEach { target ->
+            target.compilations.configureEach(colonFreeModuleName)
+        }
+    }
+
     // Apply detekt to all subprojects that use Kotlin.
     //
     // NOTE: we use `pluginManager.apply("dev.detekt")` instead of the legacy

--- a/changelog.d/3467-kotlin-module-name-colon.md
+++ b/changelog.d/3467-kotlin-module-name-colon.md
@@ -22,7 +22,11 @@
   `sceneview-compose`, `android-demo_release` — which is the name KGP used before 2.4. It
   covers `kotlin-android` modules and the multiplatform ones (`androidTarget()`, AGP 9's
   `androidLibrary { }` and `jvm()` targets) alike; Kotlin/Native and Kotlin/JS compilations
-  are untouched. The published `.api` dumps are unchanged (`apiCheck` passes).
+  are untouched. The only trace in the binary-compatibility dumps is `arsceneview.api`, where
+  the mangled accessors of seven `internal` Compose lambda singletons move from
+  `…$SceneView_arsceneview_release` to `…$arsceneview_release` — the module name is part of
+  the JVM mangling of `internal` members, which are not public API; the dump merely records
+  them. No public declaration changes, in any module.
 
   `:samples:android-demo:bundleRelease` — the exact task the Play deploys run — joins the
   local verification list for build-system changes alongside the `assembleDebug` /

--- a/changelog.d/3467-kotlin-module-name-colon.md
+++ b/changelog.d/3467-kotlin-module-name-colon.md
@@ -1,0 +1,33 @@
+<!-- category: Fixed -->
+- **The demo's release bundle builds again under AGP 9; the Play Internal deploy on
+  `main` was broken since the AGP 9 move
+  ([#3467](https://github.com/sceneview/sceneview/issues/3467)).**
+  `:samples:android-demo:buildReleasePreBundle` failed with `Entry name contains invalid
+  characters: root/META-INF/SceneView:sceneview_release.kotlin_module`. Kotlin Gradle
+  plugin 2.4.10 names every JVM/Android compilation `<project.group>:<project.name>` (plus
+  `_<variant>` for Android variants), and the default Gradle group of a subproject is the
+  root project's name — so every module in this build compiled as `SceneView:<module>`,
+  with a colon in the Kotlin module name. The compiler writes the `.kotlin_module` file
+  under a sanitised name (`SceneView_sceneview_release`), which is why debug APKs, the
+  AARs and `assembleDebug` were all green; but R8, on the minified release build, re-emits
+  that resource under the raw module name, and AGP 9's bundle packaging validates zip entry
+  names and rejects the colon. The app's existing `META-INF/*.kotlin_module` packaging
+  exclude is not a fallback: AGP 9 does not apply it on the bundle path at all — the AAB
+  built with this fix still carries all 19 `.kotlin_module` entries, so excluding the
+  resource could never have made the entry legal.
+
+  The fix is at the root: the root `build.gradle` now sets a colon-free Kotlin module name
+  on every JVM/Android compilation of every subproject — `<project.name>` for `main`,
+  `<project.name>_<compilation>` otherwise, i.e. `sceneview_release`, `sceneview-core`,
+  `sceneview-compose`, `android-demo_release` — which is the name KGP used before 2.4. It
+  covers `kotlin-android` modules and the multiplatform ones (`androidTarget()`, AGP 9's
+  `androidLibrary { }` and `jvm()` targets) alike; Kotlin/Native and Kotlin/JS compilations
+  are untouched. The published `.api` dumps are unchanged (`apiCheck` passes).
+
+  `:samples:android-demo:bundleRelease` — the exact task the Play deploys run — joins the
+  local verification list for build-system changes alongside the `assembleDebug` /
+  `testReleaseUnitTest` / `lintDebug` set recorded for the AGP 9 move
+  ([#3440](https://github.com/sceneview/sceneview/issues/3440)), and CI's `build` job now
+  builds the demo's release bundle whenever a PR touches the build system (`gradle/**`,
+  `build.gradle*`, `settings.gradle*`, `gradle.properties`, the wrapper), so this gap
+  cannot reopen silently.


### PR DESCRIPTION
Fixes #3467

## Root cause

Kotlin Gradle plugin 2.4.10 sets the convention for every JVM/Android compilation's `compilerOptions.moduleName` to `<project.group>:<project.name>` (plus `_<compilation>` for anything other than `main`), and a subproject's default Gradle `group` is the root project's name (`SceneView`, `SceneView.samples` under `samples/`). Measured on `main` with an init script: `:sceneview:compileReleaseKotlin` → `SceneView:sceneview_release`, `:samples:android-demo:compileReleaseKotlin` → `SceneView.samples:android-demo_release`, `:sceneview-core:compileKotlinAndroid` → `SceneView:sceneview-core`, `:sceneview-compose:compileAndroidMain` → `SceneView:sceneview-compose` (it is not `archivesName`, which stays `sceneview`). The compiler writes the `.kotlin_module` file under a sanitised name — `META-INF/SceneView_sceneview_release.kotlin_module` on disk, in the AAR `classes.jar` and in debug APKs, which is why `assembleDebug` and the AARs were green — but the raw name is recorded in every class's Kotlin metadata (285 class files of `:sceneview` carry the string `SceneView:sceneview_release`), and R8 on the minified release build re-emits the resource under that raw name: `minifyReleaseWithR8/base.jar` contains `META-INF/SceneView:sceneview_release.kotlin_module`, `SceneView:sceneview-core…`, `SceneView:arsceneview_release…`, `SceneView.samples:android-demo_release…`, `SceneView.samples:common_release…`. AGP 9's `buildReleasePreBundle` validates zip entry names and rejects the colon. The app's existing `META-INF/*.kotlin_module` packaging exclude is not a fallback: AGP 9 does not apply it on the bundle path at all — the fixed AAB still carries all 19 `.kotlin_module` entries (ours and AndroidX's).

## Fix

Root `build.gradle`, in the existing `subprojects { }` block: a colon-free module name is set through the KGP compilation API on every compilation whose options are `KotlinJvmCompilerOptions` — `<project.name>` for `main`, `<project.name>_<compilation>` otherwise. That is the pre-2.4 KGP convention (`sceneview_release`, `sceneview-core`, `sceneview-compose`, `android-demo_release`). Wired for `org.jetbrains.kotlin.android` (`kotlin.target.compilations`) and `org.jetbrains.kotlin.multiplatform` (`kotlin.targets.*.compilations`), so `androidTarget()`, AGP 9's `androidLibrary { }` (`:sceneview-compose`) and `jvm()` targets are all covered; Native and JS compilations are untouched. `android.builtInKotlin` / `android.newDsl` are not changed.

CI: `ci.yml` gains a `build-system` path verdict (exactly the existing `shared` anchor: `gradle/**`, `build.gradle*`, `settings.gradle*`, `gradle.properties`, the wrapper, the workflow itself) and one gated step in the `build` job that runs `:samples:android-demo:bundleRelease` (unsigned, `SV_ALLOW_MISSING_SECRETS=1`). It costs ~3 extra minutes of R8 only on PRs that touch the build system; nothing on the rest.

## Verification (local, `--no-daemon --max-workers=2`)

- `./gradlew :samples:android-demo:bundleRelease` on `main` (fa1354029) → `FAILED`, `buildReleasePreBundle`: `Entry name contains invalid characters: root/META-INF/SceneView:sceneview_release.kotlin_module` (reproduced, 6m20s).
- `./gradlew help -I <init script printing compilerOptions.moduleName>` after the fix → `sceneview_release`, `arsceneview_release`, `sceneview-core`, `sceneview-compose`, `android-demo_release`, `common_release`, `android-tv-demo_release`, `snippets-check_release`; no colon anywhere.
- `./gradlew :samples:android-demo:bundleRelease :samples:android-demo:assembleDebug :sceneview:apiCheck --rerun --continue` → `BUILD SUCCESSFUL in 5m 4s`; `compileReleaseKotlin` re-ran in all four Android modules, `:sceneview:apiBuild` and `:sceneview:apiCheck` executed (not UP-TO-DATE).
- `unzip -l android-demo-release.aab | awk '{print $4}' | grep -c ':'` → `0`.
- `unzip -l minifyReleaseWithR8/base.jar | grep kotlin_module` → `sceneview_release`, `sceneview-core`, `android-demo_release`, `common_release`, `arsceneview_release`.
- `./gradlew apiDump` at the root, then `./gradlew apiCheck --rerun` → BUILD SUCCESSFUL for `:sceneview`, `:arsceneview`, `:sceneview-core`, `:sceneview-compose`. The only dump that changed is `arsceneview/api/arsceneview.api` (7 lines): the mangled accessors of seven `internal` Compose lambda singletons moved from `getLambda$<hash>$SceneView_arsceneview_release` to `getLambda$<hash>$arsceneview_release`, because the Kotlin module name is part of the JVM name mangling of `internal` members. That is not a public API change — `internal` members are not part of the published API; the dump merely records them under their JVM names — and no public declaration changed in any module.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → parses.

## Needs device

None — this is a packaging change; nothing rendered or touched at runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
