### PR TITLE
fix(ci): keep the Gradle cache read-only on self-hosted runners (#3469)

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -38,11 +38,29 @@ runs:
     # build cache (compiled task outputs) for richer hit rates across
     # ci/build-apks/render-tests.
     # `cache-read-only` on every non-push event so PRs (incl. forks) read
-    # but never write the cache; pushes to main repopulate it.
+    # but never write the cache; pushes to main repopulate it — from hosted
+    # runners only.
+    #
+    # A self-hosted runner never writes (#3469). Its Gradle User Home is the
+    # machine's own `~/.gradle`, which the action refuses to restore into
+    # anyway ("Gradle User Home already exists: will not restore from cache"),
+    # so nothing saved from it is ever consumed by that machine — yet on every
+    # `main` push the post-step tarred and uploaded that whole home. On
+    # `sceneview-mac` that meant a 2.2 GB + 3.0 GB upload still at
+    # `Sent 1073741824 of 2201734690 (48.8%), 0.6 MBs/sec` when the job's
+    # 30 min timeout fired (job 100769714909), or a transfer stuck at
+    # `Sent 0 of 1269721491 (0.0%), 0.0 MBs/sec` for the full 30 min (job
+    # 100796430540): every `main` push that reached the iOS-sim job ended
+    # `cancelled` in `Post Run ./.github/actions/setup-gradle` with the tests
+    # green in ~20 s, while the same commits' PR runs (read-only) spent 0 s
+    # there. The save also ran `gradle --stop` against the developer's live
+    # daemons and pushed multi-GB macOS entries into a repo cache already at
+    # 14.5 GB active against the 10 GB quota, evicting the Linux entries every
+    # hosted job restores.
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v6
       with:
-        cache-read-only: ${{ github.event_name != 'push' }}
+        cache-read-only: ${{ github.event_name != 'push' || runner.environment == 'self-hosted' }}
 
     # Verify the checked-in gradle-wrapper.jar matches the SHA of a known-good
     # Gradle distribution. A malicious PR can otherwise sneak a tampered

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -896,6 +896,15 @@ jobs:
     # whole cost: measured locally on an M-series Mac at 9 min 46 s from cold,
     # and 33 s to re-link and re-run after a one-file change. The 30 min is
     # headroom for a slower hosted runner, not an expected duration.
+    #
+    # If this job shows `cancelled` again with the test step green in ~20 s,
+    # read `Post Run ./.github/actions/setup-gradle` before touching this
+    # value: on `main` pushes that post-step used to upload the self-hosted
+    # Mac's entire `~/.gradle` to the Actions cache until this timeout fired
+    # (#3469, jobs 100769714909 and 100796430540 — `Sent 1073741824 of
+    # 2201734690 (48.8%), 0.6 MBs/sec` at minute 30). The composite action
+    # is now read-only on self-hosted runners; the timeout was never the
+    # problem and is unchanged.
     timeout-minutes: 30
 
     steps:

--- a/changelog.d/3469-self-hosted-gradle-cache-save.md
+++ b/changelog.d/3469-self-hosted-gradle-cache-save.md
@@ -1,0 +1,23 @@
+<!-- category: Fixed -->
+- **CI on `main` no longer ends `cancelled` in "KMP native unit tests (iOS sim)" when
+  the job runs on the self-hosted Mac
+  ([#3469](https://github.com/sceneview/sceneview/issues/3469)).**
+  The tests were green in ~20 s on every affected push; the 30 minutes were spent in
+  `Post Run ./.github/actions/setup-gradle`. The composite action writes the Gradle
+  cache on `push` events, and on a self-hosted runner the Gradle User Home is the
+  machine's own `~/.gradle` — a home the action never restores into ("Gradle User Home
+  already exists: will not restore from cache") but did tar and upload in full on every
+  `main` push: 2.2 GB + 3.0 GB entries still at `Sent 1073741824 of 2201734690 (48.8%),
+  0.6 MBs/sec` when the job timeout fired (job 100769714909), or a transfer stuck at
+  `Sent 0 of 1269721491 (0.0%), 0.0 MBs/sec` for the whole 30 minutes (job 100796430540).
+  The same commits' PR runs are read-only and spent 0 s in that step, which is why the
+  failure only ever showed on `main`. All four `main` runs that reached this job on the
+  self-hosted runner spent 17 to 30 minutes there. The save also ran `gradle --stop`
+  against the developer's live daemons (one of the two it stopped belonged to a local
+  Flutter build) and pushed multi-GB macOS entries into a repository cache already at
+  14.5 GB active against the 10 GB quota.
+
+  `setup-gradle` now stays `cache-read-only` whenever `runner.environment` is
+  `self-hosted`, on every workflow that uses it; hosted runners keep repopulating the
+  cache on `push` exactly as before. The job's `timeout-minutes` was not the problem and
+  is unchanged; a comment next to it points at the post-step for the next reader.


### PR DESCRIPTION
Fixes #3469

## Root cause

Not the concurrency group, not a runner restart, not a queued-job lease, and not a too-short timeout for the tests. Both cancelled jobs have the same shape (`gh api .../actions/jobs/<id>`):

| Job | Test step | `Post Run ./.github/actions/setup-gradle` |
|---|---|---|
| 100769714909 (run 33791720663, `fa1354029`) | 18:38:57 → 18:39:16, **success** | 18:39:18 → 19:09:11, **cancelled** |
| 100796430540 (run 33799847366, `1dc9cb700`) | 20:02:09 → 20:02:27, **success** | 20:02:29 → 20:32:22, **cancelled** |

The job's `timeout-minutes: 30` fires at minute 30 while the post-step is still uploading; the runner's `_diag/Worker_20260903-183850-utc.log` simply records `JobRunner] Job result after all job steps finish: Canceled` — no worker crash, no restart, no server-side cancel for another reason.

The composite action sets `cache-read-only: ${{ github.event_name != 'push' }}`, so only `push` runs write. On the self-hosted Mac the job log shows:

```
cache-read-only: false
Gradle User Home already exists at /Users/thomasgorisse/.gradle
Gradle User Home already exists: will not restore from cache.
...
##[group]Stopping Gradle daemons
2 Daemons stopped
##[group]Performing cache cleanup
Removed 947 inactive cross-version entries
Removed 1084 inactive version-scoped entries
##[group]Caching Gradle state
Saved cache entry with key gradle-build-cache-v2-... in 170980ms
2026-09-03T19:09:09Z Sent 1073741824 of 2201734690 (48.8%), 0.6 MBs/sec
2026-09-03T19:09:09Z Sent 2013265920 of 3005444078 (67.0%), 1.1 MBs/sec
2026-09-03T19:09:10Z ##[error]The operation was canceled.
```

and for the second job the transfer never started: `Sent 0 of 1269721491 (0.0%), 0.0 MBs/sec` repeated for 30 minutes. The action tars and uploads the machine's whole `~/.gradle` (2.4 GB of `caches/` on this Mac) on every `main` push, into a home it will never restore into on that same machine. The same commits' PR runs are read-only and spent 0 s in the post-step (job 100761885140: `18:15:25 → 18:15:25`), which is exactly the push-vs-PR asymmetry in the issue.

This has held for every `main` run that reached the job on the self-hosted runner: 33686388588 (Sep 2, success, post-step 17 min), 33733653165 (Sep 3 08:29, post-step 27 min, cancelled), then the two in the issue. All other `main` runs skipped the job through the `changes` filter.

Two side effects worth knowing: the post-step's `gradle --stop` killed local daemons — one of the two stopped at 18:39:20 belonged to a local agent's Flutter build (`~/.gradle/daemon/9.7.1/daemon-18789.out.log`, `currentDir=.../worktrees/agent-.../samples/flutter-demo/android`) — and the repository's Actions cache is at 14.5 GB active across 37 entries against the 10 GB quota (`gh api repos/{owner}/{repo}/actions/cache/usage`), so each multi-GB macOS entry evicts the Linux entries the hosted jobs restore.

## Change

- `.github/actions/setup-gradle/action.yml`: `cache-read-only: ${{ github.event_name != 'push' || runner.environment == 'self-hosted' }}`. Hosted runners keep writing on `push` exactly as before; the self-hosted Mac now behaves on `push` as it already does on PRs (0 s post-step, no `gradle --stop`, no upload). Applies to every workflow that uses the composite action, which today means only this job runs on `sceneview-mac` with it.
- `.github/workflows/ci.yml`: a comment at the job's `timeout-minutes` pointing at the post-step; the value is unchanged, it was never the problem.
- `changelog.d/3469-self-hosted-gradle-cache-save.md`.

No runner-side change. The alternatives in the issue (raise the timeout, hosted runner for `push`, `continue-on-error` on `main`) would all keep a pointless multi-GB upload from this Mac on every push.

## Verification

`actionlint .github/workflows/ci.yml` clean; the composite action parses. The real check is this PR's own CI plus the next `main` push that touches `sceneview-compose/**`: the iOS-sim job should complete in about a minute with `Post Run ./.github/actions/setup-gradle` at 0 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
