### PR TITLE
fix(demo): wire detekt to generateDemoRegistry, lint the demo in CI; refresh Flutter demo lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,10 @@ jobs:
         run: ./gradlew :sceneview:lintDebug :arsceneview:lintDebug --stacktrace
 
       # detekt is applied to every Kotlin Android/KMP subproject in
-      # build.gradle with a hand-tuned config (buildSrc/config/detekt/detekt.yml),
-      # scoped to the four library modules.
+      # build.gradle with a hand-tuned config (buildSrc/config/detekt/detekt.yml).
+      # Runs on the four library modules plus the Play Store demo (#3450): the
+      # demo's task used to be scheduled nowhere, so its missing dependency on
+      # `generateDemoRegistry` and its 93 grandfathered findings went unseen.
       #
       # BLOCKING: detekt was upgraded from 1.23.8 (which silently no-op'd task
       # registration on Kotlin 2.3.x / AGP 8.13.x) to detekt 2.0.0-alpha.0 in
@@ -398,7 +400,7 @@ jobs:
       # cleanup PR, run `./gradlew :<module>:detektBaseline` locally and commit
       # the regenerated XML.
       - name: Detekt
-        run: ./gradlew :sceneview:detekt :arsceneview:detekt :sceneview-core:detekt :sceneview-compose:detekt --stacktrace
+        run: ./gradlew :sceneview:detekt :arsceneview:detekt :sceneview-core:detekt :sceneview-compose:detekt :samples:android-demo:detekt --stacktrace
 
       - name: Upload detekt reports
         if: always()
@@ -410,6 +412,7 @@ jobs:
             arsceneview/build/reports/detekt/
             sceneview-core/build/reports/detekt/
             sceneview-compose/build/reports/detekt/
+            samples/android-demo/build/reports/detekt/
           if-no-files-found: ignore
 
       - name: Upload lint reports

--- a/buildSrc/config/detekt/baseline-android-demo.xml
+++ b/buildSrc/config/detekt/baseline-android-demo.xml
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:DemoHelpers.kt:EntranceCameraManipulator$!length.isFinite() || length &lt;= 1e-5f || !distance.isFinite() || distance &lt;= 0f</ID>
+    <ID>ComplexCondition:OrbitalARDemo.kt:anchor != null &amp;&amp; isTracking &amp;&amp; projectedTargets.isNotEmpty() &amp;&amp; projectedTargets.size != offscreenTargets.size</ID>
+    <ID>CyclomaticComplexMethod:CloudAnchorFlow.kt:fun CloudAnchorFlowState.allows: Boolean</ID>
+    <ID>LongMethod:RawDepthCloud.kt:RawDepthCloud$@Suppress("NestedBlockDepth") // y→x→confidence→depth nested loops are the canonical depth-cloud pattern fun buildCloud: IntArray</ID>
+    <ID>LoopWithTooManyJumpStatements:DemoScaffold.kt:while</ID>
+    <ID>LoopWithTooManyJumpStatements:WhatsNewChangelog.kt:for</ID>
+    <ID>LoopWithTooManyJumpStatements:WhatsNewSinceSheet.kt:while</ID>
+    <ID>MatchingDeclarationName:AskCaptureGeometry.kt:AskCaptureRegion</ID>
+    <ID>MatchingDeclarationName:AskFrameCheck.kt:AskFrameVerdict</ID>
+    <ID>MatchingDeclarationName:DemoStatusBanner.kt:DemoStatusTone</ID>
+    <ID>MatchingDeclarationName:EnvironmentSheet.kt:ViewerEnvironment</ID>
+    <ID>MatchingDeclarationName:HomeFilter.kt:HomeSearchEntry</ID>
+    <ID>MatchingDeclarationName:HomeScreen.kt:HomeTestTags</ID>
+    <ID>MatchingDeclarationName:ModelPickerSheet.kt:BundledViewerModel</ID>
+    <ID>MatchingDeclarationName:ParkFraming.kt:ParkSlot</ID>
+    <ID>MatchingDeclarationName:PointAndAskDemo.kt:PointAndAskTestTags</ID>
+    <ID>MatchingDeclarationName:RerunSaveUx.kt:RerunSaveActionUx</ID>
+    <ID>MaxLineLength:ARStreetscapeDemo.kt:"${geospatialUnavailable!!} \u2014 needs outdoor area with Street View coverage + Cloud API key"</ID>
+    <ID>MaxLineLength:AnimationBar.kt:@Composable</ID>
+    <ID>MaxLineLength:AnimationBar.kt:Box { TextButton(onClick = { menu = true }) { Text(clipNames.getOrNull(selectedClip) ?: "Clip ${selectedClip + 1}") }; DropdownMenu(menu, { menu = false }) { clipNames.forEachIndexed { i, name -> DropdownMenuItem({ Text(name) }, { onClipChange(i); menu = false }) } } }</ID>
+    <ID>MaxLineLength:AnimationBar.kt:IconButton(onClick = { onPlayingChange(!playing) }, modifier = Modifier.size(SceneViewTokens.Layout.viewerAnimationButton)) { Icon(if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow, if (playing) "Pause" else "Play") }</ID>
+    <ID>MaxLineLength:AnimationBar.kt:Row</ID>
+    <ID>MaxLineLength:AnimationBar.kt:Surface</ID>
+    <ID>MaxLineLength:CatchTargetTest.kt:CatchTargetTest$assertEquals("one second after release the flyer has advanced by one second of orbit", expected, justAfter, 1e-3f)</ID>
+    <ID>MaxLineLength:DemoMath.kt:DemoMath$val safeHorizontalFill = if (horizontalFill.isFinite() &amp;&amp; horizontalFill > 0f) horizontalFill else VIEWER_HORIZONTAL_FILL</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"animation-physics" to PreviewPair(R.drawable.preview_animation_physics_light, R.drawable.preview_animation_physics_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-body-tracker" to PreviewPair(R.drawable.preview_ar_body_tracker_light, R.drawable.preview_ar_body_tracker_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-cloud-anchor" to PreviewPair(R.drawable.preview_ar_cloud_anchor_light, R.drawable.preview_ar_cloud_anchor_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-collaborative" to PreviewPair(R.drawable.preview_ar_collaborative_light, R.drawable.preview_ar_collaborative_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-depth-collider" to PreviewPair(R.drawable.preview_ar_depth_collider_light, R.drawable.preview_ar_depth_collider_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-depth-occlusion" to PreviewPair(R.drawable.preview_ar_depth_occlusion_light, R.drawable.preview_ar_depth_occlusion_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-depth-of-field" to PreviewPair(R.drawable.preview_ar_depth_of_field_light, R.drawable.preview_ar_depth_of_field_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-depth-visualization" to PreviewPair(R.drawable.preview_ar_depth_visualization_light, R.drawable.preview_ar_depth_visualization_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-geospatial-anchors" to PreviewPair(R.drawable.preview_ar_geospatial_anchors_light, R.drawable.preview_ar_geospatial_anchors_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-hand-tracking" to PreviewPair(R.drawable.preview_ar_hand_tracking_light, R.drawable.preview_ar_hand_tracking_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-image-stabilization" to PreviewPair(R.drawable.preview_ar_image_stabilization_light, R.drawable.preview_ar_image_stabilization_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-ml-object-label" to PreviewPair(R.drawable.preview_ar_ml_object_label_light, R.drawable.preview_ar_ml_object_label_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-people-occlusion" to PreviewPair(R.drawable.preview_ar_people_occlusion_light, R.drawable.preview_ar_people_occlusion_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-plane-renderer-v2" to PreviewPair(R.drawable.preview_ar_plane_renderer_v2_light, R.drawable.preview_ar_plane_renderer_v2_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-point-cloud" to PreviewPair(R.drawable.preview_ar_point_cloud_light, R.drawable.preview_ar_point_cloud_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-raw-depth-point-cloud" to PreviewPair(R.drawable.preview_ar_raw_depth_point_cloud_light, R.drawable.preview_ar_raw_depth_point_cloud_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-record-playback" to PreviewPair(R.drawable.preview_ar_record_playback_light, R.drawable.preview_ar_record_playback_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-scene-semantics" to PreviewPair(R.drawable.preview_ar_scene_semantics_light, R.drawable.preview_ar_scene_semantics_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"ar-streetscape" to PreviewPair(R.drawable.preview_ar_streetscape_light, R.drawable.preview_ar_streetscape_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"camera-gestures" to PreviewPair(R.drawable.preview_camera_gestures_light, R.drawable.preview_camera_gestures_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"contact-shadow-preview" to PreviewPair(R.drawable.preview_contact_shadow_preview_light, R.drawable.preview_contact_shadow_preview_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"custom-geometry" to PreviewPair(R.drawable.preview_custom_geometry_light, R.drawable.preview_custom_geometry_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"double-pendulum" to PreviewPair(R.drawable.preview_double_pendulum_light, R.drawable.preview_double_pendulum_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"picking-collision" to PreviewPair(R.drawable.preview_picking_collision_light, R.drawable.preview_picking_collision_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"placement-scene" to PreviewPair(R.drawable.preview_placement_scene_light, R.drawable.preview_placement_scene_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"secondary-camera" to PreviewPair(R.drawable.preview_secondary_camera_light, R.drawable.preview_secondary_camera_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"two-d-in-three-d" to PreviewPair(R.drawable.preview_two_d_in_three_d_light, R.drawable.preview_two_d_in_three_d_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"video-recording" to PreviewPair(R.drawable.preview_video_recording_light, R.drawable.preview_video_recording_dark)</ID>
+    <ID>MaxLineLength:DemoPreviews.kt:DemoPreviews$"wall-placement" to PreviewPair(R.drawable.preview_wall_placement_light, R.drawable.preview_wall_placement_dark)</ID>
+    <ID>MaxLineLength:DemoRegistryIntegrityTest.kt:DemoRegistryIntegrityTest$assertTrue("Tag '$tag' on '${demo.id}' must be lowercase and non-blank", tag.isNotBlank() &amp;&amp; tag == tag.lowercase())</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:.</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:@Composable</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:LabeledSlider("IBL intensity", intensity, onIntensity, 0f..2f, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.md), valueText = "%.1f×".format(intensity))</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:ModalBottomSheet</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:Modifier.size(SceneViewTokens.Layout.dockIconSize).background(MaterialTheme.colorScheme.primary, MaterialTheme.shapes.extraLarge).padding(SceneViewTokens.Space.xs)</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:Row</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:Row(Modifier.fillMaxWidth().padding(horizontal = SceneViewTokens.Space.md), horizontalArrangement = Arrangement.SpaceBetween) { Text("Show environment"); Switch(showEnvironment, onShowEnvironment) }</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:Text("Lighting", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.md))</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:TextButton(onClick = onReset, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.sm)) { Text("Reset lighting") }</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:ViewerEnvironment</ID>
+    <ID>MaxLineLength:EnvironmentSheet.kt:color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant</ID>
+    <ID>MaxLineLength:IcosaGalleryService.kt:IcosaAsset$listOf(GalleryThumbnail(it, thumbnail.width.takeIf { w -> w > 0 } ?: 1024, thumbnail.height.takeIf { h -> h > 0 } ?: 1024))</ID>
+    <ID>MaxLineLength:MainActivity.kt:popEnterTransition = { slideInHorizontally(navMotion()) { -it / NAV_SLIDE_FRACTION } + fadeIn(navMotion()) }</ID>
+    <ID>MaxLineLength:ModelPickerSheet.kt:.</ID>
+    <ID>MaxLineLength:ModelPickerSheet.kt:Box</ID>
+    <ID>MaxLineLength:ModelPickerSheet.kt:ModelThumbnails.resourceFor(model.assetName)?.let { Image(painterResource(it), null, Modifier.fillMaxSize()) }</ID>
+    <ID>MaxLineLength:ModelPickerSheet.kt:Text("Models", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(horizontal = SceneViewTokens.Space.md))</ID>
+    <ID>MaxLineLength:ModelPickerSheet.kt:Text(model.displayName, style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(top = SceneViewTokens.Space.xs))</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:(0 until animator.animationCount).map { animator.getAnimationName(it).takeIf(String::isNotBlank) ?: "Clip ${it + 1}" }</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:)</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:Row</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:activeModelInstance?.animator?.takeIf { selectedAnimation in 0 until it.animationCount }</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:animator.applyAnimation(selectedAnimation, it * animator.getAnimationDuration(selectedAnimation))</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:derivedStateOf { firstFrame.rendered.value &amp;&amp; firstEnvironmentLoaded &amp;&amp; modelFramesSeen.value >= MODEL_COVER_FRAMES }</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:onSelect = { requestedEnvironment = it }</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:onSurprise = { if (!surpriseInFlight) { surpriseInFlight = true; scope.launch { streamedFileUrl = runCatching { pickRandomDownloadableModel(service, resolver) }.getOrNull(); surpriseInFlight = false; modelSheetOpen = false } } }</ID>
+    <ID>MaxLineLength:ModelViewerDemo.kt:val modelYaw = rememberHeroYaw(trigger = spinScene &amp;&amp; activeModelInstance != null, durationMillis = 20_000, staticYaw = 0f)</ID>
+    <ID>MaxLineLength:SceneViewTokens.kt:SceneViewTokens.Type$val display = TextStyle(fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold, letterSpacing = (-0.02).em)</ID>
+    <ID>MaxLineLength:SceneViewTokens.kt:SceneViewTokens.Type$val title = TextStyle(fontSize = 22.sp, lineHeight = 26.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-0.02).em)</ID>
+    <ID>MaxLineLength:SketchfabAssetResolverTest.kt:SketchfabAssetResolverTest$assertFalse("a streamed download must not be reported as bundled", SketchfabAssetResolver.isBundledFallback(streamed))</ID>
+    <ID>MaxLineLength:WallPlacementDemo.kt:CubeNode(size = Size(1.20f, 0.68f, 0.01f), position = Position(z = 0.045f), materialInstance = screen)</ID>
+    <ID>MaxLineLength:WallPlacementDemo.kt:CubeNode(size = Size(1.26f, 0.74f, 0.04f), position = Position(z = 0.02f), materialInstance = body)</ID>
+    <ID>ThrowsCount:NetworkModelDownloader.kt:NetworkModelDownloader$@Suppress("NestedBlockDepth") // use{} + temp-file try/catch + streaming loop is inherently nested private suspend fun streamTo</ID>
+    <ID>TooManyFunctions:CloudAnchorCardsPreviews.kt:io.github.sceneview.demo.common.CloudAnchorCardsPreviews.kt</ID>
+    <ID>UnusedParameter:ModelViewerDemo.kt:mode: ModelViewerMode</ID>
+    <ID>UnusedParameter:ModelViewerDemo.kt:onModeChange: (ModelViewerMode) -> Unit</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/changelog.d/3450-demo-detekt-task-dependency.md
+++ b/changelog.d/3450-demo-detekt-task-dependency.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **`./gradlew :samples:android-demo:detekt` no longer fails Gradle's task-ordering validation
+  ([#3450](https://github.com/sceneview/sceneview/issues/3450)).** detekt scans the same
+  `src/main/java` tree kotlinc compiles, which contains the build-generated `GeneratedDemos.kt`,
+  but only the Kotlin compile tasks declared their dependency on `generateDemoRegistry`; the demo's
+  detekt tasks now declare it too. The CI `Lint` job runs the demo's detekt alongside the four
+  library modules, so the task is exercised on every Android PR instead of only on a maintainer's
+  machine; its 93 pre-existing findings (70 of them `MaxLineLength`, 91 distinct signatures) are grandfathered in
+  `buildSrc/config/detekt/baseline-android-demo.xml`, the same treatment the library modules got, so
+  only new violations fail.

--- a/changelog.d/3462-flutter-demo-lockfile.md
+++ b/changelog.d/3462-flutter-demo-lockfile.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+- **The Flutter demo's `pubspec.lock` now records `flutter_sceneview` at the plugin's current version
+  ([#3462](https://github.com/sceneview/sceneview/issues/3462)).** The lockfile still pinned the
+  path-based plugin entry at 4.31.0 while `flutter/sceneview_flutter/pubspec.yaml` had moved on, so
+  a fresh clone's first `flutter pub get` rewrote a tracked file before any code was touched. The
+  lockfile stays committed (the Flutter team's recommendation for applications); the demo README now
+  says it is refreshed by `flutter pub get` and never hand-edited.

--- a/samples/android-demo/build.gradle
+++ b/samples/android-demo/build.gradle
@@ -388,6 +388,14 @@ tasks.matching { it.name.startsWith("compile") && it.name.endsWith("Kotlin") }.c
 tasks.matching { it.name == "preBuild" }.configureEach {
     dependsOn(generateDemoRegistry)
 }
+// detekt reads the same `src/main/java` tree kotlinc does, so every detekt task
+// (`detekt`, `detektBaseline`, ...) consumes `GeneratedDemos.kt` too. Without this
+// edge Gradle fails validation with "implicit dependency on generateDemoRegistry"
+// as soon as both tasks are in the graph (#3450) — which is also why the demo's
+// detekt task must run in CI: it was never scheduled, so nobody saw it.
+tasks.matching { it.name.startsWith("detekt") }.configureEach {
+    dependsOn(generateDemoRegistry)
+}
 
 // ─── Bundled "What's new" changelog ──────────────────────────────────────
 //

--- a/samples/flutter-demo/README.md
+++ b/samples/flutter-demo/README.md
@@ -63,6 +63,11 @@ flutter pub get
 flutter run
 ```
 
+`pubspec.lock` is committed (the Flutter team's recommendation for applications) and
+is refreshed by `flutter pub get` — never hand-edit it. After bumping the plugin's
+`version` in `flutter/sceneview_flutter/pubspec.yaml`, re-run `flutter pub get` here
+and commit the lockfile so a fresh clone and CI resolve the same `flutter_sceneview`.
+
 ## Integration Tests
 
 ```bash

--- a/samples/flutter-demo/pubspec.lock
+++ b/samples/flutter-demo/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: "../../flutter/sceneview_flutter"
       relative: true
     source: path
-    version: "4.31.0"
+    version: "4.34.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter


### PR DESCRIPTION
Fixes #3450
Fixes #3462

## #3450 — `:samples:android-demo:detekt` task-ordering validation error

**Cause.** detekt scans `src/main/java`, which holds the build-generated (gitignored) `GeneratedDemos.kt`; only the `compile*Kotlin` tasks and `preBuild` declared `dependsOn(generateDemoRegistry)`. With both tasks in one graph, Gradle 9.7.1 refuses to run.

**Fix.** `samples/android-demo/build.gradle`: every `detekt*` task (`detekt`, `detektBaseline`, ...) now `dependsOn(generateDemoRegistry)`, using the same `tasks.matching { ... }.configureEach` form the compile wiring already uses.

**CI made honest.** The `Lint` job's Detekt step now includes `:samples:android-demo:detekt` and uploads its report. The demo has 93 pre-existing findings (70 `MaxLineLength`, 10 `MatchingDeclarationName`, 4 `UnusedParameter`, 3 `LoopWithTooManyJumpStatements`, 2 `ComplexCondition`, 1 each `TooManyFunctions` / `ThrowsCount` / `LongMethod` / `CyclomaticComplexMethod`) — not a handful, so they are grandfathered in `buildSrc/config/detekt/baseline-android-demo.xml` (91 distinct signatures), the treatment the library modules received in #1740. Only new violations fail from here. Nothing to add to CONTRIBUTING.md since the demo is now included rather than excluded.

Commands (all `--no-daemon --max-workers=2`, Gradle 9.7.1):

| Command | Result |
|---|---|
| HEAD `build.gradle`: `./gradlew :samples:android-demo:generateDemoRegistry :samples:android-demo:detekt --rerun` | BUILD FAILED in 36s — "Property has implicit dependency … Task ':samples:android-demo:detekt' uses this output of task ':samples:android-demo:generateDemoRegistry' without declaring an explicit or implicit dependency" |
| HEAD `build.gradle`: `./gradlew :samples:android-demo:detekt --rerun` (generated file already on disk, generator not scheduled) | BUILD FAILED in 1m 13s — "Analysis failed with 93 issues" |
| Fixed: `./gradlew :samples:android-demo:detektBaseline` | BUILD SUCCESSFUL in 2m 47s — wrote `baseline-android-demo.xml` |
| Fixed: `./gradlew :samples:android-demo:detekt --rerun` | BUILD SUCCESSFUL in 6m 58s — `generateDemoRegistry` UP-TO-DATE, `detekt` executed, 0 new issues |

## #3462 — stale `samples/flutter-demo/pubspec.lock`

Flutter on this Mac: **3.41.6 stable** (`flutter --version --machine`), the version the issue and CI use.

| Command | Result |
|---|---|
| `flutter pub get --directory samples/flutter-demo` | "Changed 1 dependency" — the only lockfile diff is `flutter_sceneview` `version: "4.31.0"` → `"4.34.0"` (the plugin's current `pubspec.yaml`; it was 4.33.0 when the issue was filed). No transitive pin changed. |
| `flutter analyze --no-fatal-infos --no-fatal-warnings` (demo, CI flags) | exit 0 — 26 issues, all infos/warnings, same untriaged set CI already tolerates |

**Decision.** The lockfile stays committed: the Flutter team recommends committing `pubspec.lock` for applications, and the demo is one. `samples/flutter-demo/README.md` now states it is refreshed by `flutter pub get`, never hand-edited, and must be re-run after a plugin version bump so a fresh clone and CI resolve the same `flutter_sceneview`. The Flutter track stays independent of `VERSION_NAME`; nothing under `flutter/` changed.

## Changelog

- `changelog.d/3450-demo-detekt-task-dependency.md` (Fixed)
- `changelog.d/3462-flutter-demo-lockfile.md` (Fixed)

## Needs device

None — build wiring, CI configuration and a lockfile refresh; no runtime behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
