### PR TITLE
refactor(demo): one gated qa_state extra for every QA state pin (#3455)

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -186,6 +186,12 @@ and pass `--allow-offline` to acknowledge a deliberately offline run.
    (the same closed-registry allow-list as the `sceneview://demo/<id>` scheme),
    and `qa_mode` freezes auto-rotation for a deterministic screenshot. Maestro
    `launchApp` has no `deepLink` property — that key aborts flow parsing.
+   State-driven flows (`flows/ar-cloud-anchor.yaml`) add one more argument,
+   `qa_state: <id>` — the single seam that pins a demo to a named state the
+   emulator cannot reach on its own ([#3421](https://github.com/sceneview/sceneview/issues/3421),
+   [#3455](https://github.com/sceneview/sceneview/issues/3455)). It is ignored
+   unless `qa_mode` is also set; the per-demo id lists live in
+   `samples/android-demo/README.md`.
 2. Orbit the camera (two opposite horizontal drags + one vertical drag).
 3. Tap the viewport centre (node pick / harmless empty-space tap).
 4. Capture **exactly one** screenshot (`demo-<id>`).

--- a/changelog.d/3455-qa-state-single-seam.md
+++ b/changelog.d/3455-qa-state-single-seam.md
@@ -1,0 +1,14 @@
+<!-- category: Changed -->
+- **One QA state-pin extra instead of two ([#3455](https://github.com/sceneview/sceneview/issues/3455)).**
+  #3449 and #3451 each landed an intent extra that pins an Android demo into a named UI
+  state so the emulator, which has neither ARCore nor AICore (#2754), can capture every
+  state: `qa_ask_state` for Point & Ask, ungated, and `qa_state` for Cloud Anchors, gated
+  on `qa_mode`. They are now the same seam. `--ez qa_mode true --es qa_state <id>` carries
+  every demo's vocabulary — Point & Ask reads its eleven card ids (`checking` … `failed-persistent`)
+  through it, Cloud Anchors its fourteen scenarios — and each demo ignores the ids it does
+  not know. The gate lives in one pure function, `DeepLinkRouter.resolveQaState`, which
+  returns `null` unless `qa_mode` is on; a unit test pins both the accepted and the ignored
+  path, and Point & Ask now also drops its pin at runtime when QA mode is toggled off from
+  the sheet, as Cloud Anchors already did. State ids are unchanged, so an existing capture
+  command only renames the extra. `qa_ask_state` is gone; the demo README lists both id
+  sets next to the one command that uses them.

--- a/samples/android-demo/README.md
+++ b/samples/android-demo/README.md
@@ -58,6 +58,23 @@ within 1.5 s, and switches itself off as soon as one does. The photos are genera
 `python3 tools/demo-previews/backdrops.py` into `src/debug/res/drawable-nodpi/` and are
 never shipped in release builds. The Maestro flows under `.maestro/android/` pass it.
 
+A backdrop gives an AR demo a background; it cannot give it a *state*. Demos whose
+interesting states need something the emulator does not have (a live Cloud Anchors project
+and a second phone, AICore) can be pinned to one named state with `--es qa_state <id>`,
+which is **ignored unless `qa_mode` is on** (`DeepLinkRouter.resolveQaState`,
+`DemoSettings.qaDemoState`). One extra, one vocabulary per demo — an id a demo does not
+know leaves it in its real state:
+
+```bash
+adb shell am start -n io.github.sceneview.demo/.MainActivity --es demo ar-cloud-anchor --ez qa_mode true --es qa_state hosted
+adb shell am start -n io.github.sceneview.demo/.MainActivity --es demo point-and-ask --ez qa_mode true --es qa_state streaming
+```
+
+| Demo | `qa_state` ids | Resolver |
+|---|---|---|
+| `ar-cloud-anchor` | `placing` `mapping` `ready_to_host` `hosting` `hosted` `host_failed` `resolve_empty` `resolve_ready` `resolving` `resolved` `resolve_not_found` `api_key_missing` `api_key_rejected` `no_network` (case- and separator-insensitive) | `cloudAnchorScenarioOf` |
+| `point-and-ask` | `checking` `downloadable` `downloading` `unsupported` `ready` `capturing` `thinking` `streaming` `answered` `failed` `failed-persistent` | `askStepForQaOverride` (`ASK_QA_STATE_IDS`) |
+
 ## Requirements
 
 - Android device or emulator (API 28+) — this is the demo app's `minSdk`; the SceneView library itself supports API 24+

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DeepLinkRouter.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DeepLinkRouter.kt
@@ -350,6 +350,23 @@ internal object DeepLinkRouter {
     }
 
     /**
+     * Resolves the `--es qa_state <id>` intent extra to the state id a demo may pin itself
+     * to, or `null` for "run the real state machine" (#3421, #3455).
+     *
+     * One extra carries every demo's vocabulary — Cloud Anchors resolves its ids with
+     * `cloudAnchorScenarioOf`, Point & Ask with `askStepForQaOverride` — and this is the
+     * single place the gate lives: the id is returned **only when [qaMode] is on**. A
+     * pinned state makes a screen claim something that never happened (a hosted anchor
+     * code, a streamed answer), so unlike `qa_backdrop`, which only changes what is behind
+     * the scene, an intent extra alone must never be enough to reach it. Blank ids are
+     * dropped so a demo never has to distinguish `""` from absent. Never throws.
+     */
+    fun resolveQaState(qaMode: Boolean, raw: String?): String? {
+        if (!qaMode) return null
+        return raw?.trim()?.takeIf { it.isNotBlank() }
+    }
+
+    /**
      * Extracts the raw id token from a URI without validating it against
      * a registry. Exposed so tests can verify the URI parser separately
      * from the registry lookup.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
@@ -43,33 +43,32 @@ object DemoSettings {
     var qaBackdrop: Boolean? by mutableStateOf(null)
 
     /**
-     * QA-only name of the visual state a demo should force itself into (`--es qa_state
-     * <name>`), or `null` for the demo's real, live state (#3421).
+     * QA-only id of the visual state a demo should force itself into (`--es qa_state
+     * <id>`), or `null` for the demo's real, live state (#3421, #3455).
      *
      * The generic seam for a problem `qaBackdrop` does not solve. The backdrop gives an AR
      * demo a *background* on a device without a camera; it cannot give it a *state*. Cloud
-     * Anchors is the first demo whose interesting states — hosting, hosted, code expired —
+     * Anchors was the first demo whose interesting states — hosting, hosted, code expired —
      * need a live cloud service and a second phone, so none of them can be reached on
      * `emulator-5554` (#2754) and the smoke suite could only ever capture the empty first
-     * frame. That is precisely the frame that looked fine while #3421 was open.
+     * frame. That is precisely the frame that looked fine while #3421 was open. Point & Ask
+     * has the same problem with AICore: without it, every card past "checking" is
+     * unreachable (#3407).
      *
-     * Each demo owns its own vocabulary of names and resolves them itself (Cloud Anchors:
-     * [io.github.sceneview.demo.demos.internal.cloudAnchorScenarioOf]); an unknown name
-     * leaves the demo alone rather than guessing. Only read where
-     * [io.github.sceneview.demo.common.qaStateOverridesAllowed] is honoured, so a release
-     * build cannot be steered into a fake state by an intent.
+     * One extra, per-demo vocabularies. Each demo resolves the ids it knows and ignores the
+     * rest, so an unknown id leaves the demo alone rather than guessing:
+     *  - Cloud Anchors: [io.github.sceneview.demo.demos.internal.cloudAnchorScenarioOf]
+     *    (`placing`, `hosted`, `resolve_not_found`, …);
+     *  - Point & Ask: [io.github.sceneview.demo.ai.askStepForQaOverride], ids listed in
+     *    [io.github.sceneview.demo.ai.ASK_QA_STATE_IDS] (`ready`, `streaming`, `failed`, …).
+     *
+     * Set only through [io.github.sceneview.demo.DeepLinkRouter.resolveQaState], which
+     * returns `null` unless [qaMode] is on, and only read where
+     * [io.github.sceneview.demo.common.qaStateOverridesAllowed] is honoured — so a release
+     * build cannot be steered into a fake state by an intent, and toggling QA mode off from
+     * the sheet drops the pin at once.
      */
     var qaDemoState: String? by mutableStateOf(null)
-
-    /**
-     * QA-only Point & Ask card override (#3407). `--es qa_ask_state <id>` pins the demo's
-     * bottom card to one state — see [io.github.sceneview.demo.ai.askStepForQaOverride] and
-     * [io.github.sceneview.demo.ai.ASK_QA_STATE_IDS] — so a light + dark screenshot of every
-     * state can be taken on an emulator that has neither ARCore nor AICore (#2754). `null`
-     * (default) leaves the demo running its real state machine; an unrecognised id is
-     * ignored the same way.
-     */
-    var qaAskState: String? by mutableStateOf(null)
 
     /**
      * Optional camera-to-model distance, in metres, the 3D demos should frame the model at

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -105,10 +105,10 @@ class MainActivity : ComponentActivity() {
         // showcase frozen until process death.
         DemoSettings.qaMode = intent?.getBooleanExtra("qa_mode", false) ?: false
         DemoSettings.qaBackdrop = resolveQaBackdrop(intent)
-        // Optional name of a visual state a demo should pin itself to (#3421). Only honoured
-        // in QA mode — a forced state makes a demo show something that never happened.
+        // Optional id of a visual state a demo should pin itself to (#3421, #3455). One extra
+        // for every demo's vocabulary (Cloud Anchors, Point & Ask). Only honoured in QA mode
+        // — a forced state makes a demo show something that never happened.
         DemoSettings.qaDemoState = resolveQaDemoState(intent)
-        DemoSettings.qaAskState = intent?.getStringExtra("qa_ask_state")
         // Optional path to an ARCore playback fixture (.mp4). Confined to the app's own
         // external-files dir so a malicious deep link can't probe arbitrary device paths
         // (`/data/data/...`, photos, configs). The path is consumed once by
@@ -146,7 +146,6 @@ class MainActivity : ComponentActivity() {
         DemoSettings.qaMode = intent.getBooleanExtra("qa_mode", false)
         DemoSettings.qaBackdrop = resolveQaBackdrop(intent)
         DemoSettings.qaDemoState = resolveQaDemoState(intent)
-        DemoSettings.qaAskState = intent.getStringExtra("qa_ask_state")
         DemoSettings.arPendingPlaybackFile = intent.getStringExtra("ar_playback_file")
             ?.takeIf { isWithinAppFilesDir(it) }
         DemoSettings.cameraDistance = resolveCameraDistance(intent)
@@ -161,17 +160,20 @@ class MainActivity : ComponentActivity() {
         intent?.takeIf { it.hasExtra("qa_backdrop") }?.getBooleanExtra("qa_backdrop", false)
 
     /**
-     * `--es qa_state <name>` pins a demo to one named visual state (#3421) — the seam the
-     * emulator smoke suite uses to capture Cloud Anchor states that need a live cloud
-     * service and a second device, and are therefore unreachable on `emulator-5554`
-     * (#2754).
+     * `--es qa_state <id>` pins a demo to one named visual state (#3421, #3455) — the one
+     * seam the emulator smoke suite uses to capture states that need hardware or services
+     * `emulator-5554` does not have (#2754): Cloud Anchor host / resolve states (a live
+     * cloud project and a second device), Point & Ask cards (AICore). Each demo owns its
+     * own ids; see [DemoSettings.qaDemoState].
      *
-     * Gated on `qa_mode`, deliberately: unlike the camera backdrop, which only changes what
-     * is *behind* the scene, this changes what the demo *claims*, so it must never be
-     * reachable from an ordinary launch. Tracks the latest intent like the other QA extras.
+     * Gated on `qa_mode` by [DeepLinkRouter.resolveQaState], deliberately: unlike the camera
+     * backdrop, which only changes what is *behind* the scene, this changes what the demo
+     * *claims*, so it must never be reachable from an ordinary launch. Reads
+     * [DemoSettings.qaMode] rather than the extra again so the gate and the flag it guards
+     * cannot disagree. Tracks the latest intent like the other QA extras.
      */
     private fun resolveQaDemoState(intent: Intent?): String? =
-        intent?.getStringExtra("qa_state")?.takeIf { DemoSettings.qaMode }
+        DeepLinkRouter.resolveQaState(DemoSettings.qaMode, intent?.getStringExtra("qa_state"))
 
     /**
      * Resolves the optional initial tab a consolidated demo should pre-select from an

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFlow.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ai/AskFlow.kt
@@ -238,9 +238,11 @@ class AskFlow(
 }
 
 /**
- * QA-only step override (`--es qa_ask_state <id>`), so every card can be screenshot in light
- * and dark on an emulator that has neither ARCore nor AICore (#2754). Returns `null` for an
- * absent or unrecognised id, which leaves the demo running its real state machine.
+ * QA-only step override (`--es qa_state <id>`, the shared QA state seam — see
+ * `DemoSettings.qaDemoState`), so every card can be screenshot in light and dark on an
+ * emulator that has neither ARCore nor AICore (#2754). Returns `null` for an absent or
+ * unrecognised id, which leaves the demo running its real state machine — including the
+ * Cloud Anchor ids that travel through the same extra.
  *
  * Pure lookup — unit-tested rather than trusted, because a typo here would silently produce
  * a QA sweep of the wrong card.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PointAndAskDemo.kt
@@ -107,6 +107,7 @@ import io.github.sceneview.demo.common.QaCameraBackdrop
 import io.github.sceneview.demo.common.putVoiceSilenceExtras
 import io.github.sceneview.demo.common.qaCameraBackdropEnabled
 import io.github.sceneview.demo.common.qaCameraBackdropSurfaceType
+import io.github.sceneview.demo.common.qaStateOverridesAllowed
 import io.github.sceneview.demo.common.rememberQaCameraBackdropActive
 import io.github.sceneview.demo.demos.internal.ArPlacement
 import io.github.sceneview.demo.demos.internal.DemoMath
@@ -260,7 +261,7 @@ private class AnswerPanel(
  * Under `DemoSettings.qaMode` the engine is a deterministic canned stand-in, and a capture
  * the emulator cannot produce falls back to a synthetic (textured, so it passes the real
  * validation) frame — the tap → capture → answer UI flow stays device-QA-able. Every card
- * can additionally be pinned for screenshots with `--es qa_ask_state <id>`
+ * can additionally be pinned for screenshots with `--ez qa_mode true --es qa_state <id>`
  * (`ASK_QA_STATE_IDS`), because an emulator has neither ARCore nor AICore (#2754).
  *
  * P1+P2+P3 of [#2648](https://github.com/sceneview/sceneview/issues/2648), plus the
@@ -311,10 +312,13 @@ fun PointAndAskDemo(onBack: () -> Unit) {
     var step by remember { mutableStateOf<AskStep>(AskStep.CheckingAvailability) }
     val syncStep: () -> Unit = { step = flow.step }
 
-    // QA-only card override (`--es qa_ask_state <id>`): pins the bottom card to one state so
-    // an emulator with neither ARCore nor AICore (#2754) can still screenshot every state in
-    // light and dark. `null` for every normal launch.
-    val qaStep = remember(DemoSettings.qaAskState) { askStepForQaOverride(DemoSettings.qaAskState) }
+    // QA-only card override (`--es qa_state <id>`, the shared seam of #3421 / #3455): pins
+    // the bottom card to one state so an emulator with neither ARCore nor AICore (#2754)
+    // can still screenshot every state in light and dark. `null` for every normal launch:
+    // MainActivity only sets the id under `qa_mode`, and the runtime gate here drops the pin
+    // the moment QA mode is toggled off from the sheet, exactly like Cloud Anchors.
+    val qaStateId = DemoSettings.qaDemoState?.takeIf { qaStateOverridesAllowed() }
+    val qaStep = remember(qaStateId) { askStepForQaOverride(qaStateId) }
     val shownStep = qaStep ?: step
 
     LaunchedEffect(askEngine) {

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/DeepLinkRouterTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/DeepLinkRouterTest.kt
@@ -592,4 +592,36 @@ class DeepLinkRouterTest {
     fun `the instant-placement alias carries no tab pre-selection`() {
         assertNull(DeepLinkRouter.ALIAS_INITIAL_TAB["ar-instant-placement"])
     }
+
+    // ── `--es qa_state <id>` — the one QA state seam (#3421, #3455) ────────────────────
+
+    /**
+     * Under `qa_mode` the extra is passed through verbatim (trimmed): the router does not
+     * know any demo's vocabulary, so both Cloud Anchor and Point & Ask ids must survive it
+     * unchanged for each demo's own resolver to recognise them.
+     */
+    @Test
+    fun `qa_state is accepted when qa_mode is on`() {
+        assertEquals("placing", DeepLinkRouter.resolveQaState(qaMode = true, raw = "placing"))
+        assertEquals("resolve_not_found", DeepLinkRouter.resolveQaState(qaMode = true, raw = "resolve_not_found"))
+        assertEquals("failed-persistent", DeepLinkRouter.resolveQaState(qaMode = true, raw = "failed-persistent"))
+        assertEquals("ready", DeepLinkRouter.resolveQaState(qaMode = true, raw = "  ready "))
+    }
+
+    /**
+     * Without `qa_mode` the extra is ignored outright — a pinned state makes a screen claim
+     * something that never happened, so `adb shell am start --es qa_state hosted` against a
+     * production install must be a no-op. This is the path that keeps the seam out of
+     * release builds; a blank id is dropped on either path.
+     */
+    @Test
+    fun `qa_state is ignored when qa_mode is off`() {
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = false, raw = "placing"))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = false, raw = "hosted"))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = false, raw = "answered"))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = false, raw = null))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = true, raw = null))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = true, raw = ""))
+        assertNull(DeepLinkRouter.resolveQaState(qaMode = true, raw = "   "))
+    }
 }


### PR DESCRIPTION
Fixes #3455

## What

PR #3449 (Point & Ask) and #3451 (Cloud Anchor) each added an intent extra that pins an Android demo into a named UI state so the emulator — no ARCore, no AICore (#2754) — can capture every state. `qa_ask_state` was Point & Ask only and **not gated**; `qa_state` was generic and gated on `qa_mode`. This collapses them into the single gated seam.

- `DeepLinkRouter.resolveQaState(qaMode, raw)` is the one gate: returns the trimmed id only when `qa_mode` is on, `null` otherwise (and for blank ids). `MainActivity.resolveQaDemoState` delegates to it in both `onCreate` and `onNewIntent`.
- `PointAndAskDemo` reads `DemoSettings.qaDemoState` behind `qaStateOverridesAllowed()`, the same runtime gate Cloud Anchors uses — toggling QA mode off from the sheet now drops the Point & Ask pin too.
- `qa_ask_state` and `DemoSettings.qaAskState` are removed. **State ids are unchanged**: an existing capture command only renames the extra.
- `DeepLinkRouterTest` gains `qa_state is accepted when qa_mode is on` and `qa_state is ignored when qa_mode is off` (both vocabularies, `null`/blank on both paths).
- Docs: `samples/android-demo/README.md` gets the one command and a per-demo id table; `.maestro/README.md` points the state-driven flows at the single extra. No Maestro flow referenced `qa_ask_state` (`flows/ar-cloud-anchor.yaml` already used `qa_state`), and `device-qa.sh` never documented either extra, so neither needed a change.

## State matrix (emulator-5554, debug APK, `--ez qa_mode true --ez qa_backdrop true --es qa_state <id>`)

Each row was launched cold and verified by screenshot plus a `uiautomator dump` text check of the pinned card.

| Demo | state id | capture ok |
|---|---|---|
| `ar-cloud-anchor` | `placing` | ✓ "Tap a surface to place the anchor." |
| `ar-cloud-anchor` | `mapping` | ✓ "Walk around the anchor to map the room." / Room mapping |
| `ar-cloud-anchor` | `ready_to_host` | ✓ "Room mapped. Tap Host." |
| `ar-cloud-anchor` | `hosting` | ✓ "Hosting the anchor…" |
| `ar-cloud-anchor` | `hosted` | ✓ "Hosted. Share the code…" / Anchor code / Share / Copy (light + **dark**) |
| `ar-cloud-anchor` | `host_failed` | ✓ "Not enough room detail to host…" |
| `ar-cloud-anchor` | `resolve_empty` | ✓ "Paste a code shared from another device." |
| `ar-cloud-anchor` | `resolve_ready` | ✓ "Stand where it was hosted, then tap Resolve." |
| `ar-cloud-anchor` | `resolving` | ✓ "Resolving the code…" |
| `ar-cloud-anchor` | `resolved` | ✓ "Resolved. Look around to find the anchor." |
| `ar-cloud-anchor` | `resolve_not_found` | ✓ "No anchor for that code. Codes expire after 1 day." |
| `ar-cloud-anchor` | `api_key_missing` | ✓ "Cloud Anchors not configured" |
| `ar-cloud-anchor` | `api_key_rejected` | ✓ "ARCore key rejected" |
| `ar-cloud-anchor` | `no_network` | ✓ "No network connection…" |
| `point-and-ask` | `checking` | ✓ "Checking Gemini Nano availability…" |
| `point-and-ask` | `downloadable` | ✓ "Gemini Nano can run on this device…" |
| `point-and-ask` | `downloading` | ✓ "Downloading Gemini Nano… 412 MB" |
| `point-and-ask` | `unsupported` | ✓ "Gemini Nano isn't available on this device" |
| `point-and-ask` | `ready` | ✓ "Scanning for surfaces…" |
| `point-and-ask` | `capturing` | ✓ "Capturing the AR frame…" |
| `point-and-ask` | `thinking` | ✓ "✦ Gemini Nano is thinking…" |
| `point-and-ask` | `streaming` | ✓ partial answer + cursor (light + **dark**) |
| `point-and-ask` | `answered` | ✓ full sample answer |
| `point-and-ask` | `failed` | ✓ "The captured frame was blank…" |
| `point-and-ask` | `failed-persistent` | ✓ "This keeps failing here" |

Negative path, same APK, `--es qa_state` **without** `--ez qa_mode true`: `ar-cloud-anchor hosted` shows the live "AR is unavailable on this device." first frame and `point-and-ask streaming` shows the real "Gemini Nano isn't available on this device" card — the pin is ignored.

## Verification

- `:samples:android-demo:testDebugUnitTest` and `:samples:android-demo:testReleaseUnitTest` — BUILD SUCCESSFUL, `DeepLinkRouterTest` 46/46 in both variants (incl. the two new cases), no failing suite in the 70 result files.
- `:samples:android-demo:assembleDebug` built and installed on `emulator-5554`; 25 light captures + 2 dark + 2 negative as above.
- Maestro: not installed locally; `flows/ar-cloud-anchor.yaml` was already on `qa_state` and is unchanged, so no flow was edited or executed.

## Needs device

- Live (unpinned) Point & Ask and Cloud Anchor behaviour — the emulator has neither ARCore nor AICore (#2754), so every card past "checking" and every host/resolve state only exist here through the pin. On the emulator Point & Ask also shows the "Couldn't start AR" dialog above the pinned card (ARCore session cannot start); that is pre-existing and unrelated to this change.
- The runtime un-pin (toggle QA mode off from the settings sheet while pinned) was verified by code path, not by tapping through on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
