### PR TITLE
fix(gates): a missing tool reports "could not run", never a failing check (#3192)

### DIFF
--- a/.claude/scripts/ar-replay-qa.sh
+++ b/.claude/scripts/ar-replay-qa.sh
@@ -64,7 +64,8 @@
 #      OR the harness died before writing ANY verdict for ANY shard (a setUp /
 #      asset-deploy crash). The merged summary names the crashed demo(s) and the
 #      captured logcat holds the crash signature (#2620)
-#   2  no device / emulator connected
+#   2  could not run — no device / emulator connected, or python3 (which merges
+#      the shard verdicts) is unavailable on this host. Never a verdict about AR
 #   3  SKIPPED — no demo crashed, but one or more demos were not validated:
 #      `ar-record-playback` advanced 0 frames (ARCore dataset playback is
 #      unsupported on this emulator — #1645), and/or a shard was severed under
@@ -103,6 +104,17 @@ while [[ $# -gt 0 ]]; do
     *) echo "[ar-replay-qa] unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# ── Host check ─────────────────────────────────────────────────────────────
+# The per-shard verdicts are merged with python3 at the end of the run. Checked
+# up front so a host without it does not spend a full emulator sweep first, and
+# reported as exit 2 (could not run) — never exit 1, which this script reserves
+# for "a demo crashed" (#3192).
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[ar-replay-qa] CANNOT RUN: python3 unavailable — the shard verdicts cannot be merged." >&2
+  echo "[ar-replay-qa] Tooling gap on this host, not an AR regression." >&2
+  exit 2
+fi
 
 # ── Device check ───────────────────────────────────────────────────────────
 # Remember whether a parent (device-qa.sh) handed us the serial: it already
@@ -336,8 +348,8 @@ fi
 # (its process was severed early) is recorded `skipped` with an environmental
 # reason — accounted for, never lost silently, never folded into `passed`.
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "[ar-replay-qa] python3 unavailable — cannot merge shard verdicts." >&2
-  exit 1
+  echo "[ar-replay-qa] CANNOT RUN: python3 unavailable — cannot merge shard verdicts." >&2
+  exit 2
 fi
 
 MERGE_VERDICT="$(

--- a/.claude/scripts/device-qa.sh
+++ b/.claude/scripts/device-qa.sh
@@ -822,7 +822,7 @@ run_ar() {
         record ar failed "ar-replay-qa.sh exited 0 without a positive marker — harness aborted mid-run" "$kept" "$(( $(date +%s) - started ))"
       fi
       ;;
-    2) record ar skipped "no device for ar-replay-qa.sh" "$kept" "$(( $(date +%s) - started ))" ;;
+    2) record ar skipped "ar-replay-qa.sh could not run — no device, or python3 missing (see ar-output.txt)" "$kept" "$(( $(date +%s) - started ))" ;;
     # rc=3: no demo crashed, but one or more demos were not validated —
     # `ar-record-playback` replayed 0 frames (ARCore dataset playback unsupported
     # on this emulator, #1645) and/or a shard was severed under emulator pressure

--- a/.claude/scripts/ios-device-qa.sh
+++ b/.claude/scripts/ios-device-qa.sh
@@ -138,13 +138,16 @@ if [[ ! -f "$FLOW_FILE" ]]; then
 fi
 
 # --- Host check ------------------------------------------------------------
+# A host that cannot run this leg at all is "could not run" — exit 2, the same
+# code a bad invocation gets above — never exit 1, which is what a flow that
+# really failed on a simulator returns (#3192).
 if [[ "$(uname -s)" != "Darwin" ]]; then
-  echo "[ios-qa] ERROR: the iOS simulator only runs on macOS." >&2
-  exit 1
+  echo "[ios-qa] CANNOT RUN: the iOS simulator only runs on macOS." >&2
+  exit 2
 fi
 if ! command -v xcrun >/dev/null 2>&1; then
-  echo "[ios-qa] ERROR: xcrun not found — install Xcode + command-line tools." >&2
-  exit 1
+  echo "[ios-qa] CANNOT RUN: xcrun not found — install Xcode + command-line tools." >&2
+  exit 2
 fi
 
 # --- Boot a simulator ------------------------------------------------------

--- a/.claude/scripts/qa-android-demos.sh
+++ b/.claude/scripts/qa-android-demos.sh
@@ -206,7 +206,18 @@ if $INSTALL; then
     # cold build on a 2-core CI runner looked like a 40-min silent hang.
     # `timeout` bounds it so a genuinely stuck build/daemon fails fast with a
     # clear diagnostic instead of eating the whole CI job budget (#1560).
-    timeout "${ANDROID_BUILD_TIMEOUT:-1800}" \
+    # It is GNU coreutils, absent from a stock macOS host: a bare call there is
+    # `command not found` (127), which the `||` below reported as "APK build
+    # failed or timed out" without Gradle ever starting. Resolved the way
+    # lib/maestro.sh does — timeout, else gtimeout, else unbounded — so a
+    # missing tool can never read as a failed build (#3192).
+    build_timeout=()
+    if command -v timeout >/dev/null 2>&1; then
+      build_timeout=(timeout "${ANDROID_BUILD_TIMEOUT:-1800}")
+    elif command -v gtimeout >/dev/null 2>&1; then
+      build_timeout=(gtimeout "${ANDROID_BUILD_TIMEOUT:-1800}")
+    fi
+    ${build_timeout[@]+"${build_timeout[@]}"} \
       ./gradlew :samples:android-demo:assembleDebug --console=plain || {
         echo "[qa] ERROR: APK build failed or timed out (>${ANDROID_BUILD_TIMEOUT:-1800}s)" >&2
         exit 1

--- a/.claude/scripts/test-validate-demo-assets.sh
+++ b/.claude/scripts/test-validate-demo-assets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Self-test for validate-demo-assets.sh's could-not-run contract (#3192).
+#
+# A missing `curl` used to come back as HTTP 000 on every CDN URL, which the
+# validator's transient classifier read as a rate limit: 23 s of backoff per
+# URL, every reference reported "not checked (transient)", exit 0. The gate
+# must instead refuse to run (exit 2) and name the tool — and `--no-cdn`,
+# which never touches curl, must not trip that guard. curl is hidden by running
+# the validator under a PATH that mirrors the real one minus `curl`, so the
+# result does not depend on what this host has installed.
+#
+# Usage: bash .claude/scripts/test-validate-demo-assets.sh
+set -uo pipefail
+
+GATE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/validate-demo-assets.sh"
+[ -f "$GATE" ] || { echo "test-validate-demo-assets: gate not found at $GATE" >&2; exit 2; }
+
+GREEN=$'\033[0;32m'; RED=$'\033[0;31m'; NC=$'\033[0m'
+if [ ! -t 1 ]; then GREEN=""; RED=""; NC=""; fi
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "  ${GREEN}✓${NC} $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  ${RED}✗${NC} $1"; }
+
+# ── a PATH with everything the real one has, except curl ─────────────────────
+NOCURL="$(mktemp -d)"
+trap 'rm -rf "$NOCURL"' EXIT
+IFS=: read -r -a _dirs <<< "$PATH"
+for _p in "${_dirs[@]}"; do
+    [ -d "$_p" ] || continue
+    for _f in "$_p"/*; do
+        _b="$(basename "$_f")"
+        [ "$_b" = "curl" ] && continue
+        [ -e "$NOCURL/$_b" ] || ln -s "$_f" "$NOCURL/$_b" 2>/dev/null || true
+    done
+done
+if env PATH="$NOCURL" bash -c 'command -v curl' >/dev/null 2>&1; then
+    echo "test-validate-demo-assets: could not build a PATH without curl" >&2
+    exit 2
+fi
+
+# `--rn` keeps the scan itself to the smallest platform; the guard under test
+# fires before any scanning, so the platform only matters for the second case.
+run_gate() { OUT="$(env PATH="$NOCURL" bash "$GATE" "$@" 2>&1)"; RC=$?; }
+
+echo "test-validate-demo-assets"
+echo ""
+
+# ── 1. no curl, CDN checks on → could not run ────────────────────────────────
+run_gate --rn
+if [ "$RC" -eq 2 ] && printf '%s' "$OUT" | grep -q "CANNOT RUN: 'curl'"; then
+    ok "without curl the validator refuses to run (exit 2) and names the tool"
+else
+    bad "without curl: expected exit 2 + CANNOT RUN line, got rc=$RC: $(printf '%s' "$OUT" | tail -3 | tr '\n' ' ')"
+fi
+if ! printf '%s' "$OUT" | grep -q 'CDN refs checked'; then
+    ok "the refusal comes before any scan — no summary is printed"
+else
+    bad "a summary was printed by a run that could not check anything"
+fi
+
+# ── 2. no curl, --no-cdn → the guard stays out of the way ────────────────────
+# rc is whatever the tree earns today; only the could-not-run outcome is
+# asserted against.
+run_gate --rn --no-cdn
+if [ "$RC" -ne 2 ] && ! printf '%s' "$OUT" | grep -q 'CANNOT RUN'; then
+    ok "--no-cdn does not need curl and is not refused (rc=$RC)"
+else
+    bad "--no-cdn was refused without curl (rc=$RC)"
+fi
+
+echo ""
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/scripts/validate-demo-assets.sh
+++ b/.claude/scripts/validate-demo-assets.sh
@@ -20,7 +20,7 @@
 # Exit codes:
 #   0  all references resolve and the catalog has no drift
 #   1  at least one broken reference, or a bundled asset missing from catalog.json
-#   2  invalid arguments
+#   2  could not run — invalid arguments, or curl is unavailable while CDN checks are enabled
 
 set -euo pipefail
 
@@ -59,6 +59,18 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# A missing `curl` used to come back as HTTP 000 on every CDN URL, which the
+# transient classifier below reads as a rate limit: 23 s of backoff per URL,
+# every CDN reference reported "not checked (transient)", exit 0. A tool this
+# leg cannot do without is "could not run" (exit 2) — never a network hiccup
+# and never a pass (#3192). `--no-cdn` never touches curl and is not gated.
+if [ "$check_cdn" = true ] && ! command -v curl >/dev/null 2>&1; then
+    echo -e "${RED}CANNOT RUN: 'curl' is not available — every CDN reachability probe is a curl.${NC}" >&2
+    echo "  This is a tooling gap on this host, NOT evidence about the asset references." >&2
+    echo "  Install curl, or pass --no-cdn to run the bundled-file half on its own." >&2
+    exit 2
+fi
 
 total_bundled=0
 total_cdn=0

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -59,6 +59,8 @@ on:
       - '**/package.json'
       - '.claude/scripts/check-test-suites-reachable.sh'
       - '.claude/scripts/test-check-test-suites-reachable.sh'
+      - '.claude/scripts/validate-demo-assets.sh'
+      - '.claude/scripts/test-validate-demo-assets.sh'
   workflow_dispatch:
 
 concurrency:
@@ -192,6 +194,12 @@ jobs:
 
       - name: Self-test the test-suite reachability gate
         run: bash .claude/scripts/test-check-test-suites-reachable.sh
+
+      # Same shape, next gate over: the demo-asset validator must refuse to
+      # run without curl (exit 2) rather than report every CDN URL as a
+      # transient miss and exit 0 (#3192).
+      - name: Self-test the demo-asset validator's could-not-run contract
+        run: bash .claude/scripts/test-validate-demo-assets.sh
 
       - name: Check every test suite is reachable from a workflow
         run: bash .claude/scripts/check-test-suites-reachable.sh

--- a/changelog.d/3192-gate-exit-127.md
+++ b/changelog.d/3192-gate-exit-127.md
@@ -1,0 +1,15 @@
+<!-- category: Fixed -->
+- **A gate script that cannot find its tool now says "could not run" instead of reporting a
+  failure ([#3192](https://github.com/sceneview/sceneview/issues/3192), workstream 2).** Audit of
+  every script a workflow or `CLAUDE.md` still invokes as a check, now that #3244 has removed the
+  local harness (`pre-push-check.sh` and the `script_report_failure` helper the issue names are
+  gone with it). Four legs turned a missing tool into a verdict about the tree:
+  `validate-demo-assets.sh` read a missing `curl` as HTTP 000 → "transient", spent 23 s of
+  backoff per URL and exited 0 with every CDN reference "not checked"; `ios-device-qa.sh` exited
+  1 — the code a flow that really failed returns — when `xcrun` (or macOS itself) was absent;
+  `ar-replay-qa.sh` exited 1 — "a demo crashed" — when `python3` was missing for the verdict
+  merge, and only found out after a full emulator sweep; `qa-android-demos.sh` printed "APK
+  build failed or timed out" on a stock macOS host that has no GNU `timeout`, without Gradle
+  ever starting. Each now uses the code its own header reserves for "could not run" (exit 2,
+  checked up front), or resolves `gtimeout` the way `lib/maestro.sh` already does; nothing
+  changes when the tool is present. `test-validate-demo-assets.sh` pins the `curl` contract.

--- a/samples/README.md
+++ b/samples/README.md
@@ -219,7 +219,7 @@ clean checkout of `main` (validated in session 34, 2026-04-11).
 
 ## Asset integrity
 
-All demo apps are continuously verified by
+All demo apps are verified by
 `.claude/scripts/validate-demo-assets.sh`, which:
 
 - Scans every Kotlin, Swift, Dart, and TypeScript source file under
@@ -232,15 +232,12 @@ All demo apps are continuously verified by
   `Models/`, `src/jsMain/resources/`, and similar platform-specific
   asset directories.
 
-The script runs in three enforcement gates:
-
-1. **Local pre-push**: `bash .claude/scripts/pre-push-check.sh` runs it
-   with `--no-cdn` (fast) after all other checks.
-2. **Quality gate**: `bash .claude/scripts/quality-gate.sh` runs it with
-   full CDN checks unless `--quick` is passed.
-3. **CI on every PR**: `.github/workflows/pr-check.yml` runs both
-   `test-validate-demo-assets.sh` (self-test on a synthetic fixture)
-   and the full validator with live CDN checks.
+Nothing runs the validator automatically since #3244 removed the local
+harness (`pre-push-check.sh`, `quality-gate.sh`) — run it by hand before
+touching demo assets. Its could-not-run contract (no `curl` → exit 2, never
+a pass and never a "broken CDN") is self-tested by
+`.claude/scripts/test-validate-demo-assets.sh`, which `mcp-tests.yml` runs
+next to the other shell self-test.
 
 To run it manually:
 


### PR DESCRIPTION
Part of #3192 — workstream 2 only ("Gate internals: `exit 127` can read as a failing check").

## The precedent, and where it went

The helper the issue names, `script_report_failure`, lived in `.claude/scripts/lib/gradle-run.sh` and was removed together with `pre-push-check.sh` and ~40 other gate scripts by #3244 ("Remove the agent harness and keep only verification"). It classified exit ≥ 2 as INCOMPLETE (126/127: "the checker could not be executed"), exit 1 without the checker's proof line as INCOMPLETE, and only exit 1 *with* proof as a real error; the aggregator pre-checked tools with `command -v` and counted a `NOT_COVERED` "⚠ tool missing — NOT checked here (CI still gates it)" line. Nothing shared survives. What `main` has instead is the same rule in per-script form: **exit 2 = could not run**, declared in the header and enforced by an up-front `command -v` that prints `CANNOT RUN: '<tool>' … a tooling gap, not evidence` — `sync-versions.sh`, `web-bundle-smoke.sh`, `check-web-filamat-abi.sh`, `verify-published-version.sh`, and `store-preflight.sh`'s `skip_all`. This PR applies that per-script pattern to the legs that still miss it; no new mechanism.

## Audit — every script a workflow or `CLAUDE.md` still invokes as a check

| Leg | Runs from | External tools | Missing tool, before | After |
|---|---|---|---|---|
| `validate-demo-assets.sh` | manual (`samples/README.md`) | `curl` | HTTP 000 on every URL → "transient", 23 s backoff per URL, **exit 0**, `All references resolve ✓` | **fixed**: exit 2 `CANNOT RUN: 'curl'`, before any scan; `--no-cdn` untouched |
| `ios-device-qa.sh` | `device-qa.sh` ios leg; manual | `xcrun` (+ macOS) | **exit 1** `ERROR` — the same code a flow that really failed returns | **fixed**: exit 2 `CANNOT RUN` |
| `ar-replay-qa.sh` | `device-qa.sh` ar leg; manual | `python3`, `adb` | `python3`: **exit 1** = "a demo crashed", discovered only after a full emulator sweep | **fixed**: exit 2 up front (the script's own could-not-run code, header widened); `device-qa.sh` records the leg `skipped`, its one detail string updated |
| `qa-android-demos.sh` | `device-qa.sh` android leg; manual | `timeout`, `adb`, `gradlew` | stock macOS has no GNU `timeout` → `APK build failed or timed out`, **exit 1**, Gradle never started | **fixed**: `timeout` → `gtimeout` → unbounded, the resolution `lib/maestro.sh` already uses |
| `web-bundle-smoke.sh` | `ci.yml` | `node`, `npm`, `npx` | exit 2 `CANNOT RUN: 'node'` | already correct |
| `store-preflight.sh` | `play-store.yml`, `app-store.yml` | `openssl`, `curl`, `jq`, `xxd` | `[SKIP] jq not available — cannot run the ASC preflight`, exit 0 advisory | already correct |
| `sync-versions.sh` | `release-fast.yml` | `python3`; `node`, `perl` (`--fix` only) | `python3`: exit 2; `node`: "Skipped … node not found" | already correct; `perl` in `--fix` left out (base system on every host; `set -e` aborts with 127 before any verdict is printed) |
| `verify-published-version.sh` | `release.yml` | `curl`, `python3` | exit 2 `CANNOT RUN` | already correct |
| `check-web-filamat-abi.sh` | manual (`CLAUDE.md`) | `shasum`/`sha256sum`, `git` | exit 2 | already correct |
| `check-sceneview-skill.sh` | manual | `python3` | exit 2 | already correct |
| `validate-release-artifact.sh` | `play-store.yml`, `main-internal-deploy.yml` | `bundletool`/`java`/`curl`/`wget`, `python3` | WARN + SKIP by its documented skip-vs-fail discipline | already correct |
| `verify-sketchfab-key.sh`, `verify-arcore-key.sh` | store/deploy workflows | `curl` | live probe skipped with ⚠; presence check still applies | already correct |
| `device-qa.sh` | `release-fast.yml`, `device-qa.yml` | `adb`, `xcrun`, `node`/`npx` | leg recorded `skipped`; in `--ci` a skipped *required* leg fails the gate — deliberate (#1670) | already correct |
| `check-breaking-change-bump.sh`, `check-ios-floor.sh`, `check-web-dts.sh`, `check-test-suites-reachable.sh`, `collate-changelog.sh`, `update-site-metrics.sh`, `collate-demos.sh`, `collate-ios-demos.sh`, `tools/GenerateFilamat.sh --check` | CI / manual | nothing beyond `git`, `cmp`, `awk`, `sed` (`git` guarded → exit 2 where used; `matc` is downloaded or exit 2) | — | nothing to fix |
| `tag-release.sh` | `tag-release.yml`, `release-fast.yml` | `git`, `gh` | `gh` missing → 127 after the tag is pushed | out of scope: a release mutation, not a check; GitHub runners always ship `gh` |
| `.github/scripts/ci-gate-*.sh` | **no caller anywhere** — the CI Gate aggregator they served is gone | `jq` | unguarded `jq`, but nothing invokes them | left out; they are orphaned, and deleting them is a separate decision |
| `lib/maestro.sh` (install path) | via the QA legs | `curl`, `java` | `return 1` with a named reason; the caller decides | left as is |

## Before / after, measured on this host

`curl` hidden by a PATH mirroring the real one minus `curl` (`env PATH=/tmp/nopath-curl …`), `--flutter` slice (14 CDN refs):

```
# before (origin/main)                         # after
== Summary ==                                  CANNOT RUN: 'curl' is not available — every CDN reachability probe is a curl.
  Bundled refs checked : 12                      This is a tooling gap on this host, NOT evidence about the asset references.
  CDN refs checked     : 0/14                    Install curl, or pass --no-cdn to run the bundled-file half on its own.
  CDN not checked      : 14 (transient — rate limit, timeout or 5xx)
  All references resolve ✓                     rc=2 elapsed=0s
rc=0 elapsed=208s
```

With `curl` present, `--flutter` is unchanged: `CDN refs checked: 14/14 · All references resolve ✓ · rc=0` in 3 s. `--flutter --no-cdn` with `curl` hidden: not refused, `rc=0`.

`xcrun` hidden, `ios-device-qa.sh`: before `[ios-qa] ERROR: xcrun not found … rc=1` → after `[ios-qa] CANNOT RUN: xcrun not found … rc=2`.

`node` (genuinely absent on this host) and `jq` hidden, on the legs that already used the pattern — unchanged and quoted for the record: `web-bundle-smoke.sh` → `[web-bundle-smoke] CANNOT RUN: 'node' is not available.` (exit 2); `store-preflight.sh` → `[SKIP] App Store Connect preflight  jq not available — cannot run the ASC preflight.` (exit 0, advisory).

The `python3` (`ar-replay-qa.sh`) and `timeout` (`qa-android-demos.sh`) branches sit behind an emulator and were not executed; both hunks are guarded `command -v` branches of the shape used elsewhere in the same scripts, parse under the system bash 3.2, and are shellcheck-identical to `main` (same findings, only line numbers moved).

## Test

`.claude/scripts/test-validate-demo-assets.sh` — same shape as `test-check-test-suites-reachable.sh`: hides `curl` via a mirrored PATH, asserts exit 2 + the `CANNOT RUN` line before any summary, and that `--no-cdn` is not refused. 3/3 locally. Wired as one step of the existing `test-suite-reachability` job in `mcp-tests.yml` (plus two path-filter entries); drop that step if you would rather keep the job single-purpose — the script stands on its own.

## Checks

`shellcheck` 0.11.0 on all six touched scripts: identical findings to `origin/main` per file; the new test file is clean. `bash -n` on all; `actionlint` clean on `mcp-tests.yml`.

## Observed, not touched

- `bash .claude/scripts/validate-demo-assets.sh --ios --no-cdn` exits 1 on `main` today (`Missing bundled: 7`) — a real asset finding, unrelated to tooling.
- `samples/README.md`, `docs/docs/desktop-filament.md` and the android-demo fragments README still describe `pre-push-check.sh` / `quality-gate.sh` / `pr-check.yml` as live gates. Only the `samples/README.md` block that describes this validator is corrected here.

## Needs device

None. No Gradle build, no emulator, no device was used; the two device-side hunks are not executed by this PR's verification, as stated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
