### PR TITLE
fix(mcp): declare the MCP Apps extension so hosts can find the 3D viewer (#3192)

### DIFF
--- a/changelog.d/3192-mcp-apps-protocol-bump.md
+++ b/changelog.d/3192-mcp-apps-protocol-bump.md
@@ -1,0 +1,32 @@
+<!-- category: Fixed -->
+- **MCP Apps is now declared as an extension, so a host that follows the negotiation rules can
+  find the 3D viewer ([#3192](https://github.com/sceneview/sceneview/issues/3192), workstream
+  4).** Everything the widget needs shipped a while ago — the `ui://widget/3d-viewer.html`
+  resource, its `text/html;profile=mcp-app` mime type, and `_meta.ui.resourceUri` on both tool
+  declarations and tool results — but MCP Apps is *opt-in*, negotiated through
+  `capabilities.extensions` (SEP-1724), and neither `sceneview-mcp` nor the hosted gateway ever
+  named `io.modelcontextprotocol/ui` anywhere. A spec-following host had nothing to switch on: it
+  saw a server with tools and resources and no reason to look for a UI. Both handshakes now
+  declare `extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } }`
+  from one shared source in `mcp/src/widgets.ts`, so the gateway and `npx sceneview-mcp` cannot
+  drift. The declaration is additive on every revision either server speaks — the `ext-apps` spec
+  advertises the same capability over `protocolVersion: "2024-11-05"` in its own example — so
+  hosts negotiating an earlier revision are unaffected.
+- **The gateway answers `server/discover`, so a 2026-07-28 client can discover it at all.** That
+  revision removes the `initialize` handshake, which means an `extensions` block living only in
+  the handshake result is invisible to a modern client; it would have got a bare `-32601` and
+  learned nothing. The gateway now returns the same identity, capabilities and revision list
+  without a session or a handshake, the way `sceneview-mcp` already did (#3349). It advertises
+  only the revisions it actually implements (`2025-06-18`, `2025-03-26`) — announcing 2026-07-28
+  while implementing none of its per-request `_meta` versioning or result envelopes would be the
+  worse bug.
+- **The gateway degrades to text for a client that negotiated MCP Apps without our mime type.**
+  The extension spec asks servers to check the peer's capabilities before advertising UI-enabled
+  tools. Silence stays permissive on purpose: every host predating the extension framework —
+  ChatGPT included, which drives the widget off the `openai/*` `_meta` keys — declares nothing,
+  and gating on silence would have dark-shipped the live listing. Only a client that names the
+  extension *and* lists mime types excluding ours loses the pointer; the tool stays listed and
+  callable. Tool declarations also merge `_meta.ui` instead of replacing it, so re-affirming the
+  widget pointer can no longer drop the `openai/*` spellings or any key the declaration gains
+  later. The mime type itself is unchanged and correct: `text/html;profile=mcp-app` is the
+  current MCP Apps value, not the withdrawn `text/html+skybridge`.

--- a/mcp-gateway/src/mcp/session.ts
+++ b/mcp-gateway/src/mcp/session.ts
@@ -32,6 +32,17 @@ export interface SessionState {
     name?: string;
     version?: string;
   };
+  /**
+   * MCP Apps extension settings the client declared at `initialize`
+   * (`capabilities.extensions["io.modelcontextprotocol/ui"]`, SEP-1724).
+   *
+   * Absent means the client named no extension — which is NOT the same as
+   * refusing widgets, since every host predating the extension framework is
+   * silent here. See `serveWidgetsTo` in `mcp/src/widgets.ts` (#3192).
+   */
+  uiExtension?: {
+    mimeTypes: string[];
+  };
   /** Unix epoch ms the session was created. */
   createdAt: number;
 }

--- a/mcp-gateway/src/mcp/transport.ts
+++ b/mcp-gateway/src/mcp/transport.ts
@@ -35,7 +35,14 @@
 
 import type { DispatchContext } from "./types.js";
 import { dispatch as registryDispatch, getAllTools } from "./registry.js";
-import { listWidgetResources, readWidgetResource } from "./widgets.js";
+import {
+  listWidgetResources,
+  readWidgetResource,
+  readUiExtension,
+  serveWidgetsTo,
+  UI_EXTENSION_ID,
+  uiExtensionSettings,
+} from "./widgets.js";
 import { widgetResourceFor } from "./widget-tools.js";
 import {
   loadSession,
@@ -111,9 +118,51 @@ const SERVER_INFO = {
 
 /**
  * Protocol revisions implemented by this server, newest first.
+ *
+ * This list says what the transport below *implements*, never what the ecosystem
+ * has published — announcing a revision we cannot serve is the worse bug, and
+ * the same rule is written down in `mcp/src/discover.ts` (#3349). 2026-07-28
+ * removes the `initialize` handshake, moves version and client capabilities into
+ * per-request `_meta`, and wraps every result in a `resultType` envelope; none of
+ * that is implemented here, so it is not listed here. What a 2026-07-28 client
+ * does get is `server/discover` (below), which tells it exactly this list in one
+ * round trip instead of a bare `-32601`.
  */
 export const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26"] as const;
 export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+/**
+ * Capabilities this server declares — one object, used by both `initialize` and
+ * `server/discover` so the two answers cannot drift.
+ *
+ * A function rather than a const: each answer gets its own object graph, so a
+ * caller mutating one response cannot corrupt the next.
+ */
+export function serverCapabilities(): Record<string, unknown> {
+  return {
+    tools: { listChanged: false },
+    // Resources advertise the MCP Apps widget templates served by
+    // `widgets.ts` (currently the 3D viewer at `ui://widget/3d-viewer.html`).
+    // Without this capability a host never asks `resources/read`, so the
+    // widget pointer attached to tool results would be silently ignored.
+    resources: { listChanged: false, subscribe: false },
+    // Empty prompts capability — keeps clients that probe for it happy
+    // without inventing prompt content.
+    prompts: { listChanged: false },
+    // MCP Apps is opt-in and negotiated through the extensions mechanism
+    // (SEP-1724). The gateway served widget resources, the
+    // `text/html;profile=mcp-app` mime type and `_meta.ui.resourceUri` on both
+    // declarations and results while naming the extension nowhere, so a host
+    // playing by the negotiation rules had nothing to switch on (#3192).
+    extensions: { [UI_EXTENSION_ID]: uiExtensionSettings() },
+  };
+}
+
+/** How long a client may cache the `server/discover` answer. */
+export const DISCOVER_TTL_MS = 3_600_000;
+
+/** Method name defined by MCP 2026-07-28 for handshake-free discovery. */
+export const DISCOVER_METHOD = "server/discover";
 
 /** Default origins always allowed even when a caller passes an allowlist. */
 const DEFAULT_ORIGIN_ALLOWLIST = [
@@ -293,8 +342,14 @@ async function routeMethod(
     case "ping":
       return {};
 
+    // Handshake-free discovery (MCP 2026-07-28). Deliberately routed before
+    // any session state is consulted: the whole point is that it works without
+    // an `initialize`.
+    case DISCOVER_METHOD:
+      return handleDiscover();
+
     case "tools/list":
-      return handleToolsList();
+      return handleToolsList(session);
 
     case "tools/call":
       return handleToolsCall(req, ctx);
@@ -349,21 +404,45 @@ function handleInitialize(
         typeof clientInfo.version === "string" ? clientInfo.version : undefined,
     };
   }
+  // Remember what the client said about MCP Apps. `undefined` means it named
+  // no extension at all, which is not the same as refusing widgets — see
+  // `handleToolsList`.
+  const uiExtension = readUiExtension(params.capabilities);
+  session.uiExtension = uiExtension ?? undefined;
   return {
     protocolVersion,
-    capabilities: {
-      tools: { listChanged: false },
-      // Resources advertise the OpenAI Apps SDK widget templates served
-      // by `widgets.ts` (currently the 3D viewer at
-      // `ui://widget/3d-viewer.html`). Without this capability ChatGPT
-      // never asks `resources/read`, so the widget pointer attached to
-      // tool results would be silently ignored.
-      resources: { listChanged: false, subscribe: false },
-      // Empty prompts capability — keeps clients that probe for it happy
-      // without inventing prompt content.
-      prompts: { listChanged: false },
-    },
+    capabilities: serverCapabilities(),
     serverInfo: SERVER_INFO,
+  };
+}
+
+/**
+ * Handles `server/discover` — the handshake-free discovery request MCP
+ * 2026-07-28 lets a client send *before* (or instead of) `initialize`, with no
+ * session and no negotiated version.
+ *
+ * Answering a 2026-07-28 method while serving 2025-06-18 is deliberate, and it
+ * is what makes the MCP Apps declaration reachable at all: a modern client never
+ * sends `initialize`, so an `extensions` block that lives only in the handshake
+ * result is invisible to it. One cheap, purely informational round trip replaces
+ * a `-32601` that would have told it nothing. Same reasoning, and same shape, as
+ * `mcp/src/discover.ts` (#3349).
+ */
+function handleDiscover(): unknown {
+  return {
+    resultType: "complete",
+    ttlMs: DISCOVER_TTL_MS,
+    // Nothing here is user-specific: identity, capabilities and the revision
+    // list are the same for an anonymous caller and a Pro key, so a shared
+    // proxy may serve one cached copy to everyone.
+    cacheScope: "public",
+    supportedVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+    capabilities: serverCapabilities(),
+    serverInfo: { ...SERVER_INFO },
+    instructions:
+      "SceneView MCP gateway — the full SceneView SDK (Android/Compose + Filament, " +
+      "iOS/SwiftUI + RealityKit, AR via ARCore/ARKit) as tools, with an inline 3D " +
+      "viewer widget for hosts that negotiate the MCP Apps extension.",
   };
 }
 
@@ -394,16 +473,37 @@ function handleResourcesRead(req: JsonRpcRequest): unknown {
  * Widget-bearing tools carry `_meta.ui.resourceUri` on the DECLARATION as
  * well as on the result (see `handleToolsCall`): a host that decides from
  * `tools/list` whether a tool has a UI never sees a result first, so a
- * pointer that only rides on results is invisible to it (#3192).
+ * pointer that only rides on results is invisible to it (#3279).
+ *
+ * The pointer is withheld only from a client that negotiated MCP Apps and
+ * listed mime types excluding ours — the one case the client stated itself.
+ * A client that named no extension keeps the pointer: ChatGPT declares none
+ * and drives the widget off the `openai/*` keys, so gating on silence would
+ * dark-ship the live listing (#3192).
  */
-function handleToolsList(): unknown {
+function handleToolsList(session: SessionState): unknown {
+  const withWidgets = serveWidgetsTo(session.uiExtension);
   const tools = getAllTools().map((def) => {
     const widgetUri = widgetResourceFor(def.name);
-    // Merge rather than replace: the upstream declaration already carries
-    // the pointer plus the OpenAI Apps SDK keys (`openai/outputTemplate`…).
-    return widgetUri
-      ? { ...def, _meta: { ...(def._meta ?? {}), ui: { resourceUri: widgetUri } } }
-      : def;
+    if (!widgetUri) return def;
+    const meta = { ...(def._meta ?? {}) } as Record<string, unknown>;
+    if (!withWidgets) {
+      // The client negotiated MCP Apps and listed mime types excluding ours:
+      // it cannot render this widget, so it must not be pointed at one. The
+      // tool stays listed and callable and still returns its text content —
+      // the graceful degradation the extension spec asks for. The `openai/*`
+      // keys are left alone: they are a different vendor's mechanism, and a
+      // client that speaks the extension is not the host that reads them.
+      delete meta.ui;
+      return { ...def, _meta: meta };
+    }
+    // Merge both levels rather than replace: the upstream declaration already
+    // carries the pointer, any other `ui` keys, and the OpenAI Apps SDK
+    // spellings (`openai/outputTemplate`…). Overwriting `_meta` — or `ui`
+    // itself — would silently drop whatever the declaration adds to it next.
+    const prevUi = (def._meta as { ui?: Record<string, unknown> } | undefined)?.ui;
+    meta.ui = { ...(prevUi ?? {}), resourceUri: widgetUri };
+    return { ...def, _meta: meta };
   });
   return { tools };
 }

--- a/mcp-gateway/src/mcp/widgets.ts
+++ b/mcp-gateway/src/mcp/widgets.ts
@@ -23,14 +23,30 @@
 
 import {
   MCP_APP_MIME_TYPE,
+  UI_EXTENSION_ID,
   WIDGET_3D_VIEWER_HTML,
   WIDGET_3D_VIEWER_URI,
   listWidgetResources as listUpstreamWidgetResources,
   readWidgetResource as readUpstreamWidgetResource,
+  readUiExtension,
+  serveWidgetsTo,
+  uiExtensionSettings,
+  type UiExtensionSettings,
 } from "../../../mcp/src/widgets.js";
 
 /** Canonical mime type for MCP Apps widget resources (re-exported upstream value). */
 export const APPS_SDK_MIME_TYPE: string = MCP_APP_MIME_TYPE;
+
+// The MCP Apps extension identity and its negotiation helpers come from the
+// same upstream module as the widget HTML, so the gateway and `npx
+// sceneview-mcp` can never disagree about what MCP Apps means here (#3192).
+export {
+  UI_EXTENSION_ID,
+  readUiExtension,
+  serveWidgetsTo,
+  uiExtensionSettings,
+  type UiExtensionSettings,
+};
 
 /**
  * Scene showcase widget — exercises the FULL SceneView.js API, not just

--- a/mcp-gateway/test/transport.test.ts
+++ b/mcp-gateway/test/transport.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   handleMcpRequest,
   JSON_RPC_ERRORS,
+  SUPPORTED_PROTOCOL_VERSIONS,
   type JsonRpcResponse,
 } from "../src/mcp/transport.js";
 import { MockKv } from "./helpers/mock-kv.js";
@@ -137,6 +138,82 @@ describe("transport: tools/list", () => {
     expect(plain?._meta).toBeUndefined();
   });
 
+  it("keeps the OpenAI Apps SDK keys alongside the MCP Apps pointer", async () => {
+    // The transport re-affirms `_meta.ui.resourceUri` on top of the upstream
+    // declaration; overwriting `_meta` (or `_meta.ui`) wholesale would strip
+    // the `openai/*` spellings the live ChatGPT listing renders from.
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+      { kv: new MockKv().asKv() },
+    );
+    const body = await asJsonRpc(res);
+    const result = body.result as {
+      tools: { name: string; _meta?: Record<string, unknown> }[];
+    };
+    const widget = result.tools.find((t) => t.name === "view_3d_model");
+    expect(widget?._meta?.["openai/outputTemplate"]).toBe("ui://widget/3d-viewer.html");
+  });
+
+  it("still declares the widget to a client that named no extension", async () => {
+    // Every host predating SEP-1724 — ChatGPT included — sends no `extensions`
+    // block. Silence must stay permissive or the live listing goes dark.
+    const kv = new MockKv();
+    const init = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {} },
+      }),
+      { kv: kv.asKv() },
+    );
+    const sessionId = init.headers.get("mcp-session-id") as string;
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" }, {
+        "mcp-session-id": sessionId,
+      }),
+      { kv: kv.asKv() },
+    );
+    const result = (await asJsonRpc(res)).result as {
+      tools: { name: string; _meta?: { ui?: { resourceUri?: string } } }[];
+    };
+    const widget = result.tools.find((t) => t.name === "view_3d_model");
+    expect(widget?._meta?.ui?.resourceUri).toBe("ui://widget/3d-viewer.html");
+  });
+
+  it("degrades to text for a client that negotiated MCP Apps without our mime type", async () => {
+    const kv = new MockKv();
+    const init = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {
+            extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/uri-list"] } },
+          },
+        },
+      }),
+      { kv: kv.asKv() },
+    );
+    const sessionId = init.headers.get("mcp-session-id") as string;
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" }, {
+        "mcp-session-id": sessionId,
+      }),
+      { kv: kv.asKv() },
+    );
+    const result = (await asJsonRpc(res)).result as {
+      tools: { name: string; _meta?: { ui?: { resourceUri?: string } } }[];
+    };
+    // The tool stays listed and callable — only the UI pointer is withheld,
+    // which is the graceful degradation the extension spec asks for.
+    const widget = result.tools.find((t) => t.name === "view_3d_model");
+    expect(widget).toBeDefined();
+    expect(widget?._meta?.ui?.resourceUri).toBeUndefined();
+  });
+
   it("advertises outputSchema only for structured tools", async () => {
     const res = await handleMcpRequest(
       mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
@@ -162,6 +239,110 @@ describe("transport: tools/list", () => {
       "validate_medical_code",
       "view_3d_model",
     ]);
+  });
+});
+
+describe("transport: MCP Apps extension + server/discover (#3192)", () => {
+  it("declares the MCP Apps extension in the initialize result", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {} },
+      }),
+      { kv: new MockKv().asKv() },
+    );
+    const result = (await asJsonRpc(res)).result as {
+      capabilities: { extensions?: Record<string, { mimeTypes?: string[] }> };
+    };
+    expect(result.capabilities.extensions).toBeDefined();
+    expect(result.capabilities.extensions?.["io.modelcontextprotocol/ui"]).toEqual({
+      mimeTypes: ["text/html;profile=mcp-app"],
+    });
+  });
+
+  it("declares it on the OLDEST revision it serves too", async () => {
+    // The extensions framework is versioned into 2026-07-28, but the ext-apps
+    // spec advertises the very same capability over `2024-11-05` in its own
+    // example: it is additive, and a peer that does not know the key ignores
+    // it. Backward compatibility is the point, not a caveat.
+    const res = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-03-26" },
+      }),
+      { kv: new MockKv().asKv() },
+    );
+    const result = (await asJsonRpc(res)).result as {
+      protocolVersion: string;
+      capabilities: { extensions?: Record<string, unknown> };
+    };
+    expect(result.protocolVersion).toBe("2025-03-26");
+    expect(result.capabilities.extensions?.["io.modelcontextprotocol/ui"]).toBeDefined();
+  });
+
+  it("answers server/discover with no session and no handshake", async () => {
+    // A 2026-07-28 client never sends `initialize`, so this is the only place
+    // it can read the extension declaration — and it beats a bare -32601.
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 1, method: "server/discover", params: {} }),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(200);
+    const body = await asJsonRpc(res);
+    expect(body.error).toBeUndefined();
+    const result = body.result as {
+      resultType: string;
+      ttlMs: number;
+      cacheScope: string;
+      supportedVersions: string[];
+      capabilities: { extensions?: Record<string, unknown> };
+      serverInfo: { name: string };
+    };
+    // The five fields the 2026-07-28 DiscoverResult schema requires.
+    for (const field of ["cacheScope", "capabilities", "resultType", "supportedVersions", "ttlMs"]) {
+      expect(result, `missing required field: ${field}`).toHaveProperty(field);
+    }
+    expect(result.resultType).toBe("complete");
+    expect(result.cacheScope).toBe("public");
+    expect(result.ttlMs).toBeGreaterThan(0);
+    expect(result.serverInfo.name).toBe("sceneview-mcp-gateway");
+    expect(result.capabilities.extensions?.["io.modelcontextprotocol/ui"]).toBeDefined();
+  });
+
+  it("advertises through discover only the revisions it really implements", async () => {
+    // Announcing 2026-07-28 here would be the actual bug: none of its
+    // per-request `_meta` versioning or result envelopes is implemented.
+    const res = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 1, method: "server/discover" }),
+      { kv: new MockKv().asKv() },
+    );
+    const result = (await asJsonRpc(res)).result as { supportedVersions: string[] };
+    expect(result.supportedVersions).toEqual([...SUPPORTED_PROTOCOL_VERSIONS]);
+    expect(result.supportedVersions).not.toContain("2026-07-28");
+  });
+
+  it("gives discover and initialize the same capabilities, from one source", async () => {
+    const kv = new MockKv();
+    const init = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      }),
+      { kv: kv.asKv() },
+    );
+    const discover = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "server/discover" }),
+      { kv: kv.asKv() },
+    );
+    const initCaps = ((await asJsonRpc(init)).result as { capabilities: unknown }).capabilities;
+    const discCaps = ((await asJsonRpc(discover)).result as { capabilities: unknown }).capabilities;
+    expect(discCaps).toEqual(initCaps);
   });
 });
 

--- a/mcp/src/discover.test.ts
+++ b/mcp/src/discover.test.ts
@@ -9,6 +9,7 @@ import {
   SERVER_INFO,
 } from "./discover.js";
 import { PACKAGE_VERSION } from "./generated/version.js";
+import { MCP_APP_MIME_TYPE, UI_EXTENSION_ID } from "./widgets.js";
 
 // The conformance suite (@hasmcp/mcp-spec-test) checks these five fields on the
 // `server/discover` result; `serverInfo` is expected on top of them. Keep this
@@ -75,6 +76,18 @@ describe("buildDiscoverResult", () => {
     expect(result.capabilities).toEqual({ ...SERVER_CAPABILITIES });
     expect(result.capabilities).toHaveProperty("tools");
     expect(result.capabilities).toHaveProperty("resources");
+  });
+
+  it("declares the MCP Apps extension, with the mime type it serves", () => {
+    // #3192: the widget resource, its mime type and the `_meta.ui` pointers
+    // all shipped while the extension itself was named nowhere, so a host
+    // following the negotiation rules had nothing to switch on. A modern
+    // client never sends `initialize`, so `server/discover` is the ONLY place
+    // it can read this.
+    const extensions = buildDiscoverResult().capabilities.extensions as Record<string, unknown>;
+    expect(extensions).toBeDefined();
+    expect(extensions[UI_EXTENSION_ID]).toEqual({ mimeTypes: [MCP_APP_MIME_TYPE] });
+    expect(MCP_APP_MIME_TYPE).toBe("text/html;profile=mcp-app");
   });
 
   it("includes instructions that point at the API resource", () => {

--- a/mcp/src/discover.ts
+++ b/mcp/src/discover.ts
@@ -35,6 +35,7 @@
 import { RequestSchema, SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { PACKAGE_VERSION } from "./generated/version.js";
+import { UI_EXTENSION_ID, uiExtensionSettings } from "./widgets.js";
 
 /** JSON-RPC method name defined by MCP 2026-07-28. */
 export const DISCOVER_METHOD = "server/discover";
@@ -50,8 +51,22 @@ export const DiscoverRequestSchema = RequestSchema.extend({
 /**
  * Server capabilities, declared once and shared between the `Server`
  * constructor and `server/discover` so the two can never drift apart.
+ *
+ * `extensions` carries the MCP Apps declaration (#3192). The server has shipped
+ * the widget resource, its `text/html;profile=mcp-app` mime type and the
+ * `_meta.ui.resourceUri` pointers on tool declarations for several releases —
+ * but never named the extension, so a host that follows the negotiation rules
+ * had nothing to switch on. The extension *framework* is versioned into
+ * 2026-07-28, yet the `ext-apps` spec advertises the very same capability over
+ * `protocolVersion: "2024-11-05"` in its own example: a party declares what it
+ * supports, and a peer that does not know the key ignores it. So this is
+ * additive on every revision we serve, and does not wait on an SDK bump.
  */
-export const SERVER_CAPABILITIES = { resources: {}, tools: {} } as const;
+export const SERVER_CAPABILITIES = {
+  resources: {},
+  tools: {},
+  extensions: { [UI_EXTENSION_ID]: uiExtensionSettings() },
+} as const;
 
 /** Server identity, likewise shared with the `Server` constructor. */
 export const SERVER_INFO = { name: "sceneview-mcp", version: PACKAGE_VERSION } as const;

--- a/mcp/src/http.test.ts
+++ b/mcp/src/http.test.ts
@@ -90,6 +90,12 @@ describe("POST /mcp — Streamable HTTP, stateless", () => {
     expect(body.error).toBeUndefined();
     expect(body.result?.serverInfo).toEqual({ name: "sceneview-mcp", version: PACKAGE_VERSION });
     expect(body.result?.capabilities).toMatchObject({ tools: {}, resources: {} });
+    // #3192 — end-to-end, over a real handshake: MCP Apps is opt-in via the
+    // extensions mechanism, so a host that follows the spec learns the widget
+    // exists from this block and nowhere else.
+    expect(body.result?.capabilities).toMatchObject({
+      extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+    });
   });
 
   it("tools/list exposes the free tier only, with view_3d_model bound to the widget", async () => {

--- a/mcp/src/widgets.test.ts
+++ b/mcp/src/widgets.test.ts
@@ -10,7 +10,11 @@ import { dispatchTool, TOOL_DEFINITIONS } from "./tools/index.js";
 import {
   listWidgetResources,
   MCP_APP_MIME_TYPE,
+  readUiExtension,
   readWidgetResource,
+  serveWidgetsTo,
+  UI_EXTENSION_ID,
+  uiExtensionSettings,
   WIDGET_3D_VIEWER_HTML,
   WIDGET_3D_VIEWER_URI,
   WIDGET_UI_META,
@@ -150,5 +154,73 @@ describe("view_3d_model tool", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toContain("modelUrl");
     expect(result.structuredContent).toBeUndefined();
+  });
+});
+
+describe("MCP Apps extension negotiation (#3192)", () => {
+  it("uses the spec's extension identifier", () => {
+    // SEP-1724 / ext-apps 2026-01-26. A typo here is invisible at runtime —
+    // the host simply never sees a widget — so it is pinned literally.
+    expect(UI_EXTENSION_ID).toBe("io.modelcontextprotocol/ui");
+  });
+
+  it("advertises the mime type it actually serves", () => {
+    const settings = uiExtensionSettings();
+    expect(settings.mimeTypes).toEqual([MCP_APP_MIME_TYPE]);
+    // The value the widget resource is really served with, so the declaration
+    // and the resource cannot promise different content types.
+    expect(settings.mimeTypes).toContain(readWidgetResource(WIDGET_3D_VIEWER_URI)?.mimeType);
+  });
+
+  it("hands out a fresh settings object each call", () => {
+    uiExtensionSettings().mimeTypes.push("text/plain");
+    expect(uiExtensionSettings().mimeTypes).toEqual([MCP_APP_MIME_TYPE]);
+  });
+
+  it("reads a peer's declaration out of its capabilities", () => {
+    const settings = readUiExtension({
+      roots: {},
+      extensions: { [UI_EXTENSION_ID]: { mimeTypes: [MCP_APP_MIME_TYPE] } },
+    });
+    expect(settings).toEqual({ mimeTypes: [MCP_APP_MIME_TYPE] });
+  });
+
+  it("returns null when the peer named no extension", () => {
+    expect(readUiExtension(undefined)).toBeNull();
+    expect(readUiExtension({})).toBeNull();
+    expect(readUiExtension({ extensions: {} })).toBeNull();
+    expect(readUiExtension({ extensions: { "io.modelcontextprotocol/tasks": {} } })).toBeNull();
+  });
+
+  it("survives a malformed declaration instead of throwing", () => {
+    expect(readUiExtension({ extensions: { [UI_EXTENSION_ID]: {} } })).toEqual({ mimeTypes: [] });
+    expect(readUiExtension({ extensions: { [UI_EXTENSION_ID]: { mimeTypes: "html" } } })).toEqual({
+      mimeTypes: [],
+    });
+    expect(readUiExtension({ extensions: { [UI_EXTENSION_ID]: { mimeTypes: [1, "a"] } } })).toEqual(
+      {
+        mimeTypes: ["a"],
+      }
+    );
+    expect(readUiExtension("nonsense")).toBeNull();
+  });
+
+  it("keeps serving widgets to a peer that declared nothing", () => {
+    // ChatGPT today: no `extensions` block, drives the widget off `openai/*`.
+    // Gating on silence would dark-ship the live listing.
+    expect(serveWidgetsTo(null)).toBe(true);
+    expect(serveWidgetsTo(undefined)).toBe(true);
+    expect(serveWidgetsTo({ mimeTypes: [] })).toBe(true);
+  });
+
+  it("serves widgets to a peer that negotiated our mime type", () => {
+    expect(serveWidgetsTo({ mimeTypes: [MCP_APP_MIME_TYPE] })).toBe(true);
+    expect(serveWidgetsTo({ mimeTypes: ["text/uri-list", MCP_APP_MIME_TYPE] })).toBe(true);
+  });
+
+  it("degrades to text only when the peer excluded our mime type itself", () => {
+    expect(serveWidgetsTo({ mimeTypes: ["text/uri-list"] })).toBe(false);
+    // `text/html+skybridge` is the WITHDRAWN OpenAI spelling, not ours (#3189).
+    expect(serveWidgetsTo({ mimeTypes: ["text/html+skybridge"] })).toBe(false);
   });
 });

--- a/mcp/src/widgets.ts
+++ b/mcp/src/widgets.ts
@@ -34,6 +34,74 @@ import { LATEST_SCENEVIEW_RELEASE, PACKAGE_VERSION } from "./generated/version.j
 /** Canonical MCP Apps mime type for widget resources. */
 export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
+/**
+ * Extension identifier under which MCP Apps is negotiated (SEP-1724, `ext-apps`
+ * spec 2026-01-26).
+ *
+ * MCP Apps is an *extension*, not core protocol: a party that never names it in
+ * `capabilities.extensions` has, as far as the other side can tell, no widget
+ * support at all. Declaring the widget resource and hanging `_meta.ui` off tool
+ * declarations is necessary but not sufficient — the extension has to be
+ * advertised, or a spec-following host has no reason to look for either (#3192).
+ */
+export const UI_EXTENSION_ID = "io.modelcontextprotocol/ui";
+
+/** Settings object for the MCP Apps extension, as declared by a party. */
+export interface UiExtensionSettings {
+  /** Content types this party can serve or render. REQUIRED by the spec. */
+  mimeTypes: string[];
+}
+
+/**
+ * The settings SceneView advertises under
+ * `capabilities.extensions["io.modelcontextprotocol/ui"]`.
+ *
+ * A fresh object every call: the value is spread into handshake results that
+ * callers are free to mutate, and a shared array would let one of them corrupt
+ * every later handshake.
+ */
+export function uiExtensionSettings(): UiExtensionSettings {
+  return { mimeTypes: [MCP_APP_MIME_TYPE] };
+}
+
+/**
+ * Reads the peer's MCP Apps settings out of a `capabilities` object, or `null`
+ * when it declared none.
+ *
+ * `null` means "did not say", NOT "does not support": hosts predating the
+ * extension framework (ChatGPT today, which drives the widget off the
+ * `openai/*` `_meta` keys) declare nothing and still render widgets. Callers
+ * must treat `null` as unknown and keep their pre-extension behaviour — see
+ * `serveWidgetsTo`.
+ */
+export function readUiExtension(capabilities: unknown): UiExtensionSettings | null {
+  if (!capabilities || typeof capabilities !== "object") return null;
+  const extensions = (capabilities as { extensions?: unknown }).extensions;
+  if (!extensions || typeof extensions !== "object") return null;
+  const settings = (extensions as Record<string, unknown>)[UI_EXTENSION_ID];
+  if (!settings || typeof settings !== "object") return null;
+  const mimeTypes = (settings as { mimeTypes?: unknown }).mimeTypes;
+  return {
+    mimeTypes: Array.isArray(mimeTypes) ? mimeTypes.filter((m) => typeof m === "string") : [],
+  };
+}
+
+/**
+ * Whether to attach widget pointers for a peer that declared `settings`.
+ *
+ * The spec asks servers to check client capabilities before advertising
+ * UI-enabled tools and to degrade to text otherwise. The only case that
+ * degrades here is the one the client stated itself: it negotiated MCP Apps
+ * *and* listed mime types that exclude ours. Silence stays permissive, because
+ * the live ChatGPT listing is silent and withholding the pointer from it would
+ * turn a spec conformance fix into an outage.
+ */
+export function serveWidgetsTo(settings: UiExtensionSettings | null | undefined): boolean {
+  if (!settings) return true;
+  if (settings.mimeTypes.length === 0) return true;
+  return settings.mimeTypes.includes(MCP_APP_MIME_TYPE);
+}
+
 /** Resource URI of the 3D viewer widget (`ui://widget/<name>.html` convention). */
 export const WIDGET_3D_VIEWER_URI = "ui://widget/3d-viewer.html";
 


### PR DESCRIPTION
Closes nothing — **Part of #3192** (workstream 4). Workstreams 1 and 3 are untouched.

## What was actually wrong

The issue names two defects. Checked against the code rather than the line numbers, **one of the two was already fixed** and the framing of the other needed correcting:

| Issue claim | Reality on `main` |
|---|---|
| `_meta.ui.resourceUri` rides on results only; `tools/list` returns 67 tools with zero `resourceUri` | **Already fixed** by #3279 (`ab56c4e69`), with a test. `view_3d_model` carries the pointer on its declaration today. |
| The gateway advertises `2025-03-26`, four revisions back | **Already `2025-06-18`** since #3288 (`c31fd9ba9`). |
| `initialize` declares no `extensions` capability | **True, on both servers**, and it is the whole defect. |

So this PR is about the one real finding, and it is narrower and more actionable than "bump the protocol".

## The actual defect

MCP Apps is **opt-in**. `sceneview-mcp` and the gateway have shipped every visible part of it for several releases — the `ui://widget/3d-viewer.html` resource, its `text/html;profile=mcp-app` mime type, `_meta.ui.resourceUri` on declarations *and* results — while naming `io.modelcontextprotocol/ui` nowhere. Per [SEP-1724 / the extensions mechanism](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning#extension-negotiation), a party that does not list an extension in `capabilities.extensions` has, as far as the peer can tell, no support for it. A host following the negotiation rules saw a server with tools and resources and no reason to look for a UI.

**The protocol bump is not the prerequisite the issue assumed.** The extensions *framework* is versioned into 2026-07-28, but the `ext-apps` spec advertises this very capability over `protocolVersion: "2024-11-05"` in its own example — it is additive, and a peer that does not know the key ignores it. Declaring it needs no SDK upgrade and no revision bump, which is why it lands here on its own.

## Changes

**Declare the extension, from one source.** `mcp/src/widgets.ts` — which already owns the widget HTML and the mime type — now also owns `UI_EXTENSION_ID`, `uiExtensionSettings()`, `readUiExtension()` and `serveWidgetsTo()`. `mcp/src/discover.ts`'s `SERVER_CAPABILITIES` (shared by the SDK `Server` and `server/discover`) and the gateway's `serverCapabilities()` (shared by `initialize` and discover) both build on it, so the two servers cannot disagree about what MCP Apps means here.

**`server/discover` on the gateway.** This is what makes the declaration reachable: a 2026-07-28 client never sends `initialize`, so an `extensions` block living only in the handshake result is invisible to it — it would have got a bare `-32601`. Discover answers identity, capabilities and the revision list with no session and no handshake, the same shape and for the same reason as `mcp/src/discover.ts` (#3349).

It lists only the revisions the transport really implements (`2025-06-18`, `2025-03-26`). Announcing 2026-07-28 while implementing none of its per-request `_meta` versioning, result envelopes or stateless semantics would be the actual bug — the rule is already written down in `mcp/src/discover.ts`.

**Graceful degradation, carefully.** The spec asks servers to check the peer's capabilities before advertising UI-enabled tools. The pointer is withheld only from a client that named the extension **and** listed mime types excluding ours — the one case the client stated itself. Silence stays permissive on purpose: every host predating the framework declares nothing, ChatGPT included (it renders from the `openai/*` `_meta` keys), so gating on silence would have dark-shipped the live listing. The tool stays listed and callable either way.

**One latent trap closed.** `handleToolsList` replaced `_meta.ui` wholesale when re-affirming the pointer. Harmless today (the upstream `ui` block holds only `resourceUri`) but it would silently drop whatever the declaration adds to it next. Both levels are merged now, and a test pins that `openai/outputTemplate` survives.

**The mimeType is not touched.** `text/html;profile=mcp-app` is the current value; `text/html+skybridge` is the withdrawn OpenAI spelling. A test pins the distinction so the older claim cannot come back.

## Proof

Against the **real built server** (`node dist/index.js --http`, not a mock):

```console
$ curl -s .../mcp -d '{...,"method":"initialize",...}'   # -> result.capabilities
{ "resources": {}, "tools": {},
  "extensions": { "io.modelcontextprotocol/ui": { "mimeTypes": ["text/html;profile=mcp-app"] } } }

$ curl -s .../mcp -d '{...,"method":"server/discover","params":{}}'
{ "supportedVersions": ["2025-11-25","2025-06-18","2025-03-26","2024-11-05","2024-10-07"],
  "extensions": { "io.modelcontextprotocol/ui": { "mimeTypes": ["text/html;profile=mcp-app"] } } }

$ curl -s .../mcp -d '{...,"method":"tools/list"}'
tools: 29
view_3d_model -> {"resourceUri":"ui://widget/3d-viewer.html"}
```

Suites, all green locally:

| Suite | Before | After |
|---|---|---|
| `mcp-gateway` vitest | 197 | **205** |
| `mcp` vitest | 2001 | **2011** |
| `mcp` Biome | 1 error, 113 warnings | **0 errors, 113 warnings** |
| `mcp` `tsc` / gateway `tsc` | clean | clean |
| 5 vertical packages | — | 191 / 157 / 135 / 153 / 76, all pass |

No new workflow, gate, hook or script. **Nothing is deployed** — the Cloudflare Worker is live and takes Stripe webhooks; this stops at the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
