### PR TITLE
feat(core): read 3MF, the format AI print flows emit (#3482)

### DIFF
--- a/changelog.d/3482-3mf-loader.md
+++ b/changelog.d/3482-3mf-loader.md
@@ -1,0 +1,22 @@
+<!-- category: Added -->
+- **SceneView opens `.3mf` — the format AI print flows emit, that nothing on Android or the web
+  could view ([#3482](https://github.com/sceneview/sceneview/issues/3482)).** Ask ChatGPT for a 3D
+  print from a drawing and you get a `.3mf`: an OPC/ZIP package whose `3D/3dmodel.model` part is XML
+  with `<vertices>`, `<triangles>`, `<components>` and a `<build>` plate, in millimetres and Z-up.
+  Until now no Android app and no web page opened one in 3D, let alone in AR. `sceneview-core` now
+  reads 3MF in pure Kotlin on **every** platform — no `java.util.zip`, no XML library, no
+  `expect`/`actual` — and converts it to GLB in memory, so the whole existing glTF path (materials,
+  gestures, AR placement, the web viewer) is reused instead of a second loader per renderer.
+  **There is no new API to learn on Android:** `ModelLoader` sniffs the payload by its ZIP magic, so
+  `rememberModelInstance(modelLoader, uri.toString())`, `loadModel("print.3mf")` and every other
+  entry point already accept a 3MF; a payload that is not a ZIP costs a 4-byte comparison.
+  Conversion scales the file's declared unit to metres (a 60 mm print is life-size in AR without a
+  magic number), rotates the printer's Z-up to glTF's Y-up so the part stands up instead of lying on
+  its back, and gives every face its own normal — flat shading is what a printed part looks like,
+  and a smoothed normal would round over the facets the slicer will extrude. `<basematerials>` and
+  the materials extension's `<colorgroup>` become one glTF material per colour, per object and per
+  triangle, all `doubleSided` because generated meshes are often inconsistently wound. Unrecognised
+  3MF extensions (slice, beamlattice, production) are skipped rather than rejected: an unknown
+  extension must not stop a print from being previewed. For a custom pipeline,
+  `ThreeMfLoader.parse()` returns the file's own objects, meshes and build items, and
+  `ThreeMfLoader.toGlb()` / `isThreeMf()` are public in `sceneview-core`.

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3246,6 +3246,67 @@ The cost is one decode + PNG encode per WebP texture — on the calling thread f
 `createModel*` methods, off the main thread for the `suspend`/`Async` ones. A model with no WebP
 texture is passed through untouched.
 
+### 3MF — open a printable model (`.3mf`) (#3482)
+
+**Every loader entry point above also accepts a `.3mf` file. There is no separate API.** 3MF is what
+ChatGPT, every slicer and every image-to-print flow emit for a printable model; SceneView detects the
+payload by its ZIP magic and converts it to GLB in memory before Filament sees it, so the format is
+one more thing you can pass to the code you already write:
+
+```kotlin
+// A 3MF shared into your app (ChatGPT, Files, a slicer) — this is the whole of it.
+@Composable
+fun PrintViewer(uri: Uri) {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    SceneView(modifier = Modifier.fillMaxSize()) {
+        rememberModelInstance(modelLoader, uri.toString())?.let { instance ->
+            ModelNode(modelInstance = instance, scaleToUnits = 0.3f)
+        }
+    }
+}
+```
+
+Works identically in AR — `ARScene { … }`, `PlacementScene`, an anchored `ModelNode` — because by
+the time a node sees it, a 3MF *is* a glTF model.
+
+**What conversion does, and why each part matters:**
+- **Millimetres → metres.** 3MF carries real-world size (`unit="millimeter"` unless stated
+  otherwise). A 60 mm print becomes 0.06 scene units, so AR placement is life-size without a magic
+  number. Pass `scaleToUnits` on the node if you want it framed to a fixed size instead.
+- **Z-up → Y-up.** 3MF uses the printer's build-plate axes; glTF and SceneView use Y-up. The print
+  stands upright instead of lying on its back.
+- **Flat normals.** 3MF stores no normals. Faces are de-indexed and given per-face normals, which is
+  what a printed part actually looks like — a smoothed normal would round over the facets the slicer
+  will extrude.
+- **Colours.** `<basematerials>` and the materials extension's `<colorgroup>` become one glTF
+  material per colour, per object *and* per triangle. Materials are `doubleSided`, because generated
+  3MF meshes are often inconsistently wound and a one-sided print renders inside-out.
+
+Conversion happens off the main thread for `loadModel*` / `rememberModelInstance(fileLocation)`, and
+on the calling thread for the synchronous `createModel*` overloads. A payload that is not a ZIP
+costs a 4-byte comparison.
+
+**Direct access (all platforms — Android, iOS, web; `sceneview-core`, no platform dependency):**
+```kotlin
+import io.github.sceneview.core.threemf.ThreeMfLoader
+
+// isThreeMf is a cheap sniff — ZIP magic plus a 3D/3dmodel.model part — so it is safe to call on
+// any buffer before deciding what to do with it. toGlb returns a self-contained GLB.
+fun asGlb(bytes: ByteArray): ByteArray =
+    if (ThreeMfLoader.isThreeMf(bytes)) ThreeMfLoader.toGlb(bytes) else bytes
+
+// parse() instead, when you want the file's own data rather than a renderable model.
+fun triangleCount(bytes: ByteArray): Int = ThreeMfLoader.parse(bytes).triangleCount
+```
+`ThreeMfModel` keeps the file's own frame — `unit: ThreeMfUnit` (with `.meters`), `objects`
+(`ThreeMfObject`: `mesh`, `components`, `color`), `items` (build-plate placements, each a 16-float
+column-major matrix), `objectsById`, `triangleCount`. Meshes are `positions` (xyz triplets),
+`indices` and an optional per-triangle `triangleColors` packed `0xRRGGBBAA`. Every failure — not a
+ZIP, no model part, malformed XML, an out-of-range vertex index — is a `ThreeMfParseException`.
+Unrecognised 3MF extensions (slice, beamlattice, production) are skipped, never rejected: an
+unknown extension must not stop a print from being previewed.
+
 ### MaterialLoader
 ```kotlin
 class MaterialLoader(engine: Engine, context: Context) {

--- a/llms.txt
+++ b/llms.txt
@@ -3276,6 +3276,67 @@ The cost is one decode + PNG encode per WebP texture — on the calling thread f
 `createModel*` methods, off the main thread for the `suspend`/`Async` ones. A model with no WebP
 texture is passed through untouched.
 
+### 3MF — open a printable model (`.3mf`) (#3482)
+
+**Every loader entry point above also accepts a `.3mf` file. There is no separate API.** 3MF is what
+ChatGPT, every slicer and every image-to-print flow emit for a printable model; SceneView detects the
+payload by its ZIP magic and converts it to GLB in memory before Filament sees it, so the format is
+one more thing you can pass to the code you already write:
+
+```kotlin
+// A 3MF shared into your app (ChatGPT, Files, a slicer) — this is the whole of it.
+@Composable
+fun PrintViewer(uri: Uri) {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+    SceneView(modifier = Modifier.fillMaxSize()) {
+        rememberModelInstance(modelLoader, uri.toString())?.let { instance ->
+            ModelNode(modelInstance = instance, scaleToUnits = 0.3f)
+        }
+    }
+}
+```
+
+Works identically in AR — `ARScene { … }`, `PlacementScene`, an anchored `ModelNode` — because by
+the time a node sees it, a 3MF *is* a glTF model.
+
+**What conversion does, and why each part matters:**
+- **Millimetres → metres.** 3MF carries real-world size (`unit="millimeter"` unless stated
+  otherwise). A 60 mm print becomes 0.06 scene units, so AR placement is life-size without a magic
+  number. Pass `scaleToUnits` on the node if you want it framed to a fixed size instead.
+- **Z-up → Y-up.** 3MF uses the printer's build-plate axes; glTF and SceneView use Y-up. The print
+  stands upright instead of lying on its back.
+- **Flat normals.** 3MF stores no normals. Faces are de-indexed and given per-face normals, which is
+  what a printed part actually looks like — a smoothed normal would round over the facets the slicer
+  will extrude.
+- **Colours.** `<basematerials>` and the materials extension's `<colorgroup>` become one glTF
+  material per colour, per object *and* per triangle. Materials are `doubleSided`, because generated
+  3MF meshes are often inconsistently wound and a one-sided print renders inside-out.
+
+Conversion happens off the main thread for `loadModel*` / `rememberModelInstance(fileLocation)`, and
+on the calling thread for the synchronous `createModel*` overloads. A payload that is not a ZIP
+costs a 4-byte comparison.
+
+**Direct access (all platforms — Android, iOS, web; `sceneview-core`, no platform dependency):**
+```kotlin
+import io.github.sceneview.core.threemf.ThreeMfLoader
+
+// isThreeMf is a cheap sniff — ZIP magic plus a 3D/3dmodel.model part — so it is safe to call on
+// any buffer before deciding what to do with it. toGlb returns a self-contained GLB.
+fun asGlb(bytes: ByteArray): ByteArray =
+    if (ThreeMfLoader.isThreeMf(bytes)) ThreeMfLoader.toGlb(bytes) else bytes
+
+// parse() instead, when you want the file's own data rather than a renderable model.
+fun triangleCount(bytes: ByteArray): Int = ThreeMfLoader.parse(bytes).triangleCount
+```
+`ThreeMfModel` keeps the file's own frame — `unit: ThreeMfUnit` (with `.meters`), `objects`
+(`ThreeMfObject`: `mesh`, `components`, `color`), `items` (build-plate placements, each a 16-float
+column-major matrix), `objectsById`, `triangleCount`. Meshes are `positions` (xyz triplets),
+`indices` and an optional per-triangle `triangleColors` packed `0xRRGGBBAA`. Every failure — not a
+ZIP, no model part, malformed XML, an out-of-range vertex index — is a `ThreeMfParseException`.
+Unrecognised 3MF extensions (slice, beamlattice, production) are skipped, never rejected: an
+unknown extension must not stop a print from being previewed.
+
 ### MaterialLoader
 ```kotlin
 class MaterialLoader(engine: Engine, context: Context) {

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -795,6 +795,84 @@ public final class io/github/sceneview/core/splat/SplatParser {
 	public final fun parse ([B)Lio/github/sceneview/core/splat/SplatCloud;
 }
 
+public final class io/github/sceneview/core/threemf/ThreeMfComponent {
+	public fun <init> (I[F)V
+	public final fun getObjectId ()I
+	public final fun getTransform ()[F
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfItem {
+	public fun <init> (I[F)V
+	public final fun getObjectId ()I
+	public final fun getTransform ()[F
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfLoader {
+	public static final field INSTANCE Lio/github/sceneview/core/threemf/ThreeMfLoader;
+	public final fun isThreeMf ([B)Z
+	public final fun parse ([B)Lio/github/sceneview/core/threemf/ThreeMfModel;
+	public final fun toGlb (Lio/github/sceneview/core/threemf/ThreeMfModel;)[B
+	public final fun toGlb ([B)[B
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfMesh {
+	public fun <init> ([F[I[I)V
+	public synthetic fun <init> ([F[I[IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIndices ()[I
+	public final fun getPositions ()[F
+	public final fun getTriangleColors ()[I
+	public final fun getTriangleCount ()I
+	public final fun getVertexCount ()I
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfModel {
+	public fun <init> (Lio/github/sceneview/core/threemf/ThreeMfUnit;Ljava/util/List;Ljava/util/List;)V
+	public final fun getItems ()Ljava/util/List;
+	public final fun getObjects ()Ljava/util/List;
+	public final fun getObjectsById ()Ljava/util/Map;
+	public final fun getTriangleCount ()I
+	public final fun getUnit ()Lio/github/sceneview/core/threemf/ThreeMfUnit;
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfModelKt {
+	public static final field NoColor I
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfObject {
+	public fun <init> (ILjava/lang/String;Lio/github/sceneview/core/threemf/ThreeMfMesh;Ljava/util/List;I)V
+	public synthetic fun <init> (ILjava/lang/String;Lio/github/sceneview/core/threemf/ThreeMfMesh;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getColor ()I
+	public final fun getComponents ()Ljava/util/List;
+	public final fun getId ()I
+	public final fun getMesh ()Lio/github/sceneview/core/threemf/ThreeMfMesh;
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfParseException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfUnit : java/lang/Enum {
+	public static final field CENTIMETER Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static final field Companion Lio/github/sceneview/core/threemf/ThreeMfUnit$Companion;
+	public static final field FOOT Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static final field INCH Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static final field METER Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static final field MICRON Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static final field MILLIMETER Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMeters ()F
+	public static fun valueOf (Ljava/lang/String;)Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static fun values ()[Lio/github/sceneview/core/threemf/ThreeMfUnit;
+}
+
+public final class io/github/sceneview/core/threemf/ThreeMfUnit$Companion {
+	public final fun fromId (Ljava/lang/String;)Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public final fun getDefault ()Lio/github/sceneview/core/threemf/ThreeMfUnit;
+}
+
 public final class io/github/sceneview/geometries/BoundingBox {
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;)V
 	public final fun component1 ()Ldev/romainguy/kotlin/math/Float3;

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/splat/Inflate.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/splat/Inflate.kt
@@ -64,6 +64,17 @@ internal object Inflate {
         return output
     }
 
+    /**
+     * Decompress a **raw** DEFLATE stream (RFC 1951, no gzip or zlib wrapper) starting at [start]
+     * in [input]. [sizeHint] is the expected uncompressed size when the container knows it — a ZIP
+     * central directory does — and is only an allocation hint: it is clamped against a sane
+     * expansion ratio and never trusted as a length.
+     *
+     * Used by the ZIP reader behind the 3MF loader, where every entry is a raw DEFLATE member.
+     */
+    fun raw(input: ByteArray, start: Int, sizeHint: Int = 0): ByteArray =
+        Inflater(input, start).inflate(sizeHint)
+
     private fun skipZeroTerminated(data: ByteArray, start: Int): Int {
         var p = start
         while (p < data.size && data[p].toInt() != 0) p++

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -1,0 +1,372 @@
+package io.github.sceneview.core.threemf
+
+import kotlin.math.pow
+
+/**
+ * Encodes a parsed [ThreeMfModel] as a self-contained **GLB** (binary glTF 2.0) byte array.
+ *
+ * This is what makes 3MF a first-class SceneView format for the cost of one converter instead of
+ * one loader per renderer: Filament (Android), Filament.js (web) and every other glTF consumer in
+ * this SDK already read GLB, so a 3MF becomes an ordinary model the moment it leaves this file.
+ *
+ * Three conversions happen here, and each is a correctness requirement, not a preference:
+ * - **Units.** 3MF is a manufacturing format carrying real-world size; glTF is metres. The root
+ *   node scales by [ThreeMfUnit.meters], so a 60 mm print is 0.06 units — the size AR placement
+ *   needs to be believable.
+ * - **Axes.** 3MF is Z-up (the printer's build plate); glTF is Y-up. The root node rotates −90°
+ *   about X, so the print stands upright instead of lying on its back.
+ * - **Normals.** 3MF stores none. Faces are de-indexed and given per-face normals: flat shading is
+ *   the honest look for a print — a smoothed normal would round over the facets the slicer will
+ *   actually extrude.
+ */
+internal object ThreeMfGlb {
+
+    fun encode(model: ThreeMfModel): ByteArray {
+        val builder = GltfBuilder()
+        builder.addRootNode(model)
+        return builder.toGlb()
+    }
+
+    private class GltfBuilder {
+        private val bin = ByteArrayBuilder()
+        private val bufferViews = ArrayList<String>()
+        private val accessors = ArrayList<String>()
+        private val meshes = ArrayList<String>()
+        private val nodes = ArrayList<String>()
+        private val materials = ArrayList<String>()
+
+        /** 3MF object id → glTF mesh index, so an object instanced twice is stored once. */
+        private val meshIndexByObject = HashMap<Int, Int>()
+
+        /** Packed colour → glTF material index. */
+        private val materialIndexByColor = HashMap<Int, Int>()
+
+        fun addRootNode(model: ThreeMfModel) {
+            val children = model.items.mapNotNull { item ->
+                model.objectsById[item.objectId]?.let { addNode(model, it, item.transform) }
+            }
+            if (children.isEmpty()) threeMfError("3MF <build> references no printable object")
+            val scale = model.unit.meters
+            // Column-major: X keeps its axis, 3MF's Y becomes glTF's −Z, 3MF's Z becomes glTF's Y.
+            val root = floatArrayOf(
+                scale, 0f, 0f, 0f,
+                0f, 0f, -scale, 0f,
+                0f, scale, 0f, 0f,
+                0f, 0f, 0f, 1f
+            )
+            nodes += """{"name":"3mf","matrix":${root.toJsonArray()},""" +
+                """"children":${children.joinToString(",", "[", "]")}}"""
+        }
+
+        /** Emits the node for [object3mf] placed by [transform], recursing into its components. */
+        private fun addNode(
+            model: ThreeMfModel,
+            object3mf: ThreeMfObject,
+            transform: FloatArray,
+            depth: Int = 0
+        ): Int? {
+            if (depth > MAX_COMPONENT_DEPTH) {
+                threeMfError("3MF component nesting exceeds $MAX_COMPONENT_DEPTH levels (cycle?)")
+            }
+            val meshIndex = object3mf.mesh?.let { meshIndex(object3mf, it) }
+            val children = object3mf.components.mapNotNull { component ->
+                model.objectsById[component.objectId]
+                    ?.let { addNode(model, it, component.transform, depth + 1) }
+            }
+            if (meshIndex == null && children.isEmpty()) return null
+            val fields = ArrayList<String>(4)
+            object3mf.name?.let { fields += """"name":${it.toJsonString()}""" }
+            fields += """"matrix":${transform.toJsonArray()}"""
+            meshIndex?.let { fields += """"mesh":$it""" }
+            if (children.isNotEmpty()) {
+                fields += """"children":${children.joinToString(",", "[", "]")}"""
+            }
+            nodes += fields.joinToString(",", "{", "}")
+            return nodes.size - 1
+        }
+
+        private fun meshIndex(object3mf: ThreeMfObject, mesh: ThreeMfMesh): Int =
+            meshIndexByObject.getOrPut(object3mf.id) {
+                val primitives = groupByColor(mesh, object3mf.color).map { (color, triangles) ->
+                    primitive(mesh, triangles, color)
+                }
+                meshes += """{"primitives":${primitives.joinToString(",", "[", "]")}}"""
+                meshes.size - 1
+            }
+
+        /**
+         * Split a mesh's triangles by resolved colour. glTF carries colour on the material, and a
+         * primitive has exactly one material — so one primitive per distinct colour is the whole of
+         * 3MF's per-triangle colouring, expressed natively.
+         */
+        private fun groupByColor(mesh: ThreeMfMesh, objectColor: Int): List<Pair<Int, IntArray>> {
+            val colors = mesh.triangleColors
+                ?: return listOf(objectColor to IntArray(mesh.triangleCount) { it })
+            val groups = LinkedHashMap<Int, IntArrayBuilder>()
+            for (triangle in 0 until mesh.triangleCount) {
+                val color = colors.getOrElse(triangle) { objectColor }
+                groups.getOrPut(color) { IntArrayBuilder() }.add(triangle)
+            }
+            return groups.map { (color, triangles) -> color to triangles.toArray() }
+        }
+
+        /** One glTF primitive: de-indexed positions + flat normals for [triangles]. */
+        private fun primitive(mesh: ThreeMfMesh, triangles: IntArray, color: Int): String {
+            val vertexCount = triangles.size * 3
+            val positions = FloatArray(vertexCount * 3)
+            val normals = FloatArray(vertexCount * 3)
+            fillFlatShaded(mesh, triangles, positions, normals)
+            val positionAccessor = addFloatAccessor(positions, withBounds = true)
+            val normalAccessor = addFloatAccessor(normals, withBounds = false)
+            return """{"attributes":{"POSITION":$positionAccessor,"NORMAL":$normalAccessor},""" +
+                """"material":${materialIndex(color)}}"""
+        }
+
+        private fun addFloatAccessor(values: FloatArray, withBounds: Boolean): Int {
+            val byteOffset = bin.size
+            for (value in values) bin.addFloatLe(value)
+            bufferViews += """{"buffer":0,"byteOffset":$byteOffset,""" +
+                """"byteLength":${values.size * Float.SIZE_BYTES},"target":$ARRAY_BUFFER}"""
+            val count = values.size / 3
+            val bounds = if (withBounds) ""","min":${min(values)},"max":${max(values)}""" else ""
+            accessors += """{"bufferView":${bufferViews.size - 1},"componentType":$FLOAT,""" +
+                """"count":$count,"type":"VEC3"$bounds}"""
+            return accessors.size - 1
+        }
+
+        private fun materialIndex(color: Int): Int = materialIndexByColor.getOrPut(color) {
+            val factor = if (color == NoColor) DefaultBaseColor else color.toLinearRgba()
+            materials += """{"pbrMetallicRoughness":{"baseColorFactor":${factor.toJsonArray()},""" +
+                """"metallicFactor":0,"roughnessFactor":$PrintRoughness},""" +
+                // 3MF requires outward-facing counter-clockwise winding, but generated files often
+                // get it wrong; a one-sided material would then render the print inside-out.
+                """"doubleSided":true${alphaMode(factor[3])}}"""
+            materials.size - 1
+        }
+
+        private fun alphaMode(alpha: Float) = if (alpha < 1f) ""","alphaMode":"BLEND"""" else ""
+
+        fun toGlb(): ByteArray {
+            val json = buildJson()
+            return packGlb(json, bin.toArray())
+        }
+
+        private fun buildJson(): String = buildString {
+            append("""{"asset":{"version":"2.0","generator":"$Generator"},""")
+            append(""""scene":0,"scenes":[{"nodes":[${nodes.size - 1}]}],""")
+            append(""""nodes":${nodes.joinToString(",", "[", "]")},""")
+            append(""""meshes":${meshes.joinToString(",", "[", "]")},""")
+            append(""""materials":${materials.joinToString(",", "[", "]")},""")
+            append(""""accessors":${accessors.joinToString(",", "[", "]")},""")
+            append(""""bufferViews":${bufferViews.joinToString(",", "[", "]")},""")
+            append(""""buffers":[{"byteLength":${bin.size}}]}""")
+        }
+    }
+
+    /**
+     * De-index [triangles] of [mesh] into [positions] and give each face its own normal.
+     *
+     * A degenerate triangle (zero-area, which slicers do emit) gets a `+Y` normal instead of a
+     * `NaN` one — a single NaN vertex would otherwise blow up the whole primitive's bounding box
+     * and make the model invisible.
+     */
+    private fun fillFlatShaded(
+        mesh: ThreeMfMesh,
+        triangles: IntArray,
+        positions: FloatArray,
+        normals: FloatArray
+    ) {
+        var out = 0
+        for (triangle in triangles) {
+            val base = triangle * 3
+            val a = mesh.indices[base] * 3
+            val b = mesh.indices[base + 1] * 3
+            val c = mesh.indices[base + 2] * 3
+            copyVertex(mesh.positions, a, positions, out)
+            copyVertex(mesh.positions, b, positions, out + 3)
+            copyVertex(mesh.positions, c, positions, out + 6)
+            writeFaceNormal(mesh.positions, a, b, c, normals, out)
+            out += 9
+        }
+    }
+
+    private fun copyVertex(source: FloatArray, from: Int, target: FloatArray, to: Int) {
+        target[to] = source[from]
+        target[to + 1] = source[from + 1]
+        target[to + 2] = source[from + 2]
+    }
+
+    private fun writeFaceNormal(
+        source: FloatArray,
+        a: Int,
+        b: Int,
+        c: Int,
+        normals: FloatArray,
+        at: Int
+    ) {
+        val ux = source[b] - source[a]
+        val uy = source[b + 1] - source[a + 1]
+        val uz = source[b + 2] - source[a + 2]
+        val vx = source[c] - source[a]
+        val vy = source[c + 1] - source[a + 1]
+        val vz = source[c + 2] - source[a + 2]
+        var nx = uy * vz - uz * vy
+        var ny = uz * vx - ux * vz
+        var nz = ux * vy - uy * vx
+        val length = kotlin.math.sqrt(nx * nx + ny * ny + nz * nz)
+        if (length > 0f && length.isFinite()) {
+            nx /= length
+            ny /= length
+            nz /= length
+        } else {
+            nx = 0f
+            ny = 1f
+            nz = 0f
+        }
+        for (corner in 0 until 3) {
+            normals[at + corner * 3] = nx
+            normals[at + corner * 3 + 1] = ny
+            normals[at + corner * 3 + 2] = nz
+        }
+    }
+
+    /** Wrap [json] and [bin] in the GLB container: 12-byte header, JSON chunk, BIN chunk. */
+    private fun packGlb(json: String, bin: ByteArray): ByteArray {
+        val jsonBytes = json.encodeToByteArray().padTo4(' '.code.toByte())
+        val binBytes = bin.padTo4(0)
+        val total = GLB_HEADER_SIZE + CHUNK_HEADER_SIZE + jsonBytes.size +
+            CHUNK_HEADER_SIZE + binBytes.size
+        val out = ByteArrayBuilder(total)
+        out.addIntLe(GLB_MAGIC)
+        out.addIntLe(GLB_VERSION)
+        out.addIntLe(total)
+        out.addIntLe(jsonBytes.size)
+        out.addIntLe(CHUNK_JSON)
+        out.addBytes(jsonBytes)
+        out.addIntLe(binBytes.size)
+        out.addIntLe(CHUNK_BIN)
+        out.addBytes(binBytes)
+        return out.toArray()
+    }
+
+    private fun ByteArray.padTo4(filler: Byte): ByteArray {
+        val padding = (4 - size % 4) % 4
+        if (padding == 0) return this
+        return copyOf(size + padding).also { for (i in size until it.size) it[i] = filler }
+    }
+
+    private fun min(values: FloatArray) = componentBound(values) { a, b -> minOf(a, b) }
+
+    private fun max(values: FloatArray) = componentBound(values) { a, b -> maxOf(a, b) }
+
+    private fun componentBound(values: FloatArray, pick: (Float, Float) -> Float): String {
+        if (values.size < 3) return floatArrayOf(0f, 0f, 0f).toJsonArray()
+        val bound = FloatArray(3) { values[it] }
+        for (i in values.indices) bound[i % 3] = pick(bound[i % 3], values[i])
+        return bound.toJsonArray()
+    }
+
+    /** sRGB `0xRRGGBBAA` → linear RGBA, the space a glTF `baseColorFactor` is defined in. */
+    private fun Int.toLinearRgba(): FloatArray {
+        val r = ((this ushr 24) and 0xFF) / 255f
+        val g = ((this ushr 16) and 0xFF) / 255f
+        val b = ((this ushr 8) and 0xFF) / 255f
+        val a = (this and 0xFF) / 255f
+        return floatArrayOf(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b), a)
+    }
+
+    private fun srgbToLinear(channel: Float): Float =
+        if (channel <= 0.04045f) channel / 12.92f else ((channel + 0.055f) / 1.055f).pow(2.4f)
+
+    private fun FloatArray.toJsonArray(): String =
+        joinToString(",", "[", "]") { it.toJsonNumber() }
+
+    /**
+     * Format a float as a JSON number, identically on every target.
+     *
+     * `Float.toString()` cannot be used: Kotlin/JS backs a `Float` with a JS double, so `0.001f`
+     * prints as `0.001000000047497451` there and `0.001` on the JVM — the same 3MF would produce
+     * two different GLBs, and a JSON six times larger in the browser. This rounds to float32's
+     * ~7 significant digits and trims, so the output is both stable and compact.
+     */
+    private fun Float.toJsonNumber(): String {
+        if (!isFinite() || this == 0f) return "0"
+        val magnitude = kotlin.math.abs(toDouble())
+        val exponent = kotlin.math.floor(kotlin.math.log10(magnitude)).toInt()
+        val decimals = (SIGNIFICANT_DIGITS - 1 - exponent).coerceIn(0, MAX_DECIMALS)
+        val scale = POWERS_OF_TEN[decimals]
+        val scaled = kotlin.math.round(magnitude * scale.toDouble()).toLong()
+        val whole = scaled / scale
+        val fraction = (scaled % scale).toString().padStart(decimals, '0').trimEnd('0')
+        val sign = if (this < 0f) "-" else ""
+        return if (fraction.isEmpty()) "$sign$whole" else "$sign$whole.$fraction"
+    }
+
+    private fun String.toJsonString(): String = buildString {
+        append('"')
+        for (char in this@toJsonString) {
+            when {
+                char == '"' -> append("\\\"")
+                char == '\\' -> append("\\\\")
+                char < ' ' -> append("\\u").append(char.code.toString(16).padStart(4, '0'))
+                else -> append(char)
+            }
+        }
+        append('"')
+    }
+
+    private const val Generator = "SceneView 3MF loader"
+    private val DefaultBaseColor = floatArrayOf(0.62f, 0.64f, 0.68f, 1f)
+
+    /** A printed part is matte, never a mirror — written literally so no float formatting applies. */
+    private const val PrintRoughness = "0.55"
+
+    private const val SIGNIFICANT_DIGITS = 7
+    private const val MAX_DECIMALS = 9
+    private val POWERS_OF_TEN = LongArray(MAX_DECIMALS + 1) { exponent ->
+        var value = 1L
+        repeat(exponent) { value *= 10 }
+        value
+    }
+    private const val MAX_COMPONENT_DEPTH = 32
+    private const val FLOAT = 5126
+    private const val ARRAY_BUFFER = 34962
+    private const val GLB_MAGIC = 0x46546C67 // "glTF"
+    private const val GLB_VERSION = 2
+    private const val GLB_HEADER_SIZE = 12
+    private const val CHUNK_HEADER_SIZE = 8
+    private const val CHUNK_JSON = 0x4E4F534A // "JSON"
+    private const val CHUNK_BIN = 0x004E4942 // "BIN\0"
+}
+
+/** Growable little-endian byte sink for the GLB payload. */
+internal class ByteArrayBuilder(initialCapacity: Int = 4096) {
+    private var data = ByteArray(maxOf(initialCapacity, 16))
+    var size = 0
+        private set
+
+    fun addIntLe(value: Int) {
+        ensure(4)
+        data[size++] = (value and 0xFF).toByte()
+        data[size++] = ((value ushr 8) and 0xFF).toByte()
+        data[size++] = ((value ushr 16) and 0xFF).toByte()
+        data[size++] = ((value ushr 24) and 0xFF).toByte()
+    }
+
+    fun addFloatLe(value: Float) = addIntLe(value.toRawBits())
+
+    fun addBytes(bytes: ByteArray) {
+        ensure(bytes.size)
+        bytes.copyInto(data, size)
+        size += bytes.size
+    }
+
+    private fun ensure(extra: Int) {
+        if (size + extra <= data.size) return
+        var capacity = data.size
+        while (size + extra > capacity) capacity = capacity shl 1
+        data = data.copyOf(capacity)
+    }
+
+    fun toArray(): ByteArray = data.copyOf(size)
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfLoader.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfLoader.kt
@@ -1,0 +1,80 @@
+package io.github.sceneview.core.threemf
+
+/**
+ * Reads **3MF** (`.3mf`, 3D Manufacturing Format) — the format every AI image-to-print flow and
+ * every modern slicer emits — on all SceneView platforms.
+ *
+ * A 3MF is an OPC package: a ZIP whose `3D/3dmodel.model` part is XML describing triangle meshes in
+ * real-world units. This object turns one into either a [ThreeMfModel] (the file's own data, for
+ * inspection or a custom pipeline) or a **GLB** byte array ([toGlb]) that every SceneView renderer
+ * already loads. The GLB route is the one to use: it costs one conversion and gains the whole
+ * existing glTF path — materials, gestures, AR placement, the web viewer.
+ *
+ * Everything is pure Kotlin with no platform dependency: no `java.util.zip`, no XML library, so the
+ * exact same code runs on Android, iOS and the browser.
+ *
+ * ```kotlin
+ * // Android: open a 3MF that another app shared with you
+ * val glb = ThreeMfLoader.toGlb(contentResolver.openInputStream(uri)!!.readBytes())
+ * val modelInstance = modelLoader.createModelInstance(ByteBuffer.wrap(glb))
+ * ```
+ *
+ * On Android you rarely need this directly: `ModelLoader` sniffs a 3MF buffer and converts it
+ * itself, so `rememberModelInstance(modelLoader, "print.3mf")` just works.
+ */
+object ThreeMfLoader {
+
+    /**
+     * `true` when [bytes] looks like a 3MF: a ZIP archive containing a `3D/3dmodel.model` part.
+     *
+     * Cheap enough to call on every buffer before deciding which loader to use — it reads the ZIP
+     * central directory, never the geometry. Returns `false` (never throws) for anything else,
+     * including a plain ZIP that is not a 3MF.
+     */
+    fun isThreeMf(bytes: ByteArray): Boolean = runCatching {
+        Zip.looksLikeZip(bytes) && Zip.entryNames(bytes).any { it.isModelPart() }
+    }.getOrDefault(false)
+
+    /**
+     * Parse a `.3mf` file into its objects, meshes and build items, in the file's own units and
+     * Z-up axes.
+     *
+     * @throws ThreeMfParseException if the archive, the model part or its XML is unreadable.
+     */
+    fun parse(bytes: ByteArray): ThreeMfModel = ThreeMfParser.parse(readModelPart(bytes))
+
+    /**
+     * Convert a `.3mf` file to a self-contained **GLB** (binary glTF 2.0) that any SceneView
+     * renderer loads — scaled to metres, rotated Y-up, flat-shaded, one material per 3MF colour.
+     *
+     * @throws ThreeMfParseException if the file cannot be read.
+     */
+    fun toGlb(bytes: ByteArray): ByteArray = toGlb(parse(bytes))
+
+    /** Convert an already-parsed [model] to GLB. @see toGlb */
+    fun toGlb(model: ThreeMfModel): ByteArray = ThreeMfGlb.encode(model)
+
+    private fun readModelPart(bytes: ByteArray): String {
+        if (!Zip.looksLikeZip(bytes)) {
+            threeMfError("Not a 3MF file: no ZIP header (a 3MF is an OPC/ZIP package)")
+        }
+        val part = Zip.readEntry(bytes, ModelPart)
+            ?: Zip.readFirstEntry(bytes) { it.isModelPart() }
+            ?: threeMfError(
+                "3MF archive has no \"$ModelPart\" part " +
+                    "(found: ${Zip.entryNames(bytes).joinToString()})"
+            )
+        return part.decodeToString()
+    }
+
+    /**
+     * The conventional part path, plus the case- and separator-tolerant fallback: the OPC
+     * relationship part is authoritative in theory, but every real writer uses this path and some
+     * differ only in case.
+     */
+    private fun String.isModelPart(): Boolean =
+        equals(ModelPart, ignoreCase = true) ||
+            (endsWith(".model", ignoreCase = true) && startsWith("3D/", ignoreCase = true))
+
+    private const val ModelPart = "3D/3dmodel.model"
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfModel.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfModel.kt
@@ -1,0 +1,127 @@
+package io.github.sceneview.core.threemf
+
+/**
+ * Thrown when a `.3mf` file cannot be read: not a ZIP/OPC package, no `3D/3dmodel.model` part,
+ * malformed XML, or geometry that does not describe a mesh. Every low-level failure (a truncated
+ * archive, an out-of-range vertex index) is translated into this one exception, so callers never
+ * have to catch anything else.
+ */
+class ThreeMfParseException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
+/**
+ * Raise a [ThreeMfParseException] — a single-throw helper in the spirit of the stdlib `error()`, so
+ * the many guard clauses in the ZIP/XML/3MF readers keep each function within detekt's
+ * `ThrowsCount` budget and error construction stays in one place.
+ */
+internal fun threeMfError(message: String, cause: Throwable? = null): Nothing =
+    throw ThreeMfParseException(message, cause)
+
+/**
+ * The length unit a 3MF declares on its root `<model>` element. 3MF is a manufacturing format, so
+ * it carries real-world size — a ChatGPT-generated print is almost always in [MILLIMETER], which is
+ * why a raw 3MF dropped into a metres-based renderer would otherwise appear 1000× too large.
+ *
+ * @property id     The token as it appears in the file's `unit` attribute.
+ * @property meters How many metres one unit is; the scale applied when converting to glTF.
+ */
+enum class ThreeMfUnit(val id: String, val meters: Float) {
+    MICRON("micron", 0.000001f),
+    MILLIMETER("millimeter", 0.001f),
+    CENTIMETER("centimeter", 0.01f),
+    INCH("inch", 0.0254f),
+    FOOT("foot", 0.3048f),
+    METER("meter", 1.0f);
+
+    companion object {
+        /** The 3MF default when a file declares no `unit` attribute. */
+        val Default = MILLIMETER
+
+        /** Parse a `unit` attribute value; unknown or absent tokens fall back to [Default]. */
+        fun fromId(id: String?): ThreeMfUnit =
+            entries.firstOrNull { it.id == id?.lowercase() } ?: Default
+    }
+}
+
+/**
+ * A triangle mesh exactly as the file stores it: indexed positions in model units, plus an optional
+ * per-triangle colour.
+ *
+ * @property positions      Vertex positions, three floats (x, y, z) per vertex, in [ThreeMfModel]'s
+ *                          unit and the file's own Z-up axis convention.
+ * @property indices        Three vertex indices per triangle.
+ * @property triangleColors One packed `0xRRGGBBAA` colour per triangle, or `null` when the whole
+ *                          mesh takes its owning object's colour. [NoColor] marks an untinted
+ *                          triangle.
+ */
+class ThreeMfMesh(
+    val positions: FloatArray,
+    val indices: IntArray,
+    val triangleColors: IntArray? = null
+) {
+    /** Number of vertices (`positions.size / 3`). */
+    val vertexCount: Int get() = positions.size / 3
+
+    /** Number of triangles (`indices.size / 3`). */
+    val triangleCount: Int get() = indices.size / 3
+}
+
+/**
+ * A child object placed inside another one, with its own placement matrix.
+ *
+ * @property objectId The referenced `<object id>`.
+ * @property transform A 16-float **column-major** 4×4 matrix, the same layout glTF node matrices
+ *                     use.
+ */
+class ThreeMfComponent(val objectId: Int, val transform: FloatArray)
+
+/**
+ * One `<object>` from the file's `<resources>`: either a mesh, or an assembly of [components], or
+ * both.
+ *
+ * @property color Packed `0xRRGGBBAA` colour resolved from the object's `pid`/`pindex` material
+ *                 reference, or [NoColor] when the file assigns none.
+ */
+class ThreeMfObject(
+    val id: Int,
+    val name: String?,
+    val mesh: ThreeMfMesh?,
+    val components: List<ThreeMfComponent> = emptyList(),
+    val color: Int = NoColor
+)
+
+/**
+ * One `<build><item>`: the placement of an object on the print plate.
+ *
+ * @property transform A 16-float **column-major** 4×4 matrix.
+ */
+class ThreeMfItem(val objectId: Int, val transform: FloatArray)
+
+/**
+ * A parsed 3MF document — the printable objects it defines and where the build plate places them.
+ *
+ * The data is kept in the file's own frame: **Z-up**, in [unit]. The conversion to a renderer's
+ * Y-up metres happens once, in [ThreeMfLoader.toGlb].
+ */
+class ThreeMfModel(
+    val unit: ThreeMfUnit,
+    val objects: List<ThreeMfObject>,
+    val items: List<ThreeMfItem>
+) {
+    /** Objects by `id`, for resolving [ThreeMfItem.objectId] and [ThreeMfComponent.objectId]. */
+    val objectsById: Map<Int, ThreeMfObject> = objects.associateBy { it.id }
+
+    /** Total triangles across every object defined in the file (before build-item instancing). */
+    val triangleCount: Int get() = objects.sumOf { it.mesh?.triangleCount ?: 0 }
+}
+
+/** The "no colour assigned" sentinel: fully transparent black, which no 3MF ever means literally. */
+const val NoColor: Int = 0
+
+/** The identity matrix, column-major — the placement of an item or component with no `transform`. */
+internal fun identityMatrix() = floatArrayOf(
+    1f, 0f, 0f, 0f,
+    0f, 1f, 0f, 0f,
+    0f, 0f, 1f, 0f,
+    0f, 0f, 0f, 1f
+)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfParser.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfParser.kt
@@ -1,0 +1,247 @@
+package io.github.sceneview.core.threemf
+
+/**
+ * Streaming reader for the 3MF core specification (plus the colours of the materials extension).
+ *
+ * It walks the `3D/3dmodel.model` XML once with [XmlPullParser] and appends straight into growable
+ * primitive arrays, so a million-triangle print costs one float array, not a million objects.
+ *
+ * Supported: `<model unit>`, `<basematerials>`/`<base displaycolor>`, `<colorgroup>`/`<color>`,
+ * `<object>` with `<mesh>` (`<vertices>`/`<vertex>`, `<triangles>`/`<triangle>` including per
+ * triangle `pid`/`p1`) and `<components>`/`<component transform>`, and `<build>`/`<item transform>`.
+ * Anything else in the document — metadata, slice/beamlattice/production extensions, thumbnails —
+ * is skipped rather than rejected: an unrecognised extension must not stop a print from being
+ * previewed.
+ */
+internal object ThreeMfParser {
+
+    fun parse(xml: String): ThreeMfModel {
+        val parser = XmlPullParser(xml)
+        val state = ParseState()
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            when (parser.eventType) {
+                XmlPullParser.START_TAG -> onStart(parser, state)
+                XmlPullParser.END_TAG -> onEnd(parser, state)
+            }
+        }
+        if (state.objects.isEmpty()) {
+            threeMfError("3MF has no <object> in <resources>")
+        }
+        return ThreeMfModel(
+            unit = state.unit,
+            objects = state.objects,
+            // A file with no <build> still previews: show every top-level object at the origin.
+            items = state.items.ifEmpty { state.objects.map { ThreeMfItem(it.id, identityMatrix()) } }
+        )
+    }
+
+    private class ParseState {
+        var unit = ThreeMfUnit.Default
+        val objects = ArrayList<ThreeMfObject>()
+        val items = ArrayList<ThreeMfItem>()
+
+        /** `id` → palette of packed colours, for both `<basematerials>` and `<colorgroup>`. */
+        val palettes = HashMap<Int, IntArray>()
+        var paletteId: Int? = null
+        var palette = ArrayList<Int>()
+
+        var objectId: Int? = null
+        var objectName: String? = null
+        var objectColor = NoColor
+        var objectPaletteId: Int? = null
+        var positions = FloatArrayBuilder()
+        var indices = IntArrayBuilder()
+        var triangleColors = IntArrayBuilder()
+        var anyTriangleColor = false
+        var components = ArrayList<ThreeMfComponent>()
+    }
+
+    private fun onStart(parser: XmlPullParser, state: ParseState) {
+        when (parser.name) {
+            "model" -> state.unit = ThreeMfUnit.fromId(parser.attribute("unit"))
+            "basematerials", "colorgroup" -> startPalette(parser, state)
+            "base" -> state.palette += parseColor(parser.attribute("displaycolor"))
+            "color" -> state.palette += parseColor(parser.attribute("color"))
+            "object" -> startObject(parser, state)
+            "vertex" -> readVertex(parser, state)
+            "triangle" -> readTriangle(parser, state)
+            "component" -> state.components += ThreeMfComponent(
+                objectId = parser.requireInt("objectid"),
+                transform = parseTransform(parser.attribute("transform"))
+            )
+
+            "item" -> state.items += ThreeMfItem(
+                objectId = parser.requireInt("objectid"),
+                transform = parseTransform(parser.attribute("transform"))
+            )
+        }
+    }
+
+    private fun onEnd(parser: XmlPullParser, state: ParseState) {
+        when (parser.name) {
+            "basematerials", "colorgroup" -> {
+                state.paletteId?.let { state.palettes[it] = state.palette.toIntArray() }
+                state.paletteId = null
+                state.palette = ArrayList()
+            }
+
+            "object" -> endObject(state)
+        }
+    }
+
+    private fun startPalette(parser: XmlPullParser, state: ParseState) {
+        state.paletteId = parser.attribute("id")?.toIntOrNull()
+        state.palette = ArrayList()
+    }
+
+    private fun startObject(parser: XmlPullParser, state: ParseState) {
+        state.objectId = parser.requireInt("id")
+        state.objectName = parser.attribute("name")
+        state.objectPaletteId = parser.attribute("pid")?.toIntOrNull()
+        state.objectColor = state.colorAt(state.objectPaletteId, parser.attribute("pindex"))
+        state.positions = FloatArrayBuilder()
+        state.indices = IntArrayBuilder()
+        state.triangleColors = IntArrayBuilder()
+        state.anyTriangleColor = false
+        state.components = ArrayList()
+    }
+
+    private fun endObject(state: ParseState) {
+        val id = state.objectId ?: return
+        val mesh = if (state.indices.size > 0) {
+            ThreeMfMesh(
+                positions = state.positions.toArray(),
+                indices = state.indices.toArray(),
+                triangleColors = state.triangleColors.toArray().takeIf { state.anyTriangleColor }
+            )
+        } else {
+            null
+        }
+        state.objects += ThreeMfObject(
+            id = id,
+            name = state.objectName,
+            mesh = mesh,
+            components = state.components.toList(),
+            color = state.objectColor
+        )
+        state.objectId = null
+    }
+
+    private fun readVertex(parser: XmlPullParser, state: ParseState) {
+        state.positions.add(parser.requireFloat("x"))
+        state.positions.add(parser.requireFloat("y"))
+        state.positions.add(parser.requireFloat("z"))
+    }
+
+    private fun readTriangle(parser: XmlPullParser, state: ParseState) {
+        val vertexCount = state.positions.size / 3
+        val v1 = parser.requireIndex("v1", vertexCount)
+        val v2 = parser.requireIndex("v2", vertexCount)
+        val v3 = parser.requireIndex("v3", vertexCount)
+        state.indices.add(v1)
+        state.indices.add(v2)
+        state.indices.add(v3)
+        // A triangle's own `pid` overrides the object's; `p1` indexes into it. Per-vertex p2/p3
+        // (a colour gradient across the triangle) collapses to p1 — a flat-shaded print preview
+        // gains nothing from interpolating them, and glTF would need per-vertex COLOR_0 to carry it.
+        val paletteId = parser.attribute("pid")?.toIntOrNull() ?: state.objectPaletteId
+        val color = state.colorAt(paletteId, parser.attribute("p1"))
+        val resolved = if (color != NoColor) color else state.objectColor
+        state.triangleColors.add(resolved)
+        if (color != NoColor) state.anyTriangleColor = true
+    }
+
+    private fun ParseState.colorAt(paletteId: Int?, index: String?): Int {
+        val colors = palettes[paletteId ?: return NoColor] ?: return NoColor
+        val at = index?.toIntOrNull() ?: 0
+        return colors.getOrElse(at) { NoColor }
+    }
+
+    private fun XmlPullParser.requireInt(attributeName: String): Int =
+        attribute(attributeName)?.toIntOrNull()
+            ?: threeMfError("3MF <$name> has no valid \"$attributeName\" attribute")
+
+    private fun XmlPullParser.requireFloat(attributeName: String): Float =
+        attribute(attributeName)?.toFloatOrNull()
+            ?: threeMfError("3MF <$name> has no valid \"$attributeName\" attribute")
+
+    private fun XmlPullParser.requireIndex(attributeName: String, vertexCount: Int): Int {
+        val index = requireInt(attributeName)
+        if (index !in 0 until vertexCount) {
+            threeMfError(
+                "3MF <triangle $attributeName=\"$index\"> is out of range " +
+                    "(mesh has $vertexCount vertices)"
+            )
+        }
+        return index
+    }
+
+    /**
+     * `#RRGGBB` or `#RRGGBBAA` (the 3MF `displaycolor` / `color` form, sRGB) → packed
+     * `0xRRGGBBAA`. An absent or unparseable value yields [NoColor].
+     */
+    fun parseColor(value: String?): Int {
+        val hex = value?.trim()?.removePrefix("#") ?: return NoColor
+        if (hex.length < RGB_HEX_LENGTH) return NoColor
+        val rgb = hex.take(RGB_HEX_LENGTH).toLongOrNull(radix = 16) ?: return NoColor
+        val alpha = hex.drop(RGB_HEX_LENGTH).takeIf { it.length >= 2 }
+            ?.take(2)?.toIntOrNull(radix = 16) ?: 0xFF
+        return ((rgb.toInt() shl 8) or alpha)
+    }
+
+    /**
+     * The 3MF `transform` attribute: 12 numbers, row-major, describing a 4×3 matrix whose rows are
+     * the three basis vectors then the translation (3MF multiplies **row** vectors, `v * M`).
+     * Returned as the 16-float **column-major** matrix glTF and every renderer here expect —
+     * which, for this layout, is the same twelve numbers in the same order plus the `(0,0,0,1)`
+     * fourth column.
+     */
+    fun parseTransform(value: String?): FloatArray {
+        val parts = value?.trim()?.split(WHITESPACE)?.filter { it.isNotEmpty() }
+            ?: return identityMatrix()
+        if (parts.size != TRANSFORM_VALUES) {
+            threeMfError("3MF transform must have $TRANSFORM_VALUES values, got ${parts.size}")
+        }
+        val m = parts.map {
+            it.toFloatOrNull() ?: threeMfError("3MF transform has a non-numeric value \"$it\"")
+        }
+        return floatArrayOf(
+            m[0], m[1], m[2], 0f,
+            m[3], m[4], m[5], 0f,
+            m[6], m[7], m[8], 0f,
+            m[9], m[10], m[11], 1f
+        )
+    }
+
+    private val WHITESPACE = Regex("\\s+")
+    private const val TRANSFORM_VALUES = 12
+    private const val RGB_HEX_LENGTH = 6
+}
+
+/** Growable `FloatArray`, so a streamed mesh never boxes a single vertex coordinate. */
+internal class FloatArrayBuilder(initialCapacity: Int = 256) {
+    private var data = FloatArray(initialCapacity)
+    var size = 0
+        private set
+
+    fun add(value: Float) {
+        if (size == data.size) data = data.copyOf(data.size * 2)
+        data[size++] = value
+    }
+
+    fun toArray(): FloatArray = data.copyOf(size)
+}
+
+/** Growable `IntArray`, the index/colour counterpart of [FloatArrayBuilder]. */
+internal class IntArrayBuilder(initialCapacity: Int = 256) {
+    private var data = IntArray(initialCapacity)
+    var size = 0
+        private set
+
+    fun add(value: Int) {
+        if (size == data.size) data = data.copyOf(data.size * 2)
+        data[size++] = value
+    }
+
+    fun toArray(): IntArray = data.copyOf(size)
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/XmlPullParser.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/XmlPullParser.kt
@@ -1,0 +1,236 @@
+package io.github.sceneview.core.threemf
+
+/**
+ * A tiny, allocation-frugal XML pull parser — the multiplatform stand-in for `org.xmlpull` /
+ * `XMLParser`, written because Kotlin/JS and Kotlin/Native have no shared XML reader and a 3MF's
+ * `3D/3dmodel.model` is the only document this SDK has to read.
+ *
+ * **Pull, not DOM, on purpose.** A printable model is millions of `<vertex .../>` and
+ * `<triangle .../>` elements; materialising one object per element would cost hundreds of megabytes
+ * on a phone. The caller walks events and appends straight into primitive arrays.
+ *
+ * Scope is deliberately the subset 3MF uses: elements, attributes, self-closing tags, comments,
+ * CDATA, processing instructions and `<!DOCTYPE>`. Character data between tags is skipped — no 3MF
+ * geometry lives in text nodes. Namespace prefixes are stripped from element names (`m:colorgroup`
+ * reads as `colorgroup`), which is exactly the matching a single-vocabulary document needs, and
+ * makes the parser indifferent to which prefix a writer chose.
+ */
+internal class XmlPullParser(private val text: String) {
+
+    /** The event produced by the last [next] call. */
+    var eventType: Int = START_DOCUMENT
+        private set
+
+    /** Local name (prefix stripped) of the element for [START_TAG] / [END_TAG]. */
+    var name: String = ""
+        private set
+
+    /** Nesting depth after the current event: a [START_TAG] at the root reports 1. */
+    var depth: Int = 0
+        private set
+
+    private var position = 0
+    private var selfClosingPending = false
+    private var attributeNames = ArrayList<String>(ATTRIBUTES_HINT)
+    private var attributeValues = ArrayList<String>(ATTRIBUTES_HINT)
+
+    /** Value of attribute [attributeName] on the current [START_TAG], or `null` if absent. */
+    fun attribute(attributeName: String): String? {
+        for (i in attributeNames.indices) {
+            if (attributeNames[i] == attributeName) return attributeValues[i]
+        }
+        return null
+    }
+
+    /** Advance to the next event and return it. */
+    fun next(): Int {
+        if (selfClosingPending) {
+            selfClosingPending = false
+            depth--
+            eventType = END_TAG
+            return eventType
+        }
+        skipToTag()
+        if (position >= text.length) {
+            eventType = END_DOCUMENT
+            return eventType
+        }
+        return readTag()
+    }
+
+    /**
+     * Skip the whole subtree of the [START_TAG] just returned, leaving the parser positioned on its
+     * matching [END_TAG]. A no-op on any other event.
+     */
+    fun skipSubtree() {
+        if (eventType != START_TAG) return
+        val target = depth
+        while (eventType != END_DOCUMENT && !(eventType == END_TAG && depth == target - 1)) {
+            next()
+        }
+    }
+
+    private fun skipToTag() {
+        while (position < text.length && text[position] != '<') position++
+    }
+
+    private fun readTag(): Int {
+        position++ // consume '<'
+        return when {
+            startsWith("!--") -> skipUntil("-->")
+            startsWith("![CDATA[") -> skipUntil("]]>")
+            position < text.length && (text[position] == '?' || text[position] == '!') ->
+                skipUntil(">")
+            position < text.length && text[position] == '/' -> readEndTag()
+            else -> readStartTag()
+        }
+    }
+
+    private fun startsWith(token: String): Boolean = text.startsWith(token, position)
+
+    private fun skipUntil(terminator: String): Int {
+        val end = text.indexOf(terminator, position)
+        position = if (end < 0) text.length else end + terminator.length
+        return next()
+    }
+
+    private fun readEndTag(): Int {
+        position++ // consume '/'
+        val end = text.indexOf('>', position)
+        if (end < 0) threeMfError("XML: unterminated closing tag")
+        name = localName(text.substring(position, end).trim())
+        position = end + 1
+        depth--
+        eventType = END_TAG
+        return eventType
+    }
+
+    private fun readStartTag(): Int {
+        val nameEnd = scanName()
+        name = localName(text.substring(position, nameEnd))
+        position = nameEnd
+        attributeNames.clear()
+        attributeValues.clear()
+        readAttributes()
+        depth++
+        eventType = START_TAG
+        return eventType
+    }
+
+    private fun scanName(): Int {
+        var at = position
+        while (at < text.length && !text[at].isXmlNameBoundary()) at++
+        if (at == position) threeMfError("XML: empty element name")
+        return at
+    }
+
+    private fun readAttributes() {
+        while (position < text.length) {
+            skipWhitespace()
+            if (position >= text.length) threeMfError("XML: unterminated element <$name>")
+            when (text[position]) {
+                '>' -> {
+                    position++
+                    return
+                }
+
+                '/' -> {
+                    selfClosingPending = true
+                    position = text.indexOf('>', position).let {
+                        if (it < 0) threeMfError("XML: unterminated element <$name>") else it + 1
+                    }
+                    return
+                }
+
+                else -> readAttribute()
+            }
+        }
+        threeMfError("XML: unterminated element <$name>")
+    }
+
+    private fun readAttribute() {
+        val nameEnd = scanName()
+        val attributeName = localName(text.substring(position, nameEnd))
+        position = nameEnd
+        skipWhitespace()
+        if (position >= text.length || text[position] != '=') {
+            threeMfError("XML: attribute \"$attributeName\" of <$name> has no value")
+        }
+        position++
+        skipWhitespace()
+        val quote = if (position < text.length) text[position] else ' '
+        if (quote != '"' && quote != '\'') {
+            threeMfError("XML: attribute \"$attributeName\" of <$name> is not quoted")
+        }
+        position++
+        val end = text.indexOf(quote, position)
+        if (end < 0) threeMfError("XML: unterminated value for attribute \"$attributeName\"")
+        attributeNames += attributeName
+        attributeValues += decodeEntities(text.substring(position, end))
+        position = end + 1
+    }
+
+    private fun skipWhitespace() {
+        while (position < text.length && text[position].isWhitespace()) position++
+    }
+
+    companion object {
+        const val START_DOCUMENT = 0
+        const val START_TAG = 1
+        const val END_TAG = 2
+        const val END_DOCUMENT = 3
+
+        private const val ATTRIBUTES_HINT = 8
+    }
+}
+
+private fun Char.isXmlNameBoundary(): Boolean =
+    isWhitespace() || this == '=' || this == '>' || this == '/'
+
+/** `m:colorgroup` → `colorgroup`; an unprefixed name is returned unchanged. */
+private fun localName(qualified: String): String {
+    val colon = qualified.indexOf(':')
+    return if (colon < 0) qualified else qualified.substring(colon + 1)
+}
+
+/**
+ * Expand the five predefined XML entities plus numeric character references. Attribute values in a
+ * 3MF are numbers, ids and names, so the fast path — no `&` at all — is the one that runs for
+ * essentially every attribute of every vertex and triangle.
+ */
+private fun decodeEntities(raw: String): String {
+    if (!raw.contains('&')) return raw
+    val out = StringBuilder(raw.length)
+    var i = 0
+    while (i < raw.length) {
+        val char = raw[i]
+        val end = if (char == '&') raw.indexOf(';', i) else -1
+        if (end < 0) {
+            // Not an entity (or an unterminated one): copy the character through verbatim.
+            out.append(char)
+            i++
+        } else {
+            out.append(expandEntity(raw.substring(i + 1, end)))
+            i = end + 1
+        }
+    }
+    return out.toString()
+}
+
+private fun expandEntity(body: String): String = when {
+    body == "amp" -> "&"
+    body == "lt" -> "<"
+    body == "gt" -> ">"
+    body == "quot" -> "\""
+    body == "apos" -> "'"
+    body.startsWith("#x") || body.startsWith("#X") ->
+        body.drop(2).toIntOrNull(radix = 16)?.let { charOf(it) } ?: "&$body;"
+
+    body.startsWith("#") -> body.drop(1).toIntOrNull()?.let { charOf(it) } ?: "&$body;"
+    else -> "&$body;" // Unknown entity: leave the source text as-is rather than lose it.
+}
+
+private fun charOf(codePoint: Int): String? =
+    if (codePoint in 0..MAX_BMP_CODE_POINT) codePoint.toChar().toString() else null
+
+private const val MAX_BMP_CODE_POINT = 0xFFFF

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/Zip.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/Zip.kt
@@ -1,0 +1,173 @@
+package io.github.sceneview.core.threemf
+
+import io.github.sceneview.core.splat.Inflate
+import io.github.sceneview.core.splat.readLe16
+import io.github.sceneview.core.splat.readLe32
+
+/**
+ * Minimal in-memory ZIP (OPC package) reader — just enough to pull one named entry out of a `.3mf`
+ * container on every Kotlin Multiplatform target, with no `java.util.zip` and no `expect`/`actual`.
+ *
+ * A 3MF file is an OPC package: a plain ZIP whose payload is `3D/3dmodel.model`. Entries are either
+ * stored (method 0) or raw DEFLATE (method 8), both handled here — DEFLATE via the pure-Kotlin
+ * [Inflate] decoder the SPZ splat parser already ships.
+ *
+ * Deliberately not supported, each rejected with a clear message rather than a wrong result:
+ * ZIP64 (a 3MF that large is not a phone-viewable print), encryption, and any other compression
+ * method. Entry lookup goes through the central directory, so a stream written with data
+ * descriptors (sizes zeroed in the local header) still reads correctly.
+ */
+internal object Zip {
+
+    /**
+     * Read the entry named [name] (exact, case-sensitive path inside the archive), or `null` if the
+     * archive has no such entry.
+     *
+     * @throws ThreeMfParseException if [bytes] is not a readable ZIP, or the entry cannot be
+     * decompressed.
+     */
+    fun readEntry(bytes: ByteArray, name: String): ByteArray? {
+        val entry = entries(bytes).firstOrNull { it.name == name } ?: return null
+        return extract(bytes, entry)
+    }
+
+    /** The entry names in the archive's central directory, in stored order. */
+    fun entryNames(bytes: ByteArray): List<String> = entries(bytes).map { it.name }
+
+    /**
+     * Read the first entry whose name matches [predicate]. Used to find `3D/3dmodel.model` when a
+     * writer used a different case or a non-standard part name (the OPC relationship part points at
+     * it, but every real-world 3MF also uses the conventional path).
+     */
+    fun readFirstEntry(bytes: ByteArray, predicate: (String) -> Boolean): ByteArray? {
+        val entry = entries(bytes).firstOrNull { predicate(it.name) } ?: return null
+        return extract(bytes, entry)
+    }
+
+    private class Entry(
+        val name: String,
+        val method: Int,
+        val compressedSize: Int,
+        val uncompressedSize: Int,
+        val localHeaderOffset: Int
+    )
+
+    private fun entries(bytes: ByteArray): List<Entry> {
+        val eocd = findEndOfCentralDirectory(bytes)
+        val count = readLe16(bytes, eocd + EOCD_ENTRY_COUNT)
+        val directoryOffset = readLe32(bytes, eocd + EOCD_DIRECTORY_OFFSET)
+        if (directoryOffset < 0 || directoryOffset >= bytes.size) {
+            threeMfError("ZIP central directory offset out of range ($directoryOffset)")
+        }
+        val entries = ArrayList<Entry>(count)
+        var at = directoryOffset
+        repeat(count) {
+            if (at + CENTRAL_HEADER_SIZE > bytes.size ||
+                readLe32(bytes, at) != CENTRAL_HEADER_SIGNATURE
+            ) {
+                threeMfError("ZIP central directory truncated at entry ${entries.size}")
+            }
+            entries += readCentralEntry(bytes, at)
+            at += CENTRAL_HEADER_SIZE +
+                readLe16(bytes, at + CENTRAL_NAME_LENGTH) +
+                readLe16(bytes, at + CENTRAL_EXTRA_LENGTH) +
+                readLe16(bytes, at + CENTRAL_COMMENT_LENGTH)
+        }
+        return entries
+    }
+
+    private fun readCentralEntry(bytes: ByteArray, at: Int): Entry {
+        val nameLength = readLe16(bytes, at + CENTRAL_NAME_LENGTH)
+        val nameStart = at + CENTRAL_HEADER_SIZE
+        if (nameStart + nameLength > bytes.size) threeMfError("ZIP entry name truncated")
+        return Entry(
+            name = bytes.decodeToString(nameStart, nameStart + nameLength),
+            method = readLe16(bytes, at + CENTRAL_METHOD),
+            compressedSize = readLe32(bytes, at + CENTRAL_COMPRESSED_SIZE),
+            uncompressedSize = readLe32(bytes, at + CENTRAL_UNCOMPRESSED_SIZE),
+            localHeaderOffset = readLe32(bytes, at + CENTRAL_LOCAL_OFFSET)
+        )
+    }
+
+    private fun extract(bytes: ByteArray, entry: Entry): ByteArray {
+        if (entry.compressedSize == ZIP64_MARKER || entry.uncompressedSize == ZIP64_MARKER) {
+            threeMfError("ZIP64 archives are not supported (entry \"${entry.name}\")")
+        }
+        val local = entry.localHeaderOffset
+        if (local < 0 || local + LOCAL_HEADER_SIZE > bytes.size ||
+            readLe32(bytes, local) != LOCAL_HEADER_SIGNATURE
+        ) {
+            threeMfError("ZIP local header missing for entry \"${entry.name}\"")
+        }
+        val dataStart = local + LOCAL_HEADER_SIZE +
+            readLe16(bytes, local + LOCAL_NAME_LENGTH) +
+            readLe16(bytes, local + LOCAL_EXTRA_LENGTH)
+        if (dataStart < 0 || dataStart + entry.compressedSize > bytes.size) {
+            threeMfError("ZIP entry \"${entry.name}\" data truncated")
+        }
+        return when (entry.method) {
+            METHOD_STORED -> bytes.copyOfRange(dataStart, dataStart + entry.uncompressedSize)
+            METHOD_DEFLATE -> inflateEntry(bytes, dataStart, entry)
+            else -> threeMfError(
+                "ZIP entry \"${entry.name}\" uses unsupported compression method ${entry.method}"
+            )
+        }
+    }
+
+    private fun inflateEntry(bytes: ByteArray, dataStart: Int, entry: Entry): ByteArray {
+        val inflated = runCatching { Inflate.raw(bytes, dataStart, entry.uncompressedSize) }
+            .getOrElse { threeMfError("ZIP entry \"${entry.name}\" is not valid DEFLATE data", it) }
+        // The central directory's uncompressed size is authoritative: a stream that inflates to a
+        // different length is corrupt, and silently accepting it would hand the XML parser a
+        // truncated document whose error would point at the wrong layer.
+        if (entry.uncompressedSize >= 0 && inflated.size != entry.uncompressedSize) {
+            threeMfError(
+                "ZIP entry \"${entry.name}\" inflated to ${inflated.size} bytes, " +
+                    "expected ${entry.uncompressedSize}"
+            )
+        }
+        return inflated
+    }
+
+    /**
+     * Scan backwards for the End Of Central Directory record. It is the last thing in the file
+     * except for an optional trailing comment (≤ 64 KiB), so the scan is bounded.
+     */
+    private fun findEndOfCentralDirectory(bytes: ByteArray): Int {
+        if (bytes.size < EOCD_MIN_SIZE) threeMfError("Not a ZIP archive (${bytes.size} bytes)")
+        val lowest = maxOf(0, bytes.size - EOCD_MIN_SIZE - MAX_COMMENT_SIZE)
+        for (at in bytes.size - EOCD_MIN_SIZE downTo lowest) {
+            if (readLe32(bytes, at) == EOCD_SIGNATURE) return at
+        }
+        threeMfError("Not a ZIP archive (no end-of-central-directory record)")
+    }
+
+    /** `true` when [bytes] starts with the local-file-header magic `PK`. */
+    fun looksLikeZip(bytes: ByteArray): Boolean =
+        bytes.size >= 4 && readLe32(bytes, 0) == LOCAL_HEADER_SIGNATURE
+
+    private const val METHOD_STORED = 0
+    private const val METHOD_DEFLATE = 8
+    private const val ZIP64_MARKER = -1 // 0xFFFFFFFF as a signed Int
+
+    private const val EOCD_SIGNATURE = 0x06054B50
+    private const val EOCD_MIN_SIZE = 22
+    private const val EOCD_ENTRY_COUNT = 10
+    private const val EOCD_DIRECTORY_OFFSET = 16
+    private const val MAX_COMMENT_SIZE = 0xFFFF
+
+    private const val CENTRAL_HEADER_SIGNATURE = 0x02014B50
+    private const val CENTRAL_HEADER_SIZE = 46
+    private const val CENTRAL_METHOD = 10
+    private const val CENTRAL_COMPRESSED_SIZE = 20
+    private const val CENTRAL_UNCOMPRESSED_SIZE = 24
+    private const val CENTRAL_NAME_LENGTH = 28
+    private const val CENTRAL_EXTRA_LENGTH = 30
+    private const val CENTRAL_COMMENT_LENGTH = 32
+    private const val CENTRAL_LOCAL_OFFSET = 42
+
+    private const val LOCAL_HEADER_SIGNATURE = 0x04034B50
+    private const val LOCAL_HEADER_SIZE = 30
+    private const val LOCAL_NAME_LENGTH = 26
+    private const val LOCAL_EXTRA_LENGTH = 28
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfGlbTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfGlbTest.kt
@@ -1,0 +1,134 @@
+package io.github.sceneview.core.threemf
+
+import io.github.sceneview.core.splat.readLe32
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The GLB these tests assert on is what every SceneView renderer actually loads, so the checks are
+ * the ones a renderer would fail on: container framing, chunk alignment, vertex counts, and the two
+ * conversions (millimetres → metres, Z-up → Y-up) that decide whether a print shows up at the right
+ * size and the right way up.
+ */
+class ThreeMfGlbTest {
+
+    @Test
+    fun writesAWellFormedGlbContainer() {
+        val glb = ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf)
+
+        assertEquals(GlbMagic, readLe32(glb, 0), "GLB magic \"glTF\"")
+        assertEquals(2, readLe32(glb, 4), "glTF 2.0")
+        assertEquals(glb.size, readLe32(glb, 8), "header length matches the real file size")
+
+        val jsonLength = readLe32(glb, 12)
+        assertEquals(JsonChunk, readLe32(glb, 16))
+        assertEquals(0, jsonLength % 4, "the JSON chunk is 4-byte aligned")
+        val binLength = readLe32(glb, 20 + jsonLength)
+        assertEquals(BinChunk, readLe32(glb, 24 + jsonLength))
+        assertEquals(0, binLength % 4, "the BIN chunk is 4-byte aligned")
+        assertEquals(glb.size, 28 + jsonLength + binLength, "the two chunks fill the file exactly")
+    }
+
+    @Test
+    fun deIndexesEveryTriangleWithItsOwnFlatNormal() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf))
+
+        // 12 triangles split into two colour groups of 6 → 18 de-indexed vertices per primitive.
+        assertContains(json, """"count":18""")
+        assertContains(json, """"POSITION"""")
+        assertContains(json, """"NORMAL"""")
+    }
+
+    @Test
+    fun onePrimitiveAndOneMaterialPerColor() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf))
+
+        assertEquals(2, json.occurrencesOf(""""attributes":"""), "one primitive per 3MF colour")
+        assertEquals(2, json.occurrencesOf(""""pbrMetallicRoughness""""))
+        assertContains(json, """"doubleSided":true""")
+    }
+
+    @Test
+    fun rootNodeConvertsMillimetresToMetresAndZUpToYUp() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf))
+
+        // Column-major: X stays X at 1 mm = 0.001 m, 3MF's +Y becomes glTF's −Z, +Z becomes +Y.
+        assertContains(json, """"matrix":[0.001,0,0,0,0,0,-0.001,0,0,0.001,0,0,0,0,0,1]""")
+    }
+
+    @Test
+    fun aUnitlessTinyModelStillCarriesItsBuildTranslation() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf))
+
+        // The build item's 5 mm offset stays in model units under the scaling root node.
+        assertContains(json, """"matrix":[1,0,0,0,0,1,0,0,0,0,1,0,5,0,0,1]""")
+    }
+
+    @Test
+    fun positionAccessorsCarryTheBoundsGltfRequires() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.CubeThreeMf))
+
+        assertContains(json, """"min":[0,0,0]""")
+        assertContains(json, """"max":[20,20,20]""")
+    }
+
+    @Test
+    fun anUncoloredModelGetsOneDefaultMaterial() {
+        val threeMf = ThreeMfTestFixtures.threeMfOf(ThreeMfTestFixtures.modelXml())
+        val json = jsonOf(ThreeMfLoader.toGlb(threeMf))
+
+        assertEquals(1, json.occurrencesOf(""""pbrMetallicRoughness""""))
+        assertContains(json, """"count":3""", message = "one triangle → three de-indexed vertices")
+    }
+
+    @Test
+    fun assembliesBecomeNestedNodesSharingOneMesh() {
+        val xml = """<model unit="meter">
+              <resources>
+                <object id="1"><mesh>
+                  <vertices><vertex x="0" y="0" z="0"/><vertex x="1" y="0" z="0"/>
+                    <vertex x="0" y="1" z="0"/></vertices>
+                  <triangles><triangle v1="0" v2="1" v3="2"/></triangles>
+                </mesh></object>
+                <object id="2"><components>
+                  <component objectid="1" transform="1 0 0 0 1 0 0 0 1 3 0 0"/>
+                  <component objectid="1" transform="1 0 0 0 1 0 0 0 1 0 3 0"/>
+                </components></object>
+              </resources>
+              <build><item objectid="2"/></build>
+            </model>"""
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(xml)))
+
+        assertEquals(1, json.occurrencesOf(""""primitives""""), "the instanced mesh is stored once")
+        assertEquals(2, json.occurrencesOf(""""mesh":0"""), "both components reference it")
+        assertContains(json, """"children"""")
+    }
+
+    @Test
+    fun degenerateTrianglesDoNotProduceNaNNormals() {
+        val xml = """<model unit="millimeter"><resources><object id="1"><mesh>
+            <vertices><vertex x="0" y="0" z="0"/><vertex x="0" y="0" z="0"/>
+              <vertex x="0" y="0" z="0"/></vertices>
+            <triangles><triangle v1="0" v2="1" v3="2"/></triangles>
+            </mesh></object></resources><build><item objectid="1"/></build></model>"""
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(xml)))
+
+        assertTrue("NaN" !in json, "a zero-area face must not poison the bounds with NaN")
+    }
+
+    private fun jsonOf(glb: ByteArray): String {
+        val length = readLe32(glb, 12)
+        return glb.decodeToString(20, 20 + length)
+    }
+
+    private fun String.occurrencesOf(token: String): Int =
+        split(token).size - 1
+
+    private companion object {
+        const val GlbMagic = 0x46546C67
+        const val JsonChunk = 0x4E4F534A
+        const val BinChunk = 0x004E4942
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfLoaderTest.kt
@@ -1,0 +1,176 @@
+package io.github.sceneview.core.threemf
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ThreeMfLoaderTest {
+
+    // ── The real, deflate-compressed file ────────────────────────────────────────────────────────
+
+    @Test
+    fun parsesARealDeflatedThreeMf() {
+        val model = ThreeMfLoader.parse(ThreeMfTestFixtures.CubeThreeMf)
+
+        assertEquals(ThreeMfUnit.MILLIMETER, model.unit)
+        assertEquals(1, model.objects.size)
+        assertEquals(12, model.triangleCount)
+        val mesh = assertNotNull(model.objects.single().mesh)
+        assertEquals(8, mesh.vertexCount)
+        // The cube spans 0..20 mm on every axis.
+        assertEquals(0f, mesh.positions.min())
+        assertEquals(20f, mesh.positions.max())
+    }
+
+    @Test
+    fun readsBuildItemTransform() {
+        val item = ThreeMfLoader.parse(ThreeMfTestFixtures.CubeThreeMf).items.single()
+
+        assertEquals(1, item.objectId)
+        // "1 0 0 0 1 0 0 0 1 5 0 0" — the translation lands in the 4th column of a column-major
+        // matrix, which is exactly where glTF reads it from.
+        assertEquals(5f, item.transform[12])
+        assertEquals(0f, item.transform[13])
+        assertEquals(1f, item.transform[15])
+    }
+
+    @Test
+    fun resolvesPerTrianglePaletteColors() {
+        val mesh = assertNotNull(ThreeMfLoader.parse(ThreeMfTestFixtures.CubeThreeMf).objects.single().mesh)
+        val colors = assertNotNull(mesh.triangleColors)
+
+        assertEquals(12, colors.size)
+        assertEquals(0x0FB5AEFF, colors[0], "first six triangles use base 0 (teal)")
+        assertEquals(0xFFB300FF.toInt(), colors[11], "last six use base 1 (amber)")
+    }
+
+    @Test
+    fun detectsThreeMfBytes() {
+        assertTrue(ThreeMfLoader.isThreeMf(ThreeMfTestFixtures.CubeThreeMf))
+        assertFalse(ThreeMfLoader.isThreeMf("not a zip at all".encodeToByteArray()))
+        assertFalse(ThreeMfLoader.isThreeMf(ByteArray(0)))
+        assertFalse(
+            ThreeMfLoader.isThreeMf(ThreeMfTestFixtures.zipOf("readme.txt" to "a plain zip")),
+            "a ZIP without a 3D/*.model part is not a 3MF"
+        )
+    }
+
+    // ── Units, axes, structure ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun readsEveryDeclaredUnit() {
+        for (unit in ThreeMfUnit.entries) {
+            val xml = ThreeMfTestFixtures.modelXml(attributes = """unit="${unit.id}"""")
+            assertEquals(unit, ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml)).unit)
+        }
+    }
+
+    @Test
+    fun defaultsToMillimetresWhenUnitIsAbsentOrUnknown() {
+        val noUnit = ThreeMfTestFixtures.modelXml(attributes = """xml:lang="en-US"""")
+        assertEquals(ThreeMfUnit.MILLIMETER, ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(noUnit)).unit)
+
+        val bogus = ThreeMfTestFixtures.modelXml(attributes = """unit="parsecs"""")
+        assertEquals(ThreeMfUnit.MILLIMETER, ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(bogus)).unit)
+    }
+
+    @Test
+    fun aFileWithNoBuildStillShowsItsObjects() {
+        val xml = ThreeMfTestFixtures.modelXml(build = "")
+        val model = ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml))
+
+        assertEquals(listOf(1), model.items.map { it.objectId })
+    }
+
+    @Test
+    fun readsComponentAssemblies() {
+        val xml = """<?xml version="1.0"?>
+            <model unit="centimeter">
+              <resources>
+                <object id="1"><mesh>
+                  <vertices><vertex x="0" y="0" z="0"/><vertex x="1" y="0" z="0"/>
+                    <vertex x="0" y="1" z="0"/></vertices>
+                  <triangles><triangle v1="0" v2="1" v3="2"/></triangles>
+                </mesh></object>
+                <object id="2">
+                  <components>
+                    <component objectid="1" transform="1 0 0 0 1 0 0 0 1 3 4 5"/>
+                    <component objectid="1"/>
+                  </components>
+                </object>
+              </resources>
+              <build><item objectid="2"/></build>
+            </model>"""
+        val model = ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml))
+
+        assertEquals(ThreeMfUnit.CENTIMETER, model.unit)
+        val assembly = assertNotNull(model.objectsById[2])
+        assertNull(assembly.mesh, "an assembly object carries no mesh of its own")
+        assertEquals(2, assembly.components.size)
+        assertEquals(3f, assembly.components[0].transform[12])
+        assertEquals(0f, assembly.components[1].transform[12], "a missing transform is the identity")
+    }
+
+    @Test
+    fun readsMaterialExtensionColorGroups() {
+        val xml = ThreeMfTestFixtures.modelXml(
+            extra = """<m:colorgroup id="9"><m:color color="#FF0000"/><m:color color="#00FF00"/></m:colorgroup>""",
+            objectAttributes = """pid="9" pindex="1""""
+        )
+        val model = ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml))
+
+        assertEquals(0x00FF00FF, model.objects.single().color, "prefixed m:color is read like any other")
+    }
+
+    // ── Failure modes ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun rejectsSomethingThatIsNotAZip() {
+        val failure = assertFailsWith<ThreeMfParseException> {
+            ThreeMfLoader.parse("<model/>".encodeToByteArray())
+        }
+        assertContains(failure.message.orEmpty(), "ZIP")
+    }
+
+    @Test
+    fun rejectsAZipWithoutAModelPart() {
+        val failure = assertFailsWith<ThreeMfParseException> {
+            ThreeMfLoader.parse(ThreeMfTestFixtures.zipOf("hello.txt" to "world"))
+        }
+        assertContains(failure.message.orEmpty(), "3D/3dmodel.model")
+    }
+
+    @Test
+    fun rejectsAnOutOfRangeTriangleIndex() {
+        val xml = """<model unit="millimeter"><resources><object id="1"><mesh>
+            <vertices><vertex x="0" y="0" z="0"/></vertices>
+            <triangles><triangle v1="0" v2="7" v3="2"/></triangles>
+            </mesh></object></resources><build><item objectid="1"/></build></model>"""
+        val failure = assertFailsWith<ThreeMfParseException> {
+            ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml))
+        }
+        assertContains(failure.message.orEmpty(), "out of range")
+    }
+
+    @Test
+    fun rejectsAFileWithNoObjects() {
+        val xml = """<model unit="millimeter"><resources/><build/></model>"""
+        assertFailsWith<ThreeMfParseException> {
+            ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml))
+        }
+    }
+
+    @Test
+    fun skipsUnknownExtensionsInsteadOfFailing() {
+        // A production/slice-extension file must still preview: unknown elements are ignored.
+        val xml = ThreeMfTestFixtures.modelXml(
+            extra = """<s:slicestack id="4" zbottom="0"><s:slice ztop="1"/></s:slicestack>"""
+        )
+        assertEquals(1, ThreeMfLoader.parse(ThreeMfTestFixtures.threeMfOf(xml)).triangleCount)
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ThreeMfTestFixtures.kt
@@ -1,0 +1,168 @@
+package io.github.sceneview.core.threemf
+
+import io.github.sceneview.core.splat.crc32
+
+/**
+ * Fixtures for the 3MF reader tests.
+ *
+ * [CubeThreeMf] is a **real** file, not a hand-rolled approximation: it was produced by Python's
+ * `zipfile` with `ZIP_DEFLATED`, so the tests exercise the dynamic-Huffman DEFLATE path, the
+ * `[Content_Types].xml` / `_rels/.rels` OPC parts and the exact XML shape a writer emits —
+ * everything a hand-built stored ZIP would quietly skip.
+ *
+ * It is a 20 mm cube in millimetres, coloured from a two-entry `<basematerials>` palette (the first
+ * six triangles teal, the last six amber), placed by a build item translated 5 mm along X.
+ */
+internal object ThreeMfTestFixtures {
+
+    /** A deflate-compressed 3MF written by Python's `zipfile`. See the object docs. */
+    val CubeThreeMf: ByteArray get() = decodeBase64(CubeThreeMfBase64)
+
+    private const val CubeThreeMfBase64 =
+        "UEsDBBQAAAAIAJsIJl0YJdOkxwAAAEQBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbIWQTWrDMBCF9z6F0DbYchMopdjO" +
+        "oklPkB5gkMc/RBoJaRzS22ectBQKpcvH++Z9MM3+6p26YMpzoFY/VbVWSDb0M42t/ji9ly963xXN6TNiVsJSbvXEHF+N" +
+        "yXZCD7kKEUmaISQPLDGNJoI9w4hmW9fPxgZiJC553dBdoZoDDrA4VserFA9zQpe1enugq63VEKObLbD05kL9L0/55ajk" +
+        "8s7kaY55I4A2fzh86NH9I/E/w7veAy0DWF6SvKOUvA58Kxpzf0pX3ABQSwMEFAAAAAgAmwgmXWPBjv21AAAABwEAAAsA" +
+        "AABfcmVscy8ucmVsc2WPzQrCQAyE732KJXeb1oKIdOtFBK9SH2DZpj/Y/WF3FX17oyBYvARCMt/M1PuHmcWdQpyclVDm" +
+        "BQiy2nWTHSRc2uNqC/smq880q8QvcZx8FKyxUcKYkt8hRj2SUTF3nixfeheMSryGAb3SVzUQrotig+GXAU0mFlTRqjBQ" +
+        "koDVAavOuI7m/DNBnDoJrOZs7dPTn7GZdHDR9SnXzry1yt56pdMtcAv2Lissyi8TkOvgok+TvQBQSwMEFAAAAAgAmwgm" +
+        "XelX0hriAQAAegUAABAAAAAzRC8zZG1vZGVsLm1vZGVsjZTbjpswEIbv8xSWe70xh5BUK8gqW5UX2N3eGzPZuPIBYZMm" +
+        "ffoaG9QlzVKEZGPmm5l/Btv500UKdIbWcK0KHK8jjEAxXXP1XuC31/LhK37ar3KpaxCoU9wWWHIhuAQLLUbO+1HQngX1" +
+        "8PbiPyhT4JO1zSMhhp1AUrOWnLXa6KNdMy1JWkuquiNltmtdHsJ0CySJ4oxECd6vUO6C05paihSVUOBD0wjOqHUS8f6F" +
+        "gYIfHH4hC8aiI7+4KJCT0af3b8HormVg3ALlFTVOhJPLqTCI1wXO+iyDZcjxClRgVHPTCHplWui2wF+i8jk7fC9LTP7h" +
+        "D7Lq679xKMvnNIpGh5xMUvtPuvoJzHoVMUb22rhYvrl4CPytqwCjJsh0s6rhUuBoUCzBnPwbyt1Ps3yoMazggjyKrn78" +
+        "3Y/k1pwssyefAsvswZz8T8AMkHxO3Adcvyc9Qbl1fVfvYuzRuETn2Mc4JwVO3ZS6IK7V8Ydy7qFJQOM5dBPQLKDbBeg2" +
+        "oLsFAuKAZgvQQcBmDo0nZQ1a4zl0OxFwH00mfd0tQHcLBKQBjSZlzaKbuwLcHrnZFGQ8UjkJZ7O/QMjHGySvOi5qj3AL" +
+        "EgVsPMEtVeaoW+lWKPLP3znrZ5/ZXQUhiMvXn/b96g9QSwECFAMUAAAACACbCCZdGCXTpMcAAABEAQAAEwAAAAAAAAAA" +
+        "AAAAgAEAAAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLAQIUAxQAAAAIAJsIJl1jwY79tQAAAAcBAAALAAAAAAAAAAAAAACA" +
+        "AfgAAABfcmVscy8ucmVsc1BLAQIUAxQAAAAIAJsIJl3pV9Ia4gEAAHoFAAAQAAAAAAAAAAAAAACAAdYBAAAzRC8zZG1v" +
+        "ZGVsLm1vZGVsUEsFBgAAAAADAAMAuAAAAOYDAAAAAA=="
+
+    /**
+     * Wrap [parts] into a ZIP with **stored** (uncompressed) entries — enough for the reader, and
+     * the only ZIP a test can build without a deflate encoder. Used for the variant archives
+     * (units, components, malformed XML) that would be unreadable as base64 blobs.
+     */
+    fun zipOf(vararg parts: Pair<String, String>): ByteArray {
+        val local = ByteArrayBuilder()
+        val central = ByteArrayBuilder()
+        for ((name, content) in parts) {
+            val nameBytes = name.encodeToByteArray()
+            val data = content.encodeToByteArray()
+            val offset = local.size
+            local.addIntLe(LocalHeaderSignature)
+            local.addShortLe(NeedVersion)
+            local.addShortLe(0) // flags
+            local.addShortLe(0) // method: stored
+            local.addIntLe(0) // mtime + mdate
+            local.addIntLe(crc32(data))
+            local.addIntLe(data.size)
+            local.addIntLe(data.size)
+            local.addShortLe(nameBytes.size)
+            local.addShortLe(0) // extra length
+            local.addBytes(nameBytes)
+            local.addBytes(data)
+
+            central.addIntLe(CentralHeaderSignature)
+            central.addShortLe(NeedVersion) // version made by
+            central.addShortLe(NeedVersion)
+            central.addShortLe(0) // flags
+            central.addShortLe(0) // method: stored
+            central.addIntLe(0) // mtime + mdate
+            central.addIntLe(crc32(data))
+            central.addIntLe(data.size)
+            central.addIntLe(data.size)
+            central.addShortLe(nameBytes.size)
+            central.addShortLe(0) // extra
+            central.addShortLe(0) // comment
+            central.addShortLe(0) // disk
+            central.addShortLe(0) // internal attributes
+            central.addIntLe(0) // external attributes
+            central.addIntLe(offset)
+            central.addBytes(nameBytes)
+        }
+        val directory = central.toArray()
+        val out = ByteArrayBuilder()
+        out.addBytes(local.toArray())
+        val directoryOffset = out.size
+        out.addBytes(directory)
+        out.addIntLe(EndOfCentralDirectorySignature)
+        out.addShortLe(0) // this disk
+        out.addShortLe(0) // directory start disk
+        out.addShortLe(parts.size)
+        out.addShortLe(parts.size)
+        out.addIntLe(directory.size)
+        out.addIntLe(directoryOffset)
+        out.addShortLe(0) // comment length
+        return out.toArray()
+    }
+
+    /** A 3MF package around [modelXml], with the OPC part a reader may look for. */
+    fun threeMfOf(modelXml: String): ByteArray = zipOf(
+        "[Content_Types].xml" to ContentTypes,
+        "3D/3dmodel.model" to modelXml
+    )
+
+    /**
+     * A one-triangle `<model>` document: [attributes] go on the root element, [extra] is inserted
+     * at the top of `<resources>` and [objectAttributes] on the single `<object>`.
+     */
+    fun modelXml(
+        attributes: String = """unit="millimeter"""",
+        extra: String = "",
+        objectAttributes: String = "",
+        build: String = """<build><item objectid="1"/></build>"""
+    ): String = """<?xml version="1.0" encoding="UTF-8"?>
+<model $attributes xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+    $extra
+    <object id="1" type="model" $objectAttributes>
+      <mesh>
+        <vertices>
+          <vertex x="0" y="0" z="0"/>
+          <vertex x="10" y="0" z="0"/>
+          <vertex x="0" y="10" z="0"/>
+        </vertices>
+        <triangles>
+          <triangle v1="0" v2="1" v3="2"/>
+        </triangles>
+      </mesh>
+    </object>
+  </resources>
+  $build
+</model>
+"""
+
+    private const val ContentTypes =
+        """<?xml version="1.0" encoding="UTF-8"?><Types xmlns="x"><Default Extension="model"/></Types>"""
+
+    private const val LocalHeaderSignature = 0x04034B50
+    private const val CentralHeaderSignature = 0x02014B50
+    private const val EndOfCentralDirectorySignature = 0x06054B50
+    private const val NeedVersion = 20
+
+    private fun ByteArrayBuilder.addShortLe(value: Int) {
+        addBytes(byteArrayOf((value and 0xFF).toByte(), ((value ushr 8) and 0xFF).toByte()))
+    }
+
+    /** Minimal Base64 decoder — the stdlib one is still opt-in experimental on this Kotlin line. */
+    private fun decodeBase64(text: String): ByteArray {
+        val out = ByteArrayBuilder(text.length)
+        var buffer = 0
+        var bits = 0
+        for (char in text) {
+            val value = Base64Alphabet.indexOf(char)
+            if (value < 0) continue
+            buffer = (buffer shl 6) or value
+            bits += 6
+            if (bits >= 8) {
+                bits -= 8
+                out.addBytes(byteArrayOf(((buffer ushr bits) and 0xFF).toByte()))
+            }
+        }
+        return out.toArray()
+    }
+
+    private const val Base64Alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+}

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -12,6 +12,7 @@ import com.google.android.filament.gltfio.UbershaderProvider
 import io.github.sceneview.bumpLightGeneration
 import io.github.sceneview.bumpRenderableGeneration
 import io.github.sceneview.bumpTransformGeneration
+import io.github.sceneview.core.threemf.ThreeMfLoader
 import io.github.sceneview.model.Model
 import io.github.sceneview.model.ModelInstance
 import io.github.sceneview.safeDestroyModel
@@ -35,6 +36,17 @@ import java.nio.ByteBuffer
  * a bundle of Filament textures, vertex buffers, index buffers, etc.
  *
  * A [Model] is composed of 1 or more [ModelInstance] objects which contain entities and components.
+ *
+ * **`.3mf` is loaded too, through every entry point on this class** (#3482). 3MF is what ChatGPT,
+ * every slicer and every image-to-print flow emit for a printable model; a 3MF payload is detected
+ * by its ZIP magic and converted to GLB in memory by [ThreeMfLoader] before it reaches Filament, so
+ * `loadModel("print.3mf")`, `createModelInstance(uri)` and `rememberModelInstance(...)` need no
+ * separate API and no separate code path. Conversion scales the model from its declared unit
+ * (usually millimetres) to metres and rotates it from 3MF's Z-up to glTF's Y-up. A payload that is
+ * not a ZIP costs one 4-byte comparison.
+ *
+ * The `suspend` [loadModel] converts off the main thread; the [createModel] overloads convert on
+ * the calling (main) thread, like the rest of their work.
  */
 class ModelLoader(
     val engine: Engine,
@@ -78,7 +90,7 @@ class ModelLoader(
         buffer: Buffer,
         releaseSourceData: Boolean = true,
         resourceResolver: (resourceFileName: String) -> Buffer? = { null }
-    ): Model = (assetLoader.createAsset(buffer.transcodeWebPTextures())
+    ): Model = (assetLoader.createAsset(buffer.toFilamentModelSource())
         ?: throw IllegalArgumentException("Failed to parse glTF model from buffer")).also { model ->
         models += model
         loadResources(model, resourceResolver)
@@ -143,7 +155,7 @@ class ModelLoader(
         resourceResolver: (resourceFileName: String) -> String = { getFolderPath(fileLocation, it) }
     ): Model? = context.loadFileBuffer(fileLocation)?.let { buffer ->
         // Transcoding decodes and re-encodes images: keep it off the main thread.
-        val source = withContext(Dispatchers.Default) { buffer.transcodeWebPTextures() }
+        val source = withContext(Dispatchers.Default) { buffer.toFilamentModelSource() }
         val model = createOrDestroyOnCancel(::destroyModel) {
             assetLoader.createAsset(source)
         } ?: return@let null
@@ -288,7 +300,7 @@ class ModelLoader(
         resourceResolver: (resourceFileName: String) -> Buffer? = { null }
     ): List<ModelInstance> =
         arrayOfNulls<ModelInstance>(count).apply {
-            (assetLoader.createInstancedAsset(buffer.transcodeWebPTextures(), this)
+            (assetLoader.createInstancedAsset(buffer.toFilamentModelSource(), this)
                 ?: throw IllegalArgumentException("Failed to parse glTF model from buffer")).also { model ->
                 models += model
                 loadResources(model, resourceResolver)
@@ -377,7 +389,7 @@ class ModelLoader(
         resourceResolver: (resourceFileName: String) -> String = { getFolderPath(fileLocation, it) }
     ): List<ModelInstance> = context.loadFileBuffer(fileLocation)?.let { buffer ->
         val instances = arrayOfNulls<ModelInstance>(count)
-        val source = withContext(Dispatchers.Default) { buffer.transcodeWebPTextures() }
+        val source = withContext(Dispatchers.Default) { buffer.toFilamentModelSource() }
         val model = createOrDestroyOnCancel(::destroyModel) {
             assetLoader.createInstancedAsset(source, instances)
         } ?: throw IllegalArgumentException("Failed to parse glTF model from buffer")
@@ -562,6 +574,42 @@ internal suspend fun <T : Any> destroyOnCancel(
         withContext(NonCancellable + dispatcher) { destroy(created) }
         throw cancellation
     }
+}
+
+/**
+ * Normalises whatever the caller handed us into something Filament's glTF loader accepts: a 3MF is
+ * converted to GLB, then WebP textures are transcoded.
+ */
+private fun Buffer.toFilamentModelSource(): Buffer = convertThreeMfToGlb().transcodeWebPTextures()
+
+/**
+ * Converts a **3MF** payload to GLB, so `.3mf` is loadable through every entry point on this class
+ * with no separate API — the format ChatGPT and every slicer emit for a printable model, which no
+ * Android app opened in 3D before (#3482).
+ *
+ * The sniff is a ZIP-magic check plus a central-directory lookup for `3D/3dmodel.model`, so a glTF,
+ * a GLB or anything else costs one 4-byte comparison and is returned untouched.
+ */
+private fun Buffer.convertThreeMfToGlb(): Buffer {
+    val source = this as? ByteBuffer ?: return this
+    // Cheap gate first: no ZIP magic, no copy. A 100 MB GLB must not be duplicated in memory just
+    // to find out it is not a 3MF.
+    if (!source.startsWithZipMagic()) return this
+    val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+    if (!ThreeMfLoader.isThreeMf(bytes)) return this
+    val glb = ThreeMfLoader.toGlb(bytes)
+    // Direct, like every other buffer Filament's JNI layer reads (see WebPTextureTranscoder).
+    return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+/** `PK` — the local-file-header magic every ZIP, and so every 3MF, starts with. */
+private fun ByteBuffer.startsWithZipMagic(): Boolean {
+    val at = position()
+    return remaining() >= 4 &&
+        get(at) == 'P'.code.toByte() &&
+        get(at + 1) == 'K'.code.toByte() &&
+        get(at + 2) == 0x03.toByte() &&
+        get(at + 3) == 0x04.toByte()
 }
 
 /**


### PR DESCRIPTION
Ask ChatGPT for a 3D print from a drawing and you get a `.3mf`. So does every slicer, and every image-to-print flow. On Android and on the web, nothing opened one in 3D — let alone in AR. This is the loader; the demo's "Open with", the web page and the docs follow in their own PRs (#3482).

## What this adds

`sceneview-core` reads 3MF in pure Kotlin on **every** target — no `java.util.zip`, no XML library, no `expect`/`actual` — and converts it to GLB in memory. That is one converter instead of one loader per renderer: Filament, Filament.js and every other glTF consumer in this SDK read the result through the path they already have, so materials, gestures, AR placement and the web viewer come for free.

- **`Zip`** reads the OPC container through its central directory, inflating with the pure-Kotlin DEFLATE decoder the SPZ splat parser already ships (given a raw-stream entry point here). ZIP64, encryption and other compression methods are refused with a message, never a wrong result.
- **`XmlPullParser`** is a pull parser, not a DOM: a printable model is millions of `<vertex/>` elements and materialising one object each would cost hundreds of megabytes on a phone. Namespace prefixes are stripped, so `m:colorgroup` matches whatever prefix a writer chose.
- **`ThreeMfParser`** handles `<basematerials>`, `<colorgroup>`, `<object>` with `<mesh>` and `<components>`, per-triangle `pid`/`p1`, and `<build><item transform>`. Unrecognised extensions (slice, beamlattice, production) are skipped rather than rejected — an unknown extension must not stop a print from being previewed.
- **`ThreeMfGlb`** does the three conversions that decide whether a print shows up at all:
  - **units → metres**, so a 60 mm print is life-size in AR without a magic number;
  - **Z-up → Y-up**, so the part stands up instead of lying on its back;
  - **flat normals**, because 3MF stores none and a smoothed normal would round over the facets the slicer will extrude.

  Colours become one glTF material per colour, `doubleSided` because generated meshes are often inconsistently wound. Numbers are formatted to float32 precision by hand: `Float.toString()` prints `0.001` on the JVM and `0.001000000047497451` on Kotlin/JS, which would otherwise make the same 3MF produce two different GLBs — and a JSON six times larger in the browser.

## No new API on Android

`ModelLoader` sniffs the payload by its ZIP magic, so this already works:

```kotlin
rememberModelInstance(modelLoader, uri.toString())?.let { ModelNode(modelInstance = it) }
```

as do `loadModel("print.3mf")`, `createModelInstance(file)` and the rest. A payload that is not a ZIP costs a 4-byte comparison — no copy of a 100 MB GLB just to find out it is not a 3MF. Conversion runs off the main thread on the `suspend`/`Async` paths.

For a custom pipeline, `ThreeMfLoader.parse()` / `.toGlb()` / `.isThreeMf()` are public in `sceneview-core` (KMP: Android, iOS, web).

## Verification

- **23 tests, green on both the JVM and Kotlin/JS (Chrome headless) targets.** The fixture is a **real** file written by Python's `zipfile` with `ZIP_DEFLATED`, not a hand-built approximation — so the dynamic-Huffman DEFLATE path, the `[Content_Types].xml` / `_rels/.rels` OPC parts and a writer's actual XML shape are all exercised, along with units, colour palettes, component assemblies, degenerate faces and every failure mode.
- The emitted GLB was independently validated outside Kotlin: container framing, chunk alignment, every accessor's `bufferView` length and offset, declared vs actual POSITION bounds, and unit-length normals.
- `apiDump` regenerated; `detekt` clean; `:snippets-check` compiles the new `llms.txt` snippets, so the documented one-liner is proven to compile against the real API.
- `gpt/knowledge-*.md` regenerated from `llms.txt` (generator, not hand-edited).

Not verified here: on-device rendering of a 3MF. That is the next PR's screenshot.