### PR TITLE
chore(codex): pin the delegation model so a CLI update cannot change it

### DIFF
--- a/.claude/scripts/codex-delegate.sh
+++ b/.claude/scripts/codex-delegate.sh
@@ -33,6 +33,14 @@
 #
 # Common opts: --label NAME  --model M  --timeout SECS  --dir PATH
 #              --new-worktree BRANCH   --here   --schema FILE   --file F
+#              --effort low|medium|high|xhigh   (default: the model's own)
+#
+# MODEL POLICY
+#   The default model is pinned below (DEFAULT_MODEL) and passed explicitly on
+#   every call. A Codex CLI update that changes its own bundled default — 0.153.4
+#   makes gpt-6-astra the default when nothing is configured — must not silently
+#   move every delegation onto a scarcer allowance. Opt in per call with --model
+#   (e.g. --model gpt-6-astra), or globally with CODEX_DELEGATE_MODEL.
 #
 # Exit codes: 0 ok · 1 codex failed · 2 preflight refused (auth/binary/flags)
 #             3 quota or rate limit hit — tell Thomas, never work around it
@@ -253,12 +261,14 @@ invoke() {
 CMD="${1:-}"; shift || true
 reject_banned_flags ${1+"$@"}
 
-LABEL="" MODEL="" TIMEOUT="" DIR="" NEW_WT="" HERE="" SCHEMA="" FILE=""
+DEFAULT_MODEL="${CODEX_DELEGATE_MODEL:-gpt-5.6-sol}"
+LABEL="" MODEL="" EFFORT="" TIMEOUT="" DIR="" NEW_WT="" HERE="" SCHEMA="" FILE=""
 REST=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --label)        LABEL="$2"; shift 2 ;;
     --model)        MODEL="$2"; shift 2 ;;
+    --effort)       EFFORT="$2"; shift 2 ;;
     --timeout)      TIMEOUT="$2"; shift 2 ;;
     --dir)          DIR="$2"; shift 2 ;;
     --new-worktree) NEW_WT="$2"; shift 2 ;;
@@ -269,8 +279,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-CODEX_ARGS=()
-[ -n "$MODEL" ]  && CODEX_ARGS+=(-m "$MODEL")
+# The model is always passed explicitly (see MODEL POLICY above), never left to
+# the CLI's own default. `codex review` takes no -m, so it gets the same choice
+# through -c model="..." further down.
+CODEX_ARGS=(-m "${MODEL:-$DEFAULT_MODEL}")
+[ -n "$EFFORT" ] && CODEX_ARGS+=(-c "model_reasoning_effort=\"$EFFORT\"")
 [ -n "$SCHEMA" ] && CODEX_ARGS+=(--output-schema "$SCHEMA")
 
 get_prompt() {
@@ -324,9 +337,13 @@ case "$CMD" in
     if [ -n "$HAS_SEL" ] && [ -n "$HAS_PROMPT" ]; then
       die "codex review rejects free-text instructions combined with --uncommitted/--base/--commit. Use 'review --base main' alone, or pass instructions through 'ask'." 2
     fi
-    info "Codex → review (read-only, cwd=$RDIR)"
+    # `codex review` has no -m flag (0.149.0 .. 0.153.x): the model goes through
+    # the generic -c override, so the pinned default applies here too.
+    REVIEW_ARGS=(-c "model=\"${MODEL:-$DEFAULT_MODEL}\"")
+    [ -n "$EFFORT" ] && REVIEW_ARGS+=(-c "model_reasoning_effort=\"$EFFORT\"")
+    info "Codex → review (read-only, cwd=$RDIR, model=${MODEL:-$DEFAULT_MODEL})"
     ( cd "$RDIR" && PATH="$CODEX_PATH_PREFIX:$PATH" timeout --foreground "${TIMEOUT:-900}" \
-        env "${UNSET_ARGS[@]}" "$CODEX_BIN" review ${REST[@]+"${REST[@]}"} ) 2>&1 | tee "$LOG"
+        env "${UNSET_ARGS[@]}" "$CODEX_BIN" review "${REVIEW_ARGS[@]}" ${REST[@]+"${REST[@]}"} ) 2>&1 | tee "$LOG"
     RC="${PIPESTATUS[0]}"
     [ "$RC" -eq 124 ] && die "codex review timed out. Log: $LOG" 4
     check_quota_and_exit "$LOG" "$RC"
@@ -373,7 +390,7 @@ case "$CMD" in
     ;;
 
   ""|-h|--help|help)
-    sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'
     ;;
 
   *)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,13 @@ Full API reference: [`llms.txt`](./llms.txt).
 - **Codex is a delegation lever, not a rule** — it bills a quota separate from Claude's.
   Always `.claude/scripts/codex-delegate.sh` (`ask` · `review` · `implement
   --new-worktree`), never a raw `codex`, never an OpenAI API key. Commits, merges and
-  releases stay with the lead session.
+  releases stay with the lead session. Route to Codex what it does as well for less: an
+  independent review of a merged PR, a whole-module read to draft an inventory, unit
+  tests and mechanical refactors from a closed brief. Keep with Claude: product
+  decisions, UI validated by capture, anything touching secrets, billing or irreversible
+  steps — and the reading of whatever Codex returns. The script pins the model
+  (`gpt-5.6-sol`) so a CLI update cannot change it silently; `--model gpt-6-astra` is
+  opt-in, per call.
 - **CI**: `.github/workflows/ci.yml` is the one PR workflow; its `changes` job gates
   every other job and `changes-verdict` ("Path filter completed") is the required check.
   Heavy suites and their path gates: [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/changelog.d/3494-codex-model-pin.md
+++ b/changelog.d/3494-codex-model-pin.md
@@ -1,0 +1,12 @@
+<!-- category: Changed -->
+- **The Codex delegation script now pins the model it asks for
+  ([#3494](https://github.com/sceneview/sceneview/pull/3494)).**
+  `.claude/scripts/codex-delegate.sh` never passed `-m`, so it inherited whatever the
+  installed Codex CLI treats as its default. Codex CLI 0.153.4 makes `gpt-6-astra` that
+  default: updating the CLI would have moved every delegation onto a scarcer allowance
+  with no visible trace beyond the model line in each run header. The script now always
+  passes the model explicitly — `gpt-5.6-sol` by default, overridable with
+  `CODEX_DELEGATE_MODEL` or per call with `--model` — and routes the same choice into
+  `codex review`, which accepts no `-m`, through `-c model="..."`. A new `--effort`
+  reaches `model_reasoning_effort`, previously unreachable through the script.
+  `CLAUDE.md` records the routing policy that goes with it.


### PR DESCRIPTION
## Why

Codex CLI 0.153.4 makes `gpt-6-astra` the default model whenever none is
configured. `codex-delegate.sh` never passed `-m`, so a routine CLI update would
have silently moved every delegation from `gpt-5.6-sol` onto a scarcer allowance
that, per OpenAI's own docs, burns faster — and nothing would have shown it: the
model appears only in the run header of each log.

## What

- `.claude/scripts/codex-delegate.sh` always passes the model explicitly.
  `DEFAULT_MODEL` is `gpt-5.6-sol`, overridable globally with
  `CODEX_DELEGATE_MODEL` and per call with `--model` (that is the opt-in to
  `gpt-6-astra`). `codex review` accepts no `-m` in 0.149..0.153, so it gets the
  same choice through `-c model="..."`.
- New `--effort low|medium|high|xhigh`, mapped to `-c model_reasoning_effort`.
  It was previously unreachable through the script; the default stays the
  model's own.
- `CLAUDE.md`: the routing policy — what goes to Codex (independent review of a
  merged PR, whole-module reads, unit tests and mechanical refactors from a
  closed brief) and what stays with the lead session (decisions, UI validated by
  capture, secrets, billing, irreversible steps, and reading whatever Codex
  returns).

Subcommands, billing preflight and isolation rules are untouched.

## Verified

- `bash -n` clean; `codex-delegate.sh check` green (auth ChatGPT, no API key).
- `codex-delegate.sh ask "Reply with exactly one word: ok"` on the patched
  script: run header reports `model: gpt-5.6-sol`, answer `ok`, exit 0.
- `help` renders the whole header, including the new model-policy block.