### PR TITLE
test(mcp): cover guides.ts, and stop the roadmap advertising a shipped version

### DIFF
--- a/changelog.d/3506-mcp-guides-test.md
+++ b/changelog.d/3506-mcp-guides-test.md
@@ -1,0 +1,19 @@
+<!-- category: Fixed -->
+- **The MCP roadmap no longer advertises a version that already shipped
+  ([#3506](https://github.com/sceneview/sceneview/pull/3506)).**
+  `get_platform_roadmap` returned an "Upcoming" section still promising `v4.0.0` —
+  SceneViewSwift stabilization, Android XR, the Flutter and React Native bridges — while
+  4.34.0 is published, so every host that asked the server what was coming next was told
+  the current major line was still ahead of it. The section now names the workstreams
+  without a version number, and says that `5.0.0` is a deliberate milestone rather than
+  an automatic bump.
+
+<!-- category: Added -->
+- **`mcp/src/guides.ts` is under test ([#3506](https://github.com/sceneview/sceneview/pull/3506)).**
+  It was the last substantial module in `mcp/src/` with no test file: 655 lines of static
+  content that four tools return verbatim, with nothing pinning it. 18 cases now cover
+  the `BEST_PRACTICES` key set and the guarantee that `all` still contains every topic
+  body, the absence of uninterpolated module constants, every Maven and SPM coordinate
+  carrying `LATEST_SCENEVIEW_RELEASE` instead of a literal, the platform rows and the
+  Filament/RealityKit split, balanced code fences, and the Upcoming-version rule that
+  caught the rot above.

--- a/mcp/src/guides.test.ts
+++ b/mcp/src/guides.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  AR_SETUP_GUIDE,
+  BEST_PRACTICES,
+  PLATFORM_ROADMAP,
+  TROUBLESHOOTING_GUIDE,
+} from "./guides.js";
+import { LATEST_SCENEVIEW_RELEASE } from "./generated/version.js";
+
+// A `v` prefix is a word character, so a leading \b never matches "v4.0.0" — the
+// spelling the roadmap actually uses. Match the prefix explicitly and capture the
+// numeric part.
+const SEMVER = /(?<![\w.])v?(\d+\.\d+\.\d+(?:-[\da-zA-Z.-]+)?(?:\+[\da-zA-Z.-]+)?)(?![\w.])/g;
+
+function compareSemver(left: string, right: string): number {
+  const parse = (version: string) => {
+    const [core, prerelease] = version.split("+")[0].split(/-(.*)/);
+    return { core: core.split(".").map(Number), prerelease: prerelease?.split(".") };
+  };
+  const a = parse(left);
+  const b = parse(right);
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) return a.core[i] - b.core[i];
+  }
+  if (!a.prerelease) return b.prerelease ? 1 : 0;
+  if (!b.prerelease) return -1;
+  for (let i = 0; i < Math.max(a.prerelease.length, b.prerelease.length); i++) {
+    const x = a.prerelease[i];
+    const y = b.prerelease[i];
+    if (x === y) continue;
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xNumeric = /^\d+$/.test(x);
+    const yNumeric = /^\d+$/.test(y);
+    if (xNumeric && yNumeric) return Number(x) - Number(y);
+    if (xNumeric !== yNumeric) return xNumeric ? -1 : 1;
+    return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+function versionChecks(guides: Record<string, string>) {
+  // Only a SCREAMING_SNAKE placeholder can be an escaped module constant that was
+  // never interpolated. `${arcoreApiKey}` in the AR setup guide is deliberate: it is
+  // the literal Gradle manifest placeholder the reader must copy.
+  it("leaks no uninterpolated module constant", () => {
+    for (const [name, guide] of Object.entries(guides)) {
+      expect(guide.match(/\$\{[A-Z][A-Z0-9_]*\}/g), name).toBeNull();
+    }
+  });
+
+  it("only advertises Upcoming versions newer than the latest release", () => {
+    for (const [name, guide] of Object.entries(guides)) {
+      // An Upcoming heading owns its subsections until a peer or parent heading.
+      let upcomingLevel: number | undefined;
+      for (const line of guide.split("\n")) {
+        const heading = /^(#{1,6})\s+(.+)$/.exec(line);
+        if (heading && upcomingLevel !== undefined && heading[1].length <= upcomingLevel) {
+          upcomingLevel = undefined;
+        }
+        if (heading && /\bUpcoming\b/i.test(heading[2])) {
+          upcomingLevel = heading[1].length;
+        }
+        if (upcomingLevel === undefined && !/\bUpcoming\b/i.test(line)) continue;
+        for (const [, version] of line.matchAll(SEMVER)) {
+          expect(
+            compareSemver(version, LATEST_SCENEVIEW_RELEASE),
+            `${name}: Upcoming ${version} must be newer than ${LATEST_SCENEVIEW_RELEASE}`,
+          ).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+}
+
+describe("BEST_PRACTICES", () => {
+  it("has exactly the supported topic keys", () => {
+    expect(Object.keys(BEST_PRACTICES).sort()).toEqual([
+      "all", "architecture", "memory", "performance", "threading",
+    ]);
+  });
+
+  it("contains non-empty strings starting with the best practices heading", () => {
+    for (const value of Object.values(BEST_PRACTICES)) {
+      expect(typeof value).toBe("string");
+      expect(value.trim().length).toBeGreaterThan(0);
+      expect(value).toMatch(/^# SceneView Best Practices(?:\r?\n|$)/);
+    }
+  });
+
+  it("includes every topic body in all", () => {
+    for (const [topic, value] of Object.entries(BEST_PRACTICES)) {
+      if (topic === "all") continue;
+      const body = value.replace(/^# SceneView Best Practices\r?\n\s*/, "");
+      expect(body.trim().length, topic).toBeGreaterThan(0);
+      expect(BEST_PRACTICES.all, topic).toContain(body);
+    }
+  });
+
+  versionChecks(BEST_PRACTICES);
+});
+
+describe("PLATFORM_ROADMAP", () => {
+  it("uses the latest release in every Maven and SPM coordinate", () => {
+    const maven = [...PLATFORM_ROADMAP.matchAll(/\bio\.github\.sceneview:[\w.-]+:([^\s`"']+)/g)];
+    const spm = [...PLATFORM_ROADMAP.matchAll(/\b(?:from|exact)\s*:\s*"([^"]+)"/g)];
+    expect(maven.length).toBeGreaterThan(0);
+    expect(spm.length).toBeGreaterThan(0);
+    for (const [coordinate, version] of [...maven, ...spm]) {
+      expect(version, coordinate).toBe(LATEST_SCENEVIEW_RELEASE);
+    }
+  });
+
+  it("names every shipped platform row", () => {
+    for (const platform of [
+      "Android (Compose)", "Android (AR)", "iOS (SwiftUI)",
+      "macOS (SwiftUI)", "visionOS (SwiftUI)", "KMP Core",
+    ]) {
+      expect(PLATFORM_ROADMAP).toContain(`| **${platform}** |`);
+    }
+  });
+
+  it("documents Filament on Android and RealityKit on Apple", () => {
+    expect(PLATFORM_ROADMAP).toMatch(/Android:\s+Filament\b/);
+    expect(PLATFORM_ROADMAP).toMatch(/Apple:\s+RealityKit\b/);
+  });
+
+  versionChecks({ PLATFORM_ROADMAP });
+});
+
+describe("TROUBLESHOOTING_GUIDE", () => {
+  it("is non-empty and starts with an H1", () => {
+    expect(TROUBLESHOOTING_GUIDE.trim().length).toBeGreaterThan(0);
+    expect(TROUBLESHOOTING_GUIDE).toMatch(/^# [^\r\n]+/);
+  });
+
+  it("has balanced code fences", () => {
+    expect((TROUBLESHOOTING_GUIDE.match(/```/g) ?? []).length % 2).toBe(0);
+  });
+
+  versionChecks({ TROUBLESHOOTING_GUIDE });
+});
+
+describe("AR_SETUP_GUIDE", () => {
+  it("is non-empty and starts with an H1", () => {
+    expect(AR_SETUP_GUIDE.trim().length).toBeGreaterThan(0);
+    expect(AR_SETUP_GUIDE).toMatch(/^# [^\r\n]+/);
+  });
+
+  it("has balanced code fences", () => {
+    expect((AR_SETUP_GUIDE.match(/```/g) ?? []).length % 2).toBe(0);
+  });
+
+  versionChecks({ AR_SETUP_GUIDE });
+});

--- a/mcp/src/guides.test.ts
+++ b/mcp/src/guides.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { LATEST_SCENEVIEW_RELEASE } from "./generated/version.js";
 import {
   AR_SETUP_GUIDE,
   BEST_PRACTICES,
   PLATFORM_ROADMAP,
   TROUBLESHOOTING_GUIDE,
 } from "./guides.js";
-import { LATEST_SCENEVIEW_RELEASE } from "./generated/version.js";
 
 // A `v` prefix is a word character, so a leading \b never matches "v4.0.0" — the
 // spelling the roadmap actually uses. Match the prefix explicitly and capture the
@@ -65,7 +65,7 @@ function versionChecks(guides: Record<string, string>) {
         for (const [, version] of line.matchAll(SEMVER)) {
           expect(
             compareSemver(version, LATEST_SCENEVIEW_RELEASE),
-            `${name}: Upcoming ${version} must be newer than ${LATEST_SCENEVIEW_RELEASE}`,
+            `${name}: Upcoming ${version} must be newer than ${LATEST_SCENEVIEW_RELEASE}`
           ).toBeGreaterThan(0);
         }
       }
@@ -76,7 +76,11 @@ function versionChecks(guides: Record<string, string>) {
 describe("BEST_PRACTICES", () => {
   it("has exactly the supported topic keys", () => {
     expect(Object.keys(BEST_PRACTICES).sort()).toEqual([
-      "all", "architecture", "memory", "performance", "threading",
+      "all",
+      "architecture",
+      "memory",
+      "performance",
+      "threading",
     ]);
   });
 
@@ -113,8 +117,12 @@ describe("PLATFORM_ROADMAP", () => {
 
   it("names every shipped platform row", () => {
     for (const platform of [
-      "Android (Compose)", "Android (AR)", "iOS (SwiftUI)",
-      "macOS (SwiftUI)", "visionOS (SwiftUI)", "KMP Core",
+      "Android (Compose)",
+      "Android (AR)",
+      "iOS (SwiftUI)",
+      "macOS (SwiftUI)",
+      "visionOS (SwiftUI)",
+      "KMP Core",
     ]) {
       expect(PLATFORM_ROADMAP).toContain(`| **${platform}** |`);
     }

--- a/mcp/src/guides.ts
+++ b/mcp/src/guides.ts
@@ -58,8 +58,12 @@ Shared Kotlin Multiplatform module providing:
 
 ## Upcoming
 
-- **v4.0.0**: SceneViewSwift stabilization, API parity with Android core nodes, KMP core XCFramework consumption
-- **v4.0.0**: Android XR, visionOS spatial computing, cross-framework bridges (Flutter, React Native)
+- **SceneViewSwift stabilization** — API parity with the Android core nodes, KMP core consumed as an XCFramework
+- **Android XR and visionOS spatial computing**
+- **Cross-framework bridges** — Flutter and React Native over the same native cores
+
+These are not tied to a version number: \`4\` is the current major line, and \`5.0.0\` is a
+deliberate milestone rather than an automatic bump.
 
 ## How to Stay Updated
 


### PR DESCRIPTION
## Why

`mcp/src/guides.ts` was the last substantial module in `mcp/src/` without a test file — 655 lines of static content that four MCP tools return verbatim (`get_platform_roadmap`, `get_best_practices`, `get_troubleshooting`, `get_ar_setup`). Nothing pinned it, so rot in it was invisible.

It had rotted. The roadmap's **Upcoming** section still promised `v4.0.0` (SceneViewSwift stabilization, Android XR, the Flutter/RN bridges) while 4.34.0 is published: every host asking the server for the roadmap was told the current major line was still ahead of it.

## What

`mcp/src/guides.test.ts`, 18 cases:

- `BEST_PRACTICES` — exact key set, every value a non-empty string under the same H1, and `all` still containing each topic body, so a topic cannot be added to one place and dropped from the other.
- No module constant left uninterpolated. Scoped to `${SCREAMING_SNAKE}`, because `${arcoreApiKey}` in the AR setup guide is deliberate — it is the literal Gradle manifest placeholder the reader copies.
- Every Maven and SPM coordinate in the roadmap carries `LATEST_SCENEVIEW_RELEASE`, never a literal — written as a regex over the text, so a coordinate added tomorrow is covered on the day it lands.
- The platform rows, and the Filament-on-Android / RealityKit-on-Apple split.
- Balanced code fences in `TROUBLESHOOTING_GUIDE` and `AR_SETUP_GUIDE`.
- No `Upcoming` entry naming a version at or below `LATEST_SCENEVIEW_RELEASE` (semver compare, `v` prefix included — the spelling the roadmap actually uses).

`mcp/src/guides.ts`: the Upcoming section now names the workstreams without a version number, and states that `5.0.0` is a deliberate milestone rather than an automatic bump.

## Verified

`npx vitest run --configLoader runner` from `mcp/`: **87 files, 2029 tests, all green** — 18 of them new.

## Provenance

Drafted by Codex (`gpt-6-astra`, `implement --new-worktree`) from a closed brief, then reviewed and corrected here: as delivered, two assertions did not say what they meant — the placeholder check flagged the legitimate `${arcoreApiKey}`, and the semver regex began with `\b`, which never matches `v4.0.0`, so the Upcoming check was silently vacuous and would have merged green while asserting nothing. Both are fixed in this branch, with the reason in a comment next to each.