### PR TITLE
feat(demo): open a shared .3mf, .glb or .gltf in the viewer, then in AR (#3482)

### DIFF
--- a/changelog.d/3482-open-with.md
+++ b/changelog.d/3482-open-with.md
@@ -1,0 +1,16 @@
+<!-- category: Added -->
+- **The demo app is now an "Open with" target for `.3mf`, `.glb` and `.gltf` — a print shared out
+  of ChatGPT opens in 3D, then in AR ([#3482](https://github.com/sceneview/sceneview/issues/3482)).**
+  Reading 3MF in the SDK only matters if a file can reach it: on Android a `.3mf` sitting in
+  Downloads or arriving from a chat has nowhere to go, because no installed app claims it. The
+  demo now declares `ACTION_VIEW` and `ACTION_SEND` filters for all three formats and appears in
+  the chooser, so the file lands in the viewer under its own name and the dock's **View in AR**
+  carries it through to placement at its real printed size.
+  **Android's file typing is unreliable, so the file's own bytes decide.** Measured on an emulator:
+  a `.3mf` arriving through the share sheet has `application/octet-stream` as its type *and* no
+  queryable display name at all, so both metadata signals are blank and a metadata-only check
+  refuses a file the SDK reads perfectly. Incoming files are therefore sniffed — glTF magic, and
+  for a ZIP the SDK's own `ThreeMfLoader.isThreeMf`, so a `.docx` or a `.jar` is not claimed just
+  for starting with `PK` — with the declared name and MIME kept as the fallback. The file is copied
+  into the app's cache before use: a `content://` read grant is scoped to the launching intent and
+  would expire under the viewer → AR navigation, and only the previous file is kept.

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -163,6 +163,78 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="sceneview.github.io" android:pathPrefix="/open" />
             </intent-filter>
+
+            <!--
+                "Open with SceneView" (#3482) — a model file handed over by another app:
+                a file manager, Downloads, Drive, or the ChatGPT share sheet.
+
+                3MF is the reason this exists. Ask ChatGPT for a 3D print and it
+                produces a `.3mf`; on Android nothing opened one in 3D, let alone in
+                AR. GLB/glTF ride along because a viewer that opens the exotic format
+                and not the standard one makes no sense to a user.
+
+                THREE filters, because Android's file typing is three different
+                unreliable signals and a share sheet uses whichever it feels like:
+
+                1. By MIME type — the correct, declared route. `model/3mf` is the
+                   registered type; the long `vnd.ms-package...` one is what the 3MF
+                   consortium's own OPC content type is, and what Windows-authored
+                   files carry.
+                2. By MIME type with `android:host="*"` — required for `content://`
+                   URIs, where there is no file name to match a pattern against.
+                3. By path pattern on `application/octet-stream` and `*/*` — the case
+                   that actually happens. Most senders label a `.3mf` as
+                   octet-stream, so the EXTENSION is the only signal left. The
+                   pattern must be spelled once per case combination
+                   (`pathPattern` is literal, not case-insensitive) and per scheme.
+
+                `OpenedModelIntent.looksLikeModel` applies the same name-or-MIME test
+                in code, so a file that slips through a broad `*/*` filter is dropped
+                there instead of failing to load with no explanation. Both layers must
+                be widened together or not at all.
+            -->
+            <intent-filter android:label="@string/open_model_filter_label">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="model/3mf" />
+                <data android:mimeType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
+                <data android:mimeType="model/gltf-binary" />
+                <data android:mimeType="model/gltf+json" />
+            </intent-filter>
+
+            <intent-filter android:label="@string/open_model_filter_label">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.3mf" />
+                <data android:pathPattern=".*\\.3MF" />
+                <data android:pathPattern=".*\\.glb" />
+                <data android:pathPattern=".*\\.GLB" />
+                <data android:pathPattern=".*\\.gltf" />
+                <data android:pathPattern=".*\\.GLTF" />
+            </intent-filter>
+
+            <!--
+                Share sheet: "Share → SceneView" from ChatGPT, Files or Drive. Same
+                type list as the VIEW filter above; the URI arrives as EXTRA_STREAM.
+            -->
+            <intent-filter android:label="@string/open_model_filter_label">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="model/3mf" />
+                <data android:mimeType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
+                <data android:mimeType="model/gltf-binary" />
+                <data android:mimeType="model/gltf+json" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
         </activity>
 
         <!--

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
@@ -29,6 +29,23 @@ object DemoSettings {
 
     /** One-shot in-app route request used by demos that cannot own a NavController. */
     var requestedRoute: String? by mutableStateOf(null)
+
+    /**
+     * A model file another app handed to this one — "Open with SceneView" (#3482), staged into the
+     * cache by [OpenedModelIntent]. Consumed once by the Model Viewer, which shows it instead of
+     * the bundled hero, then nulled so a configuration change does not re-open it.
+     */
+    var openedModel: OpenedModel? by mutableStateOf(null)
+
+    /**
+     * The opened model's real-world size in metres — its longest dimension, measured from the
+     * loaded model by the viewer and handed to AR placement.
+     *
+     * It matters most for the format this whole path exists for: a 3MF carries true manufacturing
+     * size, so a 60 mm print placed in a room must be 60 mm, not the catalogue's default 30 cm.
+     * `null` when nothing has been measured yet.
+     */
+    var openedModelSizeMeters: Float? by mutableStateOf(null)
     /**
      * `true` = deterministic mode (no auto-orbit, no idle camera drift, no implicit
      * motion). `false` = full "wow" showcase mode. Default `false`.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -57,6 +57,9 @@ import io.github.sceneview.demo.feedback.ReportScreen
 import io.github.sceneview.demo.feedback.captureBugReportInfo
 import io.github.sceneview.demo.feedback.captureBugReportScreenshot
 import io.github.sceneview.demo.feedback.sweepStaleFeedbackMedia
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import androidx.lifecycle.lifecycleScope
 
 class MainActivity : ComponentActivity() {
 
@@ -76,6 +79,18 @@ class MainActivity : ComponentActivity() {
      */
     private val pendingDemoId = MutableStateFlow<String?>(null)
     val pendingDemoIdFlow: StateFlow<String?> get() = pendingDemoId.asStateFlow()
+
+    /**
+     * A model file another app asked this one to open — `ACTION_VIEW` on a `.3mf` / `.glb` /
+     * `.gltf`, or an `ACTION_SEND` from a share sheet (#3482).
+     *
+     * Staging copies the bytes into the cache off the main thread, so this arrives *after* the
+     * first composition; the UI observes it and navigates to the Model Viewer when it lands.
+     * Nulled by [consumePendingOpenedModel] once navigated, so a configuration change does not
+     * re-open the same file.
+     */
+    private val pendingOpenedModel = MutableStateFlow<OpenedModel?>(null)
+    val pendingOpenedModelFlow: StateFlow<OpenedModel?> get() = pendingOpenedModel.asStateFlow()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -97,6 +112,8 @@ class MainActivity : ComponentActivity() {
         // navigation through PlaceholderDemo. See #958.
         pendingDemoId.value = DeepLinkRouter.validate(intent?.getStringExtra("demo"))
             ?: DeepLinkRouter.parse(intent?.data)
+        // "Open with SceneView": a `.3mf` / `.glb` / `.gltf` handed over by another app (#3482).
+        stageOpenedModel(intent)
         // QA mode ingress: `--ez qa_mode true` freezes auto-rotation / orbit / animations
         // so screenshot tests get a deterministic frame. Same setting reachable via the
         // long-press gesture on the demo title bar (see DemoScaffold). Off by default.
@@ -143,6 +160,7 @@ class MainActivity : ComponentActivity() {
         // dropped rather than routed to PlaceholderDemo. See #958.
         pendingDemoId.value = DeepLinkRouter.validate(intent.getStringExtra("demo"))
             ?: DeepLinkRouter.parse(intent.data)
+        stageOpenedModel(intent)
         DemoSettings.qaMode = intent.getBooleanExtra("qa_mode", false)
         DemoSettings.qaBackdrop = resolveQaBackdrop(intent)
         DemoSettings.qaDemoState = resolveQaDemoState(intent)
@@ -223,6 +241,44 @@ class MainActivity : ComponentActivity() {
         return fromExtra ?: DeepLinkRouter.parseCameraDistance(intent.data)
     }
 
+    /**
+     * Copies a model handed over by another app into the cache, then publishes it for the UI.
+     *
+     * Off the main thread, because the file is read and rewritten byte for byte and a shared print
+     * can be tens of megabytes — doing it in `onCreate` would drop frames before the first one is
+     * ever drawn. The intent is inspected synchronously (cheap, and the read grant is live now);
+     * only the copy is deferred. An intent that carries no model, or a file that turns out not to
+     * be one, leaves the app on its normal start destination.
+     */
+    private fun stageOpenedModel(intent: Intent?) {
+        val uri = OpenedModelIntent.modelUri(intent) ?: return
+        val mimeType = intent?.type
+        lifecycleScope.launch {
+            val opened = withContext(Dispatchers.IO) {
+                OpenedModelIntent.stage(this@MainActivity, uri, mimeType)
+            }
+            if (opened == null) {
+                // Silence would read as "the app is broken": the user tapped a file and landed on
+                // the demo list with no explanation. Say what did not happen, once.
+                android.widget.Toast.makeText(
+                    this@MainActivity,
+                    getString(R.string.open_model_failed),
+                    android.widget.Toast.LENGTH_LONG
+                ).show()
+                return@launch
+            }
+            withContext(Dispatchers.IO) {
+                OpenedModelIntent.sweep(this@MainActivity, opened.file())
+            }
+            DemoSettings.openedModelSizeMeters = null
+            pendingOpenedModel.value = opened
+        }
+    }
+
+    fun consumePendingOpenedModel() {
+        pendingOpenedModel.value = null
+    }
+
     fun consumePendingDemo() {
         pendingDemoId.value = null
     }
@@ -281,6 +337,22 @@ fun SceneViewDemoApp(activity: MainActivity? = null) {
     // start destination on first composition. The LaunchedEffect below still
     // handles subsequent intents (onNewIntent → pendingDemoIdFlow updates).
     val initialDemo = remember { activity?.pendingDemoIdFlow?.value }
+    // "Open with SceneView" (#3482). Staging is async, so this always arrives after the first
+    // composition — never as a NavHost start destination. The Model Viewer is the target because
+    // it is the app's flagship viewer: framing, lighting, animation and the View-in-AR handoff are
+    // all already there, and an opened file deserves the same screen a bundled one gets.
+    val openedModel by (activity?.pendingOpenedModelFlow?.collectAsState()
+        ?: remember { MutableStateFlow<OpenedModel?>(null) }.collectAsState())
+    LaunchedEffect(openedModel) {
+        val opened = openedModel ?: return@LaunchedEffect
+        DemoSettings.openedModel = opened
+        navController.navigate("demo/model-viewer") {
+            // One viewer on the stack however many files are opened in a row.
+            popUpTo("demo/model-viewer") { inclusive = true }
+        }
+        activity?.consumePendingOpenedModel()
+    }
+
     LaunchedEffect(pendingId) {
         val id = pendingId ?: return@LaunchedEffect
         // If the cold-start `initialDemo` already matches `pendingId`, NavHost picked the

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
@@ -1,0 +1,223 @@
+package io.github.sceneview.demo
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.compose.runtime.Immutable
+import io.github.sceneview.core.threemf.ThreeMfLoader
+import java.io.File
+
+/**
+ * A model file another app handed to this one — "Open with SceneView" (#3482).
+ *
+ * @property location A `file://` URI inside the app's own cache. The incoming `content://`
+ *   URI is deliberately **not** carried around: its read grant is scoped to the launching
+ *   intent, so it would expire under the demo's navigation, and it is not a path the AR
+ *   handoff could pass on.
+ * @property displayName The file's own name, shown as the viewer's title — the user opened
+ *   *their* file and the screen should say so.
+ */
+@Immutable
+data class OpenedModel(val location: String, val displayName: String) {
+    /** The staged copy on disk, for cache housekeeping. */
+    fun file(): File? = Uri.parse(location).path?.let(::File)
+}
+
+/**
+ * Reads a model file out of an incoming `ACTION_VIEW` / `ACTION_SEND` intent, copies it into the
+ * app's cache and returns where it landed — or `null` when the intent carries no model.
+ *
+ * **Why a copy.** A `content://` URI arrives with a read grant tied to that one intent. The demo
+ * navigates (viewer → AR placement), survives configuration changes and may be resumed from the
+ * recents list, all of which outlive the grant; and `ARPlacementDemo` places a model by *location*
+ * string, which a revoked content URI cannot be. A cache copy is a stable `file://` path for as
+ * long as the app cares about it, and it is the same shape the Sketchfab resolver already stages.
+ */
+object OpenedModelIntent {
+
+    /** File extensions this app advertises in its manifest and accepts here. */
+    val SupportedExtensions: Set<String> = setOf("3mf", "glb", "gltf")
+
+    /**
+     * MIME types that name a model on their own. `application/octet-stream` is deliberately NOT
+     * here — a share sheet labels a `.3mf` that way on most Android versions, but so is every
+     * other binary file, so accepting it by MIME alone would claim files this app cannot open.
+     * The extension carries that case instead; see [looksLikeModel].
+     */
+    val SupportedMimeTypes: Set<String> = setOf(
+        "model/3mf",
+        "application/vnd.ms-package.3dmanufacturing-3dmodel+xml",
+        "model/gltf-binary",
+        "model/gltf+json",
+    )
+
+    /** The URI an `ACTION_VIEW` or `ACTION_SEND` intent carries a model in, if any. */
+    fun modelUri(intent: Intent?): Uri? {
+        val action = intent?.action ?: return null
+        val uri = when (action) {
+            Intent.ACTION_VIEW -> intent.data
+            // `EXTRA_STREAM` first, then the clip. A sender's read grant only ever covers
+            // `getData()` and the ClipData — never a bare extra — so a share that arrives with
+            // both must be read from the clip, or opening it is a SecurityException.
+            Intent.ACTION_SEND -> intent.clipData?.takeIf { it.itemCount > 0 }?.getItemAt(0)?.uri
+                ?: IntentCompat.getStream(intent)
+            else -> null
+        } ?: return null
+        // A `sceneview://demo/<id>` or `https://sceneview.github.io/open?...` VIEW intent is a
+        // deep link, not a file — DeepLinkRouter owns those.
+        if (uri.scheme == DeepLinkRouter.SCHEME_CUSTOM) return null
+        if (uri.host.equals(DeepLinkRouter.HOST_HTTPS, ignoreCase = true)) return null
+        return uri
+    }
+
+    /**
+     * `true` when a name/MIME pair names a model this app opens.
+     *
+     * Both signals are consulted because in practice neither is reliable on its own: a share sheet
+     * routinely labels a `.3mf` `application/octet-stream`, and a `content://` URI routinely has no
+     * usable file name. Either one saying "model" is enough.
+     */
+    fun looksLikeModel(displayName: String?, mimeType: String?): Boolean {
+        val extension = displayName?.substringAfterLast('.', "")?.lowercase()
+        if (extension in SupportedExtensions) return true
+        return mimeType?.lowercase()?.substringBefore(';')?.trim() in SupportedMimeTypes
+    }
+
+    /**
+     * Copy the model at [uri] into the cache and describe it, or return `null` if it cannot be read
+     * or is not a model this app opens.
+     *
+     * **The file's own bytes are the deciding signal, not what Android says about it.** Measured on
+     * `emulator-5554` with a real share: a `.3mf` sent through the share sheet arrives as
+     * `application/octet-stream` **and** with no queryable display name at all (the MediaStore row
+     * is not readable without a media permission the demo has no reason to hold), so both metadata
+     * signals were empty and a metadata-only check refused a file it could open perfectly. Content
+     * sniffing is what makes "Open with SceneView" work in the case it exists for.
+     *
+     * Blocking I/O — call it off the main thread.
+     */
+    fun stage(context: Context, uri: Uri, mimeType: String?): OpenedModel? {
+        val declaredName = displayName(context, uri)
+        val declaredType = mimeType ?: runCatching { context.contentResolver.getType(uri) }.getOrNull()
+        val target = File(openedModelsDir(context), STAGED_FILE_NAME)
+        val copied = runCatching {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
+        }.isSuccess
+        if (!copied || target.length() == 0L) {
+            target.delete()
+            return null
+        }
+        val format = detectFormat(target)
+        if (format == null && !looksLikeModel(declaredName, declaredType)) {
+            target.delete()
+            return null
+        }
+        val name = declaredName
+            ?: "model.${format ?: extensionFor(declaredType)}"
+        return OpenedModel(location = Uri.fromFile(target).toString(), displayName = name)
+    }
+
+    /**
+     * The extension a file's own bytes say it is (`3mf` / `glb` / `gltf`), or `null` when they say
+     * nothing this app can open.
+     *
+     * 3MF is confirmed with the SDK's own reader rather than by ZIP magic alone: a plain ZIP, a
+     * `.docx` and a `.jar` all start with `PK`, and only [ThreeMfLoader.isThreeMf] knows whether
+     * there is a `3D/3dmodel.model` part inside. That check needs the whole archive in memory, so
+     * it is capped — past the cap the declared name and MIME decide, which is the right trade for a
+     * file far larger than any print.
+     *
+     * Internal rather than private so `OpenedModelIntentTest` can point it at real bytes.
+     */
+    internal fun detectFormat(file: File): String? {
+        val header = runCatching {
+            file.inputStream().use { stream ->
+                ByteArray(HEADER_BYTES).let { it.copyOf(maxOf(stream.read(it), 0)) }
+            }
+        }.getOrNull() ?: return null
+        return when {
+            header.startsWith(GlbMagic) -> "glb"
+            header.startsWith(ZipMagic) -> "3mf".takeIf { isThreeMfFile(file) }
+            looksLikeGltfJson(header) -> "gltf"
+            else -> null
+        }
+    }
+
+    private fun isThreeMfFile(file: File): Boolean {
+        if (file.length() > MaxSniffBytes) return false
+        return runCatching { ThreeMfLoader.isThreeMf(file.readBytes()) }.getOrDefault(false)
+    }
+
+    /** A glTF JSON document opens with `{` and names its `"asset"` object near the top. */
+    private fun looksLikeGltfJson(header: ByteArray): Boolean {
+        val text = header.decodeToString().trimStart()
+        return text.startsWith("{") && text.contains("\"asset\"")
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+        size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
+
+    /**
+     * Delete previously-opened files, keeping only [keep]. Called on every open so the cache holds
+     * the file the user is looking at and nothing else — an opened model can be tens of megabytes
+     * and there is no session in which yesterday's file is wanted.
+     */
+    fun sweep(context: Context, keep: File?) {
+        openedModelsDir(context).listFiles()?.forEach { file ->
+            if (file.absolutePath != keep?.absolutePath) file.delete()
+        }
+    }
+
+    private fun openedModelsDir(context: Context): File =
+        File(context.cacheDir, "opened-models").apply { mkdirs() }
+
+    private fun displayName(context: Context, uri: Uri): String? = when (uri.scheme) {
+        ContentResolver.SCHEME_CONTENT -> runCatching {
+            context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+        }.getOrNull()
+
+        else -> uri.lastPathSegment
+    }?.takeIf { it.isNotBlank() }
+
+    private fun extensionFor(mimeType: String?): String = when {
+        mimeType?.contains("3mf", ignoreCase = true) == true -> "3mf"
+        mimeType?.contains("3dmanufacturing", ignoreCase = true) == true -> "3mf"
+        mimeType?.contains("gltf+json", ignoreCase = true) == true -> "gltf"
+        else -> "glb"
+    }
+
+    /**
+     * One staged file, always under the same name. The user's own file name is kept in
+     * [OpenedModel.displayName] for the title; using it on disk would mean sanitising untrusted
+     * text into a path, and there is never more than one opened model to hold.
+     */
+    private const val STAGED_FILE_NAME = "opened-model"
+
+    private const val HEADER_BYTES = 4096
+    private const val MaxSniffBytes = 64L * 1024 * 1024
+    private val GlbMagic = "glTF".encodeToByteArray()
+    private val ZipMagic = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+}
+
+/**
+ * Reads `EXTRA_STREAM` out of a share-sheet intent.
+ *
+ * The typed `getParcelableExtra(name, Uri::class.java)` is the non-deprecated API and is tried
+ * first — but it returns `null` for a `Uri` on Android 13/14: the framework matches the parcel's
+ * declared class against the requested one, and a real `Uri` is always a hidden subclass
+ * (`Uri$HierarchicalUri`). Verified on `emulator-5554` (API 36): a `.3mf` shared through the typed
+ * reader alone silently opened nothing. The deprecated untyped reader is the fallback, not the
+ * default, so the day the platform fixes it this code is already on the good path.
+ */
+private object IntentCompat {
+    @Suppress("DEPRECATION")
+    fun getStream(intent: Intent): Uri? =
+        androidx.core.content.IntentCompat
+            .getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
+            ?: intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+}

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementModelPicker.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementModelPicker.kt
@@ -107,10 +107,19 @@ data class PlacementModel(
      * are declared per row rather than trusted from the glTF because these assets are not
      * authored in metres (the Khronos Fox is ~140 units long).
      */
-    val realWorldSizeMeters: Float = 0.3f,
+    val realWorldSizeMeters: Float = DEFAULT_REAL_WORLD_SIZE_METERS,
     val source: PlacementModelSource = PlacementModelSource.Bundled,
     val pending: Boolean = false,
-)
+) {
+    companion object {
+        /**
+         * Fallback real-world size, in metres, for a model whose true size nothing knows — a file
+         * the user opened whose bounds have not been measured yet (#3482). Every catalogue row
+         * declares its own; this is only ever the last resort.
+         */
+        const val DEFAULT_REAL_WORLD_SIZE_METERS: Float = 0.3f
+    }
+}
 
 /**
  * The one bundled catalogue both tap-to-place entry points offer.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -120,8 +120,24 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // answered "what are we placing?", so it skips the chooser and opens the camera — which
     // is the same contract, reached from a different door.
     val requestedModel = remember { DemoSettings.requestedModel.also { DemoSettings.requestedModel = null } }
+    // "Open with SceneView" (#3482): the handoff may name a file the user opened rather than a
+    // catalogue row — a `file://` path staged by `OpenedModelIntent`. It becomes a row of its own,
+    // first in the picker, at the size the viewer measured on the loaded model. That size is the
+    // whole point for a 3MF: the format carries true manufacturing size, so a 60 mm print has to
+    // arrive in the room as 60 mm rather than as the catalogue's default.
+    val openedRow = remember(requestedModel) {
+        val location = requestedModel?.takeIf { it.startsWith("file://") } ?: return@remember null
+        PlacementModel(
+            id = "opened-file",
+            displayName = location.substringAfterLast('/').ifBlank { "Your file" },
+            assetLocation = location,
+            realWorldSizeMeters = DemoSettings.openedModelSizeMeters
+                ?.takeIf { it.isFinite() && it > 0f }
+                ?: PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS,
+        )
+    }
     val requestedRow = remember(requestedModel) {
-        BUNDLED_PLACEMENT_MODELS.firstOrNull { model ->
+        openedRow ?: BUNDLED_PLACEMENT_MODELS.firstOrNull { model ->
             model.assetLocation == requestedModel ||
                 model.assetLocation.substringAfterLast('/').substringBeforeLast('.') == requestedModel
         }
@@ -180,8 +196,8 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // OWN bundled fallback as `assetLocation` (never null), so a tap during the download
     // places that slug's stand-in rather than nothing — and the row is flagged `pending`
     // so the bar and the card both say "Streaming …" instead of lying about it.
-    val models: List<PlacementModel> = remember(placementSlugs, armedSlug, armedFile) {
-        BUNDLED_PLACEMENT_MODELS + placementSlugs.map { slug ->
+    val models: List<PlacementModel> = remember(placementSlugs, armedSlug, armedFile, openedRow) {
+        listOfNotNull(openedRow) + BUNDLED_PLACEMENT_MODELS + placementSlugs.map { slug ->
             val isArmed = slug.uid == armedSlug?.uid
             PlacementModel(
                 id = streamedModelId(slug),
@@ -212,7 +228,10 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // tap actually places. `loaded` is the FILE here, not a parsed `ModelInstance`: a tap
     // places whatever `armedFile` holds, so that is the moment the chip has something true
     // to say. See [AssetSourceProbe].
-    val assetSource = if (armedSlug == null) {
+    val assetSource = if (openedRow != null && picker.selectedId == openedRow.id) {
+        // The user's own file: neither bundled nor streamed. No chip rather than a wrong one.
+        null
+    } else if (armedSlug == null) {
         AssetSourceState.Bundled
     } else {
         AssetSourceProbe.of(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -299,7 +299,14 @@ private fun SingleModelSection(
     // Restored via remember (savedStateRegistry would survive config change
     // but we want the helmet back on every cold start so screenshots / Play
     // Store store-page assets stay deterministic).
-    var streamedFileUrl by remember { mutableStateOf<String?>(null) }
+    // "Open with SceneView" (#3482) — a `.3mf` / `.glb` / `.gltf` another app handed over,
+    // already staged into the cache as a `file://` path by `OpenedModelIntent`. It rides the
+    // same override the Sketchfab stream uses (`rememberModelInstance` resolves a `file://`
+    // location exactly like an http one), so an opened file arrives on the flagship viewer with
+    // its framing, lighting, animation bar and View-in-AR handoff already working — rather than
+    // on a second, poorer screen written to say the same thing.
+    val openedModel = remember { DemoSettings.openedModel.also { DemoSettings.openedModel = null } }
+    var streamedFileUrl by remember { mutableStateOf<String?>(openedModel?.location) }
     // Last-tapped state — when it's `true` the FAB shows a spinner. The
     // surprise-coroutine flips it back to `false` regardless of success so
     // the button doesn't get stuck in the loading state.
@@ -429,6 +436,9 @@ private fun SingleModelSection(
     // exist. The other four sites go through `SketchfabAssetResolver`, whose every
     // failure path DOES end at a fallback file, and they do share the probe.
     val assetSource = when {
+        // The user's own file is neither streamed nor bundled: its origin is the title bar,
+        // which names the file. A "Streamed" chip over a local file would simply be false.
+        openedModel != null -> null
         streamedFileUrl == null -> null
         streamedModelInstance == null -> AssetSourceState.Streaming
         else -> AssetSourceState.Streamed
@@ -519,7 +529,9 @@ private fun SingleModelSection(
     }
 
     DemoScaffold(
-        title = stringResource(R.string.demo_model_viewer_screen_title),
+        // An opened file is titled with its own name: the user came here from their file
+        // manager or a share sheet, and "Model Viewer" would not tell them it worked.
+        title = openedModel?.displayName ?: stringResource(R.string.demo_model_viewer_screen_title),
         onBack = onBack,
         assetSource = assetSource,
         firstFrameRendered = firstModelFrame,
@@ -594,7 +606,18 @@ private fun SingleModelSection(
             }
         }} else null,
         dockAccent = DockItem(Icons.Filled.ViewInAr, "View in AR", {
-            DemoSettings.requestedRoute = "demo/ar-placement?model=${selectedModel.assetPath}"
+            // An opened file goes to AR as itself, at the size it actually is. That measurement
+            // is the point for a 3MF: the format carries true manufacturing size, so a 60 mm
+            // print must arrive in the room as 60 mm, not as the catalogue's default 30 cm.
+            DemoSettings.openedModelSizeMeters = openedModel?.let {
+                bounds?.extents?.let { extents ->
+                    // `Aabb.extents` is already the FULL size (halfExtent * 2), so the longest
+                    // dimension is the object's real length — no second doubling.
+                    maxOf(extents.x, extents.y, extents.z).takeIf { it > 0f }
+                }
+            }
+            val model = openedModel?.location ?: selectedModel.assetPath
+            DemoSettings.requestedRoute = "demo/ar-placement?model=$model"
         }, enabled = arSupported == true),
         chromeToggleOnTap = true,
     ) {

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -387,4 +387,10 @@
     <string name="feedback_report_no_app">No app available to send the report</string>
     <string name="feedback_report_voice_cd">Dictate description</string>
     <string name="feedback_report_voice_prompt">Describe the issue</string>
+
+    <!-- "Open with SceneView" (#3482): the label Android shows in the app chooser and the
+         share sheet when another app hands over a .3mf / .glb / .gltf file. -->
+    <string name="open_model_filter_label">Open in SceneView</string>
+    <!-- Shown when a handed-over file cannot be read, or is not a model this app opens. -->
+    <string name="open_model_failed">Couldn\'t open that file — SceneView reads .3mf, .glb and .gltf</string>
 </resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/OpenedModelIntentTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/OpenedModelIntentTest.kt
@@ -1,0 +1,203 @@
+package io.github.sceneview.demo
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Tests for "Open with SceneView" (#3482) — the ingress that lets a `.3mf` shared out of ChatGPT
+ * land in this app.
+ *
+ * The two things worth pinning are the two that silently break the feature: which intents are
+ * treated as a file (a deep link must not be), and which name/MIME pairs count as a model (a share
+ * sheet labels a `.3mf` `application/octet-stream`, so the extension has to carry that case). Both
+ * are pure functions; Robolectric is here only for a real `android.net.Uri` parser.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OpenedModelIntentTest {
+
+    @Test
+    fun `a VIEW intent on a file is a model`() {
+        val uri = Uri.parse("content://com.android.providers.downloads/document/42")
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+
+        assertEquals(uri, OpenedModelIntent.modelUri(intent))
+    }
+
+    @Test
+    fun `a SEND intent carries its file in EXTRA_STREAM`() {
+        val uri = Uri.parse("content://media/external/downloads/17")
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "model/3mf"
+            putExtra(Intent.EXTRA_STREAM, uri)
+        }
+
+        assertEquals(uri, OpenedModelIntent.modelUri(intent))
+    }
+
+    @Test
+    fun `a deep link is not a file`() {
+        // Both deep-link shapes reach the same activity through their own VIEW filters;
+        // DeepLinkRouter owns them, and treating either as a file would try to open a demo id.
+        assertNull(
+            OpenedModelIntent.modelUri(
+                Intent(Intent.ACTION_VIEW, Uri.parse("sceneview://demo/model-viewer"))
+            )
+        )
+        assertNull(
+            OpenedModelIntent.modelUri(
+                Intent(Intent.ACTION_VIEW, Uri.parse("https://sceneview.github.io/open?demo=ar-placement"))
+            )
+        )
+    }
+
+    @Test
+    fun `a launcher intent carries no file`() {
+        assertNull(OpenedModelIntent.modelUri(Intent(Intent.ACTION_MAIN)))
+        assertNull(OpenedModelIntent.modelUri(null))
+    }
+
+    @Test
+    fun `a 3mf is recognised by extension even when the sender calls it a binary blob`() {
+        // This is the case that actually happens: most Android share sheets have no MIME type
+        // registered for 3MF and fall back to octet-stream.
+        assertTrue(OpenedModelIntent.looksLikeModel("dragon.3mf", "application/octet-stream"))
+        assertTrue(OpenedModelIntent.looksLikeModel("DRAGON.3MF", null))
+        assertTrue(OpenedModelIntent.looksLikeModel("chatgpt export.3mf", "*/*"))
+    }
+
+    @Test
+    fun `a 3mf is recognised by MIME type when there is no file name`() {
+        // A content:// URI often has no usable name — the declared type is all there is.
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "model/3mf"))
+        assertTrue(
+            OpenedModelIntent.looksLikeModel(
+                null,
+                "application/vnd.ms-package.3dmanufacturing-3dmodel+xml"
+            )
+        )
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "model/gltf-binary; charset=utf-8"))
+    }
+
+    @Test
+    fun `glTF rides along with 3MF`() {
+        assertTrue(OpenedModelIntent.looksLikeModel("helmet.glb", null))
+        assertTrue(OpenedModelIntent.looksLikeModel("helmet.gltf", null))
+    }
+
+    @Test
+    fun `anything else is refused`() {
+        // The manifest's octet-stream filter is broad by necessity; this is the layer that
+        // keeps a PDF or a ZIP from reaching the loader and failing with no explanation.
+        assertFalse(OpenedModelIntent.looksLikeModel("invoice.pdf", "application/octet-stream"))
+        assertFalse(OpenedModelIntent.looksLikeModel("archive.zip", "application/zip"))
+        assertFalse(OpenedModelIntent.looksLikeModel("photo.jpg", "image/jpeg"))
+        assertFalse(OpenedModelIntent.looksLikeModel(null, "application/octet-stream"))
+        assertFalse(OpenedModelIntent.looksLikeModel(null, null))
+    }
+
+    // A file's own bytes are the last word, and on a real share the only word. See
+    // `OpenedModelIntent.stage`: measured on emulator-5554, a shared `.3mf` arrives with no
+    // queryable display name AND `application/octet-stream`, so both metadata signals are blank.
+
+    @Test
+    fun `a real 3MF is recognised from its bytes alone`() {
+        val file = temporary("no-name-no-type")
+        file.writeBytes(threeMfBytes())
+
+        assertEquals("3mf", OpenedModelIntent.detectFormat(file))
+        // The pair that arrives from a share sheet, which metadata alone would refuse.
+        assertFalse(OpenedModelIntent.looksLikeModel(null, "application/octet-stream"))
+    }
+
+    @Test
+    fun `a plain ZIP is not a 3MF`() {
+        // A .docx, a .jar and any ordinary archive all open with `PK`; ZIP magic alone would
+        // claim every one of them, so the package has to be opened and looked into.
+        val file = temporary("archive")
+        file.writeBytes(zipOf("notes.txt" to "hello"))
+
+        assertNull(OpenedModelIntent.detectFormat(file))
+    }
+
+    @Test
+    fun `glTF is recognised binary and text`() {
+        val glb = temporary("binary")
+        glb.writeBytes("glTF".toByteArray() + byteArrayOf(2, 0, 0, 0, 32, 0, 0, 0))
+        assertEquals("glb", OpenedModelIntent.detectFormat(glb))
+
+        val gltf = temporary("text")
+        gltf.writeText("""{ "asset": { "version": "2.0" }, "scenes": [] }""")
+        assertEquals("gltf", OpenedModelIntent.detectFormat(gltf))
+    }
+
+    @Test
+    fun `an unrelated file is refused by content too`() {
+        val text = temporary("prose")
+        text.writeText("this is not a model, it is a shopping list")
+        assertNull(OpenedModelIntent.detectFormat(text))
+
+        val json = temporary("other-json")
+        json.writeText("""{ "name": "not a model" }""")
+        assertNull(OpenedModelIntent.detectFormat(json))
+
+        assertNull(OpenedModelIntent.detectFormat(temporary("empty")))
+    }
+
+    @Test
+    fun `every advertised extension is one the code accepts`() {
+        // The manifest lists path patterns; this object lists extensions. A file type advertised
+        // in one and missing from the other opens the chooser and then fails to load.
+        val manifest = File("src/main/AndroidManifest.xml").readText()
+        val advertised = Regex("""android:pathPattern="\.\*\\\\\.([A-Za-z0-9]+)"""")
+            .findAll(manifest)
+            .map { it.groupValues[1].lowercase() }
+            .toSet()
+
+        assertTrue("no pathPattern found in the manifest", advertised.isNotEmpty())
+        assertEquals(OpenedModelIntent.SupportedExtensions, advertised)
+    }
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private fun temporary(name: String): File = temporaryFolder.newFile(name)
+
+    /** A minimal but genuine 3MF package: an OPC ZIP holding a `3D/3dmodel.model` part. */
+    private fun threeMfBytes(): ByteArray = zipOf(
+        "[Content_Types].xml" to
+            """<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/""" +
+            """package/2006/content-types"><Default Extension="model" ContentType="application/""" +
+            """vnd.ms-package.3dmanufacturing-3dmodel+xml"/></Types>""",
+        "3D/3dmodel.model" to
+            """<?xml version="1.0"?><model unit="millimeter"><resources><object id="1"><mesh>""" +
+            """<vertices><vertex x="0" y="0" z="0"/><vertex x="10" y="0" z="0"/>""" +
+            """<vertex x="0" y="10" z="0"/></vertices>""" +
+            """<triangles><triangle v1="0" v2="1" v3="2"/></triangles>""" +
+            """</mesh></object></resources><build><item objectid="1"/></build></model>"""
+    )
+
+    private fun zipOf(vararg entries: Pair<String, String>): ByteArray {
+        val bytes = ByteArrayOutputStream()
+        ZipOutputStream(bytes).use { zip ->
+            entries.forEach { (name, content) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content.toByteArray())
+                zip.closeEntry()
+            }
+        }
+        return bytes.toByteArray()
+    }
+}


### PR DESCRIPTION
Follow-up to #3483, which taught the SDK to read 3MF. This is the half that lets a file
actually reach it.

## Why

Ask ChatGPT for a 3D print from a drawing and it hands back a `.3mf`. On Android that file
lands in Downloads or in a chat thread and stops there: no installed app claims the type, so
the chooser is empty. The SDK reading the format changes nothing until something in the
chooser opens it.

The demo now declares `ACTION_VIEW` and `ACTION_SEND` filters for `.3mf`, `.glb` and
`.gltf`. The file opens in the model viewer under its own name, and the dock's **View in AR**
carries it into placement at the size the viewer just measured.

## The bytes decide, not the metadata

Measured on `emulator-5554` (API 36): a `.3mf` sent through the share sheet arrives with
`application/octet-stream` as its type **and** with no queryable display name at all. Both
metadata signals blank — a name/MIME check refuses a file the SDK reads perfectly.

So `OpenedModelIntent` stages the file first and sniffs it: glTF magic, a glTF-JSON
heuristic, and for a ZIP the SDK's own `ThreeMfLoader.isThreeMf`, so a `.docx` or a `.jar`
is not claimed merely for opening with `PK`. The declared name and MIME stay as the fallback
for a file too large to sniff.

## Three things the platform forces

- **Three filter blocks, not one.** A MIME-typed VIEW covers apps that know the type; a
  `pathPattern` block under `application/octet-stream` and `*/*` covers the many that do not;
  SEND covers the share sheet.
- **ClipData before `EXTRA_STREAM`.** A sender's `FLAG_GRANT_READ_URI_PERMISSION` only ever
  covers `getData()` and the ClipData, never a bare extra — read the extra of a share that
  carries both and `openInputStream` returns null.
- **The typed `getParcelableExtra(name, Uri::class.java)` returns null for a `Uri` on
  Android 13+** (a real `Uri` is the hidden `Uri$HierarchicalUri` subclass). Tried first
  anyway, with the deprecated untyped reader documented behind it, so the day the platform
  fixes it this code is already on the good path.

The incoming file is copied into the app's cache: a `content://` grant is scoped to the
launching intent and would expire across the viewer → AR navigation, and `ARPlacementDemo`
places by location string. Only the current file is kept.

## Verified

`ACTION_VIEW` end to end on `emulator-5554` with a three-colour, 68-vertex, 114-triangle
rocket `.3mf`: it opens upright with its three colours, titled `rocket.3mf`, and the dock's
View in AR arms the opened file for placement.

13 Robolectric tests cover intent routing (deep links must not be treated as files), the
name/MIME rules, the content sniffing against a genuine ZIP-built 3MF, and a check that the
manifest's `pathPattern` list and `SupportedExtensions` cannot drift apart.

**Not verified:** the `ACTION_SEND` path end to end — `adb` cannot reproduce a real share
sheet's ClipData grant, so that path is covered by unit tests and by the grant rule above,
not by a device run. The AR session itself does not start on this emulator ("could not start
an AR session"), so the handoff is verified up to the armed placement screen, not the
placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
