### PR TITLE
docs(agents): tell the skill that .3mf needs no special handling (#3482)

### DIFF
--- a/agents/sceneview/SKILL.md
+++ b/agents/sceneview/SKILL.md
@@ -231,7 +231,17 @@ lambda — there is NO `rememberARSession()` helper, do NOT invent one.
    3D-only → `io.github.sceneview:sceneview`. AR → `io.github.sceneview:arsceneview`
    (it transitively includes `sceneview`).
 
-6. **Don't recompose-thrash the loaders.** `rememberEngine` / `rememberModelLoader`
+6. **`.3mf` needs no special handling — do not write any.** A 3MF (what ChatGPT and
+   every slicer emit for a printable model) goes through the same
+   `rememberModelInstance` / `loadModel*` call as a GLB: `ModelLoader` detects it by
+   its ZIP magic and converts it to GLB in memory (#3482). Never branch on the file
+   extension or the MIME type to decide — Android reports neither reliably, and a
+   shared `.3mf` routinely arrives as `application/octet-stream` with no name at all.
+   If you genuinely need to identify a buffer, `ThreeMfLoader.isThreeMf(bytes)` in
+   `sceneview-core` reads the bytes, on every platform. See
+   `references/recipes.md § Recipe: open a .3mf print`.
+
+7. **Don't recompose-thrash the loaders.** `rememberEngine` / `rememberModelLoader`
    / `rememberMaterialLoader` / `rememberEnvironmentLoader` belong at the top of
    the screen-level composable, NOT inside scroll lists or item composables.
 

--- a/agents/sceneview/references/cheatsheet.md
+++ b/agents/sceneview/references/cheatsheet.md
@@ -96,11 +96,11 @@ iOS: coaching overlay = `ARSceneView(showCoachingOverlay: true)` (native); retic
 | Helper | Returns | Notes |
 | --- | --- | --- |
 | `rememberEngine()` | `Engine` | One per SceneView |
-| `rememberModelLoader(engine)` | `ModelLoader` | Async GLB/GLTF loader |
+| `rememberModelLoader(engine)` | `ModelLoader` | Async GLB/GLTF **and `.3mf`** loader — 3MF is detected by ZIP magic and converted in memory, so there is no separate call (#3482) |
 | `rememberMaterialLoader(engine)` | `MaterialLoader` | `.filamat` loader |
 | `rememberEnvironmentLoader(engine)` | `EnvironmentLoader` | IBL loader |
 | `rememberCameraNode(engine) { … }` | `CameraNode` | Configure in trailing lambda |
-| `rememberModelInstance(modelLoader, "asset.glb")` | `ModelInstance?` | **Nullable while loading** |
+| `rememberModelInstance(modelLoader, "asset.glb")` | `ModelInstance?` | **Nullable while loading**. Takes `.glb`, `.gltf` or `.3mf` — asset path, URL, or a `file://` / `content://` URI shared in from another app |
 | `rememberMainLightNode(engine) { … }` | `LightNode` | Default key light (use `null` to disable) |
 | `rememberFillLightNode(engine) { … }` | `LightNode` | Default fill (use `null` to disable) |
 | `rememberCameraManipulator(orbitRadius = 2.5f)` | `CameraGestureDetector.CameraManipulator?` | Orbit/pan controller, camera `orbitRadius` m from the target; `null` to lock. `orbitHomePosition = Position(…)` for an explicit eye (no "home" gesture exists despite the name) |

--- a/agents/sceneview/references/recipes.md
+++ b/agents/sceneview/references/recipes.md
@@ -193,3 +193,57 @@ Pick the `ContactShadowContext` rather than tuning numbers: `Floor` is centred a
 is fainter, wider than tall and pushed below the object, `TableTop` is tight and crisp. It lives
 in `sceneview`, not `arsceneview` — plain 3D scenes ground models the same way. Non-AR preview
 demo: [`ContactShadowPreviewDemo.kt`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ContactShadowPreviewDemo.kt).
+
+## Recipe: open a `.3mf` print (#3482)
+
+A `.3mf` is what ChatGPT, every slicer and every image-to-print flow emit for a printable model.
+**There is no 3MF API to learn.** `ModelLoader` sniffs the payload by its ZIP magic and converts it
+to GLB in memory, so the file goes through the loader entry point you already use — the code below
+is the same code you would write for a `.glb`:
+
+```kotlin
+@Composable
+fun PrintViewer(location: String) {
+    val engine = rememberEngine()
+    val modelLoader = rememberModelLoader(engine)
+
+    SceneView(modifier = Modifier.fillMaxSize(), engine = engine, modelLoader = modelLoader) {
+        // `location` is a .3mf, a .glb or a .gltf — an asset path, a URL, or a file:// / content://
+        // URI shared in from another app. Same call for all of them.
+        rememberModelInstance(modelLoader, location)?.let { instance ->
+            ModelNode(modelInstance = instance, scaleToUnits = 0.3f)
+        }
+    }
+}
+```
+
+Identical in AR: an anchored `ModelNode` takes the same instance, because by the time a node sees
+it a 3MF *is* a glTF model.
+
+**Do not** add a format check, a branch, or a "3MF support" flag before calling the loader — and do
+not decide the format from the file's extension or its MIME type. Android does not reliably report
+either: measured on an emulator, a `.3mf` arriving through the share sheet has
+`application/octet-stream` as its type *and* no queryable display name at all. When you genuinely
+need to know what a buffer holds, ask its bytes, on any platform:
+
+```kotlin
+import io.github.sceneview.core.threemf.ThreeMfLoader
+
+fun describe(bytes: ByteArray): String =
+    if (ThreeMfLoader.isThreeMf(bytes)) {
+        val model = ThreeMfLoader.parse(bytes)
+        "a print: ${model.triangleCount} triangles, unit ${model.unit.id}"
+    } else {
+        "not a 3MF"
+    }
+```
+
+**Drop `scaleToUnits` when the real size is the point.** Conversion scales the file's declared unit
+to metres, so a 60 mm print is 0.06 scene units and lands life-size in AR with no magic number;
+`scaleToUnits` overrides that to frame the model at a fixed size, which is what a viewer wants and
+what an AR preview of a real object does not.
+
+Full behaviour — Z-up to Y-up, flat per-face normals, `<basematerials>` and `<colorgroup>` colours,
+`ThreeMfModel` — is in `llms.txt § 3MF`. The demo app's "Open with" path
+([`OpenedModel.kt`](https://github.com/sceneview/sceneview/blob/main/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt))
+is the worked example of receiving one of these files from another app.

--- a/changelog.d/3482-3mf-skill-docs.md
+++ b/changelog.d/3482-3mf-skill-docs.md
@@ -1,0 +1,9 @@
+<!-- category: Changed -->
+- **The installable SceneView skill now says that `.3mf` needs no special handling
+  ([#3482](https://github.com/sceneview/sceneview/issues/3482)).** The SDK reading 3MF is only
+  half the job: an AI that has not been told will invent a branch, a format check or a
+  "3MF support" flag before calling the loader, and worse, will decide the format from the
+  file extension or the MIME type — which Android does not reliably report. `SKILL.md` gains
+  that as a critical rule, `references/cheatsheet.md` states it on the two loader rows an AI
+  actually reads, and `references/recipes.md` gains a worked recipe whose Kotlin is compiled by
+  `:snippets-check` like every other snippet in the reference set.


### PR DESCRIPTION
Third of the 3MF set, after #3483 (SDK reads 3MF) and #3510 (the demo is an "Open with"
target for it).

## Why

#3483's whole design claim is that there is **no new API**: `ModelLoader` detects the
payload by its ZIP magic and converts it to GLB in memory, so a `.3mf` goes through the
`rememberModelInstance` call you already write. That claim only holds if the generator
knows it.

An AI that has not been told will write the branch anyway — a format check, an
`if (isThreeMf)`, a "3MF support" flag — and will reach for the two signals Android does
not reliably provide: the file extension and the MIME type. Measured on `emulator-5554`,
a `.3mf` arriving through the share sheet has `application/octet-stream` as its type
**and** no queryable display name at all. Branching on extension-and-MIME is not merely
redundant here, it is wrong, and the failure is silent.

## What changed

- **`SKILL.md`** — a new critical rule (#6) stating that `.3mf` needs no special handling,
  that the extension and the MIME type must not decide, and that
  `ThreeMfLoader.isThreeMf(bytes)` in `sceneview-core` is the byte-level answer when a
  buffer genuinely has to be identified.
- **`references/cheatsheet.md`** — the same fact on the `rememberModelLoader` and
  `rememberModelInstance` rows, the two lines an AI reads immediately before writing a
  loader call.
- **`references/recipes.md`** — a worked recipe: the viewer call, byte-level
  identification, and when to drop `scaleToUnits` so an AR preview of a real printed part
  stays life-size instead of being framed to a fixed size.

## Verified

The recipe's Kotlin is compiled by `:snippets-check` like every other snippet in the
reference set — two new snippets, `recipes/b004` and `recipes/b005` —  so it cannot drift
from the API. `./gradlew :snippets-check:compileDebugKotlin` green;
`node tools/generate-gpt-knowledge.js --check` reports in sync (`llms.txt` already carries
the full format behaviour from #3483 and is unchanged here).

`agents/OPENAI-PLUGIN.md` is deliberately untouched — its 3MF starter prompt is coming in
the web/MCP branch, which is already editing that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
