### PR TITLE
feat(ios): open STL, OBJ and PLY through ModelIO, at real-world size (#3492)

### DIFF
--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -130,7 +130,7 @@ let title = TextNode(text: "SceneView", fontSize: 0.08, depth: 0.02)
 
 | Type | Description |
 |---|---|
-| `ModelNode` | USDZ model loading with animations and collision |
+| `ModelNode` | Model loading (USDZ, STL, OBJ, PLY) with animations and collision |
 | `GeometryNode` | Procedural shapes (cube, sphere, cylinder, cone, plane) |
 | `MeshNode` | Custom mesh geometry from raw vertex data |
 | `ShapeNode` | 2D polygon shapes (flat or extruded) with ear-clipping triangulation |
@@ -158,6 +158,54 @@ let title = TextNode(text: "SceneView", fontSize: 0.08, depth: 0.02)
 | `SceneEnvironment` | 6 HDR presets: studio, outdoor, sunset, night, warm, autumn |
 | `CameraControls` | Orbit camera with inertia and auto-rotation |
 | `GeometryMaterial` | PBR material: `.simple`, `.pbr`, `.unlit` |
+| `ModelFormat` | Supported formats + content-based sniffing |
+| `ModelUnit` | The unit a file's coordinates are in |
+| `MeshAsset` | Parsed geometry, before RealityKit — measurable off the main actor |
+
+## Model Formats
+
+`ModelNode.load(contentsOf:unit:)` opens every supported format from one call. The
+format is decided by reading the file's bytes, not by trusting its extension — a model
+that arrived through a share sheet or a download often has the wrong one.
+
+| Format | Reader | Default unit |
+|---|---|---|
+| `.usdz` `.usda` `.usdc` `.usd` `.reality` | RealityKit | metres (already metric) |
+| `.stl` (ASCII + binary) | ModelIO | **millimetres** |
+| `.obj` (+ `.mtl` sidecar) | ModelIO | metres |
+| `.ply` (ASCII + binary, vertex colours) | ModelIO | metres |
+
+glTF (`.glb` / `.gltf`) is not supported on Apple platforms — neither RealityKit nor
+ModelIO reads it. Convert to USDZ first.
+
+### Units matter
+
+STL, OBJ and PLY store bare numbers with no unit. A slicer STL means millimetres; a
+photogrammetry OBJ means metres. RealityKit works in metres, so guessing wrong puts a
+21 cm print in the room at 210 m. The conversion is baked into the vertex positions, so
+your own `.scale(_:)` stays yours.
+
+```swift
+// Millimetres by default — a 210 mm print is 0.21 m in AR.
+let printed = try await ModelNode.load(contentsOf: stlURL)
+
+// Override when you know better.
+let scan = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+```
+
+`ModelFormat.carriesUnit` is `false` for exactly those three formats — the signal to show
+a mm/cm/in picker rather than guess.
+
+### Measure before rendering
+
+Parsing has no RealityKit dependency, so a file can be inspected off the main actor:
+
+```swift
+let asset = try MeshAsset.load(contentsOf: url)
+print(asset.format, asset.unit, asset.triangleCount)
+print(asset.boundsInMeters?.extents ?? .zero)   // real-world size
+let node = try await ModelNode(asset)           // then display it
+```
 
 ## Platform Support
 

--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -174,6 +174,14 @@ that arrived through a share sheet or a download often has the wrong one.
 | `.stl` (ASCII + binary) | ModelIO | **millimetres** |
 | `.obj` (+ `.mtl` sidecar) | ModelIO | metres |
 | `.ply` (ASCII + binary, vertex colours) | ModelIO | metres |
+| `.3mf` | SceneViewSwift's own parser | declared by the file |
+
+3MF is parsed here rather than by Apple: `MDLAsset` reads OBJ, STL, PLY and USD, Quick
+Look reads USDZ and Reality, and nothing on the platform opens the format 3D printing
+standardised on. `ThreeMFDocument` covers the core spec — units, meshes, components with
+row-vector transforms, build items, `<basematerials>` and `<colorgroup>` resolved per
+triangle — plus the Production extension's `p:path` references, which is how Bambu Studio
+and Orca write project files. External XML entities are refused.
 
 glTF (`.glb` / `.gltf`) is not supported on Apple platforms — neither RealityKit nor
 ModelIO reads it. Convert to USDZ first.

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
@@ -242,7 +242,7 @@ public struct MeshAsset: Sendable {
     /// Reads a mesh file into parts, choosing the reader from the file's own content.
     ///
     /// Handles the formats whose ``ModelFormat/loader`` is ``ModelFormat/Loader/modelIO``
-    /// — STL, OBJ and PLY. USD and Reality files
+    /// (STL, OBJ, PLY) or ``ModelFormat/Loader/sceneView`` (3MF). USD and Reality files
     /// are RealityKit's own business — they are rejected here with
     /// ``ModelLoadingError/unsupportedFormat(fileExtension:)`` and handled by
     /// `ModelNode.load(contentsOf:)`, which is the entry point that covers every format.
@@ -268,6 +268,12 @@ public struct MeshAsset: Sendable {
             let parts = try ModelIOMeshReader.read(contentsOf: url)
             guard !parts.isEmpty else { throw ModelLoadingError.emptyMesh }
             return MeshAsset(format: format, unit: unit ?? format.defaultUnit, parts: parts)
+        case .sceneView:
+            // 3MF is the only `.sceneView` format, and it declares its own unit — an
+            // explicit `unit:` overrides what the file says, which is what a "this was
+            // authored wrong" correction needs.
+            let document = try ThreeMFDocument.read(contentsOf: url)
+            return MeshAsset(format: format, unit: unit ?? document.unit, parts: document.parts)
         case .realityKit:
             throw ModelLoadingError.unsupportedFormat(fileExtension: format.fileExtension)
         }

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
@@ -1,0 +1,275 @@
+import Foundation
+import simd
+
+/// An axis-aligned bounding box over mesh vertices.
+///
+/// A plain value type rather than RealityKit's `BoundingBox` so that parsing, bounds
+/// arithmetic and the unit conversion are all testable without a live RealityKit scene —
+/// and so that ``MeshAsset`` stays usable on a background task.
+public struct MeshBounds: Sendable, Equatable {
+    /// The lower corner.
+    public var min: SIMD3<Float>
+    /// The upper corner.
+    public var max: SIMD3<Float>
+
+    public init(min: SIMD3<Float>, max: SIMD3<Float>) {
+        self.min = min
+        self.max = max
+    }
+
+    /// The tightest box containing every point, or `nil` for an empty sequence.
+    public init?(points: some Sequence<SIMD3<Float>>) {
+        var iterator = points.makeIterator()
+        guard let first = iterator.next() else { return nil }
+        var lo = first
+        var hi = first
+        while let point = iterator.next() {
+            lo = simd_min(lo, point)
+            hi = simd_max(hi, point)
+        }
+        self.init(min: lo, max: hi)
+    }
+
+    /// Size along each axis.
+    public var extents: SIMD3<Float> { max - min }
+
+    /// The box centre.
+    public var center: SIMD3<Float> { (min + max) / 2 }
+
+    /// The longest edge — the number a "fits in a 20 cm printer" check compares against.
+    public var largestExtent: Float {
+        let e = extents
+        return Swift.max(e.x, Swift.max(e.y, e.z))
+    }
+
+    /// The box containing both boxes.
+    public func union(_ other: MeshBounds) -> MeshBounds {
+        MeshBounds(min: simd_min(min, other.min), max: simd_max(max, other.max))
+    }
+
+    /// This box scaled about the origin — how a unit conversion moves it.
+    public func scaled(by factor: Float) -> MeshBounds {
+        MeshBounds(min: min * factor, max: max * factor)
+    }
+}
+
+/// A material as described by a source file, before it becomes a RealityKit material.
+///
+/// Deliberately small: the properties that OBJ's `.mtl`, PLY's vertex colours and 3MF's
+/// `<basematerials>` actually carry, in a form that survives being read off the main
+/// thread. ``ModelNode`` turns it into a `PhysicallyBasedMaterial`.
+public struct MeshMaterialDescription: Sendable, Equatable {
+    /// The name authored in the file, when it has one.
+    public var name: String?
+    /// Linear-space RGBA base colour, components in `0...1`.
+    public var baseColor: SIMD4<Float>?
+    /// `0` dielectric … `1` metal.
+    public var metallic: Float?
+    /// `0` mirror … `1` fully rough.
+    public var roughness: Float?
+    /// A base-colour texture sitting next to the model file (OBJ `map_Kd`, 3MF texture
+    /// part extracted to a temporary file).
+    public var baseColorTextureURL: URL?
+
+    public init(
+        name: String? = nil,
+        baseColor: SIMD4<Float>? = nil,
+        metallic: Float? = nil,
+        roughness: Float? = nil,
+        baseColorTextureURL: URL? = nil
+    ) {
+        self.name = name
+        self.baseColor = baseColor
+        self.metallic = metallic
+        self.roughness = roughness
+        self.baseColorTextureURL = baseColorTextureURL
+    }
+}
+
+/// One indexed triangle mesh with a single material — a "part" of a loaded file.
+///
+/// A file yields several of these when it has several materials (an OBJ with three
+/// `usemtl` groups, a 3MF with three build items). Vertices are **not** shared between
+/// parts: each part carries only the vertices its own indices reference, so a part can
+/// be handed to RealityKit, measured, or dropped on its own.
+public struct MeshGeometry: Sendable {
+    /// The object/group name from the file, or a generated one.
+    public var name: String
+    /// Vertex positions, in the asset's ``MeshAsset/unit``.
+    public var positions: [SIMD3<Float>]
+    /// Per-vertex normals. `nil` when the file had none and none were generated.
+    public var normals: [SIMD3<Float>]?
+    /// Per-vertex UVs.
+    public var textureCoordinates: [SIMD2<Float>]?
+    /// Per-vertex linear RGBA colours — PLY's `red/green/blue` properties, mostly.
+    ///
+    /// RealityKit's `MeshDescriptor` has no vertex-colour channel, so these are not
+    /// rendered per-vertex; ``ModelNode`` folds their average into the material tint so
+    /// a coloured scan does not come back grey. The full array stays here for callers
+    /// that want it.
+    public var colors: [SIMD4<Float>]?
+    /// Triangle indices — always a multiple of 3, always into this part's own arrays.
+    public var indices: [UInt32]
+    /// The material this part is drawn with, when the file described one.
+    public var material: MeshMaterialDescription?
+
+    public init(
+        name: String,
+        positions: [SIMD3<Float>],
+        normals: [SIMD3<Float>]? = nil,
+        textureCoordinates: [SIMD2<Float>]? = nil,
+        colors: [SIMD4<Float>]? = nil,
+        indices: [UInt32],
+        material: MeshMaterialDescription? = nil
+    ) {
+        self.name = name
+        self.positions = positions
+        self.normals = normals
+        self.textureCoordinates = textureCoordinates
+        self.colors = colors
+        self.indices = indices
+        self.material = material
+    }
+
+    /// Number of triangles.
+    public var triangleCount: Int { indices.count / 3 }
+
+    /// Bounding box of this part, `nil` when it has no vertices.
+    public var bounds: MeshBounds? { MeshBounds(points: positions) }
+
+    /// This part with every position multiplied by `factor` — the unit conversion.
+    /// Normals are left alone: a uniform positive scale does not change them.
+    public func scaled(by factor: Float) -> MeshGeometry {
+        guard factor != 1 else { return self }
+        var copy = self
+        copy.positions = positions.map { $0 * factor }
+        return copy
+    }
+
+    /// Flat-shaded normals computed from the triangles, for a file that carried none.
+    ///
+    /// Area-weighted accumulation over the incident triangles: a triangle's face normal
+    /// is added to each of its three vertices unnormalized, so larger triangles pull
+    /// harder, then each vertex normal is normalized once at the end. Degenerate
+    /// triangles contribute a zero-length cross product and therefore nothing at all.
+    public func generatingNormals() -> MeshGeometry {
+        guard normals == nil, !positions.isEmpty, indices.count >= 3 else { return self }
+        var accumulated = [SIMD3<Float>](repeating: .zero, count: positions.count)
+        var index = 0
+        while index + 2 < indices.count {
+            let a = Int(indices[index])
+            let b = Int(indices[index + 1])
+            let c = Int(indices[index + 2])
+            index += 3
+            guard a < positions.count, b < positions.count, c < positions.count else { continue }
+            let faceNormal = cross(positions[b] - positions[a], positions[c] - positions[a])
+            accumulated[a] += faceNormal
+            accumulated[b] += faceNormal
+            accumulated[c] += faceNormal
+        }
+        var copy = self
+        copy.normals = accumulated.map { vector in
+            let lengthSquared = simd_length_squared(vector)
+            // A vertex touched only by degenerate triangles has no defined normal;
+            // +Y keeps it lit rather than black, and normalize() would return NaN.
+            return lengthSquared > 0 ? vector / lengthSquared.squareRoot() : SIMD3<Float>(0, 1, 0)
+        }
+        return copy
+    }
+}
+
+/// Everything one model file describes: its parts, the format it came in, and the unit
+/// its coordinates are in.
+///
+/// This is the format-neutral layer. It has no RealityKit dependency, so it parses on a
+/// background task, is testable without a simulator scene, and can be measured
+/// ("is this print 21 cm tall?") before anything is rendered.
+///
+/// ```swift
+/// let asset = try MeshAsset.load(contentsOf: url)          // sniffs the format
+/// print(asset.format, asset.unit, asset.triangleCount)
+/// print(asset.boundsInMeters?.extents ?? .zero)            // real-world size
+/// ```
+///
+/// To display it, hand it to ``ModelNode``:
+/// `let node = try await ModelNode.load(contentsOf: url)`.
+public struct MeshAsset: Sendable {
+    /// The format the file was read as.
+    public let format: ModelFormat
+    /// The unit ``parts`` coordinates are expressed in.
+    public let unit: ModelUnit
+    /// The mesh parts, in file order.
+    public let parts: [MeshGeometry]
+
+    public init(format: ModelFormat, unit: ModelUnit, parts: [MeshGeometry]) {
+        self.format = format
+        self.unit = unit
+        self.parts = parts
+    }
+
+    /// Total vertices across every part.
+    public var vertexCount: Int { parts.reduce(0) { $0 + $1.positions.count } }
+
+    /// Total triangles across every part.
+    public var triangleCount: Int { parts.reduce(0) { $0 + $1.triangleCount } }
+
+    /// Bounding box over every part, in ``unit``.
+    public var bounds: MeshBounds? {
+        parts.compactMap(\.bounds).reduce(nil) { partial, next in
+            partial.map { $0.union(next) } ?? next
+        }
+    }
+
+    /// Bounding box in metres — the real-world size, unit applied.
+    public var boundsInMeters: MeshBounds? { bounds?.scaled(by: unit.metersPerUnit) }
+
+    /// The same asset with every coordinate converted to metres, ready for RealityKit.
+    ///
+    /// The conversion is baked into the vertex positions rather than left as an entity
+    /// scale, so a caller's later `.scale(_:)` is *their* scale and does not silently
+    /// destroy the unit correction.
+    public func inMeters() -> MeshAsset {
+        guard unit != .meters else { return self }
+        return MeshAsset(
+            format: format,
+            unit: .meters,
+            parts: parts.map { $0.scaled(by: unit.metersPerUnit) }
+        )
+    }
+
+    // MARK: - Loading
+
+    /// Reads a mesh file into parts, choosing the reader from the file's own content.
+    ///
+    /// Handles the formats whose ``ModelFormat/loader`` is ``ModelFormat/Loader/modelIO``
+    /// — STL, OBJ and PLY. USD and Reality files
+    /// are RealityKit's own business — they are rejected here with
+    /// ``ModelLoadingError/unsupportedFormat(fileExtension:)`` and handled by
+    /// `ModelNode.load(contentsOf:)`, which is the entry point that covers every format.
+    ///
+    /// - Parameters:
+    ///   - url: A local file URL.
+    ///   - unit: The unit the file's coordinates are in. `nil` means "use the unit the
+    ///     file declares, and ``ModelFormat/defaultUnit`` when it declares none".
+    /// - Throws: ``ModelLoadingError``.
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil) throws -> MeshAsset {
+        let format = try ModelFormat.sniff(contentsOf: url)
+        return try load(contentsOf: url, format: format, unit: unit)
+    }
+
+    /// Reads a mesh file whose format is already known — skips the sniffing read.
+    public static func load(
+        contentsOf url: URL,
+        format: ModelFormat,
+        unit: ModelUnit? = nil
+    ) throws -> MeshAsset {
+        switch format.loader {
+        case .modelIO:
+            let parts = try ModelIOMeshReader.read(contentsOf: url)
+            guard !parts.isEmpty else { throw ModelLoadingError.emptyMesh }
+            return MeshAsset(format: format, unit: unit ?? format.defaultUnit, parts: parts)
+        case .realityKit:
+            throw ModelLoadingError.unsupportedFormat(fileExtension: format.fileExtension)
+        }
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
@@ -41,6 +41,13 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// No unit.
     case ply
 
+    // MARK: Parsed by SceneViewSwift
+
+    /// 3D Manufacturing Format — a zip container around an XML mesh description.
+    /// The only mesh format in this list that carries its own unit, and the only one
+    /// neither RealityKit nor ModelIO reads. See ``ThreeMFDocument``.
+    case threeMF = "3mf"
+
     /// The canonical lowercase file extension, without a dot.
     public var fileExtension: String { rawValue }
 
@@ -50,6 +57,8 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         case realityKit
         /// `MDLAsset` — Apple's ModelIO importer.
         case modelIO
+        /// SceneViewSwift's own parser.
+        case sceneView
     }
 
     /// The reader used for this format.
@@ -57,6 +66,7 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         switch self {
         case .usdz, .reality, .usda, .usdc, .usd: return .realityKit
         case .stl, .obj, .ply: return .modelIO
+        case .threeMF: return .sceneView
         }
     }
 
@@ -68,11 +78,13 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// - `.obj`, `.ply` → ``ModelUnit/meters``: also unitless, but their common sources
     ///   (photogrammetry, scanners, DCC exports) author in metres. Pass `unit:`
     ///   explicitly when you know better — that is what the parameter is for.
+    /// - `.threeMF` → ``ModelUnit/millimeters``: the 3MF core spec's own default for a
+    ///   missing `unit` attribute. A 3MF that *declares* a unit overrides this.
     /// - USD / Reality → ``ModelUnit/meters``: RealityKit has already applied the
     ///   asset's `metersPerUnit`.
     public var defaultUnit: ModelUnit {
         switch self {
-        case .stl: return .millimeters
+        case .stl, .threeMF: return .millimeters
         case .obj, .ply, .usdz, .reality, .usda, .usdc, .usd: return .meters
         }
     }
@@ -81,10 +93,10 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// ``ModelUnit`` a correction rather than a guess.
     ///
     /// Drives the "what unit is this?" prompt a viewer should show: ask for `.stl`,
-    /// `.obj` and `.ply`; stay quiet for USD.
+    /// `.obj` and `.ply`; stay quiet for `.3mf` and USD.
     public var carriesUnit: Bool {
         switch self {
-        case .usdz, .reality, .usda, .usdc, .usd: return true
+        case .threeMF, .usdz, .reality, .usda, .usdc, .usd: return true
         case .stl, .obj, .ply: return false
         }
     }
@@ -105,13 +117,15 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// Identifies the format of a file, by content first and file extension second.
     ///
     /// Content wins because the extension is the least reliable thing about a file that
-    /// reached the app through a share sheet, a download, or a messaging app.
+    /// reached the app through a share sheet, a download, or a messaging app — and
+    /// because two of these formats share a container: **USDZ and 3MF are both zip
+    /// archives**, told apart here by the name of the archive's first entry.
     ///
     /// The signatures that are treated as decisive:
     ///
     /// | Format | Evidence |
     /// |---|---|
-    /// | `.usdz` | `PK\x03\x04` — a zip whose first entry is a `.usd*` |
+    /// | `.usdz` / `.3mf` | `PK\x03\x04`, then the first entry's name (`*.usd*` → USDZ, else 3MF) |
     /// | `.stl` (binary) | `84 + 50 × triangleCount == fileSize` — checked **before** the ASCII test, because binary STLs routinely start with the word `solid` too |
     /// | `.stl` (ASCII) | starts with `solid` and the header is printable text |
     /// | `.ply` | starts with `ply` + newline |
@@ -162,15 +176,14 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         guard !header.isEmpty else { return nil }
         let bytes = [UInt8](header)
 
-        // --- Zip container --------------------------------------------------------
-        // USDZ is a zip archive, and so are other 3D containers SceneViewSwift does not
-        // read, so the first entry's name decides rather than the `PK` magic alone.
+        // --- Zip container: USDZ and 3MF both live here ---------------------------
+        // USDZ stores its `.usdc` first and uncompressed; a 3MF's first entry is
+        // `[Content_Types].xml` or a `_rels`/`3D` part. Neither has a magic number of its
+        // own, so the first entry's name is the only evidence inside the probe window.
         if bytes.starts(with: [0x50, 0x4B, 0x03, 0x04]) {  // "PK\3\4"
-            if let name = zipFirstEntryName(bytes),
-               (name as NSString).pathExtension.lowercased().hasPrefix("usd") {
-                return .usdz
-            }
-            return nil
+            return zipFirstEntryName(bytes).map { name in
+                (name as NSString).pathExtension.lowercased().hasPrefix("usd") ? .usdz : .threeMF
+            } ?? .threeMF
         }
 
         // --- Binary STL: arithmetic, not a magic number ------------------------
@@ -206,7 +219,8 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     ///
     /// Only the fixed 30-byte header is needed: bytes 26–27 are the name length and the
     /// name follows the header. Returns `nil` if the probe window does not contain the
-    /// whole name.
+    /// whole name — in which case ``sniff(header:fileSize:)`` falls back to 3MF, the
+    /// format for which a long first entry name is plausible.
     private static func zipFirstEntryName(_ bytes: [UInt8]) -> String? {
         guard bytes.count >= 30 else { return nil }
         let nameLength = Int(bytes[26]) | Int(bytes[27]) << 8

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// A 3D file format SceneViewSwift can open.
+///
+/// The raw value is the canonical lowercase file extension, so
+/// `ModelFormat(rawValue: url.pathExtension.lowercased())` works, and
+/// ``sniff(contentsOf:)`` is the entry point that decides for you — by content first,
+/// extension second, because a file that arrived through Files, AirDrop or a share
+/// sheet routinely has the wrong extension or none at all.
+///
+/// ```swift
+/// switch try ModelFormat.sniff(contentsOf: url) {
+/// case .stl, .obj, .ply: print("mesh file, needs a unit")
+/// case .threeMF:         print("3MF — carries its own unit")
+/// default:               print("USD/Reality — already in metres")
+/// }
+/// ```
+public enum ModelFormat: String, Sendable, CaseIterable, Codable {
+
+    // MARK: Handled by RealityKit itself
+
+    /// Apple's zipped USD package. Read by RealityKit, already in metres.
+    case usdz
+    /// Reality Composer scene bundle. Read by RealityKit.
+    case reality
+    /// USD ASCII (`.usda`).
+    case usda
+    /// USD crate — binary USD (`.usdc`).
+    case usdc
+    /// Extension-agnostic USD (`.usd`) — ASCII or crate, RealityKit sniffs it.
+    case usd
+
+    // MARK: Mesh formats read through ModelIO
+
+    /// Stereolithography — the 3D-printing lingua franca. ASCII or binary, no unit,
+    /// no materials, per-facet normals. Defaults to ``ModelUnit/millimeters``.
+    case stl
+    /// Wavefront OBJ, with its sidecar `.mtl` when one sits next to it. No unit.
+    case obj
+    /// Polygon File Format (Stanford). ASCII or binary, optional per-vertex colours.
+    /// No unit.
+    case ply
+
+    /// The canonical lowercase file extension, without a dot.
+    public var fileExtension: String { rawValue }
+
+    /// Which code path opens this format.
+    public enum Loader: Sendable, Equatable {
+        /// `Entity(contentsOf:)` — RealityKit's own USD/Reality reader.
+        case realityKit
+        /// `MDLAsset` — Apple's ModelIO importer.
+        case modelIO
+    }
+
+    /// The reader used for this format.
+    public var loader: Loader {
+        switch self {
+        case .usdz, .reality, .usda, .usdc, .usd: return .realityKit
+        case .stl, .obj, .ply: return .modelIO
+        }
+    }
+
+    /// The unit assumed when the caller does not pass one and the file itself does not
+    /// say.
+    ///
+    /// - `.stl` → ``ModelUnit/millimeters``: STL has no unit field, and essentially every
+    ///   STL in circulation comes out of a CAD/slicer pipeline that means millimetres.
+    /// - `.obj`, `.ply` → ``ModelUnit/meters``: also unitless, but their common sources
+    ///   (photogrammetry, scanners, DCC exports) author in metres. Pass `unit:`
+    ///   explicitly when you know better — that is what the parameter is for.
+    /// - USD / Reality → ``ModelUnit/meters``: RealityKit has already applied the
+    ///   asset's `metersPerUnit`.
+    public var defaultUnit: ModelUnit {
+        switch self {
+        case .stl: return .millimeters
+        case .obj, .ply, .usdz, .reality, .usda, .usdc, .usd: return .meters
+        }
+    }
+
+    /// Whether the format carries a real-world unit of its own, making a caller-supplied
+    /// ``ModelUnit`` a correction rather than a guess.
+    ///
+    /// Drives the "what unit is this?" prompt a viewer should show: ask for `.stl`,
+    /// `.obj` and `.ply`; stay quiet for USD.
+    public var carriesUnit: Bool {
+        switch self {
+        case .usdz, .reality, .usda, .usdc, .usd: return true
+        case .stl, .obj, .ply: return false
+        }
+    }
+
+    /// Creates a format from a file extension, with or without a leading dot, in any
+    /// case. Returns `nil` for anything not in this enum.
+    public init?(fileExtension: String) {
+        var ext = fileExtension.lowercased()
+        if ext.hasPrefix(".") { ext.removeFirst() }
+        // `.gltf`/`.glb` deliberately absent: neither RealityKit nor ModelIO reads
+        // them, so claiming the extension would produce a load that always fails.
+        guard let format = ModelFormat(rawValue: ext) else { return nil }
+        self = format
+    }
+
+    // MARK: - Sniffing
+
+    /// Identifies the format of a file, by content first and file extension second.
+    ///
+    /// Content wins because the extension is the least reliable thing about a file that
+    /// reached the app through a share sheet, a download, or a messaging app.
+    ///
+    /// The signatures that are treated as decisive:
+    ///
+    /// | Format | Evidence |
+    /// |---|---|
+    /// | `.usdz` | `PK\x03\x04` — a zip whose first entry is a `.usd*` |
+    /// | `.stl` (binary) | `84 + 50 × triangleCount == fileSize` — checked **before** the ASCII test, because binary STLs routinely start with the word `solid` too |
+    /// | `.stl` (ASCII) | starts with `solid` and the header is printable text |
+    /// | `.ply` | starts with `ply` + newline |
+    /// | `.usda` | starts with `#usda` |
+    /// | `.usdc` | starts with `PXR-USDC` |
+    ///
+    /// OBJ has no signature and is therefore only ever identified by its extension.
+    ///
+    /// - Parameter url: A local file URL.
+    /// - Returns: The detected format.
+    /// - Throws: ``ModelLoadingError/unreadableFile(_:)`` when the file cannot be read,
+    ///   ``ModelLoadingError/unsupportedFormat(fileExtension:)`` when neither the content
+    ///   nor the extension identifies a supported format.
+    public static func sniff(contentsOf url: URL) throws -> ModelFormat {
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: url)
+        } catch {
+            throw ModelLoadingError.unreadableFile(url)
+        }
+        defer { try? handle.close() }
+
+        let size = (try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
+        let header = (try? handle.read(upToCount: signatureProbeBytes)) ?? Data()
+
+        if let sniffed = sniff(header: header, fileSize: size ?? header.count) {
+            return sniffed
+        }
+        if let byExtension = ModelFormat(fileExtension: url.pathExtension) {
+            return byExtension
+        }
+        throw ModelLoadingError.unsupportedFormat(fileExtension: url.pathExtension)
+    }
+
+    /// How much of the file ``sniff(contentsOf:)`` reads. Enough for a zip local header
+    /// plus a long first entry name, and for a text header to be recognisably text.
+    static let signatureProbeBytes = 512
+
+    /// Content-only detection, split out so it is testable from raw bytes.
+    ///
+    /// - Parameters:
+    ///   - header: The first ``signatureProbeBytes`` bytes (fewer for a short file).
+    ///   - fileSize: The total file size — load-bearing for the binary-STL test, which
+    ///     is a size arithmetic check, not a magic number.
+    /// - Returns: The format, or `nil` when the content is not decisive.
+    static func sniff(header: Data, fileSize: Int) -> ModelFormat? {
+        guard !header.isEmpty else { return nil }
+        let bytes = [UInt8](header)
+
+        // --- Zip container --------------------------------------------------------
+        // USDZ is a zip archive, and so are other 3D containers SceneViewSwift does not
+        // read, so the first entry's name decides rather than the `PK` magic alone.
+        if bytes.starts(with: [0x50, 0x4B, 0x03, 0x04]) {  // "PK\3\4"
+            if let name = zipFirstEntryName(bytes),
+               (name as NSString).pathExtension.lowercased().hasPrefix("usd") {
+                return .usdz
+            }
+            return nil
+        }
+
+        // --- Binary STL: arithmetic, not a magic number ------------------------
+        //
+        // 80-byte header + UInt32 triangle count + 50 bytes per triangle. This must be
+        // tested BEFORE the ASCII "solid" prefix: exporters write arbitrary text into
+        // the 80-byte header and a great many of them start it with "solid", so the
+        // prefix test alone mis-reads a binary STL as ASCII and yields an empty mesh.
+        if fileSize >= 84, bytes.count >= 84 {
+            let count = UInt32(bytes[80])
+                | UInt32(bytes[81]) << 8
+                | UInt32(bytes[82]) << 16
+                | UInt32(bytes[83]) << 24
+            if count > 0, 84 + 50 * Int(count) == fileSize {
+                return .stl
+            }
+        }
+
+        // --- Text signatures ----------------------------------------------------
+        if bytes.starts(with: Array("PXR-USDC".utf8)) { return .usdc }
+        if bytes.starts(with: Array("#usda".utf8)) { return .usda }
+        if bytes.starts(with: Array("ply".utf8)),
+           bytes.count > 3, bytes[3] == 0x0A || bytes[3] == 0x0D {
+            return .ply
+        }
+        if bytes.starts(with: Array("solid".utf8)), isPrintableText(bytes) {
+            return .stl
+        }
+        return nil
+    }
+
+    /// Reads the file name of a zip archive's first local file header.
+    ///
+    /// Only the fixed 30-byte header is needed: bytes 26–27 are the name length and the
+    /// name follows the header. Returns `nil` if the probe window does not contain the
+    /// whole name.
+    private static func zipFirstEntryName(_ bytes: [UInt8]) -> String? {
+        guard bytes.count >= 30 else { return nil }
+        let nameLength = Int(bytes[26]) | Int(bytes[27]) << 8
+        guard nameLength > 0, 30 + nameLength <= bytes.count else { return nil }
+        return String(bytes: bytes[30..<(30 + nameLength)], encoding: .utf8)
+    }
+
+    /// Whether a header looks like text rather than a binary blob — tab, newline,
+    /// carriage return and printable ASCII only. Used to separate an ASCII STL from a
+    /// binary one whose 80-byte header happens to begin with `solid`.
+    private static func isPrintableText(_ bytes: [UInt8]) -> Bool {
+        for byte in bytes.prefix(128) {
+            let isPrintable = (0x20...0x7E).contains(byte)
+                || byte == 0x09 || byte == 0x0A || byte == 0x0D
+            if !isPrintable { return false }
+        }
+        return true
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelIOMeshReader.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelIOMeshReader.swift
@@ -1,0 +1,471 @@
+import Foundation
+import ModelIO
+import simd
+
+/// Turns the mesh formats Apple's ModelIO reads — STL, OBJ (+ `.mtl`), PLY — into
+/// format-neutral ``MeshGeometry`` parts.
+///
+/// ModelIO gives back an `MDLAsset`: a tree of `MDLObject`s, each mesh carrying an
+/// interleaved, arbitrarily-laid-out vertex buffer plus one `MDLSubmesh` per material,
+/// with indices that may be 8-, 16- or 32-bit and triangles that may arrive as quads or
+/// strips. This reader flattens all of that into plain Swift arrays, which is what makes
+/// the loading path testable off a device and lets a caller measure a print before any
+/// RealityKit object exists.
+///
+/// Deliberately *not* `MeshResource.generate(from: MDLMesh)`: that convenience exists on
+/// macOS only, so the same code would not compile for iOS or visionOS.
+enum ModelIOMeshReader {
+
+    /// Reads every mesh in the file, with each node's transform baked into its vertices.
+    ///
+    /// - Parameter url: A local `.stl`, `.obj` or `.ply` file. An OBJ's `.mtl` sidecar is
+    ///   picked up by ModelIO when it sits next to the file and the `mtllib` name
+    ///   resolves; a missing one is not an error, the parts just come back untextured.
+    /// - Returns: One ``MeshGeometry`` per submesh, in file order. Empty when the file
+    ///   holds no drawable mesh.
+    /// - Throws: ``ModelLoadingError``.
+    static func read(contentsOf url: URL) throws -> [MeshGeometry] {
+        guard FileManager.default.isReadableFile(atPath: url.path) else {
+            throw ModelLoadingError.unreadableFile(url)
+        }
+        let asset = MDLAsset(url: url)
+        var parts: [MeshGeometry] = []
+        for index in 0..<asset.count {
+            try collect(
+                object: asset.object(at: index),
+                parentTransform: matrix_identity_float4x4,
+                into: &parts
+            )
+        }
+        return parts
+    }
+
+    // MARK: - Object tree
+
+    /// Walks one `MDLObject` and its children, composing transforms on the way down.
+    private static func collect(
+        object: MDLObject,
+        parentTransform: simd_float4x4,
+        into parts: inout [MeshGeometry]
+    ) throws {
+        let local = object.transform?.matrix ?? matrix_identity_float4x4
+        let world = parentTransform * local
+
+        if let mesh = object as? MDLMesh {
+            parts.append(contentsOf: try geometries(from: mesh, transform: world))
+        }
+        for child in object.children.objects {
+            try collect(object: child, parentTransform: world, into: &parts)
+        }
+    }
+
+    // MARK: - Mesh
+
+    /// Converts one `MDLMesh` into one ``MeshGeometry`` per submesh.
+    private static func geometries(
+        from mesh: MDLMesh,
+        transform: simd_float4x4
+    ) throws -> [MeshGeometry] {
+        let vertexCount = mesh.vertexCount
+        guard vertexCount > 0 else { return [] }
+
+        // No `MDLMesh.addNormals` here, deliberately. It *unwelds* the mesh — measured on
+        // a 4-vertex PLY quad, it returns 6 vertices and rewrites the index buffer — so a
+        // file's own vertex count stops matching what the loader reports, and any index
+        // captured before the call points at the wrong vertex afterwards. A file with no
+        // normals gets them from ``MeshGeometry/generatingNormals()`` instead, which
+        // keeps shared vertices shared.
+        guard var positions = readVector3(mesh, named: MDLVertexAttributePosition, count: vertexCount)
+        else {
+            throw ModelLoadingError.unreadableGeometry(reason: "mesh has no position attribute")
+        }
+        var normals = readVector3(mesh, named: MDLVertexAttributeNormal, count: vertexCount)
+        let uvs = readVector2(mesh, named: MDLVertexAttributeTextureCoordinate, count: vertexCount)
+        let colors = readVector4(mesh, named: MDLVertexAttributeColor, count: vertexCount)
+
+        // Bake the node transform. Normals take the inverse transpose so a non-uniform
+        // scale does not tilt them — the classic bug that makes a squashed model light
+        // as though it were not squashed.
+        if transform != matrix_identity_float4x4 {
+            positions = positions.map { point in
+                let transformed = transform * SIMD4<Float>(point, 1)
+                return SIMD3<Float>(transformed.x, transformed.y, transformed.z)
+            }
+            let normalMatrix = simd_transpose(simd_inverse(simd_float3x3(
+                SIMD3<Float>(transform.columns.0.x, transform.columns.0.y, transform.columns.0.z),
+                SIMD3<Float>(transform.columns.1.x, transform.columns.1.y, transform.columns.1.z),
+                SIMD3<Float>(transform.columns.2.x, transform.columns.2.y, transform.columns.2.z)
+            )))
+            normals = normals?.map { normal in
+                let rotated = normalMatrix * normal
+                let lengthSquared = simd_length_squared(rotated)
+                return lengthSquared > 0 ? rotated / lengthSquared.squareRoot() : normal
+            }
+        }
+
+        let submeshes = (mesh.submeshes as? [MDLSubmesh]) ?? []
+        guard !submeshes.isEmpty else { return [] }
+
+        let baseName = mesh.name.isEmpty ? "mesh" : mesh.name
+        // One submesh is the overwhelmingly common case (every STL, every PLY, an OBJ
+        // with a single material): its indices reference the whole vertex array, so the
+        // compaction pass below would copy every vertex to produce an identical array.
+        let skipCompaction = submeshes.count == 1
+
+        var parts: [MeshGeometry] = []
+        for (index, submesh) in submeshes.enumerated() {
+            let triangleIndices = try triangleIndices(of: submesh, vertexCount: vertexCount)
+            guard !triangleIndices.isEmpty else { continue }
+            let name = submesh.name.isEmpty
+                ? (submeshes.count == 1 ? baseName : "\(baseName)-\(index)")
+                : submesh.name
+            let material = materialDescription(of: submesh.material)
+
+            if skipCompaction {
+                parts.append(MeshGeometry(
+                    name: name,
+                    positions: positions,
+                    normals: normals,
+                    textureCoordinates: uvs,
+                    colors: colors,
+                    indices: triangleIndices,
+                    material: material
+                ))
+            } else {
+                parts.append(compacted(
+                    name: name,
+                    positions: positions,
+                    normals: normals,
+                    uvs: uvs,
+                    colors: colors,
+                    indices: triangleIndices,
+                    material: material
+                ))
+            }
+        }
+        return parts
+    }
+
+    // MARK: - Indices
+
+    /// Reads a submesh's index buffer as triangles, converting quads and strips.
+    ///
+    /// ModelIO hands back whatever topology the file used: OBJ quad faces stay quads,
+    /// and some exporters emit strips. RealityKit only draws triangles, so the
+    /// conversion has to happen somewhere, and doing it here means every downstream
+    /// consumer — bounds, volume, RealityKit — sees the same triangle list.
+    private static func triangleIndices(
+        of submesh: MDLSubmesh,
+        vertexCount: Int
+    ) throws -> [UInt32] {
+        let count = submesh.indexCount
+        guard count > 0 else { return [] }
+
+        let map = submesh.indexBuffer.map()
+        let raw = map.bytes
+        var source = [UInt32]()
+        source.reserveCapacity(count)
+
+        switch submesh.indexType {
+        case .uInt8:
+            guard submesh.indexBuffer.length >= count else {
+                throw ModelLoadingError.unreadableGeometry(reason: "index buffer shorter than indexCount")
+            }
+            for index in 0..<count {
+                source.append(UInt32(raw.loadUnaligned(fromByteOffset: index, as: UInt8.self)))
+            }
+        case .uInt16:
+            guard submesh.indexBuffer.length >= count * 2 else {
+                throw ModelLoadingError.unreadableGeometry(reason: "index buffer shorter than indexCount")
+            }
+            for index in 0..<count {
+                source.append(UInt32(raw.loadUnaligned(fromByteOffset: index * 2, as: UInt16.self)))
+            }
+        case .uInt32:
+            guard submesh.indexBuffer.length >= count * 4 else {
+                throw ModelLoadingError.unreadableGeometry(reason: "index buffer shorter than indexCount")
+            }
+            for index in 0..<count {
+                source.append(raw.loadUnaligned(fromByteOffset: index * 4, as: UInt32.self))
+            }
+        case .invalid:
+            throw ModelLoadingError.unreadableGeometry(reason: "submesh has no index type")
+        @unknown default:
+            throw ModelLoadingError.unreadableGeometry(reason: "unknown index type")
+        }
+
+        var triangles: [UInt32]
+        switch submesh.geometryType {
+        case .triangles:
+            triangles = source
+            triangles.removeLast(triangles.count % 3)
+        case .quads:
+            triangles = []
+            triangles.reserveCapacity(source.count / 4 * 6)
+            var index = 0
+            while index + 3 < source.count {
+                let (a, b, c, d) = (source[index], source[index + 1], source[index + 2], source[index + 3])
+                triangles.append(contentsOf: [a, b, c, a, c, d])
+                index += 4
+            }
+        case .triangleStrips:
+            triangles = []
+            guard source.count >= 3 else { return [] }
+            triangles.reserveCapacity((source.count - 2) * 3)
+            for index in 0..<(source.count - 2) {
+                // Alternate winding so every triangle in the strip faces the same way.
+                let triangle = index % 2 == 0
+                    ? [source[index], source[index + 1], source[index + 2]]
+                    : [source[index + 1], source[index], source[index + 2]]
+                triangles.append(contentsOf: triangle)
+            }
+        case .points, .lines, .variableTopology:
+            // Nothing to draw as a surface. Not an error: a PLY point cloud is a valid
+            // file, it simply has no triangles, and `MeshAsset` reports that as
+            // `.emptyMesh` once every submesh has been skipped.
+            return []
+        @unknown default:
+            return []
+        }
+
+        // A malformed file can index past the vertex array; RealityKit would trap on it.
+        let limit = UInt32(vertexCount)
+        if triangles.contains(where: { $0 >= limit }) {
+            throw ModelLoadingError.malformed(reason: "triangle index out of range")
+        }
+        return triangles
+    }
+
+    // MARK: - Vertex compaction
+
+    /// Rebuilds a submesh's vertex arrays so they contain only the vertices it uses.
+    ///
+    /// Without this, an OBJ with ten materials would carry ten copies of the file's
+    /// entire vertex array — the mesh's buffer is shared, but each ``MeshGeometry`` is
+    /// self-contained by design.
+    private static func compacted(
+        name: String,
+        positions: [SIMD3<Float>],
+        normals: [SIMD3<Float>]?,
+        uvs: [SIMD2<Float>]?,
+        colors: [SIMD4<Float>]?,
+        indices: [UInt32],
+        material: MeshMaterialDescription?
+    ) -> MeshGeometry {
+        var remap: [UInt32: UInt32] = [:]
+        remap.reserveCapacity(indices.count)
+        var newPositions: [SIMD3<Float>] = []
+        var newNormals: [SIMD3<Float>]? = normals == nil ? nil : []
+        var newUVs: [SIMD2<Float>]? = uvs == nil ? nil : []
+        var newColors: [SIMD4<Float>]? = colors == nil ? nil : []
+        var newIndices: [UInt32] = []
+        newIndices.reserveCapacity(indices.count)
+
+        for original in indices {
+            if let existing = remap[original] {
+                newIndices.append(existing)
+                continue
+            }
+            let next = UInt32(newPositions.count)
+            remap[original] = next
+            let source = Int(original)
+            newPositions.append(positions[source])
+            if let normals { newNormals?.append(normals[source]) }
+            if let uvs { newUVs?.append(uvs[source]) }
+            if let colors { newColors?.append(colors[source]) }
+            newIndices.append(next)
+        }
+
+        return MeshGeometry(
+            name: name,
+            positions: newPositions,
+            normals: newNormals,
+            textureCoordinates: newUVs,
+            colors: newColors,
+            indices: newIndices,
+            material: material
+        )
+    }
+
+    // MARK: - Materials
+
+    /// Maps the handful of `MDLMaterial` semantics that OBJ's `.mtl` actually carries.
+    static func materialDescription(of material: MDLMaterial?) -> MeshMaterialDescription? {
+        guard let material else { return nil }
+        var description = MeshMaterialDescription(name: material.name)
+
+        if let baseColor = material.property(with: .baseColor) {
+            switch baseColor.type {
+            case .float3:
+                let value = baseColor.float3Value
+                description.baseColor = SIMD4<Float>(value.x, value.y, value.z, 1)
+            case .float4:
+                description.baseColor = baseColor.float4Value
+            case .color:
+                if let components = baseColor.color?.components, components.count >= 3 {
+                    description.baseColor = SIMD4<Float>(
+                        Float(components[0]),
+                        Float(components[1]),
+                        Float(components[2]),
+                        components.count >= 4 ? Float(components[3]) : 1
+                    )
+                }
+            case .texture, .URL, .string:
+                description.baseColorTextureURL = textureURL(of: baseColor)
+            default:
+                break
+            }
+        }
+        if let metallic = material.property(with: .metallic), metallic.type == .float {
+            description.metallic = metallic.floatValue
+        }
+        if let roughness = material.property(with: .roughness), roughness.type == .float {
+            description.roughness = roughness.floatValue
+        }
+        // Nothing at all was recognised — an empty description would only cost the
+        // caller a pointless grey material override.
+        let isEmpty = description.baseColor == nil
+            && description.metallic == nil
+            && description.roughness == nil
+            && description.baseColorTextureURL == nil
+        return isEmpty ? nil : description
+    }
+
+    /// The on-disk URL behind a texture property, whichever way ModelIO stored it.
+    private static func textureURL(of property: MDLMaterialProperty) -> URL? {
+        if let urlTexture = property.textureSamplerValue?.texture as? MDLURLTexture {
+            return urlTexture.url
+        }
+        if let url = property.urlValue { return url }
+        if let string = property.stringValue, !string.isEmpty {
+            return URL(fileURLWithPath: string)
+        }
+        return nil
+    }
+
+    // MARK: - Buffer reads
+
+    /// How many components an `MDLVertexFormat` holds.
+    ///
+    /// `MDLVertexFormat` is a bit field — a type in the high bits, the component count
+    /// (1…4) in the low nibble — so `float3` and `uchar3` both answer 3. Reading it is
+    /// what keeps the conversion below honest, see ``readVector4(_:named:count:)``.
+    private static func componentCount(of format: MDLVertexFormat) -> Int {
+        let count = Int(format.rawValue & 0xF)
+        return (1...4).contains(count) ? count : 0
+    }
+
+    /// The native format of a named attribute, or `nil` when the mesh has no such
+    /// attribute. `attributeNamed` returns `nil` for an absent name; a present-but-unset
+    /// attribute reports `.invalid`, which is equally "not there".
+    private static func nativeFormat(_ mesh: MDLMesh, named name: String) -> MDLVertexFormat? {
+        guard let attribute = mesh.vertexDescriptor.attributeNamed(name),
+              attribute.format != .invalid else { return nil }
+        return attribute.format
+    }
+
+    /// Reads a 2-component attribute (UVs).
+    private static func readVector2(
+        _ mesh: MDLMesh,
+        named name: String,
+        count: Int
+    ) -> [SIMD2<Float>]? {
+        guard let format = nativeFormat(mesh, named: name) else { return nil }
+        let components = componentCount(of: format)
+        guard components >= 2 else { return nil }
+        // A 3-component UV set (OBJ's `vt u v w`) is read as float3 and truncated —
+        // asking ModelIO for float2 would hit the widening bug documented below.
+        if components == 2,
+           let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float2) {
+            return read(data, count: count, componentCount: 2) { SIMD2<Float>($0[0], $0[1]) }
+        }
+        if let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float3) {
+            return read(data, count: count, componentCount: 3) { SIMD2<Float>($0[0], $0[1]) }
+        }
+        return nil
+    }
+
+    /// Reads a 3-component attribute (positions, normals).
+    private static func readVector3(
+        _ mesh: MDLMesh,
+        named name: String,
+        count: Int
+    ) -> [SIMD3<Float>]? {
+        guard let format = nativeFormat(mesh, named: name) else { return nil }
+        let components = componentCount(of: format)
+        guard components >= 3 else { return nil }
+        if components == 3,
+           let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float3) {
+            return read(data, count: count, componentCount: 3) { SIMD3<Float>($0[0], $0[1], $0[2]) }
+        }
+        if let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float4) {
+            return read(data, count: count, componentCount: 4) { SIMD3<Float>($0[0], $0[1], $0[2]) }
+        }
+        return nil
+    }
+
+    /// Reads a colour attribute as RGBA, filling in an opaque alpha for an RGB source.
+    ///
+    /// The component-count dance is not defensive style, it is a measured ModelIO
+    /// behaviour: `vertexAttributeData(forAttributeNamed:as:)` converts the *type* but
+    /// not the *component count*. Asking a float3 colour attribute for `.float4` returns
+    /// a buffer sized and strided for float4 that still holds tightly packed float3 data
+    /// — every vertex after the first reads a third of a vertex out of step, so a
+    /// red/green/blue/white PLY comes back red/red/white/black. Asking for the attribute
+    /// in its own component count is correct; the widening happens here instead.
+    private static func readVector4(
+        _ mesh: MDLMesh,
+        named name: String,
+        count: Int
+    ) -> [SIMD4<Float>]? {
+        guard let format = nativeFormat(mesh, named: name) else { return nil }
+        switch componentCount(of: format) {
+        case 4:
+            guard let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float4)
+            else { return nil }
+            return read(data, count: count, componentCount: 4) {
+                SIMD4<Float>($0[0], $0[1], $0[2], $0[3])
+            }
+        case 3:
+            guard let data = mesh.vertexAttributeData(forAttributeNamed: name, as: .float3)
+            else { return nil }
+            return read(data, count: count, componentCount: 3) {
+                SIMD4<Float>($0[0], $0[1], $0[2], 1)
+            }
+        default:
+            return nil
+        }
+    }
+
+    // `loadUnaligned` below: ModelIO lays attributes out at whatever offset the file's
+    // layout implies, so a `float3` can legitimately start at byte 12 of a 24-byte
+    // stride — fine for 4-byte alignment, not for the 16-byte alignment
+    // `SIMD3<Float>` would demand if loaded as a whole value.
+
+    private static func read<Element>(
+        _ data: MDLVertexAttributeData,
+        count: Int,
+        componentCount: Int,
+        build: ([Float]) -> Element
+    ) -> [Element] {
+        var result: [Element] = []
+        result.reserveCapacity(count)
+        let stride = data.stride
+        let elementBytes = componentCount * MemoryLayout<Float>.size
+        var components = [Float](repeating: 0, count: componentCount)
+        for index in 0..<count {
+            let offset = index * stride
+            // `bufferSize` is what ModelIO says it mapped; trusting `count` alone reads
+            // past the end for a mesh whose attribute buffer is short.
+            guard offset + elementBytes <= data.bufferSize else { break }
+            for component in 0..<componentCount {
+                components[component] = data.dataStart.loadUnaligned(
+                    fromByteOffset: offset + component * MemoryLayout<Float>.size,
+                    as: Float.self
+                )
+            }
+            result.append(build(components))
+        }
+        return result
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelLoadingError.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelLoadingError.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Why a model file could not be turned into geometry.
+///
+/// Every case names the thing the caller can act on — the extension that is not
+/// supported, the URL that could not be read, the part of the file that is malformed —
+/// because "load failed" on a file the user picked from Files is a dead end for both the
+/// user and the developer.
+public enum ModelLoadingError: Error, Equatable, Sendable {
+
+    /// The file's content and extension both failed to identify a supported format.
+    ///
+    /// The associated value is the extension as it appeared on the file (possibly
+    /// empty), so a viewer can say "SceneView cannot open .fbx files yet" and a host app
+    /// can count which extensions its users actually try.
+    case unsupportedFormat(fileExtension: String)
+
+    /// The file exists but could not be opened or read.
+    case unreadableFile(URL)
+
+    /// The file is the format it claims to be, but its content is invalid.
+    /// `reason` is developer-facing English, not a localized string.
+    case malformed(reason: String)
+
+    /// The file parsed cleanly but describes no drawable triangles — an STL with zero
+    /// facets, a 3MF whose build section is empty, a point-cloud-only PLY. Distinct from
+    /// ``malformed(reason:)``: nothing is wrong with the file, there is just nothing to
+    /// show, and a viewer should say so rather than present an empty scene.
+    case emptyMesh
+
+    /// A geometry buffer could not be read in the layout it announced — a ModelIO
+    /// attribute missing after conversion, an index buffer shorter than its own count.
+    case unreadableGeometry(reason: String)
+}
+
+extension ModelLoadingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat(let ext):
+            let named = ext.isEmpty ? "This file" : ".\(ext) files"
+            return "\(named) cannot be opened — supported formats are "
+                + ModelFormat.allCases.map { ".\($0.fileExtension)" }.joined(separator: ", ")
+                + "."
+        case .unreadableFile(let url):
+            return "Could not read \(url.lastPathComponent)."
+        case .malformed(let reason):
+            return "The file is damaged or invalid: \(reason)"
+        case .emptyMesh:
+            return "The file contains no triangles to display."
+        case .unreadableGeometry(let reason):
+            return "The geometry could not be read: \(reason)"
+        }
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelNode+MeshAsset.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelNode+MeshAsset.swift
@@ -1,0 +1,120 @@
+#if os(iOS) || os(macOS) || os(visionOS)
+import Foundation
+import RealityKit
+import simd
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+extension ModelNode {
+
+    /// Builds a displayable node from parsed geometry.
+    ///
+    /// The asset is converted to metres first (``MeshAsset/inMeters()``), so the entity
+    /// that comes back is at real-world scale: a 210 mm print is 0.21 along its long
+    /// axis and stands 21 cm tall when anchored in AR, with no further scaling. That is
+    /// the whole point of ``ModelUnit`` — a viewer that shows a shape but lies about its
+    /// size is the thing every existing STL viewer already does.
+    ///
+    /// ```swift
+    /// let asset = try MeshAsset.load(contentsOf: url, unit: .millimeters)
+    /// let node = try await ModelNode(asset)
+    /// print(asset.boundsInMeters!.extents)   // real size, before rendering anything
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - asset: Parsed geometry, in whatever unit it was read with.
+    ///   - enableCollision: Generate collision shapes so taps hit the model.
+    /// - Throws: ``ModelLoadingError/emptyMesh`` when nothing drawable is left, or the
+    ///   error RealityKit raises while generating the mesh.
+    @MainActor
+    public init(_ asset: MeshAsset, enableCollision: Bool = true) async throws {
+        let metric = asset.inMeters()
+        var descriptors: [MeshDescriptor] = []
+        var materials: [any RealityKit.Material] = []
+
+        for part in metric.parts {
+            let part = part.generatingNormals()
+            guard !part.positions.isEmpty, part.indices.count >= 3 else { continue }
+
+            var descriptor = MeshDescriptor(name: part.name)
+            descriptor.positions = MeshBuffers.Positions(part.positions)
+            if let normals = part.normals, normals.count == part.positions.count {
+                descriptor.normals = MeshBuffers.Normals(normals)
+            }
+            if let uvs = part.textureCoordinates, uvs.count == part.positions.count {
+                descriptor.textureCoordinates = MeshBuffers.TextureCoordinates(uvs)
+            }
+            descriptor.primitives = .triangles(part.indices)
+            descriptor.materials = .allFaces(UInt32(materials.count))
+
+            descriptors.append(descriptor)
+            materials.append(await ModelNode.material(for: part))
+        }
+
+        guard !descriptors.isEmpty else { throw ModelLoadingError.emptyMesh }
+
+        let mesh = try MeshResource.generate(from: descriptors)
+        let entity = ModelEntity(mesh: mesh, materials: materials)
+        entity.name = metric.parts.first?.name ?? "mesh"
+        if enableCollision {
+            entity.generateCollisionShapes(recursive: true)
+            entity.makeInputTargetable()
+        }
+        self.init(entity)
+    }
+
+    /// Builds the RealityKit material for one part.
+    ///
+    /// Physically-based rather than `SimpleMaterial` for the same reason
+    /// ``GeometryNode/defaultMaterial(color:unlit:)`` is: `SimpleMaterial` ignores the
+    /// image-based lighting the scene already sets up, and an unlit grey STL looks like
+    /// a rendering bug.
+    ///
+    /// Per-vertex colours are folded into the tint. RealityKit's `MeshDescriptor` has no
+    /// vertex-colour channel, so a coloured PLY scan would otherwise come back uniformly
+    /// grey; averaging is a lossy but honest approximation, and the full array stays on
+    /// ``MeshGeometry/colors`` for callers that need it.
+    @MainActor
+    private static func material(for part: MeshGeometry) async -> any RealityKit.Material {
+        var pbr = PhysicallyBasedMaterial()
+        var tint = SIMD4<Float>(1, 1, 1, 1)
+
+        if let baseColor = part.material?.baseColor {
+            tint = baseColor
+        }
+        if let colors = part.colors, !colors.isEmpty {
+            let sum = colors.reduce(SIMD4<Float>.zero, +)
+            let average = sum / Float(colors.count)
+            tint *= average
+        }
+
+        pbr.baseColor = .init(tint: color(from: tint))
+        pbr.metallic = .init(floatLiteral: part.material?.metallic ?? 0)
+        pbr.roughness = .init(floatLiteral: part.material?.roughness ?? 0.5)
+
+        if let textureURL = part.material?.baseColorTextureURL,
+           FileManager.default.fileExists(atPath: textureURL.path),
+           let texture = try? await TextureResource(contentsOf: textureURL) {
+            pbr.baseColor = .init(tint: color(from: tint), texture: .init(texture))
+        }
+        if tint.w < 1 {
+            pbr.blending = .transparent(opacity: .init(floatLiteral: tint.w))
+        }
+        return pbr
+    }
+
+    /// Clamps and converts a linear RGBA vector into the platform colour type.
+    private static func color(from rgba: SIMD4<Float>) -> SimpleMaterial.Color {
+        func clamp(_ value: Float) -> CGFloat { CGFloat(Swift.min(Swift.max(value, 0), 1)) }
+        return SimpleMaterial.Color(
+            red: clamp(rgba.x),
+            green: clamp(rgba.y),
+            blue: clamp(rgba.z),
+            alpha: clamp(rgba.w)
+        )
+    }
+}
+#endif // os(iOS) || os(macOS) || os(visionOS)

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelUnit.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelUnit.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// The length unit a model file's coordinates are expressed in.
+///
+/// RealityKit works in **metres**: a `ModelEntity` whose mesh spans `0.2` along X is
+/// 20 cm wide in AR. Most mesh interchange formats do not carry a unit at all — an STL
+/// exported by a slicer is a pile of numbers that happen to mean millimetres, and the
+/// exact same numbers in an OBJ from a photogrammetry pipeline mean metres. Loading
+/// either one without saying which is meant produces a model that is 1000× off, which
+/// is why every loader entry point in SceneViewSwift takes a `ModelUnit`.
+///
+/// ```swift
+/// // A 3D-printing STL: coordinates are millimetres (the format's default).
+/// let part = try await ModelNode.load(contentsOf: stlURL)
+///
+/// // A photogrammetry OBJ authored in centimetres.
+/// let scan = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+/// ```
+///
+/// Formats that *do* carry a unit — 3MF (`<model unit="millimeter">`) and USD
+/// (`metersPerUnit`) — read it from the file, and an explicit `unit:` argument
+/// overrides it.
+///
+/// - SeeAlso: ``ModelFormat/defaultUnit``
+public enum ModelUnit: String, Sendable, CaseIterable, Codable {
+    /// 1 µm = 0.000001 m. The 3MF core spec's `micron`.
+    case micrometers
+    /// 1 mm = 0.001 m. The de-facto unit of STL and of every slicer.
+    case millimeters
+    /// 1 cm = 0.01 m.
+    case centimeters
+    /// 1 in = 0.0254 m.
+    case inches
+    /// 1 ft = 0.3048 m.
+    case feet
+    /// The RealityKit unit — coordinates are used as-is.
+    case meters
+
+    /// How many metres one unit is worth. Multiply a source coordinate by this to get
+    /// the RealityKit coordinate.
+    public var metersPerUnit: Float {
+        switch self {
+        case .micrometers: return 0.000_001
+        case .millimeters: return 0.001
+        case .centimeters: return 0.01
+        case .inches: return 0.0254
+        case .feet: return 0.3048
+        case .meters: return 1
+        }
+    }
+
+    /// Parses the value of the 3MF core spec's `<model unit="…">` attribute.
+    ///
+    /// The spec (3MF Core 1.4, §3.2) allows exactly `micron`, `millimeter`, `centimeter`,
+    /// `inch`, `foot`, `meter`, and says a missing attribute means `millimeter`. Anything
+    /// else returns `nil` so the caller can decide between "reject the file" and "fall
+    /// back to the spec default"; ``ThreeMFDocument`` chooses the latter, matching what
+    /// slicers do with a mildly malformed file.
+    ///
+    /// - Parameter threeMFUnit: The raw attribute value, case-insensitive.
+    public init?(threeMFUnit: String) {
+        switch threeMFUnit.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "micron": self = .micrometers
+        case "millimeter": self = .millimeters
+        case "centimeter": self = .centimeters
+        case "inch": self = .inches
+        case "foot": self = .feet
+        case "meter": self = .meters
+        default: return nil
+        }
+    }
+
+    /// The unit closest to a USD `metersPerUnit` value.
+    ///
+    /// USD stores a scale factor rather than a named unit, so this snaps to the nearest
+    /// named case within a 1 % relative tolerance and returns `nil` for anything else
+    /// (a USD authored at, say, 0.3 m/unit has no name here — scale it yourself).
+    public init?(metersPerUnit: Float) {
+        guard metersPerUnit.isFinite, metersPerUnit > 0 else { return nil }
+        for candidate in ModelUnit.allCases
+        where abs(candidate.metersPerUnit - metersPerUnit) <= candidate.metersPerUnit * 0.01 {
+            self = candidate
+            return
+        }
+        return nil
+    }
+
+    /// A short human-readable symbol — `"mm"`, `"cm"`, `"in"`, `"ft"`, `"m"`, `"µm"`.
+    ///
+    /// Meant for a unit picker in a viewer UI ("this STL has no unit — is it mm or in?"),
+    /// which is the interaction every honest STL viewer has to offer.
+    public var symbol: String {
+        switch self {
+        case .micrometers: return "µm"
+        case .millimeters: return "mm"
+        case .centimeters: return "cm"
+        case .inches: return "in"
+        case .feet: return "ft"
+        case .meters: return "m"
+        }
+    }
+
+    /// Converts a length from this unit to `other`.
+    public func convert(_ value: Float, to other: ModelUnit) -> Float {
+        value * metersPerUnit / other.metersPerUnit
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFDocument.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFDocument.swift
@@ -1,0 +1,371 @@
+import Foundation
+import simd
+
+/// A 3MF file, read into geometry.
+///
+/// 3MF is the format the 3D-printing world moved to and the one Apple does not read:
+/// `MDLAsset` handles OBJ, STL, PLY and USD, Quick Look handles USDZ and Reality, and
+/// nothing on the platform opens a `.3mf`. So this is a parser, not a wrapper — a
+/// minimal ZIP reader (``ZipArchiveReader``) plus an `XMLParser` over the package's
+/// `.model` parts.
+///
+/// What it covers, which is what slicers and marketplaces actually write:
+///
+/// - `<model unit>` — every unit the core spec defines, defaulting to millimetres.
+/// - `<mesh>` — `<vertices>` and `<triangles>`.
+/// - `<components>` — objects placed inside objects, with row-vector transforms.
+/// - `<build><item>` — the placements that decide what is shown, with their transforms.
+/// - `<basematerials>` and the materials extension's `<colorgroup>`, resolved per
+///   triangle so a multi-colour print comes back multi-colour.
+/// - Production-extension `p:path` references into other `.model` parts of the package —
+///   how Bambu Studio and Orca write project files.
+///
+/// ```swift
+/// let document = try ThreeMFDocument.read(contentsOf: url)
+/// print(document.unit, document.parts.count)
+///
+/// // Or, more usually, just open it like anything else:
+/// let node = try await ModelNode.load(contentsOf: url)
+/// ```
+public struct ThreeMFDocument: Sendable {
+
+    /// The unit the file declares — ``ModelUnit/millimeters`` when it declares none.
+    public let unit: ModelUnit
+
+    /// One part per object-and-material combination, in build order, with every
+    /// transform along the component chain already baked into the positions.
+    public let parts: [MeshGeometry]
+
+    /// Total triangles across every part.
+    public var triangleCount: Int { parts.reduce(0) { $0 + $1.triangleCount } }
+
+    /// Reads a `.3mf` file.
+    ///
+    /// - Throws: ``ModelLoadingError``.
+    public static func read(contentsOf url: URL) throws -> ThreeMFDocument {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            throw ModelLoadingError.unreadableFile(url)
+        }
+        return try read(data: data)
+    }
+
+    /// Reads a 3MF package already in memory.
+    public static func read(data: Data) throws -> ThreeMFDocument {
+        let archive = try ZipArchiveReader(data: data)
+        var loader = ThreeMFLoader(archive: archive)
+        return try loader.load()
+    }
+}
+
+/// Resolves a 3MF package's build items into flat geometry.
+///
+/// A separate type because the resolution is stateful: parts are parsed on demand and
+/// cached, and the component graph has to be walked with a visited set — a package may
+/// legally reference the same object many times, and an illegal one may reference itself.
+struct ThreeMFLoader {
+
+    private let archive: ZipArchiveReader
+    private var parts: [String: ThreeMFModelPart] = [:]
+
+    /// The default location of the root model part. Used when `_rels/.rels` is missing
+    /// or names nothing readable — a fallback the whole ecosystem relies on.
+    static let conventionalRootPath = "3D/3dmodel.model"
+
+    /// How deep a component chain may nest before it is called a cycle. Real packages
+    /// nest two or three levels; the visited set below catches direct recursion, and
+    /// this catches a chain that grows without repeating a pair.
+    static let maximumComponentDepth = 32
+
+    init(archive: ZipArchiveReader) {
+        self.archive = archive
+    }
+
+    mutating func load() throws -> ThreeMFDocument {
+        let rootPath = rootModelPath()
+        let root = try part(at: rootPath)
+
+        var geometries: [MeshGeometry] = []
+        for item in root.buildItems {
+            try append(
+                objectID: item.objectID,
+                partPath: normalize(item.path) ?? rootPath,
+                transform: item.transform,
+                depth: 0,
+                visiting: [],
+                into: &geometries
+            )
+        }
+
+        // A package whose `<build>` is empty still has objects, and a viewer that shows
+        // nothing for it is indistinguishable from a broken parser. Falling back to every
+        // mesh object in the root part is what slicers do.
+        if geometries.isEmpty {
+            for id in root.objects.keys.sorted() {
+                try append(
+                    objectID: id,
+                    partPath: rootPath,
+                    transform: matrix_identity_float4x4,
+                    depth: 0,
+                    visiting: [],
+                    into: &geometries
+                )
+            }
+        }
+
+        guard !geometries.isEmpty else { throw ModelLoadingError.emptyMesh }
+        return ThreeMFDocument(unit: root.unit, parts: geometries)
+    }
+
+    // MARK: - Package layout
+
+    /// The root `.model` part, from the package relationships when they name one.
+    private func rootModelPath() -> String {
+        guard let rels = try? archive.contents(named: "_rels/.rels") ?? Data(),
+              !rels.isEmpty,
+              let target = PackageRelationshipsParser.rootModelTarget(rels),
+              let normalized = normalize(target),
+              archive.entry(named: normalized) != nil else {
+            return Self.conventionalRootPath
+        }
+        return normalized
+    }
+
+    /// Package part names are absolute (`/3D/3dmodel.model`); ZIP entry names are not.
+    private func normalize(_ path: String?) -> String? {
+        guard var path, !path.isEmpty else { return nil }
+        while path.hasPrefix("/") { path.removeFirst() }
+        return path.isEmpty ? nil : path
+    }
+
+    private mutating func part(at path: String) throws -> ThreeMFModelPart {
+        if let cached = parts[path] { return cached }
+        guard let data = try archive.contents(named: path) else {
+            throw ModelLoadingError.malformed(reason: "3MF package has no part named \(path)")
+        }
+        let parsed = try ThreeMFModelParser.parse(data)
+        parts[path] = parsed
+        return parsed
+    }
+
+    // MARK: - Resolution
+
+    /// Walks one object, emitting its mesh and recursing into its components.
+    ///
+    /// `visiting` holds the (part, object) pairs on the current path, so an object that
+    /// contains itself — directly or through a chain — is reported instead of recursed
+    /// into forever. A *repeated* reference on separate branches is legal and stays legal.
+    private mutating func append(
+        objectID: Int,
+        partPath: String,
+        transform: simd_float4x4,
+        depth: Int,
+        visiting: Set<String>,
+        into geometries: inout [MeshGeometry]
+    ) throws {
+        guard depth <= Self.maximumComponentDepth else {
+            throw ModelLoadingError.malformed(reason: "3MF component nesting is too deep")
+        }
+        let key = "\(partPath)#\(objectID)"
+        guard !visiting.contains(key) else {
+            throw ModelLoadingError.malformed(reason: "3MF object \(objectID) contains itself")
+        }
+
+        let model = try part(at: partPath)
+        guard let object = model.objects[objectID] else {
+            // A build item pointing at a missing object is a broken package, but the
+            // rest of the plate is still worth showing.
+            return
+        }
+
+        if !object.triangles.isEmpty {
+            geometries.append(contentsOf: try meshGeometries(
+                of: object,
+                in: model,
+                transform: transform
+            ))
+        }
+
+        var nextVisiting = visiting
+        nextVisiting.insert(key)
+        for component in object.components {
+            try append(
+                objectID: component.objectID,
+                partPath: normalize(component.path) ?? partPath,
+                // The component's own transform applies first, then the parent's — the
+                // same composition order as a scene graph read from the root down.
+                transform: transform * component.transform,
+                depth: depth + 1,
+                visiting: nextVisiting,
+                into: &geometries
+            )
+        }
+    }
+
+    /// Turns one object's mesh into geometry, split by material.
+    ///
+    /// Triangles are grouped by the colour they resolve to, and each group becomes its
+    /// own ``MeshGeometry`` with only the vertices it uses. A single-material object —
+    /// the common case — takes the one-group path and keeps its vertex array intact.
+    private func meshGeometries(
+        of object: ThreeMFObject,
+        in model: ThreeMFModelPart,
+        transform: simd_float4x4
+    ) throws -> [MeshGeometry] {
+        let vertexCount = object.vertices.count
+        let positions: [SIMD3<Float>]
+        if transform == matrix_identity_float4x4 {
+            positions = object.vertices
+        } else {
+            positions = object.vertices.map { vertex in
+                let transformed = transform * SIMD4<Float>(vertex, 1)
+                return SIMD3<Float>(transformed.x, transformed.y, transformed.z)
+            }
+        }
+
+        // Group triangles by resolved colour. `nil` is "no material", which is its own
+        // group so an object with some painted and some bare triangles keeps both.
+        var groups: [ThreeMFColorKey: [UInt32]] = [:]
+        var groupOrder: [ThreeMFColorKey] = []
+        for triangle in object.triangles {
+            guard triangle.v1 >= 0, triangle.v1 < vertexCount,
+                  triangle.v2 >= 0, triangle.v2 < vertexCount,
+                  triangle.v3 >= 0, triangle.v3 < vertexCount else {
+                throw ModelLoadingError.malformed(
+                    reason: "3MF object \(object.id) has a triangle index out of range"
+                )
+            }
+            let key = ThreeMFColorKey(
+                color: color(for: triangle, of: object, in: model)
+            )
+            if groups[key] == nil {
+                groups[key] = []
+                groupOrder.append(key)
+            }
+            groups[key]?.append(contentsOf: [
+                UInt32(triangle.v1), UInt32(triangle.v2), UInt32(triangle.v3)
+            ])
+        }
+
+        let name = object.name.isEmpty ? "object-\(object.id)" : object.name
+        return groupOrder.enumerated().compactMap { index, key in
+            guard let indices = groups[key], !indices.isEmpty else { return nil }
+            let material = key.color.map {
+                MeshMaterialDescription(name: "3mf-\(object.id)-\(index)", baseColor: $0)
+            }
+            let partName = groupOrder.count == 1 ? name : "\(name)-\(index)"
+            guard groupOrder.count > 1 else {
+                return MeshGeometry(
+                    name: partName,
+                    positions: positions,
+                    indices: indices,
+                    material: material
+                )
+            }
+            return Self.compacted(
+                name: partName,
+                positions: positions,
+                indices: indices,
+                material: material
+            )
+        }
+    }
+
+    /// The colour a triangle resolves to: its own `pid`/`p1` when it has them, otherwise
+    /// the object's `pid`/`pindex`, otherwise none.
+    private func color(
+        for triangle: ThreeMFTriangle,
+        of object: ThreeMFObject,
+        in model: ThreeMFModelPart
+    ) -> SIMD4<Float>? {
+        let groupID = triangle.propertyGroup ?? object.propertyGroup
+        let index = triangle.propertyIndex ?? object.propertyIndex ?? 0
+        guard let groupID, let colors = model.propertyGroups[groupID],
+              index >= 0, index < colors.count else { return nil }
+        return colors[index]
+    }
+
+    /// Rebuilds a material group's vertex array so it holds only the vertices it uses.
+    private static func compacted(
+        name: String,
+        positions: [SIMD3<Float>],
+        indices: [UInt32],
+        material: MeshMaterialDescription?
+    ) -> MeshGeometry {
+        var remap: [UInt32: UInt32] = [:]
+        var newPositions: [SIMD3<Float>] = []
+        var newIndices: [UInt32] = []
+        newIndices.reserveCapacity(indices.count)
+        for original in indices {
+            if let existing = remap[original] {
+                newIndices.append(existing)
+                continue
+            }
+            let next = UInt32(newPositions.count)
+            remap[original] = next
+            newPositions.append(positions[Int(original)])
+            newIndices.append(next)
+        }
+        return MeshGeometry(
+            name: name,
+            positions: newPositions,
+            indices: newIndices,
+            material: material
+        )
+    }
+}
+
+/// A hashable stand-in for an optional colour, so triangles can be grouped by material.
+private struct ThreeMFColorKey: Hashable {
+    let red: Float
+    let green: Float
+    let blue: Float
+    let alpha: Float
+    let hasColor: Bool
+
+    init(color: SIMD4<Float>?) {
+        hasColor = color != nil
+        let value = color ?? .zero
+        red = value.x
+        green = value.y
+        blue = value.z
+        alpha = value.w
+    }
+
+    var color: SIMD4<Float>? {
+        hasColor ? SIMD4<Float>(red, green, blue, alpha) : nil
+    }
+}
+
+/// Reads `_rels/.rels` to find the package's root model part.
+private final class PackageRelationshipsParser: NSObject, XMLParserDelegate {
+
+    /// The OPC relationship type every 3MF writer uses for the root model.
+    private static let modelRelationshipSuffix = "/3dmodel"
+
+    private var target: String?
+
+    /// The `Target` of the first relationship whose `Type` names the 3D model, or `nil`.
+    static func rootModelTarget(_ data: Data) -> String? {
+        let delegate = PackageRelationshipsParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldResolveExternalEntities = false
+        parser.externalEntityResolvingPolicy = .never
+        parser.parse()
+        return delegate.target
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String]
+    ) {
+        guard target == nil,
+              elementName.split(separator: ":").last.map(String.init) == "Relationship",
+              let type = attributes["Type"],
+              type.lowercased().hasSuffix(Self.modelRelationshipSuffix) else { return }
+        target = attributes["Target"]
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelParser.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelParser.swift
@@ -1,0 +1,207 @@
+import Foundation
+import simd
+
+/// Streaming parser for one 3MF `.model` XML part.
+///
+/// `XMLParser` rather than a DOM: a printable model's `<triangles>` list runs to
+/// hundreds of thousands of elements, and building a node tree for it costs several times
+/// the memory of the arrays that are actually wanted.
+///
+/// **External entities are refused.** A 3MF is an untrusted file that arrives by AirDrop,
+/// email or a download, and an XML parser that resolves entities is a file-read and
+/// SSRF primitive (the "billion laughs" and XXE families). `externalEntityResolvingPolicy
+/// = .never` plus `shouldResolveExternalEntities = false` is what keeps this a parser and
+/// not a fetcher.
+final class ThreeMFModelParser: NSObject, XMLParserDelegate {
+
+    private var part = ThreeMFModelPart()
+    private var currentObject: ThreeMFObject?
+    /// The `<basematerials>` / `<colorgroup>` currently being filled, and its colours.
+    private var currentPropertyGroupID: Int?
+    private var currentPropertyColors: [SIMD4<Float>] = []
+    private var parseError: Error?
+
+    /// Parses one `.model` part.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` when the XML is invalid.
+    static func parse(_ data: Data) throws -> ThreeMFModelPart {
+        let delegate = ThreeMFModelParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldResolveExternalEntities = false
+        parser.externalEntityResolvingPolicy = .never
+        // Namespace prefixes are kept: the Production extension's attribute is literally
+        // `p:path`, and `attributeName(_:)` below matches on the local name either way.
+        parser.shouldProcessNamespaces = false
+
+        guard parser.parse() else {
+            let reason = delegate.parseError.map { String(describing: $0) }
+                ?? parser.parserError.map { String(describing: $0) }
+                ?? "invalid XML"
+            throw ModelLoadingError.malformed(reason: "3MF model XML: \(reason)")
+        }
+        if let parseError = delegate.parseError { throw parseError }
+        return delegate.part
+    }
+
+    // MARK: - XMLParserDelegate
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String]
+    ) {
+        switch localName(elementName) {
+        case "model":
+            // A `unit` the spec does not define falls back to millimetres rather than
+            // failing the file — the same forgiveness slicers show, and the alternative
+            // is refusing to open a model over one misspelled word.
+            part.unit = attributes["unit"].flatMap(ModelUnit.init(threeMFUnit:)) ?? .millimeters
+
+        case "object":
+            guard let id = integer(attributes, "id") else { return }
+            var object = ThreeMFObject(id: id)
+            object.name = attributes["name"] ?? ""
+            object.propertyGroup = integer(attributes, "pid")
+            object.propertyIndex = integer(attributes, "pindex")
+            currentObject = object
+
+        case "vertex":
+            guard var object = currentObject,
+                  let x = float(attributes, "x"),
+                  let y = float(attributes, "y"),
+                  let z = float(attributes, "z") else { return }
+            object.vertices.append(SIMD3<Float>(x, y, z))
+            currentObject = object
+
+        case "triangle":
+            guard var object = currentObject,
+                  let v1 = integer(attributes, "v1"),
+                  let v2 = integer(attributes, "v2"),
+                  let v3 = integer(attributes, "v3") else { return }
+            object.triangles.append(ThreeMFTriangle(
+                v1: v1,
+                v2: v2,
+                v3: v3,
+                propertyGroup: integer(attributes, "pid"),
+                propertyIndex: integer(attributes, "p1")
+            ))
+            currentObject = object
+
+        case "component":
+            guard var object = currentObject,
+                  let objectID = integer(attributes, "objectid") else { return }
+            object.components.append(ThreeMFComponent(
+                objectID: objectID,
+                path: attributeValue(attributes, "path"),
+                transform: transform(attributes)
+            ))
+            currentObject = object
+
+        case "item":
+            guard let objectID = integer(attributes, "objectid") else { return }
+            part.buildItems.append(ThreeMFBuildItem(
+                objectID: objectID,
+                path: attributeValue(attributes, "path"),
+                transform: transform(attributes)
+            ))
+
+        case "basematerials", "colorgroup":
+            currentPropertyGroupID = integer(attributes, "id")
+            currentPropertyColors = []
+
+        case "base":
+            // `<base displaycolor="#RRGGBB[AA]">` — the core spec's material colour.
+            if let color = Self.color(from: attributes["displaycolor"]) {
+                currentPropertyColors.append(color)
+            }
+
+        case "color":
+            // `<m:color color="#RRGGBB[AA]">` — the materials extension's colour group,
+            // which is what a multi-colour slicer project actually uses.
+            if let color = Self.color(from: attributes["color"]) {
+                currentPropertyColors.append(color)
+            }
+
+        default:
+            break
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?
+    ) {
+        switch localName(elementName) {
+        case "object":
+            if let object = currentObject { part.objects[object.id] = object }
+            currentObject = nil
+        case "basematerials", "colorgroup":
+            if let id = currentPropertyGroupID, !currentPropertyColors.isEmpty {
+                part.propertyGroups[id] = currentPropertyColors
+            }
+            currentPropertyGroupID = nil
+            currentPropertyColors = []
+        default:
+            break
+        }
+    }
+
+    func parser(_ parser: XMLParser, parseErrorOccurred error: any Error) {
+        parseError = ModelLoadingError.malformed(reason: "3MF model XML: \(error)")
+    }
+
+    // MARK: - Attribute helpers
+
+    /// Strips a namespace prefix: `p:path` → `path`, `m:color` → `color`.
+    private func localName(_ name: String) -> String {
+        name.split(separator: ":").last.map(String.init) ?? name
+    }
+
+    /// An attribute by local name, so `path` matches `p:path`, `P:path`, or a writer
+    /// that declared the Production namespace as the default.
+    private func attributeValue(_ attributes: [String: String], _ name: String) -> String? {
+        if let direct = attributes[name] { return direct }
+        return attributes.first { localName($0.key) == name }?.value
+    }
+
+    private func integer(_ attributes: [String: String], _ name: String) -> Int? {
+        attributeValue(attributes, name).flatMap { Int($0) }
+    }
+
+    private func float(_ attributes: [String: String], _ name: String) -> Float? {
+        attributeValue(attributes, name).flatMap { Float($0) }
+    }
+
+    private func transform(_ attributes: [String: String]) -> simd_float4x4 {
+        attributeValue(attributes, "transform")
+            .flatMap(simd_float4x4.init(threeMFTransform:)) ?? matrix_identity_float4x4
+    }
+
+    /// Parses `#RRGGBB` or `#RRGGBBAA` into linear-ish RGBA in `0...1`.
+    static func color(from text: String?) -> SIMD4<Float>? {
+        guard var hex = text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        guard hex.count == 6 || hex.count == 8, let value = UInt32(hex, radix: 16) else {
+            return nil
+        }
+        if hex.count == 6 {
+            return SIMD4<Float>(
+                Float((value >> 16) & 0xFF) / 255,
+                Float((value >> 8) & 0xFF) / 255,
+                Float(value & 0xFF) / 255,
+                1
+            )
+        }
+        return SIMD4<Float>(
+            Float((value >> 24) & 0xFF) / 255,
+            Float((value >> 16) & 0xFF) / 255,
+            Float((value >> 8) & 0xFF) / 255,
+            Float(value & 0xFF) / 255
+        )
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelPart.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelPart.swift
@@ -1,0 +1,81 @@
+import Foundation
+import simd
+
+/// One `.model` XML part inside a 3MF container, as parsed.
+///
+/// A 3MF is an OPC (zip) package, and the Production extension lets a package split its
+/// model across several `.model` parts that reference each other by `p:path` — which is
+/// how Bambu Studio and Orca write project files. So "the model" is a part, not the
+/// document, and ``ThreeMFLoader`` resolves references across parts.
+struct ThreeMFModelPart {
+    /// `<model unit="…">`, defaulting to millimetres per the core spec.
+    var unit: ModelUnit = .millimeters
+    /// Objects by their `id`, which is unique within a part (not across parts).
+    var objects: [Int: ThreeMFObject] = [:]
+    /// `<build><item>` — what the package actually asks to be shown.
+    var buildItems: [ThreeMFBuildItem] = []
+    /// Property groups by `id`: `<basematerials>` and the materials extension's
+    /// `<colorgroup>`, flattened to the colours they resolve to.
+    var propertyGroups: [Int: [SIMD4<Float>]] = [:]
+}
+
+/// A `<object>`: either a mesh, or a group of `<component>` references, or both.
+struct ThreeMFObject {
+    var id: Int
+    var name: String = ""
+    /// `pid` / `pindex` — the object's default property group and index within it.
+    var propertyGroup: Int?
+    var propertyIndex: Int?
+    var vertices: [SIMD3<Float>] = []
+    var triangles: [ThreeMFTriangle] = []
+    var components: [ThreeMFComponent] = []
+}
+
+/// A `<triangle>`, with the optional per-triangle property reference that makes
+/// multi-colour prints multi-colour.
+struct ThreeMFTriangle {
+    var v1: Int
+    var v2: Int
+    var v3: Int
+    /// `pid` — overrides the object's property group for this triangle.
+    var propertyGroup: Int?
+    /// `p1` — index within the group. The spec also defines `p2`/`p3` for per-vertex
+    /// interpolation; a flat `p1` fill is what slicers write and what is read here.
+    var propertyIndex: Int?
+}
+
+/// A `<component>` — another object placed with a transform, possibly in another part.
+struct ThreeMFComponent {
+    var objectID: Int
+    /// Production-extension `p:path`, e.g. `/3D/Objects/object_1.model`.
+    var path: String?
+    var transform: simd_float4x4 = matrix_identity_float4x4
+}
+
+/// A `<build><item>` — the top-level placement of an object.
+struct ThreeMFBuildItem {
+    var objectID: Int
+    var path: String?
+    var transform: simd_float4x4 = matrix_identity_float4x4
+}
+
+extension simd_float4x4 {
+    /// Parses a 3MF `transform` attribute.
+    ///
+    /// 3MF writes a 4×3 matrix as twelve numbers in **row-major, row-vector** order —
+    /// `m00 m01 m02 m10 m11 m12 m20 m21 m22 m30 m31 m32`, where a point is transformed as
+    /// `v' = v · M` and the last row is the translation. `simd_float4x4` is
+    /// column-major and multiplies as `M · v`, so the rows of the file become the
+    /// **columns** here. Getting this backwards transposes every placed part — the
+    /// failure looks like scattered geometry, not like a broken parser.
+    init?(threeMFTransform text: String) {
+        let values = text.split(whereSeparator: \.isWhitespace).compactMap { Float($0) }
+        guard values.count == 12 else { return nil }
+        self.init(
+            SIMD4<Float>(values[0], values[1], values[2], 0),
+            SIMD4<Float>(values[3], values[4], values[5], 0),
+            SIMD4<Float>(values[6], values[7], values[8], 0),
+            SIMD4<Float>(values[9], values[10], values[11], 1)
+        )
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ZipArchiveReader.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ZipArchiveReader.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Compression
+
+/// A read-only ZIP reader, just large enough for a 3MF container.
+///
+/// SceneViewSwift takes no third-party dependencies, and Foundation has no public ZIP
+/// API — `NSFileCoordinator`'s archive support is macOS-only and writes to disk. So this
+/// reads the central directory itself and inflates entries with the `Compression`
+/// framework, which is a few hundred lines and keeps the package dependency-free.
+///
+/// Scope is deliberately narrow: the stored (0) and deflate (8) methods, which is
+/// everything a 3MF writer emits. It never writes files, and it resolves entries by the
+/// exact name recorded in the archive — there is no path joining, so a `../` in an entry
+/// name is a name that matches nothing rather than a traversal.
+struct ZipArchiveReader {
+
+    /// One entry in the central directory.
+    struct Entry {
+        /// The name as recorded in the archive, e.g. `3D/3dmodel.model`.
+        let name: String
+        /// 0 = stored, 8 = deflate.
+        let compressionMethod: UInt16
+        let compressedSize: Int
+        let uncompressedSize: Int
+        /// Byte offset of this entry's local file header.
+        let localHeaderOffset: Int
+    }
+
+    private let data: Data
+    /// Entries by name, in central-directory order.
+    let entries: [Entry]
+
+    /// Refuses to inflate an entry larger than this. A 3MF's XML is text: 256 MB of it
+    /// is already far past anything a printer or a phone will do something useful with,
+    /// and the cap is what stops a deliberately crafted archive from claiming a
+    /// multi-gigabyte uncompressed size and having the allocation attempted.
+    static let maximumEntrySize = 256 * 1024 * 1024
+
+    /// Parses the archive's central directory.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` when the file is not a
+    ///   readable ZIP.
+    init(data: Data) throws {
+        self.data = data
+        self.entries = try Self.readCentralDirectory(data)
+    }
+
+    /// The entry with this exact name, or `nil`.
+    func entry(named name: String) -> Entry? {
+        entries.first { $0.name == name }
+    }
+
+    /// The decompressed content of an entry.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` for a truncated entry, an
+    ///   unsupported compression method, or a failed inflate.
+    func contents(of entry: Entry) throws -> Data {
+        guard entry.uncompressedSize <= Self.maximumEntrySize else {
+            throw ModelLoadingError.malformed(
+                reason: "archive entry \(entry.name) is \(entry.uncompressedSize) bytes, over the limit"
+            )
+        }
+        // The local header repeats the name and extra fields, and its lengths are the
+        // ones that count — a writer may pad the local extra field differently from the
+        // central one, so the payload offset cannot be derived from the central entry.
+        let headerStart = entry.localHeaderOffset
+        guard headerStart >= 0, headerStart + 30 <= data.count,
+              readUInt32(at: headerStart) == 0x0403_4B50 else {
+            throw ModelLoadingError.malformed(reason: "bad local header for \(entry.name)")
+        }
+        let nameLength = Int(readUInt16(at: headerStart + 26))
+        let extraLength = Int(readUInt16(at: headerStart + 28))
+        let payloadStart = headerStart + 30 + nameLength + extraLength
+        guard payloadStart + entry.compressedSize <= data.count else {
+            throw ModelLoadingError.malformed(reason: "truncated entry \(entry.name)")
+        }
+        let payload = data.subdata(in: payloadStart..<(payloadStart + entry.compressedSize))
+
+        switch entry.compressionMethod {
+        case 0:
+            return payload
+        case 8:
+            return try inflate(payload, uncompressedSize: entry.uncompressedSize, name: entry.name)
+        default:
+            throw ModelLoadingError.malformed(
+                reason: "entry \(entry.name) uses unsupported compression method \(entry.compressionMethod)"
+            )
+        }
+    }
+
+    /// The decompressed content of the entry with this name, or `nil` when absent.
+    func contents(named name: String) throws -> Data? {
+        guard let entry = entry(named: name) else { return nil }
+        return try contents(of: entry)
+    }
+
+    // MARK: - Inflate
+
+    /// Raw DEFLATE, via the `Compression` framework.
+    ///
+    /// `COMPRESSION_ZLIB` is Apple's name for *raw* DEFLATE — no zlib header, no
+    /// checksum — which is exactly what a ZIP entry stores. Reaching for a
+    /// header-expecting decoder here is the classic way to get an empty result with no
+    /// error.
+    private func inflate(_ payload: Data, uncompressedSize: Int, name: String) throws -> Data {
+        guard uncompressedSize > 0 else { return Data() }
+        var destination = Data(count: uncompressedSize)
+        let written: Int = destination.withUnsafeMutableBytes { destinationBuffer in
+            payload.withUnsafeBytes { sourceBuffer -> Int in
+                guard let destinationBase = destinationBuffer.bindMemory(to: UInt8.self).baseAddress,
+                      let sourceBase = sourceBuffer.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_decode_buffer(
+                    destinationBase, uncompressedSize,
+                    sourceBase, payload.count,
+                    nil, COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard written == uncompressedSize else {
+            throw ModelLoadingError.malformed(
+                reason: "entry \(name) inflated to \(written) of \(uncompressedSize) bytes"
+            )
+        }
+        return destination
+    }
+
+    // MARK: - Central directory
+
+    private static func readCentralDirectory(_ data: Data) throws -> [Entry] {
+        guard data.count >= 22 else {
+            throw ModelLoadingError.malformed(reason: "file is too small to be a zip archive")
+        }
+        guard let eocd = findEndOfCentralDirectory(data) else {
+            throw ModelLoadingError.malformed(reason: "no zip end-of-central-directory record")
+        }
+
+        let entryCount = Int(readUInt16(data, at: eocd + 10))
+        let directoryOffset = Int(readUInt32(data, at: eocd + 16))
+        // ZIP64 announces itself by saturating these 16- and 32-bit fields. Rather than
+        // read a nonsense offset and fail confusingly further down, say so here. A 3MF
+        // needs ZIP64 only past 4 GB or 65 535 parts, neither of which a printable model
+        // reaches.
+        guard entryCount != 0xFFFF, directoryOffset != 0xFFFF_FFFF else {
+            throw ModelLoadingError.malformed(reason: "ZIP64 archives are not supported")
+        }
+        guard directoryOffset >= 0, directoryOffset < data.count else {
+            throw ModelLoadingError.malformed(reason: "central directory offset out of range")
+        }
+
+        var entries: [Entry] = []
+        entries.reserveCapacity(entryCount)
+        var cursor = directoryOffset
+        for _ in 0..<entryCount {
+            guard cursor + 46 <= data.count, readUInt32(data, at: cursor) == 0x0201_4B50 else {
+                throw ModelLoadingError.malformed(reason: "bad central directory entry")
+            }
+            let method = readUInt16(data, at: cursor + 10)
+            let compressedSize = Int(readUInt32(data, at: cursor + 20))
+            let uncompressedSize = Int(readUInt32(data, at: cursor + 24))
+            let nameLength = Int(readUInt16(data, at: cursor + 28))
+            let extraLength = Int(readUInt16(data, at: cursor + 30))
+            let commentLength = Int(readUInt16(data, at: cursor + 32))
+            let localOffset = Int(readUInt32(data, at: cursor + 42))
+            guard cursor + 46 + nameLength <= data.count else {
+                throw ModelLoadingError.malformed(reason: "central directory entry name out of range")
+            }
+            let nameBytes = data.subdata(in: (cursor + 46)..<(cursor + 46 + nameLength))
+            // ZIP names are CP437 unless the UTF-8 flag is set; every 3MF writer uses
+            // ASCII part names, so a name that is not valid UTF-8 is one we could not
+            // have matched anyway — skip it rather than fail the whole archive.
+            if let name = String(data: nameBytes, encoding: .utf8) {
+                entries.append(Entry(
+                    name: name,
+                    compressionMethod: method,
+                    compressedSize: compressedSize,
+                    uncompressedSize: uncompressedSize,
+                    localHeaderOffset: localOffset
+                ))
+            }
+            cursor += 46 + nameLength + extraLength + commentLength
+        }
+        return entries
+    }
+
+    /// Scans backwards for the end-of-central-directory signature.
+    ///
+    /// Backwards because the record sits at the very end of the file *unless* the
+    /// archive carries a comment, which can be up to 65 535 bytes long — so its position
+    /// cannot be computed, only searched for.
+    private static func findEndOfCentralDirectory(_ data: Data) -> Int? {
+        let maximumCommentLength = 0xFFFF
+        let lowerBound = Swift.max(0, data.count - maximumCommentLength - 22)
+        var offset = data.count - 22
+        while offset >= lowerBound {
+            if readUInt32(data, at: offset) == 0x0605_4B50 { return offset }
+            offset -= 1
+        }
+        return nil
+    }
+
+    // MARK: - Little-endian reads
+
+    private func readUInt16(at offset: Int) -> UInt16 { Self.readUInt16(data, at: offset) }
+    private func readUInt32(at offset: Int) -> UInt32 { Self.readUInt32(data, at: offset) }
+
+    private static func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        guard offset >= 0, offset + 2 <= data.count else { return 0 }
+        return UInt16(data[data.startIndex + offset])
+            | UInt16(data[data.startIndex + offset + 1]) << 8
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        guard offset >= 0, offset + 4 <= data.count else { return 0 }
+        return UInt32(data[data.startIndex + offset])
+            | UInt32(data[data.startIndex + offset + 1]) << 8
+            | UInt32(data[data.startIndex + offset + 2]) << 16
+            | UInt32(data[data.startIndex + offset + 3]) << 24
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Nodes/ModelNode.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Nodes/ModelNode.swift
@@ -80,18 +80,33 @@ public struct ModelNode: @unchecked Sendable {
 
     /// Loads a 3D model from a bundle resource path.
     ///
-    /// Supports `.usdz` and `.reality` files natively.
+    /// Supports every format ``load(contentsOf:unit:enableCollision:)`` does — `.usdz`
+    /// and `.reality` through RealityKit, `.stl`, `.obj` and `.ply` through ModelIO.
     ///
     /// - Parameters:
-    ///   - path: Bundle resource name (e.g. `"models/car.usdz"`).
+    ///   - path: Bundle resource name (e.g. `"models/car.usdz"`, `"parts/bracket.stl"`).
+    ///   - unit: The unit a unitless mesh file is authored in — see
+    ///     ``load(contentsOf:unit:enableCollision:)``.
     ///   - enableCollision: Whether to generate a collision shape for hit testing.
+    ///   - bundle: Bundle to search. Defaults to `.main`.
     /// - Returns: A `ModelNode` wrapping the loaded entity.
     /// - Throws: If the file cannot be found or loaded.
     @MainActor
     public static func load(
         _ path: String,
-        enableCollision: Bool = true
+        unit: ModelUnit? = nil,
+        enableCollision: Bool = true,
+        bundle: Bundle = .main
     ) async throws -> ModelNode {
+        // ModelIO formats are not part of `Entity(named:)`'s vocabulary, so they have to
+        // be resolved to a URL first. USD/Reality keep the RealityKit path, which also
+        // resolves Reality Composer Pro scene names that are not plain files.
+        if let format = ModelFormat(fileExtension: (path as NSString).pathExtension),
+           format.loader != .realityKit,
+           let url = resourceURL(for: path, in: bundle) {
+            return try await load(contentsOf: url, unit: unit, enableCollision: enableCollision)
+        }
+
         let loadedEntity = try await Entity(named: path)
         let modelEntity = loadedEntity as? ModelEntity ?? {
             let me = ModelEntity()
@@ -108,18 +123,69 @@ public struct ModelNode: @unchecked Sendable {
         return ModelNode(modelEntity)
     }
 
-    /// Loads a 3D model from a URL.
+    /// Resolves a bundle resource path like `"models/part.stl"` to a file URL.
+    ///
+    /// Two lookups because Xcode's two ways of adding resources produce two layouts: a
+    /// folder reference keeps `models/` as a real subdirectory, while a group flattens
+    /// everything into the bundle root under its bare file name.
+    @MainActor
+    private static func resourceURL(for path: String, in bundle: Bundle) -> URL? {
+        let ns = path as NSString
+        let ext = ns.pathExtension
+        let withoutExtension = ns.deletingPathExtension
+        let directory = (withoutExtension as NSString).deletingLastPathComponent
+        let name = (withoutExtension as NSString).lastPathComponent
+
+        if !directory.isEmpty,
+           let url = bundle.url(forResource: name, withExtension: ext, subdirectory: directory) {
+            return url
+        }
+        return bundle.url(forResource: name, withExtension: ext)
+    }
+
+    /// Loads a 3D model from a URL — **the one entry point that opens every supported
+    /// format**.
+    ///
+    /// The format is decided by ``ModelFormat/sniff(contentsOf:)``, which reads the
+    /// file's own bytes before believing its extension, then the file goes down one of
+    /// two paths:
+    ///
+    /// | Formats | Path |
+    /// |---|---|
+    /// | `.usdz` `.usda` `.usdc` `.usd` `.reality` | RealityKit's `Entity(contentsOf:)` — already metric |
+    /// | `.stl` `.obj` `.ply` | ModelIO → ``MeshAsset`` → `MeshResource`, with `unit` applied |
+    ///
+    /// ```swift
+    /// // A slicer STL — millimetres, so this is 21 cm tall in AR, not 210 m.
+    /// let print = try await ModelNode.load(contentsOf: stlURL)
+    ///
+    /// // A scan authored in centimetres.
+    /// let scan = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+    /// ```
     ///
     /// - Parameters:
     ///   - url: File URL to the model.
+    ///   - unit: The unit the file's coordinates are in, for the formats that do not say
+    ///     (STL, OBJ, PLY). `nil` uses ``ModelFormat/defaultUnit`` — millimetres for STL,
+    ///     metres for OBJ and PLY. Ignored for USD and Reality files, which RealityKit
+    ///     has already converted to metres.
     ///   - enableCollision: Whether to generate collision shapes.
-    /// - Returns: A `ModelNode` wrapping the loaded entity.
-    /// - Throws: If the file cannot be loaded.
+    /// - Returns: A `ModelNode` wrapping the loaded entity, at real-world scale.
+    /// - Throws: ``ModelLoadingError/unsupportedFormat(fileExtension:)`` — carrying the
+    ///   extension, so a viewer can say which format it was asked for — or the underlying
+    ///   read error.
     @MainActor
     public static func load(
         contentsOf url: URL,
+        unit: ModelUnit? = nil,
         enableCollision: Bool = true
     ) async throws -> ModelNode {
+        let format = try ModelFormat.sniff(contentsOf: url)
+        guard format.loader == .realityKit else {
+            let asset = try MeshAsset.load(contentsOf: url, format: format, unit: unit)
+            return try await ModelNode(asset, enableCollision: enableCollision)
+        }
+
         let loadedEntity = try await Entity(contentsOf: url)
         let modelEntity = loadedEntity as? ModelEntity ?? {
             let me = ModelEntity()
@@ -137,8 +203,9 @@ public struct ModelNode: @unchecked Sendable {
 
     /// Loads a 3D model from a remote HTTP/HTTPS URL.
     ///
-    /// Downloads the file to a temporary directory, then loads it with RealityKit.
-    /// Supports USDZ and Reality files. The temporary file is cleaned up after loading.
+    /// Downloads the file to a temporary directory, then hands it to
+    /// ``load(contentsOf:unit:enableCollision:)`` — so it opens every supported format,
+    /// not just USDZ. The temporary file is cleaned up after loading.
     ///
     /// ```swift
     /// let model = try await ModelNode.load(
@@ -147,7 +214,9 @@ public struct ModelNode: @unchecked Sendable {
     /// ```
     ///
     /// - Parameters:
-    ///   - remoteURL: An HTTP or HTTPS URL pointing to a USDZ or Reality file. Any other
+    ///   - unit: The unit a unitless mesh file is authored in — see
+    ///     ``load(contentsOf:unit:enableCollision:)``.
+    ///   - remoteURL: An HTTP or HTTPS URL pointing to a model file. Any other
     ///     scheme throws `URLError(.unsupportedURL)` — this is now enforced, not merely
     ///     documented. `URLSession` will happily fetch a `file://` URL, so a caller
     ///     forwarding a user- or network-supplied string could otherwise turn this into
@@ -163,6 +232,7 @@ public struct ModelNode: @unchecked Sendable {
     @MainActor
     public static func load(
         from remoteURL: URL,
+        unit: ModelUnit? = nil,
         enableCollision: Bool = true,
         timeout: TimeInterval = 60.0,
         maxBytes: Int64 = 64 * 1024 * 1024
@@ -242,7 +312,11 @@ public struct ModelNode: @unchecked Sendable {
         }
         try FileManager.default.moveItem(at: tempURL, to: namedTempURL)
 
-        return try await load(contentsOf: namedTempURL, enableCollision: enableCollision)
+        return try await load(
+            contentsOf: namedTempURL,
+            unit: unit,
+            enableCollision: enableCollision
+        )
     }
 
     // MARK: - Transform helpers (mirrors Android's Node API)

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/MeshFixtures.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/MeshFixtures.swift
@@ -1,0 +1,203 @@
+import Foundation
+import simd
+
+/// Minimal, hand-built model files for the loader tests.
+///
+/// Generated in code rather than checked in as binaries for three reasons: the exact
+/// bytes are the thing under test (a binary STL whose header starts with `solid` is a
+/// *deliberate* trap, not an accident of some exporter), a reviewer can read the
+/// generator and see what the expected numbers are, and the test target needs no
+/// `resources:` wiring in `Package.swift`.
+enum MeshFixtures {
+
+    /// A scratch directory that is deleted when the test run tears it down.
+    static func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sceneview-mesh-fixtures-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    // MARK: - Geometry
+
+    /// The 12 triangles of an axis-aligned box from the origin to `size`, wound
+    /// counter-clockwise when seen from outside.
+    static func boxTriangles(size: SIMD3<Float>) -> [(SIMD3<Float>, SIMD3<Float>, SIMD3<Float>)] {
+        let (x, y, z) = (size.x, size.y, size.z)
+        let corners = [
+            SIMD3<Float>(0, 0, 0), SIMD3<Float>(x, 0, 0),
+            SIMD3<Float>(x, y, 0), SIMD3<Float>(0, y, 0),
+            SIMD3<Float>(0, 0, z), SIMD3<Float>(x, 0, z),
+            SIMD3<Float>(x, y, z), SIMD3<Float>(0, y, z)
+        ]
+        let quads = [
+            (0, 3, 2, 1),  // back  (-z)
+            (4, 5, 6, 7),  // front (+z)
+            (0, 1, 5, 4),  // bottom
+            (2, 3, 7, 6),  // top
+            (0, 4, 7, 3),  // left
+            (1, 2, 6, 5)   // right
+        ]
+        return quads.flatMap { quad in
+            [
+                (corners[quad.0], corners[quad.1], corners[quad.2]),
+                (corners[quad.0], corners[quad.2], corners[quad.3])
+            ]
+        }
+    }
+
+    /// The face normal of a triangle, or `+Y` when it is degenerate.
+    private static func normal(
+        _ triangle: (SIMD3<Float>, SIMD3<Float>, SIMD3<Float>)
+    ) -> SIMD3<Float> {
+        let raw = cross(triangle.1 - triangle.0, triangle.2 - triangle.0)
+        let lengthSquared = simd_length_squared(raw)
+        return lengthSquared > 0 ? raw / lengthSquared.squareRoot() : SIMD3<Float>(0, 1, 0)
+    }
+
+    // MARK: - STL
+
+    /// A **binary** STL whose 80-byte header begins with the word `solid`.
+    ///
+    /// This is the trap the format sniffer exists for: a prefix test alone reads this as
+    /// an ASCII STL and returns an empty mesh, which is exactly how a viewer ends up
+    /// showing nothing for a file every slicer opens. Real exporters do write `solid …`
+    /// into the binary header.
+    static func binarySTL(
+        triangles: [(SIMD3<Float>, SIMD3<Float>, SIMD3<Float>)],
+        headerText: String = "solid exported by a tool that should know better"
+    ) -> Data {
+        var data = Data()
+        var header = [UInt8](repeating: 0, count: 80)
+        for (index, byte) in Array(headerText.utf8).prefix(80).enumerated() {
+            header[index] = byte
+        }
+        data.append(contentsOf: header)
+        appendLittleEndian(UInt32(triangles.count), to: &data)
+        for triangle in triangles {
+            appendFloats(normal(triangle), to: &data)
+            appendFloats(triangle.0, to: &data)
+            appendFloats(triangle.1, to: &data)
+            appendFloats(triangle.2, to: &data)
+            appendLittleEndian(UInt16(0), to: &data)  // attribute byte count
+        }
+        return data
+    }
+
+    /// An ASCII STL — the other half of the format.
+    static func asciiSTL(
+        triangles: [(SIMD3<Float>, SIMD3<Float>, SIMD3<Float>)],
+        name: String = "fixture"
+    ) -> Data {
+        var text = "solid \(name)\n"
+        for triangle in triangles {
+            let n = normal(triangle)
+            text += "  facet normal \(n.x) \(n.y) \(n.z)\n    outer loop\n"
+            for vertex in [triangle.0, triangle.1, triangle.2] {
+                text += "      vertex \(vertex.x) \(vertex.y) \(vertex.z)\n"
+            }
+            text += "    endloop\n  endfacet\n"
+        }
+        text += "endsolid \(name)\n"
+        return Data(text.utf8)
+    }
+
+    // MARK: - OBJ
+
+    /// A one-quad OBJ plus its `.mtl` sidecar, written side by side.
+    ///
+    /// The face is a **quad**, not two triangles: OBJ allows it, ModelIO preserves it,
+    /// and RealityKit cannot draw it — so this fixture is what proves the reader
+    /// triangulates instead of dropping the face.
+    ///
+    /// - Returns: The URL of the `.obj`. The `.mtl` sits next to it.
+    @discardableResult
+    static func writeQuadOBJ(
+        in directory: URL,
+        name: String = "panel",
+        size: SIMD2<Float> = SIMD2(4, 5),
+        baseColor: SIMD3<Float> = SIMD3(0.8, 0.2, 0.1)
+    ) throws -> URL {
+        let mtl = """
+        newmtl painted
+        Kd \(baseColor.x) \(baseColor.y) \(baseColor.z)
+        Ka 0 0 0
+        Ns 120
+
+        """
+        let obj = """
+        # SceneViewSwift test fixture
+        mtllib \(name).mtl
+        o \(name)
+        v 0 0 0
+        v \(size.x) 0 0
+        v \(size.x) \(size.y) 0
+        v 0 \(size.y) 0
+        vn 0 0 1
+        usemtl painted
+        f 1//1 2//1 3//1 4//1
+
+        """
+        try Data(mtl.utf8).write(to: directory.appendingPathComponent("\(name).mtl"))
+        let url = directory.appendingPathComponent("\(name).obj")
+        try Data(obj.utf8).write(to: url)
+        return url
+    }
+
+    // MARK: - PLY
+
+    /// A binary little-endian PLY with per-vertex `uchar` colours and two triangular
+    /// faces — the shape a phone scanner exports.
+    static func binaryPLY(
+        size: SIMD2<Float> = SIMD2(2, 3),
+        colors: [SIMD3<UInt8>] = [
+            SIMD3(255, 0, 0), SIMD3(0, 255, 0), SIMD3(0, 0, 255), SIMD3(255, 255, 255)
+        ]
+    ) -> Data {
+        let header = """
+        ply
+        format binary_little_endian 1.0
+        comment SceneViewSwift test fixture
+        element vertex 4
+        property float x
+        property float y
+        property float z
+        property uchar red
+        property uchar green
+        property uchar blue
+        element face 2
+        property list uchar int vertex_indices
+        end_header
+
+        """
+        var data = Data(header.utf8)
+        let vertices = [
+            SIMD3<Float>(0, 0, 0),
+            SIMD3<Float>(size.x, 0, 0),
+            SIMD3<Float>(size.x, size.y, 0),
+            SIMD3<Float>(0, size.y, 0)
+        ]
+        for (vertex, color) in zip(vertices, colors) {
+            appendFloats(vertex, to: &data)
+            data.append(contentsOf: [color.x, color.y, color.z])
+        }
+        for face in [[0, 1, 2], [0, 2, 3]] {
+            data.append(3)  // uchar list length
+            for index in face { appendLittleEndian(Int32(index), to: &data) }
+        }
+        return data
+    }
+
+    // MARK: - Byte helpers
+
+    private static func appendFloats(_ vector: SIMD3<Float>, to data: inout Data) {
+        appendLittleEndian(vector.x.bitPattern, to: &data)
+        appendLittleEndian(vector.y.bitPattern, to: &data)
+        appendLittleEndian(vector.z.bitPattern, to: &data)
+    }
+
+    private static func appendLittleEndian<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+}

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/MeshFormatTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/MeshFormatTests.swift
@@ -1,0 +1,325 @@
+import XCTest
+import simd
+@testable import SceneViewSwift
+
+#if os(iOS) || os(macOS) || os(visionOS)
+import RealityKit
+#endif
+
+/// Format sniffing, unit arithmetic, and the ModelIO reader for STL / OBJ / PLY.
+final class MeshFormatTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try MeshFixtures.makeDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    /// 10 × 20 × 30 in the file's own unit — deliberately unequal so a swapped axis
+    /// cannot pass.
+    private let boxSize = SIMD3<Float>(10, 20, 30)
+
+    private func write(_ data: Data, as name: String) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - Units
+
+    func testUnitConversionToMeters() {
+        XCTAssertEqual(ModelUnit.millimeters.metersPerUnit, 0.001, accuracy: 1e-9)
+        XCTAssertEqual(ModelUnit.inches.metersPerUnit, 0.0254, accuracy: 1e-9)
+        XCTAssertEqual(ModelUnit.meters.convert(2, to: .centimeters), 200, accuracy: 1e-4)
+        XCTAssertEqual(ModelUnit.inches.convert(1, to: .millimeters), 25.4, accuracy: 1e-3)
+    }
+
+    func testUnitFromThreeMFSpelling() {
+        XCTAssertEqual(ModelUnit(threeMFUnit: "millimeter"), .millimeters)
+        XCTAssertEqual(ModelUnit(threeMFUnit: "MICRON"), .micrometers)
+        XCTAssertEqual(ModelUnit(threeMFUnit: " inch "), .inches)
+        XCTAssertNil(ModelUnit(threeMFUnit: "furlong"))
+    }
+
+    func testUnitFromMetersPerUnit() {
+        XCTAssertEqual(ModelUnit(metersPerUnit: 0.01), .centimeters)
+        XCTAssertEqual(ModelUnit(metersPerUnit: 1), .meters)
+        XCTAssertNil(ModelUnit(metersPerUnit: 0.3))
+        XCTAssertNil(ModelUnit(metersPerUnit: 0))
+    }
+
+    // MARK: - Sniffing
+
+    /// The regression this whole sniffer exists for: binary STLs whose 80-byte header
+    /// starts with `solid`. Detected by size arithmetic, not by the prefix.
+    func testBinarySTLWithSolidHeaderIsNotMistakenForASCII() throws {
+        let data = MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize))
+        XCTAssertTrue(String(data: data.prefix(5), encoding: .utf8) == "solid")
+        let url = try write(data, as: "trap.stl")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: url), .stl)
+
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.triangleCount, 12, "an ASCII misread yields 0 triangles")
+    }
+
+    func testSniffsAsciiSTLAndPLYBySignature() throws {
+        let ascii = try write(
+            MeshFixtures.asciiSTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "ascii.stl"
+        )
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: ascii), .stl)
+
+        let ply = try write(MeshFixtures.binaryPLY(), as: "scan.ply")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: ply), .ply)
+    }
+
+    /// Content beats the extension — the case that matters for a file arriving from a
+    /// share sheet or a messaging app that renamed it.
+    func testContentBeatsAMisleadingExtension() throws {
+        let url = try write(
+            MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "actually-an-stl.obj"
+        )
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: url), .stl)
+    }
+
+    /// OBJ has no signature at all, so it is identified by its extension alone.
+    func testOBJIsIdentifiedByExtension() throws {
+        let url = try MeshFixtures.writeQuadOBJ(in: directory)
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: url), .obj)
+    }
+
+    func testUnsupportedFormatErrorCarriesTheExtension() throws {
+        let url = try write(Data("not a model".utf8), as: "drawing.fbx")
+        XCTAssertThrowsError(try ModelFormat.sniff(contentsOf: url)) { error in
+            XCTAssertEqual(error as? ModelLoadingError, .unsupportedFormat(fileExtension: "fbx"))
+            XCTAssertTrue(
+                (error as? ModelLoadingError)?.errorDescription?.contains(".fbx") == true,
+                "the message must name the format the user tried to open"
+            )
+        }
+    }
+
+    func testDefaultUnitsMatchTheFormatsConventions() {
+        XCTAssertEqual(ModelFormat.stl.defaultUnit, .millimeters)
+        XCTAssertEqual(ModelFormat.obj.defaultUnit, .meters)
+        XCTAssertEqual(ModelFormat.ply.defaultUnit, .meters)
+        XCTAssertEqual(ModelFormat.usdz.defaultUnit, .meters)
+        XCTAssertFalse(ModelFormat.stl.carriesUnit)
+        XCTAssertTrue(ModelFormat.usdz.carriesUnit)
+    }
+
+    // MARK: - STL
+
+    func testBinarySTLBoundsAndRealWorldSize() throws {
+        let url = try write(
+            MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "part.stl"
+        )
+        let asset = try MeshAsset.load(contentsOf: url)
+
+        XCTAssertEqual(asset.format, .stl)
+        XCTAssertEqual(asset.unit, .millimeters, "STL has no unit; mm is the printing default")
+        XCTAssertEqual(asset.triangleCount, 12)
+
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.min, .zero, accuracy: 1e-4)
+        assertEqual(bounds.max, boxSize, accuracy: 1e-4)
+
+        // The point of the unit: 10 × 20 × 30 mm is 1 × 2 × 3 cm in the room.
+        let metric = try XCTUnwrap(asset.boundsInMeters)
+        assertEqual(metric.extents, SIMD3<Float>(0.01, 0.02, 0.03), accuracy: 1e-6)
+    }
+
+    func testExplicitUnitOverridesTheDefault() throws {
+        let url = try write(
+            MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "inches.stl"
+        )
+        let asset = try MeshAsset.load(contentsOf: url, unit: .inches)
+        XCTAssertEqual(asset.unit, .inches)
+        let metric = try XCTUnwrap(asset.boundsInMeters)
+        assertEqual(metric.extents, SIMD3<Float>(0.254, 0.508, 0.762), accuracy: 1e-5)
+    }
+
+    func testAsciiAndBinarySTLAgree() throws {
+        let triangles = MeshFixtures.boxTriangles(size: boxSize)
+        let binary = try MeshAsset.load(
+            contentsOf: try write(MeshFixtures.binarySTL(triangles: triangles), as: "b.stl")
+        )
+        let ascii = try MeshAsset.load(
+            contentsOf: try write(MeshFixtures.asciiSTL(triangles: triangles), as: "a.stl")
+        )
+        XCTAssertEqual(binary.triangleCount, ascii.triangleCount)
+        assertEqual(
+            try XCTUnwrap(binary.bounds).max,
+            try XCTUnwrap(ascii.bounds).max,
+            accuracy: 1e-4
+        )
+    }
+
+    func testSTLNormalsArePresent() throws {
+        let url = try write(
+            MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "normals.stl"
+        )
+        let asset = try MeshAsset.load(contentsOf: url)
+        let part = try XCTUnwrap(asset.parts.first)
+        let normals = try XCTUnwrap(part.normals, "a lit model needs normals")
+        XCTAssertEqual(normals.count, part.positions.count)
+        for normal in normals {
+            XCTAssertEqual(simd_length(normal), 1, accuracy: 1e-3)
+        }
+    }
+
+    // MARK: - OBJ
+
+    /// A quad face must come back as two triangles — RealityKit draws nothing else.
+    func testOBJQuadIsTriangulatedAndKeepsItsMaterial() async throws {
+        let url = try MeshFixtures.writeQuadOBJ(in: directory)
+        let asset = try MeshAsset.load(contentsOf: url)
+
+        XCTAssertEqual(asset.format, .obj)
+        XCTAssertEqual(asset.unit, .meters)
+        XCTAssertEqual(asset.triangleCount, 2, "one quad = two triangles")
+
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.extents, SIMD3<Float>(4, 5, 0), accuracy: 1e-4)
+
+        let material = try XCTUnwrap(asset.parts.first?.material, "the .mtl sidecar was ignored")
+        let baseColor = try XCTUnwrap(material.baseColor)
+        XCTAssertEqual(baseColor.x, 0.8, accuracy: 0.01)
+        XCTAssertEqual(baseColor.y, 0.2, accuracy: 0.01)
+        XCTAssertEqual(baseColor.z, 0.1, accuracy: 0.01)
+    }
+
+    // MARK: - PLY
+
+    func testBinaryPLYKeepsPerVertexColors() throws {
+        let url = try write(MeshFixtures.binaryPLY(), as: "scan.ply")
+        let asset = try MeshAsset.load(contentsOf: url)
+
+        XCTAssertEqual(asset.format, .ply)
+        XCTAssertEqual(asset.triangleCount, 2)
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.extents, SIMD3<Float>(2, 3, 0), accuracy: 1e-4)
+
+        let part = try XCTUnwrap(asset.parts.first)
+        let colors = try XCTUnwrap(part.colors, "PLY vertex colours were dropped")
+        XCTAssertEqual(colors.count, part.positions.count)
+
+        // Every colour, not just the first: reading a 3-component colour attribute as
+        // `.float4` makes ModelIO hand back tightly packed float3 data at a float4
+        // stride, so vertex 1 onwards drifts a third of a vertex out of step and this
+        // red/green/blue/white fixture comes back red/red/white/black.
+        let expected: [SIMD3<Float>] = [
+            SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1), SIMD3(1, 1, 1)
+        ]
+        for (index, want) in expected.enumerated() {
+            assertEqual(
+                SIMD3(colors[index].x, colors[index].y, colors[index].z),
+                want,
+                accuracy: 0.01
+            )
+            XCTAssertEqual(colors[index].w, 1, accuracy: 1e-5, "RGB sources are opaque")
+        }
+    }
+
+    /// Vertices are not silently unwelded: `MDLMesh.addNormals` turns this 4-vertex quad
+    /// into 6 vertices and rewrites the index buffer, which is why the reader generates
+    /// missing normals itself instead.
+    func testPLYVertexCountSurvivesNormalGeneration() throws {
+        let url = try write(MeshFixtures.binaryPLY(), as: "welded.ply")
+        let part = try XCTUnwrap(MeshAsset.load(contentsOf: url).parts.first)
+        XCTAssertEqual(part.positions.count, 4)
+        XCTAssertEqual(part.indices, [0, 1, 2, 0, 2, 3])
+
+        let shaded = part.generatingNormals()
+        XCTAssertEqual(shaded.positions.count, 4, "generating normals must not unweld")
+        XCTAssertEqual(shaded.normals?.count, 4)
+    }
+
+    // MARK: - Geometry helpers
+
+    func testGeneratedNormalsAreUnitLength() {
+        let geometry = MeshGeometry(
+            name: "tri",
+            positions: [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0)],
+            indices: [0, 1, 2]
+        ).generatingNormals()
+        let normals = geometry.normals
+        XCTAssertEqual(normals?.count, 3)
+        for normal in normals ?? [] {
+            XCTAssertEqual(simd_length(normal), 1, accuracy: 1e-5)
+            assertEqual(normal, SIMD3<Float>(0, 0, 1), accuracy: 1e-5)
+        }
+    }
+
+    func testInMetersBakesTheUnitIntoPositions() throws {
+        let asset = MeshAsset(
+            format: .stl,
+            unit: .millimeters,
+            parts: [MeshGeometry(
+                name: "p",
+                positions: [SIMD3(0, 0, 0), SIMD3(100, 0, 0), SIMD3(0, 100, 0)],
+                indices: [0, 1, 2]
+            )]
+        )
+        let metric = asset.inMeters()
+        XCTAssertEqual(metric.unit, .meters)
+        assertEqual(metric.parts[0].positions[1], SIMD3<Float>(0.1, 0, 0), accuracy: 1e-6)
+        // Idempotent: converting an already-metric asset changes nothing.
+        assertEqual(metric.inMeters().parts[0].positions[1], SIMD3<Float>(0.1, 0, 0), accuracy: 1e-6)
+    }
+
+    // MARK: - Entity
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    /// End to end: a millimetre STL becomes a RealityKit mesh measured in metres.
+    @MainActor
+    func testModelNodeFromSTLIsMetric() async throws {
+        let url = try write(
+            MeshFixtures.binarySTL(triangles: MeshFixtures.boxTriangles(size: boxSize)),
+            as: "metric.stl"
+        )
+        let node = try await ModelNode.load(contentsOf: url)
+        let mesh = try XCTUnwrap(node.entity.model?.mesh)
+        let extents = mesh.bounds.extents
+        XCTAssertEqual(extents.x, 0.01, accuracy: 1e-4)
+        XCTAssertEqual(extents.y, 0.02, accuracy: 1e-4)
+        XCTAssertEqual(extents.z, 0.03, accuracy: 1e-4)
+    }
+
+    /// One RealityKit material per part, so a multi-material OBJ does not collapse to a
+    /// single colour.
+    @MainActor
+    func testModelNodeFromOBJHasAMaterial() async throws {
+        let url = try MeshFixtures.writeQuadOBJ(in: directory)
+        let node = try await ModelNode.load(contentsOf: url)
+        let model = try XCTUnwrap(node.entity.model)
+        XCTAssertEqual(model.materials.count, 1)
+        XCTAssertEqual(model.mesh.expectedMaterialCount, 1)
+    }
+    #endif
+
+    // MARK: -
+
+    private func assertEqual(
+        _ lhs: SIMD3<Float>,
+        _ rhs: SIMD3<Float>,
+        accuracy: Float,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.x, rhs.x, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.y, rhs.y, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.z, rhs.z, accuracy: accuracy, file: file, line: line)
+    }
+}

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFFixtures.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFFixtures.swift
@@ -1,0 +1,244 @@
+import Foundation
+import Compression
+import simd
+
+/// Hand-built 3MF packages for the loader tests.
+///
+/// A real ZIP writer, not a canned blob: the reader's job is to walk a central
+/// directory and inflate deflate streams, so a fixture that skipped either would test
+/// nothing. Entries can be stored or deflated per test, and the CRCs are real, so the
+/// fixtures also open in any other ZIP tool if a failure ever needs inspecting by hand.
+enum ThreeMFFixtures {
+
+    // MARK: - Package assembly
+
+    struct FileEntry {
+        let name: String
+        let data: Data
+        let deflate: Bool
+
+        init(_ name: String, _ text: String, deflate: Bool = true) {
+            self.name = name
+            self.data = Data(text.utf8)
+            self.deflate = deflate
+        }
+
+        init(_ name: String, data: Data, deflate: Bool = true) {
+            self.name = name
+            self.data = data
+            self.deflate = deflate
+        }
+    }
+
+    /// The `[Content_Types].xml` every OPC package opens with. Its presence is also what
+    /// makes the format sniffer call a zip a 3MF rather than a USDZ.
+    static let contentTypes = FileEntry("[Content_Types].xml", """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+    </Types>
+    """, deflate: false)
+
+    /// `_rels/.rels` naming the root model part.
+    static func relationships(target: String = "/3D/3dmodel.model") -> FileEntry {
+        FileEntry("_rels/.rels", """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rel0" Target="\(target)"
+            Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/>
+        </Relationships>
+        """)
+    }
+
+    /// Builds a `.3mf` package from entries.
+    static func package(_ entries: [FileEntry]) -> Data {
+        var payload = Data()
+        var directory = Data()
+        var count = 0
+
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            let crc = crc32(entry.data)
+            let stored = entry.deflate ? deflate(entry.data) : nil
+            let method: UInt16 = stored == nil ? 0 : 8
+            let body = stored ?? entry.data
+            let localOffset = payload.count
+
+            append32(0x0403_4B50, to: &payload)         // local file header signature
+            append16(20, to: &payload)                  // version needed
+            append16(0, to: &payload)                   // flags
+            append16(method, to: &payload)
+            append16(0, to: &payload)                   // mod time
+            append16(0x21, to: &payload)                // mod date (1980-01-01)
+            append32(crc, to: &payload)
+            append32(UInt32(body.count), to: &payload)
+            append32(UInt32(entry.data.count), to: &payload)
+            append16(UInt16(nameBytes.count), to: &payload)
+            append16(0, to: &payload)                   // extra length
+            payload.append(contentsOf: nameBytes)
+            payload.append(body)
+
+            append32(0x0201_4B50, to: &directory)       // central directory signature
+            append16(20, to: &directory)                // version made by
+            append16(20, to: &directory)                // version needed
+            append16(0, to: &directory)                 // flags
+            append16(method, to: &directory)
+            append16(0, to: &directory)
+            append16(0x21, to: &directory)
+            append32(crc, to: &directory)
+            append32(UInt32(body.count), to: &directory)
+            append32(UInt32(entry.data.count), to: &directory)
+            append16(UInt16(nameBytes.count), to: &directory)
+            append16(0, to: &directory)                 // extra length
+            append16(0, to: &directory)                 // comment length
+            append16(0, to: &directory)                 // disk number start
+            append16(0, to: &directory)                 // internal attributes
+            append32(0, to: &directory)                 // external attributes
+            append32(UInt32(localOffset), to: &directory)
+            directory.append(contentsOf: nameBytes)
+            count += 1
+        }
+
+        let directoryOffset = payload.count
+        var archive = payload
+        archive.append(directory)
+        append32(0x0605_4B50, to: &archive)             // end of central directory
+        append16(0, to: &archive)                       // disk number
+        append16(0, to: &archive)                       // disk with central directory
+        append16(UInt16(count), to: &archive)
+        append16(UInt16(count), to: &archive)
+        append32(UInt32(directory.count), to: &archive)
+        append32(UInt32(directoryOffset), to: &archive)
+        append16(0, to: &archive)                       // comment length
+        return archive
+    }
+
+    // MARK: - Model XML
+
+    /// A `<mesh>` element for an axis-aligned box from the origin to `size`.
+    static func boxMeshXML(size: SIMD3<Float>) -> String {
+        let corners: [SIMD3<Float>] = [
+            SIMD3(0, 0, 0), SIMD3(size.x, 0, 0), SIMD3(size.x, size.y, 0), SIMD3(0, size.y, 0),
+            SIMD3(0, 0, size.z), SIMD3(size.x, 0, size.z),
+            SIMD3(size.x, size.y, size.z), SIMD3(0, size.y, size.z)
+        ]
+        let faces = [
+            (0, 3, 2), (0, 2, 1), (4, 5, 6), (4, 6, 7),
+            (0, 1, 5), (0, 5, 4), (2, 3, 7), (2, 7, 6),
+            (0, 4, 7), (0, 7, 3), (1, 2, 6), (1, 6, 5)
+        ]
+        let vertices = corners
+            .map { "      <vertex x=\"\($0.x)\" y=\"\($0.y)\" z=\"\($0.z)\"/>" }
+            .joined(separator: "\n")
+        let triangles = faces
+            .map { "      <triangle v1=\"\($0.0)\" v2=\"\($0.1)\" v3=\"\($0.2)\"/>" }
+            .joined(separator: "\n")
+        return """
+            <mesh>
+              <vertices>
+        \(vertices)
+              </vertices>
+              <triangles>
+        \(triangles)
+              </triangles>
+            </mesh>
+        """
+    }
+
+    /// A complete root `.model` part.
+    static func modelXML(
+        unit: String = "millimeter",
+        resources: String,
+        build: String,
+        extraNamespaces: String = ""
+    ) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model unit="\(unit)" xml:lang="en-US"
+          xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"\(extraNamespaces)>
+          <resources>
+        \(resources)
+          </resources>
+          <build>
+        \(build)
+          </build>
+        </model>
+        """
+    }
+
+    /// The simplest useful package: one box object, one build item.
+    static func simpleBox(
+        size: SIMD3<Float> = SIMD3(10, 20, 30),
+        unit: String = "millimeter",
+        deflate: Bool = true
+    ) -> Data {
+        let model = modelXML(
+            unit: unit,
+            resources: """
+                <object id="1" type="model" name="cube">
+            \(boxMeshXML(size: size))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        return package([
+            contentTypes,
+            relationships(),
+            FileEntry("3D/3dmodel.model", model, deflate: deflate)
+        ])
+    }
+
+    // MARK: - Byte helpers
+
+    private static func append16(_ value: UInt16, to data: inout Data) {
+        data.append(contentsOf: [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)])
+    }
+
+    private static func append32(_ value: UInt32, to data: inout Data) {
+        data.append(contentsOf: [
+            UInt8(value & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 24) & 0xFF)
+        ])
+    }
+
+    /// Raw DEFLATE — `COMPRESSION_ZLIB` is Apple's name for the headerless stream a ZIP
+    /// entry stores. Returns `nil` when the "compressed" form would not be smaller, in
+    /// which case the caller stores the entry instead, exactly like a real writer.
+    private static func deflate(_ input: Data) -> Data? {
+        guard !input.isEmpty else { return nil }
+        let capacity = input.count + 1024
+        var output = Data(count: capacity)
+        let written: Int = output.withUnsafeMutableBytes { destination in
+            input.withUnsafeBytes { source -> Int in
+                guard let destinationBase = destination.bindMemory(to: UInt8.self).baseAddress,
+                      let sourceBase = source.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_encode_buffer(
+                    destinationBase, capacity,
+                    sourceBase, input.count,
+                    nil, COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard written > 0, written < input.count else { return nil }
+        return output.prefix(written)
+    }
+
+    /// CRC-32 (IEEE), computed the slow bitwise way — a fixture builder has all the time
+    /// in the world and this needs no 1 KB table in the test target.
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc ^= UInt32(byte)
+            for _ in 0..<8 {
+                crc = (crc >> 1) ^ (0xEDB8_8320 & (0 &- (crc & 1)))
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFTests.swift
@@ -1,0 +1,487 @@
+import XCTest
+import simd
+@testable import SceneViewSwift
+
+#if os(iOS) || os(macOS) || os(visionOS)
+import RealityKit
+#endif
+
+/// The 3MF reader: ZIP container, core-spec XML, transforms, materials, and the
+/// Production extension's multi-part packages.
+final class ThreeMFTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try MeshFixtures.makeDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    private func write(_ data: Data, as name: String = "model.3mf") throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - Container
+
+    func testReadsADeflatedPackage() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(deflate: true))
+        let asset = try MeshAsset.load(contentsOf: url)
+
+        XCTAssertEqual(asset.format, .threeMF)
+        XCTAssertEqual(asset.unit, .millimeters)
+        XCTAssertEqual(asset.triangleCount, 12)
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.extents, SIMD3<Float>(10, 20, 30), accuracy: 1e-4)
+    }
+
+    /// Stored entries are legal and small writers emit them.
+    func testReadsAStoredPackage() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(deflate: false), as: "stored.3mf")
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.triangleCount, 12)
+    }
+
+    func testTruncatedArchiveFailsWithAReason() throws {
+        var data = ThreeMFFixtures.simpleBox()
+        data.removeLast(30)  // eats the end-of-central-directory record
+        let url = try write(data, as: "truncated.3mf")
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url)) { error in
+            guard case .malformed = (error as? ModelLoadingError) else {
+                return XCTFail("expected .malformed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Sniffing
+
+    /// USDZ and 3MF are both zip archives. The first entry's name is what tells them
+    /// apart — get this wrong and every 3MF is handed to RealityKit, which cannot read it.
+    func testZipIsToldApartFromUSDZ() throws {
+        let threeMF = try write(ThreeMFFixtures.simpleBox(), as: "print.3mf")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: threeMF), .threeMF)
+
+        // A zip whose first entry is a `.usdc` is a USDZ, whatever it is called.
+        let fakeUSDZ = ThreeMFFixtures.package([
+            ThreeMFFixtures.FileEntry("model.usdc", "not really usd", deflate: false)
+        ])
+        let usdzURL = try write(fakeUSDZ, as: "unlabelled.bin")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: usdzURL), .usdz)
+    }
+
+    func testThreeMFCarriesItsOwnUnit() {
+        XCTAssertTrue(ModelFormat.threeMF.carriesUnit)
+        XCTAssertEqual(ModelFormat.threeMF.defaultUnit, .millimeters)
+        XCTAssertEqual(ModelFormat.threeMF.loader, .sceneView)
+    }
+
+    // MARK: - Units
+
+    func testDeclaredUnitIsHonoured() throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(size: SIMD3(1, 2, 3), unit: "inch"),
+            as: "inch.3mf"
+        )
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.unit, .inches)
+        let metric = try XCTUnwrap(asset.boundsInMeters)
+        assertEqual(metric.extents, SIMD3<Float>(0.0254, 0.0508, 0.0762), accuracy: 1e-5)
+    }
+
+    func testAnUnknownUnitFallsBackToTheSpecDefault() throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(unit: "furlong"),
+            as: "nonsense-unit.3mf"
+        )
+        // Forgiving on purpose: refusing to open a model over one misspelled word is
+        // worse than assuming the spec's own default.
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).unit, .millimeters)
+    }
+
+    func testExplicitUnitOverridesTheFile() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(), as: "override.3mf")
+        let asset = try MeshAsset.load(contentsOf: url, unit: .centimeters)
+        XCTAssertEqual(asset.unit, .centimeters)
+    }
+
+    // MARK: - Transforms
+
+    /// A build item's transform is twelve numbers in **row-vector** order. Transposing
+    /// them scatters every placed part, so this pins the convention with a matrix whose
+    /// transpose would give a visibly different answer.
+    func testBuildItemTransformIsRowVector() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(2, 2, 2)))
+                </object>
+            """,
+            build: """
+                <item objectid="1" transform="2 0 0 0 1 0 0 0 1 100 5 0"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "placed.3mf")
+
+        let bounds = try XCTUnwrap(MeshAsset.load(contentsOf: url).bounds)
+        // x doubled then translated by 100; y translated by 5; z untouched.
+        assertEqual(bounds.min, SIMD3<Float>(100, 5, 0), accuracy: 1e-4)
+        assertEqual(bounds.max, SIMD3<Float>(104, 7, 2), accuracy: 1e-4)
+    }
+
+    /// Components compose with the item that placed them.
+    func testComponentTransformsCompose() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+                <object id="2" type="model">
+                  <components>
+                    <component objectid="1" transform="1 0 0 0 1 0 0 0 1 10 0 0"/>
+                  </components>
+                </object>
+            """,
+            build: """
+                <item objectid="2" transform="1 0 0 0 1 0 0 0 1 0 100 0"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "nested.3mf")
+
+        let bounds = try XCTUnwrap(MeshAsset.load(contentsOf: url).bounds)
+        assertEqual(bounds.min, SIMD3<Float>(10, 100, 0), accuracy: 1e-4)
+        assertEqual(bounds.max, SIMD3<Float>(11, 101, 1), accuracy: 1e-4)
+    }
+
+    func testSelfReferencingComponentIsRejected() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+                  <components><component objectid="1"/></components>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "cycle.3mf")
+
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url)) { error in
+            guard case .malformed(let reason) = (error as? ModelLoadingError) else {
+                return XCTFail("expected .malformed, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("itself"), reason)
+        }
+    }
+
+    // MARK: - Production extension
+
+    /// Bambu Studio and Orca split a project across several `.model` parts and reference
+    /// them with `p:path`. A reader that only ever opens `3D/3dmodel.model` shows an
+    /// empty plate for every one of those files.
+    func testProductionExtensionPathReferences() throws {
+        let objectPart = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="7" type="model" name="lifted">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(4, 4, 4)))
+                </object>
+            """,
+            build: ""
+        )
+        let root = ThreeMFFixtures.modelXML(
+            resources: "",
+            build: """
+                <item objectid="7" p:path="/3D/Objects/object_1.model"
+                  transform="1 0 0 0 1 0 0 0 1 0 0 50"/>
+            """,
+            extraNamespaces: """
+
+              xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06"
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", root),
+            ThreeMFFixtures.FileEntry("3D/Objects/object_1.model", objectPart)
+        ]), as: "project.3mf")
+
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.triangleCount, 12)
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.min, SIMD3<Float>(0, 0, 50), accuracy: 1e-4)
+        XCTAssertEqual(asset.parts.first?.name, "lifted")
+    }
+
+    /// The root part is found through `_rels/.rels`, not by assuming a path.
+    func testRootPartIsResolvedThroughRelationships() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(target: "/3D/unusual-name.model"),
+            ThreeMFFixtures.FileEntry("3D/unusual-name.model", model)
+        ]), as: "relocated.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    // MARK: - Materials
+
+    /// A multi-colour print must come back multi-colour: triangles are grouped by the
+    /// colour their `pid`/`p1` resolves to, one mesh part each.
+    func testTrianglesAreGroupedByMaterialColor() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <basematerials id="5">
+                  <base name="red" displaycolor="#FF0000"/>
+                  <base name="blue" displaycolor="#0000FF"/>
+                </basematerials>
+                <object id="1" type="model" pid="5" pindex="0">
+                  <mesh>
+                    <vertices>
+                      <vertex x="0" y="0" z="0"/>
+                      <vertex x="1" y="0" z="0"/>
+                      <vertex x="1" y="1" z="0"/>
+                      <vertex x="0" y="1" z="0"/>
+                    </vertices>
+                    <triangles>
+                      <triangle v1="0" v2="1" v3="2" pid="5" p1="0"/>
+                      <triangle v1="0" v2="2" v3="3" pid="5" p1="1"/>
+                    </triangles>
+                  </mesh>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "twotone.3mf")
+
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.parts.count, 2, "two colours must not collapse into one part")
+        XCTAssertEqual(asset.triangleCount, 2)
+
+        let colors = asset.parts.compactMap(\.material?.baseColor)
+        XCTAssertEqual(colors.count, 2)
+        assertEqual(SIMD3(colors[0].x, colors[0].y, colors[0].z), SIMD3(1, 0, 0), accuracy: 0.01)
+        assertEqual(SIMD3(colors[1].x, colors[1].y, colors[1].z), SIMD3(0, 0, 1), accuracy: 0.01)
+        // Each group carries only the vertices it uses.
+        XCTAssertEqual(asset.parts[0].positions.count, 3)
+        XCTAssertEqual(asset.parts[1].positions.count, 3)
+    }
+
+    func testColorGroupFromTheMaterialsExtension() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <m:colorgroup id="9">
+                  <m:color color="#20C05FFF"/>
+                </m:colorgroup>
+                <object id="1" type="model" pid="9" pindex="0">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """,
+            extraNamespaces: """
+
+              xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "colorgroup.3mf")
+
+        let color = try XCTUnwrap(MeshAsset.load(contentsOf: url).parts.first?.material?.baseColor)
+        assertEqual(
+            SIMD3(color.x, color.y, color.z),
+            SIMD3(Float(0x20) / 255, Float(0xC0) / 255, Float(0x5F) / 255),
+            accuracy: 0.01
+        )
+        XCTAssertEqual(color.w, 1, accuracy: 0.01)
+    }
+
+    // MARK: - Robustness
+
+    /// A package with no `<build>` still has objects, and showing nothing for it is
+    /// indistinguishable from a broken parser.
+    func testEmptyBuildFallsBackToTheObjects() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 2, 3)))
+                </object>
+            """,
+            build: ""
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "nobuild.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    func testOutOfRangeTriangleIndexIsRejected() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+                  <mesh>
+                    <vertices>
+                      <vertex x="0" y="0" z="0"/>
+                      <vertex x="1" y="0" z="0"/>
+                      <vertex x="1" y="1" z="0"/>
+                    </vertices>
+                    <triangles>
+                      <triangle v1="0" v2="1" v3="99"/>
+                    </triangles>
+                  </mesh>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "bad-index.3mf")
+
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url))
+    }
+
+    /// A 3MF is an untrusted file that arrives by AirDrop, email or a download. An XML
+    /// parser that resolves external entities turns opening one into a file read.
+    func testExternalEntitiesAreNotResolved() throws {
+        let hostFile = directory.appendingPathComponent("secret.txt")
+        try Data("TOP-SECRET-VALUE".utf8).write(to: hostFile)
+
+        let model = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE model [
+          <!ENTITY leak SYSTEM "file://\(hostFile.path)">
+        ]>
+        <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="1" type="model" name="&leak;">
+        \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+            </object>
+          </resources>
+          <build><item objectid="1"/></build>
+        </model>
+        """
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "xxe.3mf")
+
+        // Either the parse fails (the entity cannot be resolved, so the reference is an
+        // XML error) or it succeeds with the entity unresolved. Both are fine; what must
+        // never happen is the host file's contents reaching the caller, through the model
+        // *or* through the error message. Both branches assert, so neither is a free pass.
+        do {
+            for name in try MeshAsset.load(contentsOf: url).parts.map(\.name) {
+                XCTAssertFalse(name.contains("TOP-SECRET"), "external entity was resolved")
+            }
+        } catch {
+            XCTAssertFalse(
+                "\(error)".contains("TOP-SECRET"),
+                "external entity content leaked through the error"
+            )
+        }
+    }
+
+    /// An external DTD that is never fetched: with resolution off the declaration is
+    /// simply ignored, so the model still opens normally. This is the half of the XXE
+    /// defence that is easy to get wrong in the other direction — refusing every file
+    /// that merely *mentions* a DTD.
+    func testAnExternalDTDDoesNotBlockTheFile() throws {
+        let model = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE model SYSTEM "http://example.invalid/3mf.dtd">
+        <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="1" type="model">
+        \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+            </object>
+          </resources>
+          <build><item objectid="1"/></build>
+        </model>
+        """
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "external-dtd.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    // MARK: - Entity
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    /// End to end: a millimetre 3MF becomes a RealityKit mesh measured in metres.
+    @MainActor
+    func testModelNodeFrom3MFIsMetric() async throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(size: SIMD3(210, 100, 50)),
+            as: "print.3mf"
+        )
+        let node = try await ModelNode.load(contentsOf: url)
+        let mesh = try XCTUnwrap(node.entity.model?.mesh)
+        XCTAssertEqual(mesh.bounds.extents.x, 0.210, accuracy: 1e-4)
+        XCTAssertEqual(mesh.bounds.extents.y, 0.100, accuracy: 1e-4)
+        XCTAssertEqual(mesh.bounds.extents.z, 0.050, accuracy: 1e-4)
+    }
+    #endif
+
+    // MARK: -
+
+    private func assertEqual(
+        _ lhs: SIMD3<Float>,
+        _ rhs: SIMD3<Float>,
+        accuracy: Float,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.x, rhs.x, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.y, rhs.y, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.z, rhs.z, accuracy: accuracy, file: file, line: line)
+    }
+}

--- a/agents/sceneview-ios/SKILL.md
+++ b/agents/sceneview-ios/SKILL.md
@@ -26,6 +26,7 @@ metadata:
   - ply
   - mesh formats
   - 3d printing
+  - 3mf
 ---
 
 ## What SceneViewSwift is
@@ -67,7 +68,7 @@ Android-centric — prefer `cheatsheet-ios.md` for Swift.
 Trigger on any of:
 
 - "Build me a 3D viewer / AR app in SwiftUI."
-- "Load a `.usdz` / `.reality` / `.stl` / `.obj` / `.ply` model on iOS."
+- "Load a `.usdz` / `.reality` / `.stl` / `.obj` / `.ply` / `.3mf` model on iOS."
 - "Open an STL from Files / show a 3D print at real size in AR."
 - "Place a model on a detected AR plane in ARKit + SwiftUI."
 - "Add 3D content to a visionOS / macOS app with SceneView."
@@ -175,6 +176,11 @@ the wrong one.
 | `.stl` | ModelIO | **millimetres** |
 | `.obj` (+ `.mtl`) | ModelIO | metres |
 | `.ply` | ModelIO | metres |
+| `.3mf` | SceneViewSwift's own parser | **declared by the file** |
+
+`.3mf` is parsed by SceneViewSwift, not by Apple — `MDLAsset` does not read it and
+neither does Quick Look, even though it is the format 3D printing standardised
+on. It is also the only mesh format here that states its own unit.
 
 **glTF (`.glb` / `.gltf`) is NOT supported on Apple platforms.** Neither
 RealityKit nor ModelIO reads it. Convert to USDZ (Reality Converter,
@@ -202,6 +208,9 @@ let panel = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
 
 // PLY from a phone scanner, bundled with the app.
 let bust = try await ModelNode.load("scans/bust.ply", unit: .meters)
+
+// 3MF from a slicer — the file states its own unit, so pass none.
+let plate = try await ModelNode.load(contentsOf: threeMFURL)
 ```
 
 Measure before you render — parsing has no RealityKit dependency:

--- a/agents/sceneview-ios/SKILL.md
+++ b/agents/sceneview-ios/SKILL.md
@@ -21,6 +21,11 @@ metadata:
   - visionos
   - swift package manager
   - usdz
+  - stl
+  - obj
+  - ply
+  - mesh formats
+  - 3d printing
 ---
 
 ## What SceneViewSwift is
@@ -62,7 +67,8 @@ Android-centric — prefer `cheatsheet-ios.md` for Swift.
 Trigger on any of:
 
 - "Build me a 3D viewer / AR app in SwiftUI."
-- "Load a `.usdz` / `.glb` / `.gltf` / `.reality` model on iOS."
+- "Load a `.usdz` / `.reality` / `.stl` / `.obj` / `.ply` model on iOS."
+- "Open an STL from Files / show a 3D print at real size in AR."
 - "Place a model on a detected AR plane in ARKit + SwiftUI."
 - "Add 3D content to a visionOS / macOS app with SceneView."
 - "Convert this SceneKit / RealityView code to SceneViewSwift."
@@ -156,6 +162,63 @@ SceneView {
 .cameraControls(.orbit)
 ```
 
+## Model formats and units
+
+`ModelNode.load(contentsOf:unit:)` is the **one entry point for every supported
+format**. It sniffs the format from the file's own bytes before believing the
+extension — a model that arrived through a share sheet or a download often has
+the wrong one.
+
+| Format | Reader | Default unit |
+|---|---|---|
+| `.usdz` `.usda` `.usdc` `.usd` `.reality` | RealityKit | metres (already metric) |
+| `.stl` | ModelIO | **millimetres** |
+| `.obj` (+ `.mtl`) | ModelIO | metres |
+| `.ply` | ModelIO | metres |
+
+**glTF (`.glb` / `.gltf`) is NOT supported on Apple platforms.** Neither
+RealityKit nor ModelIO reads it. Convert to USDZ (Reality Converter,
+`usdzconvert`) or use the Android/web SDK. Do not emit Swift that loads a `.glb`.
+
+**Always reason about the unit.** STL, OBJ and PLY store bare numbers with no
+unit: a slicer STL means millimetres, a photogrammetry OBJ means metres.
+RealityKit works in metres, so getting this wrong puts a 21 cm print in the room
+at 210 m. `ModelFormat.carriesUnit` is `false` for exactly those three — that is
+the signal to ask the user, or to offer a mm/cm/in picker.
+
+One example per format — each compiles as written:
+
+```swift
+import SceneViewSwift
+
+// USDZ — already metric, `unit:` is ignored.
+let helmet = try await ModelNode.load("models/helmet.usdz")
+
+// STL — millimetres by default, so a 210 mm print is 0.21 m in AR.
+let printed = try await ModelNode.load(contentsOf: stlURL)
+
+// OBJ + .mtl sidecar, authored in centimetres.
+let panel = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+
+// PLY from a phone scanner, bundled with the app.
+let bust = try await ModelNode.load("scans/bust.ply", unit: .meters)
+```
+
+Measure before you render — parsing has no RealityKit dependency:
+
+```swift
+let asset = try MeshAsset.load(contentsOf: url)
+print(asset.format, asset.unit, asset.triangleCount)
+if let size = asset.boundsInMeters?.extents {
+    print("real size in metres:", size)   // the "will it fit?" number
+}
+let node = try await ModelNode(asset)     // then display it
+```
+
+Failures name the format: `ModelLoadingError.unsupportedFormat(fileExtension:)`
+carries the extension the user actually tried, so surface it
+("SceneView cannot open .fbx files yet") instead of a generic "load failed".
+
 ## The minimal correct AR example
 
 Verified against `samples/ios-demo/.../ARPlacementDemo.swift`. `ARSceneView` is
@@ -185,28 +248,33 @@ ARSceneView(
    nullable. Call it inside a SwiftUI `.task { }` (or another async context)
    and `try`/`try?` it. Store the result in `@State`.
 
-2. **RealityKit entities are `@MainActor`-isolated.** Never mutate an `Entity`
+2. **A unitless mesh format needs a `unit:`.** `.stl`, `.obj` and `.ply` carry no
+   unit; RealityKit is metric. Pass `unit:` when you know it, and default to the
+   format's own convention otherwise (mm for STL — see "Model formats and
+   units"). Never emit code that loads a `.glb` / `.gltf` on Apple platforms.
+
+3. **RealityKit entities are `@MainActor`-isolated.** Never mutate an `Entity`
    from `DispatchQueue.global()`. Use `await MainActor.run { }` to cross back.
    SwiftUI `.task` already runs on the main actor for view work.
 
-3. **`AnchorNode` factories are iOS-specific** — `AnchorNode.world(position:)`
+4. **`AnchorNode` factories are iOS-specific** — `AnchorNode.world(position:)`
    and `AnchorNode.plane(alignment:minimumBounds:)`. This differs from Android,
    where `AnchorNode` wraps a `com.google.ar.core.Anchor`. Do NOT translate the
    Android `AnchorNode(anchor:)` shape to Swift.
 
-4. **`GeometryNode` factories** are static methods: `.cube(size:color:)`,
+5. **`GeometryNode` factories** are static methods: `.cube(size:color:)`,
    `.sphere(radius:color:)`, `.cylinder(radius:height:color:)`,
    `.plane(width:depth:color:)`, `.cone(height:radius:color:)`, `.torus(...)`,
    `.capsule(...)`. There are NO `CubeNode` / `SphereNode` types — that naming
    is Android-only.
 
-5. **`LightNode` factories** are `.directional(color:intensity:castsShadow:)`,
+6. **`LightNode` factories** are `.directional(color:intensity:castsShadow:)`,
    `.point(color:intensity:attenuationRadius:)`,
    `.spot(color:intensity:innerAngle:outerAngle:)`. Position/aim via the fluent
    `.position(_:)` / `.lookAt(_:)` modifiers — not Android's `LightManager.Type`
    enum + `apply` lambda.
 
-6. **Some Android APIs do not port to RealityKit.** Before re-attacking a
+7. **Some Android APIs do not port to RealityKit.** Before re-attacking a
    deprecated symbol, consult the "iOS parity status (#1036)" tables in
    `cheatsheet-ios.md`: `CameraNode.exposure`, `CameraNode.depthOfField`, and
    `LightNode.shadowColor` are compile-warning no-ops on iOS;
@@ -216,10 +284,10 @@ ARSceneView(
    `SurfaceMirrorer` / `rememberSurfaceMirrorer()` (in-app scene→MP4 recording,
    #2626) is **Android-only** — on iOS record the scene via that same ReplayKit path.
 
-7. **`SceneView` is cross-platform (iOS/macOS/visionOS); `ARSceneView` is iOS
+8. **`SceneView` is cross-platform (iOS/macOS/visionOS); `ARSceneView` is iOS
    only.** macOS and visionOS get 3D but not the ARKit camera view.
 
-8. **Cloud Anchors on iOS are a wrapper you complete — not a missing feature.**
+9. **Cloud Anchors on iOS are a wrapper you complete — not a missing feature.**
    `CloudAnchorNode.host(ttlDays:completion:operation:)` /
    `.resolve(cloudAnchorId:completion:operation:)` and the cancellable
    `CloudAnchorFuture` are REAL SceneViewSwift API. By design the core library

--- a/changelog.d/3492-swift-3mf.md
+++ b/changelog.d/3492-swift-3mf.md
@@ -1,0 +1,41 @@
+<!-- category: Added -->
+- **SceneViewSwift reads 3MF — the format 3D printing standardised on and Apple never
+  shipped a reader for ([#3492](https://github.com/sceneview/sceneview/issues/3492)).**
+  `MDLAsset` reads OBJ, STL, PLY and USD; Quick Look reads USDZ and Reality; nothing on
+  the platform opens a `.3mf`, which is what a Bambu, Prusa or Orca user is handed and
+  what MakerWorld hands back. `ModelNode.load(contentsOf:)` now opens one like any other
+  file, and `ThreeMFDocument` is available directly for apps that want the geometry
+  without a scene.
+- **The parser covers what slicers actually write**, not just the happy path: `<model
+  unit>` in every unit the core spec defines, `<mesh>`, `<components>` composed through
+  their row-vector transforms, `<build><item>` placements, `<basematerials>` and the
+  materials extension's `<colorgroup>` resolved **per triangle** so a multi-colour print
+  comes back multi-colour, and Production-extension `p:path` references into other
+  `.model` parts of the package — which is how Bambu Studio and Orca write project files,
+  and the reason a reader that only ever opens `3D/3dmodel.model` shows an empty plate for
+  half the files in circulation. The root part is found through `_rels/.rels` rather than
+  assumed. A package whose `<build>` is empty falls back to its objects instead of
+  rendering nothing. 3MF declares its own unit, so it needs no `unit:` argument — passing
+  one overrides the file.
+- **A 3MF is an untrusted file**, and it is opened like one. The ZIP reader is
+  read-only, resolves entries by their exact recorded name (there is no path joining, so
+  `../` matches nothing rather than escaping), and refuses to inflate an entry over
+  256 MB. The XML parser refuses external entities outright
+  (`externalEntityResolvingPolicy = .never`) — without that, opening a file received by
+  AirDrop or email is a file-read primitive. An object that contains itself is reported,
+  not recursed into.
+<!-- RELEASE NOTE (maintainer-only):
+     No third-party dependency for either half. Foundation has no public ZIP API and
+     `NSFileCoordinator`'s archive support is macOS-only and disk-backed, so
+     `ZipArchiveReader` reads the central directory itself and inflates with the
+     `Compression` framework — `COMPRESSION_ZLIB` is Apple's name for the *raw* DEFLATE
+     stream a ZIP entry stores, and reaching for a header-expecting decoder there is the
+     classic way to get an empty result with no error. ZIP64 is refused with a named
+     reason rather than mis-parsed; a 3MF needs it only past 4 GB or 65 535 parts.
+     Two traps pinned by tests. (1) USDZ and 3MF are both ZIP archives, so the format
+     sniffer cannot stop at the `PK` magic — it reads the first entry's name (`*.usd*` →
+     USDZ, else 3MF). Getting this wrong hands every 3MF to RealityKit, which cannot read
+     it. (2) A 3MF `transform` is twelve numbers in row-vector order (`v' = v · M`, last
+     row = translation), so the file's rows become the *columns* of a `simd_float4x4`.
+     Transposing them scatters every placed part, and the symptom is wrong-looking
+     geometry rather than a parse error. -->

--- a/changelog.d/3492-swift-modelio-formats.md
+++ b/changelog.d/3492-swift-modelio-formats.md
@@ -1,0 +1,42 @@
+<!-- category: Added -->
+- **SceneViewSwift opens STL, OBJ and PLY, at real-world size
+  ([#3492](https://github.com/sceneview/sceneview/issues/3492)).** `ModelNode.load` was
+  USDZ and Reality only, which meant the Apple side could not open the files people
+  actually receive — a slicer's `.stl`, a scanner's `.ply`, a marketplace's `.obj`. It now
+  reads all three through ModelIO and is **one entry point for every format**:
+  `ModelFormat.sniff(contentsOf:)` reads the file's own bytes before believing its
+  extension, because a model that arrived through a share sheet, AirDrop or a download
+  routinely has the wrong one. `ModelLoadingError.unsupportedFormat` carries the extension
+  the user tried, so a viewer can say which format it was handed instead of "load failed".
+- **A unit, because these formats do not have one.** STL, OBJ and PLY store bare numbers:
+  the same coordinates mean millimetres out of a slicer and metres out of a photogrammetry
+  pipeline, and RealityKit is metric — so loading either without saying which is meant puts
+  a 21 cm print in the room at 210 m. `ModelNode.load(contentsOf:unit:)` takes a
+  `ModelUnit` (µm / mm / cm / in / ft / m), defaulting to **millimetres for STL** and metres
+  for OBJ and PLY, and bakes the conversion into the vertex positions so a caller's later
+  `.scale(_:)` is theirs alone. `ModelFormat.carriesUnit` is `false` for exactly those
+  three — the signal to offer a unit picker rather than guess.
+- **`MeshAsset` — geometry you can measure before you render it.** Parsing produces plain
+  Swift arrays with no RealityKit dependency, so `MeshAsset.load(contentsOf:)` runs off the
+  main actor and answers "how big is this, really?" (`boundsInMeters`, `triangleCount`)
+  before an entity exists. `ModelNode(_ asset:)` turns it into a `ModelEntity` with one
+  physically-based material per part; OBJ `.mtl` base colour, metallic and roughness are
+  carried across, quad faces are triangulated, and PLY per-vertex colours survive on
+  `MeshGeometry.colors` (averaged into the material tint, since RealityKit's
+  `MeshDescriptor` has no vertex-colour channel).
+<!-- RELEASE NOTE (maintainer-only):
+     Two ModelIO behaviours are worked around here rather than inherited, both measured on
+     Xcode 26.3 and pinned by tests. (1) `MDLMesh.addNormals` UNWELDS the mesh — a
+     4-vertex PLY quad comes back with 6 vertices and a rewritten index buffer, so any
+     vertex count read before the call is wrong afterwards. Missing normals are generated
+     by `MeshGeometry.generatingNormals()` instead, which keeps shared vertices shared.
+     (2) `vertexAttributeData(forAttributeNamed:as:)` converts the component *type* but not
+     the component *count*: asking a float3 colour attribute for `.float4` returns a buffer
+     sized and strided for float4 still holding tightly packed float3 data, so every vertex
+     after the first reads a third of a vertex out of step and a red/green/blue/white PLY
+     decodes as red/red/white/black. Attributes are now always requested in their native
+     component count and widened in Swift.
+     Also deliberate: the binary-STL test fixture's 80-byte header starts with the word
+     `solid`, which is what real exporters write. A prefix test alone reads such a file as
+     ASCII and yields an empty mesh; the sniffer uses the size arithmetic
+     (84 + 50 × triangleCount == fileSize) first. -->

--- a/llms.txt
+++ b/llms.txt
@@ -7431,7 +7431,7 @@ ARSceneView(
 
 ### Node types
 
-#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY)
+#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY / 3MF)
 
 ```swift
 public struct ModelNode: @unchecked Sendable {
@@ -7478,10 +7478,11 @@ public struct ModelNode: @unchecked Sendable {
 ```
 
 Key behaviors:
-- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit, and
-  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO. glTF is **not** supported.
-- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply`
-  is resolved to a URL and read by ModelIO instead.
+- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit,
+  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO, and `.3mf` through SceneViewSwift's
+  own parser. glTF is **not** supported.
+- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply` /
+  `.3mf` is resolved to a URL and parsed instead.
 - `load(from:)` downloads to a temp file, loads, then cleans up.
 - `scaleToUnits(_:)` mirrors Android's `ModelNode(scaleToUnits = 1f)`.
 - `centerOrigin(normalized:)` — **apply before positioning.** Unlike Android's `centerOrigin` (which composes additively — `position += translation`, independent of the current position), this reads the entity's **world** visual-bounds, so it does not compose with a previously-set position: call it on an unpositioned, unparented entity (load → scaleToUnits → centerOrigin, before `.position(_:)` or anchoring), and a later `.position(_:)` replaces the grounding offset.
@@ -7500,6 +7501,16 @@ extension only when the content is not decisive.
 | `.stl` | ModelIO | **millimetres** | ASCII and binary; no unit, no materials |
 | `.obj` | ModelIO | metres | `.mtl` sidecar picked up when next to the file; quad faces triangulated |
 | `.ply` | ModelIO | metres | ASCII and binary; per-vertex colours preserved |
+| `.3mf` | SceneViewSwift's own parser | **from the file** | Zip + XML; the only mesh format here that declares its own unit |
+
+**3MF is parsed by SceneViewSwift, not by Apple.** `MDLAsset` reads OBJ, STL, PLY and
+USD; Quick Look reads USDZ and Reality; nothing on the platform opens a `.3mf` — which is
+the format 3D printing standardised on. `ThreeMFDocument` is a minimal zip reader plus an
+`XMLParser` over the package's `.model` parts, covering `<model unit>`, `<mesh>`,
+`<components>` with row-vector transforms, `<build><item>`, `<basematerials>` and the
+materials extension's `<colorgroup>` resolved per triangle, and Production-extension
+`p:path` references into other parts (how Bambu Studio and Orca write project files).
+External XML entities are refused — an untrusted file must not become a file read.
 
 **The unit is the whole point.** STL, OBJ and PLY store bare numbers with no unit, and a
 slicer STL means millimetres while a photogrammetry OBJ means metres. RealityKit works in
@@ -7535,12 +7546,21 @@ let node = try await ModelNode(asset)                // then display it
 ```swift
 public enum ModelFormat: String, Sendable, CaseIterable {
     case usdz, reality, usda, usdc, usd, stl, obj, ply
+    case threeMF = "3mf"
     public var fileExtension: String                 // == rawValue
-    public var loader: Loader                        // .realityKit | .modelIO
+    public var loader: Loader                        // .realityKit | .modelIO | .sceneView
     public var defaultUnit: ModelUnit
     public var carriesUnit: Bool                     // false for stl/obj/ply — ask the user
     public init?(fileExtension: String)
     public static func sniff(contentsOf url: URL) throws -> ModelFormat
+}
+
+public struct ThreeMFDocument: Sendable {
+    public let unit: ModelUnit                       // as declared by the file
+    public let parts: [MeshGeometry]                 // one per object-and-material
+    public var triangleCount: Int
+    public static func read(contentsOf url: URL) throws -> ThreeMFDocument
+    public static func read(data: Data) throws -> ThreeMFDocument
 }
 
 public enum ModelUnit: String, Sendable, CaseIterable {
@@ -7588,6 +7608,11 @@ Gotchas worth knowing:
 - **A binary STL's 80-byte header often starts with the word `solid`.** Detecting ASCII by
   that prefix reads a binary file as empty; `sniff` uses the size arithmetic
   (`84 + 50 × triangleCount == fileSize`) first.
+- **USDZ and 3MF are both zip archives.** `sniff` tells them apart by the name of the
+  archive's first entry (`*.usd*` → USDZ, anything else → 3MF), not by the `PK` magic.
+- **A 3MF `transform` is twelve numbers in row-vector order** (`v' = v · M`, last row =
+  translation). Reading them as column-major transposes every placed part — the symptom is
+  scattered geometry, not a parse error.
 - **RealityKit's `MeshDescriptor` has no vertex-colour channel.** A coloured PLY keeps its
   full `colors` array on `MeshGeometry`, and `ModelNode` folds the *average* into the
   material tint so the model is not uniformly grey.

--- a/llms.txt
+++ b/llms.txt
@@ -6044,9 +6044,11 @@ public struct ModelNode: @unchecked Sendable {
     public var rotation: simd_quatf
     public var scale: SIMD3<Float>
 
-    public static func load(_ path: String, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(contentsOf url: URL, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(from remoteURL: URL, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    // Every loader sniffs the format from the file's own bytes and applies `unit`
+    // (STL/OBJ/PLY carry none). See "SceneViewSwift → Model formats and units".
+    public static func load(_ path: String, unit: ModelUnit? = nil, enableCollision: Bool = true, bundle: Bundle = .main) async throws -> ModelNode
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil, enableCollision: Bool = true) async throws -> ModelNode
+    public static func load(from remoteURL: URL, unit: ModelUnit? = nil, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
 
     // Transform (fluent)
     public func position(_ position: SIMD3<Float>) -> ModelNode
@@ -7429,16 +7431,18 @@ ARSceneView(
 
 ### Node types
 
-#### ModelNode — 3D model (USDZ / Reality)
+#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY)
 
 ```swift
 public struct ModelNode: @unchecked Sendable {
     public let entity: ModelEntity
 
-    // Loading (always @MainActor, async)
-    public static func load(_ path: String, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(contentsOf url: URL, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(from remoteURL: URL, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    // Loading (always @MainActor, async). One entry point per source; each sniffs the
+    // format from the file's own bytes, then applies `unit`. See "Model formats and units".
+    public static func load(_ path: String, unit: ModelUnit? = nil, enableCollision: Bool = true, bundle: Bundle = .main) async throws -> ModelNode
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil, enableCollision: Bool = true) async throws -> ModelNode
+    public static func load(from remoteURL: URL, unit: ModelUnit? = nil, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    public init(_ asset: MeshAsset, enableCollision: Bool = true) async throws
 
     // Transform (fluent / chainable)
     public func position(_ position: SIMD3<Float>) -> ModelNode
@@ -7474,11 +7478,123 @@ public struct ModelNode: @unchecked Sendable {
 ```
 
 Key behaviors:
-- Supports `.usdz` and `.reality` files natively. glTF support planned via GLTFKit2.
-- `load(_:)` calls `Entity(named:)` — file must be in the app bundle or an accessible URL.
+- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit, and
+  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO. glTF is **not** supported.
+- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply`
+  is resolved to a URL and read by ModelIO instead.
 - `load(from:)` downloads to a temp file, loads, then cleans up.
 - `scaleToUnits(_:)` mirrors Android's `ModelNode(scaleToUnits = 1f)`.
 - `centerOrigin(normalized:)` — **apply before positioning.** Unlike Android's `centerOrigin` (which composes additively — `position += translation`, independent of the current position), this reads the entity's **world** visual-bounds, so it does not compose with a previously-set position: call it on an unpositioned, unparented entity (load → scaleToUnits → centerOrigin, before `.position(_:)` or anchoring), and a later `.position(_:)` replaces the grounding offset.
+
+#### Model formats and units (`ModelFormat`, `ModelUnit`, `MeshAsset`)
+
+`ModelNode.load(contentsOf:unit:)` is the **single entry point for every supported
+format**. It never trusts the file extension on its own — a model that arrived through a
+share sheet, AirDrop or a download routinely has the wrong one — so
+`ModelFormat.sniff(contentsOf:)` reads the file's bytes first and falls back to the
+extension only when the content is not decisive.
+
+| Format | Reader | Default unit | Notes |
+|---|---|---|---|
+| `.usdz` `.usda` `.usdc` `.usd` `.reality` | RealityKit | metres | Already metric; `unit:` is ignored |
+| `.stl` | ModelIO | **millimetres** | ASCII and binary; no unit, no materials |
+| `.obj` | ModelIO | metres | `.mtl` sidecar picked up when next to the file; quad faces triangulated |
+| `.ply` | ModelIO | metres | ASCII and binary; per-vertex colours preserved |
+
+**The unit is the whole point.** STL, OBJ and PLY store bare numbers with no unit, and a
+slicer STL means millimetres while a photogrammetry OBJ means metres. RealityKit works in
+metres, so loading either without saying which is meant puts a 21 cm print in the room at
+210 m. The conversion is **baked into the vertex positions**, not left as an entity scale,
+so a later `.scale(_:)` is yours and does not destroy the correction.
+
+```swift
+import SceneViewSwift
+
+// A 3D-printing STL — millimetres by default, so this is 21 cm tall in AR.
+let part = try await ModelNode.load(contentsOf: stlURL)
+
+// A photogrammetry OBJ authored in centimetres.
+let scan = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+
+// A PLY from a phone scanner, straight from the app bundle.
+let bust = try await ModelNode.load("scans/bust.ply")
+```
+
+Measure a file **before** rendering it — parsing has no RealityKit dependency and runs off
+the main actor:
+
+```swift
+let asset = try MeshAsset.load(contentsOf: url)      // sniffs the format
+print(asset.format, asset.unit, asset.triangleCount) // e.g. stl millimeters 15234
+if let size = asset.boundsInMeters?.extents {
+    print("real size:", size)                        // metres, unit applied
+}
+let node = try await ModelNode(asset)                // then display it
+```
+
+```swift
+public enum ModelFormat: String, Sendable, CaseIterable {
+    case usdz, reality, usda, usdc, usd, stl, obj, ply
+    public var fileExtension: String                 // == rawValue
+    public var loader: Loader                        // .realityKit | .modelIO
+    public var defaultUnit: ModelUnit
+    public var carriesUnit: Bool                     // false for stl/obj/ply — ask the user
+    public init?(fileExtension: String)
+    public static func sniff(contentsOf url: URL) throws -> ModelFormat
+}
+
+public enum ModelUnit: String, Sendable, CaseIterable {
+    case micrometers, millimeters, centimeters, inches, feet, meters
+    public var metersPerUnit: Float
+    public var symbol: String                        // "mm", "cm", "in", "ft", "m", "µm"
+    public func convert(_ value: Float, to other: ModelUnit) -> Float
+}
+
+public struct MeshAsset: Sendable {
+    public let format: ModelFormat
+    public let unit: ModelUnit
+    public let parts: [MeshGeometry]                 // one per material
+    public var vertexCount: Int
+    public var triangleCount: Int
+    public var bounds: MeshBounds?                   // in `unit`
+    public var boundsInMeters: MeshBounds?           // real-world size
+    public func inMeters() -> MeshAsset
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil) throws -> MeshAsset
+}
+
+public struct MeshGeometry: Sendable {
+    public var name: String
+    public var positions: [SIMD3<Float>]
+    public var normals: [SIMD3<Float>]?              // nil when the file carried none
+    public var textureCoordinates: [SIMD2<Float>]?
+    public var colors: [SIMD4<Float>]?               // PLY per-vertex colours
+    public var indices: [UInt32]                     // always triangles
+    public var material: MeshMaterialDescription?
+    public var triangleCount: Int
+    public var bounds: MeshBounds?
+    public func generatingNormals() -> MeshGeometry  // flat-shaded, keeps vertices welded
+}
+
+public enum ModelLoadingError: Error, Equatable {
+    case unsupportedFormat(fileExtension: String)    // carries what the user tried to open
+    case unreadableFile(URL)
+    case malformed(reason: String)
+    case emptyMesh
+    case unreadableGeometry(reason: String)
+}
+```
+
+Gotchas worth knowing:
+- **A binary STL's 80-byte header often starts with the word `solid`.** Detecting ASCII by
+  that prefix reads a binary file as empty; `sniff` uses the size arithmetic
+  (`84 + 50 × triangleCount == fileSize`) first.
+- **RealityKit's `MeshDescriptor` has no vertex-colour channel.** A coloured PLY keeps its
+  full `colors` array on `MeshGeometry`, and `ModelNode` folds the *average* into the
+  material tint so the model is not uniformly grey.
+- **Normals are generated when a file has none** — by `MeshGeometry.generatingNormals()`,
+  not `MDLMesh.addNormals`, which unwelds the mesh (a 4-vertex quad comes back as 6).
+- `ModelLoadingError.unsupportedFormat` carries the extension, so a viewer can say
+  "SceneView cannot open .fbx files yet" and an app can count what its users actually try.
 
 #### LightNode — light source
 


### PR DESCRIPTION
Part 1 of #3492. Adds the STL / OBJ / PLY half of "SceneViewSwift opens the files people actually receive". 3MF (its own parser) and the demo app's *Open with* land in follow-ups on the same issue.

## Why

`ModelNode.load` read USDZ and Reality only. Those are the two formats an Apple user is *least* likely to be handed: a 3D print arrives as `.stl`, a phone scan as `.ply`, a marketplace download as `.obj`. Apple already ships a reader for all three — `MDLAsset` — it just was not wired up.

## What

**One entry point.** `ModelNode.load(contentsOf:unit:)` decides the format with `ModelFormat.sniff(contentsOf:)`, which reads the file's own bytes *before* believing its extension, because a model that came through a share sheet, AirDrop or a download routinely has the wrong one. Unsupported files throw `ModelLoadingError.unsupportedFormat(fileExtension:)` — carrying what the user tried, so a viewer can say "SceneView cannot open .fbx files yet" instead of "load failed".

**The unit is the point, not a parameter.** STL, OBJ and PLY store bare numbers with no unit: the same coordinates mean millimetres out of a slicer and metres out of a photogrammetry pipeline. RealityKit is metric, so loading either without saying which is meant puts a 21 cm print in the room at 210 m. `ModelUnit` (µm/mm/cm/in/ft/m) defaults to **millimetres for STL**, metres for OBJ and PLY, and the conversion is baked into the vertex positions so a caller's later `.scale(_:)` is theirs alone. `ModelFormat.carriesUnit` is `false` for exactly those three — the signal for an app to show a unit picker rather than guess.

**`MeshAsset` — measure before you render.** Parsing produces plain Swift arrays with no RealityKit dependency, so `MeshAsset.load(contentsOf:)` runs off the main actor and answers "how big is this, really?" (`boundsInMeters`, `triangleCount`) before an entity exists. `ModelNode(_ asset:)` then builds the `ModelEntity`: one physically-based material per part, OBJ `.mtl` base colour / metallic / roughness carried across, quad faces triangulated, PLY per-vertex colours preserved on `MeshGeometry.colors` and averaged into the tint (RealityKit's `MeshDescriptor` has no vertex-colour channel).

## Three deliberate decisions, each pinned by a test

1. **The binary-STL fixture's 80-byte header starts with the word `solid`** — because real exporters write that. A prefix test alone reads such a file as ASCII and returns an empty mesh, which is exactly how a viewer ends up showing nothing for a file every slicer opens. Sniffing uses the size arithmetic first: `84 + 50 × triangleCount == fileSize`.
2. **`MDLMesh.addNormals` is not used.** Measured on Xcode 26.3: it *unwelds* the mesh — a 4-vertex PLY quad comes back with 6 vertices and a rewritten index buffer — so any vertex count read before the call is wrong afterwards. Missing normals come from `MeshGeometry.generatingNormals()`, which keeps shared vertices shared.
3. **ModelIO attributes are always requested in their native component count.** `vertexAttributeData(forAttributeNamed:as:)` converts the component *type* but not the *count*: asking a float3 colour attribute for `.float4` returns a buffer sized and strided for float4 that still holds tightly packed float3 data, so every vertex after the first reads a third of a vertex out of step and a red/green/blue/white PLY decodes as red/red/white/black.

## Tests

21 new cases in `MeshFormatTests`, with fixtures generated in code (`MeshFixtures`) rather than checked in as binaries — the exact bytes are the thing under test, and a reviewer can read the generator and see where the expected numbers come from.

Measured locally on **iPhone 17 Pro Max, iOS 26.3, Xcode 26.3**:

```
xcodebuild test -scheme SceneViewSwift -destination "id=FA7716E5-…"
** TEST SUCCEEDED **  Executed 977 tests, 2 skipped, 0 failures (172.8 s)
```

`swift test` on macOS: 800 tests, 0 failures.

## Docs

`llms.txt` (iOS section only), `agents/sceneview-ios/SKILL.md` and `SceneViewSwift/README.md` all gain a "Model formats and units" section with one compiling example per format, and now say plainly that **glTF is not supported on Apple platforms** — the skill previously listed `.glb` / `.gltf` as loadable, which neither RealityKit nor ModelIO can do.

## Not in this PR

Rendering screenshots. This PR is library code with no visible surface of its own; the simulator captures of each format land with the demo-app PR, which is where a user can actually open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)