### PR TITLE
fix(demo): show an opened file's own name in the AR placement picker (#3482)

### DIFF
--- a/changelog.d/3482-ar-row-file-name.md
+++ b/changelog.d/3482-ar-row-file-name.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+- **An opened file reached the AR placement picker labelled `opened-model`
+  ([#3482](https://github.com/sceneview/sceneview/issues/3482)).** The staged copy is deliberately
+  named `opened-model` on disk — a display name comes from whichever app shared the file, so
+  putting it on a path would mean sanitising untrusted text — and AR derived its row label from
+  that path's basename. The user opened `rocket.3mf` and the picker offered them `opened-model`.
+  The viewer now carries the file's own name across to placement, next to the real-world size it
+  already measured.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
@@ -46,6 +46,17 @@ object DemoSettings {
      * `null` when nothing has been measured yet.
      */
     var openedModelSizeMeters: Float? by mutableStateOf(null)
+
+    /**
+     * The opened model's own file name, for the AR placement row's label.
+     *
+     * AR receives the file as a `file://` location, and the staged copy is deliberately named
+     * `opened-model` on disk (a display name comes from whichever app shared the file, so putting
+     * it on a path would mean sanitising untrusted text). The basename is therefore *not* the
+     * user's file name, and a picker row reading "opened-model" tells them nothing about the file
+     * they just opened. `null` when nothing has been opened.
+     */
+    var openedModelDisplayName: String? by mutableStateOf(null)
     /**
      * `true` = deterministic mode (no auto-orbit, no idle camera drift, no implicit
      * motion). `false` = full "wow" showcase mode. Default `false`.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -129,7 +129,10 @@ fun ARPlacementDemo(onBack: () -> Unit) {
         val location = requestedModel?.takeIf { it.startsWith("file://") } ?: return@remember null
         PlacementModel(
             id = "opened-file",
-            displayName = location.substringAfterLast('/').ifBlank { "Your file" },
+            // The viewer carries the user's own file name across; the location's basename is the
+            // staged copy's fixed name (`opened-model`), which would tell the user nothing.
+            displayName = DemoSettings.openedModelDisplayName
+                ?: location.substringAfterLast('/').ifBlank { "Your file" },
             assetLocation = location,
             realWorldSizeMeters = DemoSettings.openedModelSizeMeters
                 ?.takeIf { it.isFinite() && it > 0f }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -616,6 +616,9 @@ private fun SingleModelSection(
                     maxOf(extents.x, extents.y, extents.z).takeIf { it > 0f }
                 }
             }
+            // The staged file is called `opened-model` on disk, so AR cannot recover the user's
+            // file name from the location it is handed. Carry it across explicitly.
+            DemoSettings.openedModelDisplayName = openedModel?.displayName
             val model = openedModel?.location ?: selectedModel.assetPath
             DemoSettings.requestedRoute = "demo/ar-placement?model=$model"
         }, enabled = arSupported == true),


### PR DESCRIPTION
Found while re-verifying #3510 on the emulator after it merged.

## The bug

#3510 stages an incoming file under the fixed name `opened-model`. That is deliberate: a
display name comes from whichever app shared the file, so putting it on a path would mean
sanitising untrusted text into a filesystem location, and there is never more than one
opened model to hold.

AR placement receives only the `file://` location, and derived its picker row label from
that path's basename. So the user opens `rocket.3mf`, taps **View in AR**, and is offered
a model called `opened-model`.

The viewer's title was right — it reads `OpenedModel.displayName` directly — which is why
the earlier device pass caught the title and not this.

## The fix

The viewer already hands placement one thing the location cannot carry: the real-world size
it measured from the loaded bounds. The file's own name now travels the same way, in
`DemoSettings.openedModelDisplayName`, with the basename kept as the fallback.

## Verified

On `emulator-5554`: the rocket `.3mf` opens in the viewer titled `rocket.3mf`, and **View in
AR** now hands placement a row reading `Model — rocket.3mf` rather than `opened-model`.

`:samples:android-demo:assembleDebug` and `:samples:android-demo:detekt` green.

**Still not verified:** the AR session itself. This emulator reports "Google Play Services
for AR is installed, but this device could not start an AR session", so the handoff is
confirmed up to the armed placement screen, not to a model standing on a plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
