### PR TITLE
feat(ios): read 3MF in Swift — zip container plus core-spec XML (#3492)

### DIFF
--- a/SceneViewSwift/README.md
+++ b/SceneViewSwift/README.md
@@ -174,6 +174,14 @@ that arrived through a share sheet or a download often has the wrong one.
 | `.stl` (ASCII + binary) | ModelIO | **millimetres** |
 | `.obj` (+ `.mtl` sidecar) | ModelIO | metres |
 | `.ply` (ASCII + binary, vertex colours) | ModelIO | metres |
+| `.3mf` | SceneViewSwift's own parser | declared by the file |
+
+3MF is parsed here rather than by Apple: `MDLAsset` reads OBJ, STL, PLY and USD, Quick
+Look reads USDZ and Reality, and nothing on the platform opens the format 3D printing
+standardised on. `ThreeMFDocument` covers the core spec — units, meshes, components with
+row-vector transforms, build items, `<basematerials>` and `<colorgroup>` resolved per
+triangle — plus the Production extension's `p:path` references, which is how Bambu Studio
+and Orca write project files. External XML entities are refused.
 
 glTF (`.glb` / `.gltf`) is not supported on Apple platforms — neither RealityKit nor
 ModelIO reads it. Convert to USDZ first.

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/MeshAsset.swift
@@ -242,7 +242,7 @@ public struct MeshAsset: Sendable {
     /// Reads a mesh file into parts, choosing the reader from the file's own content.
     ///
     /// Handles the formats whose ``ModelFormat/loader`` is ``ModelFormat/Loader/modelIO``
-    /// — STL, OBJ and PLY. USD and Reality files
+    /// (STL, OBJ, PLY) or ``ModelFormat/Loader/sceneView`` (3MF). USD and Reality files
     /// are RealityKit's own business — they are rejected here with
     /// ``ModelLoadingError/unsupportedFormat(fileExtension:)`` and handled by
     /// `ModelNode.load(contentsOf:)`, which is the entry point that covers every format.
@@ -268,6 +268,12 @@ public struct MeshAsset: Sendable {
             let parts = try ModelIOMeshReader.read(contentsOf: url)
             guard !parts.isEmpty else { throw ModelLoadingError.emptyMesh }
             return MeshAsset(format: format, unit: unit ?? format.defaultUnit, parts: parts)
+        case .sceneView:
+            // 3MF is the only `.sceneView` format, and it declares its own unit — an
+            // explicit `unit:` overrides what the file says, which is what a "this was
+            // authored wrong" correction needs.
+            let document = try ThreeMFDocument.read(contentsOf: url)
+            return MeshAsset(format: format, unit: unit ?? document.unit, parts: document.parts)
         case .realityKit:
             throw ModelLoadingError.unsupportedFormat(fileExtension: format.fileExtension)
         }

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ModelFormat.swift
@@ -41,6 +41,13 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// No unit.
     case ply
 
+    // MARK: Parsed by SceneViewSwift
+
+    /// 3D Manufacturing Format — a zip container around an XML mesh description.
+    /// The only mesh format in this list that carries its own unit, and the only one
+    /// neither RealityKit nor ModelIO reads. See ``ThreeMFDocument``.
+    case threeMF = "3mf"
+
     /// The canonical lowercase file extension, without a dot.
     public var fileExtension: String { rawValue }
 
@@ -50,6 +57,8 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         case realityKit
         /// `MDLAsset` — Apple's ModelIO importer.
         case modelIO
+        /// SceneViewSwift's own parser.
+        case sceneView
     }
 
     /// The reader used for this format.
@@ -57,6 +66,7 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         switch self {
         case .usdz, .reality, .usda, .usdc, .usd: return .realityKit
         case .stl, .obj, .ply: return .modelIO
+        case .threeMF: return .sceneView
         }
     }
 
@@ -68,11 +78,13 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// - `.obj`, `.ply` → ``ModelUnit/meters``: also unitless, but their common sources
     ///   (photogrammetry, scanners, DCC exports) author in metres. Pass `unit:`
     ///   explicitly when you know better — that is what the parameter is for.
+    /// - `.threeMF` → ``ModelUnit/millimeters``: the 3MF core spec's own default for a
+    ///   missing `unit` attribute. A 3MF that *declares* a unit overrides this.
     /// - USD / Reality → ``ModelUnit/meters``: RealityKit has already applied the
     ///   asset's `metersPerUnit`.
     public var defaultUnit: ModelUnit {
         switch self {
-        case .stl: return .millimeters
+        case .stl, .threeMF: return .millimeters
         case .obj, .ply, .usdz, .reality, .usda, .usdc, .usd: return .meters
         }
     }
@@ -81,10 +93,10 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// ``ModelUnit`` a correction rather than a guess.
     ///
     /// Drives the "what unit is this?" prompt a viewer should show: ask for `.stl`,
-    /// `.obj` and `.ply`; stay quiet for USD.
+    /// `.obj` and `.ply`; stay quiet for `.3mf` and USD.
     public var carriesUnit: Bool {
         switch self {
-        case .usdz, .reality, .usda, .usdc, .usd: return true
+        case .threeMF, .usdz, .reality, .usda, .usdc, .usd: return true
         case .stl, .obj, .ply: return false
         }
     }
@@ -105,13 +117,15 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     /// Identifies the format of a file, by content first and file extension second.
     ///
     /// Content wins because the extension is the least reliable thing about a file that
-    /// reached the app through a share sheet, a download, or a messaging app.
+    /// reached the app through a share sheet, a download, or a messaging app — and
+    /// because two of these formats share a container: **USDZ and 3MF are both zip
+    /// archives**, told apart here by the name of the archive's first entry.
     ///
     /// The signatures that are treated as decisive:
     ///
     /// | Format | Evidence |
     /// |---|---|
-    /// | `.usdz` | `PK\x03\x04` — a zip whose first entry is a `.usd*` |
+    /// | `.usdz` / `.3mf` | `PK\x03\x04`, then the first entry's name (`*.usd*` → USDZ, else 3MF) |
     /// | `.stl` (binary) | `84 + 50 × triangleCount == fileSize` — checked **before** the ASCII test, because binary STLs routinely start with the word `solid` too |
     /// | `.stl` (ASCII) | starts with `solid` and the header is printable text |
     /// | `.ply` | starts with `ply` + newline |
@@ -162,15 +176,14 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
         guard !header.isEmpty else { return nil }
         let bytes = [UInt8](header)
 
-        // --- Zip container --------------------------------------------------------
-        // USDZ is a zip archive, and so are other 3D containers SceneViewSwift does not
-        // read, so the first entry's name decides rather than the `PK` magic alone.
+        // --- Zip container: USDZ and 3MF both live here ---------------------------
+        // USDZ stores its `.usdc` first and uncompressed; a 3MF's first entry is
+        // `[Content_Types].xml` or a `_rels`/`3D` part. Neither has a magic number of its
+        // own, so the first entry's name is the only evidence inside the probe window.
         if bytes.starts(with: [0x50, 0x4B, 0x03, 0x04]) {  // "PK\3\4"
-            if let name = zipFirstEntryName(bytes),
-               (name as NSString).pathExtension.lowercased().hasPrefix("usd") {
-                return .usdz
-            }
-            return nil
+            return zipFirstEntryName(bytes).map { name in
+                (name as NSString).pathExtension.lowercased().hasPrefix("usd") ? .usdz : .threeMF
+            } ?? .threeMF
         }
 
         // --- Binary STL: arithmetic, not a magic number ------------------------
@@ -206,7 +219,8 @@ public enum ModelFormat: String, Sendable, CaseIterable, Codable {
     ///
     /// Only the fixed 30-byte header is needed: bytes 26–27 are the name length and the
     /// name follows the header. Returns `nil` if the probe window does not contain the
-    /// whole name.
+    /// whole name — in which case ``sniff(header:fileSize:)`` falls back to 3MF, the
+    /// format for which a long first entry name is plausible.
     private static func zipFirstEntryName(_ bytes: [UInt8]) -> String? {
         guard bytes.count >= 30 else { return nil }
         let nameLength = Int(bytes[26]) | Int(bytes[27]) << 8

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFDocument.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFDocument.swift
@@ -1,0 +1,371 @@
+import Foundation
+import simd
+
+/// A 3MF file, read into geometry.
+///
+/// 3MF is the format the 3D-printing world moved to and the one Apple does not read:
+/// `MDLAsset` handles OBJ, STL, PLY and USD, Quick Look handles USDZ and Reality, and
+/// nothing on the platform opens a `.3mf`. So this is a parser, not a wrapper — a
+/// minimal ZIP reader (``ZipArchiveReader``) plus an `XMLParser` over the package's
+/// `.model` parts.
+///
+/// What it covers, which is what slicers and marketplaces actually write:
+///
+/// - `<model unit>` — every unit the core spec defines, defaulting to millimetres.
+/// - `<mesh>` — `<vertices>` and `<triangles>`.
+/// - `<components>` — objects placed inside objects, with row-vector transforms.
+/// - `<build><item>` — the placements that decide what is shown, with their transforms.
+/// - `<basematerials>` and the materials extension's `<colorgroup>`, resolved per
+///   triangle so a multi-colour print comes back multi-colour.
+/// - Production-extension `p:path` references into other `.model` parts of the package —
+///   how Bambu Studio and Orca write project files.
+///
+/// ```swift
+/// let document = try ThreeMFDocument.read(contentsOf: url)
+/// print(document.unit, document.parts.count)
+///
+/// // Or, more usually, just open it like anything else:
+/// let node = try await ModelNode.load(contentsOf: url)
+/// ```
+public struct ThreeMFDocument: Sendable {
+
+    /// The unit the file declares — ``ModelUnit/millimeters`` when it declares none.
+    public let unit: ModelUnit
+
+    /// One part per object-and-material combination, in build order, with every
+    /// transform along the component chain already baked into the positions.
+    public let parts: [MeshGeometry]
+
+    /// Total triangles across every part.
+    public var triangleCount: Int { parts.reduce(0) { $0 + $1.triangleCount } }
+
+    /// Reads a `.3mf` file.
+    ///
+    /// - Throws: ``ModelLoadingError``.
+    public static func read(contentsOf url: URL) throws -> ThreeMFDocument {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            throw ModelLoadingError.unreadableFile(url)
+        }
+        return try read(data: data)
+    }
+
+    /// Reads a 3MF package already in memory.
+    public static func read(data: Data) throws -> ThreeMFDocument {
+        let archive = try ZipArchiveReader(data: data)
+        var loader = ThreeMFLoader(archive: archive)
+        return try loader.load()
+    }
+}
+
+/// Resolves a 3MF package's build items into flat geometry.
+///
+/// A separate type because the resolution is stateful: parts are parsed on demand and
+/// cached, and the component graph has to be walked with a visited set — a package may
+/// legally reference the same object many times, and an illegal one may reference itself.
+struct ThreeMFLoader {
+
+    private let archive: ZipArchiveReader
+    private var parts: [String: ThreeMFModelPart] = [:]
+
+    /// The default location of the root model part. Used when `_rels/.rels` is missing
+    /// or names nothing readable — a fallback the whole ecosystem relies on.
+    static let conventionalRootPath = "3D/3dmodel.model"
+
+    /// How deep a component chain may nest before it is called a cycle. Real packages
+    /// nest two or three levels; the visited set below catches direct recursion, and
+    /// this catches a chain that grows without repeating a pair.
+    static let maximumComponentDepth = 32
+
+    init(archive: ZipArchiveReader) {
+        self.archive = archive
+    }
+
+    mutating func load() throws -> ThreeMFDocument {
+        let rootPath = rootModelPath()
+        let root = try part(at: rootPath)
+
+        var geometries: [MeshGeometry] = []
+        for item in root.buildItems {
+            try append(
+                objectID: item.objectID,
+                partPath: normalize(item.path) ?? rootPath,
+                transform: item.transform,
+                depth: 0,
+                visiting: [],
+                into: &geometries
+            )
+        }
+
+        // A package whose `<build>` is empty still has objects, and a viewer that shows
+        // nothing for it is indistinguishable from a broken parser. Falling back to every
+        // mesh object in the root part is what slicers do.
+        if geometries.isEmpty {
+            for id in root.objects.keys.sorted() {
+                try append(
+                    objectID: id,
+                    partPath: rootPath,
+                    transform: matrix_identity_float4x4,
+                    depth: 0,
+                    visiting: [],
+                    into: &geometries
+                )
+            }
+        }
+
+        guard !geometries.isEmpty else { throw ModelLoadingError.emptyMesh }
+        return ThreeMFDocument(unit: root.unit, parts: geometries)
+    }
+
+    // MARK: - Package layout
+
+    /// The root `.model` part, from the package relationships when they name one.
+    private func rootModelPath() -> String {
+        guard let rels = try? archive.contents(named: "_rels/.rels") ?? Data(),
+              !rels.isEmpty,
+              let target = PackageRelationshipsParser.rootModelTarget(rels),
+              let normalized = normalize(target),
+              archive.entry(named: normalized) != nil else {
+            return Self.conventionalRootPath
+        }
+        return normalized
+    }
+
+    /// Package part names are absolute (`/3D/3dmodel.model`); ZIP entry names are not.
+    private func normalize(_ path: String?) -> String? {
+        guard var path, !path.isEmpty else { return nil }
+        while path.hasPrefix("/") { path.removeFirst() }
+        return path.isEmpty ? nil : path
+    }
+
+    private mutating func part(at path: String) throws -> ThreeMFModelPart {
+        if let cached = parts[path] { return cached }
+        guard let data = try archive.contents(named: path) else {
+            throw ModelLoadingError.malformed(reason: "3MF package has no part named \(path)")
+        }
+        let parsed = try ThreeMFModelParser.parse(data)
+        parts[path] = parsed
+        return parsed
+    }
+
+    // MARK: - Resolution
+
+    /// Walks one object, emitting its mesh and recursing into its components.
+    ///
+    /// `visiting` holds the (part, object) pairs on the current path, so an object that
+    /// contains itself — directly or through a chain — is reported instead of recursed
+    /// into forever. A *repeated* reference on separate branches is legal and stays legal.
+    private mutating func append(
+        objectID: Int,
+        partPath: String,
+        transform: simd_float4x4,
+        depth: Int,
+        visiting: Set<String>,
+        into geometries: inout [MeshGeometry]
+    ) throws {
+        guard depth <= Self.maximumComponentDepth else {
+            throw ModelLoadingError.malformed(reason: "3MF component nesting is too deep")
+        }
+        let key = "\(partPath)#\(objectID)"
+        guard !visiting.contains(key) else {
+            throw ModelLoadingError.malformed(reason: "3MF object \(objectID) contains itself")
+        }
+
+        let model = try part(at: partPath)
+        guard let object = model.objects[objectID] else {
+            // A build item pointing at a missing object is a broken package, but the
+            // rest of the plate is still worth showing.
+            return
+        }
+
+        if !object.triangles.isEmpty {
+            geometries.append(contentsOf: try meshGeometries(
+                of: object,
+                in: model,
+                transform: transform
+            ))
+        }
+
+        var nextVisiting = visiting
+        nextVisiting.insert(key)
+        for component in object.components {
+            try append(
+                objectID: component.objectID,
+                partPath: normalize(component.path) ?? partPath,
+                // The component's own transform applies first, then the parent's — the
+                // same composition order as a scene graph read from the root down.
+                transform: transform * component.transform,
+                depth: depth + 1,
+                visiting: nextVisiting,
+                into: &geometries
+            )
+        }
+    }
+
+    /// Turns one object's mesh into geometry, split by material.
+    ///
+    /// Triangles are grouped by the colour they resolve to, and each group becomes its
+    /// own ``MeshGeometry`` with only the vertices it uses. A single-material object —
+    /// the common case — takes the one-group path and keeps its vertex array intact.
+    private func meshGeometries(
+        of object: ThreeMFObject,
+        in model: ThreeMFModelPart,
+        transform: simd_float4x4
+    ) throws -> [MeshGeometry] {
+        let vertexCount = object.vertices.count
+        let positions: [SIMD3<Float>]
+        if transform == matrix_identity_float4x4 {
+            positions = object.vertices
+        } else {
+            positions = object.vertices.map { vertex in
+                let transformed = transform * SIMD4<Float>(vertex, 1)
+                return SIMD3<Float>(transformed.x, transformed.y, transformed.z)
+            }
+        }
+
+        // Group triangles by resolved colour. `nil` is "no material", which is its own
+        // group so an object with some painted and some bare triangles keeps both.
+        var groups: [ThreeMFColorKey: [UInt32]] = [:]
+        var groupOrder: [ThreeMFColorKey] = []
+        for triangle in object.triangles {
+            guard triangle.v1 >= 0, triangle.v1 < vertexCount,
+                  triangle.v2 >= 0, triangle.v2 < vertexCount,
+                  triangle.v3 >= 0, triangle.v3 < vertexCount else {
+                throw ModelLoadingError.malformed(
+                    reason: "3MF object \(object.id) has a triangle index out of range"
+                )
+            }
+            let key = ThreeMFColorKey(
+                color: color(for: triangle, of: object, in: model)
+            )
+            if groups[key] == nil {
+                groups[key] = []
+                groupOrder.append(key)
+            }
+            groups[key]?.append(contentsOf: [
+                UInt32(triangle.v1), UInt32(triangle.v2), UInt32(triangle.v3)
+            ])
+        }
+
+        let name = object.name.isEmpty ? "object-\(object.id)" : object.name
+        return groupOrder.enumerated().compactMap { index, key in
+            guard let indices = groups[key], !indices.isEmpty else { return nil }
+            let material = key.color.map {
+                MeshMaterialDescription(name: "3mf-\(object.id)-\(index)", baseColor: $0)
+            }
+            let partName = groupOrder.count == 1 ? name : "\(name)-\(index)"
+            guard groupOrder.count > 1 else {
+                return MeshGeometry(
+                    name: partName,
+                    positions: positions,
+                    indices: indices,
+                    material: material
+                )
+            }
+            return Self.compacted(
+                name: partName,
+                positions: positions,
+                indices: indices,
+                material: material
+            )
+        }
+    }
+
+    /// The colour a triangle resolves to: its own `pid`/`p1` when it has them, otherwise
+    /// the object's `pid`/`pindex`, otherwise none.
+    private func color(
+        for triangle: ThreeMFTriangle,
+        of object: ThreeMFObject,
+        in model: ThreeMFModelPart
+    ) -> SIMD4<Float>? {
+        let groupID = triangle.propertyGroup ?? object.propertyGroup
+        let index = triangle.propertyIndex ?? object.propertyIndex ?? 0
+        guard let groupID, let colors = model.propertyGroups[groupID],
+              index >= 0, index < colors.count else { return nil }
+        return colors[index]
+    }
+
+    /// Rebuilds a material group's vertex array so it holds only the vertices it uses.
+    private static func compacted(
+        name: String,
+        positions: [SIMD3<Float>],
+        indices: [UInt32],
+        material: MeshMaterialDescription?
+    ) -> MeshGeometry {
+        var remap: [UInt32: UInt32] = [:]
+        var newPositions: [SIMD3<Float>] = []
+        var newIndices: [UInt32] = []
+        newIndices.reserveCapacity(indices.count)
+        for original in indices {
+            if let existing = remap[original] {
+                newIndices.append(existing)
+                continue
+            }
+            let next = UInt32(newPositions.count)
+            remap[original] = next
+            newPositions.append(positions[Int(original)])
+            newIndices.append(next)
+        }
+        return MeshGeometry(
+            name: name,
+            positions: newPositions,
+            indices: newIndices,
+            material: material
+        )
+    }
+}
+
+/// A hashable stand-in for an optional colour, so triangles can be grouped by material.
+private struct ThreeMFColorKey: Hashable {
+    let red: Float
+    let green: Float
+    let blue: Float
+    let alpha: Float
+    let hasColor: Bool
+
+    init(color: SIMD4<Float>?) {
+        hasColor = color != nil
+        let value = color ?? .zero
+        red = value.x
+        green = value.y
+        blue = value.z
+        alpha = value.w
+    }
+
+    var color: SIMD4<Float>? {
+        hasColor ? SIMD4<Float>(red, green, blue, alpha) : nil
+    }
+}
+
+/// Reads `_rels/.rels` to find the package's root model part.
+private final class PackageRelationshipsParser: NSObject, XMLParserDelegate {
+
+    /// The OPC relationship type every 3MF writer uses for the root model.
+    private static let modelRelationshipSuffix = "/3dmodel"
+
+    private var target: String?
+
+    /// The `Target` of the first relationship whose `Type` names the 3D model, or `nil`.
+    static func rootModelTarget(_ data: Data) -> String? {
+        let delegate = PackageRelationshipsParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldResolveExternalEntities = false
+        parser.externalEntityResolvingPolicy = .never
+        parser.parse()
+        return delegate.target
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String]
+    ) {
+        guard target == nil,
+              elementName.split(separator: ":").last.map(String.init) == "Relationship",
+              let type = attributes["Type"],
+              type.lowercased().hasSuffix(Self.modelRelationshipSuffix) else { return }
+        target = attributes["Target"]
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelParser.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelParser.swift
@@ -1,0 +1,207 @@
+import Foundation
+import simd
+
+/// Streaming parser for one 3MF `.model` XML part.
+///
+/// `XMLParser` rather than a DOM: a printable model's `<triangles>` list runs to
+/// hundreds of thousands of elements, and building a node tree for it costs several times
+/// the memory of the arrays that are actually wanted.
+///
+/// **External entities are refused.** A 3MF is an untrusted file that arrives by AirDrop,
+/// email or a download, and an XML parser that resolves entities is a file-read and
+/// SSRF primitive (the "billion laughs" and XXE families). `externalEntityResolvingPolicy
+/// = .never` plus `shouldResolveExternalEntities = false` is what keeps this a parser and
+/// not a fetcher.
+final class ThreeMFModelParser: NSObject, XMLParserDelegate {
+
+    private var part = ThreeMFModelPart()
+    private var currentObject: ThreeMFObject?
+    /// The `<basematerials>` / `<colorgroup>` currently being filled, and its colours.
+    private var currentPropertyGroupID: Int?
+    private var currentPropertyColors: [SIMD4<Float>] = []
+    private var parseError: Error?
+
+    /// Parses one `.model` part.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` when the XML is invalid.
+    static func parse(_ data: Data) throws -> ThreeMFModelPart {
+        let delegate = ThreeMFModelParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldResolveExternalEntities = false
+        parser.externalEntityResolvingPolicy = .never
+        // Namespace prefixes are kept: the Production extension's attribute is literally
+        // `p:path`, and `attributeName(_:)` below matches on the local name either way.
+        parser.shouldProcessNamespaces = false
+
+        guard parser.parse() else {
+            let reason = delegate.parseError.map { String(describing: $0) }
+                ?? parser.parserError.map { String(describing: $0) }
+                ?? "invalid XML"
+            throw ModelLoadingError.malformed(reason: "3MF model XML: \(reason)")
+        }
+        if let parseError = delegate.parseError { throw parseError }
+        return delegate.part
+    }
+
+    // MARK: - XMLParserDelegate
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String]
+    ) {
+        switch localName(elementName) {
+        case "model":
+            // A `unit` the spec does not define falls back to millimetres rather than
+            // failing the file — the same forgiveness slicers show, and the alternative
+            // is refusing to open a model over one misspelled word.
+            part.unit = attributes["unit"].flatMap(ModelUnit.init(threeMFUnit:)) ?? .millimeters
+
+        case "object":
+            guard let id = integer(attributes, "id") else { return }
+            var object = ThreeMFObject(id: id)
+            object.name = attributes["name"] ?? ""
+            object.propertyGroup = integer(attributes, "pid")
+            object.propertyIndex = integer(attributes, "pindex")
+            currentObject = object
+
+        case "vertex":
+            guard var object = currentObject,
+                  let x = float(attributes, "x"),
+                  let y = float(attributes, "y"),
+                  let z = float(attributes, "z") else { return }
+            object.vertices.append(SIMD3<Float>(x, y, z))
+            currentObject = object
+
+        case "triangle":
+            guard var object = currentObject,
+                  let v1 = integer(attributes, "v1"),
+                  let v2 = integer(attributes, "v2"),
+                  let v3 = integer(attributes, "v3") else { return }
+            object.triangles.append(ThreeMFTriangle(
+                v1: v1,
+                v2: v2,
+                v3: v3,
+                propertyGroup: integer(attributes, "pid"),
+                propertyIndex: integer(attributes, "p1")
+            ))
+            currentObject = object
+
+        case "component":
+            guard var object = currentObject,
+                  let objectID = integer(attributes, "objectid") else { return }
+            object.components.append(ThreeMFComponent(
+                objectID: objectID,
+                path: attributeValue(attributes, "path"),
+                transform: transform(attributes)
+            ))
+            currentObject = object
+
+        case "item":
+            guard let objectID = integer(attributes, "objectid") else { return }
+            part.buildItems.append(ThreeMFBuildItem(
+                objectID: objectID,
+                path: attributeValue(attributes, "path"),
+                transform: transform(attributes)
+            ))
+
+        case "basematerials", "colorgroup":
+            currentPropertyGroupID = integer(attributes, "id")
+            currentPropertyColors = []
+
+        case "base":
+            // `<base displaycolor="#RRGGBB[AA]">` — the core spec's material colour.
+            if let color = Self.color(from: attributes["displaycolor"]) {
+                currentPropertyColors.append(color)
+            }
+
+        case "color":
+            // `<m:color color="#RRGGBB[AA]">` — the materials extension's colour group,
+            // which is what a multi-colour slicer project actually uses.
+            if let color = Self.color(from: attributes["color"]) {
+                currentPropertyColors.append(color)
+            }
+
+        default:
+            break
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?
+    ) {
+        switch localName(elementName) {
+        case "object":
+            if let object = currentObject { part.objects[object.id] = object }
+            currentObject = nil
+        case "basematerials", "colorgroup":
+            if let id = currentPropertyGroupID, !currentPropertyColors.isEmpty {
+                part.propertyGroups[id] = currentPropertyColors
+            }
+            currentPropertyGroupID = nil
+            currentPropertyColors = []
+        default:
+            break
+        }
+    }
+
+    func parser(_ parser: XMLParser, parseErrorOccurred error: any Error) {
+        parseError = ModelLoadingError.malformed(reason: "3MF model XML: \(error)")
+    }
+
+    // MARK: - Attribute helpers
+
+    /// Strips a namespace prefix: `p:path` → `path`, `m:color` → `color`.
+    private func localName(_ name: String) -> String {
+        name.split(separator: ":").last.map(String.init) ?? name
+    }
+
+    /// An attribute by local name, so `path` matches `p:path`, `P:path`, or a writer
+    /// that declared the Production namespace as the default.
+    private func attributeValue(_ attributes: [String: String], _ name: String) -> String? {
+        if let direct = attributes[name] { return direct }
+        return attributes.first { localName($0.key) == name }?.value
+    }
+
+    private func integer(_ attributes: [String: String], _ name: String) -> Int? {
+        attributeValue(attributes, name).flatMap { Int($0) }
+    }
+
+    private func float(_ attributes: [String: String], _ name: String) -> Float? {
+        attributeValue(attributes, name).flatMap { Float($0) }
+    }
+
+    private func transform(_ attributes: [String: String]) -> simd_float4x4 {
+        attributeValue(attributes, "transform")
+            .flatMap(simd_float4x4.init(threeMFTransform:)) ?? matrix_identity_float4x4
+    }
+
+    /// Parses `#RRGGBB` or `#RRGGBBAA` into linear-ish RGBA in `0...1`.
+    static func color(from text: String?) -> SIMD4<Float>? {
+        guard var hex = text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        guard hex.count == 6 || hex.count == 8, let value = UInt32(hex, radix: 16) else {
+            return nil
+        }
+        if hex.count == 6 {
+            return SIMD4<Float>(
+                Float((value >> 16) & 0xFF) / 255,
+                Float((value >> 8) & 0xFF) / 255,
+                Float(value & 0xFF) / 255,
+                1
+            )
+        }
+        return SIMD4<Float>(
+            Float((value >> 24) & 0xFF) / 255,
+            Float((value >> 16) & 0xFF) / 255,
+            Float((value >> 8) & 0xFF) / 255,
+            Float(value & 0xFF) / 255
+        )
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelPart.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ThreeMFModelPart.swift
@@ -1,0 +1,81 @@
+import Foundation
+import simd
+
+/// One `.model` XML part inside a 3MF container, as parsed.
+///
+/// A 3MF is an OPC (zip) package, and the Production extension lets a package split its
+/// model across several `.model` parts that reference each other by `p:path` — which is
+/// how Bambu Studio and Orca write project files. So "the model" is a part, not the
+/// document, and ``ThreeMFLoader`` resolves references across parts.
+struct ThreeMFModelPart {
+    /// `<model unit="…">`, defaulting to millimetres per the core spec.
+    var unit: ModelUnit = .millimeters
+    /// Objects by their `id`, which is unique within a part (not across parts).
+    var objects: [Int: ThreeMFObject] = [:]
+    /// `<build><item>` — what the package actually asks to be shown.
+    var buildItems: [ThreeMFBuildItem] = []
+    /// Property groups by `id`: `<basematerials>` and the materials extension's
+    /// `<colorgroup>`, flattened to the colours they resolve to.
+    var propertyGroups: [Int: [SIMD4<Float>]] = [:]
+}
+
+/// A `<object>`: either a mesh, or a group of `<component>` references, or both.
+struct ThreeMFObject {
+    var id: Int
+    var name: String = ""
+    /// `pid` / `pindex` — the object's default property group and index within it.
+    var propertyGroup: Int?
+    var propertyIndex: Int?
+    var vertices: [SIMD3<Float>] = []
+    var triangles: [ThreeMFTriangle] = []
+    var components: [ThreeMFComponent] = []
+}
+
+/// A `<triangle>`, with the optional per-triangle property reference that makes
+/// multi-colour prints multi-colour.
+struct ThreeMFTriangle {
+    var v1: Int
+    var v2: Int
+    var v3: Int
+    /// `pid` — overrides the object's property group for this triangle.
+    var propertyGroup: Int?
+    /// `p1` — index within the group. The spec also defines `p2`/`p3` for per-vertex
+    /// interpolation; a flat `p1` fill is what slicers write and what is read here.
+    var propertyIndex: Int?
+}
+
+/// A `<component>` — another object placed with a transform, possibly in another part.
+struct ThreeMFComponent {
+    var objectID: Int
+    /// Production-extension `p:path`, e.g. `/3D/Objects/object_1.model`.
+    var path: String?
+    var transform: simd_float4x4 = matrix_identity_float4x4
+}
+
+/// A `<build><item>` — the top-level placement of an object.
+struct ThreeMFBuildItem {
+    var objectID: Int
+    var path: String?
+    var transform: simd_float4x4 = matrix_identity_float4x4
+}
+
+extension simd_float4x4 {
+    /// Parses a 3MF `transform` attribute.
+    ///
+    /// 3MF writes a 4×3 matrix as twelve numbers in **row-major, row-vector** order —
+    /// `m00 m01 m02 m10 m11 m12 m20 m21 m22 m30 m31 m32`, where a point is transformed as
+    /// `v' = v · M` and the last row is the translation. `simd_float4x4` is
+    /// column-major and multiplies as `M · v`, so the rows of the file become the
+    /// **columns** here. Getting this backwards transposes every placed part — the
+    /// failure looks like scattered geometry, not like a broken parser.
+    init?(threeMFTransform text: String) {
+        let values = text.split(whereSeparator: \.isWhitespace).compactMap { Float($0) }
+        guard values.count == 12 else { return nil }
+        self.init(
+            SIMD4<Float>(values[0], values[1], values[2], 0),
+            SIMD4<Float>(values[3], values[4], values[5], 0),
+            SIMD4<Float>(values[6], values[7], values[8], 0),
+            SIMD4<Float>(values[9], values[10], values[11], 1)
+        )
+    }
+}

--- a/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ZipArchiveReader.swift
+++ b/SceneViewSwift/Sources/SceneViewSwift/Loading/ThreeMF/ZipArchiveReader.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Compression
+
+/// A read-only ZIP reader, just large enough for a 3MF container.
+///
+/// SceneViewSwift takes no third-party dependencies, and Foundation has no public ZIP
+/// API — `NSFileCoordinator`'s archive support is macOS-only and writes to disk. So this
+/// reads the central directory itself and inflates entries with the `Compression`
+/// framework, which is a few hundred lines and keeps the package dependency-free.
+///
+/// Scope is deliberately narrow: the stored (0) and deflate (8) methods, which is
+/// everything a 3MF writer emits. It never writes files, and it resolves entries by the
+/// exact name recorded in the archive — there is no path joining, so a `../` in an entry
+/// name is a name that matches nothing rather than a traversal.
+struct ZipArchiveReader {
+
+    /// One entry in the central directory.
+    struct Entry {
+        /// The name as recorded in the archive, e.g. `3D/3dmodel.model`.
+        let name: String
+        /// 0 = stored, 8 = deflate.
+        let compressionMethod: UInt16
+        let compressedSize: Int
+        let uncompressedSize: Int
+        /// Byte offset of this entry's local file header.
+        let localHeaderOffset: Int
+    }
+
+    private let data: Data
+    /// Entries by name, in central-directory order.
+    let entries: [Entry]
+
+    /// Refuses to inflate an entry larger than this. A 3MF's XML is text: 256 MB of it
+    /// is already far past anything a printer or a phone will do something useful with,
+    /// and the cap is what stops a deliberately crafted archive from claiming a
+    /// multi-gigabyte uncompressed size and having the allocation attempted.
+    static let maximumEntrySize = 256 * 1024 * 1024
+
+    /// Parses the archive's central directory.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` when the file is not a
+    ///   readable ZIP.
+    init(data: Data) throws {
+        self.data = data
+        self.entries = try Self.readCentralDirectory(data)
+    }
+
+    /// The entry with this exact name, or `nil`.
+    func entry(named name: String) -> Entry? {
+        entries.first { $0.name == name }
+    }
+
+    /// The decompressed content of an entry.
+    ///
+    /// - Throws: ``ModelLoadingError/malformed(reason:)`` for a truncated entry, an
+    ///   unsupported compression method, or a failed inflate.
+    func contents(of entry: Entry) throws -> Data {
+        guard entry.uncompressedSize <= Self.maximumEntrySize else {
+            throw ModelLoadingError.malformed(
+                reason: "archive entry \(entry.name) is \(entry.uncompressedSize) bytes, over the limit"
+            )
+        }
+        // The local header repeats the name and extra fields, and its lengths are the
+        // ones that count — a writer may pad the local extra field differently from the
+        // central one, so the payload offset cannot be derived from the central entry.
+        let headerStart = entry.localHeaderOffset
+        guard headerStart >= 0, headerStart + 30 <= data.count,
+              readUInt32(at: headerStart) == 0x0403_4B50 else {
+            throw ModelLoadingError.malformed(reason: "bad local header for \(entry.name)")
+        }
+        let nameLength = Int(readUInt16(at: headerStart + 26))
+        let extraLength = Int(readUInt16(at: headerStart + 28))
+        let payloadStart = headerStart + 30 + nameLength + extraLength
+        guard payloadStart + entry.compressedSize <= data.count else {
+            throw ModelLoadingError.malformed(reason: "truncated entry \(entry.name)")
+        }
+        let payload = data.subdata(in: payloadStart..<(payloadStart + entry.compressedSize))
+
+        switch entry.compressionMethod {
+        case 0:
+            return payload
+        case 8:
+            return try inflate(payload, uncompressedSize: entry.uncompressedSize, name: entry.name)
+        default:
+            throw ModelLoadingError.malformed(
+                reason: "entry \(entry.name) uses unsupported compression method \(entry.compressionMethod)"
+            )
+        }
+    }
+
+    /// The decompressed content of the entry with this name, or `nil` when absent.
+    func contents(named name: String) throws -> Data? {
+        guard let entry = entry(named: name) else { return nil }
+        return try contents(of: entry)
+    }
+
+    // MARK: - Inflate
+
+    /// Raw DEFLATE, via the `Compression` framework.
+    ///
+    /// `COMPRESSION_ZLIB` is Apple's name for *raw* DEFLATE — no zlib header, no
+    /// checksum — which is exactly what a ZIP entry stores. Reaching for a
+    /// header-expecting decoder here is the classic way to get an empty result with no
+    /// error.
+    private func inflate(_ payload: Data, uncompressedSize: Int, name: String) throws -> Data {
+        guard uncompressedSize > 0 else { return Data() }
+        var destination = Data(count: uncompressedSize)
+        let written: Int = destination.withUnsafeMutableBytes { destinationBuffer in
+            payload.withUnsafeBytes { sourceBuffer -> Int in
+                guard let destinationBase = destinationBuffer.bindMemory(to: UInt8.self).baseAddress,
+                      let sourceBase = sourceBuffer.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_decode_buffer(
+                    destinationBase, uncompressedSize,
+                    sourceBase, payload.count,
+                    nil, COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard written == uncompressedSize else {
+            throw ModelLoadingError.malformed(
+                reason: "entry \(name) inflated to \(written) of \(uncompressedSize) bytes"
+            )
+        }
+        return destination
+    }
+
+    // MARK: - Central directory
+
+    private static func readCentralDirectory(_ data: Data) throws -> [Entry] {
+        guard data.count >= 22 else {
+            throw ModelLoadingError.malformed(reason: "file is too small to be a zip archive")
+        }
+        guard let eocd = findEndOfCentralDirectory(data) else {
+            throw ModelLoadingError.malformed(reason: "no zip end-of-central-directory record")
+        }
+
+        let entryCount = Int(readUInt16(data, at: eocd + 10))
+        let directoryOffset = Int(readUInt32(data, at: eocd + 16))
+        // ZIP64 announces itself by saturating these 16- and 32-bit fields. Rather than
+        // read a nonsense offset and fail confusingly further down, say so here. A 3MF
+        // needs ZIP64 only past 4 GB or 65 535 parts, neither of which a printable model
+        // reaches.
+        guard entryCount != 0xFFFF, directoryOffset != 0xFFFF_FFFF else {
+            throw ModelLoadingError.malformed(reason: "ZIP64 archives are not supported")
+        }
+        guard directoryOffset >= 0, directoryOffset < data.count else {
+            throw ModelLoadingError.malformed(reason: "central directory offset out of range")
+        }
+
+        var entries: [Entry] = []
+        entries.reserveCapacity(entryCount)
+        var cursor = directoryOffset
+        for _ in 0..<entryCount {
+            guard cursor + 46 <= data.count, readUInt32(data, at: cursor) == 0x0201_4B50 else {
+                throw ModelLoadingError.malformed(reason: "bad central directory entry")
+            }
+            let method = readUInt16(data, at: cursor + 10)
+            let compressedSize = Int(readUInt32(data, at: cursor + 20))
+            let uncompressedSize = Int(readUInt32(data, at: cursor + 24))
+            let nameLength = Int(readUInt16(data, at: cursor + 28))
+            let extraLength = Int(readUInt16(data, at: cursor + 30))
+            let commentLength = Int(readUInt16(data, at: cursor + 32))
+            let localOffset = Int(readUInt32(data, at: cursor + 42))
+            guard cursor + 46 + nameLength <= data.count else {
+                throw ModelLoadingError.malformed(reason: "central directory entry name out of range")
+            }
+            let nameBytes = data.subdata(in: (cursor + 46)..<(cursor + 46 + nameLength))
+            // ZIP names are CP437 unless the UTF-8 flag is set; every 3MF writer uses
+            // ASCII part names, so a name that is not valid UTF-8 is one we could not
+            // have matched anyway — skip it rather than fail the whole archive.
+            if let name = String(data: nameBytes, encoding: .utf8) {
+                entries.append(Entry(
+                    name: name,
+                    compressionMethod: method,
+                    compressedSize: compressedSize,
+                    uncompressedSize: uncompressedSize,
+                    localHeaderOffset: localOffset
+                ))
+            }
+            cursor += 46 + nameLength + extraLength + commentLength
+        }
+        return entries
+    }
+
+    /// Scans backwards for the end-of-central-directory signature.
+    ///
+    /// Backwards because the record sits at the very end of the file *unless* the
+    /// archive carries a comment, which can be up to 65 535 bytes long — so its position
+    /// cannot be computed, only searched for.
+    private static func findEndOfCentralDirectory(_ data: Data) -> Int? {
+        let maximumCommentLength = 0xFFFF
+        let lowerBound = Swift.max(0, data.count - maximumCommentLength - 22)
+        var offset = data.count - 22
+        while offset >= lowerBound {
+            if readUInt32(data, at: offset) == 0x0605_4B50 { return offset }
+            offset -= 1
+        }
+        return nil
+    }
+
+    // MARK: - Little-endian reads
+
+    private func readUInt16(at offset: Int) -> UInt16 { Self.readUInt16(data, at: offset) }
+    private func readUInt32(at offset: Int) -> UInt32 { Self.readUInt32(data, at: offset) }
+
+    private static func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        guard offset >= 0, offset + 2 <= data.count else { return 0 }
+        return UInt16(data[data.startIndex + offset])
+            | UInt16(data[data.startIndex + offset + 1]) << 8
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        guard offset >= 0, offset + 4 <= data.count else { return 0 }
+        return UInt32(data[data.startIndex + offset])
+            | UInt32(data[data.startIndex + offset + 1]) << 8
+            | UInt32(data[data.startIndex + offset + 2]) << 16
+            | UInt32(data[data.startIndex + offset + 3]) << 24
+    }
+}

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFFixtures.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFFixtures.swift
@@ -1,0 +1,244 @@
+import Foundation
+import Compression
+import simd
+
+/// Hand-built 3MF packages for the loader tests.
+///
+/// A real ZIP writer, not a canned blob: the reader's job is to walk a central
+/// directory and inflate deflate streams, so a fixture that skipped either would test
+/// nothing. Entries can be stored or deflated per test, and the CRCs are real, so the
+/// fixtures also open in any other ZIP tool if a failure ever needs inspecting by hand.
+enum ThreeMFFixtures {
+
+    // MARK: - Package assembly
+
+    struct FileEntry {
+        let name: String
+        let data: Data
+        let deflate: Bool
+
+        init(_ name: String, _ text: String, deflate: Bool = true) {
+            self.name = name
+            self.data = Data(text.utf8)
+            self.deflate = deflate
+        }
+
+        init(_ name: String, data: Data, deflate: Bool = true) {
+            self.name = name
+            self.data = data
+            self.deflate = deflate
+        }
+    }
+
+    /// The `[Content_Types].xml` every OPC package opens with. Its presence is also what
+    /// makes the format sniffer call a zip a 3MF rather than a USDZ.
+    static let contentTypes = FileEntry("[Content_Types].xml", """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+    </Types>
+    """, deflate: false)
+
+    /// `_rels/.rels` naming the root model part.
+    static func relationships(target: String = "/3D/3dmodel.model") -> FileEntry {
+        FileEntry("_rels/.rels", """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rel0" Target="\(target)"
+            Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/>
+        </Relationships>
+        """)
+    }
+
+    /// Builds a `.3mf` package from entries.
+    static func package(_ entries: [FileEntry]) -> Data {
+        var payload = Data()
+        var directory = Data()
+        var count = 0
+
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            let crc = crc32(entry.data)
+            let stored = entry.deflate ? deflate(entry.data) : nil
+            let method: UInt16 = stored == nil ? 0 : 8
+            let body = stored ?? entry.data
+            let localOffset = payload.count
+
+            append32(0x0403_4B50, to: &payload)         // local file header signature
+            append16(20, to: &payload)                  // version needed
+            append16(0, to: &payload)                   // flags
+            append16(method, to: &payload)
+            append16(0, to: &payload)                   // mod time
+            append16(0x21, to: &payload)                // mod date (1980-01-01)
+            append32(crc, to: &payload)
+            append32(UInt32(body.count), to: &payload)
+            append32(UInt32(entry.data.count), to: &payload)
+            append16(UInt16(nameBytes.count), to: &payload)
+            append16(0, to: &payload)                   // extra length
+            payload.append(contentsOf: nameBytes)
+            payload.append(body)
+
+            append32(0x0201_4B50, to: &directory)       // central directory signature
+            append16(20, to: &directory)                // version made by
+            append16(20, to: &directory)                // version needed
+            append16(0, to: &directory)                 // flags
+            append16(method, to: &directory)
+            append16(0, to: &directory)
+            append16(0x21, to: &directory)
+            append32(crc, to: &directory)
+            append32(UInt32(body.count), to: &directory)
+            append32(UInt32(entry.data.count), to: &directory)
+            append16(UInt16(nameBytes.count), to: &directory)
+            append16(0, to: &directory)                 // extra length
+            append16(0, to: &directory)                 // comment length
+            append16(0, to: &directory)                 // disk number start
+            append16(0, to: &directory)                 // internal attributes
+            append32(0, to: &directory)                 // external attributes
+            append32(UInt32(localOffset), to: &directory)
+            directory.append(contentsOf: nameBytes)
+            count += 1
+        }
+
+        let directoryOffset = payload.count
+        var archive = payload
+        archive.append(directory)
+        append32(0x0605_4B50, to: &archive)             // end of central directory
+        append16(0, to: &archive)                       // disk number
+        append16(0, to: &archive)                       // disk with central directory
+        append16(UInt16(count), to: &archive)
+        append16(UInt16(count), to: &archive)
+        append32(UInt32(directory.count), to: &archive)
+        append32(UInt32(directoryOffset), to: &archive)
+        append16(0, to: &archive)                       // comment length
+        return archive
+    }
+
+    // MARK: - Model XML
+
+    /// A `<mesh>` element for an axis-aligned box from the origin to `size`.
+    static func boxMeshXML(size: SIMD3<Float>) -> String {
+        let corners: [SIMD3<Float>] = [
+            SIMD3(0, 0, 0), SIMD3(size.x, 0, 0), SIMD3(size.x, size.y, 0), SIMD3(0, size.y, 0),
+            SIMD3(0, 0, size.z), SIMD3(size.x, 0, size.z),
+            SIMD3(size.x, size.y, size.z), SIMD3(0, size.y, size.z)
+        ]
+        let faces = [
+            (0, 3, 2), (0, 2, 1), (4, 5, 6), (4, 6, 7),
+            (0, 1, 5), (0, 5, 4), (2, 3, 7), (2, 7, 6),
+            (0, 4, 7), (0, 7, 3), (1, 2, 6), (1, 6, 5)
+        ]
+        let vertices = corners
+            .map { "      <vertex x=\"\($0.x)\" y=\"\($0.y)\" z=\"\($0.z)\"/>" }
+            .joined(separator: "\n")
+        let triangles = faces
+            .map { "      <triangle v1=\"\($0.0)\" v2=\"\($0.1)\" v3=\"\($0.2)\"/>" }
+            .joined(separator: "\n")
+        return """
+            <mesh>
+              <vertices>
+        \(vertices)
+              </vertices>
+              <triangles>
+        \(triangles)
+              </triangles>
+            </mesh>
+        """
+    }
+
+    /// A complete root `.model` part.
+    static func modelXML(
+        unit: String = "millimeter",
+        resources: String,
+        build: String,
+        extraNamespaces: String = ""
+    ) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <model unit="\(unit)" xml:lang="en-US"
+          xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"\(extraNamespaces)>
+          <resources>
+        \(resources)
+          </resources>
+          <build>
+        \(build)
+          </build>
+        </model>
+        """
+    }
+
+    /// The simplest useful package: one box object, one build item.
+    static func simpleBox(
+        size: SIMD3<Float> = SIMD3(10, 20, 30),
+        unit: String = "millimeter",
+        deflate: Bool = true
+    ) -> Data {
+        let model = modelXML(
+            unit: unit,
+            resources: """
+                <object id="1" type="model" name="cube">
+            \(boxMeshXML(size: size))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        return package([
+            contentTypes,
+            relationships(),
+            FileEntry("3D/3dmodel.model", model, deflate: deflate)
+        ])
+    }
+
+    // MARK: - Byte helpers
+
+    private static func append16(_ value: UInt16, to data: inout Data) {
+        data.append(contentsOf: [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)])
+    }
+
+    private static func append32(_ value: UInt32, to data: inout Data) {
+        data.append(contentsOf: [
+            UInt8(value & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 24) & 0xFF)
+        ])
+    }
+
+    /// Raw DEFLATE — `COMPRESSION_ZLIB` is Apple's name for the headerless stream a ZIP
+    /// entry stores. Returns `nil` when the "compressed" form would not be smaller, in
+    /// which case the caller stores the entry instead, exactly like a real writer.
+    private static func deflate(_ input: Data) -> Data? {
+        guard !input.isEmpty else { return nil }
+        let capacity = input.count + 1024
+        var output = Data(count: capacity)
+        let written: Int = output.withUnsafeMutableBytes { destination in
+            input.withUnsafeBytes { source -> Int in
+                guard let destinationBase = destination.bindMemory(to: UInt8.self).baseAddress,
+                      let sourceBase = source.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_encode_buffer(
+                    destinationBase, capacity,
+                    sourceBase, input.count,
+                    nil, COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard written > 0, written < input.count else { return nil }
+        return output.prefix(written)
+    }
+
+    /// CRC-32 (IEEE), computed the slow bitwise way — a fixture builder has all the time
+    /// in the world and this needs no 1 KB table in the test target.
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc ^= UInt32(byte)
+            for _ in 0..<8 {
+                crc = (crc >> 1) ^ (0xEDB8_8320 & (0 &- (crc & 1)))
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFTests.swift
+++ b/SceneViewSwift/Tests/SceneViewSwiftTests/ThreeMFTests.swift
@@ -1,0 +1,487 @@
+import XCTest
+import simd
+@testable import SceneViewSwift
+
+#if os(iOS) || os(macOS) || os(visionOS)
+import RealityKit
+#endif
+
+/// The 3MF reader: ZIP container, core-spec XML, transforms, materials, and the
+/// Production extension's multi-part packages.
+final class ThreeMFTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try MeshFixtures.makeDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    private func write(_ data: Data, as name: String = "model.3mf") throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - Container
+
+    func testReadsADeflatedPackage() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(deflate: true))
+        let asset = try MeshAsset.load(contentsOf: url)
+
+        XCTAssertEqual(asset.format, .threeMF)
+        XCTAssertEqual(asset.unit, .millimeters)
+        XCTAssertEqual(asset.triangleCount, 12)
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.extents, SIMD3<Float>(10, 20, 30), accuracy: 1e-4)
+    }
+
+    /// Stored entries are legal and small writers emit them.
+    func testReadsAStoredPackage() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(deflate: false), as: "stored.3mf")
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.triangleCount, 12)
+    }
+
+    func testTruncatedArchiveFailsWithAReason() throws {
+        var data = ThreeMFFixtures.simpleBox()
+        data.removeLast(30)  // eats the end-of-central-directory record
+        let url = try write(data, as: "truncated.3mf")
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url)) { error in
+            guard case .malformed = (error as? ModelLoadingError) else {
+                return XCTFail("expected .malformed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Sniffing
+
+    /// USDZ and 3MF are both zip archives. The first entry's name is what tells them
+    /// apart — get this wrong and every 3MF is handed to RealityKit, which cannot read it.
+    func testZipIsToldApartFromUSDZ() throws {
+        let threeMF = try write(ThreeMFFixtures.simpleBox(), as: "print.3mf")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: threeMF), .threeMF)
+
+        // A zip whose first entry is a `.usdc` is a USDZ, whatever it is called.
+        let fakeUSDZ = ThreeMFFixtures.package([
+            ThreeMFFixtures.FileEntry("model.usdc", "not really usd", deflate: false)
+        ])
+        let usdzURL = try write(fakeUSDZ, as: "unlabelled.bin")
+        XCTAssertEqual(try ModelFormat.sniff(contentsOf: usdzURL), .usdz)
+    }
+
+    func testThreeMFCarriesItsOwnUnit() {
+        XCTAssertTrue(ModelFormat.threeMF.carriesUnit)
+        XCTAssertEqual(ModelFormat.threeMF.defaultUnit, .millimeters)
+        XCTAssertEqual(ModelFormat.threeMF.loader, .sceneView)
+    }
+
+    // MARK: - Units
+
+    func testDeclaredUnitIsHonoured() throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(size: SIMD3(1, 2, 3), unit: "inch"),
+            as: "inch.3mf"
+        )
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.unit, .inches)
+        let metric = try XCTUnwrap(asset.boundsInMeters)
+        assertEqual(metric.extents, SIMD3<Float>(0.0254, 0.0508, 0.0762), accuracy: 1e-5)
+    }
+
+    func testAnUnknownUnitFallsBackToTheSpecDefault() throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(unit: "furlong"),
+            as: "nonsense-unit.3mf"
+        )
+        // Forgiving on purpose: refusing to open a model over one misspelled word is
+        // worse than assuming the spec's own default.
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).unit, .millimeters)
+    }
+
+    func testExplicitUnitOverridesTheFile() throws {
+        let url = try write(ThreeMFFixtures.simpleBox(), as: "override.3mf")
+        let asset = try MeshAsset.load(contentsOf: url, unit: .centimeters)
+        XCTAssertEqual(asset.unit, .centimeters)
+    }
+
+    // MARK: - Transforms
+
+    /// A build item's transform is twelve numbers in **row-vector** order. Transposing
+    /// them scatters every placed part, so this pins the convention with a matrix whose
+    /// transpose would give a visibly different answer.
+    func testBuildItemTransformIsRowVector() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(2, 2, 2)))
+                </object>
+            """,
+            build: """
+                <item objectid="1" transform="2 0 0 0 1 0 0 0 1 100 5 0"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "placed.3mf")
+
+        let bounds = try XCTUnwrap(MeshAsset.load(contentsOf: url).bounds)
+        // x doubled then translated by 100; y translated by 5; z untouched.
+        assertEqual(bounds.min, SIMD3<Float>(100, 5, 0), accuracy: 1e-4)
+        assertEqual(bounds.max, SIMD3<Float>(104, 7, 2), accuracy: 1e-4)
+    }
+
+    /// Components compose with the item that placed them.
+    func testComponentTransformsCompose() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+                <object id="2" type="model">
+                  <components>
+                    <component objectid="1" transform="1 0 0 0 1 0 0 0 1 10 0 0"/>
+                  </components>
+                </object>
+            """,
+            build: """
+                <item objectid="2" transform="1 0 0 0 1 0 0 0 1 0 100 0"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "nested.3mf")
+
+        let bounds = try XCTUnwrap(MeshAsset.load(contentsOf: url).bounds)
+        assertEqual(bounds.min, SIMD3<Float>(10, 100, 0), accuracy: 1e-4)
+        assertEqual(bounds.max, SIMD3<Float>(11, 101, 1), accuracy: 1e-4)
+    }
+
+    func testSelfReferencingComponentIsRejected() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+                  <components><component objectid="1"/></components>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "cycle.3mf")
+
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url)) { error in
+            guard case .malformed(let reason) = (error as? ModelLoadingError) else {
+                return XCTFail("expected .malformed, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("itself"), reason)
+        }
+    }
+
+    // MARK: - Production extension
+
+    /// Bambu Studio and Orca split a project across several `.model` parts and reference
+    /// them with `p:path`. A reader that only ever opens `3D/3dmodel.model` shows an
+    /// empty plate for every one of those files.
+    func testProductionExtensionPathReferences() throws {
+        let objectPart = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="7" type="model" name="lifted">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(4, 4, 4)))
+                </object>
+            """,
+            build: ""
+        )
+        let root = ThreeMFFixtures.modelXML(
+            resources: "",
+            build: """
+                <item objectid="7" p:path="/3D/Objects/object_1.model"
+                  transform="1 0 0 0 1 0 0 0 1 0 0 50"/>
+            """,
+            extraNamespaces: """
+
+              xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06"
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", root),
+            ThreeMFFixtures.FileEntry("3D/Objects/object_1.model", objectPart)
+        ]), as: "project.3mf")
+
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.triangleCount, 12)
+        let bounds = try XCTUnwrap(asset.bounds)
+        assertEqual(bounds.min, SIMD3<Float>(0, 0, 50), accuracy: 1e-4)
+        XCTAssertEqual(asset.parts.first?.name, "lifted")
+    }
+
+    /// The root part is found through `_rels/.rels`, not by assuming a path.
+    func testRootPartIsResolvedThroughRelationships() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(target: "/3D/unusual-name.model"),
+            ThreeMFFixtures.FileEntry("3D/unusual-name.model", model)
+        ]), as: "relocated.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    // MARK: - Materials
+
+    /// A multi-colour print must come back multi-colour: triangles are grouped by the
+    /// colour their `pid`/`p1` resolves to, one mesh part each.
+    func testTrianglesAreGroupedByMaterialColor() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <basematerials id="5">
+                  <base name="red" displaycolor="#FF0000"/>
+                  <base name="blue" displaycolor="#0000FF"/>
+                </basematerials>
+                <object id="1" type="model" pid="5" pindex="0">
+                  <mesh>
+                    <vertices>
+                      <vertex x="0" y="0" z="0"/>
+                      <vertex x="1" y="0" z="0"/>
+                      <vertex x="1" y="1" z="0"/>
+                      <vertex x="0" y="1" z="0"/>
+                    </vertices>
+                    <triangles>
+                      <triangle v1="0" v2="1" v3="2" pid="5" p1="0"/>
+                      <triangle v1="0" v2="2" v3="3" pid="5" p1="1"/>
+                    </triangles>
+                  </mesh>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "twotone.3mf")
+
+        let asset = try MeshAsset.load(contentsOf: url)
+        XCTAssertEqual(asset.parts.count, 2, "two colours must not collapse into one part")
+        XCTAssertEqual(asset.triangleCount, 2)
+
+        let colors = asset.parts.compactMap(\.material?.baseColor)
+        XCTAssertEqual(colors.count, 2)
+        assertEqual(SIMD3(colors[0].x, colors[0].y, colors[0].z), SIMD3(1, 0, 0), accuracy: 0.01)
+        assertEqual(SIMD3(colors[1].x, colors[1].y, colors[1].z), SIMD3(0, 0, 1), accuracy: 0.01)
+        // Each group carries only the vertices it uses.
+        XCTAssertEqual(asset.parts[0].positions.count, 3)
+        XCTAssertEqual(asset.parts[1].positions.count, 3)
+    }
+
+    func testColorGroupFromTheMaterialsExtension() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <m:colorgroup id="9">
+                  <m:color color="#20C05FFF"/>
+                </m:colorgroup>
+                <object id="1" type="model" pid="9" pindex="0">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """,
+            extraNamespaces: """
+
+              xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "colorgroup.3mf")
+
+        let color = try XCTUnwrap(MeshAsset.load(contentsOf: url).parts.first?.material?.baseColor)
+        assertEqual(
+            SIMD3(color.x, color.y, color.z),
+            SIMD3(Float(0x20) / 255, Float(0xC0) / 255, Float(0x5F) / 255),
+            accuracy: 0.01
+        )
+        XCTAssertEqual(color.w, 1, accuracy: 0.01)
+    }
+
+    // MARK: - Robustness
+
+    /// A package with no `<build>` still has objects, and showing nothing for it is
+    /// indistinguishable from a broken parser.
+    func testEmptyBuildFallsBackToTheObjects() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+            \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 2, 3)))
+                </object>
+            """,
+            build: ""
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "nobuild.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    func testOutOfRangeTriangleIndexIsRejected() throws {
+        let model = ThreeMFFixtures.modelXML(
+            resources: """
+                <object id="1" type="model">
+                  <mesh>
+                    <vertices>
+                      <vertex x="0" y="0" z="0"/>
+                      <vertex x="1" y="0" z="0"/>
+                      <vertex x="1" y="1" z="0"/>
+                    </vertices>
+                    <triangles>
+                      <triangle v1="0" v2="1" v3="99"/>
+                    </triangles>
+                  </mesh>
+                </object>
+            """,
+            build: """
+                <item objectid="1"/>
+            """
+        )
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "bad-index.3mf")
+
+        XCTAssertThrowsError(try MeshAsset.load(contentsOf: url))
+    }
+
+    /// A 3MF is an untrusted file that arrives by AirDrop, email or a download. An XML
+    /// parser that resolves external entities turns opening one into a file read.
+    func testExternalEntitiesAreNotResolved() throws {
+        let hostFile = directory.appendingPathComponent("secret.txt")
+        try Data("TOP-SECRET-VALUE".utf8).write(to: hostFile)
+
+        let model = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE model [
+          <!ENTITY leak SYSTEM "file://\(hostFile.path)">
+        ]>
+        <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="1" type="model" name="&leak;">
+        \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+            </object>
+          </resources>
+          <build><item objectid="1"/></build>
+        </model>
+        """
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "xxe.3mf")
+
+        // Either the parse fails (the entity cannot be resolved, so the reference is an
+        // XML error) or it succeeds with the entity unresolved. Both are fine; what must
+        // never happen is the host file's contents reaching the caller, through the model
+        // *or* through the error message. Both branches assert, so neither is a free pass.
+        do {
+            for name in try MeshAsset.load(contentsOf: url).parts.map(\.name) {
+                XCTAssertFalse(name.contains("TOP-SECRET"), "external entity was resolved")
+            }
+        } catch {
+            XCTAssertFalse(
+                "\(error)".contains("TOP-SECRET"),
+                "external entity content leaked through the error"
+            )
+        }
+    }
+
+    /// An external DTD that is never fetched: with resolution off the declaration is
+    /// simply ignored, so the model still opens normally. This is the half of the XXE
+    /// defence that is easy to get wrong in the other direction — refusing every file
+    /// that merely *mentions* a DTD.
+    func testAnExternalDTDDoesNotBlockTheFile() throws {
+        let model = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE model SYSTEM "http://example.invalid/3mf.dtd">
+        <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+          <resources>
+            <object id="1" type="model">
+        \(ThreeMFFixtures.boxMeshXML(size: SIMD3(1, 1, 1)))
+            </object>
+          </resources>
+          <build><item objectid="1"/></build>
+        </model>
+        """
+        let url = try write(ThreeMFFixtures.package([
+            ThreeMFFixtures.contentTypes,
+            ThreeMFFixtures.relationships(),
+            ThreeMFFixtures.FileEntry("3D/3dmodel.model", model)
+        ]), as: "external-dtd.3mf")
+
+        XCTAssertEqual(try MeshAsset.load(contentsOf: url).triangleCount, 12)
+    }
+
+    // MARK: - Entity
+
+    #if os(iOS) || os(macOS) || os(visionOS)
+    /// End to end: a millimetre 3MF becomes a RealityKit mesh measured in metres.
+    @MainActor
+    func testModelNodeFrom3MFIsMetric() async throws {
+        let url = try write(
+            ThreeMFFixtures.simpleBox(size: SIMD3(210, 100, 50)),
+            as: "print.3mf"
+        )
+        let node = try await ModelNode.load(contentsOf: url)
+        let mesh = try XCTUnwrap(node.entity.model?.mesh)
+        XCTAssertEqual(mesh.bounds.extents.x, 0.210, accuracy: 1e-4)
+        XCTAssertEqual(mesh.bounds.extents.y, 0.100, accuracy: 1e-4)
+        XCTAssertEqual(mesh.bounds.extents.z, 0.050, accuracy: 1e-4)
+    }
+    #endif
+
+    // MARK: -
+
+    private func assertEqual(
+        _ lhs: SIMD3<Float>,
+        _ rhs: SIMD3<Float>,
+        accuracy: Float,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.x, rhs.x, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.y, rhs.y, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(lhs.z, rhs.z, accuracy: accuracy, file: file, line: line)
+    }
+}

--- a/agents/sceneview-ios/SKILL.md
+++ b/agents/sceneview-ios/SKILL.md
@@ -26,6 +26,7 @@ metadata:
   - ply
   - mesh formats
   - 3d printing
+  - 3mf
 ---
 
 ## What SceneViewSwift is
@@ -67,7 +68,7 @@ Android-centric — prefer `cheatsheet-ios.md` for Swift.
 Trigger on any of:
 
 - "Build me a 3D viewer / AR app in SwiftUI."
-- "Load a `.usdz` / `.reality` / `.stl` / `.obj` / `.ply` model on iOS."
+- "Load a `.usdz` / `.reality` / `.stl` / `.obj` / `.ply` / `.3mf` model on iOS."
 - "Open an STL from Files / show a 3D print at real size in AR."
 - "Place a model on a detected AR plane in ARKit + SwiftUI."
 - "Add 3D content to a visionOS / macOS app with SceneView."
@@ -175,6 +176,11 @@ the wrong one.
 | `.stl` | ModelIO | **millimetres** |
 | `.obj` (+ `.mtl`) | ModelIO | metres |
 | `.ply` | ModelIO | metres |
+| `.3mf` | SceneViewSwift's own parser | **declared by the file** |
+
+`.3mf` is parsed by SceneViewSwift, not by Apple — `MDLAsset` does not read it and
+neither does Quick Look, even though it is the format 3D printing standardised
+on. It is also the only mesh format here that states its own unit.
 
 **glTF (`.glb` / `.gltf`) is NOT supported on Apple platforms.** Neither
 RealityKit nor ModelIO reads it. Convert to USDZ (Reality Converter,
@@ -202,6 +208,9 @@ let panel = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
 
 // PLY from a phone scanner, bundled with the app.
 let bust = try await ModelNode.load("scans/bust.ply", unit: .meters)
+
+// 3MF from a slicer — the file states its own unit, so pass none.
+let plate = try await ModelNode.load(contentsOf: threeMFURL)
 ```
 
 Measure before you render — parsing has no RealityKit dependency:

--- a/changelog.d/3492-swift-3mf.md
+++ b/changelog.d/3492-swift-3mf.md
@@ -1,0 +1,41 @@
+<!-- category: Added -->
+- **SceneViewSwift reads 3MF — the format 3D printing standardised on and Apple never
+  shipped a reader for ([#3492](https://github.com/sceneview/sceneview/issues/3492)).**
+  `MDLAsset` reads OBJ, STL, PLY and USD; Quick Look reads USDZ and Reality; nothing on
+  the platform opens a `.3mf`, which is what a Bambu, Prusa or Orca user is handed and
+  what MakerWorld hands back. `ModelNode.load(contentsOf:)` now opens one like any other
+  file, and `ThreeMFDocument` is available directly for apps that want the geometry
+  without a scene.
+- **The parser covers what slicers actually write**, not just the happy path: `<model
+  unit>` in every unit the core spec defines, `<mesh>`, `<components>` composed through
+  their row-vector transforms, `<build><item>` placements, `<basematerials>` and the
+  materials extension's `<colorgroup>` resolved **per triangle** so a multi-colour print
+  comes back multi-colour, and Production-extension `p:path` references into other
+  `.model` parts of the package — which is how Bambu Studio and Orca write project files,
+  and the reason a reader that only ever opens `3D/3dmodel.model` shows an empty plate for
+  half the files in circulation. The root part is found through `_rels/.rels` rather than
+  assumed. A package whose `<build>` is empty falls back to its objects instead of
+  rendering nothing. 3MF declares its own unit, so it needs no `unit:` argument — passing
+  one overrides the file.
+- **A 3MF is an untrusted file**, and it is opened like one. The ZIP reader is
+  read-only, resolves entries by their exact recorded name (there is no path joining, so
+  `../` matches nothing rather than escaping), and refuses to inflate an entry over
+  256 MB. The XML parser refuses external entities outright
+  (`externalEntityResolvingPolicy = .never`) — without that, opening a file received by
+  AirDrop or email is a file-read primitive. An object that contains itself is reported,
+  not recursed into.
+<!-- RELEASE NOTE (maintainer-only):
+     No third-party dependency for either half. Foundation has no public ZIP API and
+     `NSFileCoordinator`'s archive support is macOS-only and disk-backed, so
+     `ZipArchiveReader` reads the central directory itself and inflates with the
+     `Compression` framework — `COMPRESSION_ZLIB` is Apple's name for the *raw* DEFLATE
+     stream a ZIP entry stores, and reaching for a header-expecting decoder there is the
+     classic way to get an empty result with no error. ZIP64 is refused with a named
+     reason rather than mis-parsed; a 3MF needs it only past 4 GB or 65 535 parts.
+     Two traps pinned by tests. (1) USDZ and 3MF are both ZIP archives, so the format
+     sniffer cannot stop at the `PK` magic — it reads the first entry's name (`*.usd*` →
+     USDZ, else 3MF). Getting this wrong hands every 3MF to RealityKit, which cannot read
+     it. (2) A 3MF `transform` is twelve numbers in row-vector order (`v' = v · M`, last
+     row = translation), so the file's rows become the *columns* of a `simd_float4x4`.
+     Transposing them scatters every placed part, and the symptom is wrong-looking
+     geometry rather than a parse error. -->

--- a/llms.txt
+++ b/llms.txt
@@ -7431,7 +7431,7 @@ ARSceneView(
 
 ### Node types
 
-#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY)
+#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY / 3MF)
 
 ```swift
 public struct ModelNode: @unchecked Sendable {
@@ -7478,10 +7478,11 @@ public struct ModelNode: @unchecked Sendable {
 ```
 
 Key behaviors:
-- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit, and
-  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO. glTF is **not** supported.
-- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply`
-  is resolved to a URL and read by ModelIO instead.
+- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit,
+  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO, and `.3mf` through SceneViewSwift's
+  own parser. glTF is **not** supported.
+- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply` /
+  `.3mf` is resolved to a URL and parsed instead.
 - `load(from:)` downloads to a temp file, loads, then cleans up.
 - `scaleToUnits(_:)` mirrors Android's `ModelNode(scaleToUnits = 1f)`.
 - `centerOrigin(normalized:)` — **apply before positioning.** Unlike Android's `centerOrigin` (which composes additively — `position += translation`, independent of the current position), this reads the entity's **world** visual-bounds, so it does not compose with a previously-set position: call it on an unpositioned, unparented entity (load → scaleToUnits → centerOrigin, before `.position(_:)` or anchoring), and a later `.position(_:)` replaces the grounding offset.
@@ -7500,6 +7501,16 @@ extension only when the content is not decisive.
 | `.stl` | ModelIO | **millimetres** | ASCII and binary; no unit, no materials |
 | `.obj` | ModelIO | metres | `.mtl` sidecar picked up when next to the file; quad faces triangulated |
 | `.ply` | ModelIO | metres | ASCII and binary; per-vertex colours preserved |
+| `.3mf` | SceneViewSwift's own parser | **from the file** | Zip + XML; the only mesh format here that declares its own unit |
+
+**3MF is parsed by SceneViewSwift, not by Apple.** `MDLAsset` reads OBJ, STL, PLY and
+USD; Quick Look reads USDZ and Reality; nothing on the platform opens a `.3mf` — which is
+the format 3D printing standardised on. `ThreeMFDocument` is a minimal zip reader plus an
+`XMLParser` over the package's `.model` parts, covering `<model unit>`, `<mesh>`,
+`<components>` with row-vector transforms, `<build><item>`, `<basematerials>` and the
+materials extension's `<colorgroup>` resolved per triangle, and Production-extension
+`p:path` references into other parts (how Bambu Studio and Orca write project files).
+External XML entities are refused — an untrusted file must not become a file read.
 
 **The unit is the whole point.** STL, OBJ and PLY store bare numbers with no unit, and a
 slicer STL means millimetres while a photogrammetry OBJ means metres. RealityKit works in
@@ -7535,12 +7546,21 @@ let node = try await ModelNode(asset)                // then display it
 ```swift
 public enum ModelFormat: String, Sendable, CaseIterable {
     case usdz, reality, usda, usdc, usd, stl, obj, ply
+    case threeMF = "3mf"
     public var fileExtension: String                 // == rawValue
-    public var loader: Loader                        // .realityKit | .modelIO
+    public var loader: Loader                        // .realityKit | .modelIO | .sceneView
     public var defaultUnit: ModelUnit
     public var carriesUnit: Bool                     // false for stl/obj/ply — ask the user
     public init?(fileExtension: String)
     public static func sniff(contentsOf url: URL) throws -> ModelFormat
+}
+
+public struct ThreeMFDocument: Sendable {
+    public let unit: ModelUnit                       // as declared by the file
+    public let parts: [MeshGeometry]                 // one per object-and-material
+    public var triangleCount: Int
+    public static func read(contentsOf url: URL) throws -> ThreeMFDocument
+    public static func read(data: Data) throws -> ThreeMFDocument
 }
 
 public enum ModelUnit: String, Sendable, CaseIterable {
@@ -7588,6 +7608,11 @@ Gotchas worth knowing:
 - **A binary STL's 80-byte header often starts with the word `solid`.** Detecting ASCII by
   that prefix reads a binary file as empty; `sniff` uses the size arithmetic
   (`84 + 50 × triangleCount == fileSize`) first.
+- **USDZ and 3MF are both zip archives.** `sniff` tells them apart by the name of the
+  archive's first entry (`*.usd*` → USDZ, anything else → 3MF), not by the `PK` magic.
+- **A 3MF `transform` is twelve numbers in row-vector order** (`v' = v · M`, last row =
+  translation). Reading them as column-major transposes every placed part — the symptom is
+  scattered geometry, not a parse error.
 - **RealityKit's `MeshDescriptor` has no vertex-colour channel.** A coloured PLY keeps its
   full `colors` array on `MeshGeometry`, and `ModelNode` folds the *average* into the
   material tint so the model is not uniformly grey.


### PR DESCRIPTION
Part 2 of #3492, stacked on #3513 (retarget to `main` once that merges). Adds the format Apple never shipped a reader for.

## Why

`MDLAsset` reads OBJ, STL, PLY and USD. Quick Look reads USDZ and Reality. **Nothing on the platform opens a `.3mf`** — which is what a Bambu, Prusa or Orca user is handed, and what MakerWorld hands back. So this is a parser, not a wrapper: a minimal ZIP reader plus an `XMLParser` over the package's `.model` parts, with **no third-party dependency** (Foundation has no public ZIP API, and `NSFileCoordinator`'s archive support is macOS-only and disk-backed).

## What it covers

Not just the happy path — what slicers actually write:

- `<model unit>` in every unit the core spec defines, defaulting to millimetres. 3MF is the only mesh format SceneViewSwift reads that **states its own unit**, so it needs no `unit:` argument; passing one overrides the file.
- `<mesh>`, and `<components>` composed through their transforms.
- `<build><item>` placements, with theirs.
- `<basematerials>` and the materials extension's `<colorgroup>`, resolved **per triangle**, so a multi-colour print comes back multi-colour rather than collapsing to one tint. Each colour becomes its own mesh part carrying only the vertices it uses.
- **Production-extension `p:path`** references into other `.model` parts of the package. This is how Bambu Studio and Orca write project files, and the reason a reader that only ever opens `3D/3dmodel.model` shows an empty plate for a large share of the files in circulation.
- The root part is found through `_rels/.rels`, not assumed. A package with an empty `<build>` falls back to its objects instead of rendering nothing.

## Opened like the untrusted file it is

A 3MF arrives by AirDrop, email, a share sheet or a download.

- The ZIP reader is **read-only** and resolves entries by their exact recorded name — there is no path joining, so a `../` in an entry name is a name that matches nothing rather than a traversal.
- It refuses to inflate an entry over **256 MB**, so a crafted archive cannot have a multi-gigabyte allocation attempted on its say-so.
- ZIP64 is refused with a named reason rather than mis-parsed (a 3MF needs it only past 4 GB or 65 535 parts).
- The XML parser sets `externalEntityResolvingPolicy = .never` and `shouldResolveExternalEntities = false`. Without that, opening a received file is a file-read and SSRF primitive. Two tests cover both directions: an external entity must not leak host-file content (through the model **or** the error message), and a merely-declared external DTD must not block an otherwise valid file.
- An object that contains itself — directly or through a chain — is reported, not recursed into.

## Two traps, both pinned by tests

1. **USDZ and 3MF are both ZIP archives**, so format sniffing cannot stop at the `PK` magic. It reads the archive's first entry name: `*.usd*` is a USDZ, anything else a 3MF. Getting this wrong hands every 3MF to RealityKit, which cannot read it.
2. **A 3MF `transform` is twelve numbers in row-vector order** — `v' = v · M`, last row is the translation — so the file's *rows* become the *columns* of a `simd_float4x4`. Transposing them scatters every placed part, and the symptom is wrong-looking geometry, not a parse error. The test uses a matrix whose transpose would give a visibly different answer.

## Tests

20 cases over **real ZIP fixtures** — a fixture builder that writes local headers, a central directory, an EOCD record and real CRC-32s, with entries both stored and deflated — so the container half is exercised rather than stubbed, and a fixture can be opened in any ZIP tool if a failure ever needs inspecting by hand.

`swift test` on macOS: **820 tests, 0 failures**. Simulator run reported below once CI has it.

## Docs

`llms.txt` (iOS section), `agents/sceneview-ios/SKILL.md` and `SceneViewSwift/README.md` gain the `.3mf` row, the "3MF states its own unit" rule, and the two traps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)