### PR TITLE
feat(core): STL loader, binary and ASCII, to GLB in memory (#3486)

### DIFF
--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -1669,3 +1669,4 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
+

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -832,6 +832,30 @@ public final class io/github/sceneview/core/splat/SplatParser {
 	public final fun parse ([B)Lio/github/sceneview/core/splat/SplatCloud;
 }
 
+public final class io/github/sceneview/core/stl/StlLoader {
+	public static final field DEFAULT_MAX_BYTES I
+	public static final field DEFAULT_MAX_TRIANGLES I
+	public static final field INSTANCE Lio/github/sceneview/core/stl/StlLoader;
+	public final fun isStl ([B)Z
+	public final fun parse ([BLio/github/sceneview/core/threemf/ThreeMfUnit;II)Lio/github/sceneview/core/stl/StlModel;
+	public static synthetic fun parse$default (Lio/github/sceneview/core/stl/StlLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;IIILjava/lang/Object;)Lio/github/sceneview/core/stl/StlModel;
+	public final fun toGlb ([BLio/github/sceneview/core/threemf/ThreeMfUnit;II)[B
+	public static synthetic fun toGlb$default (Lio/github/sceneview/core/stl/StlLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;IIILjava/lang/Object;)[B
+}
+
+public final class io/github/sceneview/core/stl/StlModel {
+	public final fun getIndices ()[I
+	public final fun getNormals ()[F
+	public final fun getPositions ()[F
+	public final fun getTriangleCount ()I
+	public final fun getUnit ()Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public final fun getVertexCount ()I
+}
+
+public final class io/github/sceneview/core/stl/StlParseException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class io/github/sceneview/core/threemf/ThreeMfComponent {
 	public fun <init> (I[F)V
 	public final fun getObjectId ()I
@@ -1645,4 +1669,3 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
-

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlLoader.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlLoader.kt
@@ -1,0 +1,189 @@
+package io.github.sceneview.core.stl
+
+import io.github.sceneview.core.threemf.ThreeMfGlb
+import io.github.sceneview.core.threemf.ThreeMfUnit
+
+/**
+ * Reads binary and ASCII STL in pure Kotlin on Android, Apple and web, and emits an in-memory
+ * GLB through the same writer as 3MF. Android detects STL automatically:
+ * `rememberModelInstance(modelLoader, "part.stl")`.
+ *
+ * STL has **no units**: [parse] and [toGlb] assume millimetres, the printing convention. Override
+ * with `StlLoader.toGlb(bytes, unit = ThreeMfUnit.INCH)` for inch-authored geometry. GLB positions
+ * are baked in metres and axes are preserved because STL specifies no up axis.
+ *
+ * Positions are welded; valid facet normals are preserved and invalid ones are smoothed across
+ * coincident vertices. The shared writer has an indexed path for STL, splitting vertices only
+ * at normal seams, while 3MF retains its intentionally flat shading. Binary colour/attribute
+ * extensions are ignored; STL receives the writer's neutral, double-sided material.
+ */
+object StlLoader {
+    /** Default input limit (32 MiB), checked before decoding or allocating geometry. */
+    const val DEFAULT_MAX_BYTES: Int = 32 * 1024 * 1024
+
+    /** Default facet limit (250,000), bounding welded geometry, normals and GLB output allocations. */
+    const val DEFAULT_MAX_TRIANGLES: Int = 250_000
+
+    /**
+     * Sniff bytes without copying or parsing geometry; never throws. Binary length must equal
+     * `84 + 50 * unsignedTriangleCount`; that test wins even for a header beginning with `solid`.
+     * Otherwise ASCII needs a leading `solid` token and a later `facet` token. This is detection,
+     * not validation: use `StlLoader.parse(bytes)` to reject malformed or truncated data.
+     */
+    fun isStl(bytes: ByteArray): Boolean = isBinaryStl(bytes) || looksLikeAsciiStl(bytes)
+
+    /**
+     * Parse STL to welded positions in [unit] and per-corner normals; see [StlModel].
+     * `val mesh = StlLoader.parse(bytes, unit = ThreeMfUnit.MILLIMETER)`.
+     *
+     * [maxBytes] caps the input; [maxTriangles] caps decoded facets for both encodings. Increase
+     * these only when the caller has memory for the input, working geometry and output together.
+     * @throws StlParseException for invalid data, non-positive limits or exceeded limits.
+     */
+    fun parse(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.MILLIMETER,
+        maxTriangles: Int = DEFAULT_MAX_TRIANGLES,
+        maxBytes: Int = DEFAULT_MAX_BYTES
+    ): StlModel {
+        if (maxBytes <= 0 || maxTriangles <= 0) stlError("STL limits must be positive")
+        if (bytes.size > maxBytes) stlError("STL input exceeds $maxBytes bytes")
+        val builder = StlMeshBuilder(unit, minOf(maxTriangles, Int.MAX_VALUE / 128))
+        if (isBinaryStl(bytes) || !looksLikeAsciiStl(bytes)) {
+            readBinaryStl(bytes, builder)
+        } else {
+            readAsciiStl(bytes, builder)
+        }
+        return builder.build()
+    }
+
+    /**
+     * Convert STL to self-contained glTF 2.0, using [parse]'s units, normals and allocation caps.
+     * `val glb = StlLoader.toGlb(bytes)` converts millimetres to metres (70 mm becomes 0.07 m).
+     * @throws StlParseException if the input cannot be read within the supplied limits.
+     */
+    fun toGlb(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.MILLIMETER,
+        maxTriangles: Int = DEFAULT_MAX_TRIANGLES,
+        maxBytes: Int = DEFAULT_MAX_BYTES
+    ): ByteArray {
+        val model = parse(bytes, unit, maxTriangles, maxBytes)
+        return ThreeMfGlb.encodeIndexed(model.positions, model.indices, model.normals, unit.meters)
+    }
+}
+
+internal fun stlUInt32(bytes: ByteArray, at: Int): Long {
+    var value = 0L
+    repeat(4) { value = value or ((bytes[at + it].toLong() and 0xff) shl (it * 8)) }
+    return value
+}
+
+private fun isBinaryStl(bytes: ByteArray): Boolean = bytes.size >= 84 &&
+    (bytes.size - 84) % 50 == 0 && stlUInt32(bytes, 80) == (bytes.size - 84).toLong() / 50
+
+internal fun stlWhitespace(value: Int): Boolean = value == 32 || value in 9..13
+
+private fun looksLikeAsciiStl(bytes: ByteArray): Boolean {
+    var at = 0
+    while (at < bytes.size && stlWhitespace(bytes[at].toInt())) at++
+    if (!bytes.tokenAt(at, "solid")) return false
+    at += 5
+    while (at < bytes.size) {
+        val value = bytes[at].toInt()
+        if (!stlWhitespace(value) && value !in 32..126) return false
+        if (stlWhitespace(bytes[at - 1].toInt()) && bytes.tokenAt(at, "facet")) return true
+        at++
+    }
+    return false
+}
+
+private fun ByteArray.tokenAt(at: Int, token: String): Boolean =
+    at + token.length <= size && token.indices.all { this[at + it].toInt() == token[it].code } &&
+        (at + token.length == size || stlWhitespace(this[at + token.length].toInt()))
+
+private fun readBinaryStl(bytes: ByteArray, builder: StlMeshBuilder) {
+    if (bytes.size < 84) stlError("Truncated STL binary header: expected at least 84 bytes")
+    val count = stlUInt32(bytes, 80)
+    builder.checkTriangleCount(count)
+    val expected = 84L + 50L * count
+    if (bytes.size.toLong() != expected) {
+        stlError("STL binary size mismatch: expected $expected bytes, got ${bytes.size}")
+    }
+    val facet = FloatArray(12)
+    repeat(count.toInt()) { triangle ->
+        val at = 84 + triangle * 50
+        for (i in facet.indices) facet[i] = Float.fromBits(stlUInt32(bytes, at + i * 4).toInt())
+        builder.add(facet)
+    }
+}
+
+private fun readAsciiStl(bytes: ByteArray, builder: StlMeshBuilder) {
+    val reader = StlTokens(bytes)
+    val facet = FloatArray(12)
+    do {
+        reader.expect("solid")
+        reader.skipLine() // Solid names are arbitrary text, not grammar tokens.
+        while (reader.peek() == "facet") {
+            builder.checkTriangleCount(builder.triangleCount.toLong() + 1)
+            reader.expect("facet")
+            facet.fill(0f)
+            if (reader.peek() == "normal") {
+                reader.expect("normal")
+                repeat(3) { facet[it] = reader.number() }
+            }
+            reader.expect("outer")
+            reader.expect("loop")
+            repeat(3) { corner ->
+                reader.expect("vertex")
+                repeat(3) { axis -> facet[3 + corner * 3 + axis] = reader.number() }
+            }
+            reader.expect("endloop")
+            reader.expect("endfacet")
+            builder.add(facet)
+        }
+        reader.expect("endsolid")
+        reader.skipLine()
+    } while (reader.peek() == "solid")
+    if (reader.peek() != null) stlError("Unexpected data after STL endsolid")
+}
+
+/** Streaming byte tokenizer: no whole-file String, regex split, or unbounded numeric token. */
+private class StlTokens(private val bytes: ByteArray) {
+    private var at = 0
+    private var pending: String? = null
+
+    fun peek(): String? {
+        if (pending == null) pending = next()
+        return pending
+    }
+
+    fun expect(expected: String) {
+        val actual = take()
+        if (actual != expected) stlError("Expected STL '$expected', got '$actual'")
+    }
+
+    fun number(): Float = take()?.toFloatOrNull() ?: stlError("Invalid STL number")
+
+    fun skipLine() {
+        while (at < bytes.size && bytes[at].toInt() !in 10..13) {
+            if (bytes[at].toInt() !in 32..126 && bytes[at].toInt() != 9) {
+                stlError("Non-ASCII STL name")
+            }
+            at++
+        }
+    }
+
+    private fun take(): String? = peek().also { pending = null }
+
+    private fun next(): String? {
+        while (at < bytes.size && stlWhitespace(bytes[at].toInt())) at++
+        if (at == bytes.size) return null
+        val start = at
+        while (at < bytes.size && !stlWhitespace(bytes[at].toInt())) {
+            if (at - start >= 128 || bytes[at].toInt() !in 33..126) stlError("Invalid STL token")
+            at++
+        }
+        return bytes.decodeToString(start, at)
+    }
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlMeshBuilder.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlMeshBuilder.kt
@@ -1,0 +1,97 @@
+package io.github.sceneview.core.stl
+
+import io.github.sceneview.core.threemf.FloatArrayBuilder
+import io.github.sceneview.core.threemf.IntArrayBuilder
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.math.sqrt
+
+/** Weld first, then accumulate geometric area vectors across all incident faces for smooth repair. */
+internal class StlMeshBuilder(private val unit: ThreeMfUnit, private val maxTriangles: Int) {
+    private val vertices = HashMap<Vertex, Int>()
+    private val positions = FloatArrayBuilder()
+    private val indices = IntArrayBuilder()
+    private val faceNormals = FloatArrayBuilder()
+    val triangleCount: Int get() = indices.size / 3
+
+    fun checkTriangleCount(count: Long) {
+        if (count > maxTriangles) stlError("STL exceeds $maxTriangles triangles (declared $count)")
+    }
+
+    fun add(facet: FloatArray) {
+        checkTriangleCount(triangleCount.toLong() + 1)
+        repeat(3) { faceNormals.add(facet[it]) }
+        repeat(3) { corner ->
+            val at = 3 + corner * 3
+            val vertex = Vertex(coordinate(facet[at]), coordinate(facet[at + 1]), coordinate(facet[at + 2]))
+            indices.add(vertices.getOrPut(vertex) {
+                val index = positions.size / 3
+                positions.add(vertex.x)
+                positions.add(vertex.y)
+                positions.add(vertex.z)
+                index
+            })
+        }
+    }
+
+    fun build(): StlModel {
+        if (triangleCount == 0) stlError("STL contains no triangles")
+        val points = positions.toArray()
+        val triangles = indices.toArray()
+        val faces = faceNormals.toArray()
+        // Double intermediates avoid overflow/underflow for finite float32 positions and normals.
+        val sums = DoubleArray(points.size)
+        for (triangle in 0 until triangleCount) {
+            val at = triangle * 3
+            val a = triangles[at] * 3
+            val b = triangles[at + 1] * 3
+            val c = triangles[at + 2] * 3
+            val ux = points[b].toDouble() - points[a]
+            val uy = points[b + 1].toDouble() - points[a + 1]
+            val uz = points[b + 2].toDouble() - points[a + 2]
+            val vx = points[c].toDouble() - points[a]
+            val vy = points[c + 1].toDouble() - points[a + 1]
+            val vz = points[c + 2].toDouble() - points[a + 2]
+            repeat(3) { corner ->
+                val vertex = triangles[at + corner] * 3
+                sums[vertex] += uy * vz - uz * vy
+                sums[vertex + 1] += uz * vx - ux * vz
+                sums[vertex + 2] += ux * vy - uy * vx
+            }
+        }
+        val normals = FloatArray(triangles.size * 3)
+        for (corner in triangles.indices) {
+            val face = corner / 3 * 3
+            var x = faces[face].toDouble()
+            var y = faces[face + 1].toDouble()
+            var z = faces[face + 2].toDouble()
+            var length = sqrt(x * x + y * y + z * z)
+            if (length == 0.0 || !length.isFinite()) {
+                val vertex = triangles[corner] * 3
+                x = sums[vertex]
+                y = sums[vertex + 1]
+                z = sums[vertex + 2]
+                length = sqrt(x * x + y * y + z * z)
+            }
+            val at = corner * 3
+            if (length > 0.0 && length.isFinite()) {
+                normals[at] = (x / length).toFloat()
+                normals[at + 1] = (y / length).toFloat()
+                normals[at + 2] = (z / length).toFloat()
+            } else {
+                normals[at + 1] = 1f
+            }
+        }
+        return StlModel(points, triangles, normals, unit)
+    }
+
+    private fun coordinate(value: Float): Float {
+        // Kotlin/JS stores Float as double; round to float32 before validation and welding.
+        val rounded = Float.fromBits(value.toBits())
+        if (!rounded.isFinite() || !Float.fromBits((rounded * unit.meters).toBits()).isFinite()) {
+            stlError("STL position must be finite in model units and metres")
+        }
+        return if (rounded == 0f) 0f else rounded
+    }
+
+    private data class Vertex(val x: Float, val y: Float, val z: Float)
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlMeshBuilder.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlMeshBuilder.kt
@@ -38,6 +38,15 @@ internal class StlMeshBuilder(private val unit: ThreeMfUnit, private val maxTria
         val points = positions.toArray()
         val triangles = indices.toArray()
         val faces = faceNormals.toArray()
+        val sums = smoothNormalSums(points, triangles)
+        val normals = FloatArray(triangles.size * 3)
+        for (corner in triangles.indices) {
+            writeNormal(normals, corner, faces, triangles, sums)
+        }
+        return StlModel(points, triangles, normals, unit)
+    }
+
+    private fun smoothNormalSums(points: FloatArray, triangles: IntArray): DoubleArray {
         // Double intermediates avoid overflow/underflow for finite float32 positions and normals.
         val sums = DoubleArray(points.size)
         for (triangle in 0 until triangleCount) {
@@ -58,30 +67,36 @@ internal class StlMeshBuilder(private val unit: ThreeMfUnit, private val maxTria
                 sums[vertex + 2] += ux * vy - uy * vx
             }
         }
-        val normals = FloatArray(triangles.size * 3)
-        for (corner in triangles.indices) {
-            val face = corner / 3 * 3
-            var x = faces[face].toDouble()
-            var y = faces[face + 1].toDouble()
-            var z = faces[face + 2].toDouble()
-            var length = sqrt(x * x + y * y + z * z)
-            if (length == 0.0 || !length.isFinite()) {
-                val vertex = triangles[corner] * 3
-                x = sums[vertex]
-                y = sums[vertex + 1]
-                z = sums[vertex + 2]
-                length = sqrt(x * x + y * y + z * z)
-            }
-            val at = corner * 3
-            if (length > 0.0 && length.isFinite()) {
-                normals[at] = (x / length).toFloat()
-                normals[at + 1] = (y / length).toFloat()
-                normals[at + 2] = (z / length).toFloat()
-            } else {
-                normals[at + 1] = 1f
-            }
+        return sums
+    }
+
+    private fun writeNormal(
+        normals: FloatArray,
+        corner: Int,
+        faces: FloatArray,
+        triangles: IntArray,
+        sums: DoubleArray
+    ) {
+        val face = corner / 3 * 3
+        var x = faces[face].toDouble()
+        var y = faces[face + 1].toDouble()
+        var z = faces[face + 2].toDouble()
+        var length = sqrt(x * x + y * y + z * z)
+        if (length == 0.0 || !length.isFinite()) {
+            val vertex = triangles[corner] * 3
+            x = sums[vertex]
+            y = sums[vertex + 1]
+            z = sums[vertex + 2]
+            length = sqrt(x * x + y * y + z * z)
         }
-        return StlModel(points, triangles, normals, unit)
+        val at = corner * 3
+        if (length > 0.0 && length.isFinite()) {
+            normals[at] = (x / length).toFloat()
+            normals[at + 1] = (y / length).toFloat()
+            normals[at + 2] = (z / length).toFloat()
+        } else {
+            normals[at + 1] = 1f
+        }
     }
 
     private fun coordinate(value: Float): Float {

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlModel.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/stl/StlModel.kt
@@ -1,0 +1,39 @@
+package io.github.sceneview.core.stl
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+
+/**
+ * An unreadable STL: malformed text, truncated binary data, non-finite positions, or an exceeded
+ * byte/triangle limit. Catch this around `StlLoader.toGlb(bytes)` to report a failed import.
+ * No geometry is allocated before the input byte limit and binary triangle count are checked.
+ */
+class StlParseException(message: String) : RuntimeException(message)
+
+/**
+ * A welded STL mesh returned by `StlLoader.parse(bytes)`, in the caller's [unit] (millimetres by
+ * default) and original axes. STL declares neither units nor an up axis.
+ *
+ * Coincident positions are welded exactly, including signed zero; no tolerance merges nearby
+ * vertices. Normals are per **corner**, so valid facet normals retain hard edges while corners
+ * with missing, zero or non-finite normals receive area-weighted smooth normals from adjoining
+ * faces. Zero-area faces contribute nothing; a cancelled/empty sum falls back to +Y.
+ *
+ * @property positions Three floats (x, y, z) per welded vertex, in [unit].
+ * @property indices Three position indices per triangle, in the file's winding order.
+ * @property normals Three normal components per **index** (nine floats per triangle), normalized.
+ * @property unit Caller-supplied length unit; reused from 3MF without changing that public enum.
+ */
+class StlModel internal constructor(
+    val positions: FloatArray,
+    val indices: IntArray,
+    val normals: FloatArray,
+    val unit: ThreeMfUnit
+) {
+    /** Number of unique positions: `StlLoader.parse(bytes).vertexCount`. */
+    val vertexCount: Int get() = positions.size / 3
+
+    /** Number of facets: `StlLoader.parse(bytes).triangleCount`. */
+    val triangleCount: Int get() = indices.size / 3
+}
+
+internal fun stlError(message: String): Nothing = throw StlParseException(message)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -27,7 +27,30 @@ internal object ThreeMfGlb {
         return builder.toGlb()
     }
 
+<<<<<<< HEAD
     internal class GltfBuilder(private val generator: String = Generator) {
+=======
+    /**
+     * Shared STL path: positions are welded by the parser; per-corner normals preserve valid
+     * facet normals and carry smooth repairs. Split only (position, normal) seams for glTF's
+     * single index stream. Bake units into positions and preserve axes (STL declares no up axis).
+     * Accessors, materials, JSON and aligned GLB assembly remain shared with the flat 3MF path.
+     */
+    fun encodeIndexed(
+        positions: FloatArray,
+        indices: IntArray,
+        cornerNormals: FloatArray,
+        meters: Float
+    ): ByteArray {
+        val builder = GltfBuilder("SceneView STL loader")
+        builder.addIndexedMesh(positions, indices, cornerNormals, meters)
+        return builder.toGlb()
+    }
+
+    private data class NormalVertex(val position: Int, val x: Float, val y: Float, val z: Float)
+
+    private class GltfBuilder(private val generator: String = Generator) {
+>>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
         private val bin = ByteArrayBuilder()
         private val bufferViews = ArrayList<String>()
         private val accessors = ArrayList<String>()
@@ -76,6 +99,48 @@ internal object ThreeMfGlb {
             )
             nodes += """{"name":"3mf","matrix":${root.toJsonArray()},""" +
                 """"children":${children.joinToString(",", "[", "]")}}"""
+        }
+
+        fun addIndexedMesh(
+            source: FloatArray,
+            indices: IntArray,
+            cornerNormals: FloatArray,
+            meters: Float
+        ) {
+            val vertices = HashMap<NormalVertex, Int>()
+            val positions = FloatArrayBuilder()
+            val normals = FloatArrayBuilder()
+            val renderIndices = IntArray(indices.size)
+            for (corner in indices.indices) {
+                val at = corner * 3
+                val key = NormalVertex(
+                    indices[corner], cornerNormals[at], cornerNormals[at + 1], cornerNormals[at + 2]
+                )
+                renderIndices[corner] = vertices.getOrPut(key) {
+                    val index = positions.size / 3
+                    repeat(3) { axis ->
+                        positions.add(source[key.position * 3 + axis] * meters)
+                        normals.add(cornerNormals[at + axis])
+                    }
+                    index
+                }
+            }
+            val positionAccessor = addFloatAccessor(positions.toArray(), withBounds = true)
+            val normalAccessor = addFloatAccessor(normals.toArray(), withBounds = false)
+            val indexAccessor = addIndexAccessor(renderIndices)
+            meshes += """{"primitives":[{"attributes":{"POSITION":$positionAccessor,"NORMAL":$normalAccessor},""" +
+                """"indices":$indexAccessor,"material":${materialIndex(NoColor)}}]}"""
+            nodes += """{"name":"stl","mesh":0}"""
+        }
+
+        private fun addIndexAccessor(indices: IntArray): Int {
+            val byteOffset = bin.size
+            for (index in indices) bin.addIntLe(index)
+            bufferViews += """{"buffer":0,"byteOffset":$byteOffset,""" +
+                """"byteLength":${indices.size * Int.SIZE_BYTES},"target":34963}"""
+            accessors += """{"bufferView":${bufferViews.size - 1},"componentType":5125,""" +
+                """"count":${indices.size},"type":"SCALAR"}"""
+            return accessors.size - 1
         }
 
         /** Emits the node for [object3mf] placed by [transform], recursing into its components. */
@@ -177,7 +242,11 @@ internal object ThreeMfGlb {
         }
 
         private fun buildJson(): String = buildString {
+<<<<<<< HEAD
             append("""{"asset":{"version":"2.0","generator":${generator.toJsonString()}},""")
+=======
+            append("""{"asset":{"version":"2.0","generator":"$generator"},""")
+>>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
             append(""""scene":0,"scenes":[{"nodes":[${nodes.size - 1}]}],""")
             append(""""nodes":${nodes.joinToString(",", "[", "]")},""")
             append(""""meshes":${meshes.joinToString(",", "[", "]")},""")
@@ -318,6 +387,10 @@ internal object ThreeMfGlb {
         if (!isFinite() || this == 0f) return "0"
         val magnitude = kotlin.math.abs(toDouble())
         val exponent = kotlin.math.floor(kotlin.math.log10(magnitude)).toInt()
+        if (exponent < -MAX_DECIMALS || exponent > 9) {
+            val mantissa = (toDouble() / 10.0.pow(exponent)).toFloat()
+            return "${mantissa.toJsonNumber()}e$exponent"
+        }
         val decimals = (SIGNIFICANT_DIGITS - 1 - exponent).coerceIn(0, MAX_DECIMALS)
         val scale = POWERS_OF_TEN[decimals]
         val scaled = kotlin.math.round(magnitude * scale.toDouble()).toLong()

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -27,9 +27,6 @@ internal object ThreeMfGlb {
         return builder.toGlb()
     }
 
-<<<<<<< HEAD
-    internal class GltfBuilder(private val generator: String = Generator) {
-=======
     /**
      * Shared STL path: positions are welded by the parser; per-corner normals preserve valid
      * facet normals and carry smooth repairs. Split only (position, normal) seams for glTF's
@@ -49,8 +46,7 @@ internal object ThreeMfGlb {
 
     private data class NormalVertex(val position: Int, val x: Float, val y: Float, val z: Float)
 
-    private class GltfBuilder(private val generator: String = Generator) {
->>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
+    internal class GltfBuilder(private val generator: String = Generator) {
         private val bin = ByteArrayBuilder()
         private val bufferViews = ArrayList<String>()
         private val accessors = ArrayList<String>()
@@ -242,11 +238,7 @@ internal object ThreeMfGlb {
         }
 
         private fun buildJson(): String = buildString {
-<<<<<<< HEAD
             append("""{"asset":{"version":"2.0","generator":${generator.toJsonString()}},""")
-=======
-            append("""{"asset":{"version":"2.0","generator":"$generator"},""")
->>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
             append(""""scene":0,"scenes":[{"nodes":[${nodes.size - 1}]}],""")
             append(""""nodes":${nodes.joinToString(",", "[", "]")},""")
             append(""""meshes":${meshes.joinToString(",", "[", "]")},""")

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlGlbTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlGlbTest.kt
@@ -1,0 +1,111 @@
+package io.github.sceneview.core.stl
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StlGlbTest {
+    @Test
+    fun boxBoundsAndBinaryPositionsAreSeventyByFortyByThirtyMillimetres() {
+        for (bytes in listOf(StlTestFixtures.binary(), StlTestFixtures.ascii())) {
+            val glb = StlLoader.toGlb(bytes)
+            val json = json(glb)
+            assertContains(json, "\"min\":[0,0,0]")
+            assertContains(json, "\"max\":[0.07,0.04,0.03]")
+            assertContains(json, "\"count\":8,\"type\":\"VEC3\"")
+            assertContains(json, "\"indices\":2")
+            assertContains(json, "\"doubleSided\":true")
+            assertTrue("\"matrix\"" !in json, "STL axes are preserved; metres are baked into positions")
+            val start = binStart(glb)
+            val bounds = FloatArray(3)
+            repeat(8) { vertex ->
+                repeat(3) { axis ->
+                    bounds[axis] = maxOf(bounds[axis], float(glb, start + (vertex * 3 + axis) * 4))
+                }
+            }
+            assertEquals(0.07f, bounds[0], 0.0000001f)
+            assertEquals(0.04f, bounds[1], 0.0000001f)
+            assertEquals(0.03f, bounds[2], 0.0000001f)
+        }
+    }
+
+    @Test
+    fun explicitUnitsScaleToMetres() {
+        for (unit in ThreeMfUnit.entries) {
+            val glb = StlLoader.toGlb(StlTestFixtures.binary(), unit)
+            val start = binStart(glb)
+            var maxX = 0f
+            repeat(8) { maxX = maxOf(maxX, float(glb, start + it * 12)) }
+            assertEquals(70f * unit.meters, maxX, 0.00001f)
+            assertEquals(unit, StlLoader.parse(StlTestFixtures.binary(), unit).unit)
+        }
+    }
+
+    @Test
+    fun glbChunksAndViewsAreAlignedAndFillTheContainer() {
+        val glb = StlLoader.toGlb(StlTestFixtures.binary())
+        assertEquals(0x46546c67, int(glb, 0))
+        assertEquals(2, int(glb, 4))
+        assertEquals(glb.size, int(glb, 8))
+        val jsonLength = int(glb, 12)
+        assertEquals(0x4e4f534a, int(glb, 16))
+        assertEquals(0, jsonLength % 4)
+        val json = json(glb)
+        val end = json.lastIndexOf('}') + 1
+        assertTrue(json.substring(end).all { it == ' ' }, "JSON padding must be spaces")
+        assertTrue(json.length - end in 0..3)
+        val binLength = int(glb, 20 + jsonLength)
+        assertEquals(0x004e4942, int(glb, 24 + jsonLength))
+        assertEquals(0, binLength % 4)
+        assertEquals(glb.size, binStart(glb) + binLength)
+        // Eight positions + eight normals (float3), then 36 uint32 indices: no BIN padding needed.
+        assertEquals(8 * 12 * 2 + 36 * 4, binLength)
+        var expectedOffset = 0
+        val views = Regex("\"byteOffset\":(\\d+),\"byteLength\":(\\d+)").findAll(json).toList()
+        assertEquals(3, views.size)
+        for (view in views) {
+            val offset = view.groupValues[1].toInt()
+            val length = view.groupValues[2].toInt()
+            assertEquals(expectedOffset, offset)
+            assertEquals(0, offset % 4)
+            assertEquals(0, length % 4)
+            expectedOffset += length
+        }
+        assertEquals(binLength, expectedOffset)
+        val indicesStart = binStart(glb) + 8 * 12 * 2
+        repeat(36) { assertTrue(int(glb, indicesStart + it * 4) in 0..7) }
+    }
+
+    @Test
+    fun smoothNormalsReachTheGlbAndValidFacetsSplitNormalSeams() {
+        val smooth = StlLoader.toGlb(StlTestFixtures.binary(StlTestFixtures.wedge))
+        assertContains(json(smooth), "\"count\":5,\"type\":\"VEC3\"")
+        val normalStart = binStart(smooth) + 5 * 12
+        assertEquals(0f, float(smooth, normalStart))
+        assertEquals(0.4472136f, float(smooth, normalStart + 4), 0.000001f)
+        assertEquals(0.8944272f, float(smooth, normalStart + 8), 0.000001f)
+        val facets = StlTestFixtures.wedge.map { it.copyOf() }
+        facets[0][2] = 1f
+        facets[1][1] = 1f
+        val flat = StlLoader.toGlb(StlTestFixtures.binary(facets))
+        assertContains(json(flat), "\"count\":6,\"type\":\"VEC3\"")
+    }
+
+    @Test
+    fun extremeBoundsRemainJsonNumbersAndDoNotRoundToZero() {
+        for (size in listOf(1e-12f, 1e20f)) {
+            val facet = StlTestFixtures.wedge[0].copyOf()
+            facet[6] = size
+            val glb = StlLoader.toGlb(StlTestFixtures.binary(listOf(facet)), ThreeMfUnit.METER)
+            val max = Regex("\"max\":\\[([^,]+),").find(json(glb))!!.groupValues[1].toFloat()
+            assertTrue(kotlin.math.abs((max - size) / size) < 0.000001f)
+        }
+    }
+
+    private fun json(glb: ByteArray): String = glb.decodeToString(20, 20 + int(glb, 12))
+    private fun binStart(glb: ByteArray): Int = 28 + int(glb, 12)
+    private fun int(bytes: ByteArray, at: Int): Int = stlUInt32(bytes, at).toInt()
+    private fun float(bytes: ByteArray, at: Int): Float = Float.fromBits(int(bytes, at))
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlLoaderTest.kt
@@ -1,0 +1,154 @@
+package io.github.sceneview.core.stl
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StlLoaderTest {
+    @Test
+    fun binaryBoxWeldsThirtySixCornersToEightVertices() {
+        val bytes = StlTestFixtures.binary()
+        assertTrue(StlLoader.isStl(bytes))
+        val model = StlLoader.parse(bytes)
+        assertEquals(12, model.triangleCount)
+        assertEquals(8, model.vertexCount)
+        assertEquals(ThreeMfUnit.MILLIMETER, model.unit)
+        assertEquals(70f, model.positions.maxOrNull())
+    }
+
+    @Test
+    fun asciiAndBinaryHaveIdenticalGeometry() {
+        val ascii = StlTestFixtures.ascii()
+        assertTrue(StlLoader.isStl(ascii))
+        val a = StlLoader.parse(ascii)
+        val b = StlLoader.parse(StlTestFixtures.binary())
+        assertContentEquals(b.positions, a.positions)
+        assertContentEquals(b.indices, a.indices)
+        assertContentEquals(b.normals, a.normals)
+        assertContentEquals(StlLoader.toGlb(ascii), StlLoader.toGlb(StlTestFixtures.binary()))
+    }
+
+    @Test
+    fun binarySolidHeaderWinsEvenWhenItContainsFacet() {
+        val bytes = StlTestFixtures.binary(header = "solid misleading facet normal")
+        assertTrue(StlLoader.isStl(bytes))
+        assertEquals(12, StlLoader.parse(bytes).triangleCount)
+    }
+
+    @Test
+    fun binaryLengthMustMatchUnsignedCountExactly() {
+        val bytes = StlTestFixtures.binary()
+        for (length in listOf(0, 79, 83, 84, bytes.size - 1, bytes.size - 50, bytes.size + 1)) {
+            val truncated = bytes.copyOf(length)
+            assertFalse(StlLoader.isStl(truncated))
+            assertFailsWith<StlParseException> { StlLoader.parse(truncated) }
+        }
+        StlTestFixtures.putInt(bytes, 80, -1)
+        assertFailsWith<StlParseException> { StlLoader.parse(bytes, maxTriangles = Int.MAX_VALUE) }
+    }
+
+    @Test
+    fun capsRejectBothFormatsAndPermitExactLimits() {
+        for (bytes in listOf(StlTestFixtures.binary(), StlTestFixtures.ascii())) {
+            assertFailsWith<StlParseException> { StlLoader.toGlb(bytes, maxTriangles = 11) }
+            assertFailsWith<StlParseException> { StlLoader.parse(bytes, maxBytes = bytes.size - 1) }
+            assertFailsWith<StlParseException> { StlLoader.parse(bytes, maxTriangles = 0) }
+            assertFailsWith<StlParseException> { StlLoader.parse(bytes, maxBytes = -1) }
+            assertEquals(12, StlLoader.parse(bytes, maxTriangles = 12, maxBytes = bytes.size).triangleCount)
+        }
+    }
+
+    @Test
+    fun zeroNormalsAreAreaWeightedAcrossWeldedVertices() {
+        val model = StlLoader.parse(StlTestFixtures.binary(StlTestFixtures.wedge))
+        assertEquals(5, model.vertexCount)
+        // Shared origin: normalize (0,1,2), not an unweighted average of unit normals.
+        val inverseLength = (1.0 / sqrt(5.0)).toFloat()
+        assertNormal(model, 0, 0f, inverseLength, 2 * inverseLength)
+        assertNormal(model, 3, 0f, inverseLength, 2 * inverseLength)
+        assertNormal(model, 1, 0f, 0f, 1f)
+        assertNormal(model, 4, 0f, 1f, 0f)
+    }
+
+    @Test
+    fun validFacetNormalsAreNormalizedAndPreservedAlongsideRepairs() {
+        val facets = StlTestFixtures.wedge.map { it.copyOf() }
+        facets[0][0] = 3f
+        val model = StlLoader.parse(StlTestFixtures.binary(facets))
+        repeat(3) { assertNormal(model, it, 1f, 0f, 0f) }
+        val inverseLength = (1.0 / sqrt(5.0)).toFloat()
+        assertNormal(model, 3, 0f, inverseLength, 2 * inverseLength)
+    }
+
+    @Test
+    fun nonFiniteNormalsAreRepairedAndZeroAreaFacesStayFinite() {
+        for (invalid in listOf(Float.NaN, Float.POSITIVE_INFINITY)) {
+            val facets = StlTestFixtures.wedge.map { it.copyOf().also { f -> f[0] = invalid } }
+            val repaired = StlLoader.parse(StlTestFixtures.binary(facets))
+            val expected = StlLoader.parse(StlTestFixtures.binary(StlTestFixtures.wedge))
+            assertContentEquals(expected.normals, repaired.normals)
+        }
+        val degenerate = StlLoader.parse(StlTestFixtures.binary(listOf(FloatArray(12))))
+        assertEquals(1, degenerate.vertexCount)
+        repeat(3) { assertNormal(degenerate, it, 0f, 1f, 0f) }
+    }
+
+    @Test
+    fun signedZeroWeldsAndVerySmallOrLargeNormalsNormalize() {
+        val facets = StlTestFixtures.wedge.map { it.copyOf() }
+        facets[1][3] = -0f
+        facets[0][2] = Float.MIN_VALUE
+        facets[1][1] = Float.MAX_VALUE
+        val model = StlLoader.parse(StlTestFixtures.binary(facets))
+        assertEquals(5, model.vertexCount)
+        assertNormal(model, 0, 0f, 0f, 1f)
+        assertNormal(model, 3, 0f, 1f, 0f)
+    }
+
+    @Test
+    fun nonFinitePositionsFailForBothEncodings() {
+        for (value in listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY)) {
+            val facets = listOf(StlTestFixtures.wedge[0].copyOf().also { it[3] = value })
+            assertFailsWith<StlParseException> { StlLoader.parse(StlTestFixtures.binary(facets)) }
+            assertFailsWith<StlParseException> { StlLoader.parse(StlTestFixtures.ascii(facets)) }
+        }
+    }
+
+    @Test
+    fun asciiSupportsWhitespaceExponentsMissingNormalsAndMultipleSolids() {
+        val text = StlTestFixtures.ascii(StlTestFixtures.wedge).decodeToString()
+            .replace("facet normal 0.0 0.0 0.0", "facet")
+            .replace("2.0", "2e0").replace(" ", "\t").replace("\n", "\r\n")
+        val model = StlLoader.parse((" \n$text$text").encodeToByteArray())
+        assertEquals(4, model.triangleCount)
+        assertEquals(5, model.vertexCount)
+        assertTrue(model.normals.all { it.isFinite() })
+    }
+
+    @Test
+    fun malformedAsciiFailsWithTypedErrors() {
+        val text = StlTestFixtures.ascii().decodeToString()
+        for (bad in listOf(
+            "solid only\nendsolid only\n", "solidarity facet", text.replace("endfacet", ""),
+            text.replace("endsolid", "missing"), text.replace("outer loop", "outer broken"),
+            text.replaceFirst("vertex", "wrong"), text.replaceFirst("70.0", "no-number"),
+            text.replaceFirst("70.0", "1".repeat(129)), text + "garbage", "glTF"
+        )) {
+            assertFailsWith<StlParseException>(bad.take(40)) { StlLoader.parse(bad.encodeToByteArray()) }
+        }
+        assertFalse(StlLoader.isStl("solid only".encodeToByteArray()))
+        assertFalse(StlLoader.isStl("solidarity facet".encodeToByteArray()))
+        assertFalse(StlLoader.isStl("solid name\n multifacet".encodeToByteArray()))
+    }
+
+    private fun assertNormal(model: StlModel, corner: Int, x: Float, y: Float, z: Float) {
+        for ((axis, expected) in floatArrayOf(x, y, z).withIndex()) {
+            assertEquals(expected, model.normals[corner * 3 + axis], 0.000001f)
+        }
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
@@ -57,4 +57,7 @@ internal object StlTestFixtures {
  * Platform-stable float text: Kotlin/JVM prints 70f as "70.0" but Kotlin/JS prints "70", and the
  * malformed-input test edits the fixture by replacing "70.0" — so the fixture must write it.
  */
-private fun Float.stl(): String = toString().let { if (it.any { c -> c == '.' || c == 'e' || c == 'E' }) it else "$it.0" }
+private fun Float.stl(): String {
+    val text = toString()
+    return if (text.any { it == '.' || it == 'e' || it == 'E' }) text else "$text.0"
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
@@ -1,0 +1,54 @@
+package io.github.sceneview.core.stl
+
+internal object StlTestFixtures {
+    // Two non-coplanar faces sharing an edge: area vectors (0,0,2) and (0,1,0).
+    val wedge = listOf(
+        floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, 2f, 0f, 0f, 0f, 1f, 0f),
+        floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 1f, 1f, 0f, 0f)
+    )
+
+    val box: List<FloatArray> get() {
+        val vertices = arrayOf(
+            floatArrayOf(0f, 0f, 0f), floatArrayOf(70f, 0f, 0f),
+            floatArrayOf(70f, 40f, 0f), floatArrayOf(0f, 40f, 0f),
+            floatArrayOf(0f, 0f, 30f), floatArrayOf(70f, 0f, 30f),
+            floatArrayOf(70f, 40f, 30f), floatArrayOf(0f, 40f, 30f)
+        )
+        val indices = intArrayOf(
+            0, 2, 1, 0, 3, 2, 4, 5, 6, 4, 6, 7,
+            0, 1, 5, 0, 5, 4, 3, 7, 6, 3, 6, 2,
+            0, 4, 7, 0, 7, 3, 1, 2, 6, 1, 6, 5
+        )
+        return List(12) { face ->
+            FloatArray(12).also { facet ->
+                repeat(3) { vertices[indices[face * 3 + it]].copyInto(facet, 3 + it * 3) }
+            }
+        }
+    }
+
+    fun binary(facets: List<FloatArray> = box, header: String = "SceneView fixture"): ByteArray =
+        ByteArray(84 + 50 * facets.size).also { bytes ->
+            header.encodeToByteArray().copyInto(bytes, endIndex = minOf(80, header.length))
+            putInt(bytes, 80, facets.size)
+            facets.forEachIndexed { face, facet ->
+                facet.forEachIndexed { i, value -> putInt(bytes, 84 + face * 50 + i * 4, value.toBits()) }
+            }
+        }
+
+    fun ascii(facets: List<FloatArray> = box): ByteArray = buildString {
+        append("solid test part\n")
+        for (facet in facets) {
+            append("facet normal ${facet[0]} ${facet[1]} ${facet[2]}\nouter loop\n")
+            repeat(3) {
+                val at = 3 + it * 3
+                append("vertex ${facet[at]} ${facet[at + 1]} ${facet[at + 2]}\n")
+            }
+            append("endloop\nendfacet\n")
+        }
+        append("endsolid test part\n")
+    }.encodeToByteArray()
+
+    fun putInt(bytes: ByteArray, at: Int, value: Int) {
+        repeat(4) { bytes[at + it] = (value ushr (it * 8)).toByte() }
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
@@ -38,10 +38,10 @@ internal object StlTestFixtures {
     fun ascii(facets: List<FloatArray> = box): ByteArray = buildString {
         append("solid test part\n")
         for (facet in facets) {
-            append("facet normal ${facet[0]} ${facet[1]} ${facet[2]}\nouter loop\n")
+            append("facet normal ${facet[0].stl()} ${facet[1].stl()} ${facet[2].stl()}\nouter loop\n")
             repeat(3) {
                 val at = 3 + it * 3
-                append("vertex ${facet[at]} ${facet[at + 1]} ${facet[at + 2]}\n")
+                append("vertex ${facet[at].stl()} ${facet[at + 1].stl()} ${facet[at + 2].stl()}\n")
             }
             append("endloop\nendfacet\n")
         }
@@ -52,3 +52,9 @@ internal object StlTestFixtures {
         repeat(4) { bytes[at + it] = (value ushr (it * 8)).toByte() }
     }
 }
+
+/**
+ * Platform-stable float text: Kotlin/JVM prints 70f as "70.0" but Kotlin/JS prints "70", and the
+ * malformed-input test edits the fixture by replacing "70.0" — so the fixture must write it.
+ */
+private fun Float.stl(): String = toString().let { if (it.any { c -> c == '.' || c == 'e' || c == 'E' }) it else "$it.0" }

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -585,19 +585,11 @@ internal suspend fun <T : Any> destroyOnCancel(
 }
 
 /**
-<<<<<<< HEAD
- * Normalises whatever the caller handed us into something Filament's glTF loader accepts: a 3MF is
- * converted to GLB, OBJ geometry is converted next, then WebP textures are transcoded.
+ * Normalises whatever the caller handed us into something Filament's glTF loader accepts: 3MF, STL
+ * and OBJ are converted to GLB, then WebP textures are transcoded.
  */
 private fun Buffer.toFilamentModelSource(): Buffer =
-    convertThreeMfToGlb().convertObjToGlb().transcodeWebPTextures()
-=======
- * Normalises whatever the caller handed us into something Filament's glTF loader accepts: 3MF and
- * STL are converted to GLB, then WebP textures are transcoded.
- */
-private fun Buffer.toFilamentModelSource(): Buffer =
-    convertThreeMfToGlb().convertStlToGlb().transcodeWebPTextures()
->>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
+    convertThreeMfToGlb().convertStlToGlb().convertObjToGlb().transcodeWebPTextures()
 
 /**
  * Converts a **3MF** payload to GLB, so `.3mf` is loadable through every entry point on this class

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -46,6 +46,13 @@ import java.nio.ByteBuffer
  * (usually millimetres) to metres and rotates it from 3MF's Z-up to glTF's Y-up. A payload that is
  * not a ZIP costs one 4-byte comparison.
  *
+ * **Binary and ASCII `.stl` also load through every entry point** (#3486):
+ * `rememberModelInstance(modelLoader, "part.stl")`. Payload sniffing checks binary size/count
+ * before ASCII solid/facet tokens, without copying other formats. STL has no units: the default
+ * is millimetres, converted to metres, with the file's axes preserved. For another unit, first use
+ * `StlLoader.toGlb(bytes, unit = ThreeMfUnit.INCH)` from `sceneview-core` and load that GLB.
+ * Valid facet normals are kept; zero/invalid normals are repaired with smooth vertex normals.
+ *
  * The `suspend` [loadModel] converts off the main thread; the [createModel] overloads convert on
  * the calling (main) thread, like the rest of their work.
  */
@@ -578,11 +585,19 @@ internal suspend fun <T : Any> destroyOnCancel(
 }
 
 /**
+<<<<<<< HEAD
  * Normalises whatever the caller handed us into something Filament's glTF loader accepts: a 3MF is
  * converted to GLB, OBJ geometry is converted next, then WebP textures are transcoded.
  */
 private fun Buffer.toFilamentModelSource(): Buffer =
     convertThreeMfToGlb().convertObjToGlb().transcodeWebPTextures()
+=======
+ * Normalises whatever the caller handed us into something Filament's glTF loader accepts: 3MF and
+ * STL are converted to GLB, then WebP textures are transcoded.
+ */
+private fun Buffer.toFilamentModelSource(): Buffer =
+    convertThreeMfToGlb().convertStlToGlb().transcodeWebPTextures()
+>>>>>>> 084ae99b2 (feat(core): STL loader, binary and ASCII, to GLB in memory (#3486))
 
 /**
  * Converts a **3MF** payload to GLB, so `.3mf` is loadable through every entry point on this class

--- a/sceneview/src/main/java/io/github/sceneview/loaders/StlModelSource.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/StlModelSource.kt
@@ -1,0 +1,46 @@
+package io.github.sceneview.loaders
+
+import io.github.sceneview.core.stl.StlLoader
+import io.github.sceneview.core.stl.StlParseException
+import java.nio.Buffer
+import java.nio.ByteBuffer
+
+/** Convert only STL candidates; sniff with absolute reads so ordinary GLBs are never copied. */
+internal fun Buffer.convertStlToGlb(): Buffer {
+    val source = this as? ByteBuffer ?: return this
+    if (!source.looksLikeStlPayload()) return this
+    if (source.remaining() > StlLoader.DEFAULT_MAX_BYTES) {
+        throw StlParseException("STL input exceeds ${StlLoader.DEFAULT_MAX_BYTES} bytes")
+    }
+    val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+    val glb = StlLoader.toGlb(bytes)
+    return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+/** Length/count wins over ASCII detection: binary writers often start their header with solid. */
+internal fun ByteBuffer.looksLikeStlPayload(): Boolean {
+    val start = position()
+    val size = remaining()
+    if (size >= 84 && (size - 84) % 50 == 0) {
+        var count = 0L
+        repeat(4) { count = count or ((get(start + 80 + it).toLong() and 0xff) shl (it * 8)) }
+        if (count == (size - 84).toLong() / 50) return true
+    }
+    var at = start
+    while (at < limit() && stlSpace(get(at).toInt())) at++
+    if (!stlTokenAt(at, "solid")) return false
+    at += 5
+    while (at < limit()) {
+        val value = get(at).toInt()
+        if (!stlSpace(value) && value !in 32..126) return false
+        if (stlSpace(get(at - 1).toInt()) && stlTokenAt(at, "facet")) return true
+        at++
+    }
+    return false
+}
+
+private fun ByteBuffer.stlTokenAt(at: Int, token: String): Boolean =
+    at + token.length <= limit() && token.indices.all { get(at + it).toInt() == token[it].code } &&
+        (at + token.length == limit() || stlSpace(get(at + token.length).toInt()))
+
+private fun stlSpace(value: Int): Boolean = value == 32 || value in 9..13

--- a/sceneview/src/test/java/io/github/sceneview/loaders/StlModelSourceTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/loaders/StlModelSourceTest.kt
@@ -1,0 +1,75 @@
+package io.github.sceneview.loaders
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StlModelSourceTest {
+    @Test
+    fun binaryDetectionUsesRemainingRangeAndLittleEndianCountWithoutMovingTheBuffer() {
+        val bytes = ByteArray(134)
+        "solid misleading facet".encodeToByteArray().copyInto(bytes)
+        bytes[80] = 1
+        val buffer = ByteBuffer.allocateDirect(160).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(7)
+        buffer.put(bytes)
+        buffer.limit(buffer.position())
+        buffer.position(7)
+        buffer.mark()
+        val readonly = buffer.asReadOnlyBuffer()
+        assertTrue(readonly.looksLikeStlPayload())
+        val result = readonly.convertStlToGlb() as ByteBuffer
+        assertTrue(result.isDirect)
+        assertEquals('g'.code.toByte(), result.get(0))
+        assertEquals(7, readonly.position())
+        assertEquals(141, readonly.limit())
+        assertEquals(ByteOrder.BIG_ENDIAN, readonly.order())
+        buffer.reset()
+        assertEquals(7, buffer.position())
+    }
+
+    @Test
+    fun asciiNeedsBothTokensAndAcceptsLeadingWhitespace() {
+        val ascii = """  solid part
+            facet normal 0 0 0
+            outer loop
+            vertex 0 0 0
+            vertex 70 0 0
+            vertex 0 40 0
+            endloop
+            endfacet
+            endsolid part
+        """.trimIndent()
+        val buffer = ByteBuffer.wrap(ascii.encodeToByteArray())
+        assertTrue(buffer.looksLikeStlPayload())
+        assertEquals('g'.code.toByte(), (buffer.convertStlToGlb() as ByteBuffer).get(0))
+        assertEquals(0, buffer.position())
+    }
+
+    @Test
+    fun otherFormatsAreReturnedByIdentity() {
+        for (text in listOf("glTF", "{\"asset\":{}}", "PK\u0003\u0004", "solid", "solidarity facet", "solid x\n multifacet")) {
+            val buffer = ByteBuffer.wrap(text.encodeToByteArray())
+            assertFalse(buffer.looksLikeStlPayload())
+            assertSame(buffer, buffer.convertStlToGlb())
+        }
+        val largeGlb = ByteBuffer.allocate(100_084)
+        largeGlb.putInt(0, 0x676c5446)
+        assertSame(largeGlb, largeGlb.convertStlToGlb())
+        val floats = ByteBuffer.allocate(12).asFloatBuffer()
+        assertSame(floats, floats.convertStlToGlb())
+    }
+
+    @Test
+    fun mismatchedOrUnsignedBinaryCountsDoNotPassTheCheapGate() {
+        val bytes = ByteArray(134)
+        bytes[80] = 2
+        assertFalse(ByteBuffer.wrap(bytes).looksLikeStlPayload())
+        repeat(4) { bytes[80 + it] = -1 }
+        assertFalse(ByteBuffer.wrap(bytes).looksLikeStlPayload())
+    }
+}

--- a/sceneview/src/test/java/io/github/sceneview/loaders/StlModelSourceTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/loaders/StlModelSourceTest.kt
@@ -52,7 +52,11 @@ class StlModelSourceTest {
 
     @Test
     fun otherFormatsAreReturnedByIdentity() {
-        for (text in listOf("glTF", "{\"asset\":{}}", "PK\u0003\u0004", "solid", "solidarity facet", "solid x\n multifacet")) {
+        val otherFormats = listOf(
+            "glTF", "{\"asset\":{}}", "PK\u0003\u0004", "solid", "solidarity facet",
+            "solid x\n multifacet"
+        )
+        for (text in otherFormats) {
             val buffer = ByteBuffer.wrap(text.encodeToByteArray())
             assertFalse(buffer.looksLikeStlPayload())
             assertSame(buffer, buffer.convertStlToGlb())


### PR DESCRIPTION
Closes #3486 — partially. **Do not merge as is**: this is the raw output of a delegated run, opened unedited on purpose.

## What this is

An experiment, at Thomas's request, to measure Codex **GPT-6 Astra** at `--effort high` on a real backlog issue rather than on a toy task. The whole issue was handed to it in an isolated worktree with the repo conventions spelled out (pure-Kotlin `commonMain`, reuse of `ThreeMfGlb`, the `ModelLoader` sniff, the changelog and api-dump rules). Nothing was corrected before this commit — the CI is the judge, not the lead session.

## What the model produced in ~9 minutes

- `sceneview-core/.../core/stl/`: `StlLoader`, `StlMeshBuilder`, `StlModel` — binary (`84 + 50n` size check) and ASCII, vertex welding, smooth normals when the file's own normals are zero or degenerate, triangle/byte caps with a typed error.
- `ThreeMfGlb` extended so the STL path reuses the existing in-memory GLB writer instead of a second one.
- `ModelLoader` sniff on the Android side, plus `StlModelSource` and its test.
- `commonTest/.../core/stl/`: `StlLoaderTest`, `StlGlbTest`, `StlTestFixtures` (fixtures built in code, no binary assets).

843 lines added.

## What is missing, and why

The run was cut short by the ChatGPT **Plus** usage limit roughly nine minutes in, during the documentation pass. Missing: the `changelog.d/3486-stl-loader.md` fragment, the `llms.txt` row, the `agents/sceneview/SKILL.md` row, the `sceneview-core/api` dump, and the emulator screenshot the issue asks for. The model also never managed to run Gradle: the Codex sandbox denies the Gradle cache lock, so nothing here has been executed by its author.

Left open as a measurement. Completing it is a follow-up, not a fix to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
