### PR TITLE
feat(core): OBJ + MTL loader, geometry and material colours (#3488)

### DIFF
--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -773,6 +773,43 @@ public final class io/github/sceneview/collision/Vector3$Companion {
 	public final fun zero ()Lio/github/sceneview/collision/Vector3;
 }
 
+public final class io/github/sceneview/core/obj/ObjGroup {
+	public fun <init> (Ljava/lang/String;[F[F[FLjava/util/List;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNormals ()[F
+	public final fun getPositions ()[F
+	public final fun getTextureCoordinates ()[F
+	public final fun getTriangleCount ()I
+	public final fun getTriangleMaterials ()Ljava/util/List;
+}
+
+public final class io/github/sceneview/core/obj/ObjLoader {
+	public static final field INSTANCE Lio/github/sceneview/core/obj/ObjLoader;
+	public final fun isObj ([B)Z
+	public final fun parse ([BLio/github/sceneview/core/threemf/ThreeMfUnit;Lkotlin/jvm/functions/Function1;)Lio/github/sceneview/core/obj/ObjModel;
+	public static synthetic fun parse$default (Lio/github/sceneview/core/obj/ObjLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/sceneview/core/obj/ObjModel;
+	public final fun toGlb (Lio/github/sceneview/core/obj/ObjModel;)[B
+	public final fun toGlb ([BLio/github/sceneview/core/threemf/ThreeMfUnit;Lkotlin/jvm/functions/Function1;)[B
+	public static synthetic fun toGlb$default (Lio/github/sceneview/core/obj/ObjLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)[B
+}
+
+public final class io/github/sceneview/core/obj/ObjMaterial {
+	public fun <init> ([F)V
+	public final fun getBaseColorFactor ()[F
+}
+
+public final class io/github/sceneview/core/obj/ObjModel {
+	public fun <init> (Lio/github/sceneview/core/threemf/ThreeMfUnit;Ljava/util/List;Ljava/util/Map;)V
+	public final fun getGroups ()Ljava/util/List;
+	public final fun getMaterials ()Ljava/util/Map;
+	public final fun getTriangleCount ()I
+	public final fun getUnit ()Lio/github/sceneview/core/threemf/ThreeMfUnit;
+}
+
+public final class io/github/sceneview/core/obj/ObjParseException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class io/github/sceneview/core/splat/SplatCloud {
 	public fun <init> (I[F[F[F[F[F)V
 	public final fun getColors ()[F
@@ -1608,4 +1645,3 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
-

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -1645,3 +1645,4 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
+

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjGlb.kt
@@ -48,11 +48,15 @@ internal object ObjGlb {
         }
 
     private fun validate(group: ObjGroup) {
-        if (group.positions.isEmpty() || group.positions.size % 9 != 0 ||
-            group.normals.size != group.positions.size || group.triangleMaterials.size != group.triangleCount ||
-            (group.textureCoordinates != null && group.textureCoordinates.size != group.triangleCount * 6) ||
-            group.positions.any { !it.isFinite() } || group.normals.any { !it.isFinite() } ||
-            group.textureCoordinates?.any { !it.isFinite() } == true
-        ) objError("OBJ group '${group.name}': inconsistent or non-finite triangle data")
+        val positions = group.positions
+        val uvs = group.textureCoordinates
+        val sizesMatch = positions.isNotEmpty() && positions.size % 9 == 0 && group.normals.size == positions.size
+        val countsMatch = group.triangleMaterials.size == group.triangleCount &&
+            (uvs == null || uvs.size == group.triangleCount * 6)
+        val finite = positions.all { it.isFinite() } && group.normals.all { it.isFinite() } &&
+            (uvs == null || uvs.all { it.isFinite() })
+        if (!sizesMatch || !countsMatch || !finite) {
+            objError("OBJ group '${group.name}': inconsistent or non-finite triangle data")
+        }
     }
 }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjGlb.kt
@@ -1,0 +1,58 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.IntArrayBuilder
+import io.github.sceneview.core.threemf.ThreeMfGlb
+
+/** Reuse 3MF's accessors, materials, JSON escaping and aligned container assembly without its rotation. */
+internal object ObjGlb {
+    fun encode(model: ObjModel): ByteArray {
+        if (model.groups.isEmpty()) objError("OBJ contains no groups")
+        val builder = ThreeMfGlb.GltfBuilder("SceneView OBJ loader")
+        val materialIndices = HashMap<List<Float>, Int>()
+        for (group in model.groups) {
+            validate(group)
+            val trianglesByMaterial = LinkedHashMap<String?, IntArrayBuilder>()
+            for (triangle in 0 until group.triangleCount) {
+                trianglesByMaterial.getOrPut(group.triangleMaterials[triangle]) { IntArrayBuilder() }.add(triangle)
+            }
+            val primitives = trianglesByMaterial.map { (name, triangles) ->
+                val color = model.materials[name]?.baseColorFactor ?: defaultObjColor()
+                if (color.size != 4 || color.any { !it.isFinite() || it !in 0f..1f }) {
+                    objError("OBJ material '$name': expected four finite RGBA factors in [0, 1]")
+                }
+                val material = materialIndices.getOrPut(color.toList()) { builder.addMaterial(color) }
+                val selected = triangles.toArray()
+                builder.addPrimitive(
+                    select(group.positions, selected, 9),
+                    select(group.normals, selected, 9),
+                    // OBJ's v origin is bottom-left; glTF's texture origin is top-left.
+                    group.textureCoordinates?.let { uv ->
+                        select(uv, selected, 6).also { values ->
+                            for (i in 1 until values.size step 2) values[i] = 1f - values[i]
+                        }
+                    },
+                    material
+                )
+            }
+            builder.addMesh(group.name, primitives)
+        }
+        builder.addScaledRoot("obj", model.unit.meters)
+        return builder.toGlb()
+    }
+
+    private fun select(values: FloatArray, triangles: IntArray, stride: Int): FloatArray =
+        FloatArray(triangles.size * stride).also { output ->
+            triangles.forEachIndexed { index, triangle ->
+                values.copyInto(output, index * stride, triangle * stride, (triangle + 1) * stride)
+            }
+        }
+
+    private fun validate(group: ObjGroup) {
+        if (group.positions.isEmpty() || group.positions.size % 9 != 0 ||
+            group.normals.size != group.positions.size || group.triangleMaterials.size != group.triangleCount ||
+            (group.textureCoordinates != null && group.textureCoordinates.size != group.triangleCount * 6) ||
+            group.positions.any { !it.isFinite() } || group.normals.any { !it.isFinite() } ||
+            group.textureCoordinates?.any { !it.isFinite() } == true
+        ) objError("OBJ group '${group.name}': inconsistent or non-finite triangle data")
+    }
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjLoader.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjLoader.kt
@@ -1,0 +1,89 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+
+/**
+ * Reads Wavefront **OBJ + MTL** in pure Kotlin on Android, iOS and web, without dependencies.
+ * Positions, UVs, normals, all face index forms, negative indices and simple planar polygons are
+ * supported. Each nonempty object/group combination becomes one mesh; `usemtl` splits primitives.
+ * MTL `Kd`, `d` and `Tr` supply colours. **Textures are not yet supported**: `map_Kd` logs and skips.
+ *
+ * ```kotlin
+ * // Scope the resolver to the directory containing the OBJ; return null for missing siblings.
+ * val glb = ObjLoader.toGlb(objBytes, unit = ThreeMfUnit.MILLIMETER) { relativePath ->
+ *     siblingFiles[relativePath]
+ * }
+ * ```
+ *
+ * OBJ has no unit metadata. [ThreeMfUnit] is shared with the 3MF loader; millimetres are the default.
+ * Conversion scales to metres and keeps Y-up. Android `ModelLoader` automatically detects small
+ * OBJ headers, loading grey geometry; call [toGlb] explicitly for MTL colours or another unit.
+ */
+object ObjLoader {
+    /**
+     * Conservatively sniff at most 4096 bytes: a complete `v ` line followed by a complete `f ` line,
+     * skipping comments and blank lines. Tabs, CRLF and a UTF-8 BOM are accepted. Unknown directives
+     * before the first face reject the sniff, so JSON glTF and GLB are never treated as OBJ.
+     * Large files whose first face falls outside the prefix require explicit conversion.
+     * Example: `if (ObjLoader.isObj(bytes)) ObjLoader.toGlb(bytes) else bytes`.
+     */
+    fun isObj(bytes: ByteArray): Boolean {
+        val limit = minOf(bytes.size, 4096)
+        var at = objStart(bytes)
+        var vertex = false
+        while (at < limit) {
+            val start = at
+            while (at < limit && bytes[at] != 10.toByte() && bytes[at] != 13.toByte()) at++
+            if (at == limit && limit < bytes.size) return false
+            val tokens = ObjTokens(bytes.decodeToString(start, at))
+            when (val command = tokens.next()) {
+                null -> Unit
+                "v" -> {
+                    repeat(3) { if (tokens.next()?.toFloatOrNull()?.isFinite() != true) return false }
+                    vertex = true
+                }
+                "f" -> return vertex && tokens.next() != null && tokens.next() != null && tokens.next() != null
+                "vn", "vt", "o", "g", "mtllib", "usemtl", "s", "l", "p" -> Unit
+                else -> return false
+            }
+            at++
+        }
+        return false
+    }
+
+    /**
+     * Parse into de-indexed triangle groups, preserving Y-up coordinates in [unit]. Missing normals
+     * are area-weighted smooth normals at shared position indices (across UV/material/group seams).
+     * Explicit normals are normalised and retained; smoothing directives `s` are currently ignored.
+     * Degenerate or zero normals fall back to +Y. Simple concave polygons use ear clipping.
+     *
+     * [resolver] receives each `mtllib` path relative to the OBJ's directory, with `/` separators.
+     * The caller owns I/O and base-path resolution. Null resolver/results mean grey; resolver
+     * exceptions propagate. Multiple whitespace-separated libraries are supported; filenames with
+     * spaces must be quoted. Unknown directives are skipped. `map_Kd` never invokes the resolver.
+     *
+     * Example: `val model = ObjLoader.parse(bytes, ThreeMfUnit.METER) { siblings[it] }`.
+     * @throws ObjParseException for invalid geometry, indices or recognised numeric fields.
+     */
+    fun parse(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.Default,
+        resolver: ((String) -> ByteArray?)? = null
+    ): ObjModel = ObjParser.parse(bytes, unit, resolver)
+
+    /**
+     * Produce a self-contained GLB in Y-up metres, with double-sided diffuse materials and alpha
+     * blending for `d < 1` or `Tr > 0`. Missing MTL colours use opaque grey; textures are not yet
+     * loaded. Uses the shared GLB writer, including aligned JSON/BIN chunks.
+     * Example: `val glb = ObjLoader.toGlb(bytes, ThreeMfUnit.INCH) { siblings[it] }`.
+     * @throws ObjParseException if [parse] cannot read the geometry or numeric data.
+     */
+    fun toGlb(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.Default,
+        resolver: ((String) -> ByteArray?)? = null
+    ): ByteArray = toGlb(parse(bytes, unit, resolver))
+
+    /** Convert parsed data with its stored unit. Example: `ObjLoader.toGlb(ObjLoader.parse(bytes))`. */
+    fun toGlb(model: ObjModel): ByteArray = ObjGlb.encode(model)
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjModel.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjModel.kt
@@ -1,0 +1,71 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+
+/**
+ * A parsed OBJ in Y-up axes and [unit], before conversion to metres.
+ *
+ * ```kotlin
+ * val model = ObjLoader.parse(bytes)
+ * val triangles = model.triangleCount
+ * ```
+ *
+ * @property unit Caller-specified length unit; OBJ declares none. Defaults to millimetres in the loader.
+ * @property groups Nonempty object/group combinations, in first-face order.
+ * @property materials MTL material names mapped to linear RGBA factors; missing names use grey.
+ */
+class ObjModel(
+    val unit: ThreeMfUnit,
+    val groups: List<ObjGroup>,
+    val materials: Map<String, ObjMaterial>
+) {
+    /** Total triangles after polygon triangulation. Example: `model.triangleCount`. */
+    val triangleCount: Int get() = groups.sumOf { it.triangleCount }
+}
+
+/**
+ * One OBJ object/group combination, emitted as one GLB mesh with primitives split by material.
+ * Vertices are de-indexed so independent position/UV/normal indices and normal seams survive.
+ *
+ * ```kotlin
+ * val group = ObjLoader.parse(bytes).groups.first()
+ * val firstPosition = group.positions.take(3)
+ * ```
+ *
+ * @property name Object and group names joined with `/`; ungrouped faces use `default`.
+ * @property positions Three floats per corner, nine per triangle, in the caller's units.
+ * @property normals Unit normals per corner, supplied by `vn` or computed from adjacent faces.
+ * @property textureCoordinates Two floats per corner in OBJ's UV convention, or null without `vt`.
+ * Missing UVs in a mixed mesh are zero. Texture images are not loaded yet.
+ * @property triangleMaterials One `usemtl` name per triangle, null before the first assignment.
+ */
+class ObjGroup(
+    val name: String,
+    val positions: FloatArray,
+    val normals: FloatArray,
+    val textureCoordinates: FloatArray?,
+    val triangleMaterials: List<String?>
+) {
+    /** Number of triangles. Example: `group.triangleCount`. */
+    val triangleCount: Int get() = positions.size / 9
+}
+
+/**
+ * MTL diffuse colour and opacity, used directly as glTF's linear `baseColorFactor`.
+ *
+ * ```kotlin
+ * val rgba = ObjLoader.parse(bytes, resolver = resolveSibling).materials["paint"]?.baseColorFactor
+ * ```
+ *
+ * @property baseColorFactor Four floats: `Kd` red/green/blue and `d` (or `1 - Tr`) alpha in [0, 1].
+ * If both opacity directives occur, the last wins. No sRGB conversion or 8-bit quantisation occurs.
+ */
+class ObjMaterial(val baseColorFactor: FloatArray)
+
+/**
+ * Invalid OBJ geometry or malformed numeric data, with a line number when available.
+ * Example: `runCatching { ObjLoader.parse(bytes) }.exceptionOrNull() is ObjParseException`.
+ */
+class ObjParseException(message: String) : RuntimeException(message)
+
+internal fun objError(message: String): Nothing = throw ObjParseException(message)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
@@ -1,0 +1,28 @@
+package io.github.sceneview.core.obj
+
+internal object ObjMtl {
+    fun read(bytes: ByteArray, materials: MutableMap<String, ObjMaterial>) {
+        var factor: FloatArray? = null
+        objLines(bytes) { tokens, line ->
+            when (tokens.next()) {
+                "newmtl" -> {
+                    val name = tokens.rest()
+                    if (name.isEmpty()) objError("MTL line $line: newmtl needs a name")
+                    factor = defaultObjColor()
+                    materials[name] = ObjMaterial(factor!!)
+                }
+                "Kd" -> factor?.let { rgba ->
+                    repeat(3) { rgba[it] = tokens.number(line).coerceIn(0f, 1f) }
+                }
+                "d" -> factor?.let {
+                    val token = tokens.next()
+                    it[3] = (if (token == "-halo") tokens.number(line) else number(token, line)).coerceIn(0f, 1f)
+                }
+                "Tr" -> factor?.let { it[3] = 1f - tokens.number(line).coerceIn(0f, 1f) }
+                "map_Kd" -> println("SceneView OBJ: map_Kd textures not yet supported; skipping texture")
+            }
+        }
+    }
+}
+
+internal fun defaultObjColor(): FloatArray = floatArrayOf(0.62f, 0.64f, 0.68f, 1f)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
@@ -8,8 +8,9 @@ internal object ObjMtl {
                 "newmtl" -> {
                     val name = tokens.rest()
                     if (name.isEmpty()) objError("MTL line $line: newmtl needs a name")
-                    factor = defaultObjColor()
-                    materials[name] = ObjMaterial(factor!!)
+                    val color = defaultObjColor()
+                    factor = color
+                    materials[name] = ObjMaterial(color)
                 }
                 "Kd" -> factor?.let { rgba ->
                     repeat(3) { rgba[it] = tokens.number(line).coerceIn(0f, 1f) }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjParser.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjParser.kt
@@ -1,0 +1,165 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.IntArrayBuilder
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.math.sqrt
+
+internal object ObjParser {
+    fun parse(bytes: ByteArray, unit: ThreeMfUnit, resolver: ((String) -> ByteArray?)?): ObjModel {
+        val state = State()
+        objLines(bytes) { tokens, line -> state.read(tokens, line) }
+        if (state.groups.isEmpty()) objError("OBJ contains no faces")
+        val materials = LinkedHashMap<String, ObjMaterial>()
+        if (resolver != null) {
+            for (path in state.libraries) {
+                resolver(path)?.let { ObjMtl.read(it, materials) }
+            }
+        }
+        return ObjModel(unit, state.finish(), materials)
+    }
+
+    private class State {
+        val positions = ObjFloats()
+        val normals = ObjFloats()
+        val uv = ObjFloats()
+        val groups = LinkedHashMap<Pair<String, String>, Group>()
+        val libraries = LinkedHashSet<String>()
+        private var objectName = ""
+        private var groupName = ""
+        private var material: String? = null
+
+        fun read(tokens: ObjTokens, line: Int) {
+            when (tokens.next()) {
+                "v" -> repeat(3) { positions.add(tokens.number(line)) }
+                "vn" -> repeat(3) { normals.add(tokens.number(line)) }
+                "vt" -> {
+                    uv.add(tokens.number(line))
+                    uv.add(tokens.next()?.let { number(it, line) } ?: 0f)
+                    // OBJ permits a third texture coordinate; GLB uses only u/v.
+                }
+                "o" -> { objectName = tokens.rest(); groupName = "" }
+                "g" -> groupName = tokens.rest()
+                "usemtl" -> material = tokens.rest().ifEmpty { null }
+                "mtllib" -> {
+                    var path = tokens.next(quoted = true)
+                    while (path != null) {
+                        libraries += path.replace('\\', '/')
+                        path = tokens.next(quoted = true)
+                    }
+                }
+                "f" -> face(tokens, line)
+            }
+        }
+
+        private fun face(tokens: ObjTokens, line: Int) {
+            val corners = ArrayList<Corner>()
+            var token = tokens.next()
+            while (token != null) {
+                corners += corner(token, line)
+                token = tokens.next()
+            }
+            if (corners.size > 3 && corners.first().position == corners.last().position) {
+                corners.removeAt(corners.lastIndex)
+            }
+            if (corners.size < 3) objError("OBJ line $line: a face needs at least three vertices")
+            val group = groups.getOrPut(objectName to groupName) {
+                Group(listOf(objectName, groupName).filter { it.isNotEmpty() }.joinToString("/").ifEmpty { "default" })
+            }
+            val triangles = ObjTriangulation.triangulate(corners.map { it.position }, positions, line)
+            for (index in triangles) {
+                val corner = corners[index]
+                group.corners.add(corner.position)
+                group.corners.add(corner.texture)
+                group.corners.add(corner.normal)
+            }
+            repeat(triangles.size / 3) { group.materials += material }
+        }
+
+        private fun corner(token: String, line: Int): Corner {
+            val first = token.indexOf('/')
+            if (first < 0) return Corner(index(token, positions.size / 3, line), -1, -1)
+            val second = token.indexOf('/', first + 1)
+            if (second >= 0 && token.indexOf('/', second + 1) >= 0) objError("OBJ line $line: invalid face '$token'")
+            val vertex = index(token.substring(0, first), positions.size / 3, line)
+            val texture = token.substring(first + 1, if (second < 0) token.length else second)
+            val normal = if (second < 0) "" else token.substring(second + 1)
+            if ((second < 0 && texture.isEmpty()) || (second >= 0 && normal.isEmpty())) {
+                objError("OBJ line $line: incomplete face index '$token'")
+            }
+            return Corner(
+                vertex,
+                if (texture.isEmpty()) -1 else index(texture, uv.size / 2, line),
+                if (normal.isEmpty()) -1 else index(normal, normals.size / 3, line)
+            )
+        }
+
+        /** Resolve each index against the corresponding table as it exists at this face. */
+        private fun index(token: String, count: Int, line: Int): Int {
+            val value = token.toIntOrNull() ?: objError("OBJ line $line: invalid index '$token'")
+            val resolved = if (value > 0) value - 1 else count + value
+            if (value == 0 || resolved !in 0 until count) objError("OBJ line $line: index $value out of range ($count)")
+            return resolved
+        }
+
+        fun finish(): List<ObjGroup> {
+            val packed = groups.values.map { it to it.corners.toArray() }
+            // Area-weighted sums in double precision avoid overflow on large but finite positions.
+            val smooth = DoubleArray(positions.size)
+            for ((_, corners) in packed) {
+                for (at in corners.indices step 9) accumulate(corners, at, smooth)
+            }
+            return packed.map { (group, corners) -> expand(group, corners, smooth) }
+        }
+
+        private fun accumulate(corners: IntArray, at: Int, smooth: DoubleArray) {
+            val a = corners[at] * 3
+            val b = corners[at + 3] * 3
+            val c = corners[at + 6] * 3
+            val ux = positions[b].toDouble() - positions[a]
+            val uy = positions[b + 1].toDouble() - positions[a + 1]
+            val uz = positions[b + 2].toDouble() - positions[a + 2]
+            val vx = positions[c].toDouble() - positions[a]
+            val vy = positions[c + 1].toDouble() - positions[a + 1]
+            val vz = positions[c + 2].toDouble() - positions[a + 2]
+            for (corner in 0 until 3) {
+                val offset = corners[at + corner * 3] * 3
+                smooth[offset] += uy * vz - uz * vy
+                smooth[offset + 1] += uz * vx - ux * vz
+                smooth[offset + 2] += ux * vy - uy * vx
+            }
+        }
+
+        private fun expand(group: Group, corners: IntArray, smooth: DoubleArray): ObjGroup {
+            val outPositions = FloatArray(corners.size)
+            val outNormals = FloatArray(corners.size)
+            val outUv = if ((1 until corners.size step 3).any { corners[it] >= 0 }) {
+                FloatArray(corners.size / 3 * 2)
+            } else null
+            for (at in corners.indices step 3) {
+                val vertex = corners[at] * 3
+                val normal = corners[at + 2] * 3
+                repeat(3) { outPositions[at + it] = positions[vertex + it] }
+                val x = if (normal >= 0) normals[normal].toDouble() else smooth[vertex]
+                val y = if (normal >= 0) normals[normal + 1].toDouble() else smooth[vertex + 1]
+                val z = if (normal >= 0) normals[normal + 2].toDouble() else smooth[vertex + 2]
+                val length = sqrt(x * x + y * y + z * z)
+                outNormals[at] = if (length > 0.0) (x / length).toFloat() else 0f
+                outNormals[at + 1] = if (length > 0.0) (y / length).toFloat() else 1f
+                outNormals[at + 2] = if (length > 0.0) (z / length).toFloat() else 0f
+                val texture = corners[at + 1] * 2
+                if (outUv != null && texture >= 0) {
+                    outUv[at / 3 * 2] = uv[texture]
+                    outUv[at / 3 * 2 + 1] = uv[texture + 1]
+                }
+            }
+            return ObjGroup(group.name, outPositions, outNormals, outUv, group.materials)
+        }
+    }
+
+    private class Group(val name: String) {
+        val corners = IntArrayBuilder()
+        val materials = ArrayList<String?>()
+    }
+
+    private data class Corner(val position: Int, val texture: Int, val normal: Int)
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjParser.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjParser.kt
@@ -83,9 +83,8 @@ internal object ObjParser {
             val vertex = index(token.substring(0, first), positions.size / 3, line)
             val texture = token.substring(first + 1, if (second < 0) token.length else second)
             val normal = if (second < 0) "" else token.substring(second + 1)
-            if ((second < 0 && texture.isEmpty()) || (second >= 0 && normal.isEmpty())) {
-                objError("OBJ line $line: incomplete face index '$token'")
-            }
+            val incomplete = if (second < 0) texture.isEmpty() else normal.isEmpty()
+            if (incomplete) objError("OBJ line $line: incomplete face index '$token'")
             return Corner(
                 vertex,
                 if (texture.isEmpty()) -1 else index(texture, uv.size / 2, line),

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjText.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjText.kt
@@ -1,0 +1,70 @@
+package io.github.sceneview.core.obj
+
+/** Decode one logical line at a time, never a whole multi-megabyte OBJ or an array of its lines. */
+internal inline fun objLines(bytes: ByteArray, consume: (ObjTokens, Int) -> Unit) {
+    var at = objStart(bytes)
+    var line = 0
+    var continued: StringBuilder? = null
+    while (at < bytes.size) {
+        val start = at
+        while (at < bytes.size && bytes[at] != 10.toByte() && bytes[at] != 13.toByte()) at++
+        val text = bytes.decodeToString(start, at).trimEnd()
+        if (at < bytes.size && bytes[at++] == 13.toByte() && at < bytes.size && bytes[at] == 10.toByte()) at++
+        line++
+        if (text.endsWith('\\')) {
+            val pending = continued ?: StringBuilder().also { continued = it }
+            pending.append(text.dropLast(1)).append(' ')
+        } else {
+            consume(ObjTokens(continued?.append(text)?.toString() ?: text), line)
+            continued = null
+        }
+    }
+    if (continued != null) objError("OBJ line $line: unfinished line continuation")
+}
+
+internal fun objStart(bytes: ByteArray): Int =
+    if (bytes.size >= 3 && bytes[0] == 0xef.toByte() && bytes[1] == 0xbb.toByte() &&
+        bytes[2] == 0xbf.toByte()
+    ) 3 else 0
+
+/** Whitespace tokens with inline comments; quoting is opt-in for library paths only. */
+internal class ObjTokens(private val line: String) {
+    private var at = 0
+
+    fun next(quoted: Boolean = false): String? {
+        while (at < line.length && line[at].isWhitespace()) at++
+        if (at == line.length || line[at] == '#') return null
+        if (quoted && (line[at] == '"' || line[at] == '\'')) {
+            val quote = line[at++]
+            val start = at
+            while (at < line.length && line[at] != quote) at++
+            if (at == line.length) objError("OBJ/MTL: unterminated quoted path")
+            return line.substring(start, at++)
+        }
+        val start = at
+        while (at < line.length && !line[at].isWhitespace() && line[at] != '#') at++
+        return line.substring(start, at)
+    }
+
+    fun rest(): String = line.substring(at).substringBefore('#').trim()
+
+    fun number(lineNumber: Int): Float = number(next(), lineNumber)
+}
+
+internal fun number(token: String?, line: Int): Float =
+    token?.toFloatOrNull()?.takeIf { it.isFinite() }
+        ?: objError("OBJ/MTL line $line: expected a finite number, got '$token'")
+
+/** Primitive storage with indexed reads for resolving relative indices without boxing floats. */
+internal class ObjFloats {
+    private var values = FloatArray(256)
+    var size = 0
+        private set
+
+    fun add(value: Float) {
+        if (size == values.size) values = values.copyOf(size * 2)
+        values[size++] = value
+    }
+
+    operator fun get(index: Int): Float = values[index]
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjText.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjText.kt
@@ -9,7 +9,10 @@ internal inline fun objLines(bytes: ByteArray, consume: (ObjTokens, Int) -> Unit
         val start = at
         while (at < bytes.size && bytes[at] != 10.toByte() && bytes[at] != 13.toByte()) at++
         val text = bytes.decodeToString(start, at).trimEnd()
-        if (at < bytes.size && bytes[at++] == 13.toByte() && at < bytes.size && bytes[at] == 10.toByte()) at++
+        if (at < bytes.size) {
+            val carriageReturn = bytes[at++] == 13.toByte()
+            if (carriageReturn && at < bytes.size && bytes[at] == 10.toByte()) at++
+        }
         line++
         if (text.endsWith('\\')) {
             val pending = continued ?: StringBuilder().also { continued = it }
@@ -22,10 +25,11 @@ internal inline fun objLines(bytes: ByteArray, consume: (ObjTokens, Int) -> Unit
     if (continued != null) objError("OBJ line $line: unfinished line continuation")
 }
 
-internal fun objStart(bytes: ByteArray): Int =
-    if (bytes.size >= 3 && bytes[0] == 0xef.toByte() && bytes[1] == 0xbb.toByte() &&
-        bytes[2] == 0xbf.toByte()
-    ) 3 else 0
+internal fun objStart(bytes: ByteArray): Int {
+    val bom = byteArrayOf(0xef.toByte(), 0xbb.toByte(), 0xbf.toByte())
+    val hasBom = bytes.size >= bom.size && bom.indices.all { bytes[it] == bom[it] }
+    return if (hasBom) bom.size else 0
+}
 
 /** Whitespace tokens with inline comments; quoting is opt-in for library paths only. */
 internal class ObjTokens(private val line: String) {

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjTriangulation.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjTriangulation.kt
@@ -1,0 +1,77 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.IntArrayBuilder
+import kotlin.math.abs
+
+/** Convex fan fast path, then winding-preserving ear clipping for simple concave polygons. */
+internal object ObjTriangulation {
+    fun triangulate(vertices: List<Int>, positions: ObjFloats, line: Int): IntArray {
+        if (vertices.size == 3) return intArrayOf(0, 1, 2)
+        val points = project(vertices, positions)
+        var area = 0.0
+        for (i in vertices.indices) {
+            val next = (i + 1) % vertices.size
+            area += points.x[i] * points.y[next] - points.x[next] * points.y[i]
+        }
+        val direction = if (area >= 0.0) 1.0 else -1.0
+        val convex = vertices.indices.all { i ->
+            points.cross(i, (i + 1) % vertices.size, (i + 2) % vertices.size) * direction >= 0.0
+        }
+        if (convex) return IntArray((vertices.size - 2) * 3) { i ->
+            when (i % 3) { 0 -> 0; 1 -> i / 3 + 1; else -> i / 3 + 2 }
+        }
+        return clip(points, direction, line)
+    }
+
+    private fun clip(points: Points, direction: Double, line: Int): IntArray {
+        val remaining = points.x.indices.toMutableList()
+        val triangles = IntArrayBuilder()
+        while (remaining.size > 3) {
+            val ear = remaining.indices.firstOrNull { i ->
+                val a = remaining[(i + remaining.size - 1) % remaining.size]
+                val b = remaining[i]
+                val c = remaining[(i + 1) % remaining.size]
+                points.cross(a, b, c) * direction > 0.0 && remaining.none { p ->
+                    p != a && p != b && p != c &&
+                        points.cross(a, b, p) * direction >= 0.0 &&
+                        points.cross(b, c, p) * direction >= 0.0 &&
+                        points.cross(c, a, p) * direction >= 0.0
+                }
+            } ?: objError("OBJ line $line: polygon cannot be triangulated (expected a simple planar face)")
+            triangles.add(remaining[(ear + remaining.size - 1) % remaining.size])
+            triangles.add(remaining[ear])
+            triangles.add(remaining[(ear + 1) % remaining.size])
+            remaining.removeAt(ear)
+        }
+        remaining.forEach { triangles.add(it) }
+        return triangles.toArray()
+    }
+
+    /** Drop the dominant component of Newell's normal to support faces in any axis plane. */
+    private fun project(vertices: List<Int>, positions: ObjFloats): Points {
+        val normal = DoubleArray(3)
+        for (i in vertices.indices) {
+            val a = vertices[i] * 3
+            val b = vertices[(i + 1) % vertices.size] * 3
+            for (axis in 0 until 3) {
+                val u = (axis + 1) % 3
+                val v = (axis + 2) % 3
+                normal[axis] += (positions[a + u].toDouble() - positions[b + u]) *
+                    (positions[a + v].toDouble() + positions[b + v])
+            }
+        }
+        val drop = normal.indices.maxBy { abs(normal[it]) }
+        val u = (drop + 1) % 3
+        val v = (drop + 2) % 3
+        // Translate before area products to reduce cancellation on models far from the origin.
+        return Points(
+            DoubleArray(vertices.size) { positions[vertices[it] * 3 + u].toDouble() - positions[vertices[0] * 3 + u] },
+            DoubleArray(vertices.size) { positions[vertices[it] * 3 + v].toDouble() - positions[vertices[0] * 3 + v] }
+        )
+    }
+
+    private class Points(val x: DoubleArray, val y: DoubleArray) {
+        fun cross(a: Int, b: Int, c: Int): Double =
+            (x[b] - x[a]) * (y[c] - y[a]) - (y[b] - y[a]) * (x[c] - x[a])
+    }
+}

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -27,7 +27,7 @@ internal object ThreeMfGlb {
         return builder.toGlb()
     }
 
-    private class GltfBuilder {
+    internal class GltfBuilder(private val generator: String = Generator) {
         private val bin = ByteArrayBuilder()
         private val bufferViews = ArrayList<String>()
         private val accessors = ArrayList<String>()
@@ -40,6 +40,25 @@ internal object ThreeMfGlb {
 
         /** Packed colour → glTF material index. */
         private val materialIndexByColor = HashMap<Int, Int>()
+
+        /** Shared assembly for Y-up formats: one named mesh/node per group, then a scaled root. */
+        fun addMesh(name: String, primitives: List<String>) {
+            meshes += """{"name":${name.toJsonString()},"primitives":${primitives.joinToString(",", "[", "]")}}"""
+            nodes += """{"name":${name.toJsonString()},"mesh":${meshes.size - 1}}"""
+        }
+
+        fun addScaledRoot(name: String, scale: Float) {
+            val children = nodes.indices.joinToString(",", "[", "]")
+            nodes += """{"name":${name.toJsonString()},"scale":${floatArrayOf(scale, scale, scale).toJsonArray()},"children":$children}"""
+        }
+
+        /** Positions and supplied normals are already de-indexed; UVs are optional VEC2 values. */
+        fun addPrimitive(positions: FloatArray, normals: FloatArray, uv: FloatArray?, material: Int): String {
+            val position = addFloatAccessor(positions, withBounds = true)
+            val normal = addFloatAccessor(normals, withBounds = false)
+            val texture = uv?.let { ",\"TEXCOORD_0\":" + addFloatAccessor(it, false, 2) }.orEmpty()
+            return """{"attributes":{"POSITION":$position,"NORMAL":$normal$texture},"material":$material}"""
+        }
 
         fun addRootNode(model: ThreeMfModel) {
             val children = model.items.mapNotNull { item ->
@@ -122,26 +141,31 @@ internal object ThreeMfGlb {
                 """"material":${materialIndex(color)}}"""
         }
 
-        private fun addFloatAccessor(values: FloatArray, withBounds: Boolean): Int {
+        private fun addFloatAccessor(values: FloatArray, withBounds: Boolean, components: Int = 3): Int {
             val byteOffset = bin.size
             for (value in values) bin.addFloatLe(value)
             bufferViews += """{"buffer":0,"byteOffset":$byteOffset,""" +
                 """"byteLength":${values.size * Float.SIZE_BYTES},"target":$ARRAY_BUFFER}"""
-            val count = values.size / 3
+            val count = values.size / components
             val bounds = if (withBounds) ""","min":${min(values)},"max":${max(values)}""" else ""
             accessors += """{"bufferView":${bufferViews.size - 1},"componentType":$FLOAT,""" +
-                """"count":$count,"type":"VEC3"$bounds}"""
+                """"count":$count,"type":"VEC$components"$bounds}"""
             return accessors.size - 1
         }
 
         private fun materialIndex(color: Int): Int = materialIndexByColor.getOrPut(color) {
             val factor = if (color == NoColor) DefaultBaseColor else color.toLinearRgba()
+            addMaterial(factor)
+        }
+
+        /** Linear RGBA factors also support OBJ's floating-point Kd and fully transparent black. */
+        fun addMaterial(factor: FloatArray): Int {
             materials += """{"pbrMetallicRoughness":{"baseColorFactor":${factor.toJsonArray()},""" +
                 """"metallicFactor":0,"roughnessFactor":$PrintRoughness},""" +
                 // 3MF requires outward-facing counter-clockwise winding, but generated files often
                 // get it wrong; a one-sided material would then render the print inside-out.
                 """"doubleSided":true${alphaMode(factor[3])}}"""
-            materials.size - 1
+            return materials.size - 1
         }
 
         private fun alphaMode(alpha: Float) = if (alpha < 1f) ""","alphaMode":"BLEND"""" else ""
@@ -152,7 +176,7 @@ internal object ThreeMfGlb {
         }
 
         private fun buildJson(): String = buildString {
-            append("""{"asset":{"version":"2.0","generator":"$Generator"},""")
+            append("""{"asset":{"version":"2.0","generator":${generator.toJsonString()}},""")
             append(""""scene":0,"scenes":[{"nodes":[${nodes.size - 1}]}],""")
             append(""""nodes":${nodes.joinToString(",", "[", "]")},""")
             append(""""meshes":${meshes.joinToString(",", "[", "]")},""")

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -49,7 +49,8 @@ internal object ThreeMfGlb {
 
         fun addScaledRoot(name: String, scale: Float) {
             val children = nodes.indices.joinToString(",", "[", "]")
-            nodes += """{"name":${name.toJsonString()},"scale":${floatArrayOf(scale, scale, scale).toJsonArray()},"children":$children}"""
+            val scaleJson = floatArrayOf(scale, scale, scale).toJsonArray()
+            nodes += """{"name":${name.toJsonString()},"scale":$scaleJson,"children":$children}"""
         }
 
         /** Positions and supplied normals are already de-indexed; UVs are optional VEC2 values. */

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjLoaderTest.kt
@@ -1,0 +1,202 @@
+package io.github.sceneview.core.obj
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ObjLoaderTest {
+    @Test
+    fun cubeQuadsBecomeTwelveTrianglesWithOriginalBounds() {
+        val model = ObjLoader.parse(ObjTestFixtures.Cube)
+        assertEquals(ThreeMfUnit.MILLIMETER, model.unit)
+        assertEquals(12, model.triangleCount)
+        val group = model.groups.single()
+        assertEquals("cube", group.name)
+        for (axis in 0 until 3) {
+            val values = (axis until group.positions.size step 3).map { group.positions[it] }
+            assertEquals(0f, values.min())
+            assertEquals(10f, values.max())
+        }
+        for (at in group.normals.indices step 3) {
+            val length = sqrt((0..2).sumOf { group.normals[at + it].toDouble() * group.normals[at + it] })
+            assertEquals(1.0, length, 0.000001)
+        }
+    }
+
+    @Test
+    fun negativeIndicesUseTablesAtTheFaceNotAtEndOfFile() {
+        val source = ObjTestFixtures.Triangle.replace("f 1 2 3", "f -3 -2 -1") + "\nv 99 99 99"
+        val expected = ObjLoader.parse(ObjTestFixtures.Triangle.encodeToByteArray()).groups.single()
+        assertContentEquals(expected.positions, ObjLoader.parse(source.encodeToByteArray()).groups.single().positions)
+    }
+
+    @Test
+    fun allFaceIndexFormsAndIndependentNegativeNormalUvIndices() {
+        val vertices = ObjTestFixtures.Triangle.substringBefore("f ")
+        val attributes = "vt 0.25 0.75\nvt 1\nvn 0 0 -2\n"
+        for (face in listOf("1 2 3", "1/1 2/2 3/1", "1//1 2//1 3//1", "1/-2/-1 2/-1/-1 3/-2/-1")) {
+            val group = ObjLoader.parse((vertices + attributes + "f $face").encodeToByteArray()).groups.single()
+            assertEquals(1, group.triangleCount)
+            if (face.contains("//") || face.contains("/-")) {
+                assertContentEquals(floatArrayOf(0f, 0f, -1f, 0f, 0f, -1f, 0f, 0f, -1f), group.normals)
+            } else {
+                assertEquals(1f, group.normals[2])
+            }
+            if (face.contains("/1") || face.contains("/-")) {
+                assertContentEquals(floatArrayOf(0.25f, 0.75f, 1f, 0f, 0.25f, 0.75f), group.textureCoordinates)
+            } else assertNull(group.textureCoordinates)
+        }
+    }
+
+    @Test
+    fun missingNormalsAreSmoothedAcrossUvAndMaterialSeamsWhileExplicitNormalsSurvive() {
+        val source = """
+            v 0 0 0
+            v 1 0 0
+            v 0 1 0
+            v 0 0 1
+            vt 0 0
+            vt 1 1
+            vn -1 0 0
+            usemtl first
+            f 1/1 2/1 3/1
+            g second
+            usemtl second
+            f 1/2 4/2 2/2/1
+        """.trimIndent()
+        val groups = ObjLoader.parse(source.encodeToByteArray()).groups
+        val smooth = 1f / sqrt(2f)
+        assertEquals(smooth, groups[0].normals[1], 0.000001f)
+        assertEquals(smooth, groups[0].normals[2], 0.000001f)
+        assertContentEquals(groups[0].normals.copyOfRange(0, 3), groups[1].normals.copyOfRange(0, 3))
+        assertContentEquals(floatArrayOf(-1f, 0f, 0f), groups[1].normals.copyOfRange(6, 9))
+    }
+
+    @Test
+    fun twoGroupsResolveRelativeMtlColoursAndOpacity() {
+        val requested = ArrayList<String>()
+        val model = ObjLoader.parse(ObjTestFixtures.Colored) {
+            requested += it
+            if (it == "materials/paint.mtl") ObjTestFixtures.Materials else null
+        }
+        assertEquals(listOf("materials/paint.mtl"), requested, "texture images must not be resolved")
+        assertEquals(listOf("red", "green"), model.groups.map { it.name })
+        assertEquals(listOf("red", "green"), model.groups.map { it.triangleMaterials.single() })
+        assertContentEquals(floatArrayOf(1f, 0f, 0f, 0.5f), model.materials["red"]?.baseColorFactor)
+        assertContentEquals(floatArrayOf(0f, 1f, 0f, 0.75f), model.materials["green"]?.baseColorFactor)
+    }
+
+    @Test
+    fun missingMtlAndAbsentResolverStillLoad() {
+        for (model in listOf(ObjLoader.parse(ObjTestFixtures.Colored), ObjLoader.parse(ObjTestFixtures.Colored) { null })) {
+            assertEquals(2, model.triangleCount)
+            assertTrue(model.materials.isEmpty())
+            assertTrue(ObjLoader.toGlb(model).isNotEmpty())
+        }
+    }
+
+    @Test
+    fun repeatedGroupNamesMergeWithinObjectsButNotBetweenObjects() {
+        val source = ObjTestFixtures.Triangle.substringBefore("f ") + """
+            o one
+            g shared
+            f 1 2 3
+            g other
+            f 1 2 3
+            g shared
+            f 1 2 3
+            o two
+            g shared
+            f 1 2 3
+        """.trimIndent()
+        val groups = ObjLoader.parse(source.encodeToByteArray()).groups
+        assertEquals(listOf("one/shared", "one/other", "two/shared"), groups.map { it.name })
+        assertEquals(listOf(2, 1, 1), groups.map { it.triangleCount })
+    }
+
+    @Test
+    fun commentsBomTabsCrLfAndLineContinuation() {
+        val source = "\uFEFF# exporter\r\n\r\nv\t0 0 0 # origin\r\nv 2 0 0\rv 0 3 0\nf 1 \\\n2 3"
+        assertEquals(1, ObjLoader.parse(source.encodeToByteArray()).triangleCount)
+    }
+
+    @Test
+    fun concavePolygonPreservesAreaAndWindingInEveryAxisPlane() {
+        // U-shaped polygon: 3*3 minus a 1*2 notch = area 7, eight corners = six triangles.
+        val points = listOf(0 to 0, 3 to 0, 3 to 3, 2 to 3, 2 to 1, 1 to 1, 1 to 3, 0 to 3)
+        for (drop in 0 until 3) for (reverse in listOf(false, true)) {
+            val u = (drop + 1) % 3
+            val v = (drop + 2) % 3
+            val order = if (reverse) points.reversed() else points
+            val source = order.joinToString("\n") { (x, y) ->
+                val xyz = IntArray(3)
+                xyz[u] = x
+                xyz[v] = y
+                "v ${xyz.joinToString(" ") }"
+            } + "\nf 1 2 3 4 5 6 7 8"
+            val group = ObjLoader.parse(source.encodeToByteArray()).groups.single()
+            assertEquals(6, group.triangleCount)
+            var area = 0f
+            val p = group.positions
+            for (at in p.indices step 9) {
+                val cross = (p[at + 3 + u] - p[at + u]) * (p[at + 6 + v] - p[at + v]) -
+                    (p[at + 3 + v] - p[at + v]) * (p[at + 6 + u] - p[at + u])
+                assertTrue(if (reverse) cross < 0 else cross > 0)
+                area += cross / 2
+            }
+            assertEquals(7f, abs(area))
+        }
+    }
+
+    @Test
+    fun invalidIndicesAndNonFinitePositionsAreRejected() {
+        val vertices = ObjTestFixtures.Triangle.substringBefore("f ")
+        for (face in listOf("0 2 3", "-4 2 3", "4 2 3", "1/1 2 3", "1//1 2 3", "1/ 2 3", "1 2")) {
+            assertFailsWith<ObjParseException>(face) { ObjLoader.parse((vertices + "f $face").encodeToByteArray()) }
+        }
+        assertFailsWith<ObjParseException> { ObjLoader.parse(ObjTestFixtures.Triangle.replace("v 0", "v NaN").encodeToByteArray()) }
+        assertFailsWith<ObjParseException> { ObjLoader.parse("# empty".encodeToByteArray()) }
+    }
+
+    @Test
+    fun degenerateTrianglesHaveFiniteFallbackNormals() {
+        val group = ObjLoader.parse("v 0 0 0\nf 1 1 1".encodeToByteArray()).groups.single()
+        assertContentEquals(floatArrayOf(0f, 1f, 0f, 0f, 1f, 0f, 0f, 1f, 0f), group.normals)
+    }
+
+    @Test
+    fun multipleLibrariesQuotedPathsAndLastOpacityWin() {
+        val source = "mtllib first.mtl \"sub dir/second.mtl\"\n" + ObjTestFixtures.Triangle
+        val requests = ArrayList<String>()
+        val model = ObjLoader.parse(source.encodeToByteArray()) {
+            requests += it
+            "newmtl paint\nKd 0.2 0.4 0.6\nd 0.7\nTr 0.8\nd -halo 0.3".encodeToByteArray()
+        }
+        assertEquals(listOf("first.mtl", "sub dir/second.mtl"), requests)
+        assertContentEquals(floatArrayOf(0.2f, 0.4f, 0.6f, 0.3f), assertNotNull(model.materials["paint"]).baseColorFactor)
+    }
+
+    @Test
+    fun sniffIsConservativeBoundedAndAcceptsCommentsAndBom() {
+        assertTrue(ObjLoader.isObj(ObjTestFixtures.Cube))
+        assertTrue(ObjLoader.isObj(("\uFEFF# comment\r\n\r\n" + ObjTestFixtures.Triangle).encodeToByteArray()))
+        assertTrue(ObjLoader.isObj(ObjTestFixtures.Triangle.replace("v ", "v\t").encodeToByteArray()))
+        for (source in listOf("", "f 1 2 3\nv 0 0 0", "vn 0 0 1\nf 1 2 3", "v nope\nf 1 2 3",
+            "{\n\"asset\":{},\n v 0 0 0\nf 1 2 3\n}", "glTF\nv 0 0 0\nf 1 2 3", "#" + "x".repeat(4096) + "\n" + ObjTestFixtures.Triangle)) {
+            assertFalse(ObjLoader.isObj(source.encodeToByteArray()), source.take(60))
+        }
+        val prefix = ObjTestFixtures.Triangle.substringBefore("f ")
+        val partial = prefix + "#" + "x".repeat(4096 - prefix.length - 7) + "\nf 1 2 3"
+        assertEquals(4097, partial.length)
+        assertFalse(ObjLoader.isObj(partial.encodeToByteArray()), "never accept a truncated face line")
+        assertFalse(ObjLoader.isObj(ObjLoader.toGlb(ObjTestFixtures.Cube)))
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjLoaderTest.kt
@@ -50,7 +50,7 @@ class ObjLoaderTest {
             } else {
                 assertEquals(1f, group.normals[2])
             }
-            if (face.contains("/1") || face.contains("/-")) {
+            if (!face.contains("//") && face.substringBefore(' ').substringAfter('/', "").isNotEmpty()) {
                 assertContentEquals(floatArrayOf(0.25f, 0.75f, 1f, 0f, 0.25f, 0.75f), group.textureCoordinates)
             } else assertNull(group.textureCoordinates)
         }
@@ -96,7 +96,11 @@ class ObjLoaderTest {
 
     @Test
     fun missingMtlAndAbsentResolverStillLoad() {
-        for (model in listOf(ObjLoader.parse(ObjTestFixtures.Colored), ObjLoader.parse(ObjTestFixtures.Colored) { null })) {
+        val models = listOf(
+            ObjLoader.parse(ObjTestFixtures.Colored),
+            ObjLoader.parse(ObjTestFixtures.Colored) { null }
+        )
+        for (model in models) {
             assertEquals(2, model.triangleCount)
             assertTrue(model.materials.isEmpty())
             assertTrue(ObjLoader.toGlb(model).isNotEmpty())
@@ -162,7 +166,9 @@ class ObjLoaderTest {
         for (face in listOf("0 2 3", "-4 2 3", "4 2 3", "1/1 2 3", "1//1 2 3", "1/ 2 3", "1 2")) {
             assertFailsWith<ObjParseException>(face) { ObjLoader.parse((vertices + "f $face").encodeToByteArray()) }
         }
-        assertFailsWith<ObjParseException> { ObjLoader.parse(ObjTestFixtures.Triangle.replace("v 0", "v NaN").encodeToByteArray()) }
+        assertFailsWith<ObjParseException> {
+            ObjLoader.parse(ObjTestFixtures.Triangle.replace("v 0", "v NaN").encodeToByteArray())
+        }
         assertFailsWith<ObjParseException> { ObjLoader.parse("# empty".encodeToByteArray()) }
     }
 
@@ -181,7 +187,10 @@ class ObjLoaderTest {
             "newmtl paint\nKd 0.2 0.4 0.6\nd 0.7\nTr 0.8\nd -halo 0.3".encodeToByteArray()
         }
         assertEquals(listOf("first.mtl", "sub dir/second.mtl"), requests)
-        assertContentEquals(floatArrayOf(0.2f, 0.4f, 0.6f, 0.3f), assertNotNull(model.materials["paint"]).baseColorFactor)
+        assertContentEquals(
+            floatArrayOf(0.2f, 0.4f, 0.6f, 0.3f),
+            assertNotNull(model.materials["paint"]).baseColorFactor
+        )
     }
 
     @Test
@@ -189,13 +198,17 @@ class ObjLoaderTest {
         assertTrue(ObjLoader.isObj(ObjTestFixtures.Cube))
         assertTrue(ObjLoader.isObj(("\uFEFF# comment\r\n\r\n" + ObjTestFixtures.Triangle).encodeToByteArray()))
         assertTrue(ObjLoader.isObj(ObjTestFixtures.Triangle.replace("v ", "v\t").encodeToByteArray()))
-        for (source in listOf("", "f 1 2 3\nv 0 0 0", "vn 0 0 1\nf 1 2 3", "v nope\nf 1 2 3",
-            "{\n\"asset\":{},\n v 0 0 0\nf 1 2 3\n}", "glTF\nv 0 0 0\nf 1 2 3", "#" + "x".repeat(4096) + "\n" + ObjTestFixtures.Triangle)) {
+        val rejected = listOf(
+            "", "f 1 2 3\nv 0 0 0", "vn 0 0 1\nf 1 2 3", "v nope\nf 1 2 3",
+            "{\n\"asset\":{},\n v 0 0 0\nf 1 2 3\n}", "glTF\nv 0 0 0\nf 1 2 3",
+            "#" + "x".repeat(4096) + "\n" + ObjTestFixtures.Triangle
+        )
+        for (source in rejected) {
             assertFalse(ObjLoader.isObj(source.encodeToByteArray()), source.take(60))
         }
         val prefix = ObjTestFixtures.Triangle.substringBefore("f ")
         val partial = prefix + "#" + "x".repeat(4096 - prefix.length - 7) + "\nf 1 2 3"
-        assertEquals(4097, partial.length)
+        assertTrue(partial.length > 4096)
         assertFalse(ObjLoader.isObj(partial.encodeToByteArray()), "never accept a truncated face line")
         assertFalse(ObjLoader.isObj(ObjLoader.toGlb(ObjTestFixtures.Cube)))
     }

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/obj/ObjTestFixtures.kt
@@ -1,0 +1,52 @@
+package io.github.sceneview.core.obj
+
+internal object ObjTestFixtures {
+    val Triangle = """
+        v 0 0 0
+        v 2 0 0
+        v 0 3 0
+        f 1 2 3
+    """.trimIndent()
+
+    val Cube = """
+        # A 10 mm cube with outward-wound quads
+        o cube
+        v 0 0 0
+        v 10 0 0
+        v 10 10 0
+        v 0 10 0
+        v 0 0 10
+        v 10 0 10
+        v 10 10 10
+        v 0 10 10
+        f 1 4 3 2
+        f 5 6 7 8
+        f 1 2 6 5
+        f 4 8 7 3
+        f 1 5 8 4
+        f 2 3 7 6
+    """.trimIndent().encodeToByteArray()
+
+    val Colored = """
+        mtllib materials/paint.mtl
+        v 0 0 0
+        v 2 0 0
+        v 0 3 0
+        g red
+        usemtl red
+        f 1 2 3
+        g green
+        usemtl green
+        f -3 -2 -1
+    """.trimIndent().encodeToByteArray()
+
+    val Materials = """
+        newmtl red
+        Kd 1 0 0
+        d 0.5
+        map_Kd red.png
+        newmtl green
+        Kd 0 1 0
+        Tr 0.25
+    """.trimIndent().encodeToByteArray()
+}

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -622,17 +622,18 @@ private fun ByteBuffer.startsWithObjGeometry(): Boolean {
     if (!hasRemaining()) return false
     val start = position()
     val first = get(start).toInt() and 0xff
-    if (first !in 9..13 && first != 32 && first != 35 && first != 0xef &&
-        first != 'v'.code && first != 'f'.code && first != 'o'.code && first != 'g'.code &&
-        first != 'm'.code && first != 'u'.code && first != 's'.code && first != 'l'.code && first != 'p'.code
-    ) return false
-    if (remaining() >= 4 && get(start) == 'g'.code.toByte() && get(start + 1) == 'l'.code.toByte() &&
-        get(start + 2) == 'T'.code.toByte() && get(start + 3) == 'F'.code.toByte()
-    ) return false
+    if (first !in OBJ_LEAD_BYTES) return false
+    if (startsWithAscii(start, "glTF")) return false
     // Include one extra byte so isObj can distinguish a truncated line from a real EOF at 4096.
     val prefix = ByteArray(minOf(remaining(), 4097)).also { duplicate().get(it) }
     return ObjLoader.isObj(prefix)
 }
+
+/** Whitespace, '#', the UTF-8 BOM lead byte, and the first letter of every OBJ keyword. */
+private val OBJ_LEAD_BYTES: Set<Int> = (9..13).toSet() + setOf(32, 35, 0xef) + "vfogmuslp".map { it.code }
+
+private fun ByteBuffer.startsWithAscii(start: Int, text: String): Boolean =
+    remaining() >= text.length && text.indices.all { get(start + it) == text[it].code.toByte() }
 
 /** `PK` — the local-file-header magic every ZIP, and so every 3MF, starts with. */
 private fun ByteBuffer.startsWithZipMagic(): Boolean {

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -12,6 +12,7 @@ import com.google.android.filament.gltfio.UbershaderProvider
 import io.github.sceneview.bumpLightGeneration
 import io.github.sceneview.bumpRenderableGeneration
 import io.github.sceneview.bumpTransformGeneration
+import io.github.sceneview.core.obj.ObjLoader
 import io.github.sceneview.core.threemf.ThreeMfLoader
 import io.github.sceneview.model.Model
 import io.github.sceneview.model.ModelInstance
@@ -578,9 +579,10 @@ internal suspend fun <T : Any> destroyOnCancel(
 
 /**
  * Normalises whatever the caller handed us into something Filament's glTF loader accepts: a 3MF is
- * converted to GLB, then WebP textures are transcoded.
+ * converted to GLB, OBJ geometry is converted next, then WebP textures are transcoded.
  */
-private fun Buffer.toFilamentModelSource(): Buffer = convertThreeMfToGlb().transcodeWebPTextures()
+private fun Buffer.toFilamentModelSource(): Buffer =
+    convertThreeMfToGlb().convertObjToGlb().transcodeWebPTextures()
 
 /**
  * Converts a **3MF** payload to GLB, so `.3mf` is loadable through every entry point on this class
@@ -600,6 +602,36 @@ private fun Buffer.convertThreeMfToGlb(): Buffer {
     val glb = ThreeMfLoader.toGlb(bytes)
     // Direct, like every other buffer Filament's JNI layer reads (see WebPTextureTranscoder).
     return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+/**
+ * OBJ has no magic: inspect only a bounded prefix before copying the full payload. Absolute reads
+ * and a duplicate preserve the caller's position/limit, including sliced and read-only buffers.
+ * Automatic loading assumes millimetres and grey; use ObjLoader.toGlb with a resolver for MTL.
+ */
+private fun Buffer.convertObjToGlb(): Buffer {
+    val source = this as? ByteBuffer ?: return this
+    if (!source.startsWithObjGeometry()) return this
+    val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+    val glb = ObjLoader.toGlb(bytes)
+    return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+/** JSON and binary GLB fail the cheap gate; other candidates cost at most a 4 KB prefix copy. */
+private fun ByteBuffer.startsWithObjGeometry(): Boolean {
+    if (!hasRemaining()) return false
+    val start = position()
+    val first = get(start).toInt() and 0xff
+    if (first !in 9..13 && first != 32 && first != 35 && first != 0xef &&
+        first != 'v'.code && first != 'f'.code && first != 'o'.code && first != 'g'.code &&
+        first != 'm'.code && first != 'u'.code && first != 's'.code && first != 'l'.code && first != 'p'.code
+    ) return false
+    if (remaining() >= 4 && get(start) == 'g'.code.toByte() && get(start + 1) == 'l'.code.toByte() &&
+        get(start + 2) == 'T'.code.toByte() && get(start + 3) == 'F'.code.toByte()
+    ) return false
+    // Include one extra byte so isObj can distinguish a truncated line from a real EOF at 4096.
+    val prefix = ByteArray(minOf(remaining(), 4097)).also { duplicate().get(it) }
+    return ObjLoader.isObj(prefix)
 }
 
 /** `PK` — the local-file-header magic every ZIP, and so every 3MF, starts with. */


### PR DESCRIPTION
Closes #3488 — partially. **Do not merge as is**: this is the raw output of a delegated run, opened unedited on purpose.

## What this is

Same experiment as #3486's branch: the whole issue handed to Codex **GPT-6 Astra** at `--effort high` in an isolated worktree, with the repo conventions spelled out. Nothing was corrected before this commit — the CI is the judge, not the lead session.

## What the model produced in ~9 minutes

- `sceneview-core/.../core/obj/`: `ObjLoader`, `ObjParser`, `ObjModel`, `ObjMtl`, `ObjText`, `ObjTriangulation`, `ObjGlb` — `v`/`vn`/`vt`/`f` in every index form including negative indices, n-gon triangulation, `o`/`g` to one mesh per group, `usemtl`/`mtllib` with `Kd` and `d`/`Tr` as `baseColorFactor`, `map_Kd` skipped as the issue asks.
- `ThreeMfGlb` extended so OBJ reuses the existing in-memory GLB writer, without the 3MF Z-up rotation (OBJ is already Y-up).
- `ModelLoader` sniff on the Android side.
- `commonTest/.../core/obj/`: `ObjLoaderTest`, `ObjTestFixtures` (fixtures built in code, no binary assets).

876 lines added.

## What is missing, and why

The run was cut short by the ChatGPT **Plus** usage limit roughly nine minutes in, during the documentation pass. Missing: the `changelog.d/3488-obj-loader.md` fragment, the `llms.txt` row, the `sceneview-core/api` dump, and the emulator screenshot the issue asks for. The model also never managed to run Gradle: the Codex sandbox denies the Gradle cache lock, so nothing here has been executed by its author.

This branch and #3486's branch both touch `ThreeMfGlb` and `ModelLoader`; whichever lands first, the other rebases.

Left open as a measurement. Completing it is a follow-up, not a fix to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
