### PR TITLE
docs: the formats SceneView opens, and the two apps built on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ Browse all sample sources in [`samples/`](samples/) — Android · iOS · Web ·
 
 > **Tip** — every demo opens directly via `https://sceneview.github.io/open?demo=<id>`. For example, `…/open?demo=ar-rerun` lands straight on the AR Rerun debug screen with a single tap from any QR code or link.
 
+## Open any 3D file, at real size
+
+SceneView reads the files people actually receive — from a download, a chat, a 3D-printing site or
+an AI assistant — and shows them at their real size, in 3D and in AR.
+
+| Format | Android | Apple | Web |
+|---|---|---|---|
+| glTF / GLB | ✅ Filament | ✅ RealityKit | ✅ |
+| 3MF | ✅ pure Kotlin → GLB in memory, millimetres honoured | — | — |
+| STL (binary + ASCII) | ✅ pure Kotlin → GLB | — | — |
+| OBJ + MTL | ✅ pure Kotlin → GLB, material colours | — | — |
+| USDZ / Reality | — | ✅ RealityKit | — |
+
+The format is decided by the bytes, not the extension: a `.3mf` that arrives as
+`application/octet-stream` with no file name still opens. The Android demo app is an "Open with"
+target for these files, so a file tapped anywhere on the phone lands in the viewer, then in AR.
+
+Two apps built on SceneView are on Google Play:
+
+- **[AR Model Viewer](https://play.google.com/store/apps/details?id=com.gorisse.thomas.arcamera)** —
+  open any 3D file (GLB, glTF, 3MF, STL, OBJ, PLY) or browse thousands of free models, and see
+  them in your room at real size.
+- **[Will It Fit](https://play.google.com/store/apps/details?id=com.gorisse.thomas.willitfit)** —
+  type a sofa's dimensions, or pick a stand-in, and see whether it fits before you buy.
+
 ---
 
 ## Quick look

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -22,7 +22,7 @@
   <script src="/assets/analytics.js"></script>
   <title>SceneView — 3D & AR SDK for Android, iOS, Web, and more</title>
   <meta name="description" content="SceneView is an open-source, AI-first SDK for building 3D and AR applications with Jetpack Compose, SwiftUI, Kotlin/JS, Flutter, and React Native. Ships as a ChatGPT and Codex plugin, and opens the .3mf files AI print flows emit. Powered by Filament and RealityKit.">
-  <meta name="keywords" content="SceneView, 3D SDK, AR SDK, Augmented Reality, Jetpack Compose, SwiftUI, Kotlin Multiplatform, ARCore, ARKit, Filament, RealityKit, Android 3D, iOS AR, model viewer, glTF, USDZ, 3MF, 3D printing, visionOS, cross-platform 3D, AI-first SDK, MCP server, Claude 3D, ChatGPT AR, AI code generation, LLM 3D development, Copilot 3D, Gemini AR, model context protocol, ChatGPT plugin, Codex plugin, OpenAI plugin">
+  <meta name="keywords" content="SceneView, 3D SDK, AR SDK, Augmented Reality, Jetpack Compose, SwiftUI, Kotlin Multiplatform, ARCore, ARKit, Filament, RealityKit, Android 3D, iOS AR, model viewer, 3D file viewer, glTF, GLB, 3MF, STL, OBJ, USDZ, AR Model Viewer, Will It Fit, 3MF, 3D printing, visionOS, cross-platform 3D, AI-first SDK, MCP server, Claude 3D, ChatGPT AR, AI code generation, LLM 3D development, Copilot 3D, Gemini AR, model context protocol, ChatGPT plugin, Codex plugin, OpenAI plugin">
   <meta name="author" content="SceneView">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#005bc1">
@@ -225,7 +225,7 @@
     <div class="hero__container">
       <div class="hero__content">
         <h1 class="hero__title">The 3D &amp; AR SDK that AI gets right on the first try</h1>
-        <p class="hero__description">SceneView is designed so Claude, Cursor and every other coding assistant can produce correct 3D &amp; AR code on the first try — for Jetpack Compose, SwiftUI, the Web, and beyond.</p>
+        <p class="hero__description">SceneView is designed so Claude, Cursor and every other coding assistant can produce correct 3D &amp; AR code on the first try — for Jetpack Compose, SwiftUI, the Web, and beyond. It opens glTF/GLB, 3MF, STL and OBJ on Android and USDZ on Apple, and shows them at real size in AR.</p>
         <div class="hero__actions">
           <a href="/docs.html" class="hero__btn hero__btn--primary" target="_blank" rel="noopener">Get Started</a>
           <a href="https://github.com/sceneview/sceneview" class="hero__btn hero__btn--outline" target="_blank" rel="noopener">View on GitHub</a>


### PR DESCRIPTION
README: an "Open any 3D file, at real size" section with the per-platform format table (glTF/GLB, 3MF, STL, OBJ+MTL on Android; USDZ on Apple) and the two Play Store apps built on SceneView, AR Model Viewer and Will It Fit. Landing: keywords and hero sentence name the formats. Follows #3517 and #3518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)