### PR TITLE
feat(core): PLY loader, and the demo opens STL, OBJ and PLY files (#3487)

### DIFF
--- a/changelog.d/3487-demo-open-with-stl-obj-ply.md
+++ b/changelog.d/3487-demo-open-with-stl-obj-ply.md
@@ -1,0 +1,3 @@
+<!-- category: Added -->
+
+Let the Android demo open STL, OBJ, and PLY files from file managers and share sheets.

--- a/changelog.d/3487-ply-loader.md
+++ b/changelog.d/3487-ply-loader.md
@@ -1,0 +1,4 @@
+<!-- category: Added -->
+
+Add a pure-Kotlin ASCII and binary PLY loader with normals, vertex colours, polygon triangulation,
+and in-memory GLB conversion on Android, Apple, and web targets.

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3323,6 +3323,10 @@ ZIP, no model part, malformed XML, an out-of-range vertex index — is a `ThreeM
 Unrecognised 3MF extensions (slice, beamlattice, production) are skipped, never rejected: an
 unknown extension must not stop a print from being previewed.
 
+Android's loader reads glTF/GLB, 3MF, STL, OBJ + MTL, and PLY. PLY supports ASCII and both binary
+endiannesses, optional vertex normals and RGBA colours, and fan-triangulates polygon faces (#3487).
+The Android demo is an “Open with” target for `.3mf`, `.glb`, `.gltf`, `.stl`, `.obj`, and `.ply`.
+
 ### MaterialLoader
 ```kotlin
 class MaterialLoader(engine: Engine, context: Context) {
@@ -5141,16 +5145,18 @@ ARSceneView(
 
 ### Node types
 
-#### ModelNode — 3D model (USDZ / Reality)
+#### ModelNode — 3D model (USDZ / Reality / STL / OBJ / PLY / 3MF)
 
 ```swift
 public struct ModelNode: @unchecked Sendable {
     public let entity: ModelEntity
 
-    // Loading (always @MainActor, async)
-    public static func load(_ path: String, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(contentsOf url: URL, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(from remoteURL: URL, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    // Loading (always @MainActor, async). One entry point per source; each sniffs the
+    // format from the file's own bytes, then applies `unit`. See "Model formats and units".
+    public static func load(_ path: String, unit: ModelUnit? = nil, enableCollision: Bool = true, bundle: Bundle = .main) async throws -> ModelNode
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil, enableCollision: Bool = true) async throws -> ModelNode
+    public static func load(from remoteURL: URL, unit: ModelUnit? = nil, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    public init(_ asset: MeshAsset, enableCollision: Bool = true) async throws
 
     // Transform (fluent / chainable)
     public func position(_ position: SIMD3<Float>) -> ModelNode
@@ -5186,11 +5192,148 @@ public struct ModelNode: @unchecked Sendable {
 ```
 
 Key behaviors:
-- Supports `.usdz` and `.reality` files natively. glTF support planned via GLTFKit2.
-- `load(_:)` calls `Entity(named:)` — file must be in the app bundle or an accessible URL.
+- Supports `.usdz` / `.usda` / `.usdc` / `.usd` / `.reality` through RealityKit,
+  `.stl` / `.obj` (+ `.mtl`) / `.ply` through ModelIO, and `.3mf` through SceneViewSwift's
+  own parser. glTF is **not** supported.
+- `load(_:)` calls `Entity(named:)` for USD/Reality; a bundled `.stl` / `.obj` / `.ply` /
+  `.3mf` is resolved to a URL and parsed instead.
 - `load(from:)` downloads to a temp file, loads, then cleans up.
 - `scaleToUnits(_:)` mirrors Android's `ModelNode(scaleToUnits = 1f)`.
 - `centerOrigin(normalized:)` — **apply before positioning.** Unlike Android's `centerOrigin` (which composes additively — `position += translation`, independent of the current position), this reads the entity's **world** visual-bounds, so it does not compose with a previously-set position: call it on an unpositioned, unparented entity (load → scaleToUnits → centerOrigin, before `.position(_:)` or anchoring), and a later `.position(_:)` replaces the grounding offset.
+
+#### Model formats and units (`ModelFormat`, `ModelUnit`, `MeshAsset`)
+
+`ModelNode.load(contentsOf:unit:)` is the **single entry point for every supported
+format**. It never trusts the file extension on its own — a model that arrived through a
+share sheet, AirDrop or a download routinely has the wrong one — so
+`ModelFormat.sniff(contentsOf:)` reads the file's bytes first and falls back to the
+extension only when the content is not decisive.
+
+| Format | Reader | Default unit | Notes |
+|---|---|---|---|
+| `.usdz` `.usda` `.usdc` `.usd` `.reality` | RealityKit | metres | Already metric; `unit:` is ignored |
+| `.stl` | ModelIO | **millimetres** | ASCII and binary; no unit, no materials |
+| `.obj` | ModelIO | metres | `.mtl` sidecar picked up when next to the file; quad faces triangulated |
+| `.ply` | ModelIO | metres | ASCII and binary; per-vertex colours preserved |
+| `.3mf` | SceneViewSwift's own parser | **from the file** | Zip + XML; the only mesh format here that declares its own unit |
+
+**3MF is parsed by SceneViewSwift, not by Apple.** `MDLAsset` reads OBJ, STL, PLY and
+USD; Quick Look reads USDZ and Reality; nothing on the platform opens a `.3mf` — which is
+the format 3D printing standardised on. `ThreeMFDocument` is a minimal zip reader plus an
+`XMLParser` over the package's `.model` parts, covering `<model unit>`, `<mesh>`,
+`<components>` with row-vector transforms, `<build><item>`, `<basematerials>` and the
+materials extension's `<colorgroup>` resolved per triangle, and Production-extension
+`p:path` references into other parts (how Bambu Studio and Orca write project files).
+External XML entities are refused — an untrusted file must not become a file read.
+
+**The unit is the whole point.** STL, OBJ and PLY store bare numbers with no unit, and a
+slicer STL means millimetres while a photogrammetry OBJ means metres. RealityKit works in
+metres, so loading either without saying which is meant puts a 21 cm print in the room at
+210 m. The conversion is **baked into the vertex positions**, not left as an entity scale,
+so a later `.scale(_:)` is yours and does not destroy the correction.
+
+```swift
+import SceneViewSwift
+
+// A 3D-printing STL — millimetres by default, so this is 21 cm tall in AR.
+let part = try await ModelNode.load(contentsOf: stlURL)
+
+// A photogrammetry OBJ authored in centimetres.
+let scan = try await ModelNode.load(contentsOf: objURL, unit: .centimeters)
+
+// A PLY from a phone scanner, straight from the app bundle.
+let bust = try await ModelNode.load("scans/bust.ply")
+```
+
+Measure a file **before** rendering it — parsing has no RealityKit dependency and runs off
+the main actor:
+
+```swift
+let asset = try MeshAsset.load(contentsOf: url)      // sniffs the format
+print(asset.format, asset.unit, asset.triangleCount) // e.g. stl millimeters 15234
+if let size = asset.boundsInMeters?.extents {
+    print("real size:", size)                        // metres, unit applied
+}
+let node = try await ModelNode(asset)                // then display it
+```
+
+```swift
+public enum ModelFormat: String, Sendable, CaseIterable {
+    case usdz, reality, usda, usdc, usd, stl, obj, ply
+    case threeMF = "3mf"
+    public var fileExtension: String                 // == rawValue
+    public var loader: Loader                        // .realityKit | .modelIO | .sceneView
+    public var defaultUnit: ModelUnit
+    public var carriesUnit: Bool                     // false for stl/obj/ply — ask the user
+    public init?(fileExtension: String)
+    public static func sniff(contentsOf url: URL) throws -> ModelFormat
+}
+
+public struct ThreeMFDocument: Sendable {
+    public let unit: ModelUnit                       // as declared by the file
+    public let parts: [MeshGeometry]                 // one per object-and-material
+    public var triangleCount: Int
+    public static func read(contentsOf url: URL) throws -> ThreeMFDocument
+    public static func read(data: Data) throws -> ThreeMFDocument
+}
+
+public enum ModelUnit: String, Sendable, CaseIterable {
+    case micrometers, millimeters, centimeters, inches, feet, meters
+    public var metersPerUnit: Float
+    public var symbol: String                        // "mm", "cm", "in", "ft", "m", "µm"
+    public func convert(_ value: Float, to other: ModelUnit) -> Float
+}
+
+public struct MeshAsset: Sendable {
+    public let format: ModelFormat
+    public let unit: ModelUnit
+    public let parts: [MeshGeometry]                 // one per material
+    public var vertexCount: Int
+    public var triangleCount: Int
+    public var bounds: MeshBounds?                   // in `unit`
+    public var boundsInMeters: MeshBounds?           // real-world size
+    public func inMeters() -> MeshAsset
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil) throws -> MeshAsset
+}
+
+public struct MeshGeometry: Sendable {
+    public var name: String
+    public var positions: [SIMD3<Float>]
+    public var normals: [SIMD3<Float>]?              // nil when the file carried none
+    public var textureCoordinates: [SIMD2<Float>]?
+    public var colors: [SIMD4<Float>]?               // PLY per-vertex colours
+    public var indices: [UInt32]                     // always triangles
+    public var material: MeshMaterialDescription?
+    public var triangleCount: Int
+    public var bounds: MeshBounds?
+    public func generatingNormals() -> MeshGeometry  // flat-shaded, keeps vertices welded
+}
+
+public enum ModelLoadingError: Error, Equatable {
+    case unsupportedFormat(fileExtension: String)    // carries what the user tried to open
+    case unreadableFile(URL)
+    case malformed(reason: String)
+    case emptyMesh
+    case unreadableGeometry(reason: String)
+}
+```
+
+Gotchas worth knowing:
+- **A binary STL's 80-byte header often starts with the word `solid`.** Detecting ASCII by
+  that prefix reads a binary file as empty; `sniff` uses the size arithmetic
+  (`84 + 50 × triangleCount == fileSize`) first.
+- **USDZ and 3MF are both zip archives.** `sniff` tells them apart by the name of the
+  archive's first entry (`*.usd*` → USDZ, anything else → 3MF), not by the `PK` magic.
+- **A 3MF `transform` is twelve numbers in row-vector order** (`v' = v · M`, last row =
+  translation). Reading them as column-major transposes every placed part — the symptom is
+  scattered geometry, not a parse error.
+- **RealityKit's `MeshDescriptor` has no vertex-colour channel.** A coloured PLY keeps its
+  full `colors` array on `MeshGeometry`, and `ModelNode` folds the *average* into the
+  material tint so the model is not uniformly grey.
+- **Normals are generated when a file has none** — by `MeshGeometry.generatingNormals()`,
+  not `MDLMesh.addNormals`, which unwelds the mesh (a 4-vertex quad comes back as 6).
+- `ModelLoadingError.unsupportedFormat` carries the extension, so a viewer can say
+  "SceneView cannot open .fbx files yet" and an app can count what its users actually try.
 
 #### LightNode — light source
 

--- a/gpt/knowledge-overview.md
+++ b/gpt/knowledge-overview.md
@@ -138,9 +138,11 @@ public struct ModelNode: @unchecked Sendable {
     public var rotation: simd_quatf
     public var scale: SIMD3<Float>
 
-    public static func load(_ path: String, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(contentsOf url: URL, enableCollision: Bool = true) async throws -> ModelNode
-    public static func load(from remoteURL: URL, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
+    // Every loader sniffs the format from the file's own bytes and applies `unit`
+    // (STL/OBJ/PLY carry none). See "SceneViewSwift → Model formats and units".
+    public static func load(_ path: String, unit: ModelUnit? = nil, enableCollision: Bool = true, bundle: Bundle = .main) async throws -> ModelNode
+    public static func load(contentsOf url: URL, unit: ModelUnit? = nil, enableCollision: Bool = true) async throws -> ModelNode
+    public static func load(from remoteURL: URL, unit: ModelUnit? = nil, enableCollision: Bool = true, timeout: TimeInterval = 60.0) async throws -> ModelNode
 
     // Transform (fluent)
     public func position(_ position: SIMD3<Float>) -> ModelNode

--- a/llms.txt
+++ b/llms.txt
@@ -3353,10 +3353,9 @@ ZIP, no model part, malformed XML, an out-of-range vertex index — is a `ThreeM
 Unrecognised 3MF extensions (slice, beamlattice, production) are skipped, never rejected: an
 unknown extension must not stop a print from being previewed.
 
-**Formats that are NOT supported — do not emit code that loads one.** The loader reads glTF/GLB and
-3MF on Android, and USDZ on Apple. STL (#3486), PLY meshes (#3487) and OBJ + MTL (#3488) are open
-issues, a single `ModelFormat` entry point is #3489, and wiring 3MF into `sceneview-web` is #3491.
-Tell the user the format is not supported yet and link the issue rather than inventing a loader.
+Android's loader reads glTF/GLB, 3MF, STL, OBJ + MTL, and PLY. PLY supports ASCII and both binary
+endiannesses, optional vertex normals and RGBA colours, and fan-triangulates polygon faces (#3487).
+The Android demo is an “Open with” target for `.3mf`, `.glb`, `.gltf`, `.stl`, `.obj`, and `.ply`.
 
 ### MaterialLoader
 ```kotlin

--- a/samples/android-demo/src/main/AndroidManifest.xml
+++ b/samples/android-demo/src/main/AndroidManifest.xml
@@ -203,6 +203,13 @@
                 <data android:mimeType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
                 <data android:mimeType="model/gltf-binary" />
                 <data android:mimeType="model/gltf+json" />
+                <data android:mimeType="model/stl" />
+                <data android:mimeType="model/x.stl-ascii" />
+                <data android:mimeType="model/x.stl-binary" />
+                <data android:mimeType="application/sla" />
+                <data android:mimeType="application/vnd.ms-pki.stl" />
+                <data android:mimeType="model/obj" />
+                <data android:mimeType="application/x-ply" />
             </intent-filter>
 
             <intent-filter android:label="@string/open_model_filter_label">
@@ -220,6 +227,12 @@
                 <data android:pathPattern=".*\\.GLB" />
                 <data android:pathPattern=".*\\.gltf" />
                 <data android:pathPattern=".*\\.GLTF" />
+                <data android:pathPattern=".*\\.stl" />
+                <data android:pathPattern=".*\\.STL" />
+                <data android:pathPattern=".*\\.obj" />
+                <data android:pathPattern=".*\\.OBJ" />
+                <data android:pathPattern=".*\\.ply" />
+                <data android:pathPattern=".*\\.PLY" />
             </intent-filter>
 
             <!--
@@ -233,6 +246,13 @@
                 <data android:mimeType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
                 <data android:mimeType="model/gltf-binary" />
                 <data android:mimeType="model/gltf+json" />
+                <data android:mimeType="model/stl" />
+                <data android:mimeType="model/x.stl-ascii" />
+                <data android:mimeType="model/x.stl-binary" />
+                <data android:mimeType="application/sla" />
+                <data android:mimeType="application/vnd.ms-pki.stl" />
+                <data android:mimeType="model/obj" />
+                <data android:mimeType="application/x-ply" />
                 <data android:mimeType="application/octet-stream" />
             </intent-filter>
         </activity>

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/MainActivity.kt
@@ -81,8 +81,8 @@ class MainActivity : ComponentActivity() {
     val pendingDemoIdFlow: StateFlow<String?> get() = pendingDemoId.asStateFlow()
 
     /**
-     * A model file another app asked this one to open — `ACTION_VIEW` on a `.3mf` / `.glb` /
-     * `.gltf`, or an `ACTION_SEND` from a share sheet (#3482).
+     * A model file another app asked this one to open through `ACTION_VIEW`, or an `ACTION_SEND`
+     * from a share sheet (#3482).
      *
      * Staging copies the bytes into the cache off the main thread, so this arrives *after* the
      * first composition; the UI observes it and navigates to the Model Viewer when it lands.
@@ -112,7 +112,7 @@ class MainActivity : ComponentActivity() {
         // navigation through PlaceholderDemo. See #958.
         pendingDemoId.value = DeepLinkRouter.validate(intent?.getStringExtra("demo"))
             ?: DeepLinkRouter.parse(intent?.data)
-        // "Open with SceneView": a `.3mf` / `.glb` / `.gltf` handed over by another app (#3482).
+        // "Open with SceneView": a supported model file handed over by another app (#3482).
         stageOpenedModel(intent)
         // QA mode ingress: `--ez qa_mode true` freezes auto-rotation / orbit / animations
         // so screenshot tests get a deterministic frame. Same setting reachable via the

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
@@ -38,7 +38,7 @@ data class OpenedModel(val location: String, val displayName: String) {
 object OpenedModelIntent {
 
     /** File extensions this app advertises in its manifest and accepts here. */
-    val SupportedExtensions: Set<String> = setOf("3mf", "glb", "gltf")
+    val SupportedExtensions: Set<String> = setOf("3mf", "glb", "gltf", "stl", "obj", "ply")
 
     /**
      * MIME types that name a model on their own. `application/octet-stream` is deliberately NOT
@@ -51,6 +51,13 @@ object OpenedModelIntent {
         "application/vnd.ms-package.3dmanufacturing-3dmodel+xml",
         "model/gltf-binary",
         "model/gltf+json",
+        "model/stl",
+        "model/x.stl-ascii",
+        "model/x.stl-binary",
+        "application/sla",
+        "application/vnd.ms-pki.stl",
+        "model/obj",
+        "application/x-ply",
     )
 
     /** The URI an `ACTION_VIEW` or `ACTION_SEND` intent carries a model in, if any. */
@@ -188,6 +195,10 @@ object OpenedModelIntent {
         mimeType?.contains("3mf", ignoreCase = true) == true -> "3mf"
         mimeType?.contains("3dmanufacturing", ignoreCase = true) == true -> "3mf"
         mimeType?.contains("gltf+json", ignoreCase = true) == true -> "gltf"
+        mimeType?.contains("stl", ignoreCase = true) == true -> "stl"
+        mimeType?.contains("sla", ignoreCase = true) == true -> "stl"
+        mimeType?.contains("obj", ignoreCase = true) == true -> "obj"
+        mimeType?.contains("ply", ignoreCase = true) == true -> "ply"
         else -> "glb"
     }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -299,7 +299,7 @@ private fun SingleModelSection(
     // Restored via remember (savedStateRegistry would survive config change
     // but we want the helmet back on every cold start so screenshots / Play
     // Store store-page assets stay deterministic).
-    // "Open with SceneView" (#3482) — a `.3mf` / `.glb` / `.gltf` another app handed over,
+    // "Open with SceneView" — a `.3mf` / `.glb` / `.gltf` / `.stl` / `.obj` / `.ply` file,
     // already staged into the cache as a `file://` path by `OpenedModelIntent`. It rides the
     // same override the Sketchfab stream uses (`rememberModelInstance` resolves a `file://`
     // location exactly like an http one), so an opened file arrives on the flagship viewer with

--- a/samples/android-demo/src/main/res/values/strings.xml
+++ b/samples/android-demo/src/main/res/values/strings.xml
@@ -391,8 +391,8 @@
     <string name="feedback_report_voice_prompt">Describe the issue</string>
 
     <!-- "Open with SceneView" (#3482): the label Android shows in the app chooser and the
-         share sheet when another app hands over a .3mf / .glb / .gltf file. -->
+         share sheet when another app hands over a supported model file. -->
     <string name="open_model_filter_label">Open in SceneView</string>
     <!-- Shown when a handed-over file cannot be read, or is not a model this app opens. -->
-    <string name="open_model_failed">Couldn\'t open that file — SceneView reads .3mf, .glb and .gltf</string>
+    <string name="open_model_failed">Couldn\'t open that file — SceneView reads .3mf, .glb, .gltf, .stl, .obj and .ply</string>
 </resources>

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/OpenedModelIntentTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/OpenedModelIntentTest.kt
@@ -98,6 +98,22 @@ class OpenedModelIntentTest {
     }
 
     @Test
+    fun `STL OBJ and PLY are recognised by extension and MIME type`() {
+        for (extension in listOf("stl", "obj", "ply")) {
+            assertTrue(
+                OpenedModelIntent.looksLikeModel("part.$extension", "application/octet-stream")
+            )
+            assertTrue(OpenedModelIntent.looksLikeModel("PART.${extension.uppercase()}", null))
+        }
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "model/stl"))
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "model/x.stl-binary"))
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "application/sla"))
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "application/vnd.ms-pki.stl"))
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "model/obj"))
+        assertTrue(OpenedModelIntent.looksLikeModel(null, "application/x-ply"))
+    }
+
+    @Test
     fun `anything else is refused`() {
         // The manifest's octet-stream filter is broad by necessity; this is the layer that
         // keeps a PDF or a ZIP from reaching the loader and failing with no explanation.

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -810,6 +810,32 @@ public final class io/github/sceneview/core/obj/ObjParseException : java/lang/Ru
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/github/sceneview/core/ply/PlyLoader {
+	public static final field DEFAULT_MAX_BYTES I
+	public static final field DEFAULT_MAX_TRIANGLES I
+	public static final field DEFAULT_MAX_VERTICES I
+	public static final field INSTANCE Lio/github/sceneview/core/ply/PlyLoader;
+	public final fun isPly ([B)Z
+	public final fun parse ([BLio/github/sceneview/core/threemf/ThreeMfUnit;III)Lio/github/sceneview/core/ply/PlyModel;
+	public static synthetic fun parse$default (Lio/github/sceneview/core/ply/PlyLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;IIIILjava/lang/Object;)Lio/github/sceneview/core/ply/PlyModel;
+	public final fun toGlb ([BLio/github/sceneview/core/threemf/ThreeMfUnit;III)[B
+	public static synthetic fun toGlb$default (Lio/github/sceneview/core/ply/PlyLoader;[BLio/github/sceneview/core/threemf/ThreeMfUnit;IIIILjava/lang/Object;)[B
+}
+
+public final class io/github/sceneview/core/ply/PlyModel {
+	public final fun getColors ()[F
+	public final fun getIndices ()[I
+	public final fun getNormals ()[F
+	public final fun getPositions ()[F
+	public final fun getTriangleCount ()I
+	public final fun getUnit ()Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public final fun getVertexCount ()I
+}
+
+public final class io/github/sceneview/core/ply/PlyParseException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class io/github/sceneview/core/splat/SplatCloud {
 	public fun <init> (I[F[F[F[F[F)V
 	public final fun getColors ()[F
@@ -1669,4 +1695,3 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
-

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -1695,3 +1695,4 @@ public final class io/github/sceneview/utils/DurationKt {
 public final class io/github/sceneview/utils/TimeSourceKt {
 	public static final fun nanoTime ()J
 }
+

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/ply/PlyLoader.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/ply/PlyLoader.kt
@@ -1,0 +1,373 @@
+package io.github.sceneview.core.ply
+
+import io.github.sceneview.core.threemf.FloatArrayBuilder
+import io.github.sceneview.core.threemf.IntArrayBuilder
+import io.github.sceneview.core.threemf.ThreeMfGlb
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.math.sqrt
+
+/** Pure-Kotlin ASCII and binary PLY reader for Android, Apple and web. */
+object PlyLoader {
+    const val DEFAULT_MAX_BYTES: Int = 32 * 1024 * 1024
+    const val DEFAULT_MAX_VERTICES: Int = 1_000_000
+    const val DEFAULT_MAX_TRIANGLES: Int = 1_000_000
+
+    /** Cheap signature check. Validation is performed by [parse]. */
+    fun isPly(bytes: ByteArray): Boolean =
+        bytes.startsWith("ply\n") || bytes.startsWith("ply\r\n")
+
+    /** Parse vertices and fan-triangulated faces, assuming millimetres when PLY declares no unit. */
+    fun parse(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.MILLIMETER,
+        maxVertices: Int = DEFAULT_MAX_VERTICES,
+        maxTriangles: Int = DEFAULT_MAX_TRIANGLES,
+        maxBytes: Int = DEFAULT_MAX_BYTES
+    ): PlyModel {
+        if (maxVertices <= 0 || maxTriangles <= 0) plyError("PLY limits must be positive")
+        if (maxBytes <= 0) plyError("PLY limits must be positive")
+        if (bytes.size > maxBytes) plyError("PLY input exceeds $maxBytes bytes")
+        if (!isPly(bytes)) plyError("PLY header must start with ply")
+        val header = readHeader(bytes)
+        val vertexElement = header.elements.firstOrNull { it.name == "vertex" }
+            ?: plyError("PLY has no vertex element")
+        val faceElement = header.elements.firstOrNull { it.name == "face" }
+            ?: plyError("PLY has no face element")
+        if (vertexElement.count > maxVertices) plyError("PLY exceeds $maxVertices vertices")
+        val builder = PlyBuilder(vertexElement.count, maxTriangles, unit)
+        val reader = PlyDataReader(bytes, header.dataOffset, header.format)
+        for (element in header.elements) {
+            repeat(element.count) {
+                when (element.name) {
+                    "vertex" -> builder.addVertex(element, reader)
+                    "face" -> builder.addFace(element, reader)
+                    else -> reader.skip(element)
+                }
+            }
+        }
+        reader.finish()
+        if (faceElement.count == 0) plyError("PLY contains no faces")
+        return builder.build()
+    }
+
+    /** Convert PLY to a self-contained GLB, scaling the caller-selected [unit] to metres. */
+    fun toGlb(
+        bytes: ByteArray,
+        unit: ThreeMfUnit = ThreeMfUnit.MILLIMETER,
+        maxVertices: Int = DEFAULT_MAX_VERTICES,
+        maxTriangles: Int = DEFAULT_MAX_TRIANGLES,
+        maxBytes: Int = DEFAULT_MAX_BYTES
+    ): ByteArray {
+        val model = parse(bytes, unit, maxVertices, maxTriangles, maxBytes)
+        return ThreeMfGlb.encodeIndexed(
+            model.positions,
+            model.indices,
+            model.normals,
+            unit.meters,
+            model.colors,
+            "SceneView PLY loader",
+            "ply"
+        )
+    }
+}
+
+private enum class PlyFormat { ASCII, LITTLE_ENDIAN, BIG_ENDIAN }
+
+private enum class PlyType(val bytes: Int, val floating: Boolean, val unsigned: Boolean) {
+    INT8(1, false, false), UINT8(1, false, true), INT16(2, false, false),
+    UINT16(2, false, true), INT32(4, false, false), UINT32(4, false, true),
+    FLOAT32(4, true, false), FLOAT64(8, true, false)
+}
+
+private data class PlyProperty(val name: String, val type: PlyType, val countType: PlyType? = null)
+private data class PlyElement(val name: String, val count: Int, val properties: List<PlyProperty>)
+private data class PlyHeader(val format: PlyFormat, val elements: List<PlyElement>, val dataOffset: Int)
+
+private fun readHeader(bytes: ByteArray): PlyHeader {
+    var at = 0
+    var format: PlyFormat? = null
+    val elements = ArrayList<PlyElement>()
+    var currentName: String? = null
+    var currentCount = 0
+    var properties = ArrayList<PlyProperty>()
+    while (at < bytes.size) {
+        val end = bytes.lineEnd(at)
+        val line = bytes.decodeToString(at, end).trimEnd('\r')
+        at = if (end < bytes.size) end + 1 else end
+        val words = line.splitWhitespace()
+        when (words.firstOrNull()) {
+            "ply", "comment", "obj_info" -> Unit
+            "format" -> {
+                if (words.size != 3 || words[2] != "1.0") plyError("Unsupported PLY format line")
+                format = when (words[1]) {
+                    "ascii" -> PlyFormat.ASCII
+                    "binary_little_endian" -> PlyFormat.LITTLE_ENDIAN
+                    "binary_big_endian" -> PlyFormat.BIG_ENDIAN
+                    else -> plyError("Unsupported PLY encoding ${words[1]}")
+                }
+            }
+            "element" -> {
+                currentName?.let { elements += PlyElement(it, currentCount, properties) }
+                if (words.size != 3) plyError("Malformed PLY element")
+                currentName = words[1]
+                currentCount = words[2].toIntOrNull() ?: plyError("Invalid PLY element count")
+                if (currentCount < 0) plyError("Invalid PLY element count")
+                properties = ArrayList()
+            }
+            "property" -> properties += parseProperty(words)
+            "end_header" -> {
+                currentName?.let { elements += PlyElement(it, currentCount, properties) }
+                return PlyHeader(format ?: plyError("PLY format is missing"), elements, at)
+            }
+            else -> plyError("Unknown PLY header directive ${words.firstOrNull()}")
+        }
+    }
+    plyError("PLY end_header is missing")
+}
+
+private fun parseProperty(words: List<String>): PlyProperty {
+    if (words.getOrNull(1) == "list") {
+        if (words.size != 5) plyError("Malformed PLY list property")
+        return PlyProperty(words[4], plyType(words[3]), plyType(words[2]))
+    }
+    if (words.size != 3) plyError("Malformed PLY property")
+    return PlyProperty(words[2], plyType(words[1]))
+}
+
+private fun plyType(name: String): PlyType = when (name) {
+    "char", "int8" -> PlyType.INT8
+    "uchar", "uint8" -> PlyType.UINT8
+    "short", "int16" -> PlyType.INT16
+    "ushort", "uint16" -> PlyType.UINT16
+    "int", "int32" -> PlyType.INT32
+    "uint", "uint32" -> PlyType.UINT32
+    "float", "float32" -> PlyType.FLOAT32
+    "double", "float64" -> PlyType.FLOAT64
+    else -> plyError("Unsupported PLY property type $name")
+}
+
+private class PlyDataReader(
+    private val bytes: ByteArray,
+    private var at: Int,
+    private val format: PlyFormat
+) {
+    fun scalar(type: PlyType): Double = when (format) {
+        PlyFormat.ASCII -> token().toDoubleOrNull() ?: plyError("Invalid PLY number")
+        PlyFormat.LITTLE_ENDIAN -> binary(type, littleEndian = true)
+        PlyFormat.BIG_ENDIAN -> binary(type, littleEndian = false)
+    }
+
+    fun integer(type: PlyType): Long {
+        if (type.floating) plyError("PLY list count and indices must be integer")
+        val value = scalar(type)
+        if (!value.isFinite()) plyError("Invalid PLY integer")
+        if (value != value.toLong().toDouble()) plyError("Invalid PLY integer")
+        return value.toLong()
+    }
+
+    fun values(property: PlyProperty): DoubleArray {
+        val countType = property.countType ?: return doubleArrayOf(scalar(property.type))
+        val count = integer(countType)
+        if (count < 0 || count > Int.MAX_VALUE) plyError("Invalid PLY list count")
+        return DoubleArray(count.toInt()) { scalar(property.type) }
+    }
+
+    fun skip(element: PlyElement) {
+        for (property in element.properties) values(property)
+    }
+
+    fun finish() {
+        if (format == PlyFormat.ASCII) {
+            while (at < bytes.size && bytes[at].toInt().toChar().isWhitespace()) at++
+            if (at != bytes.size) plyError("Unexpected data after PLY body")
+        } else if (at != bytes.size) {
+            plyError("Unexpected data after PLY body")
+        }
+    }
+
+    private fun token(): String {
+        while (at < bytes.size && bytes[at].toInt().toChar().isWhitespace()) at++
+        if (at == bytes.size) plyError("Truncated PLY body")
+        val start = at
+        while (at < bytes.size && !bytes[at].toInt().toChar().isWhitespace()) at++
+        if (at - start > 128) plyError("PLY token is too long")
+        return bytes.decodeToString(start, at)
+    }
+
+    private fun binary(type: PlyType, littleEndian: Boolean): Double {
+        if (at > bytes.size - type.bytes) plyError("Truncated PLY binary body")
+        var bits = 0UL
+        repeat(type.bytes) { index ->
+            val source = if (littleEndian) at + index else at + type.bytes - 1 - index
+            bits = bits or ((bytes[source].toULong() and 0xffUL) shl (index * 8))
+        }
+        at += type.bytes
+        return when (type) {
+            PlyType.INT8 -> bits.toByte().toDouble()
+            PlyType.UINT8 -> bits.toUByte().toDouble()
+            PlyType.INT16 -> bits.toShort().toDouble()
+            PlyType.UINT16 -> bits.toUShort().toDouble()
+            PlyType.INT32 -> bits.toInt().toDouble()
+            PlyType.UINT32 -> bits.toUInt().toDouble()
+            PlyType.FLOAT32 -> Float.fromBits(bits.toInt()).toDouble()
+            PlyType.FLOAT64 -> Double.fromBits(bits.toLong())
+        }
+    }
+}
+
+private class PlyBuilder(
+    private val declaredVertices: Int,
+    private val maxTriangles: Int,
+    private val unit: ThreeMfUnit
+) {
+    private val positions = FloatArrayBuilder(declaredVertices * 3)
+    private val vertexNormals = FloatArrayBuilder(declaredVertices * 3)
+    private val colors = FloatArrayBuilder(declaredVertices * 4)
+    private val indices = IntArrayBuilder()
+    private var hasNormals: Boolean? = null
+    private var hasColors: Boolean? = null
+
+    fun addVertex(element: PlyElement, reader: PlyDataReader) {
+        val values = HashMap<String, Double>()
+        for (property in element.properties) {
+            val propertyValues = reader.values(property)
+            if (property.countType != null) plyError("PLY vertex properties cannot be lists")
+            values[property.name] = propertyValues[0]
+        }
+        addPosition(values)
+        addNormal(values)
+        addColor(values)
+    }
+
+    fun addFace(element: PlyElement, reader: PlyDataReader) {
+        var face: DoubleArray? = null
+        for (property in element.properties) {
+            val values = reader.values(property)
+            if (property.name == "vertex_indices" || property.name == "vertex_index") face = values
+        }
+        val vertices = face ?: plyError("PLY face has no vertex_indices property")
+        if (vertices.size < 3) plyError("PLY face must contain at least three vertices")
+        val added = vertices.size - 2
+        if (indices.size / 3 > maxTriangles - added) plyError("PLY exceeds $maxTriangles triangles")
+        for (corner in 1 until vertices.lastIndex) {
+            addIndex(vertices[0])
+            addIndex(vertices[corner])
+            addIndex(vertices[corner + 1])
+        }
+    }
+
+    fun build(): PlyModel {
+        if (positions.size / 3 != declaredVertices) plyError("PLY vertex count mismatch")
+        if (indices.size == 0) plyError("PLY contains no triangles")
+        val points = positions.toArray()
+        val triangles = indices.toArray()
+        val normals = if (hasNormals == true) {
+            indexedNormals(vertexNormals.toArray(), triangles)
+        } else {
+            smoothNormals(points, triangles)
+        }
+        return PlyModel(points, triangles, normals, colors.toArray().takeIf { hasColors == true }, unit)
+    }
+
+    private fun addPosition(values: Map<String, Double>) {
+        for (name in listOf("x", "y", "z")) {
+            val value = values[name]?.toFloat() ?: plyError("PLY vertex is missing $name")
+            if (!value.isFinite()) plyError("PLY position must be finite")
+            if (!(value * unit.meters).isFinite()) plyError("PLY position overflows in metres")
+            positions.add(if (value == 0f) 0f else value)
+        }
+    }
+
+    private fun addNormal(values: Map<String, Double>) {
+        val present = listOf("nx", "ny", "nz").map { values[it] != null }
+        if (present.any { it } && !present.all { it }) plyError("PLY vertex normal is incomplete")
+        val supplied = present.all { it }
+        if (hasNormals != null && hasNormals != supplied) plyError("Inconsistent PLY vertex normals")
+        hasNormals = supplied
+        if (supplied) {
+            val x = values.getValue("nx")
+            val y = values.getValue("ny")
+            val z = values.getValue("nz")
+            val length = sqrt(x * x + y * y + z * z)
+            if (length == 0.0 || !length.isFinite()) plyError("PLY normal must be finite and non-zero")
+            vertexNormals.add((x / length).toFloat())
+            vertexNormals.add((y / length).toFloat())
+            vertexNormals.add((z / length).toFloat())
+        }
+    }
+
+    private fun addColor(values: Map<String, Double>) {
+        val present = listOf("red", "green", "blue").map { values[it] != null }
+        if (present.any { it } && !present.all { it }) plyError("PLY vertex colour is incomplete")
+        val supplied = present.all { it }
+        if (hasColors != null && hasColors != supplied) plyError("Inconsistent PLY vertex colours")
+        hasColors = supplied
+        if (supplied) {
+            for (name in listOf("red", "green", "blue", "alpha")) {
+                val value = values[name] ?: 255.0
+                if (value < 0.0 || value > 255.0) plyError("PLY colour must be in 0..255")
+                colors.add((value / 255.0).toFloat())
+            }
+        }
+    }
+
+    private fun addIndex(value: Double) {
+        if (!value.isFinite() || value != value.toLong().toDouble()) plyError("Invalid PLY vertex index")
+        val index = value.toLong()
+        if (index < 0 || index >= declaredVertices) plyError("PLY vertex index out of range")
+        indices.add(index.toInt())
+    }
+
+    private fun indexedNormals(normals: FloatArray, triangles: IntArray): FloatArray =
+        FloatArray(triangles.size * 3) { at ->
+            normals[triangles[at / 3] * 3 + at % 3]
+        }
+
+    private fun smoothNormals(points: FloatArray, triangles: IntArray): FloatArray {
+        val sums = DoubleArray(points.size)
+        for (triangle in triangles.indices step 3) {
+            val a = triangles[triangle] * 3
+            val b = triangles[triangle + 1] * 3
+            val c = triangles[triangle + 2] * 3
+            val ux = points[b].toDouble() - points[a]
+            val uy = points[b + 1].toDouble() - points[a + 1]
+            val uz = points[b + 2].toDouble() - points[a + 2]
+            val vx = points[c].toDouble() - points[a]
+            val vy = points[c + 1].toDouble() - points[a + 1]
+            val vz = points[c + 2].toDouble() - points[a + 2]
+            for (vertex in intArrayOf(a, b, c)) {
+                sums[vertex] += uy * vz - uz * vy
+                sums[vertex + 1] += uz * vx - ux * vz
+                sums[vertex + 2] += ux * vy - uy * vx
+            }
+        }
+        return FloatArray(triangles.size * 3).also { out ->
+            for (corner in triangles.indices) writeNormal(out, corner * 3, sums, triangles[corner] * 3)
+        }
+    }
+
+    private fun writeNormal(out: FloatArray, at: Int, sums: DoubleArray, source: Int) {
+        val length = sqrt(
+            sums[source] * sums[source] + sums[source + 1] * sums[source + 1] +
+                sums[source + 2] * sums[source + 2]
+        )
+        if (length > 0.0 && length.isFinite()) {
+            repeat(3) { out[at + it] = (sums[source + it] / length).toFloat() }
+        } else {
+            out[at + 1] = 1f
+        }
+    }
+}
+
+private fun ByteArray.startsWith(text: String): Boolean {
+    if (size < text.length) return false
+    return text.indices.all { this[it] == text[it].code.toByte() }
+}
+
+private fun ByteArray.lineEnd(start: Int): Int {
+    var at = start
+    while (at < size && this[at] != '\n'.code.toByte()) at++
+    return at
+}
+
+private fun String.splitWhitespace(): List<String> = trim().split(Regex("\\s+")).filter { it.isNotEmpty() }

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/ply/PlyModel.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/ply/PlyModel.kt
@@ -1,0 +1,25 @@
+package io.github.sceneview.core.ply
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+
+/** Invalid or unsupported PLY data. */
+class PlyParseException(message: String) : RuntimeException(message)
+
+/**
+ * A triangulated PLY mesh in its source axes and [unit].
+ *
+ * [positions] and optional [colors] are per vertex. [normals] are per index so supplied vertex
+ * normals and generated smooth normals can both be passed directly to the shared GLB writer.
+ */
+class PlyModel internal constructor(
+    val positions: FloatArray,
+    val indices: IntArray,
+    val normals: FloatArray,
+    val colors: FloatArray?,
+    val unit: ThreeMfUnit
+) {
+    val vertexCount: Int get() = positions.size / 3
+    val triangleCount: Int get() = indices.size / 3
+}
+
+internal fun plyError(message: String): Nothing = throw PlyParseException(message)

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -37,10 +37,13 @@ internal object ThreeMfGlb {
         positions: FloatArray,
         indices: IntArray,
         cornerNormals: FloatArray,
-        meters: Float
+        meters: Float,
+        colors: FloatArray? = null,
+        generator: String = "SceneView STL loader",
+        nodeName: String = "stl"
     ): ByteArray {
-        val builder = GltfBuilder("SceneView STL loader")
-        builder.addIndexedMesh(positions, indices, cornerNormals, meters)
+        val builder = GltfBuilder(generator)
+        builder.addIndexedMesh(positions, indices, cornerNormals, meters, colors, nodeName)
         return builder.toGlb()
     }
 
@@ -101,11 +104,14 @@ internal object ThreeMfGlb {
             source: FloatArray,
             indices: IntArray,
             cornerNormals: FloatArray,
-            meters: Float
+            meters: Float,
+            sourceColors: FloatArray? = null,
+            nodeName: String = "stl"
         ) {
             val vertices = HashMap<NormalVertex, Int>()
             val positions = FloatArrayBuilder()
             val normals = FloatArrayBuilder()
+            val colors = sourceColors?.let { FloatArrayBuilder() }
             val renderIndices = IntArray(indices.size)
             for (corner in indices.indices) {
                 val at = corner * 3
@@ -118,15 +124,23 @@ internal object ThreeMfGlb {
                         positions.add(source[key.position * 3 + axis] * meters)
                         normals.add(cornerNormals[at + axis])
                     }
+                    sourceColors?.let { input ->
+                        colors?.let { output ->
+                            repeat(4) { output.add(input[key.position * 4 + it]) }
+                        }
+                    }
                     index
                 }
             }
             val positionAccessor = addFloatAccessor(positions.toArray(), withBounds = true)
             val normalAccessor = addFloatAccessor(normals.toArray(), withBounds = false)
+            val colorAccessor = colors?.let { addFloatAccessor(it.toArray(), false, 4) }
+            val colorAttribute = colorAccessor?.let { ",\"COLOR_0\":$it" }.orEmpty()
             val indexAccessor = addIndexAccessor(renderIndices)
-            meshes += """{"primitives":[{"attributes":{"POSITION":$positionAccessor,"NORMAL":$normalAccessor},""" +
+            meshes += """{"primitives":[{"attributes":{"POSITION":$positionAccessor,""" +
+                """"NORMAL":$normalAccessor$colorAttribute},""" +
                 """"indices":$indexAccessor,"material":${materialIndex(NoColor)}}]}"""
-            nodes += """{"name":"stl","mesh":0}"""
+            nodes += """{"name":${nodeName.toJsonString()},"mesh":0}"""
         }
 
         private fun addIndexAccessor(indices: IntArray): Int {

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyLoaderTest.kt
@@ -41,7 +41,8 @@ class PlyLoaderTest {
         val model = PlyLoader.parse(PlyTestFixtures.ascii())
         assertContentEquals(intArrayOf(0, 1, 2, 0, 2, 3), model.indices)
         assertContentEquals(floatArrayOf(1f, 0f, 0f, 1f), model.colors?.copyOfRange(0, 4))
-        assertEquals(128f / 255f, model.colors?.get(7))
+        // Tolerance: Kotlin/JS evaluates 128f / 255f in double precision, the loader stores a Float.
+        assertEquals(128f / 255f, model.colors?.get(7) ?: -1f, 0.000001f)
         val glb = PlyLoader.toGlb(PlyTestFixtures.ascii())
         assertEquals("glTF", glb.decodeToString(0, 4))
         assertTrue(glb.decodeToString().contains("COLOR_0"))

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyLoaderTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyLoaderTest.kt
@@ -1,0 +1,92 @@
+package io.github.sceneview.core.ply
+
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlyLoaderTest {
+    @Test
+    fun asciiAndBothBinaryEndiannessesMatch() {
+        val models = listOf(
+            PlyLoader.parse(PlyTestFixtures.ascii()),
+            PlyLoader.parse(PlyTestFixtures.binary(littleEndian = true)),
+            PlyLoader.parse(PlyTestFixtures.binary(littleEndian = false))
+        )
+        for (model in models.drop(1)) {
+            assertContentEquals(models[0].positions, model.positions)
+            assertContentEquals(models[0].indices, model.indices)
+            assertContentEquals(models[0].normals, model.normals)
+            assertContentEquals(models[0].colors, model.colors)
+        }
+        assertEquals(4, models[0].vertexCount)
+        assertEquals(2, models[0].triangleCount)
+        assertEquals(ThreeMfUnit.MILLIMETER, models[0].unit)
+    }
+
+    @Test
+    fun signatureAcceptsLfAndCrLfOnly() {
+        assertTrue(PlyLoader.isPly(PlyTestFixtures.ascii()))
+        val crlf = PlyTestFixtures.ascii().decodeToString().replace("\n", "\r\n")
+        assertTrue(PlyLoader.isPly(crlf.encodeToByteArray()))
+        assertFalse(PlyLoader.isPly("ply format ascii".encodeToByteArray()))
+        assertFalse(PlyLoader.isPly("glTF".encodeToByteArray()))
+    }
+
+    @Test
+    fun polygonFanTriangulatesAndPreservesVertexColor() {
+        val model = PlyLoader.parse(PlyTestFixtures.ascii())
+        assertContentEquals(intArrayOf(0, 1, 2, 0, 2, 3), model.indices)
+        assertContentEquals(floatArrayOf(1f, 0f, 0f, 1f), model.colors?.copyOfRange(0, 4))
+        assertEquals(128f / 255f, model.colors?.get(7))
+        val glb = PlyLoader.toGlb(PlyTestFixtures.ascii())
+        assertEquals("glTF", glb.decodeToString(0, 4))
+        assertTrue(glb.decodeToString().contains("COLOR_0"))
+    }
+
+    @Test
+    fun missingNormalsAreGenerated() {
+        val text = PlyTestFixtures.ascii().decodeToString()
+            .replace("property float nx\nproperty float ny\nproperty float nz\n", "")
+            .replace(Regex(" 0\\.0 0\\.0 1\\.0 (?=[0-9])"), " ")
+        val model = PlyLoader.parse(text.encodeToByteArray())
+        assertTrue(model.normals.all { it.isFinite() })
+        assertTrue(model.normals.indices.filter { it % 3 == 2 }.all { model.normals[it] == 1f })
+    }
+
+    @Test
+    fun unitAndLimitsAreApplied() {
+        val model = PlyLoader.parse(PlyTestFixtures.ascii(), unit = ThreeMfUnit.CENTIMETER)
+        assertEquals(ThreeMfUnit.CENTIMETER, model.unit)
+        assertFailsWith<PlyParseException> {
+            PlyLoader.parse(PlyTestFixtures.ascii(), maxVertices = 3)
+        }
+        assertFailsWith<PlyParseException> {
+            PlyLoader.parse(PlyTestFixtures.ascii(), maxTriangles = 1)
+        }
+        assertFailsWith<PlyParseException> {
+            PlyLoader.parse(PlyTestFixtures.ascii(), maxBytes = 10)
+        }
+    }
+
+    @Test
+    fun malformedInputsUseTypedErrors() {
+        val valid = PlyTestFixtures.ascii().decodeToString()
+        val malformed = listOf(
+            "", "ply\nend_header\n", valid.replace("format ascii", "format binary_middle_endian"),
+            valid.replace("element vertex 4", "element vertex -1"),
+            valid.replace("property float x", "property string x"),
+            valid.replace("4 0 1 2 3", "2 0 1"),
+            valid.replace("4 0 1 2 3", "3 0 1 99"),
+            valid.dropLast(4), valid + "garbage"
+        )
+        for (bytes in malformed.map { it.encodeToByteArray() }) {
+            assertFailsWith<PlyParseException> { PlyLoader.parse(bytes) }
+        }
+        val truncated = PlyTestFixtures.binary(littleEndian = true).dropLast(2).toByteArray()
+        assertFailsWith<PlyParseException> { PlyLoader.parse(truncated) }
+    }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/ply/PlyTestFixtures.kt
@@ -1,0 +1,67 @@
+package io.github.sceneview.core.ply
+
+internal object PlyTestFixtures {
+    private val vertices = arrayOf(
+        floatArrayOf(0f, 0f, 0f, 0f, 0f, 1f, 255f, 0f, 0f, 255f),
+        floatArrayOf(70f, 0f, 0f, 0f, 0f, 1f, 0f, 255f, 0f, 128f),
+        floatArrayOf(70f, 40f, 0f, 0f, 0f, 1f, 0f, 0f, 255f, 255f),
+        floatArrayOf(0f, 40f, 0f, 0f, 0f, 1f, 255f, 255f, 255f, 255f)
+    )
+
+    fun ascii(): ByteArray = buildString {
+        append(header("ascii"))
+        for (vertex in vertices) {
+            append(vertex.take(6).joinToString(" ") { it.plyText() })
+            append(" ${vertex[6].toInt()} ${vertex[7].toInt()} ${vertex[8].toInt()}")
+            append(" ${vertex[9].toInt()}\n")
+        }
+        append("4 0 1 2 3\n")
+    }.encodeToByteArray()
+
+    fun binary(littleEndian: Boolean): ByteArray {
+        val bytes = ArrayList<Byte>()
+        bytes.addAll(header(if (littleEndian) "binary_little_endian" else "binary_big_endian").bytes())
+        for (vertex in vertices) {
+            repeat(6) { bytes.putInt(vertex[it].toBits(), littleEndian) }
+            repeat(4) { bytes += vertex[6 + it].toInt().toByte() }
+        }
+        bytes += 4.toByte()
+        repeat(4) { bytes.putInt(it, littleEndian) }
+        return bytes.toByteArray()
+    }
+
+    private fun header(format: String): String = """
+        ply
+        format $format 1.0
+        comment fixture
+        element vertex 4
+        property float x
+        property float y
+        property float z
+        property float nx
+        property float ny
+        property float nz
+        property uchar red
+        property uchar green
+        property uchar blue
+        property uchar alpha
+        element face 1
+        property list uchar int vertex_indices
+        end_header
+    """.trimIndent() + "\n"
+
+    private fun String.bytes(): Collection<Byte> = encodeToByteArray().toList()
+
+    private fun ArrayList<Byte>.putInt(value: Int, littleEndian: Boolean) {
+        repeat(4) { index ->
+            val shift = if (littleEndian) index * 8 else (3 - index) * 8
+            add((value ushr shift).toByte())
+        }
+    }
+}
+
+/** Stable across Kotlin/JVM and Kotlin/JS (70f is respectively "70.0" and "70"). */
+private fun Float.plyText(): String {
+    val text = toString()
+    return if (text.any { it == '.' || it == 'e' || it == 'E' }) text else "$text.0"
+}

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -13,6 +13,7 @@ import io.github.sceneview.bumpLightGeneration
 import io.github.sceneview.bumpRenderableGeneration
 import io.github.sceneview.bumpTransformGeneration
 import io.github.sceneview.core.obj.ObjLoader
+import io.github.sceneview.core.ply.PlyLoader
 import io.github.sceneview.core.threemf.ThreeMfLoader
 import io.github.sceneview.model.Model
 import io.github.sceneview.model.ModelInstance
@@ -585,11 +586,12 @@ internal suspend fun <T : Any> destroyOnCancel(
 }
 
 /**
- * Normalises whatever the caller handed us into something Filament's glTF loader accepts: 3MF, STL
- * and OBJ are converted to GLB, then WebP textures are transcoded.
+ * Normalises whatever the caller handed us into something Filament's glTF loader accepts: 3MF,
+ * STL, OBJ and PLY are converted to GLB, then WebP textures are transcoded.
  */
 private fun Buffer.toFilamentModelSource(): Buffer =
-    convertThreeMfToGlb().convertStlToGlb().convertObjToGlb().transcodeWebPTextures()
+    convertThreeMfToGlb().convertStlToGlb().convertObjToGlb().convertPlyToGlb()
+        .transcodeWebPTextures()
 
 /**
  * Converts a **3MF** payload to GLB, so `.3mf` is loadable through every entry point on this class
@@ -622,6 +624,21 @@ private fun Buffer.convertObjToGlb(): Buffer {
     val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
     val glb = ObjLoader.toGlb(bytes)
     return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+/** PLY has an exact first line, so other formats cost at most a six-byte absolute comparison. */
+private fun Buffer.convertPlyToGlb(): Buffer {
+    val source = this as? ByteBuffer ?: return this
+    if (!source.startsWithPlyHeader()) return this
+    val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+    val glb = PlyLoader.toGlb(bytes)
+    return ByteBuffer.allocateDirect(glb.size).put(glb).apply { rewind() }
+}
+
+private fun ByteBuffer.startsWithPlyHeader(): Boolean {
+    val at = position()
+    if (!startsWithAscii(at, "ply\n") && !startsWithAscii(at, "ply\r\n")) return false
+    return true
 }
 
 /** JSON and binary GLB fail the cheap gate; other candidates cost at most a 4 KB prefix copy. */


### PR DESCRIPTION
Closes #3487. PlyLoader (ascii, binary little/big endian; normals, RGBA vertex colours as COLOR_0, fan triangulation, typed errors) in pure Kotlin, converted to GLB in memory through the shared GltfBuilder; ModelLoader sniffs the ply header. The Android demo's "Open with" filters now cover .stl, .obj and .ply next to .3mf/.glb/.gltf. llms.txt and the generated GPT knowledge files follow. Implemented by a Codex Sol run from a closed brief; validated locally (apiDump, detekt, core allTests + jsTest, sceneview and demo unit tests, demo assembleDebug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)