### PR TITLE
docs: PLY joins the formats table, the Open-with list and the landing hero (#3487)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ an AI assistant — and shows them at their real size, in 3D and in AR.
 | 3MF | ✅ pure Kotlin → GLB in memory, millimetres honoured | — | — |
 | STL (binary + ASCII) | ✅ pure Kotlin → GLB | — | — |
 | OBJ + MTL | ✅ pure Kotlin → GLB, material colours | — | — |
+| PLY (binary + ASCII) | ✅ pure Kotlin → GLB, vertex colours | — | — |
 | USDZ / Reality | — | ✅ RealityKit | — |
 
 The format is decided by the bytes, not the extension: a `.3mf` that arrives as
@@ -362,7 +363,7 @@ and `<colorgroup>` into one glTF material per colour. For a custom pipeline,
 Full section in [`llms.txt`](./llms.txt).
 
 The [Android demo](https://play.google.com/store/apps/details?id=io.github.sceneview.demo)
-registers as a handler for `.3mf`, `.glb` and `.gltf`, so a file opened from Downloads or
+registers as a handler for `.3mf`, `.glb`, `.gltf`, `.stl`, `.obj` and `.ply`, so a file opened from Downloads or
 sent through the share sheet lands in the viewer and then in AR at the size it would print
 ([#3510](https://github.com/sceneview/sceneview/pull/3510)). The format is decided by the
 bytes, not the file name — a shared `.3mf` arrives as `application/octet-stream` with no
@@ -370,12 +371,11 @@ queryable display name at all.
 
 ### Coming next
 
-The 3MF parser is deliberately dependency-free Kotlin so the same shape carries the rest.
-Tracked, not yet shipped:
+The 3MF parser is deliberately dependency-free Kotlin, and the same shape now carries
+[STL](https://github.com/sceneview/sceneview/pull/3517),
+[OBJ + MTL](https://github.com/sceneview/sceneview/pull/3518) and
+[PLY](https://github.com/sceneview/sceneview/pull/3525). Tracked, not yet shipped:
 
-[STL](https://github.com/sceneview/sceneview/issues/3486) ·
-[PLY](https://github.com/sceneview/sceneview/issues/3487) ·
-[OBJ + MTL](https://github.com/sceneview/sceneview/issues/3488) ·
 [one `ModelFormat` entry point](https://github.com/sceneview/sceneview/issues/3489) ·
 [every format on the web](https://github.com/sceneview/sceneview/issues/3491)
 

--- a/website-static/index.html
+++ b/website-static/index.html
@@ -22,7 +22,7 @@
   <script src="/assets/analytics.js"></script>
   <title>SceneView — 3D & AR SDK for Android, iOS, Web, and more</title>
   <meta name="description" content="SceneView is an open-source, AI-first SDK for building 3D and AR applications with Jetpack Compose, SwiftUI, Kotlin/JS, Flutter, and React Native. Ships as a ChatGPT and Codex plugin, and opens the .3mf files AI print flows emit. Powered by Filament and RealityKit.">
-  <meta name="keywords" content="SceneView, 3D SDK, AR SDK, Augmented Reality, Jetpack Compose, SwiftUI, Kotlin Multiplatform, ARCore, ARKit, Filament, RealityKit, Android 3D, iOS AR, model viewer, 3D file viewer, glTF, GLB, 3MF, STL, OBJ, USDZ, AR Model Viewer, Will It Fit, 3MF, 3D printing, visionOS, cross-platform 3D, AI-first SDK, MCP server, Claude 3D, ChatGPT AR, AI code generation, LLM 3D development, Copilot 3D, Gemini AR, model context protocol, ChatGPT plugin, Codex plugin, OpenAI plugin">
+  <meta name="keywords" content="SceneView, 3D SDK, AR SDK, Augmented Reality, Jetpack Compose, SwiftUI, Kotlin Multiplatform, ARCore, ARKit, Filament, RealityKit, Android 3D, iOS AR, model viewer, 3D file viewer, glTF, GLB, 3MF, STL, OBJ, PLY, USDZ, AR Model Viewer, Will It Fit, 3MF, 3D printing, visionOS, cross-platform 3D, AI-first SDK, MCP server, Claude 3D, ChatGPT AR, AI code generation, LLM 3D development, Copilot 3D, Gemini AR, model context protocol, ChatGPT plugin, Codex plugin, OpenAI plugin">
   <meta name="author" content="SceneView">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#005bc1">
@@ -225,7 +225,7 @@
     <div class="hero__container">
       <div class="hero__content">
         <h1 class="hero__title">The 3D &amp; AR SDK that AI gets right on the first try</h1>
-        <p class="hero__description">SceneView is designed so Claude, Cursor and every other coding assistant can produce correct 3D &amp; AR code on the first try — for Jetpack Compose, SwiftUI, the Web, and beyond. It opens glTF/GLB, 3MF, STL and OBJ on Android and USDZ on Apple, and shows them at real size in AR.</p>
+        <p class="hero__description">SceneView is designed so Claude, Cursor and every other coding assistant can produce correct 3D &amp; AR code on the first try — for Jetpack Compose, SwiftUI, the Web, and beyond. It opens glTF/GLB, 3MF, STL, OBJ and PLY on Android and USDZ on Apple, and shows them at real size in AR.</p>
         <div class="hero__actions">
           <a href="/docs.html" class="hero__btn hero__btn--primary" target="_blank" rel="noopener">Get Started</a>
           <a href="https://github.com/sceneview/sceneview" class="hero__btn hero__btn--outline" target="_blank" rel="noopener">View on GitHub</a>


### PR DESCRIPTION
Follow-up to #3525 (PLY loader, demo opens STL/OBJ/PLY) and #3524 (formats table).

- README: PLY row in the formats table, the demo's Open-with list now says `.stl`, `.obj`, `.ply`, and "Coming next" no longer lists STL, OBJ and PLY as unshipped.
- Landing (`website-static/index.html`): hero sentence and keywords mention PLY.

Docs only, no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)