### PR TITLE
fix(sceneview): destroy a model at most once (#3523)

### DIFF
--- a/changelog.d/3523-model-destroy-idempotent.md
+++ b/changelog.d/3523-model-destroy-idempotent.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+- **Leaving a screen while a model was still loading could kill the process
+  ([#3523](https://github.com/sceneview/sceneview/issues/3523)).** A cancelled `loadModel`
+  coroutine and `ModelLoader.clear()` could both reach `destroyAsset`/`releaseSourceData` for
+  the same glTF asset, and the second one dereferenced a freed native pointer — a `SIGSEGV` in
+  `libgltfio`, not an exception, so the `runCatching` around those calls never had a chance to
+  help. It reproduced about twice per ten QA runs on the demo app, always by navigating back
+  before the model finished loading. `ModelLoader.destroyModel` now *claims* the model out of
+  its live-asset registry and only destroys it if the claim succeeded, so of any number of
+  concurrent callers for one asset exactly one reaches Filament and the rest are no-ops.
+  Registration into that registry also moved inside the same main-thread hop as the asset
+  creation itself, closing the window where a model existed but was not yet claimable.

--- a/sceneview/src/main/java/io/github/sceneview/Engine.kt
+++ b/sceneview/src/main/java/io/github/sceneview/Engine.kt
@@ -58,6 +58,19 @@ fun Engine.drainFramePipeline() {
     }
 }
 
+/**
+ * Frees [model]'s native resources: releases whatever source glTF data is still held, then
+ * destroys the `gltfio` asset itself.
+ *
+ * **Callers must guarantee this runs at most once per [model].** `runCatching` only catches JVM
+ * exceptions — it cannot turn a JNI call into a null/already-freed native pointer into anything
+ * softer than a `SIGSEGV`, which kills the whole process rather than throwing (#3523). That makes
+ * "safe" here a promise about single-ownership bookkeeping upstream, not about this function's own
+ * try/catch: [io.github.sceneview.loaders.ModelLoader.destroyModel] is the only caller, and it
+ * enforces the at-most-once contract by atomically claiming [model] out of its live-asset registry
+ * before ever reaching this call — a second claim attempt (a cancelled coroutine racing `clear()`,
+ * say) finds the model already gone and never gets here.
+ */
 fun AssetLoader.safeDestroyModel(model: Model) {
     runCatching { model.releaseSourceData() }
     runCatching { destroyAsset(model) }

--- a/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
+++ b/sceneview/src/main/java/io/github/sceneview/loaders/ModelLoader.kt
@@ -165,10 +165,15 @@ class ModelLoader(
     ): Model? = context.loadFileBuffer(fileLocation)?.let { buffer ->
         // Transcoding decodes and re-encodes images: keep it off the main thread.
         val source = withContext(Dispatchers.Default) { buffer.toFilamentModelSource() }
+        // Registering into `models` happens *inside* the create block, in the same
+        // uninterrupted hop onto `dispatcher` as the asset creation itself (#3523): that is
+        // what guarantees a cancellation landing right after creation still finds the model
+        // in the registry, so createOrDestroyOnCancel's own destroy(created) call below goes
+        // through the same claim-then-destroy path as every other destroyModel() caller
+        // instead of racing it.
         val model = createOrDestroyOnCancel(::destroyModel) {
-            assetLoader.createAsset(source)
+            assetLoader.createAsset(source)?.also { models += it }
         } ?: return@let null
-        models += model
         destroyOnCancel(model, ::destroyModel) {
             loadResourcesSuspended(model) { resourceFileName: String ->
                 context.loadFileBuffer(resourceResolver(resourceFileName))
@@ -399,10 +404,10 @@ class ModelLoader(
     ): List<ModelInstance> = context.loadFileBuffer(fileLocation)?.let { buffer ->
         val instances = arrayOfNulls<ModelInstance>(count)
         val source = withContext(Dispatchers.Default) { buffer.toFilamentModelSource() }
+        // See loadModel(): registration happens inside the create block itself (#3523).
         val model = createOrDestroyOnCancel(::destroyModel) {
-            assetLoader.createInstancedAsset(source, instances)
+            assetLoader.createInstancedAsset(source, instances)?.also { models += it }
         } ?: throw IllegalArgumentException("Failed to parse glTF model from buffer")
-        models += model
         destroyOnCancel(model, ::destroyModel) {
             loadResourcesSuspended(model) { resourceFileName: String ->
                 context.loadFileBuffer(resourceResolver(resourceFileName))
@@ -459,17 +464,31 @@ class ModelLoader(
     @MainThread
     fun createInstance(model: Model): ModelInstance? = assetLoader.createInstance(model)
 
+    /**
+     * Destroys [model]'s native resources — a no-op if [model] is not (or is no longer)
+     * registered in [models].
+     *
+     * Goes through [claimAndDestroy] so every destroy path — this call, a cancelled
+     * [loadModel]/[loadInstancedModel] coroutine's cleanup, [clear] — shares the same
+     * synchronized claim on [models]. That closes #3523: a `destroyOnCancel` continuation
+     * resuming after [clear] already tore this same model down (or the reverse) now finds it
+     * already gone and returns instead of double-freeing the native asset — the segfault
+     * `runCatching` could never have caught in the first place. See [safeDestroyModel] for why
+     * "at most once" has to be enforced here rather than there.
+     */
     fun destroyModel(model: Model) {
-        assetLoader.safeDestroyModel(model)
-        // destroyAsset destroys every entity's components directly, bypassing Node.destroy()
-        // entirely — the sibling Nodes' cached handles need to know a reindex may have happened
-        // here too (#2978 review gap 2). A glTF asset carries renderable components on every
-        // mesh entity and light components whenever KHR_lights_punctual is present, so all three
-        // packed arrays can compact here, not just TransformManager (#3123).
-        engine.bumpTransformGeneration()
-        engine.bumpRenderableGeneration()
-        engine.bumpLightGeneration()
-        models -= model
+        claimAndDestroy(models, model) {
+            assetLoader.safeDestroyModel(it)
+            // destroyAsset destroys every entity's components directly, bypassing
+            // Node.destroy() entirely — the sibling Nodes' cached handles need to know a
+            // reindex may have happened here too (#2978 review gap 2). A glTF asset carries
+            // renderable components on every mesh entity and light components whenever
+            // KHR_lights_punctual is present, so all three packed arrays can compact here,
+            // not just TransformManager (#3123).
+            engine.bumpTransformGeneration()
+            engine.bumpRenderableGeneration()
+            engine.bumpLightGeneration()
+        }
     }
 
     fun clear() {
@@ -478,8 +497,12 @@ class ModelLoader(
         resourceLoader.asyncCancelLoad()
         resourceLoader.evictResourceData()
 
+        // A cancelled load's own cleanup (destroyOnCancel/createOrDestroyOnCancel, both wired
+        // to destroyModel) may still be queued behind this call on the main dispatcher. That is
+        // no longer a race to win: destroyModel's claim-then-destroy means whichever of the two
+        // calls on a given model runs first destroys it, and the other finds it already removed
+        // from `models` and does nothing (#3523).
         models.toList().forEach { destroyModel(it) }
-        models.clear()
     }
 
     fun destroy() {
@@ -530,6 +553,22 @@ class ModelLoader(
         fun getFolderPath(baseFileName: String, resourceFileName: String) =
             "${baseFileName.substringBeforeLast("/")}/$resourceFileName"
     }
+}
+
+/**
+ * Removes [item] from [registry] and, only if it was actually present, runs [destroy] on it.
+ *
+ * The membership check and the removal are the same call — `MutableList.remove` on the
+ * `Collections.synchronizedList` every [ModelLoader] registry is — so of any number of
+ * concurrent callers passing the same [item], exactly one sees `true` and runs [destroy]; every
+ * other caller finds [item] already gone and returns without touching it (#3523). This is the
+ * claim-then-destroy pattern [ModelLoader.destroyModel] relies on to stay safe under a
+ * cancelled-coroutine cleanup racing [ModelLoader.clear]: a native double-free is a `SIGSEGV`
+ * that crashes the process before any `try`/`catch` runs, so the guard has to sit here, in front
+ * of the call into `gltfio`, not wrapped around it.
+ */
+internal fun <T> claimAndDestroy(registry: MutableList<T>, item: T, destroy: (T) -> Unit) {
+    if (registry.remove(item)) destroy(item)
 }
 
 /**

--- a/sceneview/src/test/java/io/github/sceneview/loaders/ModelDestroyIdempotenceTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/loaders/ModelDestroyIdempotenceTest.kt
@@ -1,0 +1,175 @@
+package io.github.sceneview.loaders
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression contract for #3523 — a native SIGSEGV in `libgltfio-jni` seen when a cancelled
+ * `ModelLoader.loadModel` coroutine's `destroyOnCancel` cleanup called `destroyModel` on an
+ * asset `clear()` had already destroyed (or the reverse). `runCatching` cannot turn a JNI
+ * double-free into a catchable exception — it is a process-level `SIGSEGV` — so the fix has to
+ * make it structurally impossible to reach `AssetLoader.safeDestroyModel` twice for the same
+ * asset, not catch the fallout.
+ *
+ * [claimAndDestroy] is the extracted, Filament-free core of that guard: `ModelLoader.destroyModel`
+ * is every one of `destroyModel` (direct calls), `destroyOnCancel`'s cleanup and `clear()`'s
+ * sweep routed through it against the same `models` registry. These tests exercise the guard
+ * directly — a fake "native" resource and a `destroy` callback that counts and records calls —
+ * without needing a real Filament `Engine`/`AssetLoader`, which this module's JVM unit tests
+ * cannot construct (see `ModelLoaderCancellationTest`'s use of the same extraction strategy for
+ * #3051).
+ */
+class ModelDestroyIdempotenceTest {
+
+    @Test
+    fun `first claim destroys and removes the item from the registry`() {
+        val registry = Collections.synchronizedList(mutableListOf("model"))
+        val destroyed = mutableListOf<String>()
+
+        claimAndDestroy(registry, "model") { destroyed += it }
+
+        assertEquals(listOf("model"), destroyed)
+        assertTrue("the claimed item must leave the registry", registry.isEmpty())
+    }
+
+    @Test
+    fun `a second claim on the same item is a no-op`() {
+        val registry = Collections.synchronizedList(mutableListOf("model"))
+        val destroyed = mutableListOf<String>()
+
+        claimAndDestroy(registry, "model") { destroyed += it }
+        // This is the exact shape of the crash: destroyOnCancel's cleanup calling destroyModel
+        // on a model clear() (or another destroyOnCancel) already tore down.
+        claimAndDestroy(registry, "model") { destroyed += it }
+
+        assertEquals(
+            "the native call must run exactly once for this asset",
+            listOf("model"),
+            destroyed
+        )
+    }
+
+    @Test
+    fun `claiming an item never registered does not destroy it`() {
+        val registry = Collections.synchronizedList(mutableListOf<String>())
+        val destroyed = mutableListOf<String>()
+
+        claimAndDestroy(registry, "never-registered") { destroyed += it }
+
+        assertTrue(destroyed.isEmpty())
+    }
+
+    @Test
+    fun `claiming one item leaves an unrelated registered item alone`() {
+        val registry = Collections.synchronizedList(mutableListOf("model-a", "model-b"))
+        val destroyed = mutableListOf<String>()
+
+        claimAndDestroy(registry, "model-a") { destroyed += it }
+
+        assertEquals(listOf("model-a"), destroyed)
+        assertEquals(listOf("model-b"), registry)
+    }
+
+    /**
+     * Simulates the exact race from the tombstone: `clear()`'s synchronous sweep over a
+     * `models.toList()` snapshot racing a cancelled coroutine's `destroyOnCancel` cleanup for
+     * the very same model, on two different threads, with no synchronization between the two
+     * call sites beyond the shared registry. Runs many trials because the original bug was
+     * timing-dependent (~2 crashes per 10 QA runs) — a single trial passing would not be
+     * convincing.
+     */
+    @Test
+    fun `two threads racing to destroy the same model destroy it exactly once`() {
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            repeat(2_000) {
+                val registry = Collections.synchronizedList(mutableListOf("model"))
+                val destroyCount = AtomicInteger(0)
+                val barrier = CyclicBarrier(2)
+
+                val destroy: (String) -> Unit = { destroyCount.incrementAndGet() }
+                val racer = Runnable {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    claimAndDestroy(registry, "model", destroy)
+                }
+
+                val f1 = executor.submit(racer)
+                val f2 = executor.submit(racer)
+                f1.get(5, TimeUnit.SECONDS)
+                f2.get(5, TimeUnit.SECONDS)
+
+                assertEquals(
+                    "exactly one of the two concurrent callers must destroy the model",
+                    1,
+                    destroyCount.get()
+                )
+                assertTrue("the model must not remain claimable afterwards", registry.isEmpty())
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * `clear()` destroys whatever is still in `models` and returns without waiting for any
+     * coroutine cancellation to finish propagating (#3523's second half: "clear() races its own
+     * cancellation"). This reproduces that ordering — clear's sweep runs to completion first —
+     * and asserts the later, delayed cancellation cleanup for the same model is inert rather
+     * than reaching into a native asset `clear()` (and, in production, `ModelLoader.destroy()`
+     * right after it) already tore down.
+     */
+    @Test
+    fun `a cleanup that arrives after clear already destroyed the model is inert`() {
+        val registry = Collections.synchronizedList(mutableListOf("model"))
+        val destroyed = mutableListOf<String>()
+        fun destroyModel(model: String) = claimAndDestroy(registry, model) { destroyed += it }
+
+        // clear(): synchronous sweep over a snapshot of the registry.
+        registry.toList().forEach(::destroyModel)
+        // The cancelled coroutine's destroyOnCancel cleanup, queued on the main dispatcher
+        // behind clear(), finally gets to run.
+        destroyModel("model")
+
+        assertEquals(listOf("model"), destroyed)
+    }
+
+    /** Same race, opposite arrival order: the coroutine cleanup wins, clear's sweep is inert. */
+    @Test
+    fun `clear sweeping after a coroutine cleanup already destroyed the model is inert`() {
+        val registry = Collections.synchronizedList(mutableListOf("model"))
+        val destroyed = mutableListOf<String>()
+        fun destroyModel(model: String) = claimAndDestroy(registry, model) { destroyed += it }
+
+        // The cancelled coroutine's cleanup runs first this time.
+        destroyModel("model")
+        // clear()'s sweep now finds an empty snapshot for this model.
+        registry.toList().forEach(::destroyModel)
+
+        assertEquals(listOf("model"), destroyed)
+    }
+
+    /**
+     * A model registered mid-way through `clear()`'s cancellation fan-out (e.g. a load whose
+     * asset creation had not yet run when `coroutineScope.cancel()` fired) must still be
+     * destroyable by a later, explicit `destroyModel` call — the guard must never leave a
+     * legitimately live model permanently unclaimable.
+     */
+    @Test
+    fun `a model added after a sweep is still destroyable`() {
+        val registry = Collections.synchronizedList(mutableListOf("model-a"))
+        val destroyed = mutableListOf<String>()
+        fun destroyModel(model: String) = claimAndDestroy(registry, model) { destroyed += it }
+
+        registry.toList().forEach(::destroyModel)
+        registry += "model-b"
+        destroyModel("model-b")
+
+        assertEquals(listOf("model-a", "model-b"), destroyed)
+    }
+}


### PR DESCRIPTION
## The crash

A cancelled `loadModel` coroutine's `destroyOnCancel` cleanup and `ModelLoader.clear()` could
both call `destroyModel` on the same `FilamentAsset`. The membership bookkeeping
(`models -= model`) ran *after* `safeDestroyModel`, so both callers passed the check and the
second one released an already-freed native pointer — a `SIGSEGV` in `libgltfio`, not a Java
exception, which is why the `runCatching` inside `safeDestroyModel` never had a chance to help
(~2 crashes per 10 QA runs, always by navigating back before a model finished loading).

## The fix

- `destroyModel` now **claims** the model out of the `models` registry and destroys it only if
  the claim succeeded. `Collections.synchronizedList.remove` is the atomic test-and-take, so of
  any number of concurrent callers for one asset exactly one reaches Filament and the rest are
  no-ops.
- `clear()` keeps sweeping the registry, but no longer has to win a race against the
  cancellation it just triggered; a cleanup arriving after `destroy()` is inert rather than
  reaching into a torn-down `AssetLoader`.
- Registration into `models` moved *inside* the `createOrDestroyOnCancel` block, in the same
  uninterrupted main-thread hop as `createAsset`, closing the window where a model existed but
  was not yet claimable.
- `safeDestroyModel` keeps its name and now documents that "safe" is a promise made by its one
  caller's single-ownership bookkeeping, not by its own try/catch.

## Tests

`ModelDestroyIdempotenceTest` exercises the extracted, Filament-free guard (`claimAndDestroy`),
including a 2 000-trial two-thread race asserting exactly one destroy per asset, and both
arrival orders of the `clear()` / cancellation-cleanup interleaving.

Verified locally: `:sceneview:compileDebugKotlin`, `:sceneview:testDebugUnitTest` (whole module),
`:sceneview:apiCheck` — all green. Public API unchanged (`claimAndDestroy` is `internal`).

Fixes #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)