### PR TITLE
fix(demo): View in AR keeps the model the viewer was showing

### DIFF
--- a/changelog.d/3493-viewer-to-ar-keeps-model.md
+++ b/changelog.d/3493-viewer-to-ar-keeps-model.md
@@ -1,0 +1,10 @@
+<!-- category: Fixed -->
+- **"View in AR" from the Model Viewer sometimes dropped the current model and opened the
+  picker instead ([#3493](https://github.com/sceneview/sceneview/issues/3493)).** The handoff
+  passed whatever model the viewer was showing, but AR only recognised it when it also
+  happened to be one of the six models curated for the AR placement catalogue. The Damaged
+  Helmet is deliberately *not* one of them — a design call from #2023 about what a first-time
+  visitor should be offered — so tapping "View in AR" while looking at it silently failed to
+  arm anything and landed on the picker instead of the camera. The handoff now always wins:
+  any model the viewer was showing opens AR directly, with the same model already armed, and
+  the picker is still one tap away if the user wants to change it.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoSettings.kt
@@ -57,6 +57,17 @@ object DemoSettings {
      * they just opened. `null` when nothing has been opened.
      */
     var openedModelDisplayName: String? by mutableStateOf(null)
+
+    /**
+     * Display name for the model named by [requestedModel], when that model is neither a
+     * curated [io.github.sceneview.demo.common.placement.BUNDLED_PLACEMENT_MODELS] row (whose
+     * own name wins) nor an opened file (which uses [openedModelDisplayName]) — e.g. the Model
+     * Viewer's Damaged Helmet, deliberately left out of the placement catalogue (#2023) but
+     * still a model the "View in AR" handoff must be able to name (#3493). `null` when the
+     * handoff has nothing extra to say, in which case the receiving screen derives a label from
+     * the asset path itself.
+     */
+    var requestedModelDisplayName: String? by mutableStateOf(null)
     /**
      * `true` = deterministic mode (no auto-orbit, no idle camera drift, no implicit
      * motion). `false` = full "wow" showcase mode. Default `false`.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementModelPicker.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/common/placement/PlacementModelPicker.kt
@@ -193,6 +193,77 @@ val BUNDLED_PLACEMENT_MODELS: List<PlacementModel> = listOf(
 )
 
 /**
+ * Resolves the Model Viewer's "View in AR" handoff (#3493) — and "Open with SceneView"'s
+ * (#3482) — into the extra picker row AR must arm immediately when the model it names is NOT
+ * already in [catalogue]. Returns `null` when there is nothing to add: either no model was
+ * handed off, or it already matches a catalogue row by full asset path or bare file stem (that
+ * row's own curated name and size win instead).
+ *
+ * Before this existed, an uncatalogued handoff — the Model Viewer's Damaged Helmet, deliberately
+ * left out of [BUNDLED_PLACEMENT_MODELS] by #2023 ("a helmet hovering over a floor reads as a
+ * test payload") — silently produced no armed row at all: the caller's `requestedRow` stayed
+ * `null`, `flow.enterAr()` never fired, and the user landed on the chooser instead of the camera
+ * they explicitly asked for by tapping "View in AR" on a model they were already looking at. The
+ * catalogue's curation is a rule about what the chooser offers a fresh visitor; it must never be
+ * read as a veto over an explicit "take me to AR with THIS model" request.
+ *
+ * [requestedModel] is the raw route argument: a bundled asset path, its bare file stem, or a
+ * `file://` location for an opened/streamed file (recognised by the scheme, not a flag). A
+ * `file://` location prefers [openedDisplayName] for its label — the location's own basename is
+ * the staged copy's fixed name (`opened-model`), which would tell the user nothing — and carries
+ * whatever real-world size the viewer measured, in [openedSizeMeters] (the whole point for a
+ * 3MF, which carries true manufacturing size). Any other unmatched location falls back to
+ * [requestedDisplayName] (the viewer's own name for the model it was showing), then to a name
+ * derived from the location itself — the full basename for a user's file (extension included,
+ * because that is how they named it) and the bare stem for a bundled asset path (whose
+ * extension is an implementation detail).
+ *
+ * [openedSizeMeters] is honoured for a `file://` location only: it is a measurement of the
+ * file the viewer had loaded, and must never leak onto a bundled row whose catalogue size —
+ * or the default — is the truthful one.
+ */
+fun resolveRequestedExtraPlacementRow(
+    requestedModel: String?,
+    catalogue: List<PlacementModel> = BUNDLED_PLACEMENT_MODELS,
+    requestedDisplayName: String? = null,
+    openedDisplayName: String? = null,
+    openedSizeMeters: Float? = null,
+): PlacementModel? {
+    val location = requestedModel?.takeIf { it.isNotBlank() } ?: return null
+    val matchesCatalogue = catalogue.any { model ->
+        model.assetLocation == location ||
+            model.assetLocation.substringAfterLast('/').substringBeforeLast('.') == location
+    }
+    if (matchesCatalogue) return null
+    val isOpenedFile = location.startsWith("file://")
+    val basename = location.substringAfterLast('/')
+    return PlacementModel(
+        id = if (isOpenedFile) OPENED_FILE_PLACEMENT_ROW_ID else REQUESTED_MODEL_PLACEMENT_ROW_ID,
+        displayName = (if (isOpenedFile) openedDisplayName else null)
+            ?: requestedDisplayName
+            ?: (if (isOpenedFile) basename else basename.substringBeforeLast('.'))
+                .ifBlank { "Your file" },
+        assetLocation = location,
+        realWorldSizeMeters = openedSizeMeters
+            ?.takeIf { isOpenedFile && it.isFinite() && it > 0f }
+            ?: PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS,
+    )
+}
+
+/**
+ * Row id for a file the user opened ("Open with SceneView", #3482). Its bytes are neither
+ * bundled nor streamed, so the origin chip must stay silent on it rather than claim either.
+ */
+const val OPENED_FILE_PLACEMENT_ROW_ID: String = "opened-file"
+
+/**
+ * Row id for a bundled model the handoff named but the curated catalogue does not carry —
+ * the Model Viewer's Damaged Helmet (#3493). Bundled like any catalogue row, so the origin
+ * chip reports it as such.
+ */
+const val REQUESTED_MODEL_PLACEMENT_ROW_ID: String = "requested-model"
+
+/**
  * Selection + sheet visibility for the canonical picker, hoisted out of both hosts.
  *
  * Hoisted rather than kept inside [TapToPlaceExperience] because the hosts read the

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARPlacementDemo.kt
@@ -21,6 +21,7 @@ import io.github.sceneview.demo.R
 import io.github.sceneview.demo.common.ForceTrackingFailureMenu
 import io.github.sceneview.demo.common.placement.BUNDLED_PLACEMENT_MODELS
 import io.github.sceneview.demo.common.placement.PlacementChooserScreen
+import io.github.sceneview.demo.common.placement.OPENED_FILE_PLACEMENT_ROW_ID
 import io.github.sceneview.demo.common.placement.PlacementFlowPhase
 import io.github.sceneview.demo.common.placement.PlacementModel
 import io.github.sceneview.demo.common.placement.PlacementModelBar
@@ -32,6 +33,7 @@ import io.github.sceneview.demo.common.placement.placementBackAction
 import io.github.sceneview.demo.common.placement.rememberPlacementFlowState
 import io.github.sceneview.demo.common.placement.rememberPlacementPickerState
 import io.github.sceneview.demo.common.placement.rememberTapToPlaceState
+import io.github.sceneview.demo.common.placement.resolveRequestedExtraPlacementRow
 import io.github.sceneview.demo.sketchfab.AssetSourceProbe
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import io.github.sceneview.demo.sketchfab.SketchfabAssetResolver
@@ -120,27 +122,33 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // answered "what are we placing?", so it skips the chooser and opens the camera — which
     // is the same contract, reached from a different door.
     val requestedModel = remember { DemoSettings.requestedModel.also { DemoSettings.requestedModel = null } }
-    // "Open with SceneView" (#3482): the handoff may name a file the user opened rather than a
-    // catalogue row — a `file://` path staged by `OpenedModelIntent`. It becomes a row of its own,
-    // first in the picker, at the size the viewer measured on the loaded model. That size is the
-    // whole point for a 3MF: the format carries true manufacturing size, so a 60 mm print has to
-    // arrive in the room as 60 mm rather than as the catalogue's default.
-    val openedRow = remember(requestedModel) {
-        val location = requestedModel?.takeIf { it.startsWith("file://") } ?: return@remember null
-        PlacementModel(
-            id = "opened-file",
-            // The viewer carries the user's own file name across; the location's basename is the
-            // staged copy's fixed name (`opened-model`), which would tell the user nothing.
-            displayName = DemoSettings.openedModelDisplayName
-                ?: location.substringAfterLast('/').ifBlank { "Your file" },
-            assetLocation = location,
-            realWorldSizeMeters = DemoSettings.openedModelSizeMeters
-                ?.takeIf { it.isFinite() && it > 0f }
-                ?: PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS,
+    val requestedDisplayName = remember(requestedModel) {
+        DemoSettings.requestedModelDisplayName.also { DemoSettings.requestedModelDisplayName = null }
+    }
+    // The handoff must win even when the model it names is not one of the curated six —
+    // notably the Model Viewer's Damaged Helmet, deliberately left out of
+    // [BUNDLED_PLACEMENT_MODELS] by #2023 ("a helmet hovering over a floor reads as a test
+    // payload"). That curation is a rule about what the CHOOSER offers a fresh visitor, not
+    // a veto over an explicit "take me to AR with THIS model" request (#3493) — before this,
+    // an uncatalogued model silently produced no [requestedRow] below, so [flow.enterAr]
+    // never fired and the user landed on the picker instead of the camera.
+    //
+    // "Open with SceneView" (#3482) is the special case of this: the handoff may name a file
+    // the user opened rather than any bundled asset — a `file://` path staged by
+    // `OpenedModelIntent`. Both cases become a row of its own, first in the picker; the opened
+    // file additionally carries the real-world size the viewer measured on the loaded model —
+    // the whole point for a 3MF, which carries true manufacturing size, so a 60 mm print has
+    // to arrive in the room as 60 mm rather than as the catalogue's default.
+    val requestedExtraRow = remember(requestedModel) {
+        resolveRequestedExtraPlacementRow(
+            requestedModel = requestedModel,
+            requestedDisplayName = requestedDisplayName,
+            openedDisplayName = DemoSettings.openedModelDisplayName,
+            openedSizeMeters = DemoSettings.openedModelSizeMeters,
         )
     }
     val requestedRow = remember(requestedModel) {
-        openedRow ?: BUNDLED_PLACEMENT_MODELS.firstOrNull { model ->
+        requestedExtraRow ?: BUNDLED_PLACEMENT_MODELS.firstOrNull { model ->
             model.assetLocation == requestedModel ||
                 model.assetLocation.substringAfterLast('/').substringBeforeLast('.') == requestedModel
         }
@@ -199,8 +207,8 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // OWN bundled fallback as `assetLocation` (never null), so a tap during the download
     // places that slug's stand-in rather than nothing — and the row is flagged `pending`
     // so the bar and the card both say "Streaming …" instead of lying about it.
-    val models: List<PlacementModel> = remember(placementSlugs, armedSlug, armedFile, openedRow) {
-        listOfNotNull(openedRow) + BUNDLED_PLACEMENT_MODELS + placementSlugs.map { slug ->
+    val models: List<PlacementModel> = remember(placementSlugs, armedSlug, armedFile, requestedExtraRow) {
+        listOfNotNull(requestedExtraRow) + BUNDLED_PLACEMENT_MODELS + placementSlugs.map { slug ->
             val isArmed = slug.uid == armedSlug?.uid
             PlacementModel(
                 id = streamedModelId(slug),
@@ -231,7 +239,9 @@ fun ARPlacementDemo(onBack: () -> Unit) {
     // tap actually places. `loaded` is the FILE here, not a parsed `ModelInstance`: a tap
     // places whatever `armedFile` holds, so that is the moment the chip has something true
     // to say. See [AssetSourceProbe].
-    val assetSource = if (openedRow != null && picker.selectedId == openedRow.id) {
+    val assetSource = if (requestedExtraRow?.id == OPENED_FILE_PLACEMENT_ROW_ID &&
+        picker.selectedId == requestedExtraRow.id
+    ) {
         // The user's own file: neither bundled nor streamed. No chip rather than a wrong one.
         null
     } else if (armedSlug == null) {

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -619,6 +619,13 @@ private fun SingleModelSection(
             // The staged file is called `opened-model` on disk, so AR cannot recover the user's
             // file name from the location it is handed. Carry it across explicitly.
             DemoSettings.openedModelDisplayName = openedModel?.displayName
+            // #3493 — whatever the viewer is showing must be what AR opens on, never a picker.
+            // `selectedModel.assetPath` covers every bundled row, including ones the AR
+            // placement catalogue itself doesn't curate (the Damaged Helmet, #2023) — its name
+            // has to ride along too, for AR to label a row the catalogue has no entry for. Set
+            // unconditionally: a match against the curated catalogue uses ITS OWN name instead,
+            // and this value is consumed once then cleared.
+            DemoSettings.requestedModelDisplayName = openedModel?.displayName ?: selectedModel.displayName
             val model = openedModel?.location ?: selectedModel.assetPath
             DemoSettings.requestedRoute = "demo/ar-placement?model=$model"
         }, enabled = arSupported == true),

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/common/placement/PlacementModelPickerTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/common/placement/PlacementModelPickerTest.kt
@@ -1,0 +1,134 @@
+package io.github.sceneview.demo.common.placement
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the Model Viewer → AR handoff (#3493): what [resolveRequestedExtraPlacementRow] decides
+ * to arm when the viewer's "View in AR" button names a model.
+ *
+ * The bug this guards: the report was filed from the Model Viewer while looking at the bundled
+ * Damaged Helmet — deliberately absent from [BUNDLED_PLACEMENT_MODELS] (#2023) — and tapping
+ * "View in AR" dropped the user on the model picker instead of opening the camera on the helmet.
+ * The handoff silently produced no armed row for any model outside the curated six, so
+ * `ARPlacementDemo`'s `flow.enterAr()` never fired.
+ */
+class PlacementModelPickerTest {
+
+    private val catalogue = listOf(
+        PlacementModel(
+            id = "soldier",
+            displayName = "Soldier",
+            assetLocation = "models/threejs_soldier.glb",
+        ),
+    )
+
+    @Test
+    fun `no handoff means nothing to add`() {
+        assertNull(resolveRequestedExtraPlacementRow(requestedModel = null, catalogue = catalogue))
+        assertNull(resolveRequestedExtraPlacementRow(requestedModel = "", catalogue = catalogue))
+    }
+
+    @Test
+    fun `a full asset path already in the catalogue needs no extra row`() {
+        // The catalogue's own row is armed instead — see the caller's fallback lookup.
+        assertNull(
+            resolveRequestedExtraPlacementRow(
+                requestedModel = "models/threejs_soldier.glb",
+                catalogue = catalogue,
+            ),
+        )
+    }
+
+    @Test
+    fun `a bare file stem already in the catalogue needs no extra row`() {
+        assertNull(
+            resolveRequestedExtraPlacementRow(requestedModel = "threejs_soldier", catalogue = catalogue),
+        )
+    }
+
+    @Test
+    fun `the Damaged Helmet — bundled, but outside the curated six — still gets a row`() {
+        // This is the exact #3493 repro: a bundled model the Model Viewer shows but the AR
+        // placement catalogue does not curate. It must not be dropped on the floor.
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "models/khronos_damaged_helmet.glb",
+            catalogue = catalogue,
+            requestedDisplayName = "Damaged Helmet",
+        )
+        assertEquals(REQUESTED_MODEL_PLACEMENT_ROW_ID, row?.id)
+        assertEquals("Damaged Helmet", row?.displayName)
+        assertEquals("models/khronos_damaged_helmet.glb", row?.assetLocation)
+    }
+
+    @Test
+    fun `an uncatalogued model with no viewer-supplied name derives one from the file stem`() {
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "models/khronos_damaged_helmet.glb",
+            catalogue = catalogue,
+        )
+        assertEquals("khronos_damaged_helmet", row?.displayName)
+    }
+
+    @Test
+    fun `an opened file is recognised by its scheme and named from openedDisplayName first`() {
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "file:///data/user/0/io.github.sceneview.demo/cache/opened-model.glb",
+            catalogue = catalogue,
+            requestedDisplayName = "should not win for an opened file",
+            openedDisplayName = "my_scan.3mf",
+            openedSizeMeters = 0.06f,
+        )
+        assertEquals(OPENED_FILE_PLACEMENT_ROW_ID, row?.id)
+        assertEquals("my_scan.3mf", row?.displayName)
+        assertEquals(0.06f, row?.realWorldSizeMeters)
+    }
+
+    @Test
+    fun `a measured opened-file size never leaks onto a bundled row`() {
+        // DemoSettings.openedModelSizeMeters is a measurement of the file the viewer had
+        // loaded. A bundled handoff must not inherit it just because the field was still set.
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "models/khronos_damaged_helmet.glb",
+            catalogue = catalogue,
+            openedSizeMeters = 0.06f,
+        )
+        assertEquals(PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS, row?.realWorldSizeMeters)
+    }
+
+    @Test
+    fun `an opened file with no display name falls back to its staged basename`() {
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "file:///data/user/0/io.github.sceneview.demo/cache/opened-model.glb",
+            catalogue = catalogue,
+        )
+        assertEquals("opened-model.glb", row?.displayName)
+    }
+
+    @Test
+    fun `an opened file with no measured size falls back to the catalogue default`() {
+        val row = resolveRequestedExtraPlacementRow(
+            requestedModel = "file:///tmp/opened-model.glb",
+            catalogue = catalogue,
+        )
+        assertEquals(PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS, row?.realWorldSizeMeters)
+    }
+
+    @Test
+    fun `a non-finite or non-positive measured size is rejected, not trusted blindly`() {
+        val nan = resolveRequestedExtraPlacementRow(
+            requestedModel = "file:///tmp/opened-model.glb",
+            catalogue = catalogue,
+            openedSizeMeters = Float.NaN,
+        )
+        assertEquals(PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS, nan?.realWorldSizeMeters)
+
+        val zero = resolveRequestedExtraPlacementRow(
+            requestedModel = "file:///tmp/opened-model.glb",
+            catalogue = catalogue,
+            openedSizeMeters = 0f,
+        )
+        assertEquals(PlacementModel.DEFAULT_REAL_WORLD_SIZE_METERS, zero?.realWorldSizeMeters)
+    }
+}


### PR DESCRIPTION
## The bug

Tapping **View in AR** from the Model Viewer while looking at the Damaged Helmet dropped the
user on the AR model picker instead of opening the camera on the helmet.

The handoff passed whatever model was on screen, but `ARPlacementDemo` only recognised it when
that model also happened to be one of the six rows curated for the AR placement catalogue. The
Damaged Helmet is deliberately *not* one of them (#2023 — "a helmet hovering over a floor reads
as a test payload"), so the requested row resolved to `null`, `flow.enterAr()` never fired, and
the explicit "take me to AR with THIS model" request was silently discarded.

That curation is a rule about what the chooser offers a fresh visitor. It must never act as a
veto over a model the user is already looking at.

## The fix

Row resolution moves into a pure, testable `resolveRequestedExtraPlacementRow`: any model the
viewer names gets a row of its own when the curated catalogue does not already carry it, so the
handoff always wins and the camera opens directly on that model. "Open with SceneView" (#3482)
becomes the special case of the same rule — a `file://` location, recognised by its scheme,
keeps the user's own file name and the real-world size the viewer measured (the whole point for
a 3MF). A measured size never leaks onto a bundled row.

The in-AR model bar and the back arrow both still reach the full picker if the user wants to
change model.

## Verified

- `:samples:android-demo:testDebugUnitTest --tests '*PlacementModelPicker*'` — 10 tests, green.
  They pin the exact repro, the catalogue-match cases (full path and bare stem), the name
  fallbacks and the size-leak guard.
- On `Pixel_7a` (emulator-5554), debug APK: Model Viewer on the Damaged Helmet → **View in AR**
  lands on the AR screen ("Tap to Place"), model bar already armed on **Damaged Helmet** — no
  picker. Captures: `/tmp/pr-3493/3493-1-viewer-helmet.png` and `/tmp/pr-3493/3493-2-ar.png`.
  The second one also shows "Couldn't start AR": ARCore has no arm64 emulator build (#2754), so
  no live session can start there. That is the emulator, not this change — what it proves is
  the routing and the armed row, which is exactly what regressed.

Fixes #3493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
