### PR TITLE
feat(ios-demo): iOS demo Open with — STL, OBJ, PLY and 3MF from Files and share sheets

### DIFF
--- a/changelog.d/3492-ios-demo-open-with.md
+++ b/changelog.d/3492-ios-demo-open-with.md
@@ -1,0 +1,33 @@
+<!-- category: Added -->
+- **The iOS demo app opens 3D files from Files, Mail, Messages and any share sheet
+  ([#3492](https://github.com/sceneview/sceneview/issues/3492)).** `.stl`, `.obj`, `.ply`,
+  `.3mf`, `.usdz` and `.reality` are declared in `Info.plist`, so SceneView shows up in the
+  "Open with" list for files iOS otherwise has nothing to open — Quick Look reads USDZ and
+  Reality only, and an STL or a 3MF that arrives by AirDrop or comes down from a
+  marketplace is a dead end on a stock iPhone. `LSSupportsOpeningDocumentsInPlace` means
+  the system hands over the original file instead of copying a 500 MB scan into the app's
+  Inbox.
+- **The opened file answers "how big is this, really?"** The viewer shows the size in the
+  file's own unit *and* in centimetres, plus the triangle count. The formats that carry no
+  unit — STL, OBJ, PLY — get a mm / cm / in / m picker under the readout, because they
+  store bare numbers and guessing silently is what puts a 21 cm print in the room at
+  210 m. 3MF and USD state their own unit and get no picker. **View in AR** places the
+  model at that real size, bottom-aligned on the detected plane — not shrunk to a tidy
+  preview, which would answer a different question than the one the file was opened to
+  ask.
+<!-- RELEASE NOTE (maintainer-only):
+     STL, OBJ, PLY and 3MF have no `UTType` constant in `UniformTypeIdentifiers`, so the
+     app declares them itself. STL, OBJ and PLY are *imported* types — the app understands
+     them, it does not define them — under the identifiers Apple's own ModelIO uses:
+     `public.standard-tesselated-geometry-format`, `public.geometry-definition-format` and
+     `public.polygon-file-format`. 3MF is *exported* (`io.3mf.3mf`, reverse-DNS on the 3MF
+     Consortium's 3mf.io), because nothing else on the system declares 3MF at all: this is
+     the declaration that binds the `.3mf` extension and `model/3mf` for the device. The
+     filename-extension tag is what actually routes a file, so a differing identifier
+     elsewhere costs nothing. USD and Reality are declared `LSHandlerRank Alternate` on
+     purpose — Quick Look should stay the app a tap opens for those.
+     `-open_file <path>` joins `-demo <id>` as a launch argument, so the screenshot
+     pipeline can land on the opened-file screen without SpringBoard's "Open in …?"
+     confirmation. The viewer copies the incoming file to `tmp` before parsing: a
+     security-scoped URL is only valid between start/stop of the access, and a parse plus
+     the AR session that may follow outlives that window. -->

--- a/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
+++ b/samples/ios-demo/SceneViewDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2A3CCE30CC57827E79F2EA6F /* HomeFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2C6D9D98B09170A0E218D8 /* HomeFilterTests.swift */; };
 		D13CADF7F6A0750FD91AE404 /* ShowcaseTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1805CCAE3BB264332107B4B /* ShowcaseTab.swift */; };
 		FA3B37675AEEA33A5A8DA668 /* ViewerSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446371A911170C776F03B4EC /* ViewerSheets.swift */; };
+		FA3B37675AEEA33A5A8DA669 /* OpenedFileViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446371A911170C776F03B4ED /* OpenedFileViewer.swift */; };
 		F586F3A96E0830760ED36647 /* HomeFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE31566D2309ACB52F2541CF /* HomeFilter.swift */; };
 		B141AC6435E99FE1BD6BE44E /* DemoMediaCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F9FD53B9A5E639F22AFB91 /* DemoMediaCard.swift */; };
 		4D3AFF95252330C277928054 /* HomeHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = A251CDB4D89CD0202517E852 /* HomeHero.swift */; };
@@ -209,6 +210,7 @@
 		9D2C6D9D98B09170A0E218D8 /* HomeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeFilterTests.swift; path = SceneViewDemoTests/HomeFilterTests.swift; sourceTree = SOURCE_ROOT; };
 		F1805CCAE3BB264332107B4B /* ShowcaseTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShowcaseTab.swift; path = SceneViewDemo/Views/Tabs/ShowcaseTab.swift; sourceTree = SOURCE_ROOT; };
 		446371A911170C776F03B4EC /* ViewerSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewerSheets.swift; path = SceneViewDemo/Views/Viewer/ViewerSheets.swift; sourceTree = SOURCE_ROOT; };
+		446371A911170C776F03B4ED /* OpenedFileViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OpenedFileViewer.swift; path = SceneViewDemo/Views/Viewer/OpenedFileViewer.swift; sourceTree = SOURCE_ROOT; };
 		DE31566D2309ACB52F2541CF /* HomeFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeFilter.swift; path = SceneViewDemo/Views/Home/HomeFilter.swift; sourceTree = SOURCE_ROOT; };
 		A7F9FD53B9A5E639F22AFB91 /* DemoMediaCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DemoMediaCard.swift; path = SceneViewDemo/Views/Home/DemoMediaCard.swift; sourceTree = SOURCE_ROOT; };
 		A251CDB4D89CD0202517E852 /* HomeHero.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeHero.swift; path = SceneViewDemo/Views/Home/HomeHero.swift; sourceTree = SOURCE_ROOT; };
@@ -423,6 +425,7 @@
 			isa = PBXGroup;
 			children = (
 				446371A911170C776F03B4EC /* ViewerSheets.swift */,
+				446371A911170C776F03B4ED /* OpenedFileViewer.swift */,
 			);
 			name = Viewer;
 			sourceTree = "<group>";
@@ -906,6 +909,7 @@
 			files = (
 				D13CADF7F6A0750FD91AE404 /* ShowcaseTab.swift in Sources */,
 				FA3B37675AEEA33A5A8DA668 /* ViewerSheets.swift in Sources */,
+				FA3B37675AEEA33A5A8DA669 /* OpenedFileViewer.swift in Sources */,
 				F586F3A96E0830760ED36647 /* HomeFilter.swift in Sources */,
 				B141AC6435E99FE1BD6BE44E /* DemoMediaCard.swift in Sources */,
 				4D3AFF95252330C277928054 /* HomeHero.swift in Sources */,

--- a/samples/ios-demo/SceneViewDemo/Info.plist
+++ b/samples/ios-demo/SceneViewDemo/Info.plist
@@ -47,6 +47,173 @@
 	<dict/>
 	<key>UISupportsDocumentBrowser</key>
 	<false/>
+	<!--
+		Open a 3D file from Files, Mail, Messages or any share sheet.
+
+		`LSSupportsOpeningDocumentsInPlace` means the system hands over a
+		security-scoped URL to the original file instead of copying it into the
+		app's Inbox — so opening a 500 MB scan does not duplicate it, and the
+		document browser shows the app as a handler. `OpenedFileViewer` still
+		copies to a temp file before parsing (see its doc comment): the scoped
+		URL is only valid for the duration of the access, and a parse can outlive
+		it.
+	-->
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<!--
+				The mesh formats SceneViewSwift parses itself. No system app on
+				iOS opens an STL or a 3MF, which is the whole point: Quick Look
+				reads USDZ and Reality only.
+			-->
+			<key>CFBundleTypeName</key>
+			<string>3D Mesh File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.standard-tesselated-geometry-format</string>
+				<string>public.geometry-definition-format</string>
+				<string>public.polygon-file-format</string>
+				<string>io.3mf.3mf</string>
+			</array>
+		</dict>
+		<dict>
+			<!--
+				USD and Reality. `Alternate`, not `Default`: Quick Look is the
+				system handler for these and should stay the one a tap opens.
+			-->
+			<key>CFBundleTypeName</key>
+			<string>3D Scene</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.pixar.universal-scene-description-mobile</string>
+				<string>com.pixar.universal-scene-description</string>
+				<string>com.apple.reality</string>
+			</array>
+		</dict>
+	</array>
+	<!--
+		Imported, not exported: SceneView understands these formats, it does not
+		define them. `public.standard-tesselated-geometry-format`,
+		`public.geometry-definition-format` and `public.polygon-file-format` are
+		the identifiers Apple's own ModelIO uses for STL, OBJ and PLY; they have
+		no `UTType` constant in `UniformTypeIdentifiers`, so an app that wants to
+		be offered for those files has to declare them. In every case it is the
+		filename-extension tag below that actually routes a file, so a differing
+		identifier elsewhere in the system costs nothing. 3MF is declared just
+		below, exported rather than imported — nothing else on the system defines
+		it.
+	-->
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.standard-tesselated-geometry-format</string>
+			<key>UTTypeDescription</key>
+			<string>STL 3D Model</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.3d-content</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>stl</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>model/stl</string>
+					<string>application/sla</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.geometry-definition-format</string>
+			<key>UTTypeDescription</key>
+			<string>Wavefront OBJ 3D Model</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.3d-content</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>obj</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>model/obj</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.polygon-file-format</string>
+			<key>UTTypeDescription</key>
+			<string>PLY 3D Model</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.3d-content</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ply</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-ply</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<!--
+		Exported, not imported: no other party on this system declares 3MF at all — it
+		has no Apple identifier, and no stock app opens one. `io.3mf.3mf` is reverse-DNS
+		on the 3MF Consortium's domain (3mf.io), and this declaration is the one that
+		binds the `.3mf` extension and the `model/3mf` MIME type for the whole device.
+	-->
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>io.3mf.3mf</string>
+			<key>UTTypeDescription</key>
+			<string>3D Manufacturing Format</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.3d-content</string>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>3mf</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>model/3mf</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.entertainment</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
+++ b/samples/ios-demo/SceneViewDemo/SceneViewDemoApp.swift
@@ -24,6 +24,38 @@ struct SceneViewDemoApp: App {
     /// Reset to `nil` after presentation so a config change doesn't replay it.
     @State private var pendingDeepLinkDemo: String?
 
+    /// A 3D file handed over by Files, Mail, Messages or any share sheet — the
+    /// `CFBundleDocumentTypes` entries in `Info.plist`. Presented full screen by
+    /// `OpenedFileViewer`; reset to `nil` on dismissal so a config change does not
+    /// replay it.
+    @State private var openedFile: OpenedDocument?
+
+    /// Wraps a file URL so SwiftUI's `.fullScreenCover(item:)` accepts it — the same
+    /// shape as `ContentView.DemoLink`, for the same reason (`URL` is not
+    /// `Identifiable`, and retro-conforming a Foundation type to make it so would leak
+    /// out of this file).
+    struct OpenedDocument: Identifiable {
+        let url: URL
+        var id: String { url.absoluteString }
+    }
+
+    /// A file path pre-seeded from `-open_file <path>`, the deterministic twin of
+    /// opening a document from the share sheet.
+    ///
+    /// The screenshot pipeline needs the "Open with" screen without going through
+    /// SpringBoard's "Open in …?" confirmation, exactly as `-demo <id>` exists so a
+    /// demo can be captured without `simctl openurl`'s dialog. Ignored when the path
+    /// does not exist, so a stale argument cannot wedge a normal launch.
+    private static let launchArgOpenFile: OpenedDocument? = {
+        let args = CommandLine.arguments
+        guard let index = args.firstIndex(of: "-open_file"), index + 1 < args.count else {
+            return nil
+        }
+        let path = args[index + 1]
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        return OpenedDocument(url: URL(fileURLWithPath: path))
+    }()
+
     /// Demo id pre-seeded from a launch argument (`-demo <id>`), used by the
     /// reproducible App Store screenshot capture pipeline. Launching with a
     /// `-demo` argument routes straight to the demo on first frame, with no
@@ -77,8 +109,26 @@ struct SceneViewDemoApp: App {
                     UpdateBanner()
                         .environmentObject(updater)
                 }
+                #if os(iOS)
+                .fullScreenCover(item: $openedFile) { document in
+                    OpenedFileViewer(url: document.url)
+                }
+                #else
+                .sheet(item: $openedFile) { document in
+                    OpenedFileViewer(url: document.url)
+                }
+                #endif
+                .task {
+                    if openedFile == nil { openedFile = Self.launchArgOpenFile }
+                }
                 .onOpenURL { url in
-                    if let id = DeepLinkRouter.parse(url, allowedDemos: DemoDeepLinkRegistry.allowedIds) {
+                    // A file URL is a document the system handed us through
+                    // `CFBundleDocumentTypes`, not a deep link — and it is checked
+                    // first, because `DeepLinkRouter` would otherwise see a `file`
+                    // scheme it has no business parsing.
+                    if url.isFileURL {
+                        openedFile = OpenedDocument(url: url)
+                    } else if let id = DeepLinkRouter.parse(url, allowedDemos: DemoDeepLinkRegistry.allowedIds) {
                         pendingDeepLinkDemo = id
                     } else if let candidate = DeepLinkRouter.extractCandidate(url) {
                         // A well-formed `sceneview://demo/<id>` (or the

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/ARPlacementDemo.swift
@@ -40,6 +40,18 @@ struct ARPlacementDemo: View {
     /// `demo/ar-placement?model=` route. `nil` keeps the bundled cycle.
     var initialModel: String? = nil
 
+    /// A file URL to place instead of a bundled asset — the "Open with" handoff from
+    /// ``OpenedFileViewer``.
+    ///
+    /// Placed at its **real-world size**, not normalised to the bundled cycle's 0.3 m.
+    /// That is the entire point of opening a print or a scan in AR: a 21 cm part has to
+    /// stand 21 cm tall on the floor, or the answer to "will it fit?" is a guess.
+    var initialModelURL: URL? = nil
+
+    /// The unit the user picked in the viewer for a format that carries none (STL, OBJ,
+    /// PLY). `nil` uses the format's default.
+    var initialModelUnit: ModelUnit? = nil
+
     /// Bundled cycle preserved from the previous iOS AR demos — gives a
     /// deterministic 5-model rotation when no Sketchfab key is configured.
     /// Each entry is the bundle name without `.usdz`.
@@ -161,6 +173,23 @@ struct ARPlacementDemo: View {
                 url = resolved
                 displayName = slug.displayName
                 scaleToUnits = slug.scaleToUnits
+            } else if let opened = initialModelURL {
+                // An opened file stands at the size its unit says. No `scaleToUnits`:
+                // shrinking it to a tidy 0.3 m would answer a different question than
+                // the one the user opened it to ask.
+                let node = try await ModelNode.load(contentsOf: opened, unit: initialModelUnit)
+                // Bottom-aligned so the model sits ON the detected plane rather than
+                // straddling it — `-1` on Y selects the bounding box's floor.
+                _ = node.centerOrigin(normalized: SIMD3<Float>(0, -1, 0))
+                let anchor = AnchorNode.world(position: worldPosition)
+                anchor.add(node.entity)
+                arView.scene.addAnchor(anchor.entity)
+                arViewRef.value = arView
+                placedAnchors.append(anchor.entity)
+                #if os(iOS)
+                SceneViewHaptic.shared.light()
+                #endif
+                return
             } else {
                 // The handed-off viewer model, else the bundled round-robin cycle.
                 let assetName: String

--- a/samples/ios-demo/SceneViewDemo/Views/Viewer/OpenedFileViewer.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Viewer/OpenedFileViewer.swift
@@ -1,0 +1,325 @@
+import SwiftUI
+import RealityKit
+import SceneViewSwift
+#if os(iOS)
+import ARKit
+import UIKit
+#endif
+
+/// The screen a 3D file lands on when it is opened from Files, Mail, Messages or any
+/// share sheet.
+///
+/// This is the point of the format work: on iOS today, an STL or a 3MF received by
+/// AirDrop or downloaded from a marketplace has **nothing** to open it — Quick Look reads
+/// USDZ and Reality only. This view is the SceneView demo app's answer, and it answers
+/// the question the file cannot: *how big is this, really?*
+///
+/// - The **size readout** is in the file's own unit and in centimetres, because a print
+///   the user is about to make is a physical object, not a picture.
+/// - The **unit picker** appears only for the formats that carry no unit — STL, OBJ, PLY
+///   (``ModelFormat/carriesUnit``). Guessing silently is what puts a 21 cm print in the
+///   room at 210 m; 3MF and USD state their own unit and get no picker.
+/// - **View in AR** places the model at that real size on a detected plane. Not scaled to
+///   fit a nice preview — at size, standing on the floor, which is the only way to answer
+///   "will this fit?".
+struct OpenedFileViewer: View {
+
+    /// The file as the system handed it over.
+    let url: URL
+
+    /// Presentation dismissal — this screen is always presented, never pushed.
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var asset: MeshAsset?
+    @State private var loadedNode: ModelNode?
+    @State private var loadError: String?
+    /// The unit the user chose, once they have chosen one. `nil` = whatever the format
+    /// or the file says.
+    @State private var chosenUnit: ModelUnit?
+    @State private var format: ModelFormat?
+    @State private var showAR = false
+    @State private var recenterGeneration = 0
+    @State private var loadCount = 0
+
+    /// A working copy of the file, owned by this view.
+    ///
+    /// A security-scoped URL from the document picker is only valid between
+    /// `startAccessingSecurityScopedResource()` and its stop, and a parse (plus the AR
+    /// session that may follow) outlives that window. Copying once into `tmp` is both
+    /// simpler and safer than holding the scope open across an async boundary.
+    @State private var workingCopy: URL?
+
+    private var arSupported: Bool {
+        #if os(iOS)
+        return ARWorldTrackingConfiguration.isSupported
+        #else
+        return false
+        #endif
+    }
+
+    /// Units offered in the picker — the ones a mesh file is plausibly authored in.
+    private static let offeredUnits: [ModelUnit] = [
+        .millimeters, .centimeters, .inches, .meters
+    ]
+
+    var body: some View {
+        ZStack {
+            SceneViewTokens.Stage.background.ignoresSafeArea()
+            stage
+            VStack {
+                Spacer()
+                if let loadError {
+                    banner(loadError)
+                } else if let asset {
+                    measurements(of: asset)
+                }
+            }
+            // Clears the floating dock band with room to spare: the dock is centred and
+            // rounded, so a readout that merely *reaches* its top edge still collides
+            // with its background.
+            .padding(.bottom, SceneViewTokens.Layout.dockHeight + SceneViewTokens.Space.lg * 2)
+        }
+        .demoChrome(
+            title: url.lastPathComponent,
+            dock: dock,
+            accent: DockItem(
+                icon: "arkit",
+                label: "View in AR",
+                enabled: arSupported && loadedNode != nil
+            ) { showAR = true },
+            onReset: { recenterGeneration += 1 }
+        )
+        #if os(iOS)
+        .fullScreenCover(isPresented: $showAR) {
+            NavigationStack {
+                ARPlacementDemo(
+                    initialModelURL: workingCopy,
+                    initialModelUnit: chosenUnit
+                )
+                .navigationTitle("Tap to Place")
+                .navigationBarTitleInline()
+            }
+            .environment(\.demoTitle, "Tap to Place")
+        }
+        #endif
+        .task { await load() }
+        .onChange(of: chosenUnit) { _, _ in
+            Task { await load() }
+        }
+        .onDisappear(perform: discardWorkingCopy)
+    }
+
+    // MARK: - Stage
+
+    @ViewBuilder
+    private var stage: some View {
+        ZStack {
+            SceneView { root in
+                guard let loadedNode else { return }
+                root.addChild(loadedNode.entity)
+            }
+            .cameraControls(.orbit)
+            // A three-quarter view from slightly above. A print or a scan is a solid,
+            // and a head-on camera flattens a pyramid or a plate into a silhouette that
+            // says nothing about its depth.
+            .cameraOrbit(azimuth: .pi / 5, elevation: .pi / 9)
+            // Studio IBL for the lighting, skybox off: the subject is a part someone is
+            // measuring, and a photographic backdrop behind it competes with the
+            // silhouette instead of describing it. `Stage.background` shows through.
+            .environment(.custom(name: "Studio", hdrFile: "studio.hdr", showSkybox: false))
+            .framingMargin(1.12)
+            .contentID(loadedNode == nil ? nil : "\(loadCount)-\(recenterGeneration)")
+            .ignoresSafeArea()
+
+            if loadedNode == nil && loadError == nil {
+                ProgressView().tint(.white)
+            }
+        }
+    }
+
+    /// The size readout, and the unit picker for a format that has no unit of its own.
+    @ViewBuilder
+    private func measurements(of asset: MeshAsset) -> some View {
+        VStack(spacing: SceneViewTokens.Space.sm) {
+            GlassPill {
+                Text(sizeSummary(of: asset))
+                    .font(SceneViewTokens.TypeScale.caption)
+                    .foregroundStyle(SceneViewTokens.Glass.onGlass)
+                    .lineLimit(1)
+                    // Shrinks rather than truncates: the centimetre pair sits at the
+                    // end of the string, and it is the half the user came for. A
+                    // `127.6 × 127.6 × 127.6 mm (12.8 × 12.8 × 12.8 c…` readout drops
+                    // exactly the number that answers "how big is this, really?".
+                    .minimumScaleFactor(0.7)
+                Text("· \(asset.triangleCount) triangles")
+                    .font(SceneViewTokens.TypeScale.captionRegular)
+                    .foregroundStyle(SceneViewTokens.Glass.onGlassMuted)
+                    .lineLimit(1)
+                    // Yields its width first: the triangle count is context, the size
+                    // is the answer.
+                    .layoutPriority(-1)
+                    .minimumScaleFactor(0.7)
+            }
+
+            if let format, !format.carriesUnit {
+                unitPicker(current: asset.unit, format: format)
+            }
+        }
+        .padding(.horizontal, SceneViewTokens.Space.md)
+    }
+
+    /// `210 × 100 × 50 mm  (21.0 × 10.0 × 5.0 cm)` — the file's own numbers first,
+    /// because that is what the user will recognise from their slicer, then the
+    /// real-world size they may not have realised the first pair implied.
+    private func sizeSummary(of asset: MeshAsset) -> String {
+        guard let bounds = asset.bounds, let metric = asset.boundsInMeters else {
+            return "No measurable geometry"
+        }
+        let source = bounds.extents
+        let centimeters = metric.extents * 100
+        let native = String(
+            format: "%.4g × %.4g × %.4g %@",
+            source.x, source.y, source.z, asset.unit.symbol
+        )
+        guard asset.unit != .centimeters else { return native }
+        let real = String(
+            format: "%.1f × %.1f × %.1f cm",
+            centimeters.x, centimeters.y, centimeters.z
+        )
+        return "\(native)  (\(real))"
+    }
+
+    /// Only shown for STL, OBJ and PLY. The honest interaction: those formats store bare
+    /// numbers, so the app asks rather than guessing and being wrong by 1000×.
+    ///
+    /// A row of glass chips rather than a `Picker(.segmented)` — the segmented control
+    /// draws its own opaque track, which fights the glass it would sit on and reads as a
+    /// misaligned box over a live viewport.
+    private func unitPicker(current: ModelUnit, format: ModelFormat) -> some View {
+        HStack(spacing: SceneViewTokens.Space.xs) {
+            Text("Units")
+                .font(SceneViewTokens.TypeScale.captionRegular)
+                .foregroundStyle(SceneViewTokens.Glass.onGlassMuted)
+                .padding(.trailing, SceneViewTokens.Space.xs)
+            ForEach(Self.offeredUnits, id: \.self) { unit in
+                unitChip(unit, selected: (chosenUnit ?? current) == unit)
+            }
+        }
+        .padding(.horizontal, SceneViewTokens.Glass.pillPaddingHorizontal)
+        .frame(height: SceneViewTokens.Glass.pillHeight + SceneViewTokens.Space.sm)
+        .background(glassBackground(in: Capsule()))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Model units")
+    }
+
+    private func unitChip(_ unit: ModelUnit, selected: Bool) -> some View {
+        Button {
+            guard chosenUnit != unit else { return }
+            chosenUnit = unit
+        } label: {
+            Text(unit.symbol)
+                .font(SceneViewTokens.TypeScale.captionSemibold)
+                // `heroPillText` (#1A1A2E), not `chipSelectedText`: the selected chip is
+                // a fixed white capsule floating over a live viewport, so its label must
+                // be dark in both themes — the theme-flipping chip token would turn it
+                // white-on-white in dark mode.
+                .foregroundStyle(
+                    selected
+                        ? SceneViewTokens.HomeColor.heroPillText
+                        : SceneViewTokens.Glass.onGlass
+                )
+                .frame(minWidth: 34)
+                .frame(height: SceneViewTokens.Glass.pillHeight - SceneViewTokens.Space.sm)
+                .padding(.horizontal, SceneViewTokens.Space.sm)
+                .background(
+                    Capsule().fill(selected ? Color.white : Color.white.opacity(0.10))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(unit.rawValue)
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func banner(_ message: String) -> some View {
+        Text(message)
+            .font(SceneViewTokens.TypeScale.captionRegular)
+            .foregroundStyle(SceneViewTokens.Glass.onGlass)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, SceneViewTokens.Space.md)
+            .padding(.vertical, SceneViewTokens.Space.sm)
+            .background(glassBackground(in: RoundedRectangle(cornerRadius: SceneViewTokens.Radius.md)))
+            .padding(.horizontal, SceneViewTokens.Space.lg)
+    }
+
+    private var dock: [DockItem] {
+        [DockItem(icon: "scope", label: "Recenter") { recenterGeneration += 1 }]
+    }
+
+    // MARK: - Loading
+
+    @MainActor
+    private func load() async {
+        loadError = nil
+        do {
+            let local = try workingCopy ?? makeWorkingCopy()
+            workingCopy = local
+            let sniffed = try ModelFormat.sniff(contentsOf: local)
+            format = sniffed
+
+            if sniffed.loader == .realityKit {
+                // USD and Reality are already metric and have no MeshAsset form.
+                asset = nil
+                install(try await ModelNode.load(contentsOf: local))
+                return
+            }
+            let parsed = try MeshAsset.load(contentsOf: local, format: sniffed, unit: chosenUnit)
+            asset = parsed
+            install(try await ModelNode(parsed))
+        } catch {
+            loadedNode = nil
+            asset = nil
+            loadError = message(for: error)
+        }
+    }
+
+    @MainActor
+    private func install(_ node: ModelNode) {
+        // Framed, not resized: the entity keeps its real-world metres so the AR handoff
+        // and the size readout describe the same object. `.framingMargin` moves the
+        // camera instead of the model.
+        _ = node.centerOrigin()
+        loadedNode = node
+        loadCount += 1
+    }
+
+    /// A human-facing message. ``ModelLoadingError`` already names the format the user
+    /// tried to open, which is the one thing a "could not open this file" alert usually
+    /// fails to say.
+    private func message(for error: any Error) -> String {
+        if let loading = error as? ModelLoadingError {
+            return loading.errorDescription ?? "\(loading)"
+        }
+        return "Could not open \(url.lastPathComponent): \(error.localizedDescription)"
+    }
+
+    // MARK: - Working copy
+
+    /// Copies the incoming file into `tmp`, opening the security scope for exactly as
+    /// long as the copy takes.
+    private func makeWorkingCopy() throws -> URL {
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opened-\(UUID().uuidString)")
+            .appendingPathExtension(url.pathExtension)
+        try FileManager.default.copyItem(at: url, to: destination)
+        return destination
+    }
+
+    private func discardWorkingCopy() {
+        guard let workingCopy else { return }
+        try? FileManager.default.removeItem(at: workingCopy)
+        self.workingCopy = nil
+    }
+}


### PR DESCRIPTION
The Swift loader for these formats landed in #3513. This is the demo-app half: making iOS actually offer SceneView when the user taps a mesh file.

On a stock iPhone an STL or a 3MF is a dead end — Quick Look reads USDZ and Reality only. A file received by AirDrop or downloaded from MakerWorld has nothing to open it.

## What changed

- **`Info.plist`** — `CFBundleDocumentTypes` for the mesh formats (`Default` rank) and for USD/Reality (`Alternate`, so Quick Look stays the app a tap opens). STL, OBJ and PLY are declared as *imported* types under the identifiers Apple's own ModelIO uses; 3MF is *exported* as `io.3mf.3mf` with `model/3mf`, because nothing else on the system declares 3MF at all. `LSSupportsOpeningDocumentsInPlace` hands over the original file instead of copying a large scan into the Inbox.
- **`SceneViewDemoApp`** — `onOpenURL` routes a `file://` URL to the new viewer before `DeepLinkRouter` sees a scheme it has no business parsing.
- **`OpenedFileViewer`** — the screen the file lands on. Size in the file's own unit *and* in centimetres, plus the triangle count; a mm / cm / in / m picker for the formats that carry no unit (3MF and USD state their own and get none). It copies the incoming file to `tmp` before parsing, because a security-scoped URL is only valid between the start and stop of the access and the parse outlives that window.
- **`ARPlacementDemo`** — accepts a file URL and a unit, and places it at its **real size**, bottom-aligned on the detected plane. Shrinking it to a tidy 0.3 m preview would answer a different question than the one the file was opened to ask.
- `-open_file <path>` joins `-demo <id>` as a launch argument so the screenshot pipeline can reach this screen without SpringBoard's confirmation dialog.

## Verification

`xcodebuild -scheme SceneViewDemo -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` builds clean. Captured on that simulator (paths on the build machine):

| Capture | What it shows |
|---|---|
| `/tmp/pr-3492/3492-1.png` | A 210 × 100 × 50 mm STL opened: readout `210 × 100 × 50 mm (21.0 × 10.0 × 5.0 cm) · 12 triangles`, unit picker present with `mm` selected. |
| `/tmp/pr-3492/3492-2.png` | `printed-icosahedron.3mf` opened, per-triangle colours intact: `127.6 × 127.6 × 127.6 mm (12.8 × 12.8 × 12.8 cm) · 20 triangles`, **no** unit picker — 3MF carries its own. |
| `/tmp/pr-3492/3492-3.png` | The same STL reached through `simctl openurl file://…` rather than the launch argument, i.e. LaunchServices routing a `.stl` to the app off the `Info.plist` declarations and `onOpenURL` presenting the viewer. |

Refs #3492

🤖 Generated with [Claude Code](https://claude.com/claude-code)