### PR TITLE
fix(mcp): gateway discovery works for newer protocol revisions, and results honour the widget negotiation

### DIFF
--- a/changelog.d/3502-gateway-discovery-and-widget-negotiation.md
+++ b/changelog.d/3502-gateway-discovery-and-widget-negotiation.md
@@ -1,0 +1,16 @@
+<!-- category: Fixed -->
+- **The MCP gateway no longer refuses discovery to hosts on a newer protocol revision, and
+  a tool result no longer carries a widget the session negotiated away
+  ([#3502](https://github.com/sceneview/sceneview/issues/3502)).** `server/discover` is the
+  handshake-free call whose whole purpose is to say which revisions this server speaks, yet
+  it sat behind the `MCP-Protocol-Version` gate: a host sending its own current revision in
+  that header — exactly what the spec invites — got a 400 instead of the one answer that
+  would have let it negotiate down. Discovery is now exempt from the gate; every other
+  method still is not. Second half: `tools/list` already stripped `_meta.ui.resourceUri`
+  for a client that declared MCP Apps mime types excluding `text/html;profile=mcp-app`, but
+  `tools/call` attached the pointer unconditionally, so a host that discovers widgets from
+  results rather than declarations was still handed a widget it had just said it cannot
+  render. The call path now reads the same session decision and takes the pointer back off
+  the result — the text content and `structuredContent` are untouched, which is the
+  graceful degradation the extension asks for. Four transport tests pin both halves,
+  including that a client declaring nothing still gets its widget.

--- a/mcp-gateway/src/mcp/transport.ts
+++ b/mcp-gateway/src/mcp/transport.ts
@@ -264,7 +264,12 @@ export async function handleMcpRequest(
   // explicit version this server does not implement. As in the reference
   // SDK, an absent header is accepted for backwards compatibility and the
   // session's negotiated version remains in force.
-  if (req.method !== "initialize") {
+  //
+  // `server/discover` is exempt: it is the handshake-free call whose entire
+  // purpose is to tell a client which revisions this server speaks. A host on
+  // a NEWER revision names it in the header, as the spec invites — answering
+  // 400 would deny it the one reply that lets it negotiate down (#3502).
+  if (req.method !== "initialize" && req.method !== DISCOVER_METHOD) {
     const protocolVersion = request.headers.get("mcp-protocol-version");
     if (
       protocolVersion !== null &&
@@ -352,7 +357,7 @@ async function routeMethod(
       return handleToolsList(session);
 
     case "tools/call":
-      return handleToolsCall(req, ctx);
+      return handleToolsCall(req, ctx, session);
 
     // ── OpenAI Apps SDK widget support (resource registry) ────────────────
     case "resources/list":
@@ -508,10 +513,18 @@ function handleToolsList(session: SessionState): unknown {
   return { tools };
 }
 
-/** Validates params and dispatches a `tools/call` to the registry. */
+/**
+ * Validates params and dispatches a `tools/call` to the registry.
+ *
+ * The result widget pointer follows the SAME session decision as the
+ * declaration in `handleToolsList`: a host that discovers widgets from tool
+ * results rather than declarations must not be handed a widget the session
+ * just negotiated away, or the two answers disagree (#3502).
+ */
 async function handleToolsCall(
   req: JsonRpcRequest,
   ctx: TransportContext,
+  session: SessionState,
 ): Promise<unknown> {
   const params = (req.params ?? {}) as Record<string, unknown>;
   const toolName = params.name;
@@ -545,15 +558,30 @@ async function handleToolsCall(
   // know to fetch the bundled HTML widget and render it inline. The same
   // pointer is on the tool declaration (`handleToolsList`). Other clients
   // ignore the unknown `_meta` keys and just see the text content.
+  // Narrow through `unknown` to avoid the strict-overlap check on
+  // ToolResult (which has its own optional `_meta` field) — every consumer of
+  // the JSON-RPC response treats unknown keys as opaque.
+  const r = result as unknown as {
+    _meta?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+
+  if (!serveWidgetsTo(session.uiExtension)) {
+    // The client negotiated MCP Apps and listed mime types excluding ours.
+    // The upstream handler bakes the pointer into the result itself, so it is
+    // not enough to skip adding one: it has to come back off, or the result
+    // contradicts the declaration `handleToolsList` already stripped. The text
+    // content and `structuredContent` stay — degradation, not failure.
+    if (r._meta && "ui" in r._meta) {
+      const meta = { ...r._meta };
+      delete meta.ui;
+      return { ...r, _meta: meta };
+    }
+    return r;
+  }
+
   const widgetUri = widgetResourceFor(toolName);
   if (widgetUri) {
-    // Narrow through `unknown` to avoid the strict-overlap check on
-    // ToolResult (which has its own optional `_meta` field) — every
-    // consumer of the JSON-RPC response treats unknown keys as opaque.
-    const r = result as unknown as {
-      _meta?: Record<string, unknown>;
-      [k: string]: unknown;
-    };
     r._meta = {
       ...(r._meta ?? {}),
       ui: { resourceUri: widgetUri },

--- a/mcp-gateway/test/transport.test.ts
+++ b/mcp-gateway/test/transport.test.ts
@@ -624,3 +624,122 @@ describe("transport: HTTP-level protections", () => {
     expect(res.status).toBe(415);
   });
 });
+
+describe("transport: discovery and widget negotiation (#3502)", () => {
+  it("answers server/discover carrying a protocol version this build does not implement", async () => {
+    // Discovery is the handshake-free call whose whole purpose is to tell a
+    // client which revisions this server speaks. A host on a newer revision
+    // sends its current version in the header, as the spec invites — refusing
+    // it with a 400 denies it the one answer that lets it negotiate down.
+    const res = await handleMcpRequest(
+      mcpRequest(
+        { jsonrpc: "2.0", id: 1, method: "server/discover" },
+        { "mcp-protocol-version": "2026-07-28" },
+      ),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(200);
+    const result = (await asJsonRpc(res)).result as { supportedVersions: string[] };
+    expect(result.supportedVersions).toEqual([...SUPPORTED_PROTOCOL_VERSIONS]);
+  });
+
+  it("keeps the version gate for every other method", async () => {
+    const res = await handleMcpRequest(
+      mcpRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { "mcp-protocol-version": "2026-07-28" },
+      ),
+      { kv: new MockKv().asKv() },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("withholds the result widget pointer from a client that negotiated it away", async () => {
+    const kv = new MockKv();
+    const init = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {
+            extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/uri-list"] } },
+          },
+        },
+      }),
+      { kv: kv.asKv() },
+    );
+    const sessionId = init.headers.get("mcp-session-id") as string;
+
+    const list = await handleMcpRequest(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" }, {
+        "mcp-session-id": sessionId,
+      }),
+      { kv: kv.asKv() },
+    );
+    const listed = ((await asJsonRpc(list)).result as {
+      tools: { name: string; _meta?: { ui?: { resourceUri?: string } } }[];
+    }).tools.find((t) => t.name === "view_3d_model");
+
+    const call = await handleMcpRequest(
+      mcpRequest(
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "view_3d_model",
+            arguments: { modelUrl: "https://example.com/chair.glb" },
+          },
+        },
+        { "mcp-session-id": sessionId },
+      ),
+      { kv: kv.asKv() },
+    );
+    const called = (await asJsonRpc(call)).result as {
+      _meta?: { ui?: { resourceUri?: string } };
+      content?: unknown[];
+    };
+
+    // Declaration and result must agree: a host that discovers widgets from
+    // results must not be handed one the session just negotiated away.
+    expect(listed?._meta?.ui?.resourceUri).toBeUndefined();
+    expect(called._meta?.ui?.resourceUri).toBeUndefined();
+    // The tool still answers with its text content — degradation, not failure.
+    expect(called.content).toBeDefined();
+  });
+
+  it("still attaches the result widget pointer for a client that declared nothing", async () => {
+    const kv = new MockKv();
+    const init = await handleMcpRequest(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {} },
+      }),
+      { kv: kv.asKv() },
+    );
+    const sessionId = init.headers.get("mcp-session-id") as string;
+    const call = await handleMcpRequest(
+      mcpRequest(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "view_3d_model",
+            arguments: { modelUrl: "https://example.com/chair.glb" },
+          },
+        },
+        { "mcp-session-id": sessionId },
+      ),
+      { kv: kv.asKv() },
+    );
+    const called = (await asJsonRpc(call)).result as {
+      _meta?: { ui?: { resourceUri?: string } };
+    };
+    expect(called._meta?.ui?.resourceUri).toBe("ui://widget/3d-viewer.html");
+  });
+});


### PR DESCRIPTION
Two P2 spec-conformance defects in `mcp-gateway`'s Streamable HTTP transport, both surfaced by an independent Codex review of `1b668deaa` and reproduced here by tests that failed before the fix.

## 1. `server/discover` was 400'd for any newer protocol-version header

The `MCP-Protocol-Version` gate applied to every non-`initialize` request, discovery included. A host on a newer MCP revision that names it in the header — what the spec invites — was refused the one answer that would have let it negotiate down:

```
server/discover with MCP-Protocol-Version: 2026-07-28
→ 400 Unsupported protocol version: 2026-07-28
```

Discovery is handshake-free by definition, so it must work *before* version negotiation. It is now exempt from the gate. A test pins that every other method still is not.

## 2. `tools/call` returned a widget the session had negotiated away

`tools/list` consulted `session.uiExtension` and stripped `_meta.ui.resourceUri` when the client declared MCP Apps mime types excluding `text/html;profile=mcp-app`. `tools/call` set it unconditionally, so declaration and result disagreed and a host that discovers widgets from results still got one it cannot render.

The call path now reads the same decision. Note the upstream tool handler (`mcp/src/tools/handler.ts`) bakes the pointer into the result itself, so skipping the merge is not enough — the fix removes `_meta.ui` from the result on that condition. `content` and `structuredContent` are untouched: degradation, not failure.

## Tests

Four new cases in `mcp-gateway/test/transport.test.ts`; the two that reproduce the bugs failed on `main`. The fourth pins the behaviour that must **not** change: a client that declared no extension at all (ChatGPT today) still gets its widget pointer on both list and call. Full gateway suite: 209/209, `tsc --noEmit` clean.

No version numbers touched.

Fixes #3502

🤖 Generated with [Claude Code](https://claude.com/claude-code)