### PR TITLE
fix(mcp): the stdio server applies the MCP Apps mime negotiation it advertises

### DIFF
--- a/changelog.d/3485-stdio-widget-negotiation.md
+++ b/changelog.d/3485-stdio-widget-negotiation.md
@@ -1,0 +1,17 @@
+<!-- category: Fixed -->
+- **The `npx sceneview-mcp` stdio server now honours the MCP Apps mime negotiation it
+  advertises ([#3485](https://github.com/sceneview/sceneview/issues/3485)).** The server
+  declares the `io.modelcontextprotocol/ui` extension, which tells a host it follows the
+  extension's rule: degrade to text when the client declares mime types excluding
+  `text/html;profile=mcp-app`. The HTTP gateway did that; the stdio server did not — it
+  mapped every tool declaration through unchanged, `_meta.ui.resourceUri` included, and
+  attached the same pointer to every `view_3d_model` result, so a host that had just said
+  it cannot render our widget was pointed at one anyway. Both handlers now read the
+  client's declared extensions from the handshake and take the pointer off declaration and
+  result together, so the two transports cannot disagree. What does **not** change: a
+  client that declares no extension at all — ChatGPT today, which drives the widget off the
+  `openai/*` keys — still gets its widget, and so does one that names our mime type. The
+  tool itself stays listed, callable and text-answering in every case: degradation, not
+  failure. An explicit empty `mimeTypes` list is now documented as counting with silence,
+  since the spec makes the field required and an empty one is malformed rather than a
+  refusal.

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The shared MCP `Server` as both transports build it — specifically the MCP
+ * Apps negotiation, which the HTTP gateway honoured and the stdio server did
+ * not (#3485).
+ *
+ * These tests drive a real SDK `Client` against `createSceneViewServer()` over
+ * a linked in-memory transport pair, so the client capabilities travel through
+ * a genuine `initialize` and the server reads them back exactly as it would
+ * from a host over stdio.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import { createSceneViewServer } from "./server.js";
+import { MCP_APP_MIME_TYPE, UI_EXTENSION_ID, WIDGET_3D_VIEWER_URI } from "./widgets.js";
+
+/** A connected client/server pair over in-memory transports. */
+async function connect(capabilities: ClientCapabilities): Promise<Client> {
+  const server = createSceneViewServer({ surface: "stdio" });
+  const client = new Client({ name: "test-host", version: "0.0.1" }, { capabilities });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+/** Client capabilities declaring the MCP Apps extension with `mimeTypes`. */
+function uiCapabilities(mimeTypes: string[]): ClientCapabilities {
+  return { extensions: { [UI_EXTENSION_ID]: { mimeTypes } } } as ClientCapabilities;
+}
+
+type ListedTool = { name: string; _meta?: { ui?: { resourceUri?: string } } };
+type CallResult = { _meta?: { ui?: { resourceUri?: string } }; content?: unknown[] };
+
+const VIEWER_ARGS = { modelUrl: "https://example.com/chair.glb" };
+
+describe("stdio server: MCP Apps mime negotiation (#3485)", () => {
+  it("withholds the widget pointer from a client whose mime types exclude ours", async () => {
+    const client = await connect(uiCapabilities(["text/uri-list"]));
+
+    const { tools } = (await client.listTools()) as { tools: ListedTool[] };
+    const viewer = tools.find((t) => t.name === "view_3d_model");
+    // The tool stays listed and callable — only the UI pointer is withheld,
+    // which is the graceful degradation the extension spec asks for.
+    expect(viewer).toBeDefined();
+    expect(viewer?._meta?.ui?.resourceUri).toBeUndefined();
+
+    const result = (await client.callTool({
+      name: "view_3d_model",
+      arguments: VIEWER_ARGS,
+    })) as CallResult;
+    // Declaration and result must agree, or a host that discovers widgets
+    // from results still gets one it just said it cannot render.
+    expect(result._meta?.ui?.resourceUri).toBeUndefined();
+    expect(result.content).toBeDefined();
+  });
+
+  it("serves the widget to a client that declared our mime type", async () => {
+    const client = await connect(uiCapabilities([MCP_APP_MIME_TYPE]));
+    const { tools } = (await client.listTools()) as { tools: ListedTool[] };
+    expect(tools.find((t) => t.name === "view_3d_model")?._meta?.ui?.resourceUri).toBe(
+      WIDGET_3D_VIEWER_URI
+    );
+    const result = (await client.callTool({
+      name: "view_3d_model",
+      arguments: VIEWER_ARGS,
+    })) as CallResult;
+    expect(result._meta?.ui?.resourceUri).toBe(WIDGET_3D_VIEWER_URI);
+  });
+
+  it("keeps the widget for a client that declared no extension at all", async () => {
+    // ChatGPT today declares nothing and drives the widget off the `openai/*`
+    // keys: gating on silence would dark-ship the live listing (#3192).
+    const client = await connect({});
+    const { tools } = (await client.listTools()) as { tools: ListedTool[] };
+    expect(tools.find((t) => t.name === "view_3d_model")?._meta?.ui?.resourceUri).toBe(
+      WIDGET_3D_VIEWER_URI
+    );
+    const result = (await client.callTool({
+      name: "view_3d_model",
+      arguments: VIEWER_ARGS,
+    })) as CallResult;
+    expect(result._meta?.ui?.resourceUri).toBe(WIDGET_3D_VIEWER_URI);
+  });
+
+  it("leaves every non-widget tool declaration untouched by the negotiation", async () => {
+    const strict = await connect(uiCapabilities([MCP_APP_MIME_TYPE]));
+    const degraded = await connect(uiCapabilities(["text/uri-list"]));
+    const a = ((await strict.listTools()) as { tools: ListedTool[] }).tools;
+    const b = ((await degraded.listTools()) as { tools: ListedTool[] }).tools;
+    expect(b.map((t) => t.name)).toEqual(a.map((t) => t.name));
+    const widgetless = a.filter((t) => !t._meta?.ui?.resourceUri).map((t) => t.name);
+    for (const name of widgetless) {
+      expect(b.find((t) => t.name === name)).toEqual(a.find((t) => t.name === name));
+    }
+  });
+});

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -42,7 +42,12 @@ import { recordClientInit, recordToolCall } from "./telemetry.js";
 import { getToolTier, isProTool, TOOL_TIERS } from "./tiers.js";
 import { API_DOCS, dispatchTool, TOOL_DEFINITIONS } from "./tools/index.js";
 import type { ToolDefinition } from "./tools/types.js";
-import { listWidgetResources, readWidgetResource } from "./widgets.js";
+import {
+  listWidgetResources,
+  readUiExtension,
+  readWidgetResource,
+  serveWidgetsTo,
+} from "./widgets.js";
 
 /** Which transport the server is being built for. See the file header. */
 export type ServerSurface = "stdio" | "remote";
@@ -60,6 +65,7 @@ export interface SceneViewServerOptions {
 type SdkCallToolResult = {
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
+  _meta?: Record<string, unknown>;
 };
 
 /** Tool declarations the remote surface publishes: the free tier, nothing else. */
@@ -74,6 +80,20 @@ export function remoteProToolRefusal(toolName: string): string {
     `which exposes only the free SceneView tools. To use Pro tools, run the ` +
     `package locally (\`npx sceneview-mcp\`) with a \`SCENEVIEW_API_KEY\`.`
   );
+}
+
+/**
+ * Strips the MCP Apps `_meta.ui` pointer off a definition or a result.
+ *
+ * Everything else in `_meta` survives, the `openai/*` keys included: those are
+ * a different vendor's mechanism, and a client that speaks the extension is
+ * not the host that reads them.
+ */
+function withoutWidgetPointer<T extends { _meta?: Record<string, unknown> }>(value: T): T {
+  if (!value._meta || !("ui" in value._meta)) return value;
+  const meta = { ...value._meta };
+  delete meta.ui;
+  return { ...value, _meta: meta };
 }
 
 export function createSceneViewServer(options: SceneViewServerOptions = {}): Server {
@@ -185,10 +205,25 @@ export function createSceneViewServer(options: SceneViewServerOptions = {}): Ser
 
   // ─── Tools ─────────────────────────────────────────────────────────────────
 
+  /**
+   * Whether this session gets MCP Apps widget pointers.
+   *
+   * The client's declared mime types arrive in the `initialize` handshake and
+   * the SDK keeps them on the server, so both tool handlers can ask the same
+   * question the HTTP gateway asks — otherwise the two transports drift and
+   * the stdio server hands a widget to a host that declared it cannot render
+   * one (#3485). Silence stays permissive: see `serveWidgetsTo`.
+   */
+  const widgetsEnabled = () => serveWidgetsTo(readUiExtension(server.getClientCapabilities()));
+
   server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const withWidgets = widgetsEnabled();
+    const negotiate = <T extends { _meta?: Record<string, unknown> }>(tool: T): T =>
+      withWidgets ? tool : withoutWidgetPointer(tool);
+
     // Remote surface: the free tier only. There is no key on a shared
     // endpoint, so a `[PRO]` prefix would advertise tools nobody can call.
-    if (remote) return { tools: remoteToolDefinitions() };
+    if (remote) return { tools: remoteToolDefinitions().map(negotiate) };
 
     // v4 lite mode: we trust the gateway to enforce Pro access at call time,
     // so listing is purely cosmetic here. If no API key is set we still prefix
@@ -197,13 +232,20 @@ export function createSceneViewServer(options: SceneViewServerOptions = {}): Ser
     // list unmodified.
     const unlocked = isProxyConfigured();
     const tools = TOOL_DEFINITIONS.map((tool) => {
-      if (unlocked || !isProTool(tool.name)) return tool;
-      return { ...tool, description: `[PRO] ${tool.description}` };
+      if (unlocked || !isProTool(tool.name)) return negotiate(tool);
+      return negotiate({ ...tool, description: `[PRO] ${tool.description}` });
     });
     return { tools };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    // Same decision as the declaration above, so a host that discovers
+    // widgets from RESULTS rather than declarations cannot be handed a
+    // pointer the session negotiated away (#3485). The tool still runs and
+    // still answers with its text content: degradation, not failure.
+    const negotiateResult = (result: SdkCallToolResult): SdkCallToolResult =>
+      widgetsEnabled() ? result : withoutWidgetPointer(result);
+
     const toolName = request.params.name;
     const args = request.params.arguments as Record<string, unknown> | undefined;
 
@@ -234,7 +276,7 @@ export function createSceneViewServer(options: SceneViewServerOptions = {}): Ser
         }
       } else {
         const result = await dispatchProxyToolCall(toolName, args);
-        return result as unknown as SdkCallToolResult;
+        return negotiateResult(result as unknown as SdkCallToolResult);
       }
     }
 
@@ -242,7 +284,7 @@ export function createSceneViewServer(options: SceneViewServerOptions = {}): Ser
     // structurally matches the MCP SDK's `CallToolResult` but TS can't prove
     // it (the SDK's zod-derived type has additional optional members).
     const result = await dispatchTool(toolName, args);
-    return result as unknown as SdkCallToolResult;
+    return negotiateResult(result as unknown as SdkCallToolResult);
   });
 
   return server;

--- a/mcp/src/widgets.test.ts
+++ b/mcp/src/widgets.test.ts
@@ -243,6 +243,10 @@ describe("MCP Apps extension negotiation (#3192)", () => {
     // Gating on silence would dark-ship the live listing.
     expect(serveWidgetsTo(null)).toBe(true);
     expect(serveWidgetsTo(undefined)).toBe(true);
+    // An explicit empty list counts as silence too: `mimeTypes` is REQUIRED by
+    // the spec, so an empty one is malformed rather than a stated refusal, and
+    // reading a client bug as "render nothing" would dark-ship the widget
+    // (#3485 — decided here rather than left ambiguous).
     expect(serveWidgetsTo({ mimeTypes: [] })).toBe(true);
   });
 

--- a/mcp/src/widgets.ts
+++ b/mcp/src/widgets.ts
@@ -95,6 +95,12 @@ export function readUiExtension(capabilities: unknown): UiExtensionSettings | nu
  * *and* listed mime types that exclude ours. Silence stays permissive, because
  * the live ChatGPT listing is silent and withholding the pointer from it would
  * turn a spec conformance fix into an outage.
+ *
+ * An explicit `mimeTypes: []` counts as silence, deliberately (#3485): the
+ * spec makes `mimeTypes` REQUIRED, so an empty one is a malformed declaration
+ * rather than a stated refusal, and reading a malformed declaration as "render
+ * nothing" would dark-ship the widget on a client bug. Pinned by a test in
+ * `widgets.test.ts` so the choice cannot drift silently.
  */
 export function serveWidgetsTo(settings: UiExtensionSettings | null | undefined): boolean {
   if (!settings) return true;
@@ -479,8 +485,8 @@ export const WIDGET_3D_VIEWER_HTML = `<!DOCTYPE html>
        */
       function resolveModelUrl(url) {
         var path = String(url).split("?")[0].split("#")[0].toLowerCase();
-        var isThreeMfUrl = /\.3mf$/.test(path);
-        var isKnownGltf = /\.(glb|gltf)$/.test(path);
+        var isThreeMfUrl = /.3mf$/.test(path);
+        var isKnownGltf = /.(glb|gltf)$/.test(path);
         if (!isThreeMfUrl && isKnownGltf) return Promise.resolve(url);
 
         return fetch(url)


### PR DESCRIPTION
`mcp/src/discover.ts` advertises the `io.modelcontextprotocol/ui` extension in `SERVER_CAPABILITIES`, which tells a host this server follows the extension's degradation rule. `mcp/src/widgets.ts` ships `readUiExtension` / `serveWidgetsTo` for exactly that — but only the HTTP gateway called them.

The stdio server (`npx sceneview-mcp`, the npm path) mapped `TOOL_DEFINITIONS` through unchanged, `_meta.ui.resourceUri` included, and stamped the same pointer on every `view_3d_model` result. A client that declared mime types excluding `text/html;profile=mcp-app` was pointed at a widget it had just said it cannot render.

## Fix

Both `tools/list` and `tools/call` now read `server.getClientCapabilities()` through `readUiExtension` and drop `_meta.ui` when `serveWidgetsTo(...)` is false — declaration and result together, so a host that discovers widgets from results cannot disagree with one that reads declarations. Everything else in `_meta` survives, the `openai/*` keys included: a different vendor's mechanism, and a client speaking the extension is not the host that reads them.

## Reproduction and guard rails

New `mcp/src/server.test.ts` drives a real SDK `Client` against `createSceneViewServer()` over a linked in-memory transport pair, so the capabilities travel through a genuine `initialize`. The first test failed on `main` (`expected 'ui://widget/3d-viewer.html' to be undefined`). The other three pin what must **not** change:

- a client declaring no extension at all (ChatGPT today, which drives the widget off the `openai/*` keys) keeps its widget on list *and* call;
- a client naming our mime type keeps its widget;
- every non-widget tool declaration is byte-identical whichever way the negotiation goes.

The tool stays listed, callable and text-answering in all cases: degradation, not failure.

## The issue's secondary point

`serveWidgetsTo({ mimeTypes: [] })` — decided rather than left ambiguous: an explicit empty list counts **with silence**, because the spec makes `mimeTypes` REQUIRED, so an empty one is a malformed declaration rather than a stated refusal, and reading a client bug as "render nothing" would dark-ship the widget. The existing assertion in `widgets.test.ts` is now documented as that decision.

The third point (gateway `server/discover` running after `resolveSession`) is pre-existing #3349 and left alone. The gateway's own two defects are #3502 / #3541.

`npm test`: 2056/2056 across 89 files. `tsc` and `biome check` clean on the changed files. No version numbers touched — `mcp/` stays on its own track.

Fixes #3485

🤖 Generated with [Claude Code](https://claude.com/claude-code)