### PR TITLE
fix(demo): frame an opened model at any scale, and ask before assuming millimetres (#3543)

### DIFF
--- a/changelog.d/3543-scale-independent-framing.md
+++ b/changelog.d/3543-scale-independent-framing.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+
+Frame an opened model at any scale. The demo viewer clamped its camera to 20 cm at the near end, so
+an STL, OBJ or PLY authored in metres — read in millimetres, as those unit-less formats are — opened
+as a near-invisible dot that Recenter could not bring back. The framing distance and the camera's
+near plane now follow the subject's own size, and a unit-less file a few units across is offered the
+metre reading ("Looks like metres — open at real size") instead of being scaled in silence.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/OpenedModel.kt
@@ -6,7 +6,11 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.compose.runtime.Immutable
+import io.github.sceneview.core.obj.ObjLoader
+import io.github.sceneview.core.ply.PlyLoader
+import io.github.sceneview.core.stl.StlLoader
 import io.github.sceneview.core.threemf.ThreeMfLoader
+import io.github.sceneview.core.threemf.ThreeMfUnit
 import java.io.File
 
 /**
@@ -207,6 +211,47 @@ object OpenedModelIntent {
      * [OpenedModel.displayName] for the title; using it on disk would mean sanitising untrusted
      * text into a path, and there is never more than one opened model to hold.
      */
+    /**
+     * Re-convert the staged STL / OBJ / PLY at [unit] and return where the result landed, or `null`
+     * when the file is not one of those formats or cannot be read (#3543).
+     *
+     * None of the three formats records a length unit, so [ModelUnitGuess] can only *offer* a
+     * reading and the user picks. Taking the offer re-runs the same loader over the same staged
+     * bytes with a different scale and writes a plain GLB beside them; the original is left in
+     * place so the choice can be taken back. The staged file itself is never rewritten — a second
+     * "open at real size" must not compound.
+     *
+     * Blocking I/O and a full parse — call it off the main thread.
+     */
+    fun reopenAt(context: Context, displayName: String, unit: ThreeMfUnit): OpenedModel? {
+        val source = File(openedModelsDir(context), STAGED_FILE_NAME).takeIf { it.isFile } ?: return null
+        val bytes = runCatching { source.readBytes() }.getOrNull() ?: return null
+        val glb = runCatching {
+            when (unitLessFormat(displayName)) {
+                "stl" -> StlLoader.toGlb(bytes, unit)
+                "obj" -> ObjLoader.toGlb(bytes, unit)
+                "ply" -> PlyLoader.toGlb(bytes, unit)
+                else -> return null
+            }
+        }.getOrNull() ?: return null
+        val target = File(openedModelsDir(context), "$STAGED_FILE_NAME-${unit.id}.glb")
+        return runCatching {
+            target.writeBytes(glb)
+            OpenedModel(location = Uri.fromFile(target).toString(), displayName = displayName)
+        }.getOrNull()
+    }
+
+    /**
+     * The unit-less mesh format [displayName] names (`stl` / `obj` / `ply`), or `null`. These are
+     * the three formats that carry no unit and therefore the three the scale question applies to —
+     * a glTF and a 3MF both state their size, so neither is ever asked about.
+     */
+    fun unitLessFormat(displayName: String): String? =
+        displayName.substringAfterLast('.', "").lowercase().takeIf { it in UnitLessExtensions }
+
+    /** Extensions of [SupportedExtensions] whose files record no length unit. */
+    val UnitLessExtensions: Set<String> = setOf("stl", "obj", "ply")
+
     private const val STAGED_FILE_NAME = "opened-model"
 
     private const val HEADER_BYTES = 4096

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ModelViewerDemo.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.sceneview.SceneView
 import io.github.sceneview.createDefaultCameraManipulator
+import io.github.sceneview.rememberCameraNode
 import io.github.sceneview.model.model
 import io.github.sceneview.toAabb
 import io.github.sceneview.verticalFovDegreesForFocalLength
@@ -86,6 +87,10 @@ import io.github.sceneview.demo.ui.viewer.BundledViewerModel
 import io.github.sceneview.demo.ui.viewer.AnimationBar
 import io.github.sceneview.demo.ui.viewer.EnvironmentSheet
 import io.github.sceneview.demo.ui.viewer.ModelPickerSheet
+import io.github.sceneview.demo.ui.viewer.ModelUnitSheet
+import io.github.sceneview.demo.OpenedModelIntent
+import io.github.sceneview.core.threemf.ModelUnitGuess
+import io.github.sceneview.core.threemf.ThreeMfUnit
 import io.github.sceneview.demo.ui.viewer.ViewerEnvironment
 import io.github.sceneview.demo.demos.internal.DemoMath
 import io.github.sceneview.demo.demos.internal.PARK_EYE_HEIGHT
@@ -118,7 +123,9 @@ import io.github.sceneview.sample.ui.LabeledSlider
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import com.google.ar.core.ArCoreApk
 import kotlinx.coroutines.delay
@@ -307,6 +314,12 @@ private fun SingleModelSection(
     // on a second, poorer screen written to say the same thing.
     val openedModel = remember { DemoSettings.openedModel.also { DemoSettings.openedModel = null } }
     var streamedFileUrl by remember { mutableStateOf<String?>(openedModel?.location) }
+    // Scale question for a unit-less file (#3543). STL / OBJ / PLY record no unit, so the loader
+    // reads them in millimetres; `loadedUnit` is the reading currently on screen, and taking the
+    // offer re-converts the same staged bytes at the other one.
+    var loadedUnit by remember { mutableStateOf(ThreeMfUnit.Default) }
+    var unitSheetOpen by remember { mutableStateOf(false) }
+    var unitAnswered by remember { mutableStateOf(openedModel == null) }
     // Last-tapped state — when it's `true` the FAB shows a spinner. The
     // surprise-coroutine flips it back to `false` regardless of success so
     // the button doesn't get stuck in the loading state.
@@ -500,6 +513,20 @@ private fun SingleModelSection(
     // In `qaMode` both snap to their resting values — a screenshot taken mid-flight frames
     // the model differently every run.
     val modelPresented = firstModelFrame.value
+    // #3543 — a unit-less mesh a couple of units across is metre-authored, not a 2 mm part. The
+    // viewer frames it correctly either way now, so this is a question, asked once, about what the
+    // file MEANT — never a silent rescale, and never a hidden setting.
+    val unitSuggestion = remember(bounds, loadedUnit, openedModel) {
+        val name = openedModel?.displayName ?: return@remember null
+        if (OpenedModelIntent.unitLessFormat(name) == null) return@remember null
+        val extents = bounds?.extents ?: return@remember null
+        ModelUnitGuess.suggestFromLoaded(maxOf(extents.x, extents.y, extents.z), loadedUnit)
+    }
+    // Never in `qaMode`: a screenshot run must show the model, not a sheet over it.
+    val askAboutUnit = unitSuggestion != null && !unitAnswered && !DemoSettings.qaMode
+    LaunchedEffect(askAboutUnit, modelPresented) {
+        if (askAboutUnit && modelPresented) unitSheetOpen = true
+    }
     LaunchedEffect(bounds, recenterGeneration, modelPresented, DemoSettings.qaMode) {
         if (bounds == null) return@LaunchedEffect
         if (DemoSettings.qaMode) {
@@ -524,8 +551,10 @@ private fun SingleModelSection(
         )
     }
     // Back closes transient chrome before leaving the demo.
-    BackHandler(enabled = animationBarOpen || modelSheetOpen || environmentSheetOpen) {
+    val anySheetOpen = animationBarOpen || modelSheetOpen || environmentSheetOpen
+    BackHandler(enabled = anySheetOpen || unitSheetOpen) {
         animationBarOpen = false; modelSheetOpen = false; environmentSheetOpen = false
+        if (unitSheetOpen) { unitSheetOpen = false; unitAnswered = true }
     }
 
     DemoScaffold(
@@ -685,6 +714,15 @@ private fun SingleModelSection(
                     onDistanceChange = { DemoSettings.cameraDistance = it },
                 )
             }
+            // #3543 — the near plane moves with the subject. The library default is 1 cm, which
+            // is in front of a metre-scale model and *behind* a millimetre-scale one: a 2 mm mesh
+            // frames at ~5 mm, so a fixed 1 cm near plane clips it away entirely and no amount of
+            // recentring brings it back. `viewerNearPlane` keeps the default for everything that
+            // already worked and only tightens it for a subject smaller than it.
+            val cameraNode = rememberCameraNode(engine)
+            LaunchedEffect(autoFitRadius) {
+                cameraNode.near = DemoMath.viewerNearPlane(autoFitRadius)
+            }
             SceneView(
                 modifier = Modifier.fillMaxSize(),
                 onFrame = onFrame,
@@ -694,6 +732,7 @@ private fun SingleModelSection(
                 environment = viewerEnvironment,
                 // OFF: the camera is aimed at the measured bbox centre, see the framing notes.
                 autoCenterContent = false,
+                cameraNode = cameraNode,
                 cameraManipulator = cameraManipulator,
             ) {
                 activeModelInstance?.let { instance ->
@@ -729,6 +768,33 @@ private fun SingleModelSection(
         onBrowse = { modelSheetOpen = false; onModeChange(ModelViewerMode.Gallery) },
         onDismiss = { modelSheetOpen = false },
     )
+    if (unitSheetOpen && unitSuggestion != null) {
+        val extents = bounds?.extents
+        ModelUnitSheet(
+            loadedExtentMeters = extents?.let { maxOf(it.x, it.y, it.z) } ?: 0f,
+            suggested = unitSuggestion,
+            loadedUnit = loadedUnit,
+            onOpenAt = { unit ->
+                unitSheetOpen = false
+                unitAnswered = true
+                val name = openedModel?.displayName ?: return@ModelUnitSheet
+                scope.launch {
+                    val reopened = withContext(Dispatchers.IO) {
+                        OpenedModelIntent.reopenAt(context, name, unit)
+                    }
+                    if (reopened != null) {
+                        loadedUnit = unit
+                        streamedFileUrl = reopened.location
+                        // The file is a different size now: drop the zoom override and re-fly the
+                        // camera, or the model lands framed for the size it no longer is.
+                        DemoSettings.cameraDistance = null
+                        recenterGeneration++
+                    }
+                }
+            },
+            onDismiss = { unitSheetOpen = false; unitAnswered = true },
+        )
+    }
     if (environmentSheetOpen) EnvironmentSheet(
         environments = viewerEnvironments,
         selectedPath = requestedEnvironment.assetPath, intensity = iblIntensity, showEnvironment = showEnvironment,

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/DemoMath.kt
@@ -61,9 +61,17 @@ internal object DemoMath {
      * from the viewport centre, expressed at the target distance — a band whose centre sits
      * above the viewport centre needs a target *below* the model so the model appears higher.
      *
-     * Degenerate inputs (non-finite / non-positive extents or sizes) fall back to safe values;
-     * the distance is clamped to `[0.2, 900]` — the bundled Khronos Fox is ~155 glTF units and
-     * must stay inside the default 1000 m far plane.
+     * Degenerate inputs (non-finite / non-positive extents or sizes) fall back to safe values.
+     *
+     * **The distance follows the subject at every order of magnitude (#3543).** It used to be
+     * clamped to `[0.2, 900]`, and that 20 cm floor is what made a 2 mm mesh open as a
+     * near-invisible dot with a Recenter that could not fix it: the fit distance is ~5 mm, the
+     * clamp pushed the camera forty times further out, and Recenter dutifully returned to the same
+     * wrong place. Only the far end is a real constraint now — the bundled Khronos Fox is ~155
+     * glTF units and must stay inside the default 1000 m far plane — while the near end is
+     * [MIN_VIEWER_DISTANCE], a floating-point guard rather than a size opinion. A model too small
+     * to frame at that distance cannot be seen at any distance. Callers must move the camera's
+     * near plane with it: see [viewerNearPlane].
      */
     fun viewerFraming(
         extentX: Float,
@@ -99,7 +107,9 @@ internal object DemoMath {
         // face, which perspective enlarges: a third of the depth on top of the fit distance
         // lands them on the target fill on device (a full half over-corrected, none
         // under-corrected). It also keeps the eye outside the box.
-        val distance = (max(dVertical, dHorizontal) + ez * DEPTH_ALLOWANCE).coerceIn(0.2f, 900f)
+        val fit = max(dVertical, dHorizontal) + ez * DEPTH_ALLOWANCE
+        val distance = if (fit.isFinite() && fit > 0f) fit.coerceIn(MIN_VIEWER_DISTANCE, MAX_VIEWER_DISTANCE)
+        else DEGENERATE_VIEWER_DISTANCE
 
         // Visible-band centre relative to the viewport centre, in half-viewport units; screen Y
         // grows downwards, so a band centred above the middle yields a negative value.
@@ -110,6 +120,37 @@ internal object DemoMath {
         val eyeOffset = Triple(0f, targetOffset.second + distance * sinP, targetOffset.third + distance * cosP)
         return ViewerFraming(distance, targetOffset, eyeOffset)
     }
+
+    /**
+     * Floating-point floor on the framing distance — 1 mm, not a size opinion (#3543). A subject
+     * whose fit distance is below this is smaller than the camera's own near plane can resolve.
+     */
+    const val MIN_VIEWER_DISTANCE = 0.001f
+
+    /** Ceiling on the framing distance: the default far plane is 1000 m. */
+    const val MAX_VIEWER_DISTANCE = 900f
+
+    /** Distance used when the bounds measure nothing at all — an empty scene still needs a camera. */
+    const val DEGENERATE_VIEWER_DISTANCE = 0.2f
+
+    /**
+     * Camera near plane for a scene framed at [distance] (#3543).
+     *
+     * The library's 1 cm default is right for the metre-scale subjects every bundled sample uses
+     * and fatal for a small one: a 2 mm part frames at 5 mm, entirely inside a 1 cm near plane, so
+     * even a correctly-placed camera renders nothing. A hundredth of the framing distance keeps a
+     * comfortable margin at every scale — including a 4x pinch-in, which never gets closer than a
+     * quarter of it — and is capped at the current default so metre-scale scenes keep exactly the
+     * depth precision they have today.
+     */
+    fun viewerNearPlane(distance: Float, default: Float = DEFAULT_NEAR_PLANE): Float =
+        if (distance.isFinite() && distance > 0f) min(default, distance * NEAR_PLANE_FRACTION) else default
+
+    /** The library's [io.github.sceneview.node.CameraNode] near-plane default, in metres. */
+    const val DEFAULT_NEAR_PLANE = 0.01f
+
+    /** Share of the framing distance the near plane sits at, when that is closer than the default. */
+    const val NEAR_PLANE_FRACTION = 0.01f
 
     /** Fraction of the visible band the framed model spans (QA target: 60–70 %). */
     const val VIEWER_FILL = 0.65f

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/viewer/ModelUnitSheet.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/ui/viewer/ModelUnitSheet.kt
@@ -1,0 +1,96 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package io.github.sceneview.demo.ui.viewer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.sceneview.core.threemf.ThreeMfUnit
+import io.github.sceneview.demo.theme.SceneViewTokens
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * The scale question for a unit-less file — #3543.
+ *
+ * STL, OBJ and PLY record no length unit, so SceneView reads them in millimetres like the slicers
+ * that write most of them. A mesh a couple of units across is almost certainly a metre-authored
+ * export instead, and reading it as millimetres puts a 2 mm object on screen: technically the
+ * documented default, practically an empty-looking room. Rather than assume in silence, the viewer
+ * says what it did and offers the other reading, with both sizes spelled out so the answer is
+ * obvious without knowing what a "unit" is.
+ *
+ * Asked once per opened file, and only when [io.github.sceneview.core.threemf.ModelUnitGuess] has
+ * something to offer. Declining is a real answer: the framing works at either size (the viewer
+ * frames whatever it loads, at any order of magnitude), so nothing is broken by keeping
+ * millimetres.
+ *
+ * @param loadedExtentMeters Longest side of what is currently on screen, in metres.
+ * @param suggested          The unit being offered.
+ * @param loadedUnit         The unit the file was read in.
+ */
+@Composable
+fun ModelUnitSheet(
+    loadedExtentMeters: Float,
+    suggested: ThreeMfUnit,
+    loadedUnit: ThreeMfUnit,
+    onOpenAt: (ThreeMfUnit) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val suggestedExtent = loadedExtentMeters / loadedUnit.meters * suggested.meters
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(topStart = SceneViewTokens.Radius.xl, topEnd = SceneViewTokens.Radius.xl),
+    ) {
+        Column(
+            Modifier.fillMaxWidth().padding(SceneViewTokens.Space.md).navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+        ) {
+            Text("Looks like metres", style = MaterialTheme.typography.titleLarge)
+            Text(
+                "This file carries no unit, so it opened in millimetres — ${formatSize(loadedExtentMeters)} across. " +
+                    "A mesh this size is usually authored in metres.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = { onOpenAt(suggested) },
+                modifier = Modifier.fillMaxWidth().padding(top = SceneViewTokens.Space.xs),
+            ) { Text("Open at real size (${formatSize(suggestedExtent)})") }
+            TextButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                Text("Keep ${formatSize(loadedExtentMeters)}")
+            }
+        }
+    }
+}
+
+/**
+ * A length in the unit a person would say it in: millimetres below a centimetre, centimetres below
+ * a metre, metres above. Two significant figures at most — this is a label on a button, not a
+ * measurement, and "1.9999 m" reads as a bug.
+ */
+internal fun formatSize(meters: Float): String {
+    if (!meters.isFinite() || meters <= 0f) return "0 mm"
+    val (value, suffix) = when {
+        meters < 0.01f -> meters * 1000f to "mm"
+        meters < 1f -> meters * 100f to "cm"
+        else -> meters to "m"
+    }
+    val rounded = if (value < 10f) (value * 10f).roundToInt() / 10f else value.roundToInt().toFloat()
+    return if (abs(rounded - rounded.roundToInt()) < 0.05f) "${rounded.roundToInt()} $suffix"
+    else "${String.format(Locale.US, "%.1f", rounded)} $suffix"
+}

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/DemoMathTest.kt
@@ -1,5 +1,6 @@
 package io.github.sceneview.demo.demos.internal
 
+import io.github.sceneview.demo.VIEWER_MIN_ZOOM_FACTOR
 import io.github.sceneview.demo.sketchfab.SampleAssets
 import kotlin.math.atan
 import kotlin.math.hypot
@@ -81,6 +82,43 @@ class DemoMathTest {
         val empty = DemoMath.viewerFraming(0f, Float.NaN, -1f, 0f, 0f, 0f, 0f)
         assertEquals(0.2f, empty.distance, 0.0001f)
         assertTrue(empty.eyeOffset.toList().all { it.isFinite() })
+    }
+
+    @Test fun `viewerFraming frames the same mesh identically at every order of magnitude`() {
+        // #3543 — an STL authored in metres and read as millimetres is 2 mm across. The framing
+        // must put it on screen at the same size as the same mesh a hundred, and a million, times
+        // bigger: the 0.2 m floor this used to carry framed the small one forty times too far out,
+        // which is the "near-invisible dot" of the report. The top of the range stops short of the
+        // 900 m far-plane ceiling, which is a real constraint rather than a scale opinion.
+        val tiny = DemoMath.viewerFraming(0.002f, 0.00114f, 0.00086f, 411f, 914f, 96f, 128f)
+        for (scale in listOf(1f, 100f, 1_000f, 100_000f)) {
+            val scaled = DemoMath.viewerFraming(
+                0.002f * scale, 0.00114f * scale, 0.00086f * scale, 411f, 914f, 96f, 128f,
+            )
+            assertEquals("distance scales with the subject", tiny.distance * scale, scaled.distance,
+                tiny.distance * scale * 0.0001f)
+            // Same angular size on screen, therefore the same picture.
+            assertEquals(
+                heightFraction(tiny, 0.00114f, 0.00086f),
+                heightFraction(scaled, 0.00114f * scale, 0.00086f * scale),
+                0.0001f,
+            )
+        }
+        // And the tiny one is genuinely close, not parked on an absolute floor.
+        assertTrue("2 mm frames at millimetres, not at 20 cm", tiny.distance < 0.02f)
+        assertTrue(tiny.distance > DemoMath.MIN_VIEWER_DISTANCE)
+    }
+
+    @Test fun `viewerNearPlane follows a small subject and leaves metre-scale scenes alone`() {
+        // A metre-scale scene keeps the library default exactly — no depth-precision change.
+        assertEquals(DemoMath.DEFAULT_NEAR_PLANE, DemoMath.viewerNearPlane(2.7f), 0f)
+        assertEquals(DemoMath.DEFAULT_NEAR_PLANE, DemoMath.viewerNearPlane(1f), 0f)
+        // The 2 mm mesh frames at ~5 mm: a 1 cm near plane would swallow it whole.
+        val tiny = DemoMath.viewerFraming(0.002f, 0.00114f, 0.00086f, 411f, 914f, 96f, 128f)
+        val near = DemoMath.viewerNearPlane(tiny.distance)
+        assertTrue("near plane is in front of the subject", near < tiny.distance * VIEWER_MIN_ZOOM_FACTOR)
+        assertEquals(DemoMath.DEFAULT_NEAR_PLANE, DemoMath.viewerNearPlane(Float.NaN), 0f)
+        assertEquals(DemoMath.DEFAULT_NEAR_PLANE, DemoMath.viewerNearPlane(0f), 0f)
     }
 
     private val eps = 0.001f

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/ui/viewer/ModelUnitSheetTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/ui/viewer/ModelUnitSheetTest.kt
@@ -1,0 +1,32 @@
+package io.github.sceneview.demo.ui.viewer
+
+import io.github.sceneview.demo.OpenedModelIntent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** #3543 — the two pure pieces behind the scale question. */
+class ModelUnitSheetTest {
+
+    @Test fun `a size is labelled in the unit a person would say it in`() {
+        assertEquals("2 mm", formatSize(0.002f))
+        assertEquals("2 m", formatSize(2f))
+        assertEquals("7 cm", formatSize(0.07f))
+        assertEquals("1.5 m", formatSize(1.54f))
+        assertEquals("155 m", formatSize(155f))
+        // Never "1.9999 m" on a button.
+        assertEquals("2 m", formatSize(1.9999f))
+        assertEquals("0 mm", formatSize(0f))
+        assertEquals("0 mm", formatSize(Float.NaN))
+    }
+
+    @Test fun `only the three unit-less formats are asked about`() {
+        assertEquals("stl", OpenedModelIntent.unitLessFormat("part.STL"))
+        assertEquals("obj", OpenedModelIntent.unitLessFormat("scan.obj"))
+        assertEquals("ply", OpenedModelIntent.unitLessFormat("cloud.ply"))
+        // glTF and 3MF both state their size, so neither is ever asked.
+        assertNull(OpenedModelIntent.unitLessFormat("helmet.glb"))
+        assertNull(OpenedModelIntent.unitLessFormat("print.3mf"))
+        assertNull(OpenedModelIntent.unitLessFormat("noextension"))
+    }
+}

--- a/sceneview-core/api/sceneview-core.api
+++ b/sceneview-core/api/sceneview-core.api
@@ -882,6 +882,14 @@ public final class io/github/sceneview/core/stl/StlParseException : java/lang/Ru
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/github/sceneview/core/threemf/ModelUnitGuess {
+	public static final field INSTANCE Lio/github/sceneview/core/threemf/ModelUnitGuess;
+	public final fun getMetreLikeExtent ()Lkotlin/ranges/ClosedFloatingPointRange;
+	public final fun suggest (F)Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public final fun suggestFromLoaded (FLio/github/sceneview/core/threemf/ThreeMfUnit;)Lio/github/sceneview/core/threemf/ThreeMfUnit;
+	public static synthetic fun suggestFromLoaded$default (Lio/github/sceneview/core/threemf/ModelUnitGuess;FLio/github/sceneview/core/threemf/ThreeMfUnit;ILjava/lang/Object;)Lio/github/sceneview/core/threemf/ThreeMfUnit;
+}
+
 public final class io/github/sceneview/core/threemf/ThreeMfComponent {
 	public fun <init> (I[F)V
 	public final fun getObjectId ()I

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ModelUnitGuess.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ModelUnitGuess.kt
@@ -1,0 +1,51 @@
+package io.github.sceneview.core.threemf
+
+/**
+ * What a unit-less mesh format (STL, OBJ, PLY) most likely meant by "1" — #3543.
+ *
+ * None of the three formats records a length unit, so the loaders default to [ThreeMfUnit.Default]
+ * (millimetres), the convention of the printing tools that write most of them. That default is
+ * right for a part exported from a slicer and wrong for a mesh exported from a game engine, a
+ * photogrammetry scan or Blender, where the working unit is the metre.
+ *
+ * Coordinate magnitude tells the two apart well enough to *ask*: a printable part is tens to
+ * hundreds of millimetres across, so it reads as tens to hundreds of units; a metre-authored scene
+ * reads as a handful of units. When the longest side of a file's bounding box lands in
+ * [MetreLikeExtent] — 5 cm to 50 m read as metres — millimetres would make the object smaller than
+ * a grain of sand, and metres is the better guess.
+ *
+ * The guess is never applied silently: the demo offers it ("Looks like metres") and the user
+ * decides. This object only answers the question, so the answer can be unit-tested and shared by
+ * every platform that asks it.
+ */
+object ModelUnitGuess {
+
+    /**
+     * Longest-side range, in the file's own units, that reads as metre-authored. Below 0.05 the
+     * file is more likely a badly-scaled scan than a 5 cm object stored in metres; above 50 the
+     * millimetre reading (5 cm to 50 m) is already plausible on its own.
+     */
+    val MetreLikeExtent: ClosedFloatingPointRange<Float> = 0.05f..50f
+
+    /**
+     * The unit to *offer* for a unit-less file whose bounding box is [maxExtent] units on its
+     * longest side, or `null` when [ThreeMfUnit.Default] is the sensible reading and nothing
+     * should be asked.
+     *
+     * `ModelUnitGuess.suggest(2f)` → [ThreeMfUnit.METER] (a 2-unit mesh is 2 m, not 2 mm).
+     * `ModelUnitGuess.suggest(70f)` → `null` (a 70-unit mesh is a 70 mm part).
+     */
+    fun suggest(maxExtent: Float): ThreeMfUnit? =
+        ThreeMfUnit.METER.takeIf { maxExtent.isFinite() && maxExtent in MetreLikeExtent }
+
+    /**
+     * Same question asked from a model already loaded at [loadedUnit]: [maxExtentMeters] is the
+     * longest side of the world-space bounding box, in metres, which is the only measurement a
+     * renderer has once the file is converted. Returns `null` when the loaded unit is already the
+     * suggestion, so a re-open is never offered for the size it is showing.
+     */
+    fun suggestFromLoaded(
+        maxExtentMeters: Float,
+        loadedUnit: ThreeMfUnit = ThreeMfUnit.Default,
+    ): ThreeMfUnit? = suggest(maxExtentMeters / loadedUnit.meters)?.takeIf { it != loadedUnit }
+}

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/stl/StlTestFixtures.kt
@@ -7,7 +7,13 @@ internal object StlTestFixtures {
         floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 1f, 1f, 0f, 0f)
     )
 
-    val box: List<FloatArray> get() {
+    val box: List<FloatArray> get() = boxOf(1f)
+
+    /**
+     * The same 70 x 40 x 30 box with every coordinate multiplied by [scale] — `boxOf(1f / 35f)` is
+     * the 2-unit mesh of #3543, the size a metre-authored export lands at.
+     */
+    fun boxOf(scale: Float): List<FloatArray> {
         val vertices = arrayOf(
             floatArrayOf(0f, 0f, 0f), floatArrayOf(70f, 0f, 0f),
             floatArrayOf(70f, 40f, 0f), floatArrayOf(0f, 40f, 0f),
@@ -21,7 +27,10 @@ internal object StlTestFixtures {
         )
         return List(12) { face ->
             FloatArray(12).also { facet ->
-                repeat(3) { vertices[indices[face * 3 + it]].copyInto(facet, 3 + it * 3) }
+                repeat(3) {
+                    val vertex = vertices[indices[face * 3 + it]]
+                    repeat(3) { axis -> facet[3 + it * 3 + axis] = vertex[axis] * scale }
+                }
             }
         }
     }

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ModelUnitGuessTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/ModelUnitGuessTest.kt
@@ -1,0 +1,73 @@
+package io.github.sceneview.core.threemf
+
+import io.github.sceneview.core.stl.StlLoader
+import io.github.sceneview.core.stl.StlTestFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** #3543 — a unit-less mesh a few units across is metre-authored, not a 2 mm part. */
+class ModelUnitGuessTest {
+
+    @Test
+    fun aFewUnitsAcrossReadsAsMetres() {
+        assertEquals(ThreeMfUnit.METER, ModelUnitGuess.suggest(2f))
+        assertEquals(ThreeMfUnit.METER, ModelUnitGuess.suggest(0.05f))
+        assertEquals(ThreeMfUnit.METER, ModelUnitGuess.suggest(50f))
+    }
+
+    @Test
+    fun printableAndDegenerateExtentsKeepTheMillimetreDefault() {
+        // 70 units is the everyday printed part: 70 mm, and nothing is offered.
+        assertNull(ModelUnitGuess.suggest(70f))
+        assertNull(ModelUnitGuess.suggest(50.001f))
+        assertNull(ModelUnitGuess.suggest(0.049f))
+        assertNull(ModelUnitGuess.suggest(0f))
+        assertNull(ModelUnitGuess.suggest(Float.NaN))
+        assertNull(ModelUnitGuess.suggest(Float.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun theQuestionIsNeverAskedAboutTheUnitAlreadyLoaded() {
+        // 2 m loaded as metres: already the suggestion, so no re-open is offered.
+        assertNull(ModelUnitGuess.suggestFromLoaded(2f, ThreeMfUnit.METER))
+        // The same file loaded as millimetres is 2 mm on screen — that one is worth asking about.
+        assertEquals(ThreeMfUnit.METER, ModelUnitGuess.suggestFromLoaded(0.002f, ThreeMfUnit.MILLIMETER))
+        assertNull(ModelUnitGuess.suggestFromLoaded(0.07f, ThreeMfUnit.MILLIMETER))
+    }
+
+    @Test
+    fun theTwoUnitStlOfTheIssueIsOfferedInMetresAndOpensAtTwoMetres() {
+        // 70 x 40 x 30 scaled by 1/35 → 2 x 1.14 x 0.86 units, an export authored in metres.
+        val stl = StlTestFixtures.binary(StlTestFixtures.boxOf(1f / 35f))
+
+        // As loaded today: millimetres, so 2 mm across — the "near-invisible dot" of #3543.
+        val asMillimetres = StlLoader.parse(stl)
+        assertEquals(0.002f, asMillimetres.maxExtentMeters(), 0.00001f)
+        assertEquals(
+            ThreeMfUnit.METER,
+            ModelUnitGuess.suggestFromLoaded(asMillimetres.maxExtentMeters(), ThreeMfUnit.MILLIMETER)
+        )
+
+        // Taking the offer opens the same bytes at two metres.
+        val asMetres = StlLoader.parse(stl, ThreeMfUnit.METER)
+        assertEquals(2f, asMetres.maxExtentMeters(), 0.0001f)
+        assertNull(ModelUnitGuess.suggestFromLoaded(asMetres.maxExtentMeters(), ThreeMfUnit.METER))
+    }
+}
+
+/** Longest side of the parsed bounding box, in metres. */
+private fun io.github.sceneview.core.stl.StlModel.maxExtentMeters(): Float {
+    var extent = 0f
+    repeat(3) { axis ->
+        var min = Float.MAX_VALUE
+        var max = -Float.MAX_VALUE
+        for (vertex in 0 until positions.size / 3) {
+            val value = positions[vertex * 3 + axis]
+            min = minOf(min, value)
+            max = maxOf(max, value)
+        }
+        extent = maxOf(extent, (max - min) * unit.meters)
+    }
+    return extent
+}


### PR DESCRIPTION
An STL whose coordinates span ~2 units opens as a barely visible dot in the demo viewer, and **Recenter** does not fix it. Two independent causes, both absolute distances in a scene whose subject is not.

### 1. The framing floor

`DemoMath.viewerFraming` clamped its distance to `[0.2, 900]` m. A 2 mm mesh fits at ~6 mm, so the 20 cm floor parked the camera 34x too far out — and Recenter, which returns to exactly that framing, returned to exactly that mistake. The floor is now `MIN_VIEWER_DISTANCE = 1 mm`, a floating-point guard rather than a size opinion. The 900 m ceiling stays: it is a real constraint (the 1000 m far plane).

### 2. The near plane

The camera's near plane is the library's 1 cm default, which sits *behind* a subject framed at 6 mm — even a correctly placed camera renders nothing. `DemoMath.viewerNearPlane` moves it to a hundredth of the framing distance **when that is closer than the current default**, so every metre-scale scene keeps exactly the depth precision it has today and only a smaller-than-1 cm subject changes.

### 3. Why it was 2 mm at all

STL, OBJ and PLY record no unit, so the loaders read them in millimetres like the slicers that write most of them. A mesh a couple of units across is far more likely a metre-authored export. `ModelUnitGuess` (in `sceneview-core`, so every platform shares one heuristic) offers metres for a longest side in `0.05..50` units, and the viewer asks once:

> **Looks like metres**
> This file carries no unit, so it opened in millimetres — 2 mm across. A mesh this size is usually authored in metres.
> **[ Open at real size (2 m) ]**
> Keep 2 mm

Taking the offer re-runs the same loader over the same staged bytes at the new scale (`OpenedModelIntent.reopenAt`) and re-frames. Declining is a real answer now that the small reading is visible. Nothing is rescaled in silence, and there is no new setting. The sheet never appears in `qaMode`, so screenshot runs are unaffected.

### Tests

- `ModelUnitGuessTest` — including `theTwoUnitStlOfTheIssueIsOfferedInMetresAndOpensAtTwoMetres`, which builds the 2-unit STL in code and walks the whole path.
- `DemoMathTest.viewerFraming frames the same mesh identically at every order of magnitude` — same picture at x1, x100, x1 000, x100 000.
- `DemoMathTest.viewerNearPlane follows a small subject and leaves metre-scale scenes alone`.
- `ModelUnitSheetTest` — the size labels and the three unit-less extensions.

### QA — `Pixel_7a`, `emulator-5554`, opened through a `content://` VIEW intent

| | |
|---|---|
| Before | `/tmp/3543-before.png` — a ~20 x 10 px dot in the middle of an apparently empty scene; Recenter returns to the same dot. |
| The question | `/tmp/3543-after-sheet.png` — model framed **and** the sheet, reading "2 mm across" / "Open at real size (2 m)". |
| Keep millimetres | `/tmp/3543-after-keep-mm.png` — the 2 mm box, framed. |
| Open at real size | `/tmp/3543-open-at-real-size.png` — the 2 m box, framed identically. |
| Recenter after an orbit | `/tmp/3543-recentered.png` — back to the framed pose. |
| Regression | `/tmp/3543-regression-helmet.png` — the bundled Damaged Helmet, unchanged. |

Fixes #3543

🤖 Generated with [Claude Code](https://claude.com/claude-code)