### PR TITLE
fix(core): a colourless 3MF, STL, PLY or OBJ renders as a lit neutral grey (#3548)

### DIFF
--- a/changelog.d/3548-colourless-model-default-material.md
+++ b/changelog.d/3548-colourless-model-default-material.md
@@ -1,0 +1,17 @@
+<!-- category: Fixed -->
+- **A 3MF, STL, PLY or OBJ that declares no colour now renders as a lit, shaded, neutral
+  grey instead of a blown-out white solid wearing a bloom halo
+  ([#3548](https://github.com/sceneview/sceneview/issues/3548)).** The fallback albedo the
+  four loaders share was written `0.62, 0.64, 0.68` — sRGB numbers, put straight into
+  glTF's `baseColorFactor`, which is defined in **linear** space. So the "light grey"
+  those numbers describe was really an sRGB 0.81 near-white, and SceneView's camera runs
+  about two stops over sunny-16 by design (f/12, 1/200 s, ISO 200, to match RealityKit).
+  Under the model viewer's 30,000-lux IBL that albedo clipped: every shading cue vanished,
+  the surface read as unlit, and it crossed the bloom threshold so the print wore a yellow
+  halo. A CadQuery chair measured 435 of 480 sampled surface pixels fully clipped, with a
+  visible glow outside its own silhouette. The fallback is now **18% linear grey** — the
+  photographic mid-grey, neutral on all three channels — defined once and shared by the
+  3MF, STL, PLY and OBJ paths, so a colourless file reads the same whatever format it
+  arrived in. Same chair after: zero clipped pixels, no glow outside the silhouette, and
+  facet-by-facet shading you can read. Files that *do* carry colour are untouched — an
+  explicit 3MF `displaycolor` still goes through the sRGB→linear transfer it always did.

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/obj/ObjMtl.kt
@@ -1,5 +1,7 @@
 package io.github.sceneview.core.obj
 
+import io.github.sceneview.core.threemf.ThreeMfGlb
+
 internal object ObjMtl {
     fun read(bytes: ByteArray, materials: MutableMap<String, ObjMaterial>) {
         var factor: FloatArray? = null
@@ -26,4 +28,8 @@ internal object ObjMtl {
     }
 }
 
-internal fun defaultObjColor(): FloatArray = floatArrayOf(0.62f, 0.64f, 0.68f, 1f)
+/**
+ * The shared neutral fallback, in linear space — identical to the one the 3MF, STL and PLY paths
+ * use, so a colourless file reads the same grey whatever format it arrived in (#3548).
+ */
+internal fun defaultObjColor(): FloatArray = ThreeMfGlb.defaultBaseColor()

--- a/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
+++ b/sceneview-core/src/commonMain/kotlin/io/github/sceneview/core/threemf/ThreeMfGlb.kt
@@ -230,7 +230,7 @@ internal object ThreeMfGlb {
         }
 
         private fun materialIndex(color: Int): Int = materialIndexByColor.getOrPut(color) {
-            val factor = if (color == NoColor) DefaultBaseColor else color.toLinearRgba()
+            val factor = if (color == NoColor) defaultBaseColor() else color.toLinearRgba()
             addMaterial(factor)
         }
 
@@ -420,7 +420,32 @@ internal object ThreeMfGlb {
     }
 
     private const val Generator = "SceneView 3MF loader"
-    private val DefaultBaseColor = floatArrayOf(0.62f, 0.64f, 0.68f, 1f)
+
+    /**
+     * The albedo every loader here falls back to when its file declares no colour at all: a 3MF
+     * with no `<basematerials>`, a plain STL, a PLY without `red`/`green`/`blue`, an OBJ whose MTL
+     * omits `Kd`.
+     *
+     * **18% neutral grey, in linear space** — the photographic mid-grey a light meter is calibrated
+     * to, and the reference clay every 3D print viewer falls back to. It is written linear because
+     * that is the space glTF defines `baseColorFactor` in.
+     *
+     * #3548 is what the previous value cost: `0.62, 0.64, 0.68` are *sRGB* numbers that were
+     * written straight into that linear field, so the fallback was not the light grey it read as
+     * but an sRGB 0.81 near-white — and SceneView's camera runs about two stops over sunny-16 by
+     * design (the f/12, 1/200 s, ISO 200 defaults that match RealityKit). Under the viewer's
+     * 30,000-lux IBL that albedo clipped to flat white and crossed the bloom threshold: an
+     * untinted print rendered as an unlit solid wearing a yellow halo instead of a shaded grey.
+     */
+    private const val DefaultGrey = 0.18f
+
+    /**
+     * The neutral fallback as glTF wants it: linear RGB, opaque alpha.
+     *
+     * A fresh array every call — `ObjMtl` mutates its copy in place as it reads `Kd`, `d` and `Tr`.
+     */
+    internal fun defaultBaseColor(): FloatArray =
+        floatArrayOf(DefaultGrey, DefaultGrey, DefaultGrey, 1f)
 
     /** A printed part is matte, never a mirror — written literally so no float formatting applies. */
     private const val PrintRoughness = "0.55"

--- a/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/DefaultMaterialTest.kt
+++ b/sceneview-core/src/commonTest/kotlin/io/github/sceneview/core/threemf/DefaultMaterialTest.kt
@@ -1,0 +1,131 @@
+package io.github.sceneview.core.threemf
+
+import io.github.sceneview.core.obj.ObjLoader
+import io.github.sceneview.core.ply.PlyLoader
+import io.github.sceneview.core.splat.readLe32
+import io.github.sceneview.core.stl.StlLoader
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The material a colourless file gets — a 3MF with no `<basematerials>`, a plain STL, a PLY with no
+ * `red`/`green`/`blue`, an OBJ with no MTL. All four share one fallback, and #3548 is what happens
+ * when it is wrong: the fallback held sRGB numbers written straight into glTF's *linear*
+ * `baseColorFactor`, so what read as a 0.62 grey was really an sRGB 0.81 near-white. It clipped to
+ * a flat, unlit white and bloomed under the demo viewer's 30,000-lux IBL.
+ *
+ * These tests assert the emitted GLB, because that is what a renderer actually reads.
+ */
+class DefaultMaterialTest {
+
+    @Test
+    fun theFallbackIsALitNeutralGreyNotAnUnlitWhite() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(ThreeMfTestFixtures.modelXml())))
+
+        val rgba = baseColorFactorOf(json)
+        // 18% linear grey: the photographic mid-grey, and glTF's baseColorFactor is linear.
+        // Tolerance, not equality: Kotlin/JS backs a Float with a double and `String.toFloat()`
+        // rounds to float32 while a `0.18f` literal does not, so the two differ in the 8th digit.
+        assertEquals(0.18f, rgba[0], Epsilon, "red")
+        assertEquals(0.18f, rgba[1], Epsilon, "green")
+        assertEquals(0.18f, rgba[2], Epsilon, "blue")
+        assertEquals(1f, rgba[3], Epsilon, "opaque")
+        assertEquals(rgba[0], rgba[1], Epsilon, "neutral: no colour cast")
+        assertEquals(rgba[1], rgba[2], Epsilon, "neutral: no colour cast")
+        assertTrue(
+            rgba.take(3).all { it < 0.5f },
+            "a light albedo clips to white under a 30,000-lux IBL two stops over sunny-16 (#3548)"
+        )
+    }
+
+    @Test
+    fun theFallbackIsShadedRatherThanEmissiveOrUnlit() {
+        val json = jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(ThreeMfTestFixtures.modelXml())))
+
+        assertContains(json, """"metallicFactor":0""", message = "a print is a dielectric")
+        assertContains(json, """"roughnessFactor":0.55""", message = "matte, never a mirror")
+        assertTrue("emissiveFactor" !in json, "an emissive fallback would glow and bloom")
+        assertTrue("KHR_materials_unlit" !in json, "the fallback must be lit, so the print shades")
+        assertTrue("extensions" !in json, "no extension is needed for a plain PBR grey")
+    }
+
+    @Test
+    fun everyColourlessFormatEmitsTheSameFallback() {
+        val threeMf = baseColorFactorOf(
+            jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(ThreeMfTestFixtures.modelXml())))
+        )
+        val stl = baseColorFactorOf(jsonOf(StlLoader.toGlb(AsciiStl.encodeToByteArray())))
+        val ply = baseColorFactorOf(jsonOf(PlyLoader.toGlb(AsciiPly.encodeToByteArray())))
+        val obj = baseColorFactorOf(jsonOf(ObjLoader.toGlb(AsciiObj.encodeToByteArray())))
+
+        assertEquals(threeMf.toList(), stl.toList(), "STL shares 3MF's fallback")
+        assertEquals(threeMf.toList(), ply.toList(), "PLY shares 3MF's fallback")
+        assertEquals(threeMf.toList(), obj.toList(), "OBJ shares 3MF's fallback")
+    }
+
+    @Test
+    fun anExplicitColourStillWinsOverTheFallback() {
+        val xml = ThreeMfTestFixtures.modelXml(
+            extra = """<basematerials id="5"><base name="red" displaycolor="#FF0000"/></basematerials>""",
+            objectAttributes = """pid="5" pindex="0""""
+        )
+        val rgba = baseColorFactorOf(jsonOf(ThreeMfLoader.toGlb(ThreeMfTestFixtures.threeMfOf(xml))))
+
+        assertEquals(1f, rgba[0], Epsilon, "pure red survives the sRGB→linear transfer unchanged")
+        assertEquals(0f, rgba[1], Epsilon)
+        assertEquals(0f, rgba[2], Epsilon)
+    }
+
+    private fun baseColorFactorOf(json: String): FloatArray {
+        val at = json.indexOf(""""baseColorFactor":[""")
+        assertTrue(at >= 0, "the GLB declares a baseColorFactor")
+        val open = json.indexOf('[', at)
+        val close = json.indexOf(']', open)
+        val values = json.substring(open + 1, close).split(',').map { it.trim().toFloat() }
+        assertEquals(4, values.size, "baseColorFactor is RGBA")
+        return values.toFloatArray()
+    }
+
+    private fun jsonOf(glb: ByteArray): String =
+        glb.decodeToString(20, 20 + readLe32(glb, 12))
+
+    private companion object {
+        /** Wide enough to absorb Kotlin/JS float32 rounding, far tighter than any visible step. */
+        const val Epsilon = 1e-5f
+
+        const val AsciiStl = """solid one
+facet normal 0 0 1
+outer loop
+vertex 0 0 0
+vertex 10 0 0
+vertex 0 10 0
+endloop
+endfacet
+endsolid one
+"""
+
+        const val AsciiPly = """ply
+format ascii 1.0
+element vertex 3
+property float x
+property float y
+property float z
+element face 1
+property list uchar int vertex_index
+end_header
+0 0 0
+10 0 0
+0 10 0
+3 0 1 2
+"""
+
+        const val AsciiObj = """v 0 0 0
+v 10 0 0
+v 0 10 0
+vn 0 0 1
+f 1//1 2//1 3//1
+"""
+    }
+}


### PR DESCRIPTION
Opening a 3MF that carries geometry but no `<basematerials>` — what CadQuery, trimesh and most image-to-print flows emit — showed the object in the demo viewer as a saturated pale-yellow solid with no shading at all and a strong bloom halo. The same file is a neutral grey lit solid in any desktop viewer.

## Cause

Not the demo, and not the 3MF path specifically: the GLB the loader emits was structurally correct all along (`metallicFactor` 0, `roughnessFactor` 0.55, no `emissiveFactor`, no `KHR_materials_unlit`). The bug was the **value** of the fallback albedo, and all four loaders share it — 3MF, STL, PLY and OBJ all route through `ThreeMfGlb`.

It was written `0.62, 0.64, 0.68`. Those are **sRGB** numbers, written straight into glTF's `baseColorFactor`, which is defined in **linear** space — the one colour in the file that skipped the very `srgbToLinear` transfer every explicit 3MF `displaycolor` already goes through. So the "light grey" those numbers describe was really an sRGB 0.81 near-white.

That alone would only be pale. What made it read as *unlit* is that SceneView's camera runs about two stops over sunny-16 by design (`f/12, 1/200 s, ISO 200`, chosen in `SceneFactories` to match the RealityKit look). Under the model viewer's 30,000-lux IBL, a 0.62-linear albedo clips: every shading cue is crushed against white, and the surface crosses the bloom threshold, hence the halo.

## Fix

The fallback becomes **18% linear grey** — the photographic mid-grey, neutral on all three channels — defined once in `ThreeMfGlb.defaultBaseColor()` and shared by the 3MF, STL, PLY and OBJ paths, so a colourless file reads the same grey whatever format it arrived in. `defaultObjColor()` now delegates to it instead of carrying a second copy of the same constant.

Files that *do* carry colour are untouched. An explicit 3MF `displaycolor` still goes through the sRGB→linear transfer it always did — covered by a test here so the two paths cannot drift again.

## Tests

`DefaultMaterialTest` asserts the emitted GLB, which is what a renderer actually reads:
- the fallback is a neutral, sub-0.5 linear grey (the ceiling above which it clips under this IBL);
- it is lit and shaded — no `emissiveFactor`, no `KHR_materials_unlit`, no extension at all;
- 3MF, STL, PLY and OBJ emit an identical fallback;
- an explicit colour still wins over it.

## Visual validation

Emulator `Pixel_7a`, the repro `chair.3mf` pushed through MediaStore and opened on `MainActivity` via `content://`.

| | before | after |
|---|---|---|
| clipped surface pixels | 435 / 480 | **0 / 480** |
| glow just outside the silhouette (RGB) | 24, 25, 2 | **0, 0, 0** |

Captures (local, not attachable from this run):
- `/tmp/3548-repro-before.png` — blown white, no edges, yellow halo
- `/tmp/3548-after-2.png` — shaded, halo gone, facets readable
- `/tmp/3548-studio.png` — same model on the Studio HDR: plainly neutral grey, which is the check that the material itself carries no cast

Under the viewer's *default* environment ("Chinese Garden") the chair keeps a warm tint. That is the HDR's own colour and it tints every model equally, the bundled helmet included — the albedo is now exactly neutral, as the Studio capture shows. Changing the viewer's default environment would be a separate product call, not this bug.

Fixes #3548

🤖 Generated with [Claude Code](https://claude.com/claude-code)