### PR TITLE
fix(ios-demo): hide the navigation bar through a cross-platform helper so the macOS archive compiles again (#3556)

### DIFF
--- a/changelog.d/3556-macos-demo-navigationbar.md
+++ b/changelog.d/3556-macos-demo-navigationbar.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+The demo app builds for macOS again: the iOS-only navigation bar calls that broke the App Store macOS archive since v4.33.0 now go through platform-guarded helpers (#3556).

--- a/samples/ios-demo/SceneViewDemo/Theme.swift
+++ b/samples/ios-demo/SceneViewDemo/Theme.swift
@@ -352,6 +352,18 @@ extension View {
         #endif
     }
 
+    /// Hides the navigation bar on iOS (`.toolbar(.hidden, for: .navigationBar)`);
+    /// a no-op on macOS, where `ToolbarPlacement.navigationBar` does not exist
+    /// and the call fails to compile (the v4.33.0 macOS archive, #3556).
+    @ViewBuilder
+    func hideNavigationBar() -> some View {
+        #if os(iOS)
+        self.toolbar(.hidden, for: .navigationBar)
+        #else
+        self
+        #endif
+    }
+
     /// Apply SceneView card styling
     func sceneViewCard() -> some View {
         self

--- a/samples/ios-demo/SceneViewDemo/Views/Components/DemoSheet.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Components/DemoSheet.swift
@@ -98,7 +98,7 @@ public struct DemoChromeModifier<Controls: View>: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .ignoresSafeArea()
-            .toolbar(.hidden, for: .navigationBar)
+            .hideNavigationBar()
             .overlay(alignment: .top) { identityRow }
             .overlay(alignment: .bottom) { dockView }
             .sheet(isPresented: $controlsPresented) {

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/DebugOverlayDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/DebugOverlayDemo.swift
@@ -53,7 +53,7 @@ struct DebugOverlayDemo: View {
         }
         .navigationTitle("Debug Overlay")
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleInline()
         #endif
         .onAppear  { fps.start() }
         .onDisappear { fps.stop() }

--- a/samples/ios-demo/SceneViewDemo/Views/Demos/OcclusionMaterialDemo.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Demos/OcclusionMaterialDemo.swift
@@ -39,7 +39,7 @@ struct OcclusionMaterialDemo: View {
         .onChange(of: showOccluder) { _, _ in applyOccluderMaterial() }
         .navigationTitle("Occlusion Material")
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleInline()
         #endif
     }
 

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ShowcaseTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ShowcaseTab.swift
@@ -96,7 +96,7 @@ struct ShowcaseTab: View {
             .overlay(alignment: .top) {
                 HomeHeader(scrolled: scrolled, query: $query, searchOpen: $searchOpen)
             }
-            .toolbar(.hidden, for: .navigationBar)
+            .hideNavigationBar()
             .navigationDestination(isPresented: $showExplore) {
                 ExploreTab(embedded: true)
             }


### PR DESCRIPTION
Closes #3556.

`.toolbar(.hidden, for: .navigationBar)` and `.navigationBarTitleDisplayMode(.inline)` are iOS-only; the macOS archive of app-store.yml has failed on every tag since v4.33.0. All four call sites now use the `#if os(iOS)`-guarded helpers in `Theme.swift`.

Verified locally: `xcodebuild build -scheme SceneViewDemo -destination generic/platform=macOS` on Xcode 26.3, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
