### PR TITLE
fix(release): dispatch the store workflows from tag-release.sh, and probe what is really live (#3557)

### DIFF
--- a/.claude/scripts/prod-status.sh
+++ b/.claude/scripts/prod-status.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# prod-status.sh — what is actually LIVE, surface by surface, versus VERSION_NAME.
+#
+# Read-only. Every line is measured on the public surface a user sees (the
+# Play page, the App Store page, repo1.maven.org, the npm registry, pub.dev,
+# the GitHub release list) — never on a workflow conclusion or a Play API
+# track status. Both lied for three months in 2026: play-store.yml reported
+# "success" on every tag from v4.20.0 to v4.33.0 while the public Play page
+# stayed on v4.18.0 (2026-06-06), because the release commit succeeded but
+# publication was held in the console (#3557).
+#
+# Usage:  bash .claude/scripts/prod-status.sh        # table, exit 1 if any lag
+#         bash .claude/scripts/prod-status.sh --json # machine-readable
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+EXPECTED=$(sed -n 's/^VERSION_NAME=//p' gradle.properties)
+JSON=${1:-}
+lag=0
+rows=()
+
+row() { # surface live extra
+  local surface=$1 live=$2 extra=${3:-}
+  local status="ok"
+  if [ "$live" != "$EXPECTED" ]; then status="LAG"; lag=1; fi
+  rows+=("$surface|$live|$status|$extra")
+}
+
+maven() { curl -sf "https://repo1.maven.org/maven2/io/github/sceneview/$1/maven-metadata.xml" \
+  | sed -n 's:.*<latest>\(.*\)</latest>.*:\1:p'; }
+for a in sceneview arsceneview sceneview-compose sceneview-core; do
+  row "maven:$a" "$(maven "$a" || echo none)"
+done
+
+npmv() { curl -sf "https://registry.npmjs.org/$1/latest" | python3 -c 'import sys,json;print(json.load(sys.stdin)["version"])' 2>/dev/null || echo none; }
+row "npm:sceneview-web" "$(npmv sceneview-web)"
+row "npm:@sceneview-sdk/react-native" "$(npmv @sceneview-sdk/react-native)"
+
+row "pub.dev:flutter_sceneview" "$(curl -sf https://pub.dev/api/packages/flutter_sceneview | python3 -c 'import sys,json;print(json.load(sys.stdin)["latest"]["version"])' 2>/dev/null || echo none)"
+
+row "github:release" "$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null | sed 's/^v//')"
+
+# Play: the public page. The version string Play serves is the release name of
+# the PUBLISHED production release — exactly the thing a visitor sees.
+PLAY=$(curl -sL "https://play.google.com/store/apps/details?id=io.github.sceneview.demo&hl=en&gl=US")
+play_ver=$(printf '%s' "$PLAY" | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?"' | head -1 | tr -d '"' | sed 's/-.*//')
+play_date=$(printf '%s' "$PLAY" | grep -oE 'Updated on.{0,80}' | sed 's/<[^>]*>/ /g; s/Updated on *//' | awk '{print $1,$2,$3}')
+row "play:io.github.sceneview.demo" "${play_ver:-none}" "updated ${play_date:-?}"
+
+# App Store: the public page (iOS + macOS share the listing).
+ASV=$(curl -sL "https://apps.apple.com/us/app/sceneview/id6761329763" | grep -oE 'Version [0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
+row "appstore:id6761329763" "${ASV:-none}"
+
+if [ "$JSON" = "--json" ]; then
+  printf '{"expected":"%s","surfaces":[' "$EXPECTED"
+  first=1
+  for r in "${rows[@]}"; do IFS='|' read -r s l st e <<<"$r"
+    [ $first = 1 ] || printf ','; first=0
+    printf '{"surface":"%s","live":"%s","status":"%s","note":"%s"}' "$s" "$l" "$st" "$e"
+  done
+  printf ']}\n'
+else
+  printf 'expected (gradle.properties VERSION_NAME): %s\n\n' "$EXPECTED"
+  printf '%-34s %-10s %-4s %s\n' SURFACE LIVE STATE NOTE
+  for r in "${rows[@]}"; do IFS='|' read -r s l st e <<<"$r"; printf '%-34s %-10s %-4s %s\n' "$s" "$l" "$st" "$e"; done
+fi
+exit $lag

--- a/.claude/scripts/tag-release.sh
+++ b/.claude/scripts/tag-release.sh
@@ -74,8 +74,16 @@ if ! git push origin "v$V"; then
   exit 1
 fi
 
-echo "Tagged v$V — dispatching release.yml on the tag ref."
-# The tag was pushed with GITHUB_TOKEN, so release.yml's `on: push: tags:`
-# trigger will NOT fire (same suppression as above). release.yml accepts
-# workflow_dispatch, and running it on the tag ref is equivalent.
+echo "Tagged v$V — dispatching release.yml, play-store.yml and app-store.yml on the tag ref."
+# The tag was pushed with GITHUB_TOKEN, so the `on: push: tags:` trigger of
+# release.yml, play-store.yml and app-store.yml will NOT fire (same suppression
+# as above). All three accept workflow_dispatch; running them on the tag ref with
+# the inputs below is equivalent to the tag-push path.
+#
+# Until 2026-09-09 only release.yml was dispatched here: v4.32.0 and v4.34.0
+# reached Maven Central and pub.dev but never went to Play production nor to
+# App Store review, and nobody noticed because the store workflows simply had
+# no run to fail (#3557).
 gh workflow run release.yml --ref "v$V"
+gh workflow run play-store.yml --ref "v$V" -f track=auto
+gh workflow run app-store.yml --ref "v$V" -f submit_for_review=true

--- a/changelog.d/3557-release-dispatch-stores.md
+++ b/changelog.d/3557-release-dispatch-stores.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+Release-fast releases now reach the stores: `tag-release.sh` dispatches play-store.yml and app-store.yml alongside release.yml, and a read-only `prod-status.sh` probe reports what is actually live on every public surface versus `VERSION_NAME` (#3557).


### PR DESCRIPTION
Closes #3557.

- `tag-release.sh` now dispatches `play-store.yml` (track=auto) and `app-store.yml` (submit_for_review=true) after `release.yml`. Same inputs as the tag-push path that GITHUB_TOKEN tags never trigger.
- New read-only `.claude/scripts/prod-status.sh`: one table, one line per public surface, exit 1 on any lag. Today's output:

```
expected (gradle.properties VERSION_NAME): 4.34.0

SURFACE                            LIVE       STATE NOTE
maven:sceneview                    4.34.0     ok   
maven:arsceneview                  4.34.0     ok   
maven:sceneview-compose            4.34.0     ok   
maven:sceneview-core               4.34.0     ok   
npm:sceneview-web                  4.31.0     LAG  
npm:@sceneview-sdk/react-native    4.31.0     LAG  
pub.dev:flutter_sceneview          4.34.0     ok   
github:release                     4.34.0     ok   
play:io.github.sceneview.demo      4.18.0     LAG  updated Jun 6, 2026
appstore:id6761329763              4.33.0     LAG  
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)