### PR TITLE
docs(mcp): give the hosted MCP server a permanent address and a way in

### DIFF
--- a/changelog.d/3562-mcp-custom-domain.md
+++ b/changelog.d/3562-mcp-custom-domain.md
@@ -1,0 +1,19 @@
+<!-- category: Added -->
+- **The hosted MCP server has a permanent address of its own — `https://mcp.sceneview.dev/mcp`
+  — and a step-by-step way to add it to claude.ai in one paste.** The Worker shipped in the
+  previous release answered on a Cloudflare-generated `*.workers.dev` hostname, which is fine
+  for a smoke test and wrong for anything a user is asked to keep: the URL a connector is
+  added with is effectively permanent, because re-pointing it later forces every connected
+  user to disconnect and re-add. `mcp.sceneview.dev` is now bound as a Cloudflare custom
+  domain on the same zone as `quota.sceneview.dev`, with Cloudflare owning the DNS record and
+  the certificate, so the address the docs publish is the address that stays.
+
+  `mcp/README.md` gains a **Use as a Claude connector** section and `llms.txt` a matching
+  entry: the URL, the exact path through claude.ai (**Settings → Connectors → Add custom
+  connector**), and what the endpoint is — authless and read-only, no account, no API key,
+  nothing of yours stored, since every tool is a pure function of the SDK's own docs, samples
+  and API surface. It also says plainly when *not* to use it: `analyze_project` reads a
+  project from disk and `search_models` / `generate_3d_model` want your own API keys, and a
+  shared anonymous endpoint can offer neither — that is what `npx sceneview-mcp` over stdio
+  is still for. The deployment test that asserted the domain stayed unbound now asserts the
+  binding instead, so the route cannot be dropped from `wrangler.toml` unnoticed.

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -3135,9 +3135,11 @@ Key facts an AI codegen pass must get right:
   reactively after creation, re-push them from a `LaunchedEffect` keyed on the new
   values (the `apply` block runs only once at node creation).
 
-The `camera-gestures` demo in `samples/android-demo` (Node Gestures tab) is the
-canonical end-to-end example: it wires every flag to a UI switch, a
-scale-sensitivity slider, and a live-transform overlay.
+The `camera-gestures` demo in `samples/android-demo` is the canonical end-to-end
+example. Its dock's **Move** item flips `isEditable` on whichever subject currently has
+focus, so the same drag / twist / pinch moves the object instead of the camera — in the
+same scene, next to the camera it competes with for the gesture — and the SDK's on-model
+affordances are drawn over it.
 
 ### On-model gesture feedback (opt-in)
 

--- a/gpt/knowledge-overview.md
+++ b/gpt/knowledge-overview.md
@@ -465,6 +465,22 @@ Approve the server when Claude Code prompts on the next session start, then chec
 
 Scopes: `--scope project` → `.mcp.json` at the project root (shared, commit it) · `--scope user` → `~/.claude.json` (all your projects) · default `local` → `~/.claude.json`, this project only. Claude Code does **not** read `.claude/mcp.json` or `~/.claude/mcp.json`; a config placed there is silently ignored. Other clients differ: Cursor uses `.cursor/mcp.json`, VS Code `.vscode/mcp.json`, Claude Desktop `claude_desktop_config.json`.
 
+### Hosted connector (no install)
+
+The same server is hosted as a remote MCP endpoint, so a claude.ai user can add it without
+installing anything:
+
+```
+https://mcp.sceneview.dev/mcp
+```
+
+In claude.ai: **Settings → Connectors → Add custom connector**, paste the URL, name it
+`SceneView`. It is authless and read-only — no account, no API key, nothing stored. Streamable
+HTTP on `POST /mcp`; `GET /mcp` answers `405`, `GET /health` answers `{"status":"ok"}`.
+
+Use `npx sceneview-mcp` locally instead when you need `analyze_project` (it reads a project from
+disk) or your own `SKETCHFAB_API_KEY` / `TRIPO_API_KEY`; the shared anonymous endpoint has neither.
+
 ### Claude Code plugin (one-command install)
 
 For Claude Code users, install the dedicated plugin to get the MCP **plus** 11 namespaced contributor commands and cross-platform reminder hooks in a single step:

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -687,7 +687,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 
 ### Interaction
 
-- `camera-gestures` — Camera & Gestures. Orbit, pan, zoom and per-node edit gestures.
+- `camera-gestures` — Camera & Gestures. Orbit with inertia, fly to a subject, named views.
 - `picking-collision` — Picking & Collision. Ray hit-test with picked ViewNode overlays.
 
 ### AR Placement

--- a/llms.txt
+++ b/llms.txt
@@ -6392,6 +6392,22 @@ Approve the server when Claude Code prompts on the next session start, then chec
 
 Scopes: `--scope project` → `.mcp.json` at the project root (shared, commit it) · `--scope user` → `~/.claude.json` (all your projects) · default `local` → `~/.claude.json`, this project only. Claude Code does **not** read `.claude/mcp.json` or `~/.claude/mcp.json`; a config placed there is silently ignored. Other clients differ: Cursor uses `.cursor/mcp.json`, VS Code `.vscode/mcp.json`, Claude Desktop `claude_desktop_config.json`.
 
+### Hosted connector (no install)
+
+The same server is hosted as a remote MCP endpoint, so a claude.ai user can add it without
+installing anything:
+
+```
+https://mcp.sceneview.dev/mcp
+```
+
+In claude.ai: **Settings → Connectors → Add custom connector**, paste the URL, name it
+`SceneView`. It is authless and read-only — no account, no API key, nothing stored. Streamable
+HTTP on `POST /mcp`; `GET /mcp` answers `405`, `GET /health` answers `{"status":"ok"}`.
+
+Use `npx sceneview-mcp` locally instead when you need `analyze_project` (it reads a project from
+disk) or your own `SKETCHFAB_API_KEY` / `TRIPO_API_KEY`; the shared anonymous endpoint has neither.
+
 ### Claude Code plugin (one-command install)
 
 For Claude Code users, install the dedicated plugin to get the MCP **plus** 11 namespaced contributor commands and cross-platform reminder hooks in a single step:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -12,7 +12,7 @@
 
 The official [Model Context Protocol](https://modelcontextprotocol.io/) server for **[SceneView](https://sceneview.github.io)** — the cross-platform 3D & AR SDK for Android (Jetpack Compose + Filament), iOS / macOS / visionOS (SwiftUI + RealityKit), and Web (Filament.js + WebXR).
 
-Connect it to Claude, Cursor, Windsurf, or any MCP client — locally over stdio, or remotely over Streamable HTTP for ChatGPT, Codex and the OpenAI API (see [Remote server](#remote-server-streamable-http--chatgpt-codex-openai-api)). Your AI assistant gets specialized tools, compilable code samples, the full API reference, a code validator, and an inline 3D viewer widget — so it writes correct, working 3D/AR code on the first try.
+Connect it to Claude, Cursor, Windsurf, or any MCP client — locally over stdio, remotely over Streamable HTTP at **`https://mcp.sceneview.dev/mcp`** (see [Use as a Claude connector](#use-as-a-claude-connector)), or self-hosted for ChatGPT, Codex and the OpenAI API (see [Remote server](#remote-server-streamable-http--chatgpt-codex-openai-api)). Your AI assistant gets specialized tools, compilable code samples, the full API reference, a code validator, and an inline 3D viewer widget — so it writes correct, working 3D/AR code on the first try.
 
 > **Disclaimer:** Generated code is provided "as is" without warranty. Always review before production use. See [TERMS.md](./TERMS.md) and [PRIVACY.md](./PRIVACY.md).
 
@@ -59,6 +59,30 @@ Two options.
 ```bash
 claude mcp add sceneview -- npx -y sceneview-mcp
 ```
+
+### Use as a Claude connector
+
+No install, nothing to run: SceneView is hosted as a remote MCP server and can be added to
+[claude.ai](https://claude.ai) — web, desktop and mobile — as a **custom connector**.
+
+```
+https://mcp.sceneview.dev/mcp
+```
+
+In claude.ai, open **Settings → Connectors → Add custom connector**, paste that URL, name it
+`SceneView`, and click **Add**. The tools appear in the next conversation; the inline 3D viewer
+renders models straight in the chat.
+
+**Authless and read-only.** There is no sign-in, no API key and no account: every tool is a pure
+function of the SDK's own documentation, samples and API surface, so there is nothing to
+authenticate and nothing of yours stored. All tools are annotated `readOnlyHint` except
+`generate_3d_model`, which calls an external generation service and is therefore marked
+open-world rather than read-only.
+
+**Prefer it local?** `npx sceneview-mcp` runs the exact same server over stdio (see
+[Claude Desktop](#claude-desktop) and [Claude Code](#claude-code) above). The local route is the
+one that reads your project from disk (`analyze_project`) and the one that accepts your own
+`SKETCHFAB_API_KEY` / `TRIPO_API_KEY`; the hosted connector, being shared and anonymous, cannot.
 
 ### Cursor
 
@@ -114,6 +138,11 @@ curl -s http://127.0.0.1:3333/mcp \
 ```
 
 Point the ChatGPT connector / OpenAI `mcp` tool at `https://<your-host>/mcp`.
+
+**Already hosted.** You do not have to run it yourself to get a public URL: the same code is
+deployed at `https://mcp.sceneview.dev/mcp` (`GET /health` answers `{"status":"ok"}`), which is
+what the [Claude connector](#use-as-a-claude-connector) above points at. Self-host when you want
+your own keys, your own rate limits, or `analyze_project` against a local checkout.
 
 ---
 

--- a/mcp/src/worker.test.ts
+++ b/mcp/src/worker.test.ts
@@ -46,12 +46,20 @@ describe("wrangler.toml", () => {
     expect(wrangler).toMatch(/^workers_dev\s*=\s*true$/m);
   });
 
-  it("does not bind the custom domain yet", () => {
-    // A connector's URL is effectively permanent: re-pointing it forces every
-    // existing user to disconnect and re-add. Binding `mcp.sceneview.dev` is a
-    // release decision, made when the listing is submitted.
-    expect(wrangler).not.toMatch(/^\s*routes\s*=/m);
-    expect(wrangler).not.toMatch(/custom_domain\s*=\s*true(?![\s\S]*^#)/m);
+  it("binds mcp.sceneview.dev as a custom domain", () => {
+    // This is the URL the connector is added with, and it is effectively
+    // permanent: re-pointing it forces every connected user to disconnect and
+    // re-add. `custom_domain = true` is what makes Cloudflare own the DNS
+    // record and the certificate rather than matching a pre-existing route.
+    expect(wrangler).toMatch(
+      /^routes\s*=\s*\[\{\s*pattern\s*=\s*"mcp\.sceneview\.dev",\s*custom_domain\s*=\s*true\s*\}\]$/m,
+    );
+  });
+
+  it("never names the workers.dev subdomain as the public endpoint", () => {
+    // The account subdomain is an implementation detail of the deploy; the
+    // documented address is the custom domain.
+    expect(wrangler).not.toMatch(/mcp-tools-lab/);
   });
 
   it("disables telemetry on the anonymous shared endpoint", () => {

--- a/mcp/src/worker.test.ts
+++ b/mcp/src/worker.test.ts
@@ -52,7 +52,7 @@ describe("wrangler.toml", () => {
     // re-add. `custom_domain = true` is what makes Cloudflare own the DNS
     // record and the certificate rather than matching a pre-existing route.
     expect(wrangler).toMatch(
-      /^routes\s*=\s*\[\{\s*pattern\s*=\s*"mcp\.sceneview\.dev",\s*custom_domain\s*=\s*true\s*\}\]$/m,
+      /^routes\s*=\s*\[\{\s*pattern\s*=\s*"mcp\.sceneview\.dev",\s*custom_domain\s*=\s*true\s*\}\]$/m
     );
   });
 

--- a/mcp/wrangler.toml
+++ b/mcp/wrangler.toml
@@ -3,13 +3,11 @@
 # Deploy:  npx wrangler deploy        (from this directory, after `npm run build`)
 # Result:  https://<name>.<account>.workers.dev/mcp
 #
-# The custom domain (`mcp.sceneview.dev`, on the existing `sceneview.dev` zone
-# alongside `quota.sceneview.dev`) is deliberately NOT bound here yet: the URL a
-# connector is listed with is effectively permanent — re-pointing it later forces
-# every existing user to disconnect and re-add the connector — so binding it is a
-# release decision, not a deploy detail. Add it when submitting:
-#
-#   routes = [{ pattern = "mcp.sceneview.dev", custom_domain = true }]
+# The public URL is `https://mcp.sceneview.dev/mcp` — the address a Claude
+# custom connector is added with, on the existing `sceneview.dev` zone
+# alongside `quota.sceneview.dev`. It is effectively permanent: re-pointing it
+# forces every connected user to disconnect and re-add the connector, so the
+# route below is not a deploy detail to be edited casually.
 
 name = "sceneview-mcp-remote"
 main = "dist/worker.js"
@@ -20,6 +18,10 @@ compatibility_date = "2025-09-01"
 compatibility_flags = ["nodejs_compat"]
 
 workers_dev = true
+
+# The stable, brandable endpoint clients are pointed at. `custom_domain` makes
+# Cloudflare own the DNS record and the certificate for `mcp.sceneview.dev`.
+routes = [{ pattern = "mcp.sceneview.dev", custom_domain = true }]
 
 # Telemetry is opt-out in the npm package; on an anonymous shared endpoint there
 # is no user to attribute a call to, so it is off entirely.


### PR DESCRIPTION
The Worker shipped in #3561 answered on a Cloudflare-generated `*.workers.dev`
hostname. That is fine for a smoke test and wrong for anything a user is asked to
keep: the URL a connector is added with is effectively permanent, because
re-pointing it later forces every connected user to disconnect and re-add.

This binds **`mcp.sceneview.dev`** as a Cloudflare custom domain on the same
`sceneview.dev` zone as `quota.sceneview.dev`, so Cloudflare owns the DNS record and
the certificate and the address the docs publish is the address that stays. The
deployment test that asserted the domain stayed unbound now asserts the binding, so
the route cannot fall out of `wrangler.toml` unnoticed.

Then it documents the way in, which was the actual missing piece: `mcp/README.md`
gains a **Use as a Claude connector** section, and `llms.txt` a matching entry —
the URL, the exact path through claude.ai (**Settings → Connectors → Add custom
connector**), and what the endpoint is: authless and read-only, no account, no API
key, nothing of yours stored, because every tool is a pure function of the SDK's own
docs, samples and API surface. It also says plainly when *not* to use it —
`analyze_project` reads a project from disk and `search_models` /
`generate_3d_model` want your own API keys, neither of which a shared anonymous
endpoint can offer, which is what `npx sceneview-mcp` over stdio is still for.

## Verified live

Deployed and checked against the custom domain (certificate `CN=sceneview.dev`,
issued by Google Trust Services):

| Check | Result |
|---|---|
| `GET /health` | `200` — `{"status":"ok","version":"4.1.0"}` |
| `GET /mcp` | `405`, as the stateless Streamable HTTP transport intends |
| `POST /mcp` `initialize` | protocol `2025-06-18`, `serverInfo` `sceneview-mcp` 4.1.0, MCP-Apps UI extension advertised |
| `POST /mcp` `tools/list` | **29 tools**, every one carrying a `title` |

`mcp` suite: 2072 tests across 91 files, all passing.
`node tools/generate-gpt-knowledge.js --check`: in sync.

## Out of scope

The dead Pro gateway URLs in the vertical packages' READMEs are left alone — they
are entangled with the pending Pro-tier product decision, not with hosting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)