### PR TITLE
fix(ar): show the Augmented Faces mesh, and light it (#3575, #3576)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -149,6 +149,27 @@ open class AugmentedFaceNode(
     private var constructed = false
 
     init {
+        // #3575 — a front-camera session NEVER reports a tracking device camera.
+        //
+        // `Session.Feature.FRONT_CAMERA` documents that, for the whole life of the session,
+        // `Camera.getTrackingState()` always returns `TrackingState.PAUSED` (and
+        // `Camera.getDisplayOrientedPose()` always returns identity, and every `Frame.hitTest()`
+        // returns an empty list). Augmented Faces is front-camera only, so that PAUSED verdict is
+        // the *normal* state here, not a failure.
+        //
+        // `PoseNode` hides any node whose `cameraTrackingState` is not in
+        // `visibleCameraTrackingStates`, and the inherited default is `{TRACKING}`. The face mesh
+        // is built inside this constructor, while the field still holds its `TRACKING` initial
+        // value — so it rendered for one or two frames and then `update(session, frame)` wrote
+        // PAUSED into it and hid the whole subtree (`Node.isVisible` walks the parent chain, so
+        // `centerNode` and the mesh go with it) for the rest of the session. The demo's banner
+        // still said "Tracking 1 face(s)" the whole time, because ARCore's detection was never
+        // the problem: only the SDK's own visibility gate was.
+        //
+        // Opting this node out of the camera-tracking gate is the fix. The face's OWN tracking
+        // state is still honoured through `TrackableNode.visibleTrackingStates` (`{TRACKING}`),
+        // which is the state that actually means "there is a face here".
+        visibleCameraTrackingStates = kFaceVisibleCameraTrackingStates
         trackable = augmentedFace
         constructed = true
         // Apply the initial state that the gated update() skipped during the constructor dispatch.
@@ -410,6 +431,21 @@ open class AugmentedFaceNode(
         super.destroy()
     }
 }
+
+/**
+ * Every [TrackingState] — the set [AugmentedFaceNode] uses for `visibleCameraTrackingStates`.
+ *
+ * Augmented Faces only runs on a `Session.Feature.FRONT_CAMERA` session, and ARCore documents
+ * that such a session never tracks the device pose: `Camera.getTrackingState()` always returns
+ * [TrackingState.PAUSED]. Gating face-mesh visibility on the *camera's* tracking state — the
+ * `PoseNode` default of `{TRACKING}` — therefore hides the mesh permanently (#3575). The face's
+ * own tracking state remains gated by `TrackableNode.visibleTrackingStates`.
+ *
+ * Top-level and `internal` so the contract can be asserted on the JVM, where neither an ARCore
+ * `AugmentedFace` nor a Filament `Engine` can be instantiated.
+ */
+internal val kFaceVisibleCameraTrackingStates: Set<TrackingState> =
+    TrackingState.values().toSet()
 
 /**
  * Pure logic for [AugmentedFaceNode]'s identity-tangent buffer cache (#1758).

--- a/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt
@@ -158,7 +158,7 @@ open class AugmentedFaceNode(
         // the *normal* state here, not a failure.
         //
         // `PoseNode` hides any node whose `cameraTrackingState` is not in
-        // `visibleCameraTrackingStates`, and the inherited default is `{TRACKING}`. The face mesh
+        // `visibleCameraTrackingStates`, and the inherited default is TRACKING-only. The face mesh
         // is built inside this constructor, while the field still holds its `TRACKING` initial
         // value — so it rendered for one or two frames and then `update(session, frame)` wrote
         // PAUSED into it and hid the whole subtree (`Node.isVisible` walks the parent chain, so
@@ -167,8 +167,11 @@ open class AugmentedFaceNode(
         // the problem: only the SDK's own visibility gate was.
         //
         // Opting this node out of the camera-tracking gate is the fix. The face's OWN tracking
-        // state is still honoured through `TrackableNode.visibleTrackingStates` (`{TRACKING}`),
-        // which is the state that actually means "there is a face here".
+        // state is still honoured through `TrackableNode.visibleTrackingStates`, which stays
+        // TRACKING-only and is the state that actually means "there is a face here".
+        //
+        // Keep this comment free of curly braces: TrackableNodeConstructionGuardContractTest
+        // reads the init body up to the first closing brace it finds in the source.
         visibleCameraTrackingStates = kFaceVisibleCameraTrackingStates
         trackable = augmentedFace
         constructed = true

--- a/arsceneview/src/test/java/io/github/sceneview/ar/node/AugmentedFaceCameraTrackingVisibilityTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/node/AugmentedFaceCameraTrackingVisibilityTest.kt
@@ -1,0 +1,89 @@
+package io.github.sceneview.ar.node
+
+import com.google.ar.core.TrackingState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression contract for #3575 — the Augmented Faces mesh was hidden one frame after it was
+ * built, on every device, for the whole life of the demo.
+ *
+ * ARCore documents that a `Session.Feature.FRONT_CAMERA` session — the only kind Augmented Faces
+ * runs on — never tracks the device pose: `Camera.getTrackingState()` **always** returns
+ * [TrackingState.PAUSED], `Camera.getDisplayOrientedPose()` always returns identity, and every
+ * `Frame.hitTest()` returns an empty list.
+ *
+ * `PoseNode` hides any node whose `cameraTrackingState` is outside `visibleCameraTrackingStates`,
+ * and that set defaults to `{TRACKING}`. `AugmentedFaceNode` builds its mesh inside its own
+ * constructor, while the field still holds its `TRACKING` initial value, and then writes the
+ * frame's camera tracking state into it on the first `update(session, frame)` — so the mesh was
+ * visible for one or two frames and invisible for the rest of the session, while the demo banner
+ * kept truthfully reporting "Tracking 1 face(s)".
+ *
+ * Neither leg of that runtime path can execute on the JVM (ARCore's `AugmentedFace` and Filament's
+ * `Engine` are both device-bound), so the fix is pinned two ways: the value of the opt-out set,
+ * and its assignment in `init` **before** `trackable` is assigned — the point at which the mesh is
+ * built.
+ */
+class AugmentedFaceCameraTrackingVisibilityTest {
+
+    // JVM tests run with the module directory as CWD.
+    private val source =
+        File("src/main/java/io/github/sceneview/ar/node/AugmentedFaceNode.kt").readText()
+
+    @Test
+    fun `the opt-out set covers every tracking state, PAUSED included`() {
+        assertEquals(
+            "A front-camera session reports PAUSED for the device camera forever, so the face " +
+                "mesh must not be gated on the camera's tracking state at all.",
+            TrackingState.values().toSet(),
+            kFaceVisibleCameraTrackingStates
+        )
+        assertTrue(
+            "PAUSED is the state ARCore actually reports on a front-camera session — it is the " +
+                "one membership this whole fix exists for.",
+            TrackingState.PAUSED in kFaceVisibleCameraTrackingStates
+        )
+    }
+
+    @Test
+    fun `AugmentedFaceNode opts out of the camera-tracking visibility gate`() {
+        assertTrue(
+            "AugmentedFaceNode must assign `visibleCameraTrackingStates = " +
+                "kFaceVisibleCameraTrackingStates` (#3575).",
+            source.contains("visibleCameraTrackingStates = kFaceVisibleCameraTrackingStates")
+        )
+    }
+
+    @Test
+    fun `the opt-out is applied before the mesh is built`() {
+        // Anchored at the start of a line, so the prose that names either assignment in a
+        // comment cannot stand in for the assignment itself.
+        val optOutIdx = Regex(
+            """^\s*visibleCameraTrackingStates = kFaceVisibleCameraTrackingStates""",
+            RegexOption.MULTILINE
+        ).find(source)?.range?.first ?: -1
+        val trackableIdx = Regex("""^\s*trackable = augmentedFace""", RegexOption.MULTILINE)
+            .find(source)?.range?.first ?: -1
+        assertTrue("Expected the visibility opt-out in the source.", optOutIdx >= 0)
+        assertTrue("Expected `trackable = augmentedFace` in the init block.", trackableIdx >= 0)
+        assertTrue(
+            "The opt-out must run BEFORE `trackable = augmentedFace`: that assignment is what " +
+                "dispatches update() and builds the face mesh, and a mesh built while the gate " +
+                "still reads {TRACKING} is a mesh that Filament is told to show and then hide.",
+            optOutIdx < trackableIdx
+        )
+    }
+
+    @Test
+    fun `the face's own tracking state is still what gates the mesh`() {
+        assertTrue(
+            "Opting out of the CAMERA gate must not opt out of the FACE gate — " +
+                "TrackableNode.visibleTrackingStates stays at its {TRACKING} default, which is " +
+                "the state that actually means \"there is a face here\".",
+            !source.contains("visibleTrackingStates =")
+        )
+    }
+}

--- a/changelog.d/3575-augmented-faces-mesh-visible-and-lit.md
+++ b/changelog.d/3575-augmented-faces-mesh-visible-and-lit.md
@@ -1,0 +1,24 @@
+<!-- category: Fixed -->
+- **The Augmented Faces mesh is visible again, and it is lit
+  ([#3575](https://github.com/sceneview/sceneview/issues/3575),
+  [#3576](https://github.com/sceneview/sceneview/issues/3576)).** Face detection was never
+  broken — the demo banner truthfully read "Tracking 1 face(s)" while the screen showed
+  nothing. Augmented Faces only runs on a `Session.Feature.FRONT_CAMERA` session, and ARCore
+  documents that such a session never tracks the device pose: `Camera.getTrackingState()`
+  always returns `PAUSED`. `PoseNode` hides any node whose camera tracking state falls
+  outside `visibleCameraTrackingStates`, which defaults to `{TRACKING}`. `AugmentedFaceNode`
+  builds its mesh inside its own constructor, while that field still holds its initial
+  value, so the mesh appeared for a frame or two and was then hidden — with its children —
+  for the rest of the session. `AugmentedFaceNode` now opts out of the *camera* gate
+  entirely; the face's own `TrackingState`, which is the one that actually means "there is a
+  face here", still gates the mesh.
+  With the mesh back on screen, its shading was the second half of the report: the demo
+  painted it with an **unlit** flat colour and `computeTangents = false`, one uniform blue
+  with no highlight and no falloff — a filter, not a fitted mesh. ARCore force-disables
+  light estimation on a front-camera session, which is why the demo had drifted to unlit,
+  but "no estimate" argues for a deterministic rig rather than for no shading. The face is
+  now a lit PBR material with per-frame tangent quaternions, and the demo installs its own
+  key and fill lights instead of inheriting the SDK's straight-down `(0, -1, 0)` default —
+  the overhead angle that buries the eyes, the base of the nose and the mouth. A
+  front-camera session pins world space to the device, so a fixed direction out of the
+  screen is a stable, camera-anchored portrait key light.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/SceneViewColors.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/SceneViewColors.kt
@@ -56,6 +56,17 @@ object SceneViewColors {
     val PrimaryOverlay = Primary.copy(alpha = 0.4f)
 
     /**
+     * Face-mesh overlay tint — [Primary] at alpha 0.55.
+     *
+     * Sits between [PrimaryOverlay] (0.4) and opaque: the ARCore face mesh is worn on a live
+     * selfie preview that is often backlit and dark, and at 0.4 a *lit* mesh's specular sweep —
+     * the cue that says "fitted 3D topology" rather than "blue filter" — washed out against it.
+     * 0.55 keeps the real face readable underneath while giving the shading something to sit on
+     * (#3576).
+     */
+    val FaceMeshOverlay = Primary.copy(alpha = 0.55f)
+
+    /**
      * Semi-transparent Accent — secondary AR overlay tint for callouts / highlighted
      * geometry, kept distinct from [PrimaryOverlay] so stacked passes remain readable.
      */

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt
@@ -28,19 +28,23 @@ import io.github.sceneview.demo.SceneViewColors
 import io.github.sceneview.demo.common.DemoStatusBanner
 import io.github.sceneview.demo.common.DemoStatusTone
 import io.github.sceneview.demo.rememberArPlaybackDataset
+import io.github.sceneview.math.Direction
 import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberFillLightNode
+import io.github.sceneview.rememberMainLightNode
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
-import io.github.sceneview.sample.rememberUnlitMaterialInstance
+import io.github.sceneview.sample.rememberMaterialInstance
 import kotlinx.coroutines.delay
 
 /**
  * Augmented face mesh tracking demo.
  *
  * Configures the AR session with the front camera and [Config.AugmentedFaceMode.MESH3D] to
- * detect face meshes. When a face is detected, an [AugmentedFaceNode] renders a translucent
- * unlit-blue mesh overlay on the user's face — alpha 0.4 so the user's actual facial features
- * remain visible underneath the fitted topology.
+ * detect face meshes. When a face is detected, an [AugmentedFaceNode] renders a translucent,
+ * **lit** mesh overlay on the user's face — semi-transparent so the real face stays visible
+ * underneath the fitted topology, and shaded by a fixed key + fill rig so the topology reads as
+ * a 3D surface instead of a flat sticker (#3576).
  *
  * Augmented Faces needs **two** session settings, not one: `sessionFeatures` must include
  * [Session.Feature.FRONT_CAMERA] *and* `sessionCameraConfig` must select a FRONT-facing
@@ -81,22 +85,24 @@ fun ARFaceDemo(onBack: () -> Unit) {
     // the real onSessionFailed callback so it gets a distinct, honest message.
     var sessionFailed by remember { mutableStateOf(false) }
 
-    // Unlit translucent overlay for the face mesh. ARCore disables `ENVIRONMENTAL_HDR`
-    // light estimation when the front camera is in use, so any lit material falls
-    // back to whatever neutral IBL is in scope — which historically rendered the
-    // mesh near-invisible even after the tangent-quaternion fix in `35e5990d`.
+    // Lit translucent overlay for the face mesh (#3576).
     //
-    // `createUnlitColorInstance` ships the mesh's flat colour in a single fragment
-    // pass (no PBR shading, no IBL dependency), so the overlay reads as a clean
-    // SceneView-blue tone regardless of front-camera lighting. No fill light needed —
-    // the previous explicit 100 000 lux directional was a workaround for the lit
-    // material that's now obsolete.
+    // ARCore force-disables light estimation on a front-camera session (see the front-camera
+    // guard in `ARSession.configure`), so there is no estimate to react to — but that is an
+    // argument for a *deterministic* rig, not for no shading at all. The previous unlit flat
+    // colour painted the whole face one uniform blue: no highlight, no falloff, no silhouette,
+    // so nothing on screen said "this is a mesh fitted to your face" rather than "a blue filter".
     //
-    // [SceneViewColors.PrimaryOverlay] (alpha 0.4) routes through `transparent_unlit_colored.mat`
-    // which is `doubleSided: true` — pairs with `culling(false)` on the face mesh.
-    // We use a translucent overlay (not opaque blue) so the user can SEE their face
-    // through the fitted topology — that's the entire point of a face-mesh demo.
-    val faceMaterial = rememberUnlitMaterialInstance(materialLoader, SceneViewColors.PrimaryOverlay)
+    // A lit PBR instance shades the mesh with the key + fill rig installed below. Roughness is
+    // low enough for a visible specular sweep across the cheekbones and the bridge of the nose —
+    // that highlight is the depth cue the flat colour lacked — and the alpha keeps the real face
+    // readable underneath, which is the entire point of a face-mesh demo.
+    val faceMaterial = rememberMaterialInstance(
+        materialLoader,
+        SceneViewColors.FaceMeshOverlay,
+        metallic = 0.0f,
+        roughness = 0.35f,
+    )
 
     // Slow-front-camera hint. Anchored on the session RESUME (not composition) and
     // non-latching: it resets on every (re)launch and only trips if, a full
@@ -161,6 +167,28 @@ fun ARFaceDemo(onBack: () -> Unit) {
                 materialLoader = materialLoader,
                 playbackDataset = arPlaybackDataset,
                 planeRenderer = false,
+                // Selfie lighting rig (#3576). A front-camera session never tracks the device
+                // pose — ARCore documents `Camera.getDisplayOrientedPose()` as always identity —
+                // so the world frame is pinned to the phone: -Z points straight out of the screen
+                // at the user's face, +Y is up. That makes a FIXED direction a perfectly stable,
+                // camera-anchored light, which is exactly what a portrait wants and what the SDK
+                // defaults do NOT give: `DefaultLightNode` points straight down (0, -1, 0), the
+                // classic overhead angle that buries the eyes, the nose base and the mouth in
+                // shadow — the "lighting is not good at all" report of #3576.
+                //
+                // Key light: slightly above and in front, aimed back into the face. Fill: from
+                // the other side and a little below, at ~40% intensity, to open the shadow side
+                // without flattening the relief. Intensities stay in the same lux ballpark as the
+                // AR defaults (10 000 / 3 000) so the mesh sits at the same exposure as every
+                // other AR demo.
+                mainLightNode = rememberMainLightNode(engine) {
+                    lightDirection = Direction(x = 0.0f, y = -0.35f, z = -1.0f)
+                    intensity = 9_000.0f
+                },
+                fillLightNode = rememberFillLightNode(engine) {
+                    lightDirection = Direction(x = -0.6f, y = 0.25f, z = -1.0f)
+                    intensity = 3_500.0f
+                },
                 sessionFeatures = setOf(Session.Feature.FRONT_CAMERA),
                 // CRITICAL for Augmented Faces (#1436). `sessionFeatures = FRONT_CAMERA`
                 // only makes the front camera *eligible* — it does NOT switch the camera.
@@ -186,11 +214,10 @@ fun ARFaceDemo(onBack: () -> Unit) {
                 // exposure realignment after #1067 + #1088.
                 //
                 // ARSession force-DISABLES light estimation for front-camera sessions
-                // (see the front-camera guard in `ARSession.configure`), so the new
-                // `ARDefaultCameraNode` defaults
-                // (f/12, 1/200 s, ISO 200 ≈ EV 11.6) + 10k+3k lux main/fill lights
-                // give a correctly exposed selfie preview on Pixel 9 without any
-                // per-demo override. If the preview ever shows up over-bright again on
+                // (see the front-camera guard in `ARSession.configure`), so the
+                // `ARDefaultCameraNode` defaults (f/12, 1/200 s, ISO 200 ≈ EV 11.6)
+                // plus the fixed key/fill rig declared above give a correctly exposed
+                // selfie preview on Pixel 9 without any per-demo exposure override. If the preview ever shows up over-bright again on
                 // a new device, fix via a per-facing AE strategy in `arsceneview/`
                 // (e.g. front-camera-specific `ARDefaultCameraNode`), not a per-demo
                 // linear-gain hack.
@@ -219,17 +246,15 @@ fun ARFaceDemo(onBack: () -> Unit) {
                     faceCount = detectedFaces.size
                 }
             ) {
-                // Unlit material — no fill light needed. The previous 100 000-lux
-                // directional was a workaround for the lit-PBR material's IBL
-                // dependency; the unlit path renders the mesh's flat colour
-                // straight to the framebuffer regardless of scene lighting.
                 detectedFaces.forEach { face ->
                     AugmentedFaceNode(
                         augmentedFace = face,
                         meshMaterialInstance = faceMaterial,
-                        // Unlit material → no PBR sampling of TANGENTS, so skip the
-                        // per-frame Mikkelsen compute + JNI upload (#878).
-                        computeTangents = false,
+                        // The material is lit again (#3576), so the per-vertex tangent
+                        // quaternions PBR samples have to be rebuilt on every frame the mesh
+                        // deforms. `computeTangents = false` is the unlit-only shortcut (#878)
+                        // and would leave the shading undefined here.
+                        computeTangents = true,
                         onTrackingStateChanged = { state ->
                             // Face tracking state changed
                         }

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARFaceDemoLightingContractTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/ARFaceDemoLightingContractTest.kt
@@ -1,0 +1,95 @@
+package io.github.sceneview.demo.demos
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source contract for #3576 — the Augmented Faces overlay had no lighting model at all.
+ *
+ * The demo painted the ARCore face mesh with an **unlit** flat colour: one uniform blue across the
+ * whole face, no highlight, no falloff, nothing that reads as fitted 3D topology. ARCore
+ * force-disables light estimation on a front-camera session, which is why the demo had drifted to
+ * unlit — but "no estimate" argues for a *deterministic* rig, not for no shading.
+ *
+ * A front-camera session never tracks the device pose (`Camera.getDisplayOrientedPose()` is always
+ * identity), so world space is pinned to the phone and a fixed light direction is a stable,
+ * camera-anchored rig. The SDK defaults are wrong for a portrait specifically: `DefaultLightNode`
+ * points straight down `(0, -1, 0)`, the overhead angle that buries the eyes and the mouth.
+ *
+ * None of this renders on the JVM — and it cannot render on the shared emulator either, which has
+ * no camera — so the wiring is pinned at the source level.
+ */
+class ARFaceDemoLightingContractTest {
+
+    // JVM tests run with the module directory as CWD.
+    private val source =
+        File("src/main/java/io/github/sceneview/demo/demos/ARFaceDemo.kt").readText()
+
+    @Test
+    fun `the face mesh uses a lit material`() {
+        assertTrue(
+            "ARFaceDemo must build its face material with `rememberMaterialInstance` (lit PBR).",
+            source.contains("rememberMaterialInstance(")
+        )
+        assertFalse(
+            "The unlit flat-colour overlay is the #3576 defect — it cannot come back without " +
+                "this contract being revisited.",
+            source.contains("rememberUnlitMaterialInstance")
+        )
+    }
+
+    @Test
+    fun `a lit material must get its per-frame tangent quaternions`() {
+        assertTrue(
+            "PBR samples the FLOAT4 TANGENTS attribute; `computeTangents = false` is the " +
+                "unlit-only shortcut (#878) and leaves a lit face mesh with undefined shading.",
+            source.contains("computeTangents = true")
+        )
+        // Anchored: the comment above the call names the old value on purpose.
+        assertFalse(
+            "`computeTangents = false` must not come back on a lit face mesh.",
+            Regex("""^\s*computeTangents = false""", RegexOption.MULTILINE).containsMatchIn(source)
+        )
+    }
+
+    @Test
+    fun `the demo installs its own key and fill lights`() {
+        assertTrue(
+            "The demo must override the SDK's straight-down default rig with a portrait rig.",
+            source.contains("mainLightNode = rememberMainLightNode(") &&
+                source.contains("fillLightNode = rememberFillLightNode(")
+        )
+    }
+
+    @Test
+    fun `the key light points out of the screen at the user, not straight down`() {
+        val key = source.substringAfter("mainLightNode = rememberMainLightNode(")
+            .substringBefore("},")
+        val z = Regex("""z\s*=\s*(-?[\d.]+)f""").find(key)?.groupValues?.get(1)?.toFloat()
+        assertTrue(
+            "The key light's direction must travel along -Z — out of the screen and into the " +
+                "user's face. Found z=$z.",
+            z != null && z < 0f
+        )
+        val y = Regex("""y\s*=\s*(-?[\d.]+)f""").find(key)?.groupValues?.get(1)?.toFloat()
+        assertTrue(
+            "The key light must not be the straight-down (0, -1, 0) default that buries the " +
+                "eyes and mouth in shadow. Found y=$y.",
+            y != null && y > -1f
+        )
+    }
+
+    @Test
+    fun `the face tint comes from a design token, never a hardcoded colour`() {
+        assertTrue(
+            "DESIGN.md: demo UI never hardcodes colours — the face tint is a SceneViewColors token.",
+            source.contains("SceneViewColors.FaceMeshOverlay")
+        )
+        assertFalse(
+            "No raw ARGB literal in the demo's material setup.",
+            Regex("""Color\(0x[0-9A-Fa-f]{8}\)""").containsMatchIn(source)
+        )
+    }
+}


### PR DESCRIPTION
Closes #3575. Closes #3576.

From Thomas's QA of the Play Store demo v4.34.0, findings 12 and 13: *"ça me
reconnaît pas"* and *"l'éclairage soit pas du tout top"*.

## #3575 — the mesh, not the detection

Detection was never broken. The QA frame shows the demo's own banner reading
**"Tracking 1 face(s)"** over an empty camera preview, so ARCore, the front-camera
`CameraConfig` and `AugmentedFaceMode.MESH3D` all work.

The mesh is hidden by SceneView's own visibility gate:

- ARCore documents that a `Session.Feature.FRONT_CAMERA` session **never** tracks the
  device pose — `Camera.getTrackingState()` always returns `PAUSED`,
  `getDisplayOrientedPose()` is always identity, `hitTest()` is always empty.
- `PoseNode.visibleCameraTrackingStates` defaults to `{TRACKING}`
  (`arsceneview/.../PoseNode.kt:100`) and `PoseNode.isVisible` ANDs the camera state
  into visibility (`:134-136`).
- `AugmentedFaceNode` builds its mesh **inside its own constructor**, while the field
  still holds that `TRACKING` default; the first `update(session, frame)` then writes
  `PAUSED` into `cameraTrackingState` (`AugmentedFaceNode.kt:311`), `updateVisibility()`
  runs, and `Node.isVisible`'s parent-chain walk (`sceneview/.../Node.kt:184-185`) takes
  the centre node and the face `MeshNode` down with it — permanently.

That is also why Thomas said *"ça marche plus ou moins"*: the one or two frames before
the first `update()`. The node now opts out of the **camera** gate, before the mesh is
built. The face's own `TrackingState` gate is untouched — it is the one that actually
means "there is a face here".

## #3576 — the lighting

Two causes, both in the demo:

1. The overlay was an **unlit** flat colour with `computeTangents = false` — one uniform
   blue, no specular, no falloff. It reads as a filter, not as fitted topology.
2. ARCore light estimation is force-disabled on front-camera sessions
   (`arsceneview/.../ArSession.kt:101-105`), so the scene kept `DefaultLightNode`'s
   straight-down `(0, -1, 0)` key light — the overhead angle that buries the eyes, the
   base of the nose and the mouth.

The face is now a lit PBR material (`metallic = 0`, `roughness = 0.35`) with per-frame
tangent quaternions, tinted from a `SceneViewColors` token, under an explicit key + fill
rig aimed out of the screen. A front-camera session pins world space to the device, so a
fixed direction is a stable, camera-anchored portrait rig.

## Verification

- `:arsceneview:testDebugUnitTest` and `:samples:android-demo:testDebugUnitTest` — 9 new
  source-contract tests, green.
- `:samples:android-demo:assembleDebug` — green.
- **Not verifiable here**: neither leg renders on the JVM, and the shared emulator has no
  camera, so nothing about this can be seen before a phone runs it. Both fixes are pinned
  by source contracts precisely because of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
