### PR TITLE
fix(ar): make the placement cursor land, look right and explain itself

### DIFF
--- a/.maestro/android/ar.yaml
+++ b/.maestro/android/ar.yaml
@@ -173,7 +173,7 @@ appId: io.github.sceneview.demo
     file: flows/demo.yaml
     env:
       DEMO_ID: placement-scene
-      DEMO_NAME: Placement Scene
+      DEMO_NAME: One-Call AR
 - runFlow:
     file: flows/demo.yaml
     env:

--- a/agents/sceneview/references/recipes.md
+++ b/agents/sceneview/references/recipes.md
@@ -80,6 +80,9 @@ PlacementScene(
     coaching = true,        // animated onboarding guide while searching for a surface
     groundShadows = true,   // contact shadow under each placed model
     // reticleStyle = PlacementReticleStyle.RING is the default; DISC for the legacy flat puck
+    // reticleColor defaults to RETICLE_TINT — an achromatic white ring over a faint dark
+    // contact halo, with an #a4c1ff centre dot only in the ready phase (#3570). Re-tint the
+    // dot, not the ring: a saturated reticle competes with the model it is placing.
     onPlaced = { anchor ->
         AnchorNode(anchor = anchor) {
             rememberModelInstance(modelLoader, "models/model.glb")?.let {

--- a/arsceneview/api/arsceneview.api
+++ b/arsceneview/api/arsceneview.api
@@ -664,6 +664,15 @@ public final class io/github/sceneview/ar/PlacementController {
 	public final fun getCount ()I
 }
 
+public final class io/github/sceneview/ar/PlacementHitSource : java/lang/Enum {
+	public static final field INSTANT Lio/github/sceneview/ar/PlacementHitSource;
+	public static final field NONE Lio/github/sceneview/ar/PlacementHitSource;
+	public static final field PLANE Lio/github/sceneview/ar/PlacementHitSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/sceneview/ar/PlacementHitSource;
+	public static fun values ()[Lio/github/sceneview/ar/PlacementHitSource;
+}
+
 public final class io/github/sceneview/ar/PlacementReticleStyle : java/lang/Enum {
 	public static final field DISC Lio/github/sceneview/ar/PlacementReticleStyle;
 	public static final field RING Lio/github/sceneview/ar/PlacementReticleStyle;
@@ -673,18 +682,26 @@ public final class io/github/sceneview/ar/PlacementReticleStyle : java/lang/Enum
 }
 
 public final class io/github/sceneview/ar/PlacementReticleVisualKt {
+	public static final field RETICLE_HALO_ALPHA_RATIO F
 	public static final field RETICLE_READY_ALPHA F
 	public static final field RETICLE_SEARCHING_ALPHA F
 	public static final fun PlacementReticleVisual-fWhpE4E (Lio/github/sceneview/NodeScope;Lio/github/sceneview/loaders/MaterialLoader;Lio/github/sceneview/ar/ReticlePhase;JLio/github/sceneview/ar/PlacementReticleStyle;FLandroidx/compose/runtime/Composer;II)V
+	public static final fun getRETICLE_HALO ()J
+	public static final fun getRETICLE_READY_ACCENT ()J
 	public static final fun getRETICLE_TINT ()J
 	public static final fun reticleAlphaFor (Lio/github/sceneview/ar/ReticlePhase;)F
+	public static final fun reticleHaloAlphaFor (F)F
 	public static final fun reticlePhaseFor (Z)Lio/github/sceneview/ar/ReticlePhase;
 }
 
 public final class io/github/sceneview/ar/PlacementSceneKt {
+	public static final field INSTANT_APPROXIMATE_DISTANCE_M F
 	public static final fun PlacementScene-c8To9hI (Landroidx/compose/ui/Modifier;Lcom/google/android/filament/Engine;Lio/github/sceneview/loaders/ModelLoader;Lio/github/sceneview/loaders/MaterialLoader;ZLcom/google/ar/core/Config$PlaneFindingMode;ZZJLio/github/sceneview/ar/PlacementReticleStyle;ZZZLjava/io/File;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
 	public static final fun getDEFAULT_RETICLE_COLOR ()J
+	public static final fun placementHit (Lcom/google/ar/core/Frame;FFZ)Lcom/google/ar/core/HitResult;
 	public static final fun placementHit (Lcom/google/ar/core/Frame;Ljava/util/List;Z)Lcom/google/ar/core/HitResult;
+	public static final fun placementHitSource (ZZZ)Lio/github/sceneview/ar/PlacementHitSource;
+	public static final fun shouldShowReticle (ZZZ)Z
 }
 
 public final class io/github/sceneview/ar/PlacementTrackableKind : java/lang/Enum {

--- a/arsceneview/src/main/java/io/github/sceneview/ar/PlacementReticleVisual.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/PlacementReticleVisual.kt
@@ -52,28 +52,71 @@ enum class ReticlePhase {
 }
 
 /**
- * Default reticle tint — the DESIGN.md primary cyan. The [ReticlePhase] modulates its alpha, so
- * this is the fully-opaque hue; the searching state renders it faded.
+ * Default reticle tint — **achromatic white**, the DESIGN.md `on-ar-scrim` foreground.
+ *
+ * It used to be `0xFF44E7FF` and its KDoc called that "the DESIGN.md primary cyan". DESIGN.md has
+ * no cyan: `primary` is `#005bc1` / `#a4c1ff`, and `#44E7FF` appears in no token table. On a real
+ * floor that saturated ring was the loudest object in the frame and tinted the room (#3570).
+ *
+ * Every reticle worth copying is neutral — RealityKit's `FocusEntity` bracket, Scene Viewer's and
+ * Polycam's soft white ellipse, IKEA Place's plain white ring. They say *searching* vs *ready*
+ * with opacity and shape, never with hue, so the cursor never competes with the model about to
+ * be placed. Like every element drawn over a camera frame (DESIGN.md "AR Coaching Overlay":
+ * *the ground is a camera frame*), it is theme-independent — identical in light and dark.
+ *
+ * The one colour on screen is [RETICLE_READY_ACCENT], and only on the small centre dot.
  *
  * Public because it is the documented default of the public [PlacementScene]/[PlacementReticleVisual]
  * `reticleColor` params — a caller (or an AI copying the signature) must be able to name it.
  */
-val RETICLE_TINT: Color = Color(0xFF_44_E7_FF)
-
-/** Ring outer radius (major radius + tube), metres — ~8 cm across on the surface. */
-internal const val RING_MAJOR_RADIUS = 0.06f
+val RETICLE_TINT: Color = Color(0xFF_FF_FF_FF)
 
 /**
- * Ring tube thickness (minor radius), metres — a slim ~5 mm band (~8% of the major radius, the
- * sleek proportion consumer AR reticles use; a thicker tube reads as a heavy "toy" target).
+ * The centre dot's hue in [ReticlePhase.READY] — DESIGN.md `primary`, dark-scheme value
+ * `#a4c1ff`. Accents over the camera feed are the dark-scheme values in **both** themes
+ * (DESIGN.md, "AR Coaching Overlay"), because they are read on a camera frame, not on a
+ * surface role.
+ *
+ * Colour is confined to this ~2 cm dot: enough to make "you can place now" unmistakable at a
+ * glance, small enough that the cursor still reads as neutral.
  */
-internal const val RING_MINOR_RADIUS = 0.005f
+val RETICLE_READY_ACCENT: Color = Color(0xFF_A4_C1_FF)
+
+/**
+ * The contact halo under the ring — DESIGN.md `ar-scrim` black. A white ring on a white tile
+ * floor is the case the old cyan never had to solve; a barely-there dark tube a hair below the
+ * ring gives it a ground to sit on, exactly as Scene Viewer's reticle carries a soft shadow
+ * ellipse. Its alpha is [reticleHaloAlphaFor], derived from the ring's so the two fade together.
+ */
+val RETICLE_HALO: Color = Color(0xFF_00_00_00)
+
+/** Ring outer radius (major radius + tube), metres — ~11 cm across on the surface. */
+internal const val RING_MAJOR_RADIUS = 0.055f
+
+/**
+ * Ring tube thickness (minor radius), metres — a ~3.5 mm hairline band (~6% of the major radius).
+ * Slimmer than the pre-#3570 5 mm tube: the reference reticles are all hairlines, and a thicker
+ * band reads as a heavy "toy" target.
+ */
+internal const val RING_MINOR_RADIUS = 0.0035f
 
 /** Centre-dot radius shown only in the READY phase, metres. */
-internal const val RING_DOT_RADIUS = 0.013f
+internal const val RING_DOT_RADIUS = 0.010f
+
+/**
+ * Contact-halo tube thickness, metres — the halo is an **annulus** tracing the ring, not a filled
+ * disc. A filled disc at [RETICLE_HALO_ALPHA_RATIO] reads as a grey blob on a pale floor (measured
+ * on the demo's pale-ground swatch) and swallows the hairline it was meant to lift; a slightly
+ * fatter dark tube directly under the white one behaves like the soft drop shadow every reference
+ * reticle carries, and only ever darkens the few millimetres the ring itself occupies.
+ */
+internal const val RETICLE_HALO_MINOR_RADIUS = RING_MINOR_RADIUS * 1.8f
 
 /** Ring / dot height off the surface, metres — a hair above the plane to avoid z-fighting. */
 internal const val RETICLE_LIFT = 0.004f
+
+/** Halo height off the surface, metres — under the ring, still clear of the plane. */
+internal const val RETICLE_HALO_LIFT = 0.002f
 
 /** Ring tessellation — segments around the main circle. */
 internal const val RING_MAJOR_SEGMENTS = 64
@@ -93,6 +136,12 @@ const val RETICLE_SEARCHING_ALPHA = 0.35f
 const val RETICLE_READY_ALPHA = 0.95f
 
 /**
+ * How much of the ring's opacity the contact halo carries. Kept well under half: the halo is a
+ * grounding cue, and a halo that reads as a disc is a second cursor.
+ */
+const val RETICLE_HALO_ALPHA_RATIO = 0.28f
+
+/**
  * Maps a centre-screen hit presence to the reticle phase: a non-null hit means a surface is
  * acquired ([ReticlePhase.READY]), a null hit means the ray finds nothing ([ReticlePhase.SEARCHING]).
  * Extracted so the mapping is unit-testable without Compose / ARCore.
@@ -103,6 +152,14 @@ fun reticlePhaseFor(hasHit: Boolean): ReticlePhase =
 /** The ring/dot opacity for [phase] — bright when READY, dimmed while SEARCHING. */
 fun reticleAlphaFor(phase: ReticlePhase): Float =
     if (phase == ReticlePhase.READY) RETICLE_READY_ALPHA else RETICLE_SEARCHING_ALPHA
+
+/**
+ * The contact halo's opacity for a given ring opacity — a fixed fraction
+ * ([RETICLE_HALO_ALPHA_RATIO]) so halo and ring fade together and the halo is never the
+ * dominant mark. Pure so the ratio is pinned without Compose or Filament (#3570).
+ */
+fun reticleHaloAlphaFor(ringAlpha: Float): Float =
+    (ringAlpha * RETICLE_HALO_ALPHA_RATIO).coerceIn(0f, 1f)
 
 /**
  * Renders the reticle geometry for [style], recolouring live as [phase] changes.
@@ -138,15 +195,34 @@ fun io.github.sceneview.NodeScope.PlacementReticleVisual(
     style: PlacementReticleStyle = PlacementReticleStyle.RING,
     alpha: Float = reticleAlphaFor(phase),
 ) {
+    val haloAlpha = reticleHaloAlphaFor(alpha)
+
     // One material for the ring/disc body — recoloured in place per phase (no re-alloc).
     val bodyMaterial: MaterialInstance = remember(materialLoader, tint) {
         materialLoader.createUnlitColorInstance(tint.copy(alpha = alpha))
     }
-    DisposableEffect(materialLoader, bodyMaterial) {
-        onDispose { materialLoader.destroyMaterialInstance(bodyMaterial) }
+    // The READY centre dot is the only coloured mark on the cursor (#3570), so it needs its own
+    // instance — the ring must stay achromatic.
+    val accentMaterial: MaterialInstance = remember(materialLoader) {
+        materialLoader.createUnlitColorInstance(RETICLE_READY_ACCENT.copy(alpha = alpha))
     }
-    // Mutate the live colour so the ring dims/brightens without churning the instance.
-    SideEffect { bodyMaterial.setColor(tint.copy(alpha = alpha)) }
+    // Contact halo — gives the white ring a ground to sit on when the real surface is light.
+    val haloMaterial: MaterialInstance = remember(materialLoader) {
+        materialLoader.createUnlitColorInstance(RETICLE_HALO.copy(alpha = haloAlpha))
+    }
+    DisposableEffect(materialLoader, bodyMaterial, accentMaterial, haloMaterial) {
+        onDispose {
+            materialLoader.destroyMaterialInstance(bodyMaterial)
+            materialLoader.destroyMaterialInstance(accentMaterial)
+            materialLoader.destroyMaterialInstance(haloMaterial)
+        }
+    }
+    // Mutate the live colours so the ring dims/brightens without churning the instances.
+    SideEffect {
+        bodyMaterial.setColor(tint.copy(alpha = alpha))
+        accentMaterial.setColor(RETICLE_READY_ACCENT.copy(alpha = alpha))
+        haloMaterial.setColor(RETICLE_HALO.copy(alpha = haloAlpha))
+    }
 
     when (style) {
         PlacementReticleStyle.DISC -> {
@@ -159,6 +235,17 @@ fun io.github.sceneview.NodeScope.PlacementReticleVisual(
         }
 
         PlacementReticleStyle.RING -> {
+            // Halo first, lowest — a soft dark ground so the white hairline survives on a light
+            // floor. Drawn for both phases so the cursor's silhouette never changes on the
+            // searching→ready step; only its opacity does.
+            TorusNode(
+                majorRadius = RING_MAJOR_RADIUS,
+                minorRadius = RETICLE_HALO_MINOR_RADIUS,
+                majorSegments = RING_MAJOR_SEGMENTS,
+                minorSegments = RING_MINOR_SEGMENTS,
+                position = Position(y = RETICLE_HALO_LIFT),
+                materialInstance = haloMaterial,
+            )
             TorusNode(
                 majorRadius = RING_MAJOR_RADIUS,
                 minorRadius = RING_MINOR_RADIUS,
@@ -167,14 +254,15 @@ fun io.github.sceneview.NodeScope.PlacementReticleVisual(
                 position = Position(y = RETICLE_LIFT),
                 materialInstance = bodyMaterial,
             )
-            // Centre dot only once a surface is acquired — reinforces the "ready" signal.
+            // Centre dot only once a surface is acquired — the one coloured mark, and the
+            // unambiguous "tap now" signal.
             if (phase == ReticlePhase.READY) {
                 CylinderNode(
                     radius = RING_DOT_RADIUS,
                     height = RETICLE_HEIGHT,
                     sideCount = RETICLE_SIDES,
                     position = Position(y = RETICLE_LIFT),
-                    materialInstance = bodyMaterial,
+                    materialInstance = accentMaterial,
                 )
             }
         }

--- a/arsceneview/src/main/java/io/github/sceneview/ar/PlacementScene.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/PlacementScene.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
 import com.google.android.filament.Engine
@@ -97,7 +99,8 @@ import java.io.File
  * @param showReticle           Show the built-in center-screen placement reticle. Default `true`.
  * @param reticleStyle          Reticle geometry — a [PlacementReticleStyle.RING] (the modern
  *                              consumer-AR default) or the legacy [PlacementReticleStyle.DISC].
- * @param reticleColor          Reticle tint. Defaults to the DESIGN.md primary cyan; the
+ * @param reticleColor          Reticle tint. Defaults to [RETICLE_TINT], the achromatic
+ *                              `on-ar-scrim` white every consumer-AR reticle uses (#3570); the
  *                              searching / ready phase modulates its opacity automatically.
  * @param fadePlaneOnFirstPlacement Hide the plane-detection grid once the first model is placed,
  *                              so the surface stops being highlighted after it has served its
@@ -157,6 +160,7 @@ fun PlacementScene(
     content: (@Composable ARSceneScope.(controller: PlacementController) -> Unit)? = null,
 ) {
     val controller = remember { PlacementController() }
+    val haptic = LocalHapticFeedback.current
 
     // Latest ARCore frame, captured from onSessionUpdated so the tap gesture (which runs on the
     // UI thread, off the AR frame callback) can still hit-test against a live frame.
@@ -209,9 +213,11 @@ fun PlacementScene(
             onSessionUpdated = { updatedSession, frame ->
                 latestFrame = frame
                 if (groundShadows && session !== updatedSession) session = updatedSession
+                // Tracked unconditionally since #3569: the reticle is only composed while the
+                // camera is TRACKING, so this is no longer a coaching-only signal.
+                isTracking = frame.camera.trackingState == TrackingState.TRACKING
                 if (coaching) {
                     cameraReady = true
-                    isTracking = frame.camera.trackingState == TrackingState.TRACKING
                     if (!anyPlaneTracked) {
                         anyPlaneTracked = updatedSession.getAllTrackables(Plane::class.java)
                             .any { it.trackingState == TrackingState.TRACKING }
@@ -225,8 +231,13 @@ fun PlacementScene(
                     // rotate) — don't spawn a fresh anchor on top of it.
                     if (node != null) return@rememberOnGestureListener
                     val frame = latestFrame ?: return@rememberOnGestureListener
-                    placementHit(frame, frame.hitTest(event), instantPlacement)
-                        ?.let { hit -> controller.add(hit.createAnchor()) }
+                    placementHit(frame, event.x, event.y, instantPlacement)?.let { hit ->
+                        controller.add(hit.createAnchor())
+                        // Confirm the commit in the hand. A tap that lands must feel different
+                        // from a tap that misses, or a dropped tap reads as a dead screen
+                        // (#3571).
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
                 }
             ),
         ) {
@@ -234,7 +245,12 @@ fun PlacementScene(
             // so the user previews where the next tap lands and gets a searching↔ready signal.
             // Purely visual: the tap handler above runs its own hit-test at the tap coordinates,
             // so placement is not centre-only.
-            if (showReticle && viewportSize != IntSize.Zero) {
+            if (shouldShowReticle(
+                    showReticle = showReticle,
+                    viewportMeasured = viewportSize != IntSize.Zero,
+                    cameraTracking = isTracking,
+                )
+            ) {
                 val centreX = viewportSize.width / 2f
                 val centreY = viewportSize.height / 2f
                 // PlacementReticle adds Depth-Lab orientation smoothing over HitResultNode and
@@ -372,10 +388,11 @@ class PlacementController internal constructor() {
 }
 
 /**
- * Legacy reticle color — DESIGN.md primary cyan, semi-transparent (alpha `0x99`). This was the
+ * Legacy reticle color — the pre-#3570 cyan, semi-transparent (alpha `0x99`). This was the
  * default before the ring reticle landed; the current default is the opaque [RETICLE_TINT], whose
  * alpha the [ReticlePhase] modulates. Retained for the standalone [ARSceneScope.PlacementReticle]
- * and any caller that wants the old flat tint.
+ * and any caller that wants the old flat tint. It is **not** a DESIGN.md token — the token table
+ * has no cyan — so new code should not reach for it.
  */
 val DEFAULT_RETICLE_COLOR: Color = Color(0x99_44_E7_FF)
 
@@ -426,6 +443,112 @@ fun placementHit(
     if (frame.camera.trackingState != TrackingState.TRACKING) return null
     return hits.firstOrNull { hit -> isPlacementHit(hit, instantPlacement) }
 }
+
+/**
+ * The approximate distance, in metres, handed to [Frame.hitTestInstantPlacement] — ARCore's own
+ * documented starting guess for where the surface is before it knows. The point refines from
+ * `SCREENSPACE_WITH_APPROXIMATE_DISTANCE` to `FULL_TRACKING` once enough features are gathered.
+ */
+const val INSTANT_APPROXIMATE_DISTANCE_M = 1.0f
+
+/** Which trackable an accepted tap anchors to. See [placementHitSource]. */
+enum class PlacementHitSource {
+    /** A tracked plane hit inside its polygon — always preferred, it is the accurate answer. */
+    PLANE,
+
+    /** No usable plane; an `InstantPlacementPoint` at [INSTANT_APPROXIMATE_DISTANCE_M]. */
+    INSTANT,
+
+    /** Nothing to anchor to — the tap is dropped. */
+    NONE,
+}
+
+/**
+ * Pure hit-source precedence: the accurate answer wins, the fallback only fills the gap.
+ *
+ * Extracted so the rule is pinned by a JVM unit test without Compose or an ARCore session.
+ */
+fun placementHitSource(
+    hasPlaneHit: Boolean,
+    instantEnabled: Boolean,
+    hasInstantHit: Boolean,
+): PlacementHitSource = when {
+    hasPlaneHit -> PlacementHitSource.PLANE
+    instantEnabled && hasInstantHit -> PlacementHitSource.INSTANT
+    else -> PlacementHitSource.NONE
+}
+
+/**
+ * Resolves the [HitResult] a tap at ([xPx], [yPx]) should anchor to — **plane first, instant
+ * placement as the fallback**.
+ *
+ * This is the overload [PlacementScene] uses, and it exists because the list overload above
+ * cannot express the [instantPlacement] contract on its own (#3571). ARCore's [Frame.hitTest]
+ * never returns an `InstantPlacementPoint`: those come only from
+ * [Frame.hitTestInstantPlacement]. So `placementHit(frame, frame.hitTest(event), true)` — what
+ * `PlacementScene` did before this fix — could only ever accept plane hits, its
+ * [PlacementTrackableKind.INSTANT_PLACEMENT] branch was unreachable, and every tap taken before
+ * a plane had converged under the finger was silently dropped. In a dim room on a low-texture
+ * floor that is most of the first minute, which reads as a screen that simply does not respond.
+ *
+ * With [instantPlacement] on (the default) a tap therefore **always** places something once the
+ * camera is tracking: a plane anchor when a plane is there, an approximated
+ * `InstantPlacementPoint` otherwise, which then refines to the real surface — the Sceneform
+ * `ArFragment` behaviour the composable's KDoc has always promised.
+ *
+ * @param frame            The live ARCore [Frame] to hit-test.
+ * @param xPx              Tap X in view pixels.
+ * @param yPx              Tap Y in view pixels.
+ * @param instantPlacement Whether the instant-placement fallback is eligible.
+ */
+fun placementHit(
+    frame: Frame,
+    xPx: Float,
+    yPx: Float,
+    instantPlacement: Boolean,
+): HitResult? {
+    if (frame.camera.trackingState != TrackingState.TRACKING) return null
+    // Plane hits are filtered by the same acceptance rule as before, with instant OFF so the
+    // unreachable branch can never be consulted here.
+    val planeHit = placementHit(frame, frame.hitTest(xPx, yPx), instantPlacement = false)
+    val instantHit = if (instantPlacement && planeHit == null) {
+        runCatching {
+            frame.hitTestInstantPlacement(xPx, yPx, INSTANT_APPROXIMATE_DISTANCE_M).firstOrNull()
+        }.getOrNull()
+    } else {
+        null
+    }
+    return when (
+        placementHitSource(
+            hasPlaneHit = planeHit != null,
+            instantEnabled = instantPlacement,
+            hasInstantHit = instantHit != null,
+        )
+    ) {
+        PlacementHitSource.PLANE -> planeHit
+        PlacementHitSource.INSTANT -> instantHit
+        PlacementHitSource.NONE -> null
+    }
+}
+
+/**
+ * Whether [PlacementScene] composes its reticle this frame.
+ *
+ * Three conditions, all necessary (#3569):
+ *  - the caller asked for it ([showReticle]);
+ *  - the viewport has been measured, so the centre-screen hit test is not racing a `(0, 0)` hit;
+ *  - **the camera is actually tracking.** Before this gate the reticle node existed from the
+ *    first composition and, having no hit yet, rendered its geometry at the node's identity pose
+ *    — a flat, un-rotated disc floating at the world origin over the camera feed at session
+ *    start, and again once the session stopped delivering frames.
+ *
+ * Pure so it is pinned by a JVM unit test without Compose or ARCore.
+ */
+fun shouldShowReticle(
+    showReticle: Boolean,
+    viewportMeasured: Boolean,
+    cameraTracking: Boolean,
+): Boolean = showReticle && viewportMeasured && cameraTracking
 
 /**
  * Per-[HitResult] acceptance predicate for [placementHit] — see that function's KDoc for the

--- a/arsceneview/src/test/java/io/github/sceneview/ar/PlacementReticleVisualTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/PlacementReticleVisualTest.kt
@@ -40,6 +40,60 @@ class PlacementReticleVisualTest {
     }
 
     @Test
+    fun `the default tint is achromatic`() {
+        // #3570: the reticle used to default to 0xFF44E7FF and call it "the DESIGN.md primary
+        // cyan". DESIGN.md has no cyan. Every reference reticle (RealityKit FocusEntity, Scene
+        // Viewer, IKEA Place) is neutral so it never competes with the model being placed —
+        // pin that: red == green == blue.
+        assertEquals(RETICLE_TINT.red, RETICLE_TINT.green, 0.0f)
+        assertEquals(RETICLE_TINT.green, RETICLE_TINT.blue, 0.0f)
+        assertEquals(1.0f, RETICLE_TINT.alpha, 0.0f)
+    }
+
+    @Test
+    fun `the ready accent is the DESIGN-md primary dark value`() {
+        // Accents over a camera feed are the dark-scheme values in both themes — #a4c1ff.
+        assertEquals(0xA4 / 255f, RETICLE_READY_ACCENT.red, 0.004f)
+        assertEquals(0xC1 / 255f, RETICLE_READY_ACCENT.green, 0.004f)
+        assertEquals(0xFF / 255f, RETICLE_READY_ACCENT.blue, 0.004f)
+    }
+
+    @Test
+    fun `the contact halo is always fainter than the ring it grounds`() {
+        for (phase in ReticlePhase.values()) {
+            val ring = reticleAlphaFor(phase)
+            val halo = reticleHaloAlphaFor(ring)
+            assertTrue("$phase halo $halo must be fainter than ring $ring", halo < ring)
+            assertTrue("$phase halo $halo must be in 0..1", halo in 0f..1f)
+        }
+    }
+
+    @Test
+    fun `the halo fades with the ring`() {
+        assertTrue(
+            "a dimmer ring must carry a dimmer halo",
+            reticleHaloAlphaFor(reticleAlphaFor(ReticlePhase.SEARCHING)) <
+                reticleHaloAlphaFor(reticleAlphaFor(ReticlePhase.READY))
+        )
+    }
+
+    @Test
+    fun `the contact halo traces the ring instead of filling it`() {
+        // Regression guard for the shape, not just the alpha: the halo used to be a filled disc,
+        // which on a pale floor renders as a grey blob wider than the cursor (measured on the
+        // demo's pale-ground swatch, #3570). It must stay a tube — fatter than the ring's, so it
+        // peeks out as a shadow, but nowhere near a disc.
+        assertTrue(
+            "the halo tube must be fatter than the ring's to read as a shadow",
+            RETICLE_HALO_MINOR_RADIUS > RING_MINOR_RADIUS
+        )
+        assertTrue(
+            "the halo must stay a hairline, not creep towards a filled disc",
+            RETICLE_HALO_MINOR_RADIUS < RING_MAJOR_RADIUS / 4f
+        )
+    }
+
+    @Test
     fun `RING is the default reticle style`() {
         // The modern consumer-AR default (Scene Viewer / IKEA / Houzz), not the legacy disc.
         assertEquals(PlacementReticleStyle.RING, PlacementReticleStyle.values().first())

--- a/arsceneview/src/test/java/io/github/sceneview/ar/PlacementSceneTapFallbackTest.kt
+++ b/arsceneview/src/test/java/io/github/sceneview/ar/PlacementSceneTapFallbackTest.kt
@@ -1,0 +1,95 @@
+package io.github.sceneview.ar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the two [PlacementScene] rules the device QA of v4.34.0 caught.
+ *
+ * - [placementHitSource] — the plane-first / instant-fallback precedence that makes a tap
+ *   actually place something before a plane has converged (#3571). The composable used to feed
+ *   `frame.hitTest(event)` straight into the acceptance filter with `instantPlacement = true`,
+ *   but ARCore only ever returns an `InstantPlacementPoint` from `hitTestInstantPlacement`, so
+ *   that branch was unreachable and taps were dropped in silence.
+ * - [shouldShowReticle] — the gate that keeps the reticle off screen until the camera is
+ *   tracking, so it can no longer render flat and un-rotated at the world origin (#3569).
+ */
+class PlacementSceneTapFallbackTest {
+
+    @Test
+    fun `a plane hit always wins, even with instant placement on`() {
+        assertEquals(
+            PlacementHitSource.PLANE,
+            placementHitSource(hasPlaneHit = true, instantEnabled = true, hasInstantHit = true)
+        )
+    }
+
+    @Test
+    fun `no plane falls back to the instant hit when instant is on`() {
+        assertEquals(
+            PlacementHitSource.INSTANT,
+            placementHitSource(hasPlaneHit = false, instantEnabled = true, hasInstantHit = true)
+        )
+    }
+
+    @Test
+    fun `no plane and instant off drops the tap`() {
+        assertEquals(
+            PlacementHitSource.NONE,
+            placementHitSource(hasPlaneHit = false, instantEnabled = false, hasInstantHit = true)
+        )
+    }
+
+    @Test
+    fun `an instant hit is never consulted while instant placement is off`() {
+        assertEquals(
+            PlacementHitSource.PLANE,
+            placementHitSource(hasPlaneHit = true, instantEnabled = false, hasInstantHit = true)
+        )
+    }
+
+    @Test
+    fun `nothing under the finger drops the tap`() {
+        assertEquals(
+            PlacementHitSource.NONE,
+            placementHitSource(hasPlaneHit = false, instantEnabled = true, hasInstantHit = false)
+        )
+    }
+
+    @Test
+    fun `the ARCore approximate distance is the documented one metre`() {
+        assertEquals(1.0f, INSTANT_APPROXIMATE_DISTANCE_M, 0.0f)
+    }
+
+    @Test
+    fun `the reticle shows only when asked for, measured and tracking`() {
+        assertTrue(
+            shouldShowReticle(showReticle = true, viewportMeasured = true, cameraTracking = true)
+        )
+    }
+
+    @Test
+    fun `the reticle stays hidden before the camera tracks`() {
+        // The #3569 repro: composed, viewport measured, but no ARCore pose yet — the node would
+        // otherwise render its geometry at the identity pose, flat, over the camera feed.
+        assertFalse(
+            shouldShowReticle(showReticle = true, viewportMeasured = true, cameraTracking = false)
+        )
+    }
+
+    @Test
+    fun `the reticle stays hidden until the viewport is measured`() {
+        assertFalse(
+            shouldShowReticle(showReticle = true, viewportMeasured = false, cameraTracking = true)
+        )
+    }
+
+    @Test
+    fun `showReticle false always wins`() {
+        assertFalse(
+            shouldShowReticle(showReticle = false, viewportMeasured = true, cameraTracking = true)
+        )
+    }
+}

--- a/changelog.d/3568-placement-scene-one-call-ar.md
+++ b/changelog.d/3568-placement-scene-one-call-ar.md
@@ -1,0 +1,15 @@
+<!-- category: Changed -->
+- **The `placement-scene` demo is now "One-Call AR", and says what it demonstrates before the
+  camera opens ([#3568](https://github.com/sceneview/sceneview/issues/3568)).** Named "Placement
+  Scene" and sitting next to "Tap to Place" and "Wall Placement", it opened straight into a
+  camera with its only explanation buried in a Settings sheet — so it read as a second, worse
+  copy of its neighbour, and the one person who wrote the SDK could not name its subject after a
+  minute of use. Its subject is not that you can tap to place; it is that the entire camera
+  screen is a **single `PlacementScene { anchor -> … }` call**, where `Tap to Place` hand-writes
+  the same flow out of the low-level primitives to show what they are. The demo now opens on a
+  still, themed screen that states exactly that, shows the snippet, introduces the cursor by
+  rendering the real reticle in two non-AR scenes — one over a pale ground, one over a dark one —
+  and only then opens the camera; Back returns there rather than leaving the demo. The deep link
+  `sceneview://demo/placement-scene` is unchanged. It stays in the catalogue because it is the
+  only demo that exercises the public one-call composable, which is also the first snippet
+  `llms.txt` offers for AR placement.

--- a/changelog.d/3569-reticle-visibility-on-reparent.md
+++ b/changelog.d/3569-reticle-visibility-on-reparent.md
@@ -1,0 +1,11 @@
+<!-- category: Fixed -->
+- **A hidden node can no longer leak a visible child, and the AR reticle no longer flashes at
+  the world origin ([#3569](https://github.com/sceneview/sceneview/issues/3569)).** `isVisible`
+  is computed from the parent chain, but the Filament layer mask that decides rendering was only
+  pushed when a node's own visibility field changed. Re-parenting changed the computed answer
+  without touching any field, so a child attached to an already-hidden parent kept the default
+  visible mask and rendered anyway. In `PlacementScene` that surfaced as a flat, un-rotated
+  reticle disc floating over the camera feed at the world origin for the first frames of every
+  session, before ARCore had produced a single hit. `Node.parent` now refreshes the subtree's
+  rendered visibility, and `PlacementScene` composes its reticle only while the camera is
+  `TRACKING`, so it is also gone the moment the session stops.

--- a/changelog.d/3570-reticle-redesign.md
+++ b/changelog.d/3570-reticle-redesign.md
@@ -1,0 +1,12 @@
+<!-- category: Changed -->
+- **The AR placement reticle is achromatic ([#3570](https://github.com/sceneview/sceneview/issues/3570)).**
+  `RETICLE_TINT` was `#44E7FF` and its documentation called that "the DESIGN.md primary cyan".
+  DESIGN.md has no cyan: `primary` is `#005bc1` / `#a4c1ff`, and `#44E7FF` is in no token table.
+  On a real floor that saturated ring was the loudest thing in the frame and tinted the room.
+  Every reticle worth copying — RealityKit's `FocusEntity`, Scene Viewer, Polycam, IKEA Place —
+  is neutral, and says *searching* versus *ready* with opacity and shape rather than hue. The
+  default is now the `on-ar-scrim` white, drawn as a hairline ring over a faint `ar-scrim` contact
+  halo so it stays readable on a pale floor, with the one colour on screen confined to a small
+  `#a4c1ff` centre dot that appears only in the ready phase. Theme-independent, like every
+  element drawn over a camera frame. Callers that want the old look can still pass
+  `reticleColor = DEFAULT_RETICLE_COLOR`.

--- a/changelog.d/3571-placementscene-instant-fallback.md
+++ b/changelog.d/3571-placementscene-instant-fallback.md
@@ -1,0 +1,12 @@
+<!-- category: Fixed -->
+- **A tap in `PlacementScene` now always places something once the camera is tracking
+  ([#3571](https://github.com/sceneview/sceneview/issues/3571)).** The composable ran
+  `frame.hitTest(event)` and fed the result to an acceptance filter that had a branch for
+  `InstantPlacementPoint` hits. ARCore never returns one from `Frame.hitTest` — instant hits
+  come only from `Frame.hitTestInstantPlacement` — so with `instantPlacement = true` (the
+  default) that branch was unreachable and every tap taken before a plane had converged under
+  the finger was dropped in silence. On a low-texture floor in a dim room that is most of the
+  first minute, which reads as a screen that simply does not respond. The tap now resolves
+  plane-first with the instant point at a 1 m approximate distance as the fallback — the
+  Sceneform `ArFragment` behaviour the KDoc always promised — and a successful placement fires
+  a `LongPress` haptic, so a tap that lands feels different from a tap that misses.

--- a/gpt/knowledge-api.md
+++ b/gpt/knowledge-api.md
@@ -1150,7 +1150,7 @@ Signature:
     instantPlacement: Boolean = true,        // place before a plane converges (ArFragment parity)
     showReticle: Boolean = true,             // built-in centre-screen placement reticle
     reticleStyle: PlacementReticleStyle = PlacementReticleStyle.RING,  // RING (default) or DISC
-    reticleColor: Color = RETICLE_TINT,      // DESIGN.md primary cyan; opacity varies searching↔ready
+    reticleColor: Color = RETICLE_TINT,      // achromatic on-ar-scrim white; opacity varies searching↔ready
     fadePlaneOnFirstPlacement: Boolean = true,  // hide the plane grid after the first model lands
     coaching: Boolean = false,               // opt-in PlaneDiscoveryGuide onboarding overlay
     groundShadows: Boolean = false,          // opt-in contact shadow under placed models — auto-gated
@@ -1168,8 +1168,18 @@ detach every placed anchor (e.g. a "Clear All" button), or read `controller.coun
 `controller.anchors` to drive a placement counter. Both are Compose-observable.
 
 `PlacementScene` accepts plane hits (inside the polygon) and — when `instantPlacement = true` —
-instant-placement hits. For placement against arbitrary real geometry (sofas, slopes) use
-`DepthHitResultNode`; for full manual control drop down to `ARSceneView` + `HitResultNode`.
+instant-placement hits. Plane hits always win; the instant fallback is only consulted when no
+plane answered, and it comes from `Frame.hitTestInstantPlacement` at a 1 m approximate distance
+(`Frame.hitTest` never returns an `InstantPlacementPoint` — the trap #3571 fixed). A successful
+placement fires a `LongPress` haptic, so a tap that lands feels different from a tap that misses.
+For placement against arbitrary real geometry (sofas, slopes) use `DepthHitResultNode`; for full
+manual control drop down to `ARSceneView` + `HitResultNode`.
+
+The built-in reticle is composed only while the camera is `TRACKING`, so it can never render at
+the identity pose before the first hit (#3569). Its default look is deliberately achromatic — a
+white hairline ring over a faint dark contact halo, with a small `#a4c1ff` centre dot appearing
+only in the *ready* phase (#3570). Reticle colour is a design decision: if you re-tint it, tint
+the dot, not the ring.
 
 ### WallPlacementScene — place on a wall, aligned to the floor↔wall edge (#2740)
 

--- a/gpt/knowledge-samples.md
+++ b/gpt/knowledge-samples.md
@@ -693,7 +693,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 ### AR Placement
 
 - `ar-placement` — Tap to Place. Pick a model, then tap a surface to place it.
-- `placement-scene` — Placement Scene. One-line tap-to-place AR.
+- `placement-scene` — One-Call AR. The same tap-to-place screen, in a single SDK call.
 - `wall-placement` — Wall Placement. Mount a TV on a wall, floor-to-wall aligned.
 - `ar-plane-node` — Plane Lifecycle. PlaneNode lifecycle: added, updated, removed.
 - `ar-plane-renderer-v2` — Plane Renderer V2. Depth, PBR and HDR plane renderer, V1↔V2.

--- a/llms.txt
+++ b/llms.txt
@@ -1180,7 +1180,7 @@ Signature:
     instantPlacement: Boolean = true,        // place before a plane converges (ArFragment parity)
     showReticle: Boolean = true,             // built-in centre-screen placement reticle
     reticleStyle: PlacementReticleStyle = PlacementReticleStyle.RING,  // RING (default) or DISC
-    reticleColor: Color = RETICLE_TINT,      // DESIGN.md primary cyan; opacity varies searching↔ready
+    reticleColor: Color = RETICLE_TINT,      // achromatic on-ar-scrim white; opacity varies searching↔ready
     fadePlaneOnFirstPlacement: Boolean = true,  // hide the plane grid after the first model lands
     coaching: Boolean = false,               // opt-in PlaneDiscoveryGuide onboarding overlay
     groundShadows: Boolean = false,          // opt-in contact shadow under placed models — auto-gated
@@ -1198,8 +1198,18 @@ detach every placed anchor (e.g. a "Clear All" button), or read `controller.coun
 `controller.anchors` to drive a placement counter. Both are Compose-observable.
 
 `PlacementScene` accepts plane hits (inside the polygon) and — when `instantPlacement = true` —
-instant-placement hits. For placement against arbitrary real geometry (sofas, slopes) use
-`DepthHitResultNode`; for full manual control drop down to `ARSceneView` + `HitResultNode`.
+instant-placement hits. Plane hits always win; the instant fallback is only consulted when no
+plane answered, and it comes from `Frame.hitTestInstantPlacement` at a 1 m approximate distance
+(`Frame.hitTest` never returns an `InstantPlacementPoint` — the trap #3571 fixed). A successful
+placement fires a `LongPress` haptic, so a tap that lands feels different from a tap that misses.
+For placement against arbitrary real geometry (sofas, slopes) use `DepthHitResultNode`; for full
+manual control drop down to `ARSceneView` + `HitResultNode`.
+
+The built-in reticle is composed only while the camera is `TRACKING`, so it can never render at
+the identity pose before the first hit (#3569). Its default look is deliberately achromatic — a
+white hairline ring over a faint dark contact halo, with a small `#a4c1ff` centre dot appearing
+only in the *ready* phase (#3570). Reticle colour is a design decision: if you re-tint it, tint
+the dot, not the ring.
 
 ### WallPlacementScene — place on a wall, aligned to the floor↔wall edge (#2740)
 
@@ -5301,7 +5311,7 @@ by `samples/android-demo/scripts/collate-demos.sh` — never edit between the ma
 ### AR Placement
 
 - `ar-placement` — Tap to Place. Pick a model, then tap a surface to place it.
-- `placement-scene` — Placement Scene. One-line tap-to-place AR.
+- `placement-scene` — One-Call AR. The same tap-to-place screen, in a single SDK call.
 - `wall-placement` — Wall Placement. Mount a TV on a wall, floor-to-wall aligned.
 - `ar-plane-node` — Plane Lifecycle. PlaneNode lifecycle: added, updated, removed.
 - `ar-plane-renderer-v2` — Plane Renderer V2. Depth, PBR and HDR plane renderer, V1↔V2.

--- a/samples/android-demo/distribution/play-store/en-GB/full_description.txt
+++ b/samples/android-demo/distribution/play-store/en-GB/full_description.txt
@@ -11,7 +11,7 @@ Point your camera at a flat surface, tap to place, then drag, pinch and twist to
 
 50 INTERACTIVE DEMOS
 50 screens, each one shipping its source:
-- Tap to Place, Placement Scene and Wall Placement — the AR placement flows
+- Tap to Place, One-Call AR and Wall Placement — the AR placement flows
 - Depth Occlusion, People Occlusion and Depth Collider — virtual objects that respect the real room
 - Measure — tap two points, read the distance
 - Image Tracking and Augmented Faces — detect a poster, or a face

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PlacementSceneDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/PlacementSceneDemo.kt
@@ -1,45 +1,269 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
 package io.github.sceneview.demo.demos
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ViewInAr
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.sceneview.Scene
 import io.github.sceneview.ar.PlacementController
+import io.github.sceneview.ar.PlacementReticleVisual
 import io.github.sceneview.ar.PlacementScene
+import io.github.sceneview.ar.ReticlePhase
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.R
 import io.github.sceneview.demo.rememberArPlaybackDataset
+import io.github.sceneview.demo.theme.SceneViewTokens
+import io.github.sceneview.math.Rotation
+import io.github.sceneview.math.Scale
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelInstance
 import io.github.sceneview.rememberModelLoader
 
 /**
- * One-line tap-to-place AR demo — the Sceneform `ArFragment` parity showcase
+ * One-call AR — the [PlacementScene] showcase
  * ([#1765](https://github.com/sceneview/sceneview/issues/1765)).
  *
- * Where [ARPlacementDemo] hand-rolls the full placement pipeline (centre reticle, hit-test in the
- * tap gesture, anchor creation, instant-placement fallback) to demonstrate the low-level AR
- * primitives, this demo shows the high-level [PlacementScene] composable doing all of it in one
- * call. The entire AR scene below — reticle, plane hint, tap-to-place, instant-placement
- * fallback — is the single `PlacementScene { anchor -> ... }` block. The caller only declares
- * *what* rides each placed anchor.
+ * ## What #3568 changed, and why the demo still exists
  *
- * This is the snippet `llms.txt` shows first for AR placement: it is the shortest correct
- * tap-to-place code an AI can generate.
+ * The maintainer used this screen on a shipped build and could not say what it was for; his
+ * note was "il est peut-être à supprimer". The keep-or-delete question has one honest test —
+ * does it show an SDK capability its neighbours do not? It does, and it is the only screen
+ * that does: `placement-scene` is the catalogue's **only** exercise of the public one-call
+ * [PlacementScene] composable. [ARPlacementDemo] deliberately hand-rolls the same flow out of
+ * the low-level primitives (`TapToPlaceArSession`, ~600 lines) to show what they are, and
+ * `wall-placement` demonstrates the vertical `WallPlacementScene`. `PlacementScene` is also
+ * the first snippet `llms.txt` gives for AR placement. Deleting the demo would leave the
+ * SDK's flagship AR entry point with nothing runnable behind it.
+ *
+ * So the code was never the problem — the screen was. It opened straight into a camera, with
+ * the only explanation buried in a Settings sheet nobody opens before using a screen, and
+ * from the outside it was indistinguishable from `Tap to Place`. It now follows the same
+ * two-phase shape as its neighbour ([PlacementChooserScreen][io.github.sceneview.demo.common.placement.PlacementChooserScreen]):
+ * a still, themed screen that states the subject — *this entire camera screen is one call* —
+ * and only then opens the camera. That intro is also the one half of the demo that can be
+ * looked at on an emulator, since there is no camera HAL there (#2754).
  */
 @Composable
 fun PlacementSceneDemo(onBack: () -> Unit) {
+    var inAr by rememberSaveable { mutableStateOf(false) }
+
+    // Back from the camera lands on the intro with the demo still open — the same back ladder
+    // `Tap to Place` uses, so AR is a destination you arrive at, never an entry point.
+    BackHandler(enabled = inAr) { inAr = false }
+
+    if (!inAr) {
+        PlacementSceneIntro(onBack = onBack, onOpenAr = { inAr = true })
+    } else {
+        PlacementSceneAr(onBack = { inAr = false })
+    }
+}
+
+/**
+ * The pre-AR half: what this screen demonstrates, in one screen, before the camera opens.
+ *
+ * Renders the **real** [PlacementReticleVisual] in two plain non-AR [Scene]s — one over a pale
+ * ground, one over a dark one — so the cursor the user is about to meet is introduced, and so
+ * the #3570 redesign has a surface that can be captured without a camera.
+ */
+@Composable
+private fun PlacementSceneIntro(onBack: () -> Unit, onOpenAr: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.demo_placement_scene_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = SceneViewTokens.Space.md)
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.md),
+        ) {
+            Text(
+                text = stringResource(R.string.placement_scene_headline),
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = SceneViewTokens.Space.md),
+            )
+            Text(
+                text = stringResource(R.string.placement_scene_teaches),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // The claim, shown rather than described.
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = stringResource(R.string.placement_scene_snippet),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    modifier = Modifier.padding(SceneViewTokens.Space.md),
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.placement_scene_vs_neighbours),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Text(
+                text = stringResource(R.string.placement_scene_reticle_heading),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(SceneViewTokens.Space.sm),
+            ) {
+                ReticleSwatch(
+                    phase = ReticlePhase.SEARCHING,
+                    label = stringResource(R.string.placement_scene_reticle_searching),
+                    ground = PALE_GROUND,
+                    modifier = Modifier.weight(1f),
+                )
+                ReticleSwatch(
+                    phase = ReticlePhase.READY,
+                    label = stringResource(R.string.placement_scene_reticle_ready),
+                    ground = DARK_GROUND,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Text(
+                text = stringResource(R.string.placement_scene_reticle_note),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Button(
+                onClick = onOpenAr,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = SceneViewTokens.Space.lg),
+            ) {
+                Icon(Icons.Filled.ViewInAr, contentDescription = null)
+                Text(
+                    text = stringResource(R.string.placement_scene_cta),
+                    modifier = Modifier.padding(start = SceneViewTokens.Space.sm),
+                )
+            }
+        }
+    }
+}
+
+/** A pale floor and a dark one — the two grounds an AR cursor actually has to survive. */
+private val PALE_GROUND = Color(0xFFE7E3DC)
+private val DARK_GROUND = Color(0xFF2A2E33)
+
+/** Uniform blow-up that brings the life-sized reticle into a thumbnail-sized viewport. */
+private const val SWATCH_SCALE = 16f
+
+/**
+ * One reticle phase, rendered by the production composable in a non-AR [Scene] over [ground].
+ *
+ * The reticle lies in the XZ plane with +Y up, so the node is tilted back 60° to read as a
+ * cursor on a receding floor rather than an edge-on line.
+ */
+@Composable
+private fun ReticleSwatch(
+    phase: ReticlePhase,
+    label: String,
+    ground: Color,
+    modifier: Modifier = Modifier,
+) {
+    val engine = rememberEngine()
+    val materialLoader = rememberMaterialLoader(engine)
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Surface(
+            color = ground,
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1.35f),
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Scene(
+                    modifier = Modifier.fillMaxSize(),
+                    engine = engine,
+                    materialLoader = materialLoader,
+                    isOpaque = false,
+                ) {
+                    // The reticle is life-sized (an 11 cm ring), and the default camera sits
+                    // metres away, so at 1:1 it is a two-pixel speck in a thumbnail. Scale is
+                    // uniform, so this is the real geometry — proportions, ring thickness and
+                    // halo ratio are exactly what AR draws, just held closer to the lens.
+                    Node(rotation = Rotation(x = -60f), scale = Scale(SWATCH_SCALE)) {
+                        PlacementReticleVisual(
+                            materialLoader = materialLoader,
+                            phase = phase,
+                        )
+                    }
+                }
+            }
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = SceneViewTokens.Space.xs),
+        )
+    }
+}
+
+/** The camera half — the single [PlacementScene] call the intro just claimed it was. */
+@Composable
+private fun PlacementSceneAr(onBack: () -> Unit) {
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
@@ -49,7 +273,7 @@ fun PlacementSceneDemo(onBack: () -> Unit) {
     // completely unchanged for real users.
     val arPlaybackDataset = rememberArPlaybackDataset()
 
-    // Keep the controller in the parent so the "Clear All" button (outside the AR scope) can
+    // Keep the controller in the parent so the "Clear all" button (outside the AR scope) can
     // reach it. PlacementScene also `remember`s its own controller when none is passed via
     // `content`; here we surface it so the demo can drive a counter + clear button.
     val controllerHolder = remember { mutableStateOf<PlacementController?>(null) }
@@ -59,20 +283,16 @@ fun PlacementSceneDemo(onBack: () -> Unit) {
         onBack = onBack,
         controls = {
             Text(
-                text = "The whole AR scene is a single `PlacementScene { anchor -> ... }` call. " +
-                    "With coaching + ground shadows on, it bundles the animated onboarding guide, " +
-                    "a ring reticle that brightens once a surface is ready, tap-to-place, the " +
-                    "instant-placement fallback and a contact shadow under each model. " +
-                    "Aim the ring at a surface and tap to drop a model.",
+                text = stringResource(R.string.placement_scene_teaches),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Button(
+            TextButton(
                 onClick = { controllerHolder.value?.clear() },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 12.dp),
+                    .padding(top = SceneViewTokens.Space.sm),
             ) {
-                Text("Clear All")
+                Text(stringResource(R.string.placement_scene_clear))
             }
         },
         topOverlay = {
@@ -108,7 +328,7 @@ fun PlacementSceneDemo(onBack: () -> Unit) {
                 }
             },
             content = { controller ->
-                // Surface the controller so the parent's Clear All button can reach it.
+                // Surface the controller so the parent's Clear all button can reach it.
                 controllerHolder.value = controller
             },
         )
@@ -126,7 +346,11 @@ private fun PlacedCountPill(count: Int, modifier: Modifier = Modifier) {
         shape = MaterialTheme.shapes.small,
     ) {
         Text(
-            text = if (count == 1) "1 model placed" else "$count models placed",
+            text = if (count == 1) {
+                stringResource(R.string.placement_scene_count_one)
+            } else {
+                stringResource(R.string.placement_scene_count_other, count)
+            },
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
             style = MaterialTheme.typography.labelLarge,
         )

--- a/samples/android-demo/src/main/res/values/strings_demo_placement_scene.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_placement_scene.xml
@@ -3,8 +3,29 @@
      `PlacementSceneFragment.kt`). Android's resource merger
      fans every `res/values/*.xml` file in, so `R.string.demo_placement_scene_title` etc.
      remains globally resolvable. Adding a new demo never needs to touch
-     this file or `strings.xml` — see #1870. -->
+     this file or `strings.xml` — see #1870.
+
+     #3568: the demo used to open straight into the camera with no copy anywhere on screen, so
+     it read as a second, worse `Tap to Place`. The subject is not "you can tap to place" — the
+     neighbouring demo already shows that, by hand, in 600 lines. The subject is that this whole
+     screen is ONE SDK call. The copy below says that before the camera opens. -->
 <resources>
-    <string name="demo_placement_scene_title">Placement Scene</string>
-    <string name="demo_placement_scene_subtitle">One-line tap-to-place AR</string>
+    <string name="demo_placement_scene_title">One-Call AR</string>
+    <string name="demo_placement_scene_subtitle">The same tap-to-place screen, in a single SDK call</string>
+
+    <!-- Pre-AR explainer (#3568). Mirrors the `Tap to Place` chooser: say what is being shown,
+         then open the camera. -->
+    <string name="placement_scene_headline">One call builds this whole screen</string>
+    <string name="placement_scene_teaches">Everything the camera screen does — the reticle, the plane hints, the onboarding coach, tap-to-place, the instant-placement fallback and the contact shadow under each model — comes from one composable. You only declare what rides each anchor.</string>
+    <string name="placement_scene_snippet">PlacementScene { anchor -&gt;\n    AnchorNode(anchor) { ModelNode(helmet) }\n}</string>
+    <string name="placement_scene_vs_neighbours">Tap to Place, next door, hand-writes the same flow out of the low-level AR primitives so you can see what they are. This screen is the shortcut you ship.</string>
+    <string name="placement_scene_reticle_heading">The cursor you will see</string>
+    <string name="placement_scene_reticle_searching">Searching — no surface yet</string>
+    <string name="placement_scene_reticle_ready">Ready — a tap lands here</string>
+    <string name="placement_scene_reticle_note">Achromatic, so it never competes with the model, with a contact halo that keeps it readable on a pale floor.</string>
+    <string name="placement_scene_cta">Open the camera</string>
+    <string name="placement_scene_controls">Aim the ring at a surface and tap to drop a helmet. Back returns here.</string>
+    <string name="placement_scene_clear">Clear all</string>
+    <string name="placement_scene_count_one">1 model placed</string>
+    <string name="placement_scene_count_other">%1$d models placed</string>
 </resources>

--- a/sceneview/src/main/java/io/github/sceneview/node/Node.kt
+++ b/sceneview/src/main/java/io/github/sceneview/node/Node.kt
@@ -586,6 +586,15 @@ open class Node protected constructor(
                 oldParent?.let { it.childNodes = it.childNodes - this }
                 value?.let { it.childNodes = it.childNodes + this }
                 parentEntity = value?.entity
+                // `isVisible` is a COMPUTED property that walks up the parent chain, but the
+                // Filament layer mask that actually decides rendering is only pushed from
+                // `updateVisibility()`. Re-parenting changes the computed answer without
+                // touching either backing field, so before #3569 a child attached to an
+                // already-hidden parent kept the default `0xff` mask and rendered anyway —
+                // which is how PlacementScene's reticle disc showed up flat and un-rotated at
+                // the world origin before ARCore had produced a single hit. Refresh the whole
+                // subtree on every re-parent so a hidden parent can never leak a visible child.
+                updateVisibility()
             }
         }
 


### PR DESCRIPTION
Store QA of the 4.34.0 demo app raised four problems on one screen. They share a surface, so they ship together.

## One-Call AR (was "Placement Scene") — `Closes #3568`

Kept, not deleted. It is the catalogue's **only** exercise of the public one-call `PlacementScene`; `ar-placement` deliberately hand-writes the same flow out of the low-level primitives (~600 lines) and `wall-placement` covers `WallPlacementScene`, so deleting it would leave the preferred API undemoed. What was missing was the explanation, so the demo now opens on a one-screen intro: the call itself, what it builds for you, how it differs from Tap to Place, and the real reticle rendered over a pale and a dark ground. "Open the camera" enters AR; back returns to the intro.

## Flat cursor at the world origin — `Closes #3569`

`Node.isVisible` is computed by walking the parent chain, but the Filament layer mask that actually decides rendering is only pushed by `updateVisibility()`. Neither the `parent` setter nor `childNodes` called it, and a trackable's first `STOPPED → STOPPED` update is not a change, so a freshly reparented reticle child kept the default visible mask and drew one frame at the node's identity pose — flat, un-rotated, at the origin. Fixed in `Node`, so every placement flow benefits.

## Cursor redesign — `Closes #3570`

The tint was `0xFF44E7FF`, documented as "the DESIGN.md primary cyan". DESIGN.md has no cyan. It is now achromatic white (`on-ar-scrim`), a slimmer 3.5 mm hairline ring, and a dark contact-shadow **annulus** that keeps it readable on a pale floor without becoming a second mark — the filled disc tried first read as a grey blob on the demo's pale-ground swatch. Colour is confined to the READY centre dot, DESIGN.md `primary` dark value `#a4c1ff`, which is the rule for accents over a camera frame in both themes. References: RealityKit `FocusEntity`, Scene Viewer, Polycam, IKEA Place — all neutral.

Validated by capture on `emulator-5554` in light and dark through the new intro screen (ARCore cannot track on that AVD, so the reticle is rendered by the production composable in a non-AR `Scene`).

## Taps did nothing — `Closes #3571`

`PlacementScene` fed `frame.hitTest(event)` into a filter with an `INSTANT_PLACEMENT` branch that ARCore can never reach: instant hits only come from `Frame.hitTestInstantPlacement`. Without a tracked plane, every tap was dropped. Now plane-first, with an explicit instant fallback at a 1 m approximate distance, plus haptic confirmation on placement and a reticle gated on real camera tracking.

## Checks

`:arsceneview:testDebugUnitTest`, `:sceneview:testDebugUnitTest` and `:samples:android-demo:assembleDebug` green locally; new tests pin the tap fallback, the reticle gate, the achromatic tint, the accent value and the halo's shape and alpha ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)