### PR TITLE
fix(demo): expand the tapped Showcase card into the demo

### DIFF
--- a/changelog.d/3599-ios-showcase-zoom-transition.md
+++ b/changelog.d/3599-ios-showcase-zoom-transition.md
@@ -1,0 +1,7 @@
+<!-- category: Fixed -->
+- **Tapping a demo card in the iOS Showcase now expands that card into the demo
+  ([#3599](https://github.com/sceneview/sceneview/issues/3599)).** The full-screen demo used
+  to appear with the stock cover slide, with nothing tying it to the card the thumb had just
+  hit. It uses the same iOS 18 zoom transition the Explore gallery already uses: the tapped
+  `DemoMediaCard` — or the hero, when the demo is opened from it — is the transition source,
+  and the demo collapses back into it on close.

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ShowcaseTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ShowcaseTab.swift
@@ -30,6 +30,11 @@ struct ShowcaseTab: View {
     @State private var comingSoonScene: DemoItem?
     @State private var showExplore = false
 
+    /// Source namespace for the iOS 18 zoom presentation transition: the tapped
+    /// card (or the hero) morphs into the full-screen demo instead of the demo
+    /// sliding up over it with no visual link to what was tapped (#3599).
+    @Namespace private var cardNamespace
+
     @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var expanded: Bool { sizeClass == .regular }
@@ -62,6 +67,9 @@ struct ShowcaseTab: View {
                                                   : SceneViewTokens.Home.heroHeight) {
                             open(sceneId: Self.heroDemoId)
                         }
+                        #if os(iOS)
+                        .matchedTransitionSource(id: Self.heroDemoId, in: cardNamespace)
+                        #endif
                     }
 
                     CategoryChipRow(selected: $selectedCategory)
@@ -75,6 +83,9 @@ struct ShowcaseTab: View {
                     LazyVGrid(columns: columns, spacing: SceneViewTokens.Home.gridGutter) {
                         ForEach(visible) { demo in
                             DemoMediaCard(demo: demo) { open(demo) }
+                                #if os(iOS)
+                                .matchedTransitionSource(id: demo.sceneId, in: cardNamespace)
+                                #endif
                         }
                         if !searching {
                             BrowseOnlineModelsCard { showExplore = true }
@@ -120,6 +131,14 @@ struct ShowcaseTab: View {
             #if os(iOS)
             .fullScreenCover(item: $fullScreenScene) { scene in
                 DemoCover(scene: scene) { fullScreenScene = nil }
+                    // The card that was tapped expands into the demo, and
+                    // collapses back into it on close. Before this, a demo
+                    // appeared with the stock cover slide and nothing tied it
+                    // to the card the thumb had just hit (#3599). The source is
+                    // the `DemoMediaCard` — or the `HomeHero` when the demo is
+                    // opened from it, which is why both carry a
+                    // `matchedTransitionSource` keyed on `sceneId`.
+                    .navigationTransition(.zoom(sourceID: scene.sceneId, in: cardNamespace))
             }
             #else
             .sheet(item: $fullScreenScene) { scene in


### PR DESCRIPTION
Closes #3599.

App Store QA of the iOS demo, 2026-09-10: "it's a bit of a shame, there might be a way to do nicer transitions". Opening a demo from the Showcase used the stock full-screen cover slide — nothing tied the destination to the card the thumb had just hit.

This reuses the iOS 18 zoom transition the Explore gallery already ships rather than inventing a second pattern: the `DemoMediaCard` — and the `HomeHero`, for the demo it opens — carry a `matchedTransitionSource` keyed on `sceneId`, and the `.fullScreenCover` applies `.navigationTransition(.zoom(sourceID:in:))`. The card expands into the demo and collapses back into it on close. macOS keeps its sheet, where the modifier does not exist.

Demo-side only; no SDK change. Split from #3600, which fixes the viewer camera itself.

**Not locally built**: the machine ran out of disk during this session, so this leans on CI's iOS demo build. The change mirrors `ExploreTab.swift:366-379` line for line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)