### PR TITLE
fix(build): Dokka no longer sees the Android source roots twice under AGP 9 (#3604)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,41 @@ subprojects {
         }
     }
 
+    // ── Dokka: one Kotlin source set per Android module (#3604) ──────────────
+    //
+    // AGP 9 registers the new-DSL Kotlin source sets (`main`, `test`,
+    // `androidTest`, `testFixtures`) ON TOP of the per-variant ones Dokka has
+    // always adapted (`debug`, `release`, ...). Dokka 2.2 turns each of them
+    // into a Dokka source set, so `:sceneview` and `:arsceneview` ended up with
+    // TWO unsuppressed ones — `main` (shown as `androidJvm`) and `release` —
+    // both rooted at `src/main/java`. Its pre-generation check refuses that:
+    //
+    //   Pre-generation validity check failed: Source sets 'androidJvm' and
+    //   'release' have the common source roots: .../src/main/java, ...
+    //   Every Kotlin source file should belong to only one source set (module).
+    //
+    // which failed `dokkaGeneratePublicationHtml` — and with it both the
+    // "Publish to Maven Central" job (the javadoc jar) and "Publish API docs"
+    // at the 4.35.0 cut. 4.34.0 predates the AGP 9 move (#3459) and had only
+    // `release`.
+    //
+    // Keep `main`, suppress every other source set of that module. `main` is
+    // AGP 9's canonical one; the variant flavour additionally leaks a build
+    // type name into the published docs and roots the generated BuildConfig
+    // directory. Output is otherwise identical (same 1713 pages), only the
+    // source-set label changes from `release` to `androidJvm`. The `main`
+    // guard keeps this a no-op for KMP modules, whose source sets are named
+    // `commonMain` / `androidMain` and never collide this way.
+    plugins.withId("org.jetbrains.dokka") {
+        dokka {
+            dokkaSourceSets.configureEach { sourceSet ->
+                if (dokkaSourceSets.findByName("main") != null && sourceSet.name != "main") {
+                    sourceSet.suppress.set(true)
+                }
+            }
+        }
+    }
+
     // Apply detekt to all subprojects that use Kotlin.
     //
     // NOTE: we use `pluginManager.apply("dev.detekt")` instead of the legacy

--- a/changelog.d/3604-dokka-android-source-sets.md
+++ b/changelog.d/3604-dokka-android-source-sets.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+Dokka no longer sees the Android source roots twice under AGP 9, so the javadoc jar and the API docs build again at release time.


### PR DESCRIPTION
The 4.35.0 release run failed in two jobs — "Publish to Maven Central"
(which builds the javadoc jar) and "Publish API docs":

    > Task :sceneview:dokkaGeneratePublicationHtml FAILED
      > Pre-generation validity check failed: Source sets 'androidJvm' and
        'release' have the common source roots: .../sceneview/src/main/java,
        ... Every Kotlin source file should belong to only one source set.

Cause: the AGP 9 move (#3459, absent from 4.34.0) registers the new-DSL
Kotlin source sets (`main`, `test`, `androidTest`, `testFixtures`) on top
of the per-variant ones Dokka has always adapted (`debug`, `release`).
Dokka 2.2 turns each into a Dokka source set, so `:sceneview` and
`:arsceneview` each ended up with two UNSUPPRESSED ones — `main` (shown
as `androidJvm`) and `release` — both rooted at `src/main/java`. Dokka's
pre-generation check refuses that overlap.

Keep `main`, suppress the module's other source sets, from the shared
`subprojects` block in the root build so both Dokka modules (and any
future one) get it. `main` is AGP 9's canonical source set; the variant
flavour additionally leaks a build type name into the published docs and
roots the generated BuildConfig directory. The guard on a `main` source
set existing keeps this a no-op for KMP modules, whose source sets are
named `commonMain` / `androidMain` and never collide this way.

Verified locally: `:sceneview:dokkaGeneratePublicationHtml`,
`:arsceneview:dokkaGeneratePublicationHtml`, the workflow's exact
`:sceneview:dokkaGenerateHtml :arsceneview:dokkaGenerateHtml`, and
`publishToMavenLocal` for both modules all BUILD SUCCESSFUL. HTML output
is unchanged page for page (1713 pages for `:sceneview`); only the source
set label goes from `release` to `androidJvm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)