### PR TITLE
fix(ios-demo): the Explore search field compiles on macOS again

### DIFF
--- a/changelog.d/3605-macos-explore-autocapitalization.md
+++ b/changelog.d/3605-macos-explore-autocapitalization.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+The Explore tab's search field no longer breaks the macOS demo build: `textInputAutocapitalization` is iOS-only and is now behind an `#if os(iOS)` guard.

--- a/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
+++ b/samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift
@@ -607,7 +607,12 @@ struct ExploreTab: View {
                 .focused($inlineSearchFocused)
                 .submitLabel(.search)
                 .autocorrectionDisabled()
+                // `.textInputAutocapitalization` is iOS-only; macOS has no
+                // software keyboard to auto-capitalise, so the modifier is
+                // simply absent there (same as the Showcase header field).
+                #if os(iOS)
                 .textInputAutocapitalization(.never)
+                #endif
                 .onSubmit { submitSearch() }
                 .accessibilityIdentifier("explore-search-field")
             if !searchText.isEmpty {


### PR DESCRIPTION
## Problem

The "Build & Upload macOS to App Store" job of `.github/workflows/app-store.yml` failed at the macOS archive on tag `v4.35.0` ([run 34570351939](https://github.com/sceneview/sceneview/actions/runs/34570351939)):

```
samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift:610:18: error: value of type 'some View' has no member 'textInputAutocapitalization'
samples/ios-demo/SceneViewDemo/Views/Tabs/ExploreTab.swift:610:47: error: cannot infer contextual base in reference to member 'never'
** ARCHIVE FAILED **
```

`textInputAutocapitalization` is iOS-only (UIKit-backed), so it does not exist in the macOS SwiftUI surface. The iOS/TestFlight leg of the same run passed. The line came in with the iOS QA pass merged yesterday (#3599/#3600/#3601, `inlineSearchField` in `ExploreTab`).

## Fix

The single call site is now behind `#if os(iOS)`, the same pattern already used elsewhere in this file (for `.navigationTransition(.zoom(...))` and `.presentationBackground`). iOS behaviour is unchanged; on macOS the modifier is simply absent, which also matches the Showcase header's search field it was styled after — that one only uses `.autocorrectionDisabled()`. No other site in `samples/ios-demo` or `SceneViewSwift` uses the modifier.

## Verification

Local `xcodebuild build` with the workflow's scheme/project, no signing (`CODE_SIGNING_ALLOWED=NO`):

- `-destination 'platform=macOS'` → `** BUILD SUCCEEDED **`
- `-destination 'generic/platform=iOS Simulator'` → `** BUILD SUCCEEDED **`

🤖 Generated with [Claude Code](https://claude.com/claude-code)