### PR TITLE
fix(sceneview): attaching a node to a live Scene schedules a frame

### DIFF
--- a/changelog.d/3560-attach-schedules-frame.md
+++ b/changelog.d/3560-attach-schedules-frame.md
@@ -1,0 +1,2 @@
+<!-- category: Fixed -->
+A `ModelNode` (or any DSL child node) added to an already-running `Scene`/`SceneView` is now drawn immediately instead of staying invisible until an unrelated surface resize. Attaching or detaching a node now schedules a frame the same way a resize does, so a render-on-demand scene (`isRendering = false`) no longer needs a workaround nudge for newly attached content to actually appear.

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -524,6 +524,26 @@ fun SceneView(
 
     val childNodesRef = remember { AtomicReference(emptyList<Node>()) }
 
+    // A frame is *owed* to the surface currently attached: `true` until one has been presented
+    // into it. Snapshot state, not a plain flag, because the paused render loop parks on it —
+    // see [awaitRenderingEnabled] and the `shouldRender` gate below (#3109). Declared here
+    // (rather than next to [sceneRenderer] below, which only needs to read it) so the DSL-node
+    // sync effect right below can set it too — see the `needsPresent.value = true` inside the
+    // `collect` block (#3560).
+    //
+    // Why this exists at all: a swap chain holds no pixels of its own. `SceneRenderer`'s
+    // `onNativeWindowChanged` creates a brand-new one and presents nothing into it, so every
+    // surface generation — first attach, app foregrounded, foldable folded or unfolded,
+    // split-screen resize — starts blank. With `isRendering = false` on an idle scene, which is
+    // this parameter's documented use, a parked loop would leave that new surface blank
+    // *indefinitely* (black, or transparent with `isOpaque = false`) until something unrelated
+    // flipped the flag. The debt makes the park wait on "rendering is on OR a frame is owed", so a
+    // re-created surface always gets exactly one frame and then parks again. Keyed on
+    // (engine, view, renderer) rather than on `sceneRenderer` itself — `sceneRenderer` is
+    // `remember`ed with the same key below, so this reproduces its recreation timing without
+    // forward-referencing it.
+    val needsPresent = remember(engine, view, renderer) { mutableStateOf(true) }
+
     LaunchedEffect(nodeManager, autoCenterContent, contentRoot) {
         var prevNodes = emptyList<Node>()
         snapshotFlow { scopeChildNodes.toList() }.collect { newNodes ->
@@ -545,6 +565,15 @@ fun SceneView(
             }
             prevNodes = newNodes
             childNodesRef.set(newNodes)
+            // A node was attached to (or detached from) the live scene — schedule a frame the
+            // same way a surface resize does (#3560). With `isRendering = false` (render-on-
+            // demand — the documented use of that parameter), the frame loop below parks on
+            // `shouldRender`, which only `needsPresent` or `isRendering` can wake. Previously
+            // only `onSurfaceResized`/`onSurfaceReady` set it, so a node added to a parked scene
+            // loaded and reported bounds but was never actually drawn until an unrelated resize
+            // (even 1px) incidentally flipped the flag — recomposition alone never reached the
+            // `withFrameNanos` loop.
+            needsPresent.value = true
         }
     }
 
@@ -675,19 +704,8 @@ fun SceneView(
         SceneRenderer(engine, view, renderer)
     }
 
-    // A frame is *owed* to the surface currently attached: `true` until one has been presented
-    // into it. Snapshot state, not a plain flag, because the paused render loop parks on it —
-    // see [awaitRenderingEnabled] and the `shouldRender` gate below (#3109).
-    //
-    // Why this exists at all: a swap chain holds no pixels of its own. `SceneRenderer`'s
-    // `onNativeWindowChanged` creates a brand-new one and presents nothing into it, so every
-    // surface generation — first attach, app foregrounded, foldable folded or unfolded,
-    // split-screen resize — starts blank. With `isRendering = false` on an idle scene, which is
-    // this parameter's documented use, a parked loop would leave that new surface blank
-    // *indefinitely* (black, or transparent with `isOpaque = false`) until something unrelated
-    // flipped the flag. The debt makes the park wait on "rendering is on OR a frame is owed", so a
-    // re-created surface always gets exactly one frame and then parks again.
-    val needsPresent = remember(sceneRenderer) { mutableStateOf(true) }
+    // `needsPresent` (the frame-owed debt) is declared earlier, next to the DSL-node sync effect
+    // that also writes it — see its doc comment above (#3560).
 
     // Wire resize and surface callbacks.
     SideEffect {

--- a/sceneview/src/test/java/io/github/sceneview/NodeAttachSchedulesFrameTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/NodeAttachSchedulesFrameTest.kt
@@ -1,0 +1,188 @@
+package io.github.sceneview
+
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the attach-path half of #3560: a `ModelNode` (or any DSL child node) added to an
+ * already-running `Scene`/`SceneView` must schedule a frame the same way a surface resize does.
+ *
+ * The reporter's repro: with a render-on-demand scene (`isRendering = false`, the documented use
+ * of that parameter — see [SceneIsRenderingTest]), a node added via the `content { … }` DSL loads
+ * and reports bounds through `onBounds`, but the parked `withFrameNanos` loop never wakes to
+ * actually draw it. Only an unrelated surface resize (which sets `needsPresent = true` in
+ * `onSurfaceResized`) incidentally unparks the loop and reveals the model.
+ *
+ * Filament itself cannot run on the JVM, so this reproduces the exact Compose-primitive shape of
+ * `SceneView.kt`'s DSL-node sync effect — a `snapshotFlow` collector over a `SnapshotStateList`
+ * that now also flips `needsPresent` — without any Filament/Node dependency, mirroring
+ * [SceneIsRenderingTest]'s `awaitRenderingEnabled` + `derivedStateOf { isRendering || needsPresent }`
+ * harness for the resize path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NodeAttachSchedulesFrameTest {
+
+    /**
+     * The DSL-node sync effect under test, extracted to a plain function: diffs
+     * [scopeChildNodes] against what was previously seen and, on any change, marks
+     * [needsPresent] — exactly what `SceneView.kt`'s `LaunchedEffect(nodeManager, …)` block does
+     * around its `snapshotFlow { scopeChildNodes.toList() }.collect { … }` (see the
+     * `needsPresent.value = true` at the end of that collector, #3560).
+     */
+    private suspend fun syncChildNodesAndScheduleFrame(
+        scopeChildNodes: SnapshotStateList<Int>,
+        needsPresent: androidx.compose.runtime.MutableState<Boolean>
+    ) {
+        var prevNodes = emptyList<Int>()
+        snapshotFlow { scopeChildNodes.toList() }.collect { newNodes ->
+            prevNodes = newNodes
+            needsPresent.value = true
+        }
+    }
+
+    @Test
+    fun attachingANodeWakesAParkedLoopWhileRenderingStaysDisabled() = runTest {
+        val isRendering = mutableStateOf(false)
+        val needsPresent = mutableStateOf(false)
+        val shouldRender = derivedStateOf { isRendering.value || needsPresent.value }
+        val scopeChildNodes = mutableStateListOf<Int>()
+
+        // The sync effect's own LaunchedEffect — runs concurrently with the render loop, exactly
+        // like in `SceneView`. Launched on `backgroundScope` because it never completes
+        // (`snapshotFlow` collects forever), same as `SceneView`'s own `LaunchedEffect`.
+        backgroundScope.launch { syncChildNodesAndScheduleFrame(scopeChildNodes, needsPresent) }
+        runCurrent()
+        // The initial emission (the starting, empty content) already schedules one frame —
+        // settle it before testing the attach itself, exactly like production settles the debt
+        // back to false once the loop presents.
+        needsPresent.value = false
+
+        var resumedAtVirtualTime = -1L
+        val renderLoop = launch {
+            awaitRenderingEnabled(shouldRender)
+            resumedAtVirtualTime = currentTime
+        }
+        advanceTimeBy(5_000)
+        runCurrent()
+        assertEquals(
+            "the loop must stay parked until a node is actually attached — nothing has happened yet",
+            -1L,
+            resumedAtVirtualTime
+        )
+
+        // What the Compose DSL does when a caller adds a `ModelNode` to a live `content { … }`:
+        // mutate the snapshot list. No resize, no recomposition of `SceneView` itself.
+        val parkedUntilVirtualTime = currentTime
+        scopeChildNodes.add(1)
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        // A second apply/runCurrent pass: outside a real Compose runtime nothing auto-propagates
+        // a chained state write, so the sync effect's own `needsPresent.value = true` (just run
+        // above) needs its own notification before `awaitRenderingEnabled`'s snapshotFlow sees it
+        // — same two-hop shape production gets for free from the Recomposer.
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+
+        assertTrue(
+            "attaching a node to the live scene must wake the parked render loop on its own — " +
+                "recomposition/snapshotFlow alone is not observed by the withFrameNanos loop unless " +
+                "it also flips needsPresent (#3560)",
+            renderLoop.isCompleted
+        )
+        assertEquals(
+            "the wake must come from the same snapshot apply that attached the node, at zero " +
+                "elapsed virtual time — same shape as a surface resize (SceneIsRenderingTest)",
+            parkedUntilVirtualTime,
+            resumedAtVirtualTime
+        )
+        assertFalse("isRendering itself must not be mutated by the attach path", isRendering.value)
+    }
+
+    @Test
+    fun detachingANodeAlsoWakesTheParkedLoop() = runTest {
+        val isRendering = mutableStateOf(false)
+        val needsPresent = mutableStateOf(false)
+        val shouldRender = derivedStateOf { isRendering.value || needsPresent.value }
+        val scopeChildNodes = mutableStateListOf(1, 2)
+
+        backgroundScope.launch { syncChildNodesAndScheduleFrame(scopeChildNodes, needsPresent) }
+        runCurrent()
+        // The initial emission of the collector (the starting content) already schedules one
+        // frame — settle it before testing the removal, exactly like production settles the
+        // debt back to false once the loop presents.
+        needsPresent.value = false
+
+        var resumedAtVirtualTime = -1L
+        launch {
+            awaitRenderingEnabled(shouldRender)
+            resumedAtVirtualTime = currentTime
+        }
+        runCurrent()
+        assertEquals(-1L, resumedAtVirtualTime)
+
+        scopeChildNodes.removeAt(0)
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        // Second hop — see the comment in `attachingANodeWakesAParkedLoopWhileRenderingStaysDisabled`.
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+
+        assertTrue(
+            "removing a node changes what is on screen just as much as adding one — the loop must " +
+                "wake to actually stop drawing it",
+            resumedAtVirtualTime >= 0L
+        )
+    }
+
+    @Test
+    fun noUnrelatedNodeChangeDoesNotLeaveTheLoopSpinning() = runTest {
+        val isRendering = mutableStateOf(false)
+        val needsPresent = mutableStateOf(false)
+        val shouldRender = derivedStateOf { isRendering.value || needsPresent.value }
+        val scopeChildNodes = mutableStateListOf<Int>()
+
+        backgroundScope.launch { syncChildNodesAndScheduleFrame(scopeChildNodes, needsPresent) }
+        runCurrent()
+        // Settle the initial-emission debt, mirroring production's post-present reset.
+        needsPresent.value = false
+
+        scopeChildNodes.add(1)
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        // Settle the debt the attach itself created — this test is about what happens *after*.
+        needsPresent.value = false
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+
+        var completed = false
+        val job = launch {
+            awaitRenderingEnabled(shouldRender)
+            completed = true
+        }
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        assertFalse(
+            "once the debt from the attach is settled and nothing else changed, the loop must go " +
+                "back to parking, not spin forever",
+            completed
+        )
+        assertTrue(job.isActive)
+
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3560. A `ModelNode` (or any DSL child node) added to an already-running Compose `Scene`/`SceneView` loaded and reported bounds through `onBounds`, but nothing was drawn until the surface received a resize — recomposition alone did not help.

Root cause: `SceneView`'s render loop parks on a `shouldRender = derivedStateOf { isRendering || needsPresent }` gate when `isRendering = false` (render-on-demand, the documented use of that parameter). `needsPresent` — the "a frame is owed to the surface" debt flag — was only ever set from `onSurfaceResized` / `onSurfaceReady`. The DSL child-node sync effect (the `LaunchedEffect` that diffs `scopeChildNodes` via `snapshotFlow` and adds/removes nodes from the Filament scene) never touched it. So a node attached while the loop was parked got registered with Filament and reported correct bounds, but the `withFrameNanos` loop never woke to actually present it — only an unrelated resize (which does set `needsPresent`) incidentally unparked the loop and revealed the model, matching the reporter's repro exactly.

`ARSceneView`/`ARScene` doesn't have this bug class: it has no `isRendering`/`needsPresent` render-on-demand gate at all (AR always renders every frame for the camera feed), so the fix is scoped to `sceneview/src/main/java/io/github/sceneview/SceneView.kt`.

## Fix

- Moved the `needsPresent` state declaration above the DSL-node sync effect (kept keyed on `(engine, view, renderer)`, the same identity `sceneRenderer` itself is keyed on, so recreation timing is unchanged).
- The sync effect's `collect` block now sets `needsPresent.value = true` on every diff (attach or detach), mirroring what `onSurfaceResized`/`onSurfaceReady` already do for a resize.

## Tests

Filament cannot run on the JVM, so `NodeAttachSchedulesFrameTest.kt` reproduces the exact Compose-primitive shape of the fix (a `snapshotFlow` collector over a `SnapshotStateList` that now also flips a `needsPresent` state) without any Filament/Node dependency, using the same `awaitRenderingEnabled` + `derivedStateOf { isRendering || needsPresent }` harness `SceneIsRenderingTest` (#3108/#3109) already established for the resize path:
- `attachingANodeWakesAParkedLoopWhileRenderingStaysDisabled` — a node added to a parked, render-on-demand scene wakes the loop on the same snapshot apply, at zero elapsed virtual time.
- `detachingANodeAlsoWakesTheParkedLoop` — removal wakes the loop too.
- `noUnrelatedNodeChangeDoesNotLeaveTheLoopSpinning` — once the debt from an attach settles, the loop parks again rather than spinning.

## Verification

- [x] `:sceneview:testDebugUnitTest` — full suite green, including the new test and the pre-existing `SceneIsRenderingTest`.
- [x] `:sceneview:detekt` — clean.
- [x] `:sceneview:apiDump` — no-op, confirmed: `git status` shows no changes to any `.api` file.
- [x] `:samples:android-demo:assembleDebug` + on-device before/after capture, `emulator-5554` (Pixel_7a).

### On-device before/after (#3560)

Used a temporary, **not committed**, debug-only harness (`DemoHostActivity` routed a `issue-3560-harness` id to a throwaway composable, deleted after the run — never part of this PR's diff): a bare `SceneView(isRendering = false)` with a `LaunchedEffect` that attaches a `CubeNode` 2s after the scene starts. No resize happens anywhere in the harness, isolating exactly the code path this PR touches.

Captured with `adb exec-out screencap -p`, kept locally in `/tmp/qa-3560/` (not part of the repo):

| Build | State (≥5s after attach) | Bright pixels (luminance > 90, 1080×2400 stage) |
|---|---|---|
| Pre-fix (`SceneView.kt` reverted to `origin/main`, harness otherwise identical) | Screen stays black — cube never drawn, even 10s after attach (`before-buggy.png` @5s and `before-buggy-10s.png` @10s are byte-identical: 2 820 bright px both times, proving the loop is genuinely parked, not just slow) | 2 820 (0.11%) |
| Fixed (this PR) | Purple cube visible immediately once attached, no resize | 4 839 (0.19%) |

The 2 019-pixel delta is exactly the cube's on-screen footprint — present with the fix, absent without it, with the surrounding UI chrome identical between the two builds (same harness, same delay, same camera).

Not done: no capture against a real bundled glTF / `ModelNode` (the reporter's exact repro) — the synthetic `CubeNode` isolates the same `needsPresent` code path without needing an asset, and is faster to iterate on than the full `ModelViewerDemo` flow. Kept out of the demo registry as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
