### PR TITLE
fix(demo): the Materials labels stop eating camera gestures, and a tap flies the camera in

### DIFF
--- a/changelog.d/3609-materials-labels-zoom.md
+++ b/changelog.d/3609-materials-labels-zoom.md
@@ -1,0 +1,9 @@
+<!-- category: Fixed -->
+**Materials demo** — a drag that started on a material name moved nothing. The floating
+labels were `clickable`, and a Compose node that accepts pointer input wins the hit test
+outright, so the `SceneView` underneath was never offered the gesture. The labels are now
+pure decoration and the wall orbits from anywhere, labels included. Tapping a sphere no
+longer teleports to *Inspect* either: the camera flies onto the picked ball on an eased
+dolly and flies back out to the wall when you leave *Inspect*. The sheet and the peek
+header now say the spheres are tappable, the tap answers with a selection haptic, and the
+focused label lights up while the camera travels. (#3609)

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -702,6 +702,15 @@ class HeroOrbitCameraManipulator(
     private val yHeight: Float,
     private val target: Position,
     private val resumeAfterMillis: Long = 3_000L,
+    /**
+     * Optional live override of [radius], read once per frame. A demo that animates the
+     * framing — zooming onto a picked object and back out (#3609) — passes the animation's
+     * current value here instead of rebuilding the manipulator, which would drop the
+     * user-control fallback mid-gesture.
+     */
+    private val radiusProvider: (() -> Float)? = null,
+    /** Optional live override of [target], same contract as [radiusProvider]. */
+    private val targetProvider: (() -> Position)? = null,
 ) : io.github.sceneview.gesture.CameraGestureDetector.CameraManipulator {
     private var fallback: io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator? =
         null
@@ -717,8 +726,26 @@ class HeroOrbitCameraManipulator(
 
     fun isPaused(): Boolean = fallback != null
 
+    private fun currentRadius(): Float = radiusProvider?.invoke() ?: radius
+
+    private fun currentTarget(): Position = targetProvider?.invoke() ?: target
+
+    /**
+     * Hand control back to the idle orbit immediately, without waiting out
+     * [resumeAfterMillis]. A demo calls this when it starts a camera animation of its own
+     * (#3609): the animation drives [radiusProvider] / [targetProvider], which the
+     * user-control fallback ignores, so an un-cleared fallback would freeze the camera for
+     * the whole animation and the zoom would simply not play.
+     */
+    fun resumeAuto() {
+        fallback = null
+        grabEndTimeNanos = 0L
+    }
+
     private fun currentEye(): Position {
         val rad = Math.toRadians(yawProvider().toDouble()).toFloat()
+        val radius = currentRadius()
+        val target = currentTarget()
         return Position(
             x = sin(rad) * radius + target.x,
             y = target.y + yHeight,
@@ -730,7 +757,7 @@ class HeroOrbitCameraManipulator(
         val eye = currentEye()
         val mat = dev.romainguy.kotlin.math.lookAt(
             eye = eye,
-            target = target,
+            target = currentTarget(),
             up = dev.romainguy.kotlin.math.Float3(0f, 1f, 0f),
         )
         return io.github.sceneview.math.Transform(mat)
@@ -742,7 +769,7 @@ class HeroOrbitCameraManipulator(
             // seamless — the first drag begins exactly where we stopped orbiting.
             fallback = io.github.sceneview.gesture.CameraGestureDetector.DefaultCameraManipulator(
                 eyePosition = currentEye(),
-                targetPosition = target,
+                targetPosition = currentTarget(),
             ).also { it.setViewport(viewportW, viewportH) }
         }
         // A new gesture is starting — clear the "idle since" stamp so the resume timer
@@ -769,6 +796,7 @@ class HeroOrbitCameraManipulator(
         // of the poles and needs no clamp.
         val transform = fb.getTransform()
         val eye = transform.position
+        val target = currentTarget()
         val clampedEye = clampOrbitEyePitch(eye, target)
         if (clampedEye == eye) return transform
         val mat = dev.romainguy.kotlin.math.lookAt(

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/MaterialsDemo.kt
@@ -2,8 +2,10 @@
 
 package io.github.sceneview.demo.demos
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
@@ -52,6 +54,8 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -81,6 +85,7 @@ import io.github.sceneview.demo.rememberHeroOrbitCameraManipulator
 import io.github.sceneview.demo.HeroOrbitCameraManipulator
 import io.github.sceneview.demo.theme.SceneViewTokens
 import io.github.sceneview.environment.rememberHDREnvironment
+import io.github.sceneview.haptic.rememberHapticFeedback
 import io.github.sceneview.loaders.MaterialLoader
 import io.github.sceneview.material.setMetallic
 import io.github.sceneview.material.setReflectance
@@ -100,6 +105,7 @@ import io.github.sceneview.sample.LifecycleAwareLaunchedEffect
 import io.github.sceneview.sample.rememberOcclusionMaterialInstance
 import io.github.sceneview.sample.rememberUnlitMaterialInstance
 import io.github.sceneview.sample.ui.LabeledSlider
+import kotlinx.coroutines.launch
 
 /**
  * **Materials** — what a physically based surface is, shown rather than described.
@@ -112,7 +118,8 @@ import io.github.sceneview.sample.ui.LabeledSlider
  * the environment's IBL finishes prefiltering.
  *
  * - **Gallery** — the nine materials at once, under a slow camera *sweep* rather than an
- *   orbit. Tap a sphere to inspect it.
+ *   orbit. Tap a sphere and the camera flies onto it, then hands over to *Inspect*;
+ *   leaving Inspect flies back out to the wall (#3609).
  * - **Inspect** — one of them, large, with its parameters on live sliders. *Compare* splits
  *   the stage so the material you were looking at a moment ago stays on screen next to the
  *   one you moved to, which is the only way to see a roughness difference of 0.1.
@@ -270,6 +277,22 @@ private fun StudioSection(
     val comparisonCamera = rememberCameraNode(engine)
     var labelFrame by remember { mutableIntStateOf(0) }
 
+    // ── Tap-to-focus (#3609) ─────────────────────────────────────────────────────────────
+    //
+    // Thomas's in-app note on 4.35.0: a tap on a sphere teleported to Inspect. The jump is
+    // now an eased dolly — the Gallery camera flies from the wall onto the picked sphere and
+    // only then hands over to Inspect, so the eye keeps track of which ball it followed.
+    //
+    // `focusIndex` is the picked sphere for the whole flight *and* for the flight back: it is
+    // cleared only once the ease-out finishes, which is what lets the reverse leg aim at the
+    // ball the user left rather than snapping through the origin.
+    var focusIndex by remember { mutableStateOf<Int?>(null) }
+    val focusZoom = remember { Animatable(0f) }
+    val focusing = focusIndex != null
+    val focusScope = rememberCoroutineScope()
+    val haptic = rememberHapticFeedback()
+    val wallPositions = remember { MaterialStudio.wallPositions() }
+
     // Push the live overrides onto the selected instance. Keyed on the values rather than on
     // `instances` — the map above produces a new List every recomposition, so keying on it
     // would restart the effect on every frame of a drag.
@@ -291,9 +314,16 @@ private fun StudioSection(
     // Gallery: a flat wall cannot be orbited — a quarter turn shows the spheres edge-on and a
     // half turn shows the back of the grid. The phase drives a bounded cosine sweep instead.
     val sweepPhase = remember { mutableFloatStateOf(MaterialStudio.STATIC_SWEEP_PHASE) }
-    LifecycleAwareLaunchedEffect(animating, inspecting, DemoSettings.qaMode) {
-        if (inspecting || !animating || DemoSettings.qaMode) {
-            if (!animating || DemoSettings.qaMode) {
+    // Two ways to stop the sweep, and they end differently. `sweepPinned` — the pause button
+    // or QA mode — also returns the phase to its canonical value, so the wall is framed the
+    // same way every time it is stilled. A focus flight (#3609) merely *suspends* it: a yaw
+    // still travelling under the dolly drags the picked sphere out of frame, and resetting
+    // the phase mid-flight would snap it there in one frame.
+    val sweepPinned = !animating || DemoSettings.qaMode
+    val sweepStopped = inspecting || sweepPinned || focusing
+    LifecycleAwareLaunchedEffect(animating, inspecting, focusing, DemoSettings.qaMode) {
+        if (sweepStopped) {
+            if (sweepPinned && !focusing) {
                 sweepPhase.floatValue = MaterialStudio.STATIC_SWEEP_PHASE
             }
             return@LifecycleAwareLaunchedEffect
@@ -320,16 +350,6 @@ private fun StudioSection(
         azimuthInvariant = false,
         fill = GALLERY_FILL,
     )
-    val galleryManipulator = remember(galleryRadius) {
-        HeroOrbitCameraManipulator(
-            yawProvider = { MaterialStudio.sweepYaw(sweepPhase.floatValue) },
-            radius = galleryRadius,
-            yHeight = 0f,
-            target = Position(0f, 0f, 0f),
-            resumeAfterMillis = 4_000L,
-        )
-    }
-
     val heroExtent = if (compare) {
         2f * MaterialStudio.COMPARE_OFFSET + 2f * MaterialStudio.COMPARE_RADIUS
     } else {
@@ -354,23 +374,102 @@ private fun StudioSection(
         staticYaw = MaterialStudio.STATIC_ORBIT_YAW,
     )
 
-    LaunchedEffect(heroRadius) {
+    // Where the tap-to-focus dolly stops. Not an arbitrary "close enough" distance: it is the
+    // distance at which a wall sphere covers the same fraction of the frame as the ball
+    // Inspect is about to draw, so the hand-over from this camera to Inspect's changes the
+    // subject's size by nothing. Apparent size is radius / distance, hence the ratio.
+    val inspectBallRadius =
+        if (compare) MaterialStudio.COMPARE_RADIUS else MaterialStudio.HERO_RADIUS
+    val focusRadius = (heroRadius * MaterialStudio.BALL_RADIUS / inspectBallRadius)
+        // Never let the eye reach into the sphere it is flying at.
+        .coerceAtLeast(3f * MaterialStudio.BALL_RADIUS)
+    // Read by the manipulator's providers on the render thread, so `compare` flipping while a
+    // flight is in the air retargets it instead of stranding it at a stale distance.
+    val focusRadiusState = rememberUpdatedState(focusRadius)
+
+    val galleryManipulator = remember(galleryRadius) {
+        HeroOrbitCameraManipulator(
+            yawProvider = { MaterialStudio.sweepYaw(sweepPhase.floatValue) },
+            radius = galleryRadius,
+            yHeight = 0f,
+            target = Position(0f, 0f, 0f),
+            resumeAfterMillis = 4_000L,
+            // The dolly is expressed as two per-frame reads rather than as a rebuilt
+            // manipulator: rebuilding one mid-flight would drop the user-control fallback and
+            // the camera would jump.
+            radiusProvider = {
+                val t = focusZoom.value
+                galleryRadius + (focusRadiusState.value - galleryRadius) * t
+            },
+            targetProvider = {
+                val t = focusZoom.value
+                val anchor = focusIndex?.let { wallPositions[it] } ?: Position(0f, 0f, 0f)
+                Position(anchor.x * t, anchor.y * t, anchor.z * t)
+            },
+        )
+    }
+
+    /**
+     * Fly onto [index], then open Inspect on it. In QA mode the flight is instantaneous so
+     * the screenshot harness never captures a half-travelled camera.
+     */
+    fun focusOn(index: Int) {
+        focusIndex = index
+        haptic.selection()
+        // A drag earlier in the session leaves the manipulator in user control, where the two
+        // providers above are ignored — without this the dolly would simply not play.
+        galleryManipulator.resumeAuto()
+        focusScope.launch {
+            focusZoom.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = if (DemoSettings.qaMode) 0 else FOCUS_FLIGHT_MILLIS,
+                    easing = FastOutSlowInEasing,
+                ),
+            )
+            selectedIndex = index
+            onModeChange(MaterialsMode.Inspect)
+        }
+    }
+
+    // The flight back. Leaving Inspect — by the dock's Gallery button or by the segmented
+    // control — eases the wall back in from wherever the camera had landed, which is the
+    // "tap again to go back out" half of #3609.
+    LaunchedEffect(inspecting) {
+        if (!inspecting && focusZoom.value > 0f) {
+            focusZoom.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(
+                    durationMillis = if (DemoSettings.qaMode) 0 else FOCUS_FLIGHT_MILLIS,
+                    easing = FastOutSlowInEasing,
+                ),
+            )
+            focusIndex = null
+        }
+    }
+
+    // Re-frame the Compare pair on every entry into it, not just when the fitted radius
+    // changes. With `compare` on there is no manipulator at all, so the camera node simply
+    // keeps the pose the *gallery* manipulator last wrote — which since #3609 is the dolly's
+    // landing pose, parked off-centre on the sphere that was tapped, leaving one of the two
+    // balls out of frame. Keying on `inspecting` and `compare` puts the pair back on the axis
+    // the moment the hand-over happens.
+    LaunchedEffect(heroRadius, inspecting, compare) {
         comparisonCamera.position = Position(0f, 0f, heroRadius)
         comparisonCamera.lookAt(Position(0f))
     }
     val firstFrame = rememberFirstFrameState()
 
-    // A tap on a gallery sphere selects it and moves to Inspect. `Node.name` carries the
-    // material id — the picker hands back the picked Node, not an index, and matching on the
-    // name is what keeps that mapping readable when the wall order changes.
+    // A tap on a gallery sphere flies the camera onto it and then moves to Inspect.
+    // `Node.name` carries the material id — the picker hands back the picked Node, not an
+    // index, and matching on the name is what keeps that mapping readable when the wall order
+    // changes. Guarded on `focusing` so a second tap during the flight cannot start a second
+    // one; the camera is already travelling and a re-aim mid-flight reads as a glitch.
     val gestureListener = rememberOnGestureListener(
         onSingleTapUp = { _, node ->
-            if (!inspecting) {
+            if (!inspecting && !focusing) {
                 val tapped = library.indexOfFirst { it.id == node?.name }
-                if (tapped >= 0) {
-                    selectedIndex = tapped
-                    onModeChange(MaterialsMode.Inspect)
-                }
+                if (tapped >= 0) focusOn(tapped)
             }
         },
     )
@@ -458,6 +557,17 @@ private fun StudioSection(
         },
         controls = {
             ModeSelector(mode, onModeChange)
+
+            // The wall does not look interactive — nine spheres read as a picture (#3609).
+            // The sheet says so once, in Gallery only, where it is true.
+            if (!inspecting) {
+                Text(
+                    text = stringResource(R.string.demo_materials_tap_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(SceneViewTokens.Space.md))
+            }
 
             Text(stringResource(R.string.demo_materials_picker_label), style = MaterialTheme.typography.labelLarge)
             Spacer(modifier = Modifier.height(SceneViewTokens.Space.sm))
@@ -634,6 +744,16 @@ private fun StudioSection(
                         if (selected.trait == MaterialTrait.None) R.string.demo_materials_base_matte
                         else R.string.demo_materials_base_layer
                     ) else stringResource(selected.nameRes)
+                    // #3609: the labels carry NO pointer-input modifier, on purpose. They
+                    // used to be `clickable`, and a Compose node that takes pointer input
+                    // wins the hit test outright — the `SceneView` sibling underneath was
+                    // never even offered the event, so a drag that happened to start on a
+                    // name did nothing at all while the same drag two pixels lower orbited
+                    // the camera. Non-consumption is not enough to fix that: hit testing
+                    // stops at the topmost node that accepts pointers, whatever it then does
+                    // with them. So the labels are pure decoration and the spheres behind
+                    // them stay both draggable and tappable.
+                    val focused = !inspecting && focusIndex == index
                     Text(
                         caption,
                         modifier = Modifier.offset {
@@ -644,18 +764,25 @@ private fun StudioSection(
                                 ((point?.y ?: -view.viewport.height.toFloat()) + gapPx).toInt())
                         }.width(captionWidth)
                             .padding(horizontal = SceneViewTokens.Space.xs)
-                            .background(MaterialTheme.colorScheme.surface, MaterialTheme.shapes.small)
-                            .clickable(enabled = !inspecting) {
-                                selectedIndex = index
-                                onModeChange(MaterialsMode.Inspect)
-                            }
+                            .background(
+                                if (focused) {
+                                    MaterialTheme.colorScheme.primaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.surface
+                                },
+                                MaterialTheme.shapes.small,
+                            )
                             .padding(SceneViewTokens.Space.xs),
                         style = if (inspecting) {
                             MaterialTheme.typography.titleSmall
                         } else {
                             MaterialTheme.typography.labelSmall
                         },
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = if (focused) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
                         textAlign = TextAlign.Center,
                     )
                 }
@@ -670,6 +797,14 @@ private fun StudioSection(
         }
     }
 }
+
+/**
+ * Duration of the tap-to-focus dolly, in and out (#3609).
+ *
+ * Long enough to read as travel rather than as a cut — under ~300 ms the eye registers a jump
+ * — and short enough that it never feels like a wait before Inspect opens.
+ */
+private const val FOCUS_FLIGHT_MILLIS: Int = 520
 
 /** Fraction of the frame the gallery wall spans. Leaves the chrome bands their own air. */
 private const val GALLERY_FILL: Float = 0.88f

--- a/samples/android-demo/src/main/res/values/strings_demo_materials.xml
+++ b/samples/android-demo/src/main/res/values/strings_demo_materials.xml
@@ -21,7 +21,10 @@
     <string name="demo_materials_mode_inspect">Inspect</string>
     <string name="demo_materials_mode_occlusion">Occlusion</string>
 
-    <string name="demo_materials_gallery_hint">Tap a sphere to inspect its material</string>
+    <!-- #3609: the peek header and the sheet line both say the same thing, because the
+         wall reads as a picture and nothing else on screen suggests the spheres respond. -->
+    <string name="demo_materials_gallery_hint">Tap a sphere to zoom in on it</string>
+    <string name="demo_materials_tap_hint">Tap any sphere to fly the camera onto it and open its parameters. Drag anywhere — over the labels too — to move the camera.</string>
     <string name="demo_materials_picker_label">Material</string>
     <string name="demo_materials_environment_label">Environment</string>
 


### PR DESCRIPTION
Fixes #3609

Thomas, in-app on a Pixel 9 running 4.35.0: *« j'ai l'impression que les labels
empêchent le mouvement de caméra quand on commence la gesture dessus. faire un effet de
zoom progressif quand on clique et montrer plus qu'on peut cliquer sur les boules »* —
three asks, all on `sceneview://demo/materials`.

## 1. The labels were eating the gesture

The floating material names were `clickable`. A Compose node that accepts pointer input
wins the hit test outright, so the `SceneView` sibling underneath was never offered the
event — a drag that happened to start on a name did nothing at all, while the same drag
two pixels lower orbited the wall. Making the modifier non-consuming would not have
helped: hit testing stops at the topmost node that accepts pointers, whatever it then
does with them.

So the labels carry **no pointer-input modifier at all** and are pure decoration. Nothing
is lost: the spheres themselves are pickable, and the material picker in the control
sheet is still the accessible, TalkBack-reachable way to select one.

## 2. A tap now flies the camera in

Tapping a sphere used to cut straight to Inspect. It now dollies: 520 ms of
`FastOutSlowIn` from the wall onto the picked ball, then the hand-over to Inspect;
leaving Inspect flies back out to the wall.

The flight is two per-frame reads on `HeroOrbitCameraManipulator` — new optional
`radiusProvider` / `targetProvider` — rather than a rebuilt manipulator, which would drop
the user-control fallback mid-gesture. A new `resumeAuto()` hands control back from an
earlier drag, without which the providers are ignored and the dolly simply does not play.
It stops at the distance where a wall sphere covers the same fraction of the frame as the
ball Inspect is about to draw, so the hand-over changes the subject's size by nothing.

**An older bug fell out of this.** With Compare on there is no manipulator, so the camera
node kept whatever pose the Gallery manipulator last wrote — now the dolly's landing
pose, off-centre, with one of the two balls out of frame. The re-framing effect is keyed
on entering Compare, not only on the fitted radius changing.

## 3. The spheres now look tappable

A hint line in the sheet (Gallery only, where it is true), the peek header reworded to
*"Tap a sphere to zoom in on it"*, a selection haptic on the tap, and the focused label
lit in `primaryContainer` for the length of the flight. Tokens only — no new colours.

## Verification

Built and driven on `emulator-5554` (Pixel_7a), captures in `/tmp/qa-3609/`, both themes.

- **Labels are transparent to touch** — `02-light-before-drag.png` / `03-light-after-drag-from-label.png`:
  the auto-sweep is paused, then `adb shell input swipe 538 1354 180 1354 700` — a drag
  whose **first touch lands on the "Glazed ceramic" label**. The wall swings round to an
  edge-on view. Before the fix that drag moved nothing.
- **Progressive zoom** — `contact-flight.png`, six frames at 8 fps through a tap on the
  Car paint sphere: the label lights up, the camera travels in over three frames, then
  Inspect takes over with the Compare pair centred and both balls in frame.
- **Flight back out** — `contact-back.png`, the same six-frame strip leaving Inspect: the
  wall eases back in from the focused ball.
- **Light + dark** — `contact-themes.png`: the wall after the return flight (highlight
  correctly cleared) beside the same screen in dark mode.
- **The hint** — `10-dark-sheet-hint.png`, the control sheet in dark mode.

`./gradlew :samples:android-demo:detekt :samples:android-demo:testDebugUnitTest` is
green. No Roborazzi golden of this screen moved — the demo renders a placeholder under
`LocalInspectionMode`, so the goldens never saw the camera.

### Astra QA finding #31, same screen

Checked on capture and **not reproduced**: the back button, the title pill and the dock
are dark translucent glass over the top/bottom scrims that #3328 already put in, not
white chrome. They read cleanly against every part of the gray studio environment in both
themes (`contact-themes.png`). No colour change made — inventing one here would undo
#3328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)