### PR TITLE
feat(gesture): double-tap to zoom in, two-finger tap to zoom out (#3608)

### DIFF
--- a/changelog.d/3608-double-tap-zoom.md
+++ b/changelog.d/3608-double-tap-zoom.md
@@ -1,0 +1,7 @@
+<!-- category: Added -->
+Double-tap to zoom in, two-finger tap to zoom out, on every `Scene` / `SceneView` — the gesture
+convention of photo viewers and maps, animated over 300 ms and clamped by the same distance limits
+as the pinch. On by default; opt out with
+`CameraGestureDetector.DefaultCameraManipulator.isDoubleTapZoomEnabled = false`, and re-tune with
+`doubleTapZoomFactor` / `doubleTapZoomDurationSeconds`. A consumer's own `onDoubleTap` callback and
+tap-to-pick still fire — the camera does not steal the event.

--- a/changelog.d/3608-double-tap-zoom.md
+++ b/changelog.d/3608-double-tap-zoom.md
@@ -5,3 +5,7 @@ as the pinch. On by default; opt out with
 `CameraGestureDetector.DefaultCameraManipulator.isDoubleTapZoomEnabled = false`, and re-tune with
 `doubleTapZoomFactor` / `doubleTapZoomDurationSeconds`. A consumer's own `onDoubleTap` callback and
 tap-to-pick still fire — the camera does not steal the event.
+
+Custom `CameraManipulator` implementations opt in by overriding `doubleTapZoom(x, y, zoomIn)`; the
+step and the easing are public (`zoomedDistanceForDoubleTap`, `animatedZoomDistance`) so they do
+not have to be reimplemented.

--- a/llms.txt
+++ b/llms.txt
@@ -3562,7 +3562,7 @@ bottom-left origin. The default being a no-op means a scene that supplies its ow
 gets no zoom until it overrides that method — the maths is public so it does not have to be
 reinvented:
 
-```kotlin
+```kotlin notest members of a custom CameraManipulator, not standalone declarations
 override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {
     zoomTarget = zoomedDistanceForDoubleTap(   // io.github.sceneview.gesture
         distance = currentDistance, homeDistance = fitDistance, zoomIn = zoomIn,

--- a/llms.txt
+++ b/llms.txt
@@ -3534,6 +3534,34 @@ SceneView(
 )
 ```
 
+### Camera gestures
+
+One finger orbits, two fingers pan, a pinch dollies — and since 4.36.0 a **double-tap zooms in**
+and a **two-finger tap zooms out**, animated over 300 ms, the same convention as Google Maps and
+Photos (#3608). Both taps are on by default in `Scene` / `SceneView` / `ARScene`, are clamped by
+the same min/max distance factors as the pinch, and leave `onSingleTapConfirmed`, node picking and
+a consumer's own `onDoubleTap` untouched — the camera and the listener both see the event.
+
+Repeated double-taps do not dead-end: once the camera sits on the closest allowed distance, the
+next double-tap cycles back to the framing the scene was homed at.
+
+```kotlin
+// Opt out, or re-tune the step, on the default manipulator:
+val manipulator = rememberCameraManipulator(orbitRadius = 3f)
+(manipulator as? CameraGestureDetector.DefaultCameraManipulator)?.apply {
+    isDoubleTapZoomEnabled = false          // default true
+    doubleTapZoomFactor = 2f                // distance ratio per tap (must be > 1)
+    doubleTapZoomDurationSeconds = 0.3f     // 0 = instantaneous
+}
+SceneView(cameraManipulator = manipulator)
+```
+
+A custom `CameraGestureDetector.CameraManipulator` gets the gesture through
+`doubleTapZoom(x, y, zoomIn)` (default implementation: no-op), with `x`/`y` in Filament's
+bottom-left origin. Note that with an ORBIT manipulator the zoom is centred on the orbit pivot,
+not anchored under the finger: Filament's `OrbitManipulator::scroll` moves the eye along the gaze
+and ignores `x`/`y`.
+
 ### How far `orbitHomePosition` actually puts the camera
 
 Getting this wrong is a factor-of-2 framing bug, and every example above hides it because

--- a/llms.txt
+++ b/llms.txt
@@ -3557,8 +3557,25 @@ SceneView(cameraManipulator = manipulator)
 ```
 
 A custom `CameraGestureDetector.CameraManipulator` gets the gesture through
-`doubleTapZoom(x, y, zoomIn)` (default implementation: no-op), with `x`/`y` in Filament's
-bottom-left origin. Note that with an ORBIT manipulator the zoom is centred on the orbit pivot,
+`doubleTapZoom(x, y, zoomIn)` (default implementation: **no-op**), with `x`/`y` in Filament's
+bottom-left origin. The default being a no-op means a scene that supplies its own manipulator
+gets no zoom until it overrides that method — the maths is public so it does not have to be
+reinvented:
+
+```kotlin
+override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {
+    zoomTarget = zoomedDistanceForDoubleTap(   // io.github.sceneview.gesture
+        distance = currentDistance, homeDistance = fitDistance, zoomIn = zoomIn,
+        minDistance = fitDistance * 0.25f, maxDistance = fitDistance * 10f,
+    )
+    zoomStart = currentDistance; zoomElapsed = 0f
+}
+
+override fun update(deltaTime: Float) {          // already ticked every frame
+    zoomElapsed += deltaTime
+    applyDistance(animatedZoomDistance(zoomStart, zoomTarget, zoomElapsed / 0.3f))
+}
+``` Note that with an ORBIT manipulator the zoom is centred on the orbit pivot,
 not anchored under the finger: Filament's `OrbitManipulator::scroll` moves the eye along the gaze
 and ignores `x`/`y`.
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/DemoHelpers.kt
@@ -1198,6 +1198,8 @@ class EntranceCameraManipulator(
     }
 
     override fun grabBegin(x: Int, y: Int, strafe: Boolean) {
+        // A new touch owns the camera: drop any double-tap zoom still in flight (#3608).
+        zoomAnimationDuration = 0f
         ensureFallback()
         fallback?.grabBegin(x, y, strafe)
     }
@@ -1211,6 +1213,7 @@ class EntranceCameraManipulator(
     }
 
     override fun scrollBegin(x: Int, y: Int, separation: Float) {
+        zoomAnimationDuration = 0f
         ensureFallback()
     }
 
@@ -1235,7 +1238,50 @@ class EntranceCameraManipulator(
         fallback?.scrollEnd()
     }
 
+    // ── Double-tap zoom (#3608) ──────────────────────────────────────────────────────────────────
+    //
+    // The SDK's built-in double-tap zoom lives in `DefaultCameraManipulator` and dollies the
+    // Filament manipulator directly. This class does not delegate its zoom — a pinch *publishes* a
+    // distance so the gesture and the "Camera distance" slider stay one number (see
+    // `scrollUpdate`) — so the built-in default no-ops here and the gesture has to be implemented
+    // against the same published distance, with the same clamps the pinch uses.
+    private var zoomAnimationStart = 0f
+    private var zoomAnimationTarget = 0f
+    private var zoomAnimationElapsed = 0f
+    private var zoomAnimationDuration = 0f
+
+    override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {
+        ensureFallback()
+        val fit = fitDistance().takeIf { it.isFinite() && it > 0f } ?: 1f
+        val start = effectiveDistance()
+        val target = io.github.sceneview.gesture.zoomedDistanceForDoubleTap(
+            distance = start,
+            homeDistance = fit,
+            zoomIn = zoomIn,
+            minDistance = fit * VIEWER_MIN_ZOOM_FACTOR,
+            maxDistance = fit * VIEWER_MAX_ZOOM_FACTOR,
+        )
+        if (target == start) return
+        zoomAnimationStart = start
+        zoomAnimationTarget = target
+        zoomAnimationElapsed = 0f
+        zoomAnimationDuration = io.github.sceneview.gesture.CameraGestureDetector
+            .DefaultCameraManipulator.DEFAULT_DOUBLE_TAP_ZOOM_DURATION_SECONDS
+    }
+
     override fun update(deltaTime: Float) {
+        if (zoomAnimationDuration > 0f) {
+            zoomAnimationElapsed += deltaTime
+            val progress = zoomAnimationElapsed / zoomAnimationDuration
+            onDistanceChange(
+                io.github.sceneview.gesture.animatedZoomDistance(
+                    start = zoomAnimationStart,
+                    target = zoomAnimationTarget,
+                    progress = progress,
+                )
+            )
+            if (progress >= 1f) zoomAnimationDuration = 0f
+        }
         fallback?.update(deltaTime)
     }
 }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/CameraAndGesturesDemo.kt
@@ -361,6 +361,11 @@ fun CameraAndGesturesDemo(onBack: () -> Unit) {
                         // void is not an accident to punish — it leaves the camera alone.
                         subjectOf(node, subjectNodes)?.let { flyTo(it, CameraView.Hero) }
                     },
+                    // This screen deliberately keeps its own meaning for the double-tap: back
+                    // to the whole stage. The SDK's built-in double-tap zoom (#3608) still runs
+                    // first — `onDoubleTapCamera` is dispatched before `listener.onDoubleTap` —
+                    // and this flight then supersedes it, which is exactly the priority a
+                    // consumer callback is supposed to have.
                     onDoubleTap = { _, _ -> flyTo(null, CameraView.Hero) },
                 ),
             ) {

--- a/sceneview-compose/src/androidMain/kotlin/io/github/sceneview/compose/SceneViewer.android.kt
+++ b/sceneview-compose/src/androidMain/kotlin/io/github/sceneview/compose/SceneViewer.android.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.filament.Engine
@@ -31,6 +33,8 @@ import io.github.sceneview.rememberEnvironment
 import io.github.sceneview.rememberEnvironmentLoader
 import io.github.sceneview.rememberModelLoader
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
@@ -314,6 +318,12 @@ private fun rememberEnvironment(
  * A tap is a down/up pair that never travelled beyond the touch slop; without that check
  * every orbit would end in a spurious tap, since a drag also ends with `ACTION_UP`.
  *
+ * Two taps inside the platform's double-tap window zoom in, a two-finger tap zooms out — the
+ * Maps / Photos convention, matching `:sceneview`'s own gesture set so the façade does not feel
+ * poorer than the SDK it mirrors (#3608). Both are animated and both respect
+ * [CameraState.gesturesEnabled]. The `onTap` callback still fires for every tap, double-tap
+ * included: the camera adds a behaviour, it does not take one away.
+ *
  * Always returns `false`: this observes events, it does not consume them.
  */
 @Composable
@@ -329,14 +339,40 @@ private fun rememberGestureHandler(
     val touchSlop = with(LocalContext.current) {
         ViewConfiguration.get(this).scaledTouchSlop.toFloat()
     }
+    val doubleTapTimeoutMs = ViewConfiguration.getDoubleTapTimeout().toLong()
+    // The zoom animation outlives the touch event that started it, so it needs a scope tied to
+    // the composition rather than to the handler.
+    val scope = rememberCoroutineScope()
 
-    return remember(touchSlop) {
+    return remember(touchSlop, doubleTapTimeoutMs, scope) {
         var downX = 0f
         var downY = 0f
         var lastX = 0f
         var lastY = 0f
         var lastSpan = 0f
         var moved = false
+        var lastTapUpTimeMs = 0L
+        var twoFingerTapCandidate = false
+        var twoFingerTapDownTimeMs = 0L
+        var zoomJob: Job? = null
+
+        // One animation at a time: a second tap retargets from wherever the first one had got
+        // to, instead of two jobs fighting over `distance` frame by frame.
+        fun zoomBy(cameraState: CameraState, ratio: Float) {
+            zoomJob?.cancel()
+            zoomJob = scope.launch {
+                val start = cameraState.distance
+                val target = start * ratio
+                val startedAt = withFrameMillis { it }
+                var progress = 0f
+                while (progress < 1f) {
+                    val now = withFrameMillis { it }
+                    progress = ((now - startedAt).toFloat() / DOUBLE_TAP_ZOOM_DURATION_MS)
+                        .coerceIn(0f, 1f)
+                    cameraState.distance = animatedZoomDistance(start, target, progress)
+                }
+            }
+        }
 
         handler@{ event, hitResult ->
             val cameraState = currentState
@@ -352,7 +388,15 @@ private fun rememberGestureHandler(
 
                 MotionEvent.ACTION_POINTER_DOWN -> {
                     lastSpan = event.spanOrZero()
+                    // Read before `moved` is set below: a second finger landing *while nothing
+                    // has moved yet* is a two-finger-tap candidate, one arriving mid-orbit is
+                    // not. A pinch disqualifies itself further down, as soon as the span drifts.
+                    twoFingerTapCandidate = event.pointerCount == 2 && !moved
                     moved = true
+                    twoFingerTapDownTimeMs = event.eventTime
+                    // A pending single tap cannot become a double-tap once a second finger is
+                    // involved — that would turn "tap, then pinch" into a spurious zoom.
+                    lastTapUpTimeMs = 0L
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -361,8 +405,14 @@ private fun rememberGestureHandler(
                     }
                     if (!cameraState.gesturesEnabled) return@handler false
 
+                    // The user's own gesture wins over an animation still playing.
+                    zoomJob?.cancel()
+
                     if (event.pointerCount >= 2) {
                         val span = event.spanOrZero()
+                        if (abs(span - lastSpan) > touchSlop) {
+                            twoFingerTapCandidate = false
+                        }
                         if (lastSpan > 0f && span > 0f) {
                             // Pinch out brings the camera closer, so divide.
                             cameraState.distance /= (span / lastSpan)
@@ -376,10 +426,26 @@ private fun rememberGestureHandler(
                     lastY = event.y
                 }
 
-                MotionEvent.ACTION_POINTER_UP -> lastSpan = 0f
+                MotionEvent.ACTION_POINTER_UP -> {
+                    lastSpan = 0f
+                    val tapped = twoFingerTapCandidate &&
+                            event.eventTime - twoFingerTapDownTimeMs <= doubleTapTimeoutMs
+                    twoFingerTapCandidate = false
+                    if (tapped && cameraState.gesturesEnabled) {
+                        zoomBy(cameraState, DOUBLE_TAP_ZOOM_FACTOR)
+                    }
+                }
 
                 MotionEvent.ACTION_UP -> {
                     if (!moved) {
+                        val isDoubleTap =
+                            event.eventTime - lastTapUpTimeMs <= doubleTapTimeoutMs
+                        // A third quick tap starts a new pair rather than zooming again on the
+                        // second one's timestamp — the platform's own double-tap bookkeeping.
+                        lastTapUpTimeMs = if (isDoubleTap) 0L else event.eventTime
+                        if (isDoubleTap && cameraState.gesturesEnabled) {
+                            zoomBy(cameraState, 1f / DOUBLE_TAP_ZOOM_FACTOR)
+                        }
                         currentOnTap?.invoke(
                             hitResult?.nodeOrNull?.let {
                                 ModelHit(
@@ -388,6 +454,8 @@ private fun rememberGestureHandler(
                                 )
                             },
                         )
+                    } else {
+                        lastTapUpTimeMs = 0L
                     }
                 }
             }

--- a/sceneview-compose/src/commonMain/kotlin/io/github/sceneview/compose/DoubleTapZoom.kt
+++ b/sceneview-compose/src/commonMain/kotlin/io/github/sceneview/compose/DoubleTapZoom.kt
@@ -1,0 +1,41 @@
+package io.github.sceneview.compose
+
+import kotlin.math.exp
+import kotlin.math.ln
+
+/**
+ * Distance ratio one double-tap covers: a double-tap halves the camera-to-target distance, a
+ * two-finger tap doubles it back. The step every map and photo viewer uses (#3608).
+ */
+internal const val DOUBLE_TAP_ZOOM_FACTOR = 2f
+
+/**
+ * How long the double-tap zoom takes, in milliseconds — the platform's own double-tap zoom
+ * timing. Long enough to read as a move rather than a jump cut, short enough not to feel slow.
+ */
+internal const val DOUBLE_TAP_ZOOM_DURATION_MS = 300L
+
+/**
+ * Standard cubic ease-in-out on `[0, 1]`, clamped. Mirrors the curve `:sceneview` uses for the
+ * same gesture, so the façade and the Android SDK feel identical.
+ */
+internal fun easeInOutCubic(progress: Float): Float {
+    if (progress.isNaN()) return 1f
+    val t = progress.coerceIn(0f, 1f)
+    return if (t < 0.5f) 4f * t * t * t else 1f - (-2f * t + 2f).let { it * it * it } / 2f
+}
+
+/**
+ * The camera-to-target distance part-way through a double-tap zoom.
+ *
+ * Interpolation is **geometric**, not linear: `start · (target / start)^eased(progress)`. What the
+ * eye reads is the *ratio* of successive framings, not their difference, so a linear ramp looks
+ * fast at the far end and crawls at the near end. Geometric interpolation keeps the apparent zoom
+ * speed constant over the whole move.
+ */
+internal fun animatedZoomDistance(start: Float, target: Float, progress: Float): Float {
+    if (!start.isFinite() || start <= 0f) return target
+    if (!target.isFinite() || target <= 0f) return start
+    val interpolated = start * exp(ln(target / start) * easeInOutCubic(progress))
+    return if (interpolated.isFinite() && interpolated > 0f) interpolated else target
+}

--- a/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/DoubleTapZoomTest.kt
+++ b/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/DoubleTapZoomTest.kt
@@ -1,0 +1,74 @@
+package io.github.sceneview.compose
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The façade's double-tap zoom curve (#3608).
+ *
+ * Same contract as `:sceneview`'s: a double-tap halves the distance, a two-finger tap doubles it
+ * back, and the move between the two is geometric so the apparent zoom speed stays constant
+ * instead of crawling at the near end.
+ */
+class DoubleTapZoomTest {
+
+    @Test
+    fun `the easing starts and ends where it should`() {
+        assertEquals(0f, easeInOutCubic(0f), 1e-6f)
+        assertEquals(0.5f, easeInOutCubic(0.5f), 1e-6f)
+        assertEquals(1f, easeInOutCubic(1f), 1e-6f)
+    }
+
+    @Test
+    fun `the easing is clamped and monotonic`() {
+        assertEquals(0f, easeInOutCubic(-1f), 1e-6f)
+        assertEquals(1f, easeInOutCubic(2f), 1e-6f)
+        var previous = -1f
+        for (i in 0..20) {
+            val value = easeInOutCubic(i / 20f)
+            assertTrue(value >= previous, "monotonic at $i")
+            previous = value
+        }
+    }
+
+    @Test
+    fun `the animation lands exactly on its end points`() {
+        assertEquals(4f, animatedZoomDistance(4f, 2f, 0f), 1e-4f)
+        assertEquals(2f, animatedZoomDistance(4f, 2f, 1f), 1e-4f)
+    }
+
+    /** Geometric, not linear: halfway through, the distance is the *geometric* mean. */
+    @Test
+    fun `the animation interpolates the ratio, not the difference`() {
+        val mid = animatedZoomDistance(4f, 1f, 0.5f)
+        assertEquals(2f, mid, 1e-3f)
+        assertTrue(mid < 2.5f, "below the arithmetic mean")
+    }
+
+    @Test
+    fun `the animation never leaves the interval it was given`() {
+        var previous = 4f
+        for (i in 1..20) {
+            val value = animatedZoomDistance(4f, 2f, i / 20f)
+            assertTrue(value in 2f..4f, "inside [2, 4] at $i")
+            assertTrue(value <= previous + 1e-5f, "monotonic at $i")
+            previous = value
+        }
+    }
+
+    /** A double-tap then a two-finger tap must land back on the starting framing. */
+    @Test
+    fun `the zoom in and zoom out steps are exact inverses`() {
+        val start = 4f
+        val zoomedIn = start * (1f / DOUBLE_TAP_ZOOM_FACTOR)
+        assertEquals(start, zoomedIn * DOUBLE_TAP_ZOOM_FACTOR, 1e-4f)
+    }
+
+    @Test
+    fun `degenerate endpoints degrade instead of producing NaN`() {
+        assertEquals(2f, animatedZoomDistance(0f, 2f, 0.5f), 1e-4f)
+        assertEquals(4f, animatedZoomDistance(4f, 0f, 0.5f), 1e-4f)
+        assertTrue(animatedZoomDistance(4f, 2f, Float.NaN).isFinite())
+    }
+}

--- a/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/DoubleTapZoomTest.kt
+++ b/sceneview-compose/src/commonTest/kotlin/io/github/sceneview/compose/DoubleTapZoomTest.kt
@@ -10,18 +10,23 @@ import kotlin.test.assertTrue
  * Same contract as `:sceneview`'s: a double-tap halves the distance, a two-finger tap doubles it
  * back, and the move between the two is geometric so the apparent zoom speed stays constant
  * instead of crawling at the near end.
+ *
+ * Test names are plain identifiers, not backticked prose, because this is `commonTest`:
+ * Kotlin/Native rejects a declaration name containing `,` outright ("Name contains illegal
+ * characters"), while the JVM compiles it happily — so the mistake only surfaces in the
+ * iOS-simulator job. The module's other common tests follow the same style.
  */
 class DoubleTapZoomTest {
 
     @Test
-    fun `the easing starts and ends where it should`() {
+    fun easing_starts_and_ends_where_it_should() {
         assertEquals(0f, easeInOutCubic(0f), 1e-6f)
         assertEquals(0.5f, easeInOutCubic(0.5f), 1e-6f)
         assertEquals(1f, easeInOutCubic(1f), 1e-6f)
     }
 
     @Test
-    fun `the easing is clamped and monotonic`() {
+    fun easing_is_clamped_and_monotonic() {
         assertEquals(0f, easeInOutCubic(-1f), 1e-6f)
         assertEquals(1f, easeInOutCubic(2f), 1e-6f)
         var previous = -1f
@@ -33,21 +38,21 @@ class DoubleTapZoomTest {
     }
 
     @Test
-    fun `the animation lands exactly on its end points`() {
+    fun animation_lands_exactly_on_its_end_points() {
         assertEquals(4f, animatedZoomDistance(4f, 2f, 0f), 1e-4f)
         assertEquals(2f, animatedZoomDistance(4f, 2f, 1f), 1e-4f)
     }
 
     /** Geometric, not linear: halfway through, the distance is the *geometric* mean. */
     @Test
-    fun `the animation interpolates the ratio, not the difference`() {
+    fun animation_interpolates_the_ratio_not_the_difference() {
         val mid = animatedZoomDistance(4f, 1f, 0.5f)
         assertEquals(2f, mid, 1e-3f)
         assertTrue(mid < 2.5f, "below the arithmetic mean")
     }
 
     @Test
-    fun `the animation never leaves the interval it was given`() {
+    fun animation_never_leaves_the_interval_it_was_given() {
         var previous = 4f
         for (i in 1..20) {
             val value = animatedZoomDistance(4f, 2f, i / 20f)
@@ -59,14 +64,14 @@ class DoubleTapZoomTest {
 
     /** A double-tap then a two-finger tap must land back on the starting framing. */
     @Test
-    fun `the zoom in and zoom out steps are exact inverses`() {
+    fun zoom_in_and_zoom_out_steps_are_exact_inverses() {
         val start = 4f
         val zoomedIn = start * (1f / DOUBLE_TAP_ZOOM_FACTOR)
         assertEquals(start, zoomedIn * DOUBLE_TAP_ZOOM_FACTOR, 1e-4f)
     }
 
     @Test
-    fun `degenerate endpoints degrade instead of producing NaN`() {
+    fun degenerate_endpoints_degrade_instead_of_producing_NaN() {
         assertEquals(2f, animatedZoomDistance(0f, 2f, 0.5f), 1e-4f)
         assertEquals(4f, animatedZoomDistance(4f, 0f, 0.5f), 1e-4f)
         assertTrue(animatedZoomDistance(4f, 2f, Float.NaN).isFinite())

--- a/sceneview/api/sceneview.api
+++ b/sceneview/api/sceneview.api
@@ -1481,13 +1481,17 @@ public class io/github/sceneview/gesture/CameraGestureDetector {
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lcom/google/android/filament/utils/Manipulator;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;)V
 	public final fun getCameraManipulator ()Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;
+	public final fun isDoubleTapZoomEnabled ()Z
 	public final fun isPanEnabled ()Z
+	public final fun onDoubleTap (Landroid/view/MotionEvent;)V
 	public final fun onTouchEvent (Landroid/view/MotionEvent;)V
 	public final fun setCameraManipulator (Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;)V
+	public final fun setDoubleTapZoomEnabled (Z)V
 	public final fun setPanEnabled (Z)V
 }
 
 public abstract interface class io/github/sceneview/gesture/CameraGestureDetector$CameraManipulator {
+	public fun doubleTapZoom (IIZ)V
 	public abstract fun getTransform ()Ldev/romainguy/kotlin/math/Mat4;
 	public abstract fun grabBegin (IIZ)V
 	public abstract fun grabEnd ()V
@@ -1499,6 +1503,10 @@ public abstract interface class io/github/sceneview/gesture/CameraGestureDetecto
 	public abstract fun update (F)V
 }
 
+public final class io/github/sceneview/gesture/CameraGestureDetector$CameraManipulator$DefaultImpls {
+	public static fun doubleTapZoom (Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;IIZ)V
+}
+
 public final class io/github/sceneview/gesture/CameraGestureDetector$Companion {
 	public final fun createDefaultCameraManipulator (Lcom/google/android/filament/utils/Manipulator;)Lio/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator;
 	public static synthetic fun createDefaultCameraManipulator$default (Lio/github/sceneview/gesture/CameraGestureDetector$Companion;Lcom/google/android/filament/utils/Manipulator;ILjava/lang/Object;)Lio/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator;
@@ -1507,6 +1515,8 @@ public final class io/github/sceneview/gesture/CameraGestureDetector$Companion {
 public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator : io/github/sceneview/gesture/CameraGestureDetector$CameraManipulator {
 	public static final field $stable I
 	public static final field Companion Lio/github/sceneview/gesture/CameraGestureDetector$DefaultCameraManipulator$Companion;
+	public static final field DEFAULT_DOUBLE_TAP_ZOOM_DURATION_SECONDS F
+	public static final field DEFAULT_DOUBLE_TAP_ZOOM_FACTOR F
 	public static final field DEFAULT_MAX_ZOOM_DISTANCE_FACTOR F
 	public static final field DEFAULT_MIN_ZOOM_DISTANCE_FACTOR F
 	public static final field DEFAULT_ORBIT_ZOOM_SPEED F
@@ -1528,6 +1538,9 @@ public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraMani
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;F)V
 	public fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;FF)V
 	public synthetic fun <init> (Ldev/romainguy/kotlin/math/Float3;Ldev/romainguy/kotlin/math/Float3;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun doubleTapZoom (IIZ)V
+	public final fun getDoubleTapZoomDurationSeconds ()F
+	public final fun getDoubleTapZoomFactor ()F
 	protected final fun getManipulator ()Lcom/google/android/filament/utils/Manipulator;
 	protected final fun getManipulatorZoomSpeed ()F
 	public final fun getMaxZoomDistanceFactor ()F
@@ -1538,9 +1551,13 @@ public class io/github/sceneview/gesture/CameraGestureDetector$DefaultCameraMani
 	public fun grabBegin (IIZ)V
 	public fun grabEnd ()V
 	public fun grabUpdate (II)V
+	public final fun isDoubleTapZoomEnabled ()Z
 	public fun scrollBegin (IIF)V
 	public fun scrollEnd ()V
 	public fun scrollUpdate (IIFF)V
+	public final fun setDoubleTapZoomDurationSeconds (F)V
+	public final fun setDoubleTapZoomEnabled (Z)V
+	public final fun setDoubleTapZoomFactor (F)V
 	public final fun setMaxZoomDistanceFactor (F)V
 	public final fun setMinZoomDistanceFactor (F)V
 	public fun setViewport (II)V
@@ -1574,6 +1591,7 @@ public final class io/github/sceneview/gesture/FovZoomCameraManipulator : io/git
 	public fun <init> (Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;Lio/github/sceneview/node/CameraNode;Lkotlin/ranges/ClosedFloatingPointRange;)V
 	public fun <init> (Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;Lio/github/sceneview/node/CameraNode;Lkotlin/ranges/ClosedFloatingPointRange;F)V
 	public synthetic fun <init> (Lio/github/sceneview/gesture/CameraGestureDetector$CameraManipulator;Lio/github/sceneview/node/CameraNode;Lkotlin/ranges/ClosedFloatingPointRange;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun doubleTapZoom (IIZ)V
 	public fun getTransform ()Ldev/romainguy/kotlin/math/Mat4;
 	public fun grabBegin (IIZ)V
 	public fun grabEnd ()V

--- a/sceneview/api/sceneview.api
+++ b/sceneview/api/sceneview.api
@@ -1568,6 +1568,11 @@ public final class io/github/sceneview/gesture/CameraGestureDetector$DefaultCame
 }
 
 public final class io/github/sceneview/gesture/CameraGestureMathKt {
+	public static final fun animatedZoomDistance (FFF)F
+	public static final fun easeInOutCubic (F)F
+	public static final fun zoomedDistanceForDoubleTap (FFZFF)F
+	public static final fun zoomedDistanceForDoubleTap (FFZFFF)F
+	public static synthetic fun zoomedDistanceForDoubleTap$default (FFZFFFILjava/lang/Object;)F
 	public static final fun zoomedDistanceForPinch (FFFFF)F
 	public static final fun zoomedDistanceForPinch (FFFFFF)F
 	public static final fun zoomedDistanceForPinch (FFFFFFF)F

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -605,8 +605,19 @@ fun SceneView(
     // redundant JNI setViewport call every frame.
     val seededManipulatorRef = remember { AtomicReference<CameraGestureDetector.CameraManipulator?>(null) }
 
+    // True while the live touch stream is absorbed by an editable node. Double-tap recognition
+    // happens inside `gestureDetector`, which — unlike the camera detector — is fed even for
+    // editable nodes, so the built-in zoom needs this flag to honour the same gesture isolation
+    // the rest of the camera gestures get below (#3608).
+    val cameraGesturesAbsorbedRef = remember { AtomicBoolean(false) }
+
     SideEffect {
         gestureDetector.listener = onGestureListener
+        gestureDetector.onDoubleTapCamera = { event ->
+            if (!cameraGesturesAbsorbedRef.get()) {
+                cameraGestureDetectorRef.get()?.onDoubleTap(event)
+            }
+        }
         cameraGestureDetectorRef.get()?.cameraManipulator = cameraManipulator
         // Re-seed the (newly-swapped) manipulator with the current viewport so its pan/raycast
         // math is correct from the first gesture, without waiting for a surface resize. Only when
@@ -646,13 +657,16 @@ fun SceneView(
             consumedByNode = capturedNode?.onCapturedTouchEvent(event) == true ||
                     (hitResult != null && hitNode?.onTouchEvent(event, hitResult) == true)
             if (!consumedByNode) {
-                gestureDetector.onTouchEvent(event, hitResult)
                 // Skip the camera detector when the touch is on an editable node — the node
                 // owns the gesture. We check the hit node's master `isEditable` (and not the
                 // per-axis flags) so a node that's "editable but with all axes locked" still
                 // absorbs the touch — locking an axis should freeze the node, not divert the
                 // gesture to the camera (that would surprise the user).
                 val absorbedByEditableNode = hitNode?.isEditable == true
+                // Published before `gestureDetector` runs: its double-tap callback fires from
+                // inside that call and reads this to apply the same isolation (#3608).
+                cameraGesturesAbsorbedRef.set(absorbedByEditableNode)
+                gestureDetector.onTouchEvent(event, hitResult)
                 if (!absorbedByEditableNode) {
                     cameraGestureDetectorRef.get()?.onTouchEvent(event)
                 }

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureDetector.kt
@@ -1,11 +1,13 @@
 package io.github.sceneview.gesture
 
 import android.view.MotionEvent
+import android.view.ViewConfiguration
 import com.google.android.filament.Camera
 import com.google.android.filament.utils.Float2
 import com.google.android.filament.utils.Manipulator
 import com.google.android.filament.utils.distance
 import com.google.android.filament.utils.mix
+import kotlin.math.abs
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Transform
 import io.github.sceneview.node.CameraNode
@@ -52,6 +54,26 @@ open class CameraGestureDetector(
         fun scrollUpdate(x: Int, y: Int, prevSeparation: Float, currSeparation: Float)
         fun scrollEnd()
         fun update(deltaTime: Float)
+
+        /**
+         * A double-tap (or two-finger tap) asked the camera to zoom, at screen point [x], [y].
+         *
+         * Called by [CameraGestureDetector] when [CameraGestureDetector.isDoubleTapZoomEnabled] is
+         * on. Coordinates are in Filament's convention — origin bottom-left, i.e. already
+         * y-flipped from [android.view.MotionEvent] — the same ones [grabBegin] and [scrollBegin]
+         * receive.
+         *
+         * The step is expected to be *animated*: implementations start the move here and advance
+         * it from [update], which the render loop already calls once per frame. The default
+         * implementation does nothing, so existing manipulators keep compiling and behaving
+         * exactly as before.
+         *
+         * @param x      Tap x, in pixels, origin bottom-left.
+         * @param y      Tap y, in pixels, origin bottom-left.
+         * @param zoomIn `true` for a double-tap (move closer), `false` for a two-finger tap
+         *               (move away).
+         */
+        fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {}
     }
 
     /**
@@ -117,6 +139,49 @@ open class CameraGestureDetector(
 
         /** The distance the manipulator was homed at — the reference for the zoom clamps. */
         private var homeDistance: Float = -1f
+
+        /**
+         * Double-tap to zoom in, two-finger tap to zoom out — the convention every photo viewer
+         * and map trains users to expect, on by default (#3608).
+         *
+         * Set to `false` to opt out; the taps are then ignored by this manipulator and a consumer
+         * `onDoubleTap` callback is the only thing that runs. Toggling it mid-animation cancels
+         * the move in flight.
+         *
+         * ```kotlin
+         * val manipulator = rememberCameraManipulator(orbitRadius = 3f).apply {
+         *     (this as? CameraGestureDetector.DefaultCameraManipulator)
+         *         ?.isDoubleTapZoomEnabled = false
+         * }
+         * ```
+         */
+        var isDoubleTapZoomEnabled: Boolean = true
+
+        /**
+         * Distance ratio one double-tap covers. `2` (the default) halves the camera-to-target
+         * distance on a double-tap and doubles it back on a two-finger tap. Must be `> 1`;
+         * anything else falls back to the default.
+         */
+        var doubleTapZoomFactor: Float = DEFAULT_DOUBLE_TAP_ZOOM_FACTOR
+
+        /**
+         * How long the double-tap zoom takes, in seconds. `0.3` matches the platform's own
+         * double-tap zoom; `0` makes the step instantaneous.
+         */
+        var doubleTapZoomDurationSeconds: Float = DEFAULT_DOUBLE_TAP_ZOOM_DURATION_SECONDS
+
+        /**
+         * In-flight double-tap zoom: where it started, where it lands, and how far along it is.
+         * Advanced from [update] (the render loop already ticks that every frame), so the SDK
+         * needs neither a coroutine nor a second frame callback for it. `animationDuration <= 0`
+         * means "no animation running".
+         */
+        private var animationStartDistance: Float = 0f
+        private var animationTargetDistance: Float = 0f
+        private var animationElapsed: Float = 0f
+        private var animationDuration: Float = 0f
+        private var animationX: Int = 0
+        private var animationY: Int = 0
 
         /**
          * `true` when the wrapped manipulator is an `ORBIT` one, i.e. when `scroll` means "dolly
@@ -215,6 +280,8 @@ open class CameraGestureDetector(
         }
 
         override fun grabBegin(x: Int, y: Int, strafe: Boolean) {
+            // The user's own gesture always wins over an animation still playing.
+            cancelDoubleTapZoom()
             // Last moment the pose is still readable — `grabUpdate` is what re-plants the target.
             currentOrbitDistance()
             manipulator.grabBegin(x, y, strafe)
@@ -229,6 +296,8 @@ open class CameraGestureDetector(
         }
 
         override fun scrollBegin(x: Int, y: Int, separation: Float) {
+            // A pinch takes over from a double-tap zoom still in flight.
+            cancelDoubleTapZoom()
             // Seed the tracked radius from the manipulator while its reported target is still the
             // orbit pivot (see [orbitDistance]) — cheap, and a no-op once measured.
             currentOrbitDistance()
@@ -264,8 +333,87 @@ open class CameraGestureDetector(
 
         override fun scrollEnd() {}
 
+        /**
+         * Starts the animated dolly towards (or away from) the orbit pivot.
+         *
+         * The tap point is remembered and forwarded to `Manipulator.scroll` for the modes that
+         * read it, but an ORBIT manipulator does not: Filament's `OrbitManipulator::scroll` moves
+         * the eye strictly along the gaze and ignores `x`/`y`, so the zoom is centred on the orbit
+         * pivot rather than anchored under the finger. See the `doubleTapZoom` KDoc on
+         * [CameraManipulator].
+         */
+        override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {
+            if (!isDoubleTapZoomEnabled) return
+            val distance = if (isOrbitMode()) currentOrbitDistance() else -1f
+            // Non-orbit modes (MAP scrolls an extent, FREE_FLIGHT a move speed): a
+            // camera-to-target distance is not what their scroll means, so there is nothing
+            // meaningful to animate. Leave them alone rather than invent a step.
+            if (distance <= 0f) return
+            val home = if (homeDistance > 0f) homeDistance else distance
+            val target = doubleTapZoomedDistance(
+                distance = distance,
+                homeDistance = home,
+                zoomIn = zoomIn,
+                factor = doubleTapZoomFactor,
+                minDistanceFactor = minZoomDistanceFactor,
+                maxDistanceFactor = maxZoomDistanceFactor,
+            )
+            if (target == distance) return
+            animationX = x
+            animationY = y
+            animationStartDistance = distance
+            animationTargetDistance = target
+            animationElapsed = 0f
+            animationDuration = doubleTapZoomDurationSeconds.takeIf { it.isFinite() && it > 0f }
+                ?: 0f
+            if (animationDuration <= 0f) {
+                // Duration 0 is a legal setting, not an error: land on the target immediately.
+                applyDistance(target)
+            }
+        }
+
+        /** Drops any double-tap zoom in flight, leaving the camera exactly where it is. */
+        private fun cancelDoubleTapZoom() {
+            animationDuration = 0f
+        }
+
         override fun update(deltaTime: Float) {
+            advanceDoubleTapZoom(deltaTime)
             manipulator.update(deltaTime)
+        }
+
+        /**
+         * Advances an in-flight double-tap zoom by one frame. No-op — and no allocation, no JNI
+         * call — when nothing is animating, which is every frame but the ~18 of a 300 ms move.
+         */
+        private fun advanceDoubleTapZoom(deltaTime: Float) {
+            if (animationDuration <= 0f) return
+            if (!deltaTime.isFinite() || deltaTime < 0f) return
+            animationElapsed += deltaTime
+            val progress = (animationElapsed / animationDuration).coerceIn(0f, 1f)
+            val next = if (progress >= 1f) {
+                animationTargetDistance
+            } else {
+                animatedZoomDistance(
+                    animationStartDistance, animationTargetDistance, progress
+                )
+            }
+            applyDistance(next)
+            if (progress >= 1f) cancelDoubleTapZoom()
+        }
+
+        /**
+         * Dollies the wrapped manipulator to an absolute camera-to-target [distance], going
+         * through the same `scroll` inversion the pinch uses so the tracked [orbitDistance] and
+         * Filament's own eye stay in step.
+         */
+        private fun applyDistance(distance: Float) {
+            val current = currentOrbitDistance()
+            if (current <= 0f || distance == current) return
+            manipulator.scroll(
+                animationX, animationY, dollyScrollDelta(current, distance, manipulatorZoomSpeed)
+            )
+            orbitDistance = distance
         }
 
         companion object {
@@ -301,6 +449,20 @@ open class CameraGestureDetector(
 
             /** Furthest the pinch may take the camera, as a multiple of the homed distance. */
             const val DEFAULT_MAX_ZOOM_DISTANCE_FACTOR: Float = 8f
+
+            /**
+             * Default distance ratio one double-tap covers — `2`, i.e. a double-tap halves the
+             * camera-to-target distance and a two-finger tap doubles it back. The step every map
+             * and photo viewer uses, and small enough that two taps in a row stay legible.
+             */
+            const val DEFAULT_DOUBLE_TAP_ZOOM_FACTOR: Float = 2f
+
+            /**
+             * Default duration of the double-tap zoom animation, in seconds. `0.3` is the
+             * platform's own double-tap zoom timing — long enough to read as a move rather than a
+             * jump cut, short enough not to feel like waiting.
+             */
+            const val DEFAULT_DOUBLE_TAP_ZOOM_DURATION_SECONDS: Float = 0.3f
 
             /**
              * Default damping exponent for pinch deltas. Sub-1 values create a sqrt-like response
@@ -358,12 +520,87 @@ open class CameraGestureDetector(
     private val kPanConfidenceDistance = 10
     private val kZoomConfidenceDistance = 10
 
+    /**
+     * How far, in pixels, the two-finger midpoint or the inter-finger separation may drift and
+     * still count as a tap. Matches [kPanConfidenceDistance] / [kZoomConfidenceDistance] on
+     * purpose: past that drift the stream is already being promoted to PAN or ZOOM, so the tap and
+     * the drag gestures can never both claim the same movement.
+     */
+    private val kTwoFingerTapSlop = 10f
+
+    /**
+     * How long, in milliseconds, two fingers may rest before lifting and still count as a tap.
+     * [ViewConfiguration.getDoubleTapTimeout] is the platform's own answer to exactly this
+     * question (300 ms), so the two-finger tap and the double-tap share one timing budget.
+     */
+    private val kTwoFingerTapTimeoutMs = ViewConfiguration.getDoubleTapTimeout().toLong()
+
     var isPanEnabled: Boolean = true
+
+    /**
+     * Double-tap to zoom in, two-finger tap to zoom out — on by default (#3608).
+     *
+     * When on, [onDoubleTap] and the two-finger tap recognised below are forwarded to
+     * [CameraManipulator.doubleTapZoom]. Consumer `onDoubleTap` callbacks are untouched either
+     * way: they come from the separate [GestureDetector] and both run.
+     */
+    var isDoubleTapZoomEnabled: Boolean = true
+
+    /**
+     * A confirmed double-tap landed on the scene: zoom in, animated.
+     *
+     * Called by `SceneView` from the [GestureDetector] that already owns double-tap recognition,
+     * so the camera and the consumer's own `onDoubleTap` see the same event and neither steals it
+     * from the other. Not called when the touch was absorbed by an editable node — that node owns
+     * the gesture.
+     */
+    fun onDoubleTap(event: MotionEvent) {
+        if (!isDoubleTapZoomEnabled) return
+        twoFingerTapCandidate = false
+        val touch = TouchPair.of(event, viewHeight())
+        requestZoom(touch.x, touch.y, zoomIn = true)
+    }
+
+    /**
+     * Asks the manipulator to zoom, tolerating a manipulator that predates the gesture.
+     *
+     * [CameraManipulator.doubleTapZoom] has a default implementation, so every Kotlin manipulator
+     * — including one compiled against 4.35 — already answers it. A **Java** class implementing
+     * the interface before 4.36 does not: Kotlin emits the default into a `DefaultImpls` bridge on
+     * the implementor's side, which such a class never got, so the call would land on an abstract
+     * method. Major version 4 is frozen, so that must not become a crash for a consumer who only
+     * upgraded the SDK. Swallowing it here means the worst case is "double-tap does nothing",
+     * which is exactly the 4.35 behaviour they already had.
+     */
+    private fun requestZoom(x: Int, y: Int, zoomIn: Boolean) {
+        val manipulator = cameraManipulator ?: return
+        runCatching { manipulator.doubleTapZoom(x, y, zoomIn) }
+    }
+
+    // ── Two-finger tap (zoom out) ────────────────────────────────────────────────────────────────
+    //
+    // Android's `GestureDetector` has no two-finger tap, but this class already tracks everything
+    // needed to recognise one for free: a second pointer going down while no camera gesture has
+    // started, both fingers lifting within the double-tap window, and the midpoint never
+    // travelling past the pan slop. An aborted pinch fails all three — it either promotes itself
+    // to ZOOM/PAN, or moves further than the slop — so it cannot be mistaken for a tap.
+    private var twoFingerTapCandidate = false
+    private var twoFingerTapDownTimeMs = 0L
+    private var twoFingerTapDownMidpoint = Float2(0f)
+    private var twoFingerTapDownSeparation = 0f
 
     fun onTouchEvent(event: MotionEvent) {
         val touch = TouchPair.of(event, viewHeight())
         when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> twoFingerTapCandidate = false
+
+            MotionEvent.ACTION_POINTER_DOWN -> beginTwoFingerTap(event, touch)
+
             MotionEvent.ACTION_MOVE -> {
+
+                // A tap that travels is not a tap. Checked before the gesture logic below so a
+                // stream promoted to PAN/ZOOM on this very event is already disqualified.
+                invalidateTwoFingerTapIfMoved(touch)
 
                 // CANCEL GESTURE DUE TO UNEXPECTED POINTER COUNT
 
@@ -421,10 +658,58 @@ open class CameraGestureDetector(
                 }
             }
 
+            MotionEvent.ACTION_POINTER_UP -> endTwoFingerTap(event)
+
             MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
+                twoFingerTapCandidate = false
                 endGesture()
             }
         }
+    }
+
+    /**
+     * Arms the two-finger tap on the second finger going down: exactly two fingers, nothing else
+     * in flight. A third pointer, or a pointer arriving mid-orbit, disqualifies the whole stream.
+     */
+    private fun beginTwoFingerTap(event: MotionEvent, touch: TouchPair) {
+        twoFingerTapCandidate = isDoubleTapZoomEnabled &&
+                event.pointerCount == 2 &&
+                currentGesture == Gesture.NONE
+        if (twoFingerTapCandidate) {
+            twoFingerTapDownTimeMs = event.eventTime
+            twoFingerTapDownMidpoint = touch.midpoint
+            twoFingerTapDownSeparation = touch.separation
+        }
+    }
+
+    /** Disarms the two-finger tap once either finger has travelled past the tap slop. */
+    private fun invalidateTwoFingerTapIfMoved(touch: TouchPair) {
+        if (!twoFingerTapCandidate) return
+        val drifted = distance(touch.midpoint, twoFingerTapDownMidpoint) > kTwoFingerTapSlop
+        val pinched =
+            abs(touch.separation - twoFingerTapDownSeparation) > kTwoFingerTapSlop
+        if (drifted || pinched) {
+            twoFingerTapCandidate = false
+        }
+    }
+
+    /**
+     * Fires the zoom-out when the first of the two fingers lifts inside the tap window.
+     *
+     * `event.eventTime` rather than `System.currentTimeMillis()`: the event's own clock is what
+     * the platform's tap timeouts are expressed in, and it does not drift with dispatch latency.
+     */
+    private fun endTwoFingerTap(event: MotionEvent) {
+        val tapped = twoFingerTapCandidate &&
+                currentGesture == Gesture.NONE &&
+                event.eventTime - twoFingerTapDownTimeMs <= kTwoFingerTapTimeoutMs
+        twoFingerTapCandidate = false
+        if (!tapped) return
+        requestZoom(
+            twoFingerTapDownMidpoint.x.toInt(),
+            twoFingerTapDownMidpoint.y.toInt(),
+            zoomIn = false,
+        )
     }
 
     private fun endGesture() {
@@ -528,6 +813,11 @@ class FovZoomCameraManipulator @JvmOverloads constructor(
 
     override fun scrollEnd() {}
     override fun update(deltaTime: Float) = inner.update(deltaTime)
+
+    // Double-tap stays a dolly, handled by the inner manipulator: this class only re-maps the
+    // *pinch* to a FOV change, and a double-tap that narrowed the lens instead of approaching the
+    // subject would contradict the dolly the orbit/pan half of the camera still does.
+    override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) = inner.doubleTapZoom(x, y, zoomIn)
 
     companion object {
         const val DEFAULT_PINCH_FOV_SPEED: Float = 0.05f

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
@@ -205,10 +205,69 @@ internal fun doubleTapZoomedDistance(
 ): Float {
     val home = if (homeDistance.isFinite() && homeDistance > 0f) homeDistance else distance
     if (!home.isFinite() || home <= 0f) return MIN_ORBIT_DISTANCE
-    val low = (home * minDistanceFactor)
-        .takeIf { it.isFinite() && it > 0f } ?: MIN_ORBIT_DISTANCE
-    val high = (home * maxDistanceFactor)
-        .takeIf { it.isFinite() && it > low } ?: low
+    return zoomedDistanceForDoubleTap(
+        distance = distance,
+        homeDistance = home,
+        zoomIn = zoomIn,
+        minDistance = (home * minDistanceFactor)
+            .takeIf { it.isFinite() && it > 0f } ?: MIN_ORBIT_DISTANCE,
+        maxDistance = home * maxDistanceFactor,
+        factor = factor,
+    )
+}
+
+/**
+ * The camera-to-target distance a double-tap should land on — the public, absolute-bounds form of
+ * the same step [doubleTapZoomedDistance] applies internally, and the double-tap counterpart of
+ * [zoomedDistanceForPinch].
+ *
+ * Use it when your manipulator owns its own orbit distance (a slider, a saved state) instead of
+ * delegating the dolly to a Filament `Manipulator`. Pair it with [animatedZoomDistance] driven
+ * from `update(deltaTime)` to get the eased move rather than a jump cut:
+ *
+ * ```kotlin
+ * override fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {
+ *     animationStart = zoom
+ *     animationTarget = zoomedDistanceForDoubleTap(
+ *         distance = zoom,
+ *         homeDistance = fit,
+ *         zoomIn = zoomIn,
+ *         minDistance = fit * 0.25f,
+ *         maxDistance = fit * 4f,
+ *     )
+ *     animationElapsed = 0f
+ * }
+ *
+ * override fun update(deltaTime: Float) {
+ *     animationElapsed += deltaTime
+ *     val progress = animationElapsed / 0.3f
+ *     zoom = animatedZoomDistance(animationStart, animationTarget, progress)
+ * }
+ * ```
+ *
+ * @param distance     Current camera-to-target distance. Non-finite / non-positive returns
+ *                     [minDistance].
+ * @param homeDistance Distance the scene was framed at — the target of the dead-end escape
+ *                     described above.
+ * @param zoomIn       `true` for a double-tap (closer), `false` for a two-finger tap.
+ * @param minDistance  Closest the tap may take the camera. Must be `> 0`.
+ * @param maxDistance  Furthest the tap may take the camera.
+ * @param factor       Distance ratio one tap covers. Must be `> 1`; `2` halves the distance.
+ * @return The clamped new distance. Equal to [distance] when the gesture would not move.
+ */
+@JvmOverloads
+fun zoomedDistanceForDoubleTap(
+    distance: Float,
+    homeDistance: Float,
+    zoomIn: Boolean,
+    minDistance: Float,
+    maxDistance: Float,
+    factor: Float =
+        CameraGestureDetector.DefaultCameraManipulator.DEFAULT_DOUBLE_TAP_ZOOM_FACTOR,
+): Float {
+    val low = minDistance.takeIf { it.isFinite() && it > 0f } ?: MIN_ORBIT_DISTANCE
+    val high = maxDistance.takeIf { it.isFinite() && it > low } ?: low
+    val home = if (homeDistance.isFinite() && homeDistance > 0f) homeDistance else distance
     if (!distance.isFinite() || distance <= 0f) return low
     val step = if (factor.isFinite() && factor > 1f) {
         factor
@@ -227,7 +286,7 @@ internal fun doubleTapZoomedDistance(
  * Standard cubic ease-in-out on `[0, 1]`, clamped — the acceleration curve every platform's
  * double-tap zoom uses, so the move reads as one deliberate gesture instead of a jump cut.
  */
-internal fun easeInOutCubic(progress: Float): Float {
+fun easeInOutCubic(progress: Float): Float {
     if (!progress.isFinite()) return 1f
     val t = progress.coerceIn(0f, 1f)
     return if (t < 0.5f) 4f * t * t * t else 1f - (-2f * t + 2f).let { it * it * it } / 2f
@@ -246,7 +305,7 @@ internal fun easeInOutCubic(progress: Float): Float {
  * @param target   Distance it ends on. Must be `> 0`.
  * @param progress Elapsed fraction in `[0, 1]`; clamped, and eased by [easeInOutCubic].
  */
-internal fun animatedZoomDistance(start: Float, target: Float, progress: Float): Float {
+fun animatedZoomDistance(start: Float, target: Float, progress: Float): Float {
     if (!start.isFinite() || start <= 0f) return target
     if (!target.isFinite() || target <= 0f) return start
     val eased = easeInOutCubic(progress)

--- a/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/CameraGestureMath.kt
@@ -169,3 +169,87 @@ internal fun nextFov(
         range.endInclusive.toDouble(),
     )
 }
+
+/**
+ * The camera-to-target distance a **double-tap** (or two-finger tap) should land on.
+ *
+ * Mirrors the Maps / Photos convention: one double-tap divides the distance by [factor], one
+ * two-finger tap multiplies it back. The step is a *ratio*, like the pinch (see [zoomedDistance]),
+ * so the gesture covers the same fraction of the framing whether the subject is a 5 cm bee or a
+ * 155 m landscape, and it is clamped into the same `[home · minFactor, home · maxFactor]` window
+ * the pinch uses — the eye can never reach, let alone cross, the orbit pivot (#3403).
+ *
+ * **The dead-end escape.** Repeatedly double-tapping a photo viewer that has no zoom-out gesture
+ * would strand the user at the closest distance. So when the camera is already sitting on the
+ * lower clamp, a zoom-**in** double-tap returns [homeDistance] instead: the gesture cycles back to
+ * the framing the scene was homed at, exactly like a second double-tap in Google Photos.
+ *
+ * @param distance          Current camera-to-target distance. Non-finite / non-positive returns
+ *                          the lower clamp.
+ * @param homeDistance      Distance the manipulator was homed at — the reference for the clamps
+ *                          and the target of the dead-end escape. Non-positive falls back to
+ *                          [distance].
+ * @param zoomIn            `true` for a double-tap (closer), `false` for a two-finger tap.
+ * @param factor            Distance ratio one tap covers. Must be `> 1`; `2` halves the distance.
+ * @param minDistanceFactor Closest the tap may take the camera, as a fraction of [homeDistance].
+ * @param maxDistanceFactor Furthest, as a multiple of [homeDistance].
+ * @return The clamped new distance. Equal to [distance] when the gesture would not move.
+ */
+internal fun doubleTapZoomedDistance(
+    distance: Float,
+    homeDistance: Float,
+    zoomIn: Boolean,
+    factor: Float,
+    minDistanceFactor: Float,
+    maxDistanceFactor: Float,
+): Float {
+    val home = if (homeDistance.isFinite() && homeDistance > 0f) homeDistance else distance
+    if (!home.isFinite() || home <= 0f) return MIN_ORBIT_DISTANCE
+    val low = (home * minDistanceFactor)
+        .takeIf { it.isFinite() && it > 0f } ?: MIN_ORBIT_DISTANCE
+    val high = (home * maxDistanceFactor)
+        .takeIf { it.isFinite() && it > low } ?: low
+    if (!distance.isFinite() || distance <= 0f) return low
+    val step = if (factor.isFinite() && factor > 1f) {
+        factor
+    } else {
+        CameraGestureDetector.DefaultCameraManipulator.DEFAULT_DOUBLE_TAP_ZOOM_FACTOR
+    }
+    // Already on the lower clamp and asked to go closer: cycle back to the homed framing rather
+    // than no-op forever. `1.001` absorbs the float drift of the repeated multiply/divide.
+    if (zoomIn && distance <= low * 1.001f) return home.coerceIn(low, high)
+    val raw = if (zoomIn) distance / step else distance * step
+    if (!raw.isFinite()) return distance.coerceIn(low, high)
+    return raw.coerceIn(low, high)
+}
+
+/**
+ * Standard cubic ease-in-out on `[0, 1]`, clamped — the acceleration curve every platform's
+ * double-tap zoom uses, so the move reads as one deliberate gesture instead of a jump cut.
+ */
+internal fun easeInOutCubic(progress: Float): Float {
+    if (!progress.isFinite()) return 1f
+    val t = progress.coerceIn(0f, 1f)
+    return if (t < 0.5f) 4f * t * t * t else 1f - (-2f * t + 2f).let { it * it * it } / 2f
+}
+
+/**
+ * The camera-to-target distance part-way through a double-tap zoom animation.
+ *
+ * Interpolation is **geometric**, not linear: `start · (target / start)^eased(progress)`. A linear
+ * ramp on a distance looks fast at the far end and crawls at the near end, because what the eye
+ * reads is the *ratio* of successive framings, not their difference — the same reason the pinch is
+ * exponential ([zoomedDistance]). Geometric interpolation keeps the apparent zoom speed constant
+ * over the whole move.
+ *
+ * @param start    Distance the animation began at. Must be `> 0`.
+ * @param target   Distance it ends on. Must be `> 0`.
+ * @param progress Elapsed fraction in `[0, 1]`; clamped, and eased by [easeInOutCubic].
+ */
+internal fun animatedZoomDistance(start: Float, target: Float, progress: Float): Float {
+    if (!start.isFinite() || start <= 0f) return target
+    if (!target.isFinite() || target <= 0f) return start
+    val eased = easeInOutCubic(progress)
+    val interpolated = start * exp(ln(target / start) * eased)
+    return if (interpolated.isFinite() && interpolated > 0f) interpolated else target
+}

--- a/sceneview/src/main/java/io/github/sceneview/gesture/GestureDetector.kt
+++ b/sceneview/src/main/java/io/github/sceneview/gesture/GestureDetector.kt
@@ -64,6 +64,17 @@ open class GestureDetector(context: Context, var listener: OnGestureListener?) {
 
     var touchedNode: Node? = null
 
+    /**
+     * SDK-internal double-tap hook, invoked just **before** [listener]'s `onDoubleTap`.
+     *
+     * `SceneView` wires this to the camera gesture detector so the built-in double-tap-to-zoom
+     * (#3608) rides the one double-tap recogniser the scene already has. Keeping it separate from
+     * [listener] is the whole point: a consumer that supplies its own `onGestureListener` replaces
+     * [listener] wholesale, and the camera must not lose its zoom because of it. Both run, in this
+     * order, on every double-tap.
+     */
+    internal var onDoubleTapCamera: ((MotionEvent) -> Unit)? = null
+
     private var lastTouchEvent: MotionEvent? = null
 
     private val gestureDetector = android.view.GestureDetector(context,
@@ -114,6 +125,7 @@ open class GestureDetector(context: Context, var listener: OnGestureListener?) {
             }
 
             override fun onDoubleTap(e: MotionEvent) = super.onDoubleTap(e).also {
+                onDoubleTapCamera?.invoke(e)
                 touchedNode?.onDoubleTap(e)
                 listener?.onDoubleTap(e, touchedNode)
             }

--- a/sceneview/src/test/java/io/github/sceneview/gesture/DoubleTapZoomTest.kt
+++ b/sceneview/src/test/java/io/github/sceneview/gesture/DoubleTapZoomTest.kt
@@ -1,0 +1,163 @@
+package io.github.sceneview.gesture
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins for the double-tap / two-finger-tap zoom step (#3608).
+ *
+ * The gesture is the one photo viewers and maps trained everyone on: a double-tap halves the
+ * camera-to-subject distance, a two-finger tap doubles it back, and neither can push the eye onto
+ * (or through) the orbit pivot — the failure mode #3403 cost the camera before the clamps existed.
+ */
+class DoubleTapZoomTest {
+
+    private val factor =
+        CameraGestureDetector.DefaultCameraManipulator.DEFAULT_DOUBLE_TAP_ZOOM_FACTOR
+    private val minFactor =
+        CameraGestureDetector.DefaultCameraManipulator.DEFAULT_MIN_ZOOM_DISTANCE_FACTOR
+    private val maxFactor =
+        CameraGestureDetector.DefaultCameraManipulator.DEFAULT_MAX_ZOOM_DISTANCE_FACTOR
+
+    private fun tap(
+        distance: Float,
+        home: Float = 4f,
+        zoomIn: Boolean = true,
+        step: Float = factor,
+    ) = doubleTapZoomedDistance(
+        distance = distance,
+        homeDistance = home,
+        zoomIn = zoomIn,
+        factor = step,
+        minDistanceFactor = minFactor,
+        maxDistanceFactor = maxFactor,
+    )
+
+    @Test
+    fun `double tap halves the distance`() {
+        assertEquals(2f, tap(distance = 4f), 1e-4f)
+    }
+
+    @Test
+    fun `two finger tap doubles it back`() {
+        assertEquals(4f, tap(distance = 2f, zoomIn = false), 1e-4f)
+    }
+
+    @Test
+    fun `zoom in then out returns to the starting framing`() {
+        val start = 3f
+        assertEquals(start, tap(tap(start), zoomIn = false), 1e-4f)
+    }
+
+    /** The step is a ratio, so the gesture feels identical on a bee and on a landscape. */
+    @Test
+    fun `the step is scale invariant`() {
+        assertEquals(0.5f, tap(0.05f, home = 0.1f) / 0.05f, 1e-4f)
+        assertEquals(0.5f, tap(80f, home = 160f) / 80f, 1e-4f)
+    }
+
+    @Test
+    fun `zooming in is clamped to the min distance`() {
+        val home = 4f
+        val min = home * minFactor
+        var distance = home
+        // Deliberately short of the dead-end escape: each tap halves, and the clamp catches it
+        // before the "already at the minimum" branch can fire.
+        repeat(3) { distance = tap(distance, home = home) }
+        assertTrue("never crosses the pivot", distance >= min - 1e-5f)
+        assertEquals(min, tap(min * 1.5f, home = home), 1e-4f)
+    }
+
+    @Test
+    fun `zooming out is clamped to the max distance`() {
+        val home = 4f
+        var distance = home
+        repeat(10) { distance = tap(distance, home = home, zoomIn = false) }
+        assertEquals(home * maxFactor, distance, 1e-3f)
+    }
+
+    /** The dead end Google Photos does not have: a tap on the closest framing goes back home. */
+    @Test
+    fun `double tapping at the min distance cycles back to the home framing`() {
+        val home = 4f
+        assertEquals(home, tap(home * minFactor, home = home), 1e-4f)
+    }
+
+    @Test
+    fun `a non positive or non finite distance falls back to the min clamp`() {
+        val home = 4f
+        val min = home * minFactor
+        assertEquals(min, tap(0f, home = home), 1e-4f)
+        assertEquals(min, tap(-1f, home = home), 1e-4f)
+        assertEquals(min, tap(Float.NaN, home = home), 1e-4f)
+    }
+
+    @Test
+    fun `an illegal factor falls back to the default`() {
+        assertEquals(tap(4f), tap(4f, step = 1f), 1e-4f)
+        assertEquals(tap(4f), tap(4f, step = 0f), 1e-4f)
+        assertEquals(tap(4f), tap(4f, step = Float.NaN), 1e-4f)
+    }
+
+    @Test
+    fun `an unusable home distance falls back to the current one`() {
+        // No crash, no zero: the clamps are then relative to where the camera actually is.
+        assertTrue(tap(4f, home = 0f) > 0f)
+        assertTrue(tap(4f, home = Float.NaN) > 0f)
+    }
+
+    // ── Animation curve ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the easing starts and ends where it should`() {
+        assertEquals(0f, easeInOutCubic(0f), 1e-6f)
+        assertEquals(0.5f, easeInOutCubic(0.5f), 1e-6f)
+        assertEquals(1f, easeInOutCubic(1f), 1e-6f)
+    }
+
+    @Test
+    fun `the easing is clamped and monotonic`() {
+        assertEquals(0f, easeInOutCubic(-1f), 1e-6f)
+        assertEquals(1f, easeInOutCubic(2f), 1e-6f)
+        var previous = -1f
+        for (i in 0..20) {
+            val value = easeInOutCubic(i / 20f)
+            assertTrue("monotonic at $i", value >= previous)
+            previous = value
+        }
+    }
+
+    @Test
+    fun `the animation lands exactly on its end points`() {
+        assertEquals(4f, animatedZoomDistance(4f, 2f, 0f), 1e-4f)
+        assertEquals(2f, animatedZoomDistance(4f, 2f, 1f), 1e-4f)
+    }
+
+    /** Geometric, not linear: halfway through, the distance is the *geometric* mean. */
+    @Test
+    fun `the animation interpolates the ratio, not the difference`() {
+        val mid = animatedZoomDistance(4f, 1f, 0.5f)
+        assertEquals(2f, mid, 1e-3f)
+        assertTrue("below the arithmetic mean", mid < 2.5f)
+    }
+
+    @Test
+    fun `the animation never leaves the interval it was given`() {
+        var previous = 4f
+        for (i in 1..20) {
+            val value = animatedZoomDistance(4f, 2f, i / 20f)
+            assertTrue("inside [2, 4] at $i", value in 2f..4f)
+            assertTrue("monotonic at $i", value <= previous + 1e-5f)
+            previous = value
+        }
+    }
+
+    @Test
+    fun `degenerate animation endpoints degrade instead of producing NaN`() {
+        assertEquals(2f, animatedZoomDistance(0f, 2f, 0.5f), 1e-4f)
+        assertEquals(4f, animatedZoomDistance(4f, 0f, 0.5f), 1e-4f)
+        assertEquals(4f, animatedZoomDistance(4f, Float.NaN, 0.5f), 1e-4f)
+        assertTrue(animatedZoomDistance(4f, 2f, Float.NaN).isFinite())
+    }
+}


### PR DESCRIPTION
Fixes #3608

Thomas, in-app feedback from the `model-viewer` screen on a Pixel 9: *« le double click sur le viewer devrait faire un zoom. faudrait appliquer les mêmes règles de gestures que sur les photos ou cartes. à appliquer partout dans SceneView »*. Confirmed, and applied at SDK level so every `Scene` / `SceneView` gets it — not just the demo.

## What the gesture does

| Gesture | Effect |
|---|---|
| **Double-tap** | Animated dolly to **half** the distance to the orbit pivot |
| **Two-finger tap** | Animated dolly **back out** by the same factor |

Both eased over 300 ms (cubic in-out). The step is a *ratio*, like the pinch since #3426, so it covers the same fraction of the framing on a 5 cm bee and a 155 m landscape, and it is clamped by the same `minZoomDistanceFactor` / `maxZoomDistanceFactor` as the pinch — the eye can never reach the orbit pivot and invert the camera (#3403).

Two details worth the words:

- **Geometric interpolation, not linear.** What the eye reads is the ratio of successive framings, not their difference, so a linear ramp looks fast at the far end and crawls at the near end.
- **No dead end.** Once the camera sits on the closest allowed distance, the next double-tap cycles back to the framing the scene was homed at — the way a second double-tap works in Google Photos. A user who never discovers the two-finger tap is never stuck.

The animation is advanced from `CameraManipulator.update(deltaTime)`, which the render loop already ticks once per frame: no coroutine, no second frame callback, and no work at all on frames where nothing is animating. Any user gesture (orbit, pan, pinch) cancels a move in flight.

## Nothing existing changes

- The double-tap rides the one `GestureDetector` the scene already has, through a new **internal** hook that fires *in addition to* `listener.onDoubleTap`. A consumer who supplies their own `onGestureListener` keeps their callback **and** gets the zoom — neither steals the event from the other.
- `onSingleTapConfirmed`, `onSingleTapUp` and node picking are untouched.
- A touch absorbed by an editable node does not move the camera — the same gesture isolation the other camera gestures already have.
- The two-finger tap is recognised in `CameraGestureDetector`, which already tracks the pointer state it needs. An aborted pinch fails the slop guard and the gesture-in-flight guard, so it cannot masquerade as a tap.

## API added

```kotlin
// CameraGestureDetector.CameraManipulator — default no-op body, existing manipulators unaffected
fun doubleTapZoom(x: Int, y: Int, zoomIn: Boolean) {}

// CameraGestureDetector
var isDoubleTapZoomEnabled: Boolean = true
fun onDoubleTap(event: MotionEvent)

// CameraGestureDetector.DefaultCameraManipulator
var isDoubleTapZoomEnabled: Boolean = true      // the opt-out switch
var doubleTapZoomFactor: Float = 2f             // distance ratio per tap (must be > 1)
var doubleTapZoomDurationSeconds: Float = 0.3f  // 0 = instantaneous
```

The `.api` diff is purely additive. The `doubleTapZoom` call is wrapped in `runCatching`: a **Java** class implementing `CameraManipulator` before this change never got Kotlin's `DefaultImpls` bridge, and major version 4 is frozen — the worst case must be "double-tap does nothing" (i.e. the 4.35 behaviour), not an `AbstractMethodError`.

`llms.txt` gains a **Camera gestures** section documenting the gesture, the opt-out and the limitation below.

## `sceneview-compose`

It drives its own camera (`cameraManipulator = null` on the inner `SceneView`), so the SDK fix does not reach it. The Android facade gets the same gesture against `CameraState.distance`, gated by the existing `gesturesEnabled` switch, with **no new public API** — the `.api` dump is unchanged. Desktop is left alone: it is mouse-driven with a scroll-wheel zoom, and double-click-to-zoom is not a desktop convention.

## Known limitation

With an ORBIT manipulator the zoom is **centred on the orbit pivot, not anchored under the finger**. Filament's `OrbitManipulator::scroll` moves the eye strictly along the gaze and ignores its `x`/`y` arguments. The only lateral lever is `grabBegin(x, y, strafe = true)` + `grabUpdate`, which recomputes the pose from a snapshot taken at `grabBegin` — it would clobber the dolly frame by frame rather than compose with it. Anchoring the tapped point would need a pivot setter Filament does not expose, so it is not hacked in here. The tap coordinates *are* forwarded to `doubleTapZoom` / `Manipulator.scroll`, so a custom manipulator that can use them has them. Documented in `llms.txt`.

## Verification

- `:sceneview:testDebugUnitTest` — green. New `DoubleTapZoomTest`: **16/16**, covering the zoom step (halving, inverse round-trip, scale invariance), both clamps, the dead-end escape, degenerate inputs (`0`, negative, `NaN`, illegal factor, unusable home distance), and the animation curve (end points, clamping, monotonicity, geometric-mean midpoint, NaN-free degradation).
- `:sceneview-compose:desktopTest` — green. New common `DoubleTapZoomTest`: **7/7** on the shared curve.
- `:sceneview:detekt`, `:sceneview-compose:detekt`, `:arsceneview:detekt` — green.
- `:sceneview:apiDump` — additive only; `:sceneview-compose:apiDump` — no change.
- `:snippets-check:compileDebugKotlin` — green, so the new `llms.txt` snippet compiles against the real API.
### On-device QA — `emulator-5554` (Pixel_7a, API 36), debug build of `samples/android-demo`

Deep link `sceneview://demo/model-viewer`, gesture injected with two `input tap` calls inside a
single `adb shell` (measured 217 ms apart), screenshot taken ~2 s later so the 300 ms animation has
settled.

| # | Action | Result |
|---|---|---|
| 1 | baseline | helmet framed whole, ~1/3 of the screen height |
| 2 | double-tap at the helmet | **zoomed ~2x**, visor fills the viewport, animation smooth |
| 3 | double-tap again | zoomed to the 0.25x min-distance clamp, stops there |
| 4 | double-tap again | returns **exactly** to the home framing (the dead-end escape) |
| 5 | single tap | no zoom; the demo's own tap-to-hide-chrome still fires |
| 6 | drag | still orbits, distance preserved — the zoom does not leak into the pan/orbit path |

Two calibration facts, both measured rather than assumed, because each one fails *silently*:
two taps issued from two `adb shell` round trips land 300-600 ms apart (past
`ViewConfiguration.getDoubleTapTimeout()`, scored as two single taps), while two `input tap` inside
one shell land ~27 ms apart (under `GestureDetector.DOUBLE_TAP_MIN_TIME`, 40 ms, also rejected).
The usable window is 40-300 ms.

**The two-finger tap could not be injected on this emulator, so it is verified by unit test only.**
All three channels are dead: `adb shell input` is single-touch by construction; `adb emu event send`
returns `OK` but its events never reach the app (proved by aiming the same sequence at a plain
button, which also did nothing); `sendevent` on `/dev/input/event1` is SELinux-denied for the shell
user even though it is in group `input`, and `adb root` is refused on a production build. Flagging
this rather than hacking around it: the zoom-out path shares all of its maths with the zoom-in path
(`zoomedDistanceForDoubleTap(zoomIn = false)`, covered by the inverse-round-trip test), but the
*recognition* of the two-finger tap has had no device run.

### Found by this QA, fixed in this PR

The gesture did nothing on Model Viewer at first: that screen supplies its own
`EntranceCameraManipulator`, and `CameraManipulator.doubleTapZoom` defaults to a no-op. So every app
with a custom manipulator would have silently got no zoom. Fixed by making the step and the easing
public (`zoomedDistanceForDoubleTap`, `animatedZoomDistance`, `easeInOutCubic` — additive to the
`.api` dump), overriding `doubleTapZoom` in the demo manipulator, and saying so plainly in
`llms.txt` and the changelog. The Camera & Gestures screen keeps its own `onDoubleTap` (fly back to
the whole stage) on purpose: the SDK zoom runs first and that flight supersedes it, which is the
priority a consumer callback is supposed to have.

Remaining demo manipulators that still fall through to the no-op, and are not covered here:
`HeroOrbitCameraManipulator` (`DemoHelpers.kt`) and the one in `AnimationPhysicsDemo.kt`. Both drive
scripted camera moves rather than a free-look viewer, so a double-tap dolly would fight the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

