### PR TITLE
fix(sceneview): mirror the scene with a second render pass instead of copyFrame (#3602)

### DIFF
--- a/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
+++ b/arsceneview/src/main/java/io/github/sceneview/ar/ARSceneView.kt
@@ -750,10 +750,9 @@ fun ARSceneView(
      * call [SurfaceMirrorer.startMirroring][io.github.sceneview.utils.SurfaceMirrorer.startMirroring] /
      * [SurfaceMirrorer.stopMirroring][io.github.sceneview.utils.SurfaceMirrorer.stopMirroring].
      *
-     * Wiring a non-null `surfaceMirrorer` keeps the window swap chain `CONFIG_READABLE` for the
-     * composable's whole lifetime — a small always-on GPU-readback cost that does not revert when
-     * you set it back to null (it clears only at surface detach). Prefer passing it unconditionally
-     * over toggling it per-recording.
+     * Wiring a non-null `surfaceMirrorer` costs nothing while nothing is being mirrored: the
+     * window swap chain is untouched, and each mirrored surface is rendered a second time only
+     * between `startMirroring` and `stopMirroring`. Pass it unconditionally.
      */
     surfaceMirrorer: SurfaceMirrorer? = null,
     /**

--- a/changelog.d/3602-surface-mirrorer-black.md
+++ b/changelog.d/3602-surface-mirrorer-black.md
@@ -1,0 +1,8 @@
+<!-- category: Fixed -->
+`SurfaceMirrorer` recordings are no longer uniformly black, and the live viewport no longer
+goes black while recording. Mirroring now renders the scene a second time into each mirrored
+surface's own swap chain, after the scene's own frame has been presented, instead of calling
+Filament's `Renderer.copyFrame` in the middle of it — that copy left the window's colour buffer
+undefined on drivers that discard it once it leaves the EGL draw slot, so both the MP4 and the
+on-screen frame came out black. Wiring a `surfaceMirrorer` no longer forces the window swap
+chain to `CONFIG_READABLE`.

--- a/sceneview/src/main/java/io/github/sceneview/SceneRenderer.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneRenderer.kt
@@ -10,7 +10,6 @@ import android.view.TextureView
 import com.google.android.filament.Engine
 import com.google.android.filament.Renderer
 import com.google.android.filament.SwapChain
-import com.google.android.filament.SwapChainFlags
 import com.google.android.filament.View
 import com.google.android.filament.Viewport
 import com.google.android.filament.android.DisplayHelper
@@ -69,60 +68,17 @@ class SceneRenderer(
     // ── Surface mirroring ───────────────────────────────────────────────────────────────────────
 
     /**
-     * Optional [SurfaceMirrorer] that copies every rendered frame to additional [Surface]s —
+     * Optional [SurfaceMirrorer] that mirrors every rendered frame to additional [Surface]s —
      * e.g. a [android.media.MediaRecorder] input surface for clean in-app video recording
      * (no MediaProjection consent dialog, no foreground service, no overlay UI in the frame).
      *
      * Wired automatically by the `SceneView` / `ARSceneView` composables from their
-     * `surfaceMirrorer` parameter. The frame copy runs between `Renderer.render` and
-     * `Renderer.endFrame`, as Filament's `copyFrame` requires.
-     *
-     * Setting a mirrorer makes the window swap chain **readable**
-     * ([SwapChainFlags.CONFIG_READABLE]) — a hard
-     * Filament requirement for `Renderer.copyFrame` to read the rendered frame back (without it
-     * the mirrored output is black). The flag is applied at swap-chain creation; if the swap
-     * chain already exists non-readable when the mirrorer is attached, it is recreated in place.
+     * `surfaceMirrorer` parameter. Mirroring runs **after** the scene's `Renderer.endFrame()`:
+     * each mirrored surface gets its own swap chain and its own render pass, so the live view's
+     * frame is complete and presented before any mirror work starts. Wiring a mirrorer changes
+     * nothing about the window swap chain — it can be attached and detached at any time.
      */
     var surfaceMirrorer: SurfaceMirrorer? = null
-        set(value) {
-            field = value
-            // Late attach: the surface was created before a mirrorer was wired, so the swap
-            // chain lacks CONFIG_READABLE and every mirrored frame would come out black.
-            // Recreate it readable, in place. Main thread only (same as all Filament calls) and
-            // never concurrent with renderFrame — both run on the main looper.
-            if (value != null && !swapChainReadable && swapChainRef.get() != null) {
-                recreateSwapChain()
-            }
-        }
-
-    /** Whether the current swap chain was created with [SwapChainFlags.CONFIG_READABLE]. */
-    private var swapChainReadable = false
-
-    /** The native window surface backing the current swap chain — kept for recreation. */
-    private var nativeWindowSurface: Surface? = null
-
-    /**
-     * Swap-chain creation flags: UiHelper's opacity-derived flags, plus CONFIG_READABLE when a
-     * [surfaceMirrorer] is wired (required by `Renderer.copyFrame` — see [surfaceMirrorer]).
-     */
-    private fun swapChainFlags(): Long =
-        uiHelper.swapChainFlags or if (surfaceMirrorer != null) {
-            SwapChainFlags.CONFIG_READABLE
-        } else {
-            0L
-        }
-
-    /** Destroys and recreates the swap chain on the retained surface with fresh [swapChainFlags]. */
-    private fun recreateSwapChain() {
-        val surface = nativeWindowSurface ?: return
-        swapChainRef.getAndSet(null)?.let {
-            engine.destroySwapChain(it)
-            engine.flushAndWait()
-        }
-        swapChainReadable = swapChainFlags() and
-                SwapChainFlags.CONFIG_READABLE != 0L
-        swapChainRef.set(engine.createSwapChain(surface, swapChainFlags()))
-    }
 
     // ── Resize callback ─────────────────────────────────────────────────────────────────────────
 
@@ -252,11 +208,15 @@ class SceneRenderer(
 
         if (renderer.beginFrame(sc, frameTimeNanos)) {
             renderer.render(view)
-            // Copy the rendered frame to any mirrored surfaces (in-app video recording).
-            // Must run between render() and endFrame() — Filament's copyFrame contract.
-            surfaceMirrorer?.onFrame(engine, renderer, view)
             renderer.endFrame()
             presentedFrameCount++
+            // Mirror the scene onto any mirrored surfaces (in-app video recording), as a second
+            // render pass on its own renderer. Deliberately AFTER endFrame: mirroring must never
+            // touch the window swap chain's frame — `Renderer.copyFrame`, which ran between
+            // render() and endFrame(), left the window's colour buffer undefined on drivers that
+            // discard it once it leaves the EGL draw slot, blacking both the recording and the
+            // live view (#3602).
+            surfaceMirrorer?.onFrame(engine, view, frameTimeNanos)
         }
 
         // Destroy GPU resources whose grace period has elapsed. Runs after endFrame on the main
@@ -308,13 +268,8 @@ class SceneRenderer(
     private fun makeRendererCallback(viewHeight: () -> Int) = object : UiHelper.RendererCallback {
         override fun onNativeWindowChanged(surface: Surface) {
             // Create a new swap chain for the surface; destroy the old one if any.
-            // Retain the surface + readability so a mirrorer attached later can recreate the
-            // swap chain with CONFIG_READABLE (see [surfaceMirrorer]).
-            nativeWindowSurface = surface
-            swapChainReadable = swapChainFlags() and
-                    SwapChainFlags.CONFIG_READABLE != 0L
             swapChainRef.getAndSet(
-                engine.createSwapChain(surface, swapChainFlags())
+                engine.createSwapChain(surface, uiHelper.swapChainFlags)
             )?.let { engine.destroySwapChain(it) }
 
             displayHelper?.let { dh ->
@@ -326,8 +281,6 @@ class SceneRenderer(
 
         override fun onDetachedFromSurface() {
             onSurfaceDestroyed?.invoke()
-            nativeWindowSurface = null
-            swapChainReadable = false
             // Detach the DisplayHelper (unregisters its display-changed listener) BEFORE
             // destroying the swap chain and flushAndWait(). Destroying the surface makes an
             // adaptive-refresh display switch its refresh rate back, posting a display-changed

--- a/sceneview/src/main/java/io/github/sceneview/SceneView.kt
+++ b/sceneview/src/main/java/io/github/sceneview/SceneView.kt
@@ -360,10 +360,9 @@ fun SceneView(
      * [SurfaceMirrorer.startMirroring][io.github.sceneview.utils.SurfaceMirrorer.startMirroring] /
      * [SurfaceMirrorer.stopMirroring][io.github.sceneview.utils.SurfaceMirrorer.stopMirroring].
      *
-     * Wiring a non-null `surfaceMirrorer` keeps the window swap chain `CONFIG_READABLE` for the
-     * composable's whole lifetime — a small always-on GPU-readback cost that does not revert when
-     * you set it back to null (it clears only at surface detach). Prefer passing it unconditionally
-     * over toggling it per-recording.
+     * Wiring a non-null `surfaceMirrorer` costs nothing while nothing is being mirrored: the
+     * window swap chain is untouched, and each mirrored surface is rendered a second time only
+     * between `startMirroring` and `stopMirroring`. Pass it unconditionally.
      */
     surfaceMirrorer: SurfaceMirrorer? = null,
     /**

--- a/sceneview/src/main/java/io/github/sceneview/utils/SurfaceMirrorer.kt
+++ b/sceneview/src/main/java/io/github/sceneview/utils/SurfaceMirrorer.kt
@@ -11,7 +11,7 @@ import com.google.android.filament.Viewport
  * Mirrors the rendered Filament frame to additional [Surface]s — the primitive behind clean
  * **in-app video recording** of a `SceneView` / `ARSceneView`.
  *
- * Every rendered frame is copied (GPU-side, letterboxed to preserve aspect ratio) onto each
+ * Every rendered frame is drawn again (GPU-side, letterboxed to preserve aspect ratio) onto each
  * mirrored surface. Point it at a [android.media.MediaRecorder]'s input surface and you get an
  * MP4 of exactly what the scene renders — camera feed and virtual content composited, **without
  * MediaProjection**: no system consent dialog, no `mediaProjection` foreground service, and no
@@ -42,6 +42,17 @@ import com.google.android.filament.Viewport
  *
  * Multiple surfaces can be mirrored simultaneously — each [startMirroring] call adds one target.
  *
+ * ### How a frame reaches the surface
+ * Each mirrored surface gets its own Filament swap chain, and the scene is **rendered a second
+ * time** into it — from a dedicated [Renderer], right after the scene's own frame has been
+ * presented. It does *not* use `Renderer.copyFrame`: that copy runs on Filament's legacy
+ * `blitDEPRECATED` path and needs an `eglMakeCurrent` with the window as EGL *read* surface and
+ * the recorder as *draw* surface, in the middle of the window's frame. Drivers that treat the
+ * window's colour buffer as undefined once it leaves the draw slot then hand back a black read
+ * *and* present a black window — a uniformly black MP4 with a blacked-out live viewport (#3602).
+ * A second render depends on no such cross-surface read, so it behaves the same everywhere, at
+ * the cost of one extra scene pass per mirrored surface per frame.
+ *
  * ### Threading
  * [startMirroring] performs no Filament call and is safe from any thread — the swap chain is
  * created lazily on the render (main) thread at the next frame. [stopMirroring] destroys the
@@ -67,6 +78,15 @@ class SurfaceMirrorer {
     private var engine: Engine? = null
 
     /**
+     * Dedicated Filament [Renderer] for the mirror passes, created at the first mirrored frame.
+     *
+     * A *separate* renderer, not the scene's: Filament keeps frame-pacing history per [Renderer]
+     * and documents that alternating swap chains on a single renderer loses all or part of it, so
+     * mirroring through the scene's own renderer would degrade the live view's pacing.
+     */
+    private var mirrorRenderer: Renderer? = null
+
+    /**
      * The [Surface]s currently being mirrored to (snapshot copy).
      */
     val mirroredSurfaces: List<Surface>
@@ -83,12 +103,12 @@ class SurfaceMirrorer {
      *
      * Use [android.media.MediaRecorder.getSurface], [android.media.MediaCodec.createInputSurface]
      * or [android.media.MediaCodec.createPersistentInputSurface] to obtain a recording input
-     * surface. Mirroring incurs a per-frame GPU copy — only mirror while capturing, and call
-     * [stopMirroring] when done.
+     * surface. Mirroring costs one extra scene render per frame — only mirror while capturing, and
+     * call [stopMirroring] when done.
      *
      * The frame is letterboxed into the destination rectangle so the scene's aspect ratio is
      * preserved. No-op if [surface] is already being mirrored (double-start safe). Safe to call
-     * from any thread, and before the scene's first frame — copying begins with the next
+     * from any thread, and before the scene's first frame — mirroring begins with the next
      * rendered frame.
      *
      * @param surface the [Surface] onto which the rendered scene is mirrored.
@@ -130,7 +150,7 @@ class SurfaceMirrorer {
     /**
      * Stops mirroring to [surface].
      *
-     * Call when capture is complete — otherwise the per-frame GPU copy cost remains. The caller
+     * Call when capture is complete — otherwise the per-frame render cost remains. The caller
      * stays responsible for releasing the [Surface] itself (e.g. `MediaRecorder.stop()`).
      *
      * Idempotent: no-op if [surface] is not currently mirrored. Must be called from the main
@@ -152,29 +172,46 @@ class SurfaceMirrorer {
     }
 
     /**
-     * Copies the frame just rendered by [renderer] to every mirrored surface.
+     * Renders the scene onto every mirrored surface.
      *
-     * Called by [io.github.sceneview.SceneRenderer] on the render thread, between
-     * `Renderer.render(view)` and `Renderer.endFrame()`.
+     * Called by [io.github.sceneview.SceneRenderer] on the render thread, right after the scene's
+     * own `Renderer.endFrame()`. Each mirror gets its own `beginFrame`/`render`/`endFrame` on the
+     * dedicated [mirrorRenderer], with [view]'s viewport temporarily set to the letterboxed
+     * destination rectangle and restored before returning.
      */
-    internal fun onFrame(engine: Engine, renderer: Renderer, view: View) {
+    internal fun onFrame(engine: Engine, view: View, frameTimeNanos: Long) {
         this.engine = engine
         synchronized(surfaceMirrors) {
-            surfaceMirrors.forEach { mirror ->
-                // Lazy swap-chain creation — startMirroring is JNI-free.
-                val swapChain = mirror.swapChain
-                    ?: runCatching { engine.createSwapChain(mirror.surface) }.getOrNull()
-                        ?.also { mirror.swapChain = it }
-                    ?: return@forEach
-                val destViewport = mirror.viewport ?: view.viewport
-                renderer.copyFrame(
-                    swapChain,
-                    getLetterboxViewport(view.viewport, destViewport),
-                    view.viewport,
-                    Renderer.MIRROR_FRAME_FLAG_COMMIT
-                            or Renderer.MIRROR_FRAME_FLAG_SET_PRESENTATION_TIME
-                            or Renderer.MIRROR_FRAME_FLAG_CLEAR
-                )
+            if (surfaceMirrors.isEmpty()) return
+            val renderer = mirrorRenderer ?: engine.createRenderer().also {
+                // Clear the whole destination every frame so the letterbox bars stay black
+                // instead of keeping whatever the previous frame left there.
+                it.clearOptions = Renderer.ClearOptions().apply {
+                    clear = true
+                    clearColor = doubleArrayOf(0.0, 0.0, 0.0, 1.0)
+                }
+                mirrorRenderer = it
+            }
+            val sourceViewport = view.viewport
+            try {
+                surfaceMirrors.forEach { mirror ->
+                    // Lazy swap-chain creation — startMirroring is JNI-free.
+                    val swapChain = mirror.swapChain
+                        ?: runCatching { engine.createSwapChain(mirror.surface) }.getOrNull()
+                            ?.also { mirror.swapChain = it }
+                        ?: return@forEach
+                    val destViewport = mirror.viewport ?: sourceViewport
+                    // Draw into the centred sub-rectangle that preserves the scene's aspect
+                    // ratio; the rest of the destination stays cleared to black.
+                    view.viewport = getLetterboxViewport(sourceViewport, destViewport)
+                    if (renderer.beginFrame(swapChain, frameTimeNanos)) {
+                        renderer.render(view)
+                        renderer.endFrame()
+                    }
+                }
+            } finally {
+                // The live view must get its own viewport back whatever happened above.
+                view.viewport = sourceViewport
             }
         }
     }
@@ -194,6 +231,10 @@ class SurfaceMirrorer {
                 mirror.swapChain = null
             }
             surfaceMirrors.clear()
+            mirrorRenderer?.let { renderer ->
+                engine?.let { runCatching { it.destroyRenderer(renderer) } }
+            }
+            mirrorRenderer = null
         }
         this.engine = null
     }


### PR DESCRIPTION
Fixes #3602

## The bug

`SurfaceMirrorer` recording produced a well-formed but uniformly black MP4 (every frame Y=16),
and the live 3D viewport went black for the whole duration of the recording, recovering on Stop.
`SurfaceMirrorer` is public API since #2626, sold as "clean in-app video recording" — so the
feature reported success while producing unusable output.

## Root cause

Mirroring called `Renderer.copyFrame` between `render()` and `endFrame()`. In Filament 1.72.1
(`filament/src/details/Renderer.cpp`) that is:

```cpp
driver.makeCurrent(dstSwapChain->getHwHandle(), mSwapChain->getHwHandle()); // draw=recorder, read=window
...
driver.blitDEPRECATED(TargetBufferFlags::COLOR, mRenderTargetHandle, dstViewport,
                      mRenderTargetHandle, srcViewport, SamplerMagFilter::LINEAR);
mSwapChain->makeCurrent(driver);
```

It pulls the window's colour buffer out of the EGL **draw** slot in the middle of the window's own
frame and reads it as the EGL **read** surface. Where the driver treats that buffer as undefined
once it stops being the draw surface, the blit reads black *and* the following `endFrame()`
presents black — one mechanism, both symptoms.

This was measured, not inferred. An instrumented build read back a 16x16 block at the centre of
the **window** swap chain twice in the same frame, immediately before and immediately after the
`copyFrame` call:

```
probe[pre]  frame=1680 mean=42  max=116      <- scene is rendered
probe[post] frame=1680 mean=0   max=0        <- window colour buffer destroyed
probe[pre]  frame=1800 mean=119 max=245
probe[post] frame=1800 mean=0   max=0
```

Outside the recording, `pre` and `post` are identical and non-black. Two hypotheses were tested
and refuted along the way: `CONFIG_READABLE` is not missing (it was already set, and the viewport
is fine before Record is tapped even though the flag is on from the first frame), and dropping
`MIRROR_FRAME_FLAG_CLEAR` does not help (`post` still reads 0).

## The fix

Each mirrored surface is rendered into directly: its own swap chain, its own
`beginFrame`/`render`/`endFrame`, on a `Renderer` dedicated to mirroring, and only **after** the
scene's own frame has been presented. Nothing reads across surfaces any more, so the path stops
depending on driver-specific EGL behaviour. The view's viewport is set to the letterboxed
destination rectangle for the mirror pass and restored in a `finally`.

The mirror renderer is deliberately separate from the scene's: Filament keeps frame-pacing history
per `Renderer` and documents that alternating swap chains on a single renderer loses all or part
of it, so sharing would degrade the live view's pacing.

Wiring a `surfaceMirrorer` no longer forces the window swap chain to `CONFIG_READABLE` — that was
only ever a `copyFrame` requirement. `SceneRenderer` therefore no longer retains the native window
surface nor recreates the swap chain in place on late attach. **No public API change**
(`:sceneview:apiCheck` passes unmodified).

## Verification

`emulator-5554` (Pixel_7a AVD), demo `sceneview://demo/video-recording`, Record → ~4 s → Stop, MP4
pulled from `/sdcard/Android/data/io.github.sceneview.demo/files/recordings/` and measured with
`ffmpeg -vf signalstats`:

| | before (`copyFrame`) | after (this PR) |
|---|---|---|
| frames | 761 | 150 |
| `YAVG` min / max / mean | 16.00 / 16.00 / **16.00** | 17.09 / 17.29 / **17.15** |
| `YMAX` min / max / mean | 16 / 16 / **16** | 224 / 243 / **234.9** |
| live viewport during recording | black | scene visible |

`YMAX` is the telling column: before, the brightest pixel of every single frame is limited-range
black; after, every frame peaks at 224-243. `YAVG` stays low simply because the scene is a small
helmet on a black background, pillarboxed into a 1280x720 frame — the extracted frames show the
helmet rendered and animating.

Cost, measured on the same emulator with an instrumented build: the mirror pass adds ~0.3 ms of
main-thread submit time per frame (one extra scene pass at the recording resolution on the GPU),
and Filament's frame skipper on the dedicated renderer lets ~78 % of scene frames through to the
mirror — the 5 s capture came out at 150 frames / 30 fps.

Not established here: behaviour on physical hardware. The mechanism is driver-dependent, and only
the emulator was available; the new path removes the cross-surface read entirely rather than
working around one driver, so it should be at least as correct everywhere, but a device pass on
the recording demo is still worth doing.

Also run: `:sceneview:detekt`, `:sceneview:testDebugUnitTest`, `:sceneview:apiCheck` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
