### PR TITLE
fix(demo): the emulator dies allocating the capture surface, and Lighting Lab held two 2048² HDR environments

### DIFF
--- a/changelog.d/3554-lighting-lab-lazy-probe.md
+++ b/changelog.d/3554-lighting-lab-lazy-probe.md
@@ -1,0 +1,3 @@
+<!-- category: Fixed -->
+- **Lighting Lab no longer builds the reflection probe's environment before the probe is switched on ([#3554](https://github.com/sceneview/sceneview/issues/3554)).** The demo decoded a second 2048² HDR into a full cubemap and specular mip chain as soon as the screen composed, even though the local reflection probe it feeds starts off — making it the only demo holding two cubemap pyramids at once. It is now built the first time the probe is turned on, and without a skybox, since
+  `ReflectionProbeNode` only ever reads the environment's indirect light and that skybox could never be drawn.

--- a/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/render/DemoRenderingScreenshotTest.kt
+++ b/samples/android-demo/src/androidTest/java/io/github/sceneview/demo/render/DemoRenderingScreenshotTest.kt
@@ -196,15 +196,24 @@ class DemoRenderingScreenshotTest {
 
     @Test
     fun lightingLabDemo_default_state() {
-        // #2239 Batch 2 — `dynamic-sky`, `environment`, `reflection-probes`, and
-        // `post-processing` consolidated into `lighting-lab`. Default landing tab is
-        // Sky (the dynamic-sky scene), so the captured frame is comparable to the
-        // prior `dynamicsky_default` golden once re-baselined. The Environment /
-        // Reflections / Post-FX sub-modes are reachable via segmented-button taps but
-        // covered only via DemoInteractionTest; dedicated screenshot captures would
-        // need a tab-aware deep-link parameter (follow-up). The procedural-sky shader
-        // has very high gradient sensitivity around the horizon, so TAA jitter bleeds
-        // into entire pixel rows along the sun band — 15 % handles cold + warm runs.
+        // #2239 Batch 2 folded `dynamic-sky`, `environment`, `reflection-probes` and
+        // `post-processing` into `lighting-lab`; #3539 then rebuilt the screen and the
+        // tabs are gone. There is one frame now — the shared `LightingStage` (helmet on
+        // a lit floor between a chrome and a matte probe ball) under a studio IBL and a
+        // single shadow-casting key — with every knob live in the sheet. `DynamicSkyNode`
+        // moved to the `lighting` showcase's Sun rig, so there is no procedural sky on
+        // this screen any more.
+        //
+        // The tolerance is inherited from the scene that DID have a procedural sky and
+        // has not been re-measured against the rebuilt frame, because this case has never
+        // completed a CI run (#3554). The IBL prefilter still has cold/warm cache variance
+        // and the chrome probe magnifies it, so 15 % is kept as the conservative value
+        // until a green run gives a real number to tighten it to.
+        //
+        // #3554: this case killed the emulator process at capture. The screen was the only
+        // demo building two 2 048² HDR environments at once, and it built the probe's one
+        // eagerly although the probe starts off — see `LightingLabDemo.probeEnvironment`.
+        // That allocation is now deferred, which is the fix under test here.
         captureAndCompare(demoSlug = "lighting-lab", goldenName = "lightinglab_default", settleSeconds = 14,
             pixelDiffTolerancePercent = 15.0f, maxChannelDiff = 24)
     }

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/LightingLabDemo.kt
@@ -107,6 +107,17 @@ import com.google.android.filament.Scene as FilamentScene
  * Filament JNI, main thread: the model comes from `rememberModelInstance`, the environments are
  * built inside `remember` blocks that run in composition, and the `View` options are pushed from
  * a `SideEffect` — never from a background coroutine.
+ *
+ * ## What the default frame is allowed to allocate
+ *
+ * Every knob on this bench is off or at the library default when the screen opens, and the
+ * allocations have to match: a control that is off must not have paid for itself yet. That is not
+ * a style rule here, it is #3554 — the screen used to build the local probe's 2 048² HDR the
+ * moment it composed, which made it the only demo in the catalogue holding two full cubemap
+ * pyramids at once, and the only case in `DemoRenderingScreenshotTest` that took the emulator
+ * process down with it. `probeEnvironment` documents the cost in detail.
+ *
+ * So: anything a switch guards is built when that switch is first turned on, not before.
  */
 @Composable
 fun LightingLabDemo(onBack: () -> Unit) {
@@ -125,6 +136,20 @@ fun LightingLabDemo(onBack: () -> Unit) {
     var showSky by remember { mutableStateOf(false) }
     var probeEnabled by remember { mutableStateOf(false) }
     var probeZone by remember { mutableFloatStateOf(LightingStage.PROBE_ZONE_DEFAULT) }
+
+    /**
+     * Whether the probe's own HDR has ever been asked for — see [probeEnvironment] for why this
+     * latch exists rather than a plain `remember(probeEnabled)`.
+     *
+     * Flipped from the two controls that turn the probe on, never written during composition, and
+     * never reset: once the environment is built, switching the probe off keeps it around so the
+     * next toggle is instant instead of paying the decode again.
+     */
+    var probeEnvironmentRequested by remember { mutableStateOf(false) }
+    val setProbeEnabled: (Boolean) -> Unit = { enabled ->
+        probeEnabled = enabled
+        if (enabled) probeEnvironmentRequested = true
+    }
     // Defaults mirror the library's own `createView` (SceneFactories.kt): SSAO on, MSAA off,
     // FXAA on, dithering on. A lab that opened with the wrong defaults would teach them.
     var ssaoEnabled by remember { mutableStateOf(true) }
@@ -177,10 +202,36 @@ fun LightingLabDemo(onBack: () -> Unit) {
     DisposableEffect(benchEnvironment) {
         onDispose { benchEnvironment?.let { environmentLoader.destroyEnvironment(it) } }
     }
-    val probeEnvironment: Environment? = remember(environmentLoader) {
-        environmentLoader.createHDREnvironment(
-            assetFileLocation = LightingStage.PROBE_ENVIRONMENT_FILE,
-        )
+    /**
+     * The local probe's IBL — built the first time the probe is switched on, never before, and
+     * without a skybox.
+     *
+     * Both halves of that are #3554. This screen was the only demo in the catalogue that built
+     * **two** 2 048² HDR environments at once, and it built the second one eagerly even though
+     * the probe it feeds starts off. `createHDREnvironment` is not a file read: each call decodes
+     * the HDR to a float equirect texture, renders it to a cubemap, then runs the specular
+     * prefilter over a full mip chain — so the default frame was paying for a second cubemap
+     * pyramid that nothing sampled.
+     *
+     * `createSkybox = false` is the other half, and it is free: [ReflectionProbeNode] only ever
+     * reads `environment.indirectLight`, so the skybox this used to build could never be drawn.
+     * Passing `false` also lets the loader destroy the intermediate cubemap once the prefilter has
+     * consumed it instead of retaining it for a `Skybox` that does not exist.
+     *
+     * On the `demo-render-goldens` leg that matters more than it looks: SwiftShader presents no
+     * frame at all there (`softwareRenderer=true`), so nothing on this screen is ever rasterised —
+     * but the allocations above still happen at composition, because they are what *builds* the
+     * environment rather than what draws it.
+     */
+    val probeEnvironment: Environment? = remember(environmentLoader, probeEnvironmentRequested) {
+        if (!probeEnvironmentRequested) {
+            null
+        } else {
+            environmentLoader.createHDREnvironment(
+                assetFileLocation = LightingStage.PROBE_ENVIRONMENT_FILE,
+                createSkybox = false,
+            )
+        }
     }
     DisposableEffect(probeEnvironment) {
         onDispose { probeEnvironment?.let { environmentLoader.destroyEnvironment(it) } }
@@ -281,7 +332,7 @@ fun LightingLabDemo(onBack: () -> Unit) {
                 icon = Icons.Filled.Lens,
                 label = "Reflections",
                 selected = probeEnabled,
-                onClick = { probeEnabled = !probeEnabled },
+                onClick = { setProbeEnabled(!probeEnabled) },
             ),
         ),
         controls = {
@@ -340,7 +391,7 @@ fun LightingLabDemo(onBack: () -> Unit) {
             SwitchRow(
                 label = stringResource(R.string.demo_lighting_lab_probe),
                 checked = probeEnabled,
-                onCheckedChange = { probeEnabled = it },
+                onCheckedChange = setProbeEnabled,
             )
             LabeledSlider(
                 label = stringResource(R.string.demo_lighting_lab_probe_zone),


### PR DESCRIPTION
The emulator dies allocating the capture surface, and Lighting Lab held two
2048² HDR environments.

## What is established

From the artifact attached to #3554:

- The allocation that fails is `claimShared [0x3f93c8000 0x3f9dac000]` =
  **10,371,072 bytes**. `1080 × 2400 × 4 = 10,368,000`, plus one 3 KB page of
  alignment. That region **is the screenshot colour buffer** — the emulator dies
  allocating the capture surface, not drawing the scene. That is why the last log
  line is the one that *starts* the capture.
- The leg runs `-Pandroid.testInstrumentationRunnerArguments.softwareRenderer=true`,
  and `render-tests.yml` states that on SwiftShader **Filament presents no frame
  at all** — every capture from this leg is the demo's own "the scene has not
  rendered a frame yet" card. So shadow maps, light count and rasterisation load
  cannot be the cause here: nothing is rasterised. Only what is allocated **at
  composition** counts.
- Of everything allocated at composition, the environments dominate. Grepping
  the catalogue, exactly two demos build an HDR environment from an asset —
  `lighting` (one) and `lighting-lab` (**two**). Lighting Lab was the only demo
  holding two cubemap pyramids at once, and it is the only case that takes the
  process down.

## The change

Lighting Lab built the local reflection probe's 2048² HDR eagerly, although the
probe it feeds **starts switched off**.

`createHDREnvironment` is not a file read. Each call decodes the HDR to a float
equirect texture, renders it to a cubemap, then runs the specular prefilter over
a full mip chain. The default frame was paying for a second cubemap pyramid that
nothing sampled.

- Built the first time the probe is switched on, via a latch written from the two
  controls that turn it on — never during composition — and kept afterwards so
  toggling back on stays instant.
- Built with `createSkybox = false`. `ReflectionProbeNode` only ever reads
  `environment.indirectLight`, so that skybox could never be drawn; passing
  `false` also lets the loader destroy the intermediate cubemap once the
  prefilter has consumed it.

Also refreshes the stale comment on `lightingLabDemo_default_state`, which still
described the five-tab dynamic-sky scene that #3539 deleted, and records that its
15 % tolerance is **inherited, never measured** — because this case has never
completed a CI run.

## What is still hypothesis

- That removing one cubemap pyramid is *enough* headroom for the 10 MB claim to
  succeed. Unprovable from here: the case has never completed once, so the next
  `render-tests` run on this branch is the experiment.
- Whether the real ceiling is per-process guest address space or host RAM on the
  runner. If it is the latter, `ram-size: 4096M` / `-partition-size 4096` in
  `render-tests.yml` is the other lever — a one-line change deliberately **not**
  made blind, so that this run isolates one variable.

The test is therefore left **enabled and unannotated**. Marking it skipped would
hide the only signal that tells us whether this worked.

## Context — the lighting catalogue

Kept here because it is what established the "only demo with two environments"
claim above. Read from the composables, not the titles:

| Card | What it is the demo *of* | Overlap |
|---|---|---|
| `lighting` | The **showcase** — *where does the light come from?* Three rigs: Image (HDR environment), Studio (three-point `LightNode` rig, `LightManager.Type`), Sun (`DynamicSkyNode` on a clock) | shares `LightingStage` with the lab, by design |
| `lighting-lab` | The **workbench** — *what can I turn?* One fixed rig, every knob live on one frame: exposure, IBL intensity + rotation, skybox, `ReflectionProbeNode`, SSAO, `FogNode`, MSAA, FXAA, dithering | same stage, different job |
| `contact-shadow-preview` | The only non-AR demo of `ContactShadowContext` (`.Floor` / `.Wall`). Its two chips are a simultaneous A/B, not a mode switch | none |
| `materials` | Procedural material studio (#3495). Lights the spheres, but the subject is the material | none |
| `ar-fog` / `fog` | `FogNode` in AR. `fog` was folded into `lighting-lab` by #2239 | `FogNode` appears in both |

**What only Lighting Lab demonstrates:** `ReflectionProbeNode` (a *local* IBL
override inside a radius), `IndirectLight.setRotation`, and the per-`View` frame
options — SSAO, MSAA, FXAA, dithering — each starting from the value `SceneView`
actually ships, so a flipped switch shows the contrast against the library
default rather than teaching a wrong one.

The split with `lighting` is by **role, not subject**: same helmet, same floor,
same two probe balls, so moving between them changes only the question being
asked.

**Not done here, on purpose:** #3463 item 4 proposes merging `lighting` +
`lighting-lab` into one card. That removes a card and contradicts the split
#3539 deliberately built, so it stays Thomas's decision. Nothing merged, nothing
deleted, no asset touched.

## QA

`./gradlew :samples:android-demo:assembleDebug :samples:android-demo:testDebugUnitTest`
— **BUILD SUCCESSFUL**, APK produced, **897 unit tests, 0 failures, 1 skipped**.

No emulator captures: the default frame is unchanged, because the only thing this
touches is an allocation behind a control that starts off. No control's layout,
label or default was altered.

Part of #3554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
