### PR TITLE
fix(demo): ar-scene-semantics overlay never appeared over the camera feed

### DIFF
--- a/changelog.d/3527-semantics-overlay.md
+++ b/changelog.d/3527-semantics-overlay.md
@@ -1,0 +1,14 @@
+<!-- category: Fixed -->
+- **`ar-scene-semantics` overlay never appeared, on every device
+  ([#3527](https://github.com/sceneview/sceneview/issues/3527),
+  [#3396](https://github.com/sceneview/sceneview/issues/3396)).** The demo painted the
+  per-pixel semantic raster on a Filament 3D quad parented to the AR camera, but the camera
+  background is deliberately drawn *last* (`ARCameraStream` priority 7, so it can early-Z-reject
+  pixels already covered by opaque virtual geometry — #1617) while the overlay material had to
+  disable depth *write* so `UNLABELED` pixels could stay transparent instead of punching an
+  opaque hole. With nothing left in the depth buffer for the camera pass to reject against, the
+  camera silently overdrew the overlay every single frame, regardless of device or opacity.
+  The demo now colours the raster into a bitmap and composites it as a Compose `Image` on top
+  of the `ARSceneView`, the same architecture `ARDepthVisualizationDemo` already uses — sidestepping
+  Filament's render-order bookkeeping entirely. The colouring + display-rotation logic is a
+  pure function, `SemanticsOverlay.labelBufferToArgb`, pinned by JVM tests.

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneSemanticsDemo.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/ARSceneSemanticsDemo.kt
@@ -1,8 +1,14 @@
 package io.github.sceneview.demo.demos
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,7 +31,6 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,10 +39,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import com.google.android.filament.Texture
 import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.SemanticLabel
@@ -47,8 +54,6 @@ import com.google.ar.core.TrackingState
 import io.github.sceneview.ar.ARSceneView
 import io.github.sceneview.ar.arcore.semanticImage
 import io.github.sceneview.ar.arcore.semanticLabelFraction
-import io.github.sceneview.ar.node.ARCameraNode
-import io.github.sceneview.ar.rememberARCameraNode
 import io.github.sceneview.demo.DemoScaffold
 import io.github.sceneview.demo.DemoSettings
 import io.github.sceneview.demo.R
@@ -56,21 +61,9 @@ import io.github.sceneview.demo.common.ForceTrackingFailureMenu
 import io.github.sceneview.demo.common.ForcedTrackingFailure
 import io.github.sceneview.demo.demos.internal.SemanticsOverlay
 import io.github.sceneview.demo.rememberArPlaybackDataset
-import io.github.sceneview.material.setSemanticsOpacity
-import io.github.sceneview.math.Direction
-import io.github.sceneview.math.Position
-import io.github.sceneview.math.Size
-import io.github.sceneview.node.PlaneNode
 import io.github.sceneview.rememberEngine
 import io.github.sceneview.rememberMaterialLoader
 import io.github.sceneview.rememberModelLoader
-
-/**
- * Local-space distance (metres) from the AR camera at which the full-screen semantic-overlay
- * quad is parented. Any value inside the near/far clip range works — the quad is sized to the
- * camera frustum at this distance every frame, so it always fills the viewport exactly.
- */
-private const val OVERLAY_QUAD_DISTANCE = 1.0f
 
 /**
  * AR demo — Scene Semantics: read ARCore's per-pixel 12-class outdoor semantic model and render
@@ -85,16 +78,24 @@ private const val OVERLAY_QUAD_DISTANCE = 1.0f
  *    the support gate via [io.github.sceneview.ar.arcore.resolveSemanticMode]) and the HUD
  *    surfaces a "not supported" banner — so the screen is never just black (#1617 principle).
  * 2. On every `onSessionUpdated`, call [Frame.semanticLabelFraction] for each of the 12 labels
- *    (a cheap GPU-backed query) to drive the HUD, **and** acquire the full per-pixel raster
- *    via [Frame.semanticImage] and upload it into a Filament `R8` [Texture].
- * 3. The overlay quad is a full-screen [PlaneNode] parented to the AR camera node, painted with
- *    the **`semantics_overlay.filamat`** material ([io.github.sceneview.loaders.MaterialLoader.createSemanticsOverlayInstance]):
- *    the shader maps each label ordinal to one of 12 fixed colors. A Compose [Slider] drives
- *    `opacity` (0.0 = camera only, 1.0 = full overlay) — same blend UX as `ARDepthVisualizationDemo`.
+ *    (a cheap GPU-backed query) to drive the HUD, **and** acquire the full per-pixel raster via
+ *    [Frame.semanticImage] and colour it into an `ARGB_8888` [Bitmap] via
+ *    [SemanticsOverlay.labelBufferToArgb] — rotated to the display orientation the same way
+ *    `ARDepthVisualizationDemo` rotates its depth bitmap (#3184-class mismatch).
+ * 3. The bitmap is composited as a Compose [Image], on top of the [ARSceneView] itself, with
+ *    `alpha` driven by the Camera ↔ Semantic [Slider] (0.0 = camera only, 1.0 = full overlay) —
+ *    the exact same architecture `ARDepthVisualizationDemo` uses for its depth overlay.
  *
- * The custom `.filamat` shader is the per-pixel label-overlay port of Google's
- * `samples/semantics_java` `background_semantics.frag`, deferred from #1730 / PR #1867 so the
- * matc-toolchain ABI work could be sequenced after the Config + Frame-accessor API landed.
+ * This demo used to paint the raster with a custom `semantics_overlay.filamat` material on a
+ * full-screen quad parented to the AR camera node instead. That never actually appeared: the
+ * camera background is deliberately drawn *last* in Filament's render order (`ARCameraStream`
+ * priority 7, so it can early-Z-reject pixels already covered by opaque virtual geometry,
+ * #1617) — but the overlay material had to disable depth *write* (so `UNLABELED` pixels could
+ * stay transparent instead of leaving an opaque hole), so it left nothing in the depth buffer
+ * for the camera pass to reject against, and the camera silently overdrew the overlay every
+ * frame, on every device. See [SemanticsOverlay]'s class KDoc for the full account. That is the
+ * root cause of [#3396](https://github.com/sceneview/sceneview/issues/3396) and
+ * [#3527](https://github.com/sceneview/sceneview/issues/3527).
  *
  * **Outdoor only.** The ARCore model has no indoor training data — pointing the camera at a
  * living-room wall will return mostly `UNLABELED`. Take this demo outside (street / park /
@@ -105,14 +106,26 @@ private const val OVERLAY_QUAD_DISTANCE = 1.0f
  */
 @Composable
 fun ARSceneSemanticsDemo(onBack: () -> Unit) {
+    val context = LocalContext.current
+    // Resolved once: the Display *object* is stable for the lifetime of this context, while
+    // `rotation` on it is live — so the per-frame read below stays cheap. Same pattern as
+    // `ARDepthVisualizationDemo`. `Context.display` was added in API 30; fall back to the
+    // deprecated accessor on API 28–29.
+    val display = remember(context) {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                context.display
+            } else {
+                @Suppress("DEPRECATION")
+                (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+            }
+        }.getOrNull()
+    }
+
     val engine = rememberEngine()
     val modelLoader = rememberModelLoader(engine)
     val materialLoader = rememberMaterialLoader(engine)
     val arPlaybackDataset = rememberArPlaybackDataset()
-
-    // The AR camera node is hoisted so the semantic-overlay quad can be parented to it — the
-    // quad then tracks the camera and is sized to its frustum every frame, filling the viewport.
-    val cameraNode = rememberARCameraNode(engine)
 
     // Capability gate: null while we wait for the first session.configure callback;
     // true if the device shipped the Scene Semantics ML model; false otherwise.
@@ -143,15 +156,16 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
     // Camera ↔ Semantic overlay blend [0..1]. 0 = camera feed only; 1 = full segmentation overlay.
     var overlayBlend by remember { mutableStateOf(0.5f) }
 
-    // ── Filament resources for the GPU overlay (#1868) ──────────────────────────────────────
-    // The semantic raster is uploaded into this single-channel R8 texture, recreated only when
-    // the ARCore image dimensions change. The PlaneNode paints it with the custom .filamat.
-    // Held in `remember` holders so they survive recomposition; released in the DisposableEffect.
-    val overlay = remember { SemanticsOverlayResources() }
-
-    DisposableEffect(Unit) {
-        onDispose { overlay.release(materialLoader) }
-    }
+    // ── Compose bitmap overlay (#1868, #3396, #3527) ──────────────────────────────────
+    // Mutable bitmap; reallocated when the semantic-image resolution or display rotation
+    // changes. Composited as a Compose Image on top of the ARSceneView — see the class KDoc
+    // for why a Filament 3D quad could never actually appear over the live camera feed.
+    var semanticsBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    var bitmapWidth by remember { mutableStateOf(0) }
+    var bitmapHeight by remember { mutableStateOf(0) }
+    // Version counter incremented after every successful upload so Compose recomposes the
+    // Image even though the Bitmap reference is unchanged.
+    var semanticsFrameVersion by remember { mutableStateOf(0) }
 
     DemoScaffold(
         title = stringResource(R.string.demo_ar_scene_semantics_title),
@@ -356,7 +370,6 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
                 engine = engine,
                 modelLoader = modelLoader,
                 materialLoader = materialLoader,
-                cameraNode = cameraNode,
                 playbackDataset = arPlaybackDataset,
                 sessionConfiguration = { session: Session, config: Config ->
                     // Capability probe — uses ARCore's `isSemanticModeSupported` so we set the
@@ -392,162 +405,64 @@ fun ARSceneSemanticsDemo(onBack: () -> Unit) {
                             )
                         } ?: false
 
-                        // Per-pixel raster overlay — acquire the R8 semantic image, upload it
-                        // into the Filament texture, (re)build the camera-parented overlay quad
-                        // and size it to the current frustum. All Filament JNI calls run here on
-                        // the ARCore frame callback (the render/main thread) — never off-thread.
-                        overlay.update(
-                            frame = frame,
-                            engine = engine,
-                            materialLoader = materialLoader,
-                            cameraNode = cameraNode,
-                            opacity = overlayBlend
-                        )
+                        // Per-pixel raster overlay (#3396, #3527) — acquire the R8 semantic
+                        // image, colour it into an ARGB bitmap rotated to the display, and
+                        // composite it as a Compose Image above the ARSceneView. See the class
+                        // KDoc for why a Filament 3D quad never actually appeared on screen.
+                        val image = frame.semanticImage()
+                        if (image != null) {
+                            try {
+                                val plane = image.planes[0]
+                                val w = image.width
+                                val h = image.height
+                                val rotation = SemanticsOverlay.displayRotationToDegrees(
+                                    display?.rotation ?: Surface.ROTATION_0
+                                )
+                                val pixels = SemanticsOverlay.labelBufferToArgb(
+                                    labelBytes = plane.buffer,
+                                    width = w,
+                                    height = h,
+                                    rowStrideBytes = plane.rowStride,
+                                    rotationDegrees = rotation,
+                                )
+                                // Post-rotation dimensions — swapped on a quarter turn.
+                                val outW = SemanticsOverlay.rotatedWidth(w, h, rotation)
+                                val outH = SemanticsOverlay.rotatedHeight(w, h, rotation)
+                                if (semanticsBitmap == null ||
+                                    outW != bitmapWidth ||
+                                    outH != bitmapHeight
+                                ) {
+                                    semanticsBitmap =
+                                        Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
+                                    bitmapWidth = outW
+                                    bitmapHeight = outH
+                                }
+                                semanticsBitmap?.setPixels(pixels, 0, outW, 0, 0, outW, outH)
+                                semanticsFrameVersion++
+                            } finally {
+                                runCatching { image.close() }
+                            }
+                        }
                     }
                 },
                 onTrackingFailureChanged = { reason ->
                     trackingFailureReason = reason
                 },
             )
-        }
-    }
-}
 
-/**
- * Holds the Filament resources backing the GPU semantic overlay: the `R8` [Texture] that
- * receives the per-pixel raster, the camera-parented full-screen [PlaneNode], and its
- * `semantics_overlay.filamat` material instance. Recreated lazily and reused across frames so
- * the per-frame cost is one `setImage` upload plus a frustum-fit resize.
- *
- * All members are touched only from the ARCore frame callback (the render/main thread); none
- * are accessed off-thread, so no synchronization is needed.
- */
-private class SemanticsOverlayResources {
-    private var texture: Texture? = null
-    private var textureWidth = 0
-    private var textureHeight = 0
-    private var quad: PlaneNode? = null
-
-    /**
-     * Acquires the semantic raster from [frame], uploads it into the (lazily (re)created)
-     * `R8` texture, builds the overlay quad on first use, sizes it to the camera frustum, and
-     * applies [opacity]. A no-op when semantics are not yet available.
-     */
-    @Suppress("LongMethod") // Filament texture upload + quad lifecycle is inherently multi-step
-    fun update(
-        frame: Frame,
-        engine: com.google.android.filament.Engine,
-        materialLoader: io.github.sceneview.loaders.MaterialLoader,
-        cameraNode: ARCameraNode,
-        opacity: Float
-    ) {
-        val image = frame.semanticImage() ?: return
-        try {
-            val width = image.width
-            val height = image.height
-            if (width <= 0 || height <= 0) return
-
-            val plane = image.planes[0]
-            val packed = SemanticsOverlay.stripRowStride(
-                source = plane.buffer,
-                width = width,
-                height = height,
-                rowStrideBytes = plane.rowStride
-            )
-
-            // (Re)create the R8 texture when the ARCore image resolution changes.
-            if (texture == null || width != textureWidth || height != textureHeight) {
-                texture?.let { runCatching { engine.destroyTexture(it) } }
-                texture = Texture.Builder()
-                    .width(width)
-                    .height(height)
-                    .levels(1)
-                    .sampler(Texture.Sampler.SAMPLER_2D)
-                    .format(Texture.InternalFormat.R8)
-                    .build(engine)
-                textureWidth = width
-                textureHeight = height
-                // The texture identity changed — rebuild the quad so its material instance
-                // samples the fresh texture.
-                disposeQuad(cameraNode, materialLoader)
-            }
-
-            val tex = texture ?: return
-            tex.setImage(
-                engine,
-                0,
-                Texture.PixelBufferDescriptor(
-                    packed,
-                    Texture.Format.R,
-                    Texture.Type.UBYTE
+            // Read the version so Compose recomposes when a new semantic frame arrives.
+            val versionRead = semanticsFrameVersion
+            val bitmap = semanticsBitmap
+            if (bitmap != null && versionRead >= 0) {
+                Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    alpha = overlayBlend,
+                    modifier = Modifier.fillMaxSize()
                 )
-            )
-
-            // Build the camera-parented full-screen quad on first use.
-            if (quad == null) {
-                quad = PlaneNode(
-                    engine = engine,
-                    size = Size(1.0f, 1.0f),
-                    center = Position(0.0f, 0.0f, -OVERLAY_QUAD_DISTANCE),
-                    // Plane faces the camera (-Z is the look direction; the quad's outward
-                    // normal must point back toward the camera at +Z in camera-local space).
-                    normal = Direction(0.0f, 0.0f, 1.0f),
-                    materialInstance = materialLoader.createSemanticsOverlayInstance(
-                        semanticTexture = tex,
-                        opacity = opacity
-                    )
-                ).also { cameraNode.addChildNode(it) }
             }
-
-            // Size the quad to exactly fill the camera frustum at OVERLAY_QUAD_DISTANCE.
-            // The projection matrix is column-major: m[5] = 1/tan(vFov/2), m[0] = m[5]/aspect.
-            val projection = cameraNode.projectionTransform
-            val m11 = projection.y.y
-            val m00 = projection.x.x
-            quad?.let { node ->
-                if (m11 != 0.0f && m00 != 0.0f) {
-                    val visibleHeight = 2.0f * OVERLAY_QUAD_DISTANCE / m11
-                    val visibleWidth = 2.0f * OVERLAY_QUAD_DISTANCE / m00
-                    node.updateGeometry(
-                        size = Size(visibleWidth, visibleHeight),
-                        center = Position(0.0f, 0.0f, -OVERLAY_QUAD_DISTANCE),
-                        normal = Direction(0.0f, 0.0f, 1.0f)
-                    )
-                }
-                node.materialInstance.setSemanticsOpacity(opacity)
-            }
-        } finally {
-            runCatching { image.close() }
         }
-    }
-
-    private fun disposeQuad(
-        cameraNode: ARCameraNode,
-        materialLoader: io.github.sceneview.loaders.MaterialLoader
-    ) {
-        quad?.let { node ->
-            cameraNode.removeChildNode(node)
-            val mi = node.materialInstance
-            node.destroy()
-            materialLoader.destroyMaterialInstance(mi)
-        }
-        quad = null
-    }
-
-    /** Releases the texture, the quad and its material instance. Call on demo teardown. */
-    fun release(materialLoader: io.github.sceneview.loaders.MaterialLoader) {
-        quad?.let { node ->
-            val mi = runCatching { node.materialInstance }.getOrNull()
-            runCatching { node.destroy() }
-            mi?.let { materialLoader.destroyMaterialInstance(it) }
-        }
-        quad = null
-        texture?.let { tex ->
-            // The quad's renderable is already destroyed above, so the texture is no longer
-            // bound — safe to destroy directly on the engine.
-            runCatching { materialLoader.engine.destroyTexture(tex) }
-        }
-        texture = null
     }
 }
 

--- a/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/SemanticsOverlay.kt
+++ b/samples/android-demo/src/main/java/io/github/sceneview/demo/demos/internal/SemanticsOverlay.kt
@@ -7,23 +7,37 @@ import java.nio.ByteBuffer
  *
  * ARCore's [com.google.ar.core.Frame.acquireSemanticImage] returns an `R8` image — one byte
  * per pixel, the byte being a [com.google.ar.core.SemanticLabel] ordinal (`0..11`). The
- * `ARSceneSemanticsDemo` uploads that raster into a Filament `R8` [com.google.android.filament.Texture]
- * and renders it through the `semantics_overlay.filamat` material, which maps each ordinal to
- * one of 12 fixed outdoor-class colours.
+ * `ARSceneSemanticsDemo` colours that raster into an `ARGB_8888` [android.graphics.Bitmap] via
+ * [labelBufferToArgb] and composites it as a Compose `Image` **on top of** the `ARSceneView** —
+ * the same architecture [DepthVisualization] already uses for the depth-visualization demo.
+ *
+ * This demo used to upload the raster into a Filament `R8` texture and paint a camera-parented
+ * 3D quad with a custom `.filamat` material instead (#1868's original design). That never
+ * actually composited over the live camera feed: `ARCameraStream`'s flat (non-occlusion)
+ * material is deliberately drawn **last** (`RenderableManager` priority 7) so it can early-Z
+ * reject pixels already covered by opaque virtual geometry (#1617) — but the overlay quad's
+ * material set `depthWrite: false` (it has to, to let `UNLABELED` pixels stay transparent
+ * without leaving a see-through "hole" behind them), so it never left anything in the depth
+ * buffer for the camera pass to reject against. The camera quad then unconditionally overdrew
+ * the overlay every frame, on every device, regardless of `SemanticMode` support or opacity —
+ * this is the actual defect behind
+ * [#3396](https://github.com/sceneview/sceneview/issues/3396) and
+ * [#3527](https://github.com/sceneview/sceneview/issues/3527) ("overlay not visible" /
+ * "nothing renders"). Compositing in Compose, above the `SurfaceView`/`TextureView` entirely,
+ * sidesteps Filament's render-order bookkeeping the same way the depth demo already does.
  *
  * Two things need a non-Filament, JVM-testable home:
  *
- *  1. [stripRowStride] — ARCore hands back a **row-strided** buffer (`rowStride >= width`);
- *     Filament's `PixelBufferDescriptor` upload expects a tightly-packed `width * height`
- *     buffer. This compacts it.
- *  2. [PALETTE_ARGB] — the 12-class colour palette used to draw the demo's on-screen colour
- *     legend. It mirrors the `const vec3 SEMANTIC_PALETTE[12]` baked into
- *     `semantics_overlay.mat` (the `.mat` shader is the source of truth); keep the two in
- *     sync so the legend swatches read the same as the GPU overlay.
+ *  1. [labelBufferToArgb] — colours a **row-strided** `R8` label buffer
+ *     (`rowStride >= width`) into a packed `ARGB_8888` pixel array, rotated to match the
+ *     display (ARCore hands the raster out in the landscape camera-sensor frame — same
+ *     mismatch [DepthVisualization.depthBufferToArgb] corrects for depth, #3184).
+ *  2. [PALETTE_ARGB] — the 12-class colour palette, used both by [labelBufferToArgb] and the
+ *     demo's on-screen colour legend.
  *
- * Extracted as an `internal object` so the logic is unit-testable without ARCore /
- * Filament on the classpath — `com.google.ar.core.Image` is not mockable on the JVM, but a
- * plain [ByteBuffer] is. See `SemanticsOverlayTest`.
+ * Extracted as an `internal object` so the logic is unit-testable without ARCore on the
+ * classpath — `com.google.ar.core.Image` is not mockable on the JVM, but a plain [ByteBuffer]
+ * is. See `SemanticsOverlayTest`.
  *
  * Closes part of [#1868](https://github.com/sceneview/sceneview/issues/1868).
  */
@@ -66,41 +80,108 @@ internal object SemanticsOverlay {
         "Structure", "Object", "Vehicle", "Person", "Water", "Unlabeled"
     )
 
+    /** Sentinel written for [UNLABELED_ORDINAL] pixels — fully transparent. */
+    private const val ARGB_TRANSPARENT: Int = 0x00000000
+
     /**
-     * Compacts a row-strided single-channel (`R8`) image buffer into a tightly-packed
-     * `width * height` [ByteBuffer] suitable for a Filament `PixelBufferDescriptor` upload.
+     * Clockwise rotation, in degrees, that makes an ARCore semantic image upright on screen for
+     * a given `android.view.Surface.ROTATION_*` display rotation.
      *
-     * ARCore returns the semantic raster with `rowStrideBytes >= width`; Filament expects no
-     * inter-row padding. When the stride already equals the width this still returns a fresh,
-     * rewound, position-0 buffer so the caller can hand it straight to Filament.
+     * ARCore hands the semantic raster out in the **camera sensor** frame, which is landscape
+     * and does not follow the display — same mismatch as the depth image
+     * ([DepthVisualization.displayRotationToDegrees], #3184). The back-camera sensor
+     * orientation is 90° on every Android phone this demo targets.
      *
-     * @param source         direct buffer with ARCore's `R8` semantic data; not consumed.
+     * @param surfaceRotation One of the `Surface.ROTATION_*` **ordinals** (0, 1, 2, 3) — not
+     *                        degrees. An unknown value falls back to the portrait mapping.
+     */
+    fun displayRotationToDegrees(surfaceRotation: Int): Int =
+        DepthVisualization.displayRotationToDegrees(surfaceRotation)
+
+    /** Width of a `width` × `height` image after [rotationDegrees] of clockwise rotation. */
+    fun rotatedWidth(width: Int, height: Int, rotationDegrees: Int): Int =
+        DepthVisualization.rotatedWidth(width, height, rotationDegrees)
+
+    /** Height of a `width` × `height` image after [rotationDegrees] of clockwise rotation. */
+    fun rotatedHeight(width: Int, height: Int, rotationDegrees: Int): Int =
+        DepthVisualization.rotatedHeight(width, height, rotationDegrees)
+
+    /**
+     * Colours a row-strided single-channel (`R8`) ARCore Scene Semantics label buffer into a
+     * packed `ARGB_8888` pixel array suitable for `Bitmap.setPixels`, rotated to match the
+     * display so the overlay lines up with the live camera feed underneath it (#3184-class
+     * mismatch — see [displayRotationToDegrees]).
+     *
+     * Each source byte is a [com.google.ar.core.SemanticLabel] ordinal (`0..11`); it is mapped
+     * through [PALETTE_ARGB], with [UNLABELED_ORDINAL] painted fully transparent so un-classified
+     * pixels show the live camera through instead of a solid colour. The demo composites the
+     * result via Compose `Image(alpha = blend)`, on top of the `ARSceneView` — see the class
+     * KDoc above for why a Filament 3D quad could never make this composite over the camera feed.
+     *
+     * With a non-zero [rotationDegrees] the samples are written straight into their rotated
+     * destination index, so making the overlay upright costs no extra pass and no second buffer.
+     * The returned array is then [rotatedWidth] × [rotatedHeight] — for a quarter turn those are
+     * the *swapped* source dimensions, and the caller's bitmap must be allocated to match.
+     *
+     * @param labelBytes     direct buffer with ARCore's `R8` semantic data; not consumed.
      * @param width          pixel width of the semantic image.
      * @param height         pixel height of the semantic image.
-     * @param rowStrideBytes bytes between consecutive rows in [source] (`>= width`).
-     * @return a packed buffer of exactly `width * height` bytes, rewound to position 0.
+     * @param rowStrideBytes bytes between consecutive rows in [labelBytes] (`>= width`).
+     * @param rotationDegrees clockwise rotation to apply while writing, a multiple of 90. Use
+     *                        [displayRotationToDegrees] to derive it from the current display
+     *                        rotation.
+     * @return a packed `width * height` `ARGB_8888` pixel array (rotated dimensions).
      */
-    fun stripRowStride(
-        source: ByteBuffer,
+    fun labelBufferToArgb(
+        labelBytes: ByteBuffer,
         width: Int,
         height: Int,
-        rowStrideBytes: Int
-    ): ByteBuffer {
+        rowStrideBytes: Int,
+        rotationDegrees: Int = 0,
+    ): IntArray {
         require(width > 0 && height > 0) {
             "semantic image must be non-empty (got $width x $height)"
         }
         require(rowStrideBytes >= width) {
             "rowStrideBytes ($rowStrideBytes) must be >= width ($width)"
         }
-        val packed = ByteBuffer.allocateDirect(width * height)
+        val rotation = normalizeRotation(rotationDegrees)
+        val outWidth = rotatedWidth(width, height, rotation)
+        val out = IntArray(width * height)
         for (y in 0 until height) {
             val rowStart = y * rowStrideBytes
             for (x in 0 until width) {
-                packed.put(source.get(rowStart + x))
+                val ordinal = (labelBytes.get(rowStart + x).toInt() and 0xFF)
+                    .coerceIn(0, LABEL_COUNT - 1)
+                val argb = if (ordinal == UNLABELED_ORDINAL) {
+                    ARGB_TRANSPARENT
+                } else {
+                    PALETTE_ARGB[ordinal]
+                }
+                // Where this sample lands once the image is turned clockwise — mirrors
+                // DepthVisualization.depthBufferToArgb's indexing exactly.
+                val outIndex = when (rotation) {
+                    90 -> (x * outWidth) + (height - 1 - y)
+                    180 -> ((height - 1 - y) * outWidth) + (width - 1 - x)
+                    270 -> ((width - 1 - x) * outWidth) + y
+                    else -> (y * outWidth) + x
+                }
+                out[outIndex] = argb
             }
         }
-        packed.rewind()
-        return packed
+        return out
+    }
+
+    /**
+     * Fold an arbitrary degree value into the `{0, 90, 180, 270}` quarter-turn set, rejecting
+     * anything that is not a multiple of 90 — this pipeline rotates by whole quarter turns only
+     * (it re-indexes pixels, it does not resample).
+     */
+    private fun normalizeRotation(rotationDegrees: Int): Int {
+        require(rotationDegrees % 90 == 0) {
+            "rotationDegrees ($rotationDegrees) must be a multiple of 90"
+        }
+        return ((rotationDegrees % 360) + 360) % 360
     }
 
     /**

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
@@ -59,13 +59,18 @@ class SemanticsOverlayTest {
     }
 
     @Test
-    fun `labelBufferToArgb clamps an out-of-range byte into the palette`() {
+    fun `labelBufferToArgb clamps an out-of-range byte to UNLABELED and paints it transparent`() {
         val source = ByteBuffer.allocateDirect(1)
         source.put(0, 200.toByte()) // way past LABEL_COUNT - 1
 
         val pixels = SemanticsOverlay.labelBufferToArgb(source, width = 1, height = 1, rowStrideBytes = 1)
 
-        assertEquals(SemanticsOverlay.PALETTE_ARGB[SemanticsOverlay.LABEL_COUNT - 1], pixels[0])
+        // coerceIn(0, LABEL_COUNT - 1) folds any garbage ordinal onto UNLABELED_ORDINAL (11), the
+        // last valid entry — and UNLABELED is by contract painted fully transparent (see the
+        // "paints UNLABELED fully transparent" test above), not PALETTE_ARGB[11]'s opaque black.
+        // A corrupt/unrecognized byte should show the live camera through, never a solid colour
+        // that looks like a deliberate classification.
+        assertEquals(0x00000000, pixels[0])
     }
 
     @Test

--- a/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
+++ b/samples/android-demo/src/test/java/io/github/sceneview/demo/demos/internal/SemanticsOverlayTest.kt
@@ -8,66 +8,128 @@ import org.junit.Test
 import java.nio.ByteBuffer
 
 /**
- * JVM unit tests for [SemanticsOverlay]. ARCore's `Image` is not mockable on the JVM, so the
- * row-stride compaction is fed a plain [ByteBuffer] shaped like an ARCore `R8` semantic image
- * (one byte per pixel, a label ordinal, row-strided) instead.
+ * JVM unit tests for [SemanticsOverlay]. ARCore's `Image` is not mockable on the JVM, so
+ * [labelBufferToArgb][SemanticsOverlay.labelBufferToArgb] is fed a plain [ByteBuffer] shaped like
+ * an ARCore `R8` semantic image (one byte per pixel, a label ordinal, row-strided) instead.
  *
- * Pins the contract that backs the `ARSceneSemanticsDemo` GPU overlay (#1868): the packed
- * buffer must be tightly-packed `width * height` bytes regardless of input stride, and the
- * 12-class colour palette / label tables must stay the right size.
+ * Pins the contract that backs the `ARSceneSemanticsDemo` Compose bitmap overlay (#1868,
+ * #3396, #3527): row-strided input compacts and colours correctly regardless of stride, rotation
+ * re-indexes without resampling, `UNLABELED` stays transparent, and the 12-class colour
+ * palette / label tables stay the right size.
  */
 class SemanticsOverlayTest {
 
-    // ── stripRowStride ─────────────────────────────────────────────────────
+    // ── labelBufferToArgb ──────────────────────────────────────────────────
 
     @Test
-    fun `stripRowStride compacts a strided buffer to width times height bytes`() {
+    fun `labelBufferToArgb colours each pixel from the palette, ignoring row padding`() {
         val width = 3
         val height = 2
         val rowStride = 5 // 2 padding bytes per row
         val source = ByteBuffer.allocateDirect(rowStride * height)
-        // Row 0: ordinals 0,1,2 then padding; Row 1: ordinals 3,4,5 then padding.
+        // Row 0: ordinals 0(SKY),1(BUILDING),2(TREE) then padding.
+        // Row 1: ordinals 3(ROAD),4(SIDEWALK),5(TERRAIN) then padding.
+        val ordinals = intArrayOf(0, 1, 2, 3, 4, 5)
         for (y in 0 until height) {
             for (x in 0 until width) {
-                source.put(y * rowStride + x, (y * width + x).toByte())
+                source.put(y * rowStride + x, ordinals[y * width + x].toByte())
             }
         }
-        val packed = SemanticsOverlay.stripRowStride(source, width, height, rowStride)
 
-        assertEquals(width * height, packed.remaining())
-        for (i in 0 until width * height) {
-            assertEquals("packed[$i]", i.toByte(), packed.get(i))
+        val pixels = SemanticsOverlay.labelBufferToArgb(source, width, height, rowStride)
+
+        assertEquals(width * height, pixels.size)
+        for (i in ordinals.indices) {
+            assertEquals("pixel[$i]", SemanticsOverlay.PALETTE_ARGB[ordinals[i]], pixels[i])
         }
     }
 
     @Test
-    fun `stripRowStride handles a zero-padding buffer (stride equals width)`() {
-        val width = 4
-        val height = 3
+    fun `labelBufferToArgb paints UNLABELED fully transparent`() {
+        val width = 2
+        val height = 1
         val source = ByteBuffer.allocateDirect(width * height)
-        for (i in 0 until width * height) source.put(i, (i % 12).toByte())
+        source.put(0, SemanticsOverlay.UNLABELED_ORDINAL.toByte())
+        source.put(1, 0) // SKY
 
-        val packed = SemanticsOverlay.stripRowStride(source, width, height, width)
+        val pixels = SemanticsOverlay.labelBufferToArgb(source, width, height, width)
 
-        assertEquals(0, packed.position())
-        assertEquals(width * height, packed.remaining())
-        assertEquals(7.toByte(), packed.get(7))
+        assertEquals(0x00000000, pixels[0])
+        assertEquals(SemanticsOverlay.PALETTE_ARGB[0], pixels[1])
     }
 
     @Test
-    fun `stripRowStride rejects a stride smaller than the width`() {
+    fun `labelBufferToArgb clamps an out-of-range byte into the palette`() {
+        val source = ByteBuffer.allocateDirect(1)
+        source.put(0, 200.toByte()) // way past LABEL_COUNT - 1
+
+        val pixels = SemanticsOverlay.labelBufferToArgb(source, width = 1, height = 1, rowStrideBytes = 1)
+
+        assertEquals(SemanticsOverlay.PALETTE_ARGB[SemanticsOverlay.LABEL_COUNT - 1], pixels[0])
+    }
+
+    @Test
+    fun `labelBufferToArgb rejects a stride smaller than the width`() {
         val source = ByteBuffer.allocateDirect(16)
         assertThrows(IllegalArgumentException::class.java) {
-            SemanticsOverlay.stripRowStride(source, width = 8, height = 2, rowStrideBytes = 4)
+            SemanticsOverlay.labelBufferToArgb(source, width = 8, height = 2, rowStrideBytes = 4)
         }
     }
 
     @Test
-    fun `stripRowStride rejects an empty image`() {
+    fun `labelBufferToArgb rejects an empty image`() {
         val source = ByteBuffer.allocateDirect(4)
         assertThrows(IllegalArgumentException::class.java) {
-            SemanticsOverlay.stripRowStride(source, width = 0, height = 2, rowStrideBytes = 4)
+            SemanticsOverlay.labelBufferToArgb(source, width = 0, height = 2, rowStrideBytes = 4)
         }
+    }
+
+    @Test
+    fun `labelBufferToArgb rejects a rotation that is not a multiple of 90`() {
+        val source = ByteBuffer.allocateDirect(4)
+        assertThrows(IllegalArgumentException::class.java) {
+            SemanticsOverlay.labelBufferToArgb(
+                source,
+                width = 2,
+                height = 2,
+                rowStrideBytes = 2,
+                rotationDegrees = 45,
+            )
+        }
+    }
+
+    @Test
+    fun `labelBufferToArgb rotates 90 degrees clockwise without resampling`() {
+        // 2x1 source: [SKY(0), BUILDING(1)] -> rotated 90 becomes a 1x2 column,
+        // reading top-to-bottom as [SKY, BUILDING] (matches DepthVisualization's indexing).
+        val width = 2
+        val height = 1
+        val source = ByteBuffer.allocateDirect(width * height)
+        source.put(0, 0) // SKY
+        source.put(1, 1) // BUILDING
+
+        val pixels = SemanticsOverlay.labelBufferToArgb(
+            source,
+            width,
+            height,
+            rowStrideBytes = width,
+            rotationDegrees = 90,
+        )
+        val outWidth = SemanticsOverlay.rotatedWidth(width, height, 90)
+        val outHeight = SemanticsOverlay.rotatedHeight(width, height, 90)
+
+        assertEquals(1, outWidth)
+        assertEquals(2, outHeight)
+        assertEquals(SemanticsOverlay.PALETTE_ARGB[0], pixels[0])
+        assertEquals(SemanticsOverlay.PALETTE_ARGB[1], pixels[1])
+    }
+
+    @Test
+    fun `displayRotationToDegrees matches the depth-visualization portrait mapping`() {
+        assertEquals(90, SemanticsOverlay.displayRotationToDegrees(0))
+        assertEquals(0, SemanticsOverlay.displayRotationToDegrees(1))
+        assertEquals(270, SemanticsOverlay.displayRotationToDegrees(2))
+        assertEquals(180, SemanticsOverlay.displayRotationToDegrees(3))
     }
 
     // ── palette / label tables ─────────────────────────────────────────────


### PR DESCRIPTION
## Cause (established by code reading — see below)

`ar-scene-semantics` painted ARCore's per-pixel semantic raster on a Filament 3D quad parented
to the AR camera, using a custom `semantics_overlay.filamat` material. That overlay could
never actually appear over the live camera feed, on any device, regardless of `SemanticMode`
support or slider position:

- `ARCameraStream`'s flat (non-occlusion) material is deliberately drawn **last** in
  Filament's render order (`RenderableManager` priority 7 — `arsceneview/src/main/java/io/github/sceneview/ar/camera/ARCameraStream.kt:494-500`),
  so it can early-Z-reject pixels already covered by opaque virtual geometry (the #1617 fix).
- The overlay's material set `depthWrite: false` / `depthCulling: false`
  (`sceneview/src/main/materials/semantics_overlay.mat`), which it *has to* — `UNLABELED`
  pixels need to stay transparent so the camera shows through them, not become an opaque hole.
- But that also means the overlay never left anything in the depth buffer for the camera
  pass, drawn afterwards, to reject against — so the opaque camera quad silently overdrew the
  overlay every single frame.

This is a demo-only defect (the SDK's `Frame.semanticImage()` / `Config.semanticMode` /
`resolveSemanticMode` plumbing is correct and untouched here) — same class of finding as the
prior #3293 fix for the sibling point-cloud/raw-depth demos.

## Fix

Replaces the Filament-quad pipeline with the same architecture `ARDepthVisualizationDemo`
already uses successfully for its own camera-blended overlay: colour the `R8` label raster
into an `ARGB_8888` bitmap (rotated to the display orientation — the same #3184-class
sensor/display mismatch already handled for the depth demo), and composite it as a Compose
`Image(alpha = blend)` **on top of** the `ARSceneView`. Compositing above the
`SurfaceView`/`TextureView` entirely sidesteps Filament's render-order bookkeeping instead of
fighting it.

`SemanticsOverlay.stripRowStride` (the old Filament-upload helper) is replaced by
`SemanticsOverlay.labelBufferToArgb`, covered by new JVM tests: palette mapping, `UNLABELED`
transparency, out-of-range byte clamping, rotation rejection, and 90° rotation re-indexing
(mirroring `DepthVisualizationTest`'s coverage of the equivalent depth-image path).

The Filament `semantics_overlay.mat` / `.filamat` and
`MaterialLoader.createSemanticsOverlayInstance` SDK API are untouched — they're public API
documented for third-party use with `#1868`, out of scope for a demo fix, though they carry
the same underlying depth-ordering caveat for anyone using them the same way.

## needs-device

Disk on the build machine dropped to ~3 GB free mid-task (shared machine, other sessions
building concurrently) — below this task's 6 GB build stop-gate, so **`assembleDebug` /
`testDebugUnitTest` were not run for this PR**. Please run them (and detekt) before merging,
then on a Pixel 9 / `main`-based build of `ar-scene-semantics`:

1. Point the camera at an outdoor scene (sky, road, trees, etc. — the model has no indoor
   training data). Confirm the color-coded overlay now actually appears blended over the live
   camera feed (it previously never did, on any device).
2. Move the Camera ↔ Semantic slider through its full range — confirm the overlay fades in/out
   smoothly and `UNLABELED` regions stay see-through at every blend level (not just 0%).
3. Rotate the device between portrait and landscape — confirm the overlay stays aligned with
   the live camera image (no 90° offset, the #3184-class bug this demo's colouring pass
   guards against).
4. Confirm the bottom color legend still reads correctly and the top HUD (label percentages),
   "warming up", "unsupported", and "nothing classified — outdoor only" banners are unaffected
   (their logic was not touched).

Fixes #3527
Fixes #3396

🤖 Generated with [Claude Code](https://claude.com/claude-code)